### PR TITLE
New backoffice: Data type API

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/ByKeyDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/ByKeyDataTypeController.cs
@@ -21,7 +21,7 @@ public class ByKeyDataTypeController : DataTypeControllerBase
     [HttpGet("{key:guid}")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(DataTypeViewModel), StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(NotFoundResult), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<DataTypeViewModel>> ByKey(Guid key)
     {
         IDataType? dataType = _dataTypeService.GetDataType(key);

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/CreateDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/CreateDataTypeController.cs
@@ -1,10 +1,8 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.DataType;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 
@@ -32,11 +30,14 @@ public class CreateDataTypeController : DataTypeControllerBase
         IDataType? created = _umbracoMapper.Map<IDataType>(dataTypeCreateModel);
         if (created == null)
         {
-            return BadRequest("Could not map the POSTed model to a datatype");
+            return BadRequest("Could not map the POSTed model to a data type");
         }
 
-        IUser? currentUser = _backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser;
-        _dataTypeService.Save(created, currentUser?.Id ?? Constants.Security.SuperUserId);
+        ProblemDetails? validationIssues = Save(created, _dataTypeService, _backOfficeSecurityAccessor);
+        if (validationIssues != null)
+        {
+            return BadRequest(validationIssues);
+        }
 
         return await Task.FromResult(Ok(_umbracoMapper.Map<DataTypeViewModel>(created)));
     }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/CreateDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/CreateDataTypeController.cs
@@ -23,7 +23,7 @@ public class CreateDataTypeController : DataTypeControllerBase
 
     [HttpPost]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<DataTypeViewModel>> Create(DataTypeCreateModel dataTypeCreateModel)
     {
@@ -39,6 +39,6 @@ public class CreateDataTypeController : DataTypeControllerBase
             return BadRequest(validationIssues);
         }
 
-        return await Task.FromResult(Ok(_umbracoMapper.Map<DataTypeViewModel>(created)));
+        return await Task.FromResult(CreatedAtAction<ByKeyDataTypeController>(controller => nameof(controller.ByKey), created.Key));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/CreateDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/CreateDataTypeController.cs
@@ -25,7 +25,7 @@ public class CreateDataTypeController : DataTypeControllerBase
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<DataTypeViewModel>> Create(DataTypeCreateModel dataTypeCreateModel)
+    public async Task<ActionResult> Create(DataTypeCreateModel dataTypeCreateModel)
     {
         IDataType? created = _umbracoMapper.Map<IDataType>(dataTypeCreateModel);
         if (created == null)

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/DataTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/DataTypeControllerBase.cs
@@ -27,8 +27,7 @@ public abstract class DataTypeControllerBase : ManagementApiControllerBase
                 .Build();
         }
 
-        IUser? currentUser = backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser;
-        dataTypeService.Save(dataType, currentUser?.Id ?? Constants.Security.SuperUserId);
+        dataTypeService.Save(dataType, CurrentUserId(backOfficeSecurityAccessor));
 
         return null;
     }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/DataTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/DataTypeControllerBase.cs
@@ -1,6 +1,12 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType;
 
@@ -10,4 +16,20 @@ namespace Umbraco.Cms.Api.Management.Controllers.DataType;
 [ApiVersion("1.0")]
 public abstract class DataTypeControllerBase : ManagementApiControllerBase
 {
+    protected static ProblemDetails? Save(IDataType dataType, IDataTypeService dataTypeService, IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+    {
+        ValidationResult[] validationResults = dataTypeService.ValidateConfigurationData(dataType).ToArray();
+        if (validationResults.Any())
+        {
+            return new ProblemDetailsBuilder()
+                .WithTitle("Invalid data type configuration")
+                .WithDetail(string.Join(Environment.NewLine, validationResults.Select(r => r.ErrorMessage)))
+                .Build();
+        }
+
+        IUser? currentUser = backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser;
+        dataTypeService.Save(dataType, currentUser?.Id ?? Constants.Security.SuperUserId);
+
+        return null;
+    }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/DeleteDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/DeleteDataTypeController.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.DataType;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.DataType;
+
+public class DeleteDataTypeController : DataTypeControllerBase
+{
+    private readonly IDataTypeService _dataTypeService;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+
+    public DeleteDataTypeController(IDataTypeService dataTypeService, IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+    {
+        _dataTypeService = dataTypeService;
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+    }
+
+    [HttpDelete("{key:guid}")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(NotFoundResult), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<DataTypeViewModel>> Delete(Guid key)
+    {
+        IDataType? dataType = _dataTypeService.GetDataType(key);
+        if (dataType == null)
+        {
+            return NotFound();
+        }
+
+        // one might expect this method to have an Attempt return value, but no - it has no
+        // return value, we'll just have to assume it succeeds
+        _dataTypeService.Delete(dataType, CurrentUserId(_backOfficeSecurityAccessor));
+        return await Task.FromResult(Ok());
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/DeleteDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/DeleteDataTypeController.cs
@@ -21,8 +21,8 @@ public class DeleteDataTypeController : DataTypeControllerBase
     [HttpDelete("{key:guid}")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(NotFoundResult), StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<DataTypeViewModel>> Delete(Guid key)
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> Delete(Guid key)
     {
         IDataType? dataType = _dataTypeService.GetDataType(key);
         if (dataType == null)

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/ByKeyDataTypeFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/ByKeyDataTypeFolderController.cs
@@ -16,6 +16,7 @@ public class ByKeyDataTypeFolderController : DataTypeFolderControllerBase
     [HttpGet("{key:guid}")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(FolderViewModel), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<FolderViewModel>> ByKey(Guid key)
         => await Task.FromResult(GetFolder(key));
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/ByKeyDataTypeFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/ByKeyDataTypeFolderController.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Folder;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.DataType.Folder;
+
+public class ByKeyDataTypeFolderController : DataTypeFolderControllerBase
+{
+    public ByKeyDataTypeFolderController(IBackOfficeSecurityAccessor backOfficeSecurityAccessor, IDataTypeService dataTypeService)
+        : base(backOfficeSecurityAccessor, dataTypeService)
+    {
+    }
+
+    [HttpGet("{key:guid}")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(FolderViewModel), StatusCodes.Status200OK)]
+    public async Task<ActionResult<FolderViewModel>> ByKey(Guid key)
+        => await Task.FromResult(GetFolder(key));
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/CreateDataTypeFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/CreateDataTypeFolderController.cs
@@ -15,7 +15,7 @@ public class CreateDataTypeFolderController : DataTypeFolderControllerBase
 
     [HttpPost]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(typeof(CreatedResult), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status201Created)]
     public async Task<ActionResult> Create(FolderCreateModel folderCreateModel)
         => await Task.FromResult(CreateFolder<ByKeyDataTypeFolderController>(folderCreateModel, controller => nameof(controller.ByKey)));
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/CreateDataTypeFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/CreateDataTypeFolderController.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Folder;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.DataType.Folder;
+
+public class CreateDataTypeFolderController : DataTypeFolderControllerBase
+{
+    public CreateDataTypeFolderController(IBackOfficeSecurityAccessor backOfficeSecurityAccessor, IDataTypeService dataTypeService)
+        : base(backOfficeSecurityAccessor, dataTypeService)
+    {
+    }
+
+    [HttpPost]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(CreatedResult), StatusCodes.Status201Created)]
+    public async Task<ActionResult> Create(FolderCreateModel folderCreateModel)
+        => await Task.FromResult(CreateFolder<ByKeyDataTypeFolderController>(folderCreateModel, controller => nameof(controller.ByKey)));
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DataTypeFolderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DataTypeFolderControllerBase.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.DataType.Folder;
+
+[ApiVersion("1.0")]
+[ApiController]
+[VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.DataType}/folder")]
+[ApiExplorerSettings(GroupName = "Data Type Folder")]
+public abstract class DataTypeFolderControllerBase : FolderManagementControllerBase
+{
+    private readonly IDataTypeService _dataTypeService;
+
+    protected DataTypeFolderControllerBase(IBackOfficeSecurityAccessor backOfficeSecurityAccessor, IDataTypeService dataTypeService)
+        : base(backOfficeSecurityAccessor) =>
+        _dataTypeService = dataTypeService;
+
+    protected override EntityContainer? GetContainer(Guid key)
+        => _dataTypeService.GetContainer(key);
+
+    protected override EntityContainer? GetContainer(int containerId)
+        => _dataTypeService.GetContainer(containerId);
+
+    protected override Attempt<OperationResult<OperationResultType, EntityContainer>?> CreateContainer(int parentId, string name, int userId)
+        => _dataTypeService.CreateContainer(parentId, Guid.NewGuid(), name, userId);
+
+    protected override Attempt<OperationResult?> SaveContainer(EntityContainer container, int userId)
+        => _dataTypeService.SaveContainer(container, userId);
+
+    protected override Attempt<OperationResult?> DeleteContainer(int containerId, int userId)
+        => _dataTypeService.DeleteContainer(containerId, userId);
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DataTypeFolderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DataTypeFolderControllerBase.cs
@@ -10,7 +10,7 @@ namespace Umbraco.Cms.Api.Management.Controllers.DataType.Folder;
 [ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.DataType}/folder")]
-[ApiExplorerSettings(GroupName = "Data Type Folder")]
+[ApiExplorerSettings(GroupName = "Data Type")]
 public abstract class DataTypeFolderControllerBase : FolderManagementControllerBase
 {
     private readonly IDataTypeService _dataTypeService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DeleteDataTypeFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DeleteDataTypeFolderController.cs
@@ -15,7 +15,8 @@ public class DeleteDataTypeFolderController : DataTypeFolderControllerBase
 
     [HttpDelete("{key:guid}")]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(typeof(FolderViewModel), StatusCodes.Status200OK)]
-    public async Task<ActionResult<FolderViewModel>> Delete(Guid key)
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> Delete(Guid key)
         => await Task.FromResult(DeleteFolder(key));
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DeleteDataTypeFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DeleteDataTypeFolderController.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Folder;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.DataType.Folder;
+
+public class DeleteDataTypeFolderController : DataTypeFolderControllerBase
+{
+    public DeleteDataTypeFolderController(IBackOfficeSecurityAccessor backOfficeSecurityAccessor, IDataTypeService dataTypeService)
+        : base(backOfficeSecurityAccessor, dataTypeService)
+    {
+    }
+
+    [HttpDelete("{key:guid}")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(FolderViewModel), StatusCodes.Status200OK)]
+    public async Task<ActionResult<FolderViewModel>> Delete(Guid key)
+        => await Task.FromResult(DeleteFolder(key));
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/UpdateDataTypeFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/UpdateDataTypeFolderController.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Folder;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.DataType.Folder;
+
+public class UpdateDataTypeFolderController : DataTypeFolderControllerBase
+{
+    public UpdateDataTypeFolderController(IBackOfficeSecurityAccessor backOfficeSecurityAccessor, IDataTypeService dataTypeService)
+        : base(backOfficeSecurityAccessor, dataTypeService)
+    {
+    }
+
+    [HttpPut("{key:guid}")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<ActionResult> Update(Guid key, FolderUpdateModel folderUpdateModel)
+        => await Task.FromResult(UpdateFolder(key, folderUpdateModel));
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/UpdateDataTypeFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/UpdateDataTypeFolderController.cs
@@ -16,6 +16,7 @@ public class UpdateDataTypeFolderController : DataTypeFolderControllerBase
     [HttpPut("{key:guid}")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> Update(Guid key, FolderUpdateModel folderUpdateModel)
         => await Task.FromResult(UpdateFolder(key, folderUpdateModel));
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/ReferencesDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/ReferencesDataTypeController.cs
@@ -22,7 +22,7 @@ public class ReferencesDataTypeController : DataTypeControllerBase
     [HttpGet("{key:guid}/references")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(DataTypeReferenceViewModel[]), StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(NotFoundResult), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<DataTypeViewModel>> References(Guid key)
     {
         IDataType? dataType = _dataTypeService.GetDataType(key);

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/ReferencesDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/ReferencesDataTypeController.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.ViewModels.DataType;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.DataType;
+
+public class ReferencesDataTypeController : DataTypeControllerBase
+{
+    private readonly IDataTypeService _dataTypeService;
+    private readonly IDataTypeReferenceViewModelFactory _dataTypeReferenceViewModelFactory;
+
+    public ReferencesDataTypeController(IDataTypeService dataTypeService, IDataTypeReferenceViewModelFactory dataTypeReferenceViewModelFactory)
+    {
+        _dataTypeService = dataTypeService;
+        _dataTypeReferenceViewModelFactory = dataTypeReferenceViewModelFactory;
+    }
+
+    [HttpGet("{key:guid}/references")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(DataTypeReferenceViewModel[]), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(NotFoundResult), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<DataTypeViewModel>> References(Guid key)
+    {
+        IDataType? dataType = _dataTypeService.GetDataType(key);
+        if (dataType == null)
+        {
+            return NotFound();
+        }
+
+        IReadOnlyDictionary<Udi, IEnumerable<string>> usages = _dataTypeService.GetReferences(dataType.Id);
+        DataTypeReferenceViewModel[] viewModels = _dataTypeReferenceViewModelFactory.CreateDataTypeReferenceViewModels(usages).ToArray();
+
+        return await Task.FromResult(Ok(viewModels));
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/ReferencesDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/ReferencesDataTypeController.cs
@@ -23,7 +23,7 @@ public class ReferencesDataTypeController : DataTypeControllerBase
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(DataTypeReferenceViewModel[]), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<DataTypeViewModel>> References(Guid key)
+    public async Task<ActionResult<DataTypeReferenceViewModel[]>> References(Guid key)
     {
         IDataType? dataType = _dataTypeService.GetDataType(key);
         if (dataType == null)

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/UpdateDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/UpdateDataTypeController.cs
@@ -1,10 +1,9 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.DataType;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 
@@ -37,8 +36,11 @@ public class UpdateDataTypeController : DataTypeControllerBase
 
         IDataType updated = _umbracoMapper.Map(dataTypeViewModel, current);
 
-        IUser? currentUser = _backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser;
-        _dataTypeService.Save(updated, currentUser?.Id ?? Constants.Security.SuperUserId);
+        ProblemDetails? validationIssues = Save(updated, _dataTypeService, _backOfficeSecurityAccessor);
+        if (validationIssues != null)
+        {
+            return BadRequest(validationIssues);
+        }
 
         return await Task.FromResult(Ok(_umbracoMapper.Map<DataTypeViewModel>(updated)));
     }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/UpdateDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/UpdateDataTypeController.cs
@@ -26,7 +26,7 @@ public class UpdateDataTypeController : DataTypeControllerBase
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<DataTypeViewModel>> Update(Guid key, DataTypeUpdateModel dataTypeViewModel)
+    public async Task<ActionResult> Update(Guid key, DataTypeUpdateModel dataTypeViewModel)
     {
         IDataType? current = _dataTypeService.GetDataType(key);
         if (current == null)
@@ -42,6 +42,6 @@ public class UpdateDataTypeController : DataTypeControllerBase
             return BadRequest(validationIssues);
         }
 
-        return await Task.FromResult(Ok(_umbracoMapper.Map<DataTypeViewModel>(updated)));
+        return await Task.FromResult(Ok());
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/FolderManagementControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/FolderManagementControllerBase.cs
@@ -1,0 +1,122 @@
+﻿using System.Linq.Expressions;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Common.Builders;
+using Umbraco.Cms.Api.Management.ViewModels.Folder;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers;
+
+public abstract class FolderManagementControllerBase : ManagementApiControllerBase
+{
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+
+    protected FolderManagementControllerBase(IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+        => _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+
+    protected ActionResult GetFolder(Guid key)
+    {
+        EntityContainer? container = GetContainer(key);
+        if (container == null)
+        {
+            return NotFound($"Could not find the folder with key: {key}");
+        }
+
+        EntityContainer? parentContainer = container.ParentId > 0
+            ? GetContainer(container.ParentId)
+            : null;
+
+        // we could implement a mapper for this but it seems rather overkill at this point
+        return Ok(new FolderViewModel
+        {
+            Name = container.Name!,
+            Key = container.Key,
+            ParentKey = parentContainer?.Key
+        });
+    }
+
+    protected ActionResult CreateFolder<TCreatedActionController>(
+        FolderCreateModel folderCreateModel,
+        Expression<Func<TCreatedActionController, string>> createdAction)
+    {
+        EntityContainer? parentContainer = folderCreateModel.ParentKey.HasValue
+            ? GetContainer(folderCreateModel.ParentKey.Value)
+            : null;
+
+        Attempt<OperationResult<OperationResultType, EntityContainer>?> result = CreateContainer(
+            parentContainer?.Id ?? Constants.System.Root,
+            folderCreateModel.Name,
+            CurrentUserId(_backOfficeSecurityAccessor));
+
+        if (result.Success == false)
+        {
+            ProblemDetails problemDetails = new ProblemDetailsBuilder()
+                .WithTitle("Unable to create the folder")
+                .WithDetail(result.Exception?.Message ?? FallbackProblemDetail(result.Result))
+                .Build();
+            return BadRequest(problemDetails);
+        }
+
+        EntityContainer container = result.Result!.Entity!;
+        return CreatedAtAction(createdAction, container.Key);
+    }
+
+    protected ActionResult UpdateFolder(Guid key, FolderUpdateModel folderUpdateModel)
+    {
+        EntityContainer? container = GetContainer(key);
+        if (container == null)
+        {
+            return NotFound($"Could not find the folder with key: {key}");
+        }
+
+        container.Name = folderUpdateModel.Name;
+
+        Attempt<OperationResult?> result = SaveContainer(container, CurrentUserId(_backOfficeSecurityAccessor));
+        if (result.Success == false)
+        {
+            ProblemDetails problemDetails = new ProblemDetailsBuilder()
+                .WithTitle("Unable to update the folder")
+                .WithDetail(result.Exception?.Message ?? FallbackProblemDetail(result.Result))
+                .Build();
+            return BadRequest(problemDetails);
+        }
+
+        return Ok();
+    }
+
+    protected ActionResult DeleteFolder(Guid key)
+    {
+        EntityContainer? container = GetContainer(key);
+        if (container == null)
+        {
+            return NotFound($"Could not find the folder with key: {key}");
+        }
+
+        Attempt<OperationResult?> result = DeleteContainer(container.Id, CurrentUserId(_backOfficeSecurityAccessor));
+        if (result.Success == false)
+        {
+            ProblemDetails problemDetails = new ProblemDetailsBuilder()
+                .WithTitle("Unable to delete the folder")
+                .WithDetail(result.Exception?.Message ?? FallbackProblemDetail(result.Result))
+                .Build();
+            return BadRequest(problemDetails);
+        }
+
+        return Ok();
+    }
+
+    private static string FallbackProblemDetail(OperationResult<OperationResultType>? result)
+        => result != null ? $"The reported operation result was: {result.Result}" : "Check the log for additional details";
+
+    protected abstract EntityContainer? GetContainer(Guid key);
+
+    protected abstract EntityContainer? GetContainer(int containerId);
+
+    protected abstract Attempt<OperationResult?> SaveContainer(EntityContainer container, int userId);
+
+    protected abstract Attempt<OperationResult<OperationResultType, EntityContainer>?> CreateContainer(int parentId, string name, int userId);
+
+    protected abstract Attempt<OperationResult?> DeleteContainer(int containerId, int userId);
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/ManagementApiControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/ManagementApiControllerBase.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Linq.Expressions;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Filters;
+using Umbraco.Cms.Core.Security;
 using Umbraco.New.Cms.Core;
 
 namespace Umbraco.Cms.Api.Management.Controllers;
@@ -7,5 +9,19 @@ namespace Umbraco.Cms.Api.Management.Controllers;
 [JsonOptionsName(Constants.JsonOptionsNames.BackOffice)]
 public class ManagementApiControllerBase : Controller
 {
+    protected CreatedAtActionResult CreatedAtAction<T>(Expression<Func<T, string>> action, Guid key)
+    {
+        if (action.Body is not ConstantExpression constantExpression)
+        {
+            throw new ArgumentException("Expression must be a constant expression.");
+        }
 
+        var controllerName = ManagementApiRegexes.ControllerTypeToNameRegex().Replace(typeof(T).Name, string.Empty);
+        var actionName = constantExpression.Value?.ToString() ?? throw new ArgumentException("Expression does not have a value.");
+
+        return base.CreatedAtAction(actionName, controllerName, new { key = key }, null);
+    }
+
+    protected static int CurrentUserId(IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+        => backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser?.Id ?? Core.Constants.Security.SuperUserId;
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/ManagementApiRegexes.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/ManagementApiRegexes.cs
@@ -1,0 +1,9 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Umbraco.Cms.Api.Management.Controllers;
+
+internal static partial class ManagementApiRegexes
+{
+    [GeneratedRegex("(Controller)$")]
+    public static partial Regex ControllerTypeToNameRegex();
+}

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/FactoryBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/FactoryBuilderExtensions.cs
@@ -15,6 +15,7 @@ public static class FactoryBuilderExtensions
         builder.Services.AddTransient<IRedirectUrlStatusViewModelFactory, RedirectUrlStatusViewModelFactory>();
         builder.Services.AddTransient<IRedirectUrlViewModelFactory, RedirectUrlViewModelFactory>();
         builder.Services.AddTransient<IRelationViewModelFactory, RelationViewModelFactory>();
+        builder.Services.AddTransient<IDataTypeReferenceViewModelFactory, DataTypeReferenceViewModelFactory>();
 
         return builder;
     }

--- a/src/Umbraco.Cms.Api.Management/Factories/DataTypeReferenceViewModelFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DataTypeReferenceViewModelFactory.cs
@@ -1,0 +1,69 @@
+﻿using Umbraco.Cms.Api.Management.ViewModels.DataType;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.Factories;
+
+public class DataTypeReferenceViewModelFactory : IDataTypeReferenceViewModelFactory
+{
+    private readonly IContentTypeService _contentTypeService;
+    private readonly IMediaTypeService _mediaTypeService;
+    private readonly IMemberTypeService _memberTypeService;
+
+    public DataTypeReferenceViewModelFactory(
+        IContentTypeService contentTypeService,
+        IMediaTypeService mediaTypeService,
+        IMemberTypeService memberTypeService)
+    {
+        _contentTypeService = contentTypeService;
+        _mediaTypeService = mediaTypeService;
+        _memberTypeService = memberTypeService;
+    }
+
+    public IEnumerable<DataTypeReferenceViewModel> CreateDataTypeReferenceViewModels(IReadOnlyDictionary<Udi, IEnumerable<string>> dataTypeUsages)
+    {
+        var result = new List<DataTypeReferenceViewModel>();
+
+        var getContentTypesByObjectType = new Dictionary<string, Func<IEnumerable<Guid>, IEnumerable<IContentTypeBase>>>
+        {
+            { UmbracoObjectTypes.DocumentType.GetUdiType(), keys => _contentTypeService.GetAll(keys) },
+            { UmbracoObjectTypes.MediaType.GetUdiType(), keys => _mediaTypeService.GetAll(keys) },
+            { UmbracoObjectTypes.MemberType.GetUdiType(), keys => _memberTypeService.GetAll(keys) }
+        };
+
+        foreach (IGrouping<string, KeyValuePair<Udi, IEnumerable<string>>> usagesByEntityType in dataTypeUsages.GroupBy(u => u.Key.EntityType))
+        {
+            if (getContentTypesByObjectType.TryGetValue(usagesByEntityType.Key, out Func<IEnumerable<Guid>, IEnumerable<IContentTypeBase>>? getContentTypes) == false)
+            {
+                continue;
+            }
+
+            var propertyAliasesByGuid = usagesByEntityType.ToDictionary(i => ((GuidUdi)i.Key).Guid, i => i.Value);
+
+            IContentTypeBase[] contentTypes = getContentTypes(propertyAliasesByGuid.Keys).ToArray();
+
+            result.AddRange(
+                contentTypes.Select(contentType =>
+                {
+                    IEnumerable<string> propertyAliases = propertyAliasesByGuid[contentType.Key];
+                    return new DataTypeReferenceViewModel
+                    {
+                        Key = contentType.Key,
+                        Type = usagesByEntityType.Key,
+                        Properties = contentType
+                            .PropertyTypes
+                            .Where(propertyType => propertyAliases.InvariantContains(propertyType.Alias))
+                            .Select(propertyType => new DataTypePropertyReferenceViewModel
+                            {
+                                Name = propertyType.Name,
+                                Alias = propertyType.Alias
+                            })
+                    };
+                }));
+        }
+
+        return result;
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Factories/DataTypeReferenceViewModelFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DataTypeReferenceViewModelFactory.cs
@@ -24,8 +24,6 @@ public class DataTypeReferenceViewModelFactory : IDataTypeReferenceViewModelFact
 
     public IEnumerable<DataTypeReferenceViewModel> CreateDataTypeReferenceViewModels(IReadOnlyDictionary<Udi, IEnumerable<string>> dataTypeUsages)
     {
-        var result = new List<DataTypeReferenceViewModel>();
-
         var getContentTypesByObjectType = new Dictionary<string, Func<IEnumerable<Guid>, IEnumerable<IContentTypeBase>>>
         {
             { UmbracoObjectTypes.DocumentType.GetUdiType(), keys => _contentTypeService.GetAll(keys) },
@@ -44,26 +42,23 @@ public class DataTypeReferenceViewModelFactory : IDataTypeReferenceViewModelFact
 
             IContentTypeBase[] contentTypes = getContentTypes(propertyAliasesByGuid.Keys).ToArray();
 
-            result.AddRange(
-                contentTypes.Select(contentType =>
+            foreach (IContentTypeBase contentType in contentTypes)
+            {
+                IEnumerable<string> propertyAliases = propertyAliasesByGuid[contentType.Key];
+                yield return new DataTypeReferenceViewModel
                 {
-                    IEnumerable<string> propertyAliases = propertyAliasesByGuid[contentType.Key];
-                    return new DataTypeReferenceViewModel
-                    {
-                        Key = contentType.Key,
-                        Type = usagesByEntityType.Key,
-                        Properties = contentType
-                            .PropertyTypes
-                            .Where(propertyType => propertyAliases.InvariantContains(propertyType.Alias))
-                            .Select(propertyType => new DataTypePropertyReferenceViewModel
-                            {
-                                Name = propertyType.Name,
-                                Alias = propertyType.Alias
-                            })
-                    };
-                }));
+                    Key = contentType.Key,
+                    Type = usagesByEntityType.Key,
+                    Properties = contentType
+                        .PropertyTypes
+                        .Where(propertyType => propertyAliases.InvariantContains(propertyType.Alias))
+                        .Select(propertyType => new DataTypePropertyReferenceViewModel
+                        {
+                            Name = propertyType.Name,
+                            Alias = propertyType.Alias
+                        })
+                };
+            }
         }
-
-        return result;
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/IDataTypeReferenceViewModelFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IDataTypeReferenceViewModelFactory.cs
@@ -1,0 +1,9 @@
+﻿using Umbraco.Cms.Api.Management.ViewModels.DataType;
+using Umbraco.Cms.Core;
+
+namespace Umbraco.Cms.Api.Management.Factories;
+
+public interface IDataTypeReferenceViewModelFactory
+{
+    IEnumerable<DataTypeReferenceViewModel> CreateDataTypeReferenceViewModels(IReadOnlyDictionary<Udi, IEnumerable<string>> dataTypeUsages);
+}

--- a/src/Umbraco.Cms.Api.Management/Mapping/DataType/DataTypeViewModelMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/DataType/DataTypeViewModelMapDefinition.cs
@@ -46,6 +46,7 @@ public class DataTypeViewModelMapDefinition : IMapDefinition
         target.ParentKey = _dataTypeService.GetContainer(source.ParentId)?.Key;
         target.Name = source.Name ?? string.Empty;
         target.PropertyEditorAlias = source.EditorAlias;
+        target.PropertyEditorUiAlias = source.EditorUiAlias;
 
         IConfigurationEditor? configurationEditor = source.Editor?.GetConfigurationEditor();
         IDictionary<string, object> configuration = configurationEditor?.ToConfigurationEditor(source.ConfigurationData)
@@ -67,6 +68,7 @@ public class DataTypeViewModelMapDefinition : IMapDefinition
 
         target.Name = source.Name;
         target.Editor = editor;
+        target.EditorUiAlias = source.PropertyEditorUiAlias;
         target.DatabaseType = GetEditorValueStorageType(editor);
         target.ConfigurationData = MapConfigurationData(source, editor);
     }
@@ -80,6 +82,7 @@ public class DataTypeViewModelMapDefinition : IMapDefinition
         target.Name = source.Name;
         target.ParentId = MapParentId(source.ParentKey);
         target.Editor = editor;
+        target.EditorUiAlias = source.PropertyEditorUiAlias;
         target.DatabaseType = GetEditorValueStorageType(editor);
         target.ConfigurationData = MapConfigurationData(source, editor);
     }

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -60,15 +60,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DataType"
-                }
-              }
-            }
+          "201": {
+            "description": "Created"
           },
           "404": {
             "description": "Not Found",
@@ -116,7 +109,39 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotFoundResult"
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Data Type"
+        ],
+        "operationId": "DeleteDataTypeByKey",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -150,14 +175,187 @@
         },
         "responses": {
           "200": {
+            "description": "Success"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/umbraco/management/api/v1/data-type/{key}/references": {
+      "get": {
+        "tags": [
+          "Data Type"
+        ],
+        "operationId": "GetDataTypeByKeyReferences",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
             "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DataType"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DataTypeReference"
+                  }
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/umbraco/management/api/v1/data-type/folder": {
+      "post": {
+        "tags": [
+          "Data Type"
+        ],
+        "operationId": "PostDataTypeFolder",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FolderCreateModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          }
+        }
+      }
+    },
+    "/umbraco/management/api/v1/data-type/folder/{key}": {
+      "get": {
+        "tags": [
+          "Data Type"
+        ],
+        "operationId": "GetDataTypeFolderByKey",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Folder"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Data Type"
+        ],
+        "operationId": "DeleteDataTypeFolderByKey",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Data Type"
+        ],
+        "operationId": "PutDataTypeFolderByKey",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FolderUpdateModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
           },
           "404": {
             "description": "Not Found",
@@ -4537,6 +4735,10 @@
             "type": "string",
             "nullable": true
           },
+          "propertyEditorUiAlias": {
+            "type": "string",
+            "nullable": true
+          },
           "data": {
             "type": "array",
             "items": {
@@ -4564,6 +4766,10 @@
             "nullable": true
           },
           "propertyEditorAlias": {
+            "type": "string",
+            "nullable": true
+          },
+          "propertyEditorUiAlias": {
             "type": "string",
             "nullable": true
           },
@@ -4595,6 +4801,41 @@
         },
         "additionalProperties": false
       },
+      "DataTypePropertyReference": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "alias": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DataTypeReference": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "properties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataTypePropertyReference"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "DataTypeUpdateModel": {
         "type": "object",
         "properties": {
@@ -4603,6 +4844,10 @@
             "nullable": true
           },
           "propertyEditorAlias": {
+            "type": "string",
+            "nullable": true
+          },
+          "propertyEditorUiAlias": {
             "type": "string",
             "nullable": true
           },
@@ -5279,6 +5524,40 @@
         },
         "additionalProperties": false
       },
+      "Folder": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "key": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "parentKey": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "FolderCreateModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentKey": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "FolderTreeItem": {
         "type": "object",
         "properties": {
@@ -5311,6 +5590,16 @@
           },
           "isFolder": {
             "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "FolderUpdateModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
           }
         },
         "additionalProperties": false

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DataTypeModelBase.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DataTypeModelBase.cs
@@ -6,5 +6,7 @@ public abstract class DataTypeModelBase
 
     public string PropertyEditorAlias { get; set; } = string.Empty;
 
+    public string? PropertyEditorUiAlias { get; set; }
+
     public IEnumerable<DataTypePropertyViewModel> Data { get; set; } = null!;
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DataTypePropertyReferenceViewModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DataTypePropertyReferenceViewModel.cs
@@ -1,0 +1,8 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.DataType;
+
+public class DataTypePropertyReferenceViewModel
+{
+    public required string Name { get; init; }
+
+    public required string Alias { get; init; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DataTypeReferenceViewModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DataTypeReferenceViewModel.cs
@@ -1,0 +1,10 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.DataType;
+
+public class DataTypeReferenceViewModel
+{
+    public required Guid Key { get; init; }
+
+    public required string Type { get; init; }
+
+    public required IEnumerable<DataTypePropertyReferenceViewModel> Properties { get; init; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Folder/FolderCreateModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Folder/FolderCreateModel.cs
@@ -1,0 +1,6 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Folder;
+
+public class FolderCreateModel : FolderModelBase
+{
+    public Guid? ParentKey { get; set; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Folder/FolderModelBase.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Folder/FolderModelBase.cs
@@ -1,0 +1,6 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Folder;
+
+public class FolderModelBase
+{
+    public string Name { get; set; } = string.Empty;
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Folder/FolderUpdateModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Folder/FolderUpdateModel.cs
@@ -1,0 +1,5 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Folder;
+
+public class FolderUpdateModel : FolderModelBase
+{
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Folder/FolderViewModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Folder/FolderViewModel.cs
@@ -1,0 +1,8 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Folder;
+
+public class FolderViewModel : FolderModelBase
+{
+    public Guid Key { get; set; }
+
+    public Guid? ParentKey { get; set; }
+}

--- a/src/Umbraco.Core/CompatibilitySuppressions.xml
+++ b/src/Umbraco.Core/CompatibilitySuppressions.xml
@@ -289,6 +289,20 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Umbraco.Cms.Core.PropertyEditors.IConfigurationEditor.Validate(System.Collections.Generic.IDictionary{System.String,System.Object})</Target>
+    <Left>lib/net7.0/Umbraco.Core.dll</Left>
+    <Right>lib/net7.0/Umbraco.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Umbraco.Cms.Core.Services.IDataTypeService.ValidateConfigurationData(Umbraco.Cms.Core.Models.IDataType)</Target>
+    <Left>lib/net7.0/Umbraco.Core.dll</Left>
+    <Right>lib/net7.0/Umbraco.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
     <Target>P:Umbraco.Cms.Core.Models.IDataType.ConfigurationData</Target>
     <Left>lib/net7.0/Umbraco.Core.dll</Left>
     <Right>lib/net7.0/Umbraco.Core.dll</Right>
@@ -297,6 +311,13 @@
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
     <Target>P:Umbraco.Cms.Core.Models.IDataType.ConfigurationObject</Target>
+    <Left>lib/net7.0/Umbraco.Core.dll</Left>
+    <Right>lib/net7.0/Umbraco.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>P:Umbraco.Cms.Core.Models.IDataType.EditorUiAlias</Target>
     <Left>lib/net7.0/Umbraco.Core.dll</Left>
     <Right>lib/net7.0/Umbraco.Core.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Umbraco.Core/Models/DataType.cs
+++ b/src/Umbraco.Core/Models/DataType.cs
@@ -60,6 +60,10 @@ public class DataType : TreeEntityBase, IDataType
 
     /// <inheritdoc />
     [DataMember]
+    public string? EditorUiAlias { get; set; }
+
+    /// <inheritdoc />
+    [DataMember]
     public ValueStorageType DatabaseType
     {
         get => _databaseType;

--- a/src/Umbraco.Core/Models/IDataType.cs
+++ b/src/Umbraco.Core/Models/IDataType.cs
@@ -19,6 +19,11 @@ public interface IDataType : IUmbracoEntity, IRememberBeingDirty
     string EditorAlias { get; }
 
     /// <summary>
+    ///     Gets the property editor UI alias.
+    /// </summary>
+    string? EditorUiAlias { get; set; }
+
+    /// <summary>
     ///     Gets or sets the database type for the data type values.
     /// </summary>
     /// <remarks>

--- a/src/Umbraco.Core/Models/Mapping/DataTypeMapDefinition.cs
+++ b/src/Umbraco.Core/Models/Mapping/DataTypeMapDefinition.cs
@@ -128,6 +128,7 @@ public class DataTypeMapDefinition : IMapDefinition
     {
         target.DatabaseType = MapDatabaseType(source);
         target.Editor = _propertyEditors[source.EditorAlias];
+        target.EditorUiAlias = null;
         target.Id = Convert.ToInt32(source.Id);
         target.Name = source.Name;
         target.ParentId = source.ParentId;

--- a/src/Umbraco.Core/PropertyEditors/ConfigurationEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/ConfigurationEditor.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Extensions;
@@ -78,6 +79,9 @@ public class ConfigurationEditor : IConfigurationEditor
         string? configuration,
         IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
         => configuration.IsNullOrWhiteSpace() ? new Dictionary<string, object>() : configurationEditorJsonSerializer.Deserialize<Dictionary<string, object>>(configuration) ?? new Dictionary<string, object>();
+
+    /// <inheritdoc />
+    public virtual IEnumerable<ValidationResult> Validate(IDictionary<string, object> configuration) => Array.Empty<ValidationResult>();
 
     /// <summary>
     ///     Gets a field by its property name.

--- a/src/Umbraco.Core/PropertyEditors/ConfigurationEditorOfTConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/ConfigurationEditorOfTConfiguration.cs
@@ -58,6 +58,12 @@ public abstract class ConfigurationEditor<TConfiguration> : ConfigurationEditor
         }
     }
 
+    protected TConfiguration? AsConfigurationObject(IDictionary<string, object> configuration,
+        IConfigurationEditorJsonSerializer configurationEditorJsonSerializer) =>
+        ToConfigurationObject(configuration, configurationEditorJsonSerializer) is TConfiguration configurationObject
+            ? configurationObject
+            : default;
+
     /// <summary>
     ///     Discovers fields from configuration properties marked with the field attribute.
     /// </summary>

--- a/src/Umbraco.Core/PropertyEditors/IConfigurationEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/IConfigurationEditor.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 using Umbraco.Cms.Core.Serialization;
 
@@ -74,4 +75,11 @@ public interface IConfigurationEditor
     IDictionary<string, object> FromDatabase(
         string? configuration,
         IConfigurationEditorJsonSerializer configurationEditorJsonSerializer);
+
+    /// <summary>
+    ///     Performs validation of configuration data.
+    /// </summary>
+    /// <param name="configuration">The configuration data to validate.</param>
+    /// <returns>One or more <see cref="ValidationResult"/> if the configuration data is invalid, an empty collection otherwise.</returns>
+    IEnumerable<ValidationResult> Validate(IDictionary<string, object> configuration);
 }

--- a/src/Umbraco.Core/Services/DataTypeService.cs
+++ b/src/Umbraco.Core/Services/DataTypeService.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.DependencyInjection;
@@ -14,7 +15,6 @@ using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Extensions;
-using static System.Formats.Asn1.AsnWriter;
 
 namespace Umbraco.Cms.Core.Services.Implement
 {
@@ -610,6 +610,18 @@ namespace Umbraco.Cms.Core.Services.Implement
         {
             using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete:true);
             return _dataTypeRepository.FindUsages(id);
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<ValidationResult> ValidateConfigurationData(IDataType dataType)
+        {
+            IConfigurationEditor? configurationEditor = dataType.Editor?.GetConfigurationEditor();
+            return configurationEditor == null
+                ? new[]
+                {
+                    new ValidationResult($"Data type with editor alias {dataType.EditorAlias} does not have a configuration editor")
+                }
+                : configurationEditor.Validate(dataType.ConfigurationData);
         }
 
         private void Audit(AuditType type, int userId, int objectId)

--- a/src/Umbraco.Core/Services/IDataTypeService.cs
+++ b/src/Umbraco.Core/Services/IDataTypeService.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Core.Services;
@@ -16,7 +17,7 @@ public interface IDataTypeService : IService
     IReadOnlyDictionary<Udi, IEnumerable<string>> GetReferences(int id);
 
     Attempt<OperationResult<OperationResultType, EntityContainer>?> CreateContainer(int parentId, Guid key, string name, int userId = Constants.Security.SuperUserId);
-    
+
     Attempt<OperationResult?> SaveContainer(EntityContainer container, int userId = Constants.Security.SuperUserId);
 
     EntityContainer? GetContainer(int containerId);
@@ -115,4 +116,10 @@ public interface IDataTypeService : IService
     /// <exception cref="NotImplementedException"></exception>
     Attempt<OperationResult<MoveOperationStatusType, IDataType>?> Copy(IDataType copying, int containerId, int userId = Constants.Security.SuperUserId) => throw new NotImplementedException();
 
+    /// <summary>
+    /// Performs validation for the configuration data of a given data type.
+    /// </summary>
+    /// <param name="dataType">The data type whose configuration to validate.</param>
+    /// <returns>One or more <see cref="ValidationResult"/> if the configuration data is invalid, an empty collection otherwise.</returns>
+    IEnumerable<ValidationResult> ValidateConfigurationData(IDataType dataType);
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -87,6 +87,7 @@ public class UmbracoPlan : MigrationPlan
         To<UseNvarcharInsteadOfNText>("{888A0D5D-51E4-4C7E-AA0A-01306523C7FB}");
 
         // To 13.0.0
+        To<AddPropertyEditorUiAliasColumn>("{419827A0-4FCE-464B-A8F3-247C6092AF55}");
         To<MigrateDataTypeConfigurations>("{5F15A1CC-353D-4889-8C7E-F303B4766196}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_0_0/AddPropertyEditorUiAliasColumn.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_0_0/AddPropertyEditorUiAliasColumn.cs
@@ -1,0 +1,23 @@
+﻿using Umbraco.Cms.Core;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_13_0_0;
+
+public class AddPropertyEditorUiAliasColumn : MigrationBase
+{
+    public AddPropertyEditorUiAliasColumn(IMigrationContext context)
+        : base(context)
+    {
+    }
+
+    protected override void Migrate()
+    {
+        if (ColumnExists(Constants.DatabaseSchema.Tables.DataType, "propertyEditorUiAlias") is false)
+        {
+            Create.Column("propertyEditorUiAlias")
+                .OnTable(Constants.DatabaseSchema.Tables.DataType)
+                .AsString(255)
+                .Nullable()
+                .Do();
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/DataTypeDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/DataTypeDto.cs
@@ -18,6 +18,7 @@ public class DataTypeDto
     public string EditorAlias { get; set; } = null!; // TODO: should this have a length
 
     [Column("propertyEditorUiAlias")]
+    [NullSetting(NullSetting = NullSettings.Null)]
     public string? EditorUiAlias { get; set; }
 
     [Column("dbType")]

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/DataTypeDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/DataTypeDto.cs
@@ -17,6 +17,9 @@ public class DataTypeDto
     [Column("propertyEditorAlias")]
     public string EditorAlias { get; set; } = null!; // TODO: should this have a length
 
+    [Column("propertyEditorUiAlias")]
+    public string? EditorUiAlias { get; set; }
+
     [Column("dbType")]
     [Length(50)]
     public string DbType { get; set; } = null!;

--- a/src/Umbraco.Infrastructure/Persistence/Factories/DataTypeFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Factories/DataTypeFactory.cs
@@ -41,6 +41,7 @@ internal static class DataTypeFactory
             dataType.SortOrder = dto.NodeDto.SortOrder;
             dataType.Trashed = dto.NodeDto.Trashed;
             dataType.CreatorId = dto.NodeDto.UserId ?? Constants.Security.UnknownUserId;
+            dataType.EditorUiAlias = dto.EditorUiAlias;
 
             dataType.SetConfigurationData(editor.GetConfigurationEditor().FromDatabase(dto.Configuration, serializer));
 
@@ -59,6 +60,7 @@ internal static class DataTypeFactory
         var dataTypeDto = new DataTypeDto
         {
             EditorAlias = entity.EditorAlias,
+            EditorUiAlias = entity.EditorUiAlias,
             NodeId = entity.Id,
             DbType = entity.DatabaseType.ToString(),
             Configuration = entity.Editor?.GetConfigurationEditor().ToDatabase(entity.ConfigurationData, serializer),


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR adds data type handling to the management API including:

- Data type CRUD operations incl. a new scheme for data type configuration validation.
- Data type references fetching.
- Data type folder CRUD operations.

![image](https://user-images.githubusercontent.com/7405322/210497588-d2f0e37b-e2e3-4a73-8fec-75b9953bdef6.png)

The PR builds on top of #13605, and once more the goal is *not* to clean up the current data type management, but rather to have that and the data type management API co-exist as best possible, until we are ready to clean up the current data type management entirely.

This PR *should* have included structural operations (move/copy), but we are currently undecided as to where these go, so we will have to circle back to those operations in a new PR.

### Special points of interest

A few honourable mentions for this PR:

- It turns out that folder management is implemented as duplicate code in the current code base. This applies to data type, content type and media type folders (possibly more). To counter this in the management API, I have added the `FolderManagementControllerBase` class to perform the heavy lifting of folder management. This will make the folder management implementation for content types and media types (and others) easier and result in less duplicate code.
- On the subject of folders, these are known by a different name at code level - *containers*. After consulting the FE team, the clear preference from an API consumption point is *folder* over *container*, which puts us in a bit of a naming pickle. I have tried to use *folder* for anything API facing (endpoints, controller actions, view models) and *container* for the inner workings (service management etc.).
- When creating new instances through the management API, it turns out we have no simple way of returning proper `HTTP 201` responses with a `location` header. This in part is due to how we've structured the code (one action, one controller), which does not play nice with the built-in `CreatedAtAction` or `CreatedAtRoute` helper methods of the `Controller` base class. To use those, one must apply magic strings for controller and action names given our code structure. Thus I have added the helper method `CreatedAtAction` to the `ManagementApiControllerBase`, which will allow us to construct `HTTP 201` responses in a simpler and type safe way (see `CreateDataTypeController.Create()`).
- In the new backoffice it will be possible to reuse the serverside property implementations (configuration editors, value converters, ...) across multiple property types, unlike today where one serverside implementation yields one backoffice property type. Data types will tie all this together, and to achieve this we need a new mapping property on data types - the `EditorUiAlias`. Combined with the existing `EditorAlias`, this will provide the necessary mapping for the backoffice. Since the server isn't concerned with the actual value of `EditorUiAlias`, there is no way to perform a migration for the `EditorUiAlias` DB column value, and thus the new backoffice will be able to perform fallback to default property implementations based solely on the current `EditorAlias` values.

### Testing this PR

Get in touch with @kjac for a Postman collection.

To test the new scheme for data type validation, replace the current `TextAreaConfigurationEditor` implementation with the following:

```csharp
using System.ComponentModel.DataAnnotations;
using Microsoft.Extensions.DependencyInjection;
using Umbraco.Cms.Core.DependencyInjection;
using Umbraco.Cms.Core.IO;
using Umbraco.Cms.Core.Serialization;
using Umbraco.Cms.Core.Services;

namespace Umbraco.Cms.Core.PropertyEditors;

public class TextAreaConfigurationEditor : ConfigurationEditor<TextAreaConfiguration>
{
    private readonly IConfigurationEditorJsonSerializer _configurationEditorJsonSerializer;

    public TextAreaConfigurationEditor(IIOHelper ioHelper, IEditorConfigurationParser editorConfigurationParser)
        : this(
            ioHelper,
            editorConfigurationParser,
            StaticServiceProvider.Instance.GetRequiredService<IConfigurationEditorJsonSerializer>())
    {
    }

    public TextAreaConfigurationEditor(
        IIOHelper ioHelper,
        IEditorConfigurationParser editorConfigurationParser,
        IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
        : base(ioHelper, editorConfigurationParser) =>
        _configurationEditorJsonSerializer = configurationEditorJsonSerializer;

    public override IEnumerable<ValidationResult> Validate(IDictionary<string, object> configuration)
    {
        TextAreaConfiguration? config = AsConfigurationObject(configuration, _configurationEditorJsonSerializer);
        if (config is { MaxChars: > 100 })
        {
            yield return new ValidationResult("No way! Too many chars, yo!");
        }
    }
}
```

Now you should see a validation error when trying to create or update a text area property with `maxChars` configured as more than 100:

![image](https://user-images.githubusercontent.com/7405322/210501900-0a95afd0-66f9-4f52-9e81-eb77009a3e71.png)
