### PR TITLE
V12: Change nullability for the log viewer

### DIFF
--- a/src/Umbraco.Infrastructure/Logging/Viewer/ILogViewer.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/ILogViewer.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Core.Logging.Viewer;
 
@@ -9,17 +9,17 @@ public interface ILogViewer
     /// <summary>
     ///     Get all saved searches from your chosen data source
     /// </summary>
-    IReadOnlyList<SavedLogSearch>? GetSavedSearches();
+    IReadOnlyList<SavedLogSearch> GetSavedSearches();
 
     /// <summary>
     ///     Adds a new saved search to chosen data source and returns the updated searches
     /// </summary>
-    IReadOnlyList<SavedLogSearch>? AddSavedSearch(string? name, string? query);
+    IReadOnlyList<SavedLogSearch> AddSavedSearch(string? name, string? query);
 
     /// <summary>
     ///     Deletes a saved search to chosen data source and returns the remaining searches
     /// </summary>
-    IReadOnlyList<SavedLogSearch>? DeleteSavedSearch(string? name, string? query);
+    IReadOnlyList<SavedLogSearch> DeleteSavedSearch(string? name, string? query);
 
     /// <summary>
     ///     A count of number of errors

--- a/src/Umbraco.Infrastructure/Logging/Viewer/ILogViewerConfig.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/ILogViewerConfig.cs
@@ -2,9 +2,9 @@ namespace Umbraco.Cms.Core.Logging.Viewer;
 
 public interface ILogViewerConfig
 {
-    IReadOnlyList<SavedLogSearch>? GetSavedSearches();
+    IReadOnlyList<SavedLogSearch> GetSavedSearches();
 
-    IReadOnlyList<SavedLogSearch>? AddSavedSearch(string? name, string? query);
+    IReadOnlyList<SavedLogSearch> AddSavedSearch(string? name, string? query);
 
-    IReadOnlyList<SavedLogSearch>? DeleteSavedSearch(string? name, string? query);
+    IReadOnlyList<SavedLogSearch> DeleteSavedSearch(string? name, string? query);
 }

--- a/src/Umbraco.Infrastructure/Logging/Viewer/LogViewerConfig.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/LogViewerConfig.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Scoping;
 using IScope = Umbraco.Cms.Infrastructure.Scoping.IScope;
@@ -16,15 +16,15 @@ public class LogViewerConfig : ILogViewerConfig
         _scopeProvider = scopeProvider;
     }
 
-    public IReadOnlyList<SavedLogSearch>? GetSavedSearches()
+    public IReadOnlyList<SavedLogSearch> GetSavedSearches()
     {
         using IScope scope = _scopeProvider.CreateScope(autoComplete: true);
-        IEnumerable<ILogViewerQuery>? logViewerQueries = _logViewerQueryRepository.GetMany();
-        SavedLogSearch[]? result = logViewerQueries?.Select(x => new SavedLogSearch() { Name = x.Name, Query = x.Query }).ToArray();
+        IEnumerable<ILogViewerQuery> logViewerQueries = _logViewerQueryRepository.GetMany();
+        SavedLogSearch[] result = logViewerQueries.Select(x => new SavedLogSearch() { Name = x.Name, Query = x.Query }).ToArray();
         return result;
     }
 
-    public IReadOnlyList<SavedLogSearch>? AddSavedSearch(string? name, string? query)
+    public IReadOnlyList<SavedLogSearch> AddSavedSearch(string? name, string? query)
     {
         using IScope scope = _scopeProvider.CreateScope(autoComplete: true);
         _logViewerQueryRepository.Save(new LogViewerQuery(name, query));
@@ -32,7 +32,7 @@ public class LogViewerConfig : ILogViewerConfig
         return GetSavedSearches();
     }
 
-    public IReadOnlyList<SavedLogSearch>? DeleteSavedSearch(string? name, string? query)
+    public IReadOnlyList<SavedLogSearch> DeleteSavedSearch(string? name, string? query)
     {
         using IScope scope = _scopeProvider.CreateScope(autoComplete: true);
         ILogViewerQuery? item = name is null ? null : _logViewerQueryRepository.GetByName(name);

--- a/src/Umbraco.Infrastructure/Logging/Viewer/SerilogLogViewerSourceBase.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/SerilogLogViewerSourceBase.cs
@@ -1,8 +1,6 @@
-﻿using System.Collections.ObjectModel;
-using Microsoft.Extensions.DependencyInjection;
+using System.Collections.ObjectModel;
 using Serilog;
 using Serilog.Events;
-using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Extensions;
 
@@ -12,26 +10,24 @@ public abstract class SerilogLogViewerSourceBase : ILogViewer
 {
     private readonly ILogLevelLoader _logLevelLoader;
     private readonly ILogViewerConfig _logViewerConfig;
-    private readonly ILogger _serilogLog;
 
     protected SerilogLogViewerSourceBase(ILogViewerConfig logViewerConfig, ILogLevelLoader logLevelLoader, ILogger serilogLog)
     {
         _logViewerConfig = logViewerConfig;
         _logLevelLoader = logLevelLoader;
-        _serilogLog = serilogLog;
     }
 
     public abstract bool CanHandleLargeLogs { get; }
 
     public abstract bool CheckCanOpenLogs(LogTimePeriod logTimePeriod);
 
-    public virtual IReadOnlyList<SavedLogSearch>? GetSavedSearches()
+    public virtual IReadOnlyList<SavedLogSearch> GetSavedSearches()
         => _logViewerConfig.GetSavedSearches();
 
-    public virtual IReadOnlyList<SavedLogSearch>? AddSavedSearch(string? name, string? query)
+    public virtual IReadOnlyList<SavedLogSearch> AddSavedSearch(string? name, string? query)
         => _logViewerConfig.AddSavedSearch(name, query);
 
-    public virtual IReadOnlyList<SavedLogSearch>? DeleteSavedSearch(string? name, string? query)
+    public virtual IReadOnlyList<SavedLogSearch> DeleteSavedSearch(string? name, string? query)
         => _logViewerConfig.DeleteSavedSearch(name, query);
 
     public int GetNumberOfErrors(LogTimePeriod logTimePeriod)

--- a/src/Umbraco.Web.BackOffice/Controllers/LogViewerController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/LogViewerController.cs
@@ -129,14 +129,14 @@ public class LogViewerController : BackOfficeNotificationsController
     }
 
     [HttpGet]
-    public IEnumerable<SavedLogSearch>? GetSavedSearches() => _logViewer.GetSavedSearches();
+    public IEnumerable<SavedLogSearch> GetSavedSearches() => _logViewer.GetSavedSearches();
 
     [HttpPost]
-    public IEnumerable<SavedLogSearch>? PostSavedSearch(SavedLogSearch item) =>
+    public IEnumerable<SavedLogSearch> PostSavedSearch(SavedLogSearch item) =>
         _logViewer.AddSavedSearch(item.Name, item.Query);
 
     [HttpPost]
-    public IEnumerable<SavedLogSearch>? DeleteSavedSearch(SavedLogSearch item) =>
+    public IEnumerable<SavedLogSearch> DeleteSavedSearch(SavedLogSearch item) =>
         _logViewer.DeleteSavedSearch(item.Name, item.Query);
 
     [HttpGet]


### PR DESCRIPTION
## Details
Fixing nullability for the log viewer since collections will be empty and not null when no elements.


## Test
- Navigate to the Log Viewer dashboard;
- Make sure you are still getting the saved searches;
- Modify them - ex: delete or save new ones;
- Get them again.