### PR TITLE
V13: Don't execute databaseconfigurestep if configured

### DIFF
--- a/src/Umbraco.New.Cms.Infrastructure/Installer/Steps/DatabaseConfigureStep.cs
+++ b/src/Umbraco.New.Cms.Infrastructure/Installer/Steps/DatabaseConfigureStep.cs
@@ -47,20 +47,7 @@ public class DatabaseConfigureStep : IInstallStep
         // If the connection string is already present in config we don't need to configure it again
         if (_connectionStrings.CurrentValue.IsConnectionStringConfigured())
         {
-            try
-            {
-                // Since a connection string was present we verify the db can connect and query
-                _databaseBuilder.ValidateSchema();
-
-                return Task.FromResult(false);
-            }
-            catch (Exception ex)
-            {
-                // Something went wrong, could not connect so probably need to reconfigure
-                _logger.LogError(ex, "An error occurred, reconfiguring...");
-
-                return Task.FromResult(true);
-            }
+            return Task.FromResult(false);
         }
 
         return Task.FromResult(true);


### PR DESCRIPTION
Fixes an issue where database wouldn't be recreated if already configured.
# Notes
- Don't run database configure step if connectionstring is already configured.

# How to test
- Set the `umbracoDbDSN` & `umbracoDbDSN_ProviderName` in your `appsettings.json`, example for SQLite:
```
  "ConnectionStrings": {
    "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
    "umbracoDbDSN_ProviderName": "Microsoft.Data.SQLite"
  },
```
- Try to install