### PR TITLE
V10: Dont configure database if connectionstring is configured

### DIFF
--- a/src/Umbraco.Infrastructure/Install/InstallSteps/DatabaseConfigureStep.cs
+++ b/src/Umbraco.Infrastructure/Install/InstallSteps/DatabaseConfigureStep.cs
@@ -36,7 +36,12 @@ public class DatabaseConfigureStep : InstallSetupStep<DatabaseModel>
 
     public override Task<InstallSetupResult?> ExecuteAsync(DatabaseModel databaseSettings)
     {
-        if (!_databaseBuilder.ConfigureDatabaseConnection(databaseSettings, false))
+        if (databaseSettings is null && string.IsNullOrWhiteSpace(_connectionStrings.CurrentValue.ConnectionString) is false)
+        {
+            return Task.FromResult<InstallSetupResult?>(null);
+        }
+
+        if (!_databaseBuilder.ConfigureDatabaseConnection(databaseSettings!, false))
         {
             throw new InstallException("Could not connect to the database");
         }


### PR DESCRIPTION
Fixes an issue where database wouldn't be recreated if already configured.
# Notes
- Check if connectionstring is there, if it is configured, don't run step

# How to test
- Set the `umbracoDbDSN` & `umbracoDbDSN_ProviderName` in your `appsettings.json`, example for SQLite:
```
  "ConnectionStrings": {
    "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
    "umbracoDbDSN_ProviderName": "Microsoft.Data.SQLite"
  },
```
- Try to install