### PR TITLE
Template API for new backoffice

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/ByKeyTemplateController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/ByKeyTemplateController.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Template;
+using Umbraco.Cms.Core.Mapping;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Template;
+
+public class ByKeyTemplateController : TemplateControllerBase
+{
+    private readonly ITemplateService _templateService;
+    private readonly IUmbracoMapper _umbracoMapper;
+
+    public ByKeyTemplateController(ITemplateService templateService, IUmbracoMapper umbracoMapper)
+    {
+        _templateService = templateService;
+        _umbracoMapper = umbracoMapper;
+    }
+
+    [HttpGet("{key:guid}")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(TemplateViewModel), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<TemplateViewModel>> ByKey(Guid key)
+    {
+        ITemplate? template = _templateService.GetTemplate(key);
+        if (template == null)
+        {
+            return NotFound();
+        }
+
+        return await Task.FromResult(Ok(_umbracoMapper.Map<TemplateViewModel>(template)));
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/ByKeyTemplateController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/ByKeyTemplateController.cs
@@ -24,12 +24,9 @@ public class ByKeyTemplateController : TemplateControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<TemplateViewModel>> ByKey(Guid key)
     {
-        ITemplate? template = _templateService.GetTemplate(key);
-        if (template == null)
-        {
-            return NotFound();
-        }
-
-        return await Task.FromResult(Ok(_umbracoMapper.Map<TemplateViewModel>(template)));
+        ITemplate? template = await _templateService.GetTemplateAsync(key);
+        return template == null
+            ? NotFound()
+            : Ok(_umbracoMapper.Map<TemplateViewModel>(template));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/CreateTemplateController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/CreateTemplateController.cs
@@ -12,11 +12,16 @@ public class CreateTemplateController : TemplateControllerBase
 {
     private readonly ITemplateService _templateService;
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+    private readonly ITemplateContentParserService _templateContentParserService;
 
-    public CreateTemplateController(ITemplateService templateService, IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+    public CreateTemplateController(
+        ITemplateService templateService,
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
+        ITemplateContentParserService templateContentParserService)
     {
         _templateService = templateService;
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+        _templateContentParserService = templateContentParserService;
     }
 
     [HttpPost]
@@ -25,13 +30,14 @@ public class CreateTemplateController : TemplateControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> Create(TemplateCreateModel createModel)
     {
+        var masterTemplateAlias = _templateContentParserService.MasterTemplateAlias(createModel.Content);
         ITemplate? masterTemplate = null;
-        if (createModel.MasterTemplateAlias.IsNullOrWhiteSpace() == false)
+        if (masterTemplateAlias.IsNullOrWhiteSpace() == false)
         {
-            masterTemplate = _templateService.GetTemplate(createModel.MasterTemplateAlias);
+            masterTemplate = _templateService.GetTemplate(masterTemplateAlias);
             if (masterTemplate == null)
             {
-                return NotFound($"Could not find a master template with alias {createModel.MasterTemplateAlias}");
+                return NotFound($"Could not find a master template with alias {masterTemplateAlias}");
             }
         }
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/CreateTemplateController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/CreateTemplateController.cs
@@ -30,24 +30,14 @@ public class CreateTemplateController : TemplateControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> Create(TemplateCreateModel createModel)
     {
-        var masterTemplateAlias = _templateContentParserService.MasterTemplateAlias(createModel.Content);
-        ITemplate? masterTemplate = null;
-        if (masterTemplateAlias.IsNullOrWhiteSpace() == false)
-        {
-            masterTemplate = _templateService.GetTemplate(masterTemplateAlias);
-            if (masterTemplate == null)
-            {
-                return NotFound($"Could not find a master template with alias {masterTemplateAlias}");
-            }
-        }
-
-        ITemplate template = _templateService.CreateTemplateWithIdentity(
+        ITemplate? template = await _templateService.CreateTemplateWithIdentityAsync(
             createModel.Name,
             createModel.Alias,
             createModel.Content,
-            masterTemplate,
             CurrentUserId(_backOfficeSecurityAccessor));
 
-        return await Task.FromResult(CreatedAtAction<ByKeyTemplateController>(controller => nameof(controller.ByKey), template.Key));
+        return template == null
+            ? NotFound()
+            : CreatedAtAction<ByKeyTemplateController>(controller => nameof(controller.ByKey), template.Key);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/CreateTemplateController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/CreateTemplateController.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Template;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Template;
+
+public class CreateTemplateController : TemplateControllerBase
+{
+    private readonly ITemplateService _templateService;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+
+    public CreateTemplateController(ITemplateService templateService, IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+    {
+        _templateService = templateService;
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+    }
+
+    [HttpPost]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> Create(TemplateCreateModel createModel)
+    {
+        ITemplate? masterTemplate = null;
+        if (createModel.MasterTemplateAlias.IsNullOrWhiteSpace() == false)
+        {
+            masterTemplate = _templateService.GetTemplate(createModel.MasterTemplateAlias);
+            if (masterTemplate == null)
+            {
+                return NotFound($"Could not find a master template with alias {createModel.MasterTemplateAlias}");
+            }
+        }
+
+        ITemplate template = _templateService.CreateTemplateWithIdentity(
+            createModel.Name,
+            createModel.Alias,
+            createModel.Content,
+            masterTemplate,
+            CurrentUserId(_backOfficeSecurityAccessor));
+
+        return await Task.FromResult(CreatedAtAction<ByKeyTemplateController>(controller => nameof(controller.ByKey), template.Key));
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/DeleteTemplateController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/DeleteTemplateController.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 
@@ -22,14 +21,7 @@ public class DeleteTemplateController : TemplateControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> Delete(Guid key)
-    {
-        ITemplate? template = _templateService.GetTemplate(key);
-        if (template == null)
-        {
-            return NotFound();
-        }
-
-        _templateService.DeleteTemplate(template.Alias, CurrentUserId(_backOfficeSecurityAccessor));
-        return await Task.FromResult(Ok());
-    }
+        => await _templateService.DeleteTemplateAsync(key, CurrentUserId(_backOfficeSecurityAccessor))
+            ? Ok()
+            : NotFound();
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/DeleteTemplateController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/DeleteTemplateController.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Template;
+
+public class DeleteTemplateController : TemplateControllerBase
+{
+    private readonly ITemplateService _templateService;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+
+    public DeleteTemplateController(ITemplateService templateService, IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+    {
+        _templateService = templateService;
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+    }
+
+    [HttpDelete("{key:guid}")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> Delete(Guid key)
+    {
+        ITemplate? template = _templateService.GetTemplate(key);
+        if (template == null)
+        {
+            return NotFound();
+        }
+
+        _templateService.DeleteTemplate(template.Alias, CurrentUserId(_backOfficeSecurityAccessor));
+        return await Task.FromResult(Ok());
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/ExecuteTemplateQueryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/ExecuteTemplateQueryController.cs
@@ -33,7 +33,7 @@ public class ExecuteTemplateQueryController : TemplateQueryControllerBase
         _contentTypeService = contentTypeService;
     }
 
-    [HttpPost]
+    [HttpPost("execute")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(TemplateQueryResultViewModel), StatusCodes.Status200OK)]
     public async Task<ActionResult<TemplateQueryResultViewModel>> Execute(TemplateQueryExecuteModel query)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/ExecuteTemplateQueryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/ExecuteTemplateQueryController.cs
@@ -1,0 +1,197 @@
+﻿using System.Diagnostics;
+using System.Linq.Expressions;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Template.Query;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Models.TemplateQuery;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Template.Query;
+
+public class ExecuteTemplateQueryController : TemplateQueryControllerBase
+{
+    private readonly IPublishedContentQuery _publishedContentQuery;
+    private readonly IVariationContextAccessor _variationContextAccessor;
+    private readonly IPublishedValueFallback _publishedValueFallback;
+    private readonly IContentTypeService _contentTypeService;
+
+    private static readonly string _indent = $"{Environment.NewLine}    ";
+
+    public ExecuteTemplateQueryController(
+        IPublishedContentQuery publishedContentQuery,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedValueFallback publishedValueFallback,
+        IContentTypeService contentTypeService)
+    {
+        _publishedContentQuery = publishedContentQuery;
+        _variationContextAccessor = variationContextAccessor;
+        _publishedValueFallback = publishedValueFallback;
+        _contentTypeService = contentTypeService;
+    }
+
+    [HttpPost]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(TemplateQueryResultViewModel), StatusCodes.Status200OK)]
+    public async Task<ActionResult<TemplateQueryResultViewModel>> Execute(TemplateQueryExecuteModel query)
+    {
+        var queryExpression = new StringBuilder();
+        IEnumerable<IPublishedContent> contents = BuildQuery(query, queryExpression);
+
+        var timer = new Stopwatch();
+        timer.Start();
+        var results = contents.ToList();
+        timer.Stop();
+
+        var contentTypeIconsByKey = _contentTypeService
+            .GetAll(results.Select(content => content.ContentType.Key).Distinct())
+            .ToDictionary(contentType => contentType.Key, contentType => contentType.Icon);
+
+        return await Task.FromResult(Ok(new TemplateQueryResultViewModel
+        {
+            QueryExpression = queryExpression.ToString(),
+            ResultCount = results.Count,
+            ExecutionTime = timer.ElapsedMilliseconds,
+            SampleResults = results.Take(20).Select(content => new TemplateQueryResultItemViewModel
+            {
+                Icon = contentTypeIconsByKey[content.ContentType.Key] ?? "icon-document",
+                Name = content.Name
+            })
+        }));
+    }
+
+    private IEnumerable<IPublishedContent> BuildQuery(TemplateQueryExecuteModel model, StringBuilder queryExpression)
+    {
+        IPublishedContent? rootContent = GetRootContent(model, queryExpression);
+
+        IEnumerable<IPublishedContent> contentQuery = GetRootContentQuery(model, rootContent, queryExpression);
+
+        contentQuery = ApplyFiltering(model, contentQuery, queryExpression);
+
+        contentQuery = ApplySorting(model, contentQuery, queryExpression);
+
+        contentQuery = ApplyPaging(model, contentQuery, queryExpression);
+
+        return contentQuery;
+    }
+
+    private IPublishedContent? GetRootContent(TemplateQueryExecuteModel model, StringBuilder queryExpression)
+    {
+        IPublishedContent? rootContent;
+
+        if (model.RootContentKey != null && model.RootContentKey != Guid.Empty)
+        {
+            rootContent = _publishedContentQuery.Content(model.RootContentKey);
+            queryExpression.Append($"Umbraco.Content(Guid.Parse(\"{model.RootContentKey}\"))");
+        }
+        else
+        {
+            rootContent = _publishedContentQuery.ContentAtRoot().FirstOrDefault();
+            queryExpression.Append("Umbraco.ContentAtRoot().FirstOrDefault()");
+        }
+
+        return rootContent;
+    }
+
+    private IEnumerable<IPublishedContent> GetRootContentQuery(TemplateQueryExecuteModel model, IPublishedContent? rootContent, StringBuilder queryExpression)
+    {
+        queryExpression.Append(_indent);
+
+        if (model.ContentTypeAlias.IsNullOrWhiteSpace() == false)
+        {
+            queryExpression.Append($".ChildrenOfType(\"{model.ContentTypeAlias}\")");
+            return rootContent == null
+                ? Enumerable.Empty<IPublishedContent>()
+                : rootContent.ChildrenOfType(_variationContextAccessor, model.ContentTypeAlias);
+        }
+
+        queryExpression.Append(".Children()");
+        return rootContent == null
+            ? Enumerable.Empty<IPublishedContent>()
+            : rootContent.Children(_variationContextAccessor);
+    }
+
+    private IEnumerable<IPublishedContent> ApplyFiltering(TemplateQueryExecuteModel model, IEnumerable<IPublishedContent> contentQuery, StringBuilder queryExpression)
+    {
+        if (model.Filters is not null)
+        {
+            var propertyTypeByAlias = GetProperties().ToDictionary(p => p.Alias, p => p.Type);
+
+            IEnumerable<QueryCondition> conditions = model.Filters
+                .Where(f => f.ConstraintValue.IsNullOrWhiteSpace() == false && propertyTypeByAlias.ContainsKey(f.PropertyAlias))
+                .Select(f => new QueryCondition
+                {
+                    Property = new PropertyModel
+                    {
+                        Alias = f.PropertyAlias,
+                        Type = propertyTypeByAlias[f.PropertyAlias]
+                    },
+                    ConstraintValue = f.ConstraintValue,
+                    Term = new OperatorTerm { Operator = f.Operator }
+                });
+
+            // apply filters
+            foreach (QueryCondition condition in conditions)
+            {
+                //x is passed in as the parameter alias for the linq where statement clause
+                Expression<Func<IPublishedContent, bool>> operation = condition.BuildCondition<IPublishedContent>("x");
+
+                //for review - this uses a tonized query rather then the normal linq query.
+                contentQuery = contentQuery.Where(operation.Compile());
+                queryExpression.Append(_indent);
+                queryExpression.Append($".Where({operation})");
+            }
+        }
+
+        contentQuery = contentQuery.Where(x => x.IsVisible(_publishedValueFallback));
+        queryExpression.Append(_indent);
+        queryExpression.Append(".Where(x => x.IsVisible())");
+
+        return contentQuery;
+    }
+
+    private IEnumerable<IPublishedContent> ApplySorting(TemplateQueryExecuteModel model, IEnumerable<IPublishedContent> contentQuery, StringBuilder queryExpression)
+    {
+        if (model.Sort != null && model.Sort.PropertyAlias.IsNullOrWhiteSpace() == false)
+        {
+            var ascending = model.Sort.Direction == "ascending";
+            contentQuery = model.Sort.PropertyAlias.ToLowerInvariant() switch
+            {
+                "id" => ascending
+                    ? contentQuery.OrderBy(content => content.Id)
+                    : contentQuery.OrderByDescending(content => content.Id),
+                "createDate" => ascending
+                    ? contentQuery.OrderBy(content => content.CreateDate)
+                    : contentQuery.OrderByDescending(content => content.CreateDate),
+                "publishDate" => ascending
+                    ? contentQuery.OrderBy(content => content.UpdateDate)
+                    : contentQuery.OrderByDescending(content => content.UpdateDate),
+                _ => ascending
+                    ? contentQuery.OrderBy(content => content.Name)
+                    : contentQuery.OrderByDescending(content => content.Name),
+            };
+
+            queryExpression.Append(_indent);
+            queryExpression.Append(ascending
+                ? $".OrderBy(x => x.{model.Sort.PropertyAlias})"
+                : $".OrderByDescending(x => x.{model.Sort.PropertyAlias})");
+        }
+
+        return contentQuery;
+    }
+
+    private IEnumerable<IPublishedContent> ApplyPaging(TemplateQueryExecuteModel model, IEnumerable<IPublishedContent> contentQuery, StringBuilder queryExpression)
+    {
+        if (model.Take > 0)
+        {
+            contentQuery = contentQuery.Take(model.Take);
+            queryExpression.Append(_indent);
+            queryExpression.Append($".Take({model.Take})");
+        }
+
+        return contentQuery;
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/ExecuteTemplateQueryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/ExecuteTemplateQueryController.cs
@@ -120,6 +120,15 @@ public class ExecuteTemplateQueryController : TemplateQueryControllerBase
         {
             var propertyTypeByAlias = GetProperties().ToDictionary(p => p.Alias, p => p.Type);
 
+            string PropertyModelType(TemplateQueryPropertyType templateQueryPropertyType)
+                => templateQueryPropertyType switch
+                {
+                    TemplateQueryPropertyType.Integer => "int",
+                    TemplateQueryPropertyType.String => "string",
+                    TemplateQueryPropertyType.DateTime => "datetime",
+                    _ => throw new ArgumentOutOfRangeException(nameof(templateQueryPropertyType))
+                };
+
             IEnumerable<QueryCondition> conditions = model.Filters
                 .Where(f => f.ConstraintValue.IsNullOrWhiteSpace() == false && propertyTypeByAlias.ContainsKey(f.PropertyAlias))
                 .Select(f => new QueryCondition
@@ -127,7 +136,7 @@ public class ExecuteTemplateQueryController : TemplateQueryControllerBase
                     Property = new PropertyModel
                     {
                         Alias = f.PropertyAlias,
-                        Type = propertyTypeByAlias[f.PropertyAlias]
+                        Type = PropertyModelType(propertyTypeByAlias[f.PropertyAlias])
                     },
                     ConstraintValue = f.ConstraintValue,
                     Term = new OperatorTerm { Operator = f.Operator }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/SettingsTemplateQueryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/SettingsTemplateQueryController.cs
@@ -12,7 +12,7 @@ public class SettingsTemplateQueryController : TemplateQueryControllerBase
     public SettingsTemplateQueryController(IContentTypeService contentTypeService)
         => _contentTypeService = contentTypeService;
 
-    [HttpGet]
+    [HttpGet("settings")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(TemplateQuerySettingsViewModel), StatusCodes.Status200OK)]
     public async Task<ActionResult<TemplateQuerySettingsViewModel>> Settings()

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/SettingsTemplateQueryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/SettingsTemplateQueryController.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Template.Query;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Template.Query;
+
+public class SettingsTemplateQueryController : TemplateQueryControllerBase
+{
+    private readonly IContentTypeService _contentTypeService;
+
+    public SettingsTemplateQueryController(IContentTypeService contentTypeService)
+        => _contentTypeService = contentTypeService;
+
+    [HttpGet]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(TemplateQuerySettingsViewModel), StatusCodes.Status200OK)]
+    public async Task<ActionResult<TemplateQuerySettingsViewModel>> Settings()
+    {
+        var contentTypeAliases = _contentTypeService
+            .GetAll()
+            .Where(contentType => contentType.IsElement == false)
+            .Select(contentType => contentType.Alias)
+            .ToArray();
+
+        IEnumerable<TemplateQueryPropertyViewModel> properties = GetProperties();
+
+        IEnumerable<TemplateQueryOperatorViewModel> operators = GetOperators();
+
+        return await Task.FromResult(Ok(new TemplateQuerySettingsViewModel
+        {
+            ContentTypeAliases = contentTypeAliases,
+            Properties = properties,
+            Operators = operators
+        }));
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/TemplateQueryControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/TemplateQueryControllerBase.cs
@@ -1,16 +1,12 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Management.Routing;
+﻿using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Api.Management.ViewModels.Template.Query;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.TemplateQuery;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Template.Query;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.Template}/query")]
-[ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Template))]
-[ApiVersion("1.0")]
-public abstract class TemplateQueryControllerBase : ManagementApiControllerBase
+public abstract class TemplateQueryControllerBase : TemplateControllerBase
 {
     protected IEnumerable<TemplateQueryOperatorViewModel> GetOperators() => new TemplateQueryOperatorViewModel[]
     {

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/TemplateQueryControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/TemplateQueryControllerBase.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Api.Management.ViewModels.Template.Query;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models.TemplateQuery;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Template.Query;
+
+[ApiController]
+[VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.Template}/query")]
+[ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Template))]
+[ApiVersion("1.0")]
+public abstract class TemplateQueryControllerBase : ManagementApiControllerBase
+{
+    protected IEnumerable<TemplateQueryOperatorViewModel> GetOperators() => new TemplateQueryOperatorViewModel[]
+    {
+        new() { Operator = Operator.Equals, AppliesTo = new[] { PropertyTypes.String } },
+        new() { Operator = Operator.NotEquals, AppliesTo = new[] { PropertyTypes.String } },
+        new() { Operator = Operator.LessThan, AppliesTo = new[] { PropertyTypes.DateTime } },
+        new() { Operator = Operator.LessThanEqualTo, AppliesTo = new[] { PropertyTypes.DateTime } },
+        new() { Operator = Operator.GreaterThan, AppliesTo = new[] { PropertyTypes.DateTime } },
+        new() { Operator = Operator.GreaterThanEqualTo, AppliesTo = new[] { PropertyTypes.DateTime } },
+        new() { Operator = Operator.Equals, AppliesTo = new[] { PropertyTypes.Integer } },
+        new() { Operator = Operator.NotEquals, AppliesTo = new[] { PropertyTypes.Integer } },
+        new() { Operator = Operator.Contains, AppliesTo = new[] { PropertyTypes.String } },
+        new() { Operator = Operator.NotContains, AppliesTo = new[] { PropertyTypes.String } },
+        new() { Operator = Operator.GreaterThan, AppliesTo = new[] { PropertyTypes.Integer } },
+        new() { Operator = Operator.GreaterThanEqualTo, AppliesTo = new[] { PropertyTypes.Integer } },
+        new() { Operator = Operator.LessThan, AppliesTo = new[] { PropertyTypes.Integer } },
+        new() { Operator = Operator.LessThanEqualTo, AppliesTo = new[] { PropertyTypes.Integer } }
+    };
+
+    protected IEnumerable<TemplateQueryPropertyViewModel> GetProperties() => new TemplateQueryPropertyViewModel[]
+    {
+        new() { Alias = "Id", Type = PropertyTypes.Integer },
+        new() { Alias = "Name", Type = PropertyTypes.String },
+        new() { Alias = "CreateDate", Type = PropertyTypes.DateTime },
+        new() { Alias = "UpdateDate", Type = PropertyTypes.DateTime }
+    };
+
+    protected static class PropertyTypes
+    {
+        public const string String = "string";
+
+        public const string DateTime = "datetime";
+
+        public const string Integer = "int";
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/TemplateQueryControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/TemplateQueryControllerBase.cs
@@ -10,36 +10,21 @@ public abstract class TemplateQueryControllerBase : TemplateControllerBase
 {
     protected IEnumerable<TemplateQueryOperatorViewModel> GetOperators() => new TemplateQueryOperatorViewModel[]
     {
-        new() { Operator = Operator.Equals, AppliesTo = new[] { PropertyTypes.String } },
-        new() { Operator = Operator.NotEquals, AppliesTo = new[] { PropertyTypes.String } },
-        new() { Operator = Operator.LessThan, AppliesTo = new[] { PropertyTypes.DateTime } },
-        new() { Operator = Operator.LessThanEqualTo, AppliesTo = new[] { PropertyTypes.DateTime } },
-        new() { Operator = Operator.GreaterThan, AppliesTo = new[] { PropertyTypes.DateTime } },
-        new() { Operator = Operator.GreaterThanEqualTo, AppliesTo = new[] { PropertyTypes.DateTime } },
-        new() { Operator = Operator.Equals, AppliesTo = new[] { PropertyTypes.Integer } },
-        new() { Operator = Operator.NotEquals, AppliesTo = new[] { PropertyTypes.Integer } },
-        new() { Operator = Operator.Contains, AppliesTo = new[] { PropertyTypes.String } },
-        new() { Operator = Operator.NotContains, AppliesTo = new[] { PropertyTypes.String } },
-        new() { Operator = Operator.GreaterThan, AppliesTo = new[] { PropertyTypes.Integer } },
-        new() { Operator = Operator.GreaterThanEqualTo, AppliesTo = new[] { PropertyTypes.Integer } },
-        new() { Operator = Operator.LessThan, AppliesTo = new[] { PropertyTypes.Integer } },
-        new() { Operator = Operator.LessThanEqualTo, AppliesTo = new[] { PropertyTypes.Integer } }
+        new() { Operator = Operator.Equals, ApplicableTypes = new[] { TemplateQueryPropertyType.Integer, TemplateQueryPropertyType.String } },
+        new() { Operator = Operator.NotEquals, ApplicableTypes = new[] { TemplateQueryPropertyType.Integer, TemplateQueryPropertyType.String } },
+        new() { Operator = Operator.LessThan, ApplicableTypes = new[] { TemplateQueryPropertyType.Integer, TemplateQueryPropertyType.DateTime } },
+        new() { Operator = Operator.LessThanEqualTo, ApplicableTypes = new[] { TemplateQueryPropertyType.Integer, TemplateQueryPropertyType.DateTime } },
+        new() { Operator = Operator.GreaterThan, ApplicableTypes = new[] { TemplateQueryPropertyType.Integer, TemplateQueryPropertyType.DateTime } },
+        new() { Operator = Operator.GreaterThanEqualTo, ApplicableTypes = new[] { TemplateQueryPropertyType.Integer, TemplateQueryPropertyType.DateTime } },
+        new() { Operator = Operator.Contains, ApplicableTypes = new[] { TemplateQueryPropertyType.String } },
+        new() { Operator = Operator.NotContains, ApplicableTypes = new[] { TemplateQueryPropertyType.String } },
     };
 
     protected IEnumerable<TemplateQueryPropertyViewModel> GetProperties() => new TemplateQueryPropertyViewModel[]
     {
-        new() { Alias = "Id", Type = PropertyTypes.Integer },
-        new() { Alias = "Name", Type = PropertyTypes.String },
-        new() { Alias = "CreateDate", Type = PropertyTypes.DateTime },
-        new() { Alias = "UpdateDate", Type = PropertyTypes.DateTime }
+        new() { Alias = "Id", Type = TemplateQueryPropertyType.Integer },
+        new() { Alias = "Name", Type = TemplateQueryPropertyType.String },
+        new() { Alias = "CreateDate", Type = TemplateQueryPropertyType.DateTime },
+        new() { Alias = "UpdateDate", Type = TemplateQueryPropertyType.DateTime }
     };
-
-    protected static class PropertyTypes
-    {
-        public const string String = "string";
-
-        public const string DateTime = "datetime";
-
-        public const string Integer = "int";
-    }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/ScaffoldTemplateController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/ScaffoldTemplateController.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Template;
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Template;
+
+public class ScaffoldTemplateController : TemplateControllerBase
+{
+    private readonly ITemplateService _templateService;
+    private readonly IDefaultViewContentProvider _defaultViewContentProvider;
+
+    public ScaffoldTemplateController(
+        ITemplateService templateService,
+        IDefaultViewContentProvider defaultViewContentProvider)
+    {
+        _templateService = templateService;
+        _defaultViewContentProvider = defaultViewContentProvider;
+    }
+
+    [HttpGet("scaffold")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(TemplateScaffoldViewModel), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<TemplateScaffoldViewModel>> Scaffold(string? masterTemplateAlias = null)
+    {
+        if (masterTemplateAlias.IsNullOrWhiteSpace() == false)
+        {
+            if (_templateService.GetTemplate(masterTemplateAlias) == null)
+            {
+                return NotFound($"Could not find a master template with alias {masterTemplateAlias}");
+            }
+        }
+
+        var scaffoldViewModel = new TemplateScaffoldViewModel
+        {
+            Content = _defaultViewContentProvider.GetDefaultFileContent(masterTemplateAlias)
+        };
+
+        return await Task.FromResult(Ok(scaffoldViewModel));
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/ScaffoldTemplateController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/ScaffoldTemplateController.cs
@@ -2,23 +2,15 @@
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Template;
 using Umbraco.Cms.Core.IO;
-using Umbraco.Cms.Core.Services;
-using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Template;
 
 public class ScaffoldTemplateController : TemplateControllerBase
 {
-    private readonly ITemplateService _templateService;
     private readonly IDefaultViewContentProvider _defaultViewContentProvider;
 
-    public ScaffoldTemplateController(
-        ITemplateService templateService,
-        IDefaultViewContentProvider defaultViewContentProvider)
-    {
-        _templateService = templateService;
-        _defaultViewContentProvider = defaultViewContentProvider;
-    }
+    public ScaffoldTemplateController(IDefaultViewContentProvider defaultViewContentProvider)
+        => _defaultViewContentProvider = defaultViewContentProvider;
 
     [HttpGet("scaffold")]
     [MapToApiVersion("1.0")]
@@ -26,14 +18,6 @@ public class ScaffoldTemplateController : TemplateControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<TemplateScaffoldViewModel>> Scaffold(string? masterTemplateAlias = null)
     {
-        if (masterTemplateAlias.IsNullOrWhiteSpace() == false)
-        {
-            if (_templateService.GetTemplate(masterTemplateAlias) == null)
-            {
-                return NotFound($"Could not find a master template with alias {masterTemplateAlias}");
-            }
-        }
-
         var scaffoldViewModel = new TemplateScaffoldViewModel
         {
             Content = _defaultViewContentProvider.GetDefaultFileContent(masterTemplateAlias)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/TemplateControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/TemplateControllerBase.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Core;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Template;
+
+[ApiController]
+[VersionedApiBackOfficeRoute(Constants.UdiEntityType.Template)]
+[ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Template))]
+[ApiVersion("1.0")]
+public class TemplateControllerBase : ManagementApiControllerBase
+{
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/UpdateTemplateController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/UpdateTemplateController.cs
@@ -13,18 +13,15 @@ public class UpdateTemplateController : TemplateControllerBase
     private readonly ITemplateService _templateService;
     private readonly IUmbracoMapper _umbracoMapper;
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
-    private readonly ITemplateContentParserService _templateContentParserService;
 
     public UpdateTemplateController(
         ITemplateService templateService,
         IUmbracoMapper umbracoMapper,
-        IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
-        ITemplateContentParserService templateContentParserService)
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
     {
         _templateService = templateService;
         _umbracoMapper = umbracoMapper;
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
-        _templateContentParserService = templateContentParserService;
     }
 
     [HttpPut("{key:guid}")]
@@ -33,18 +30,15 @@ public class UpdateTemplateController : TemplateControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> Update(Guid key, TemplateUpdateModel updateModel)
     {
-        ITemplate? template = _templateService.GetTemplate(key);
+        ITemplate? template = await _templateService.GetTemplateAsync(key);
         if (template == null)
         {
             return NotFound();
         }
 
         template = _umbracoMapper.Map(updateModel, template);
+        await _templateService.SaveTemplateAsync(template, CurrentUserId(_backOfficeSecurityAccessor));
 
-        var masterTemplateAlias = _templateContentParserService.MasterTemplateAlias(updateModel.Content);
-        _templateService.SetMasterTemplate(template, masterTemplateAlias);
-        _templateService.SaveTemplate(template, CurrentUserId(_backOfficeSecurityAccessor));
-
-        return await Task.FromResult(Ok());
+        return Ok();
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/UpdateTemplateController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/UpdateTemplateController.cs
@@ -13,12 +13,18 @@ public class UpdateTemplateController : TemplateControllerBase
     private readonly ITemplateService _templateService;
     private readonly IUmbracoMapper _umbracoMapper;
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+    private readonly ITemplateContentParserService _templateContentParserService;
 
-    public UpdateTemplateController(ITemplateService templateService, IUmbracoMapper umbracoMapper, IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+    public UpdateTemplateController(
+        ITemplateService templateService,
+        IUmbracoMapper umbracoMapper,
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
+        ITemplateContentParserService templateContentParserService)
     {
         _templateService = templateService;
         _umbracoMapper = umbracoMapper;
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+        _templateContentParserService = templateContentParserService;
     }
 
     [HttpPut("{key:guid}")]
@@ -35,7 +41,8 @@ public class UpdateTemplateController : TemplateControllerBase
 
         template = _umbracoMapper.Map(updateModel, template);
 
-        _templateService.SetMasterTemplate(template, updateModel.MasterTemplateAlias);
+        var masterTemplateAlias = _templateContentParserService.MasterTemplateAlias(updateModel.Content);
+        _templateService.SetMasterTemplate(template, masterTemplateAlias);
         _templateService.SaveTemplate(template, CurrentUserId(_backOfficeSecurityAccessor));
 
         return await Task.FromResult(Ok());

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/UpdateTemplateController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/UpdateTemplateController.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Template;
+using Umbraco.Cms.Core.Mapping;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Template;
+
+public class UpdateTemplateController : TemplateControllerBase
+{
+    private readonly ITemplateService _templateService;
+    private readonly IUmbracoMapper _umbracoMapper;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+
+    public UpdateTemplateController(ITemplateService templateService, IUmbracoMapper umbracoMapper, IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+    {
+        _templateService = templateService;
+        _umbracoMapper = umbracoMapper;
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+    }
+
+    [HttpPut("{key:guid}")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> Update(Guid key, TemplateUpdateModel updateModel)
+    {
+        ITemplate? template = _templateService.GetTemplate(key);
+        if (template == null)
+        {
+            return NotFound();
+        }
+
+        template = _umbracoMapper.Map(updateModel, template);
+
+        _templateService.SetMasterTemplate(template, updateModel.MasterTemplateAlias);
+        _templateService.SaveTemplate(template, CurrentUserId(_backOfficeSecurityAccessor));
+
+        return await Task.FromResult(Ok());
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/MappingBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/MappingBuilderExtensions.cs
@@ -7,6 +7,7 @@ using Umbraco.Cms.Api.Management.Mapping.HealthCheck;
 using Umbraco.Cms.Api.Management.Mapping.Installer;
 using Umbraco.Cms.Api.Management.Mapping.Languages;
 using Umbraco.Cms.Api.Management.Mapping.Relation;
+using Umbraco.Cms.Api.Management.Mapping.Template;
 using Umbraco.Cms.Api.Management.Mapping.TrackedReferences;
 using Umbraco.New.Cms.Infrastructure.Persistence.Mappers;
 
@@ -26,7 +27,8 @@ public static class MappingBuilderExtensions
             .Add<CultureViewModelMapDefinition>()
             .Add<HealthCheckViewModelsMapDefinition>()
             .Add<CultureViewModelMapDefinition>()
-            .Add<DataTypeViewModelMapDefinition>();
+            .Add<DataTypeViewModelMapDefinition>()
+            .Add<TemplateViewModelMapDefinition>();
 
         return builder;
     }

--- a/src/Umbraco.Cms.Api.Management/Mapping/Template/TemplateViewModelMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Template/TemplateViewModelMapDefinition.cs
@@ -25,9 +25,6 @@ public class TemplateViewModelMapDefinition : IMapDefinition
         target.Name = source.Name ?? string.Empty;
         target.Alias = source.Alias;
         target.Content = source.Content;
-        target.VirtualPath = source.VirtualPath;
-        target.IsMasterTemplate = source.IsMasterTemplate;
-        target.MasterTemplateAlias = source.MasterTemplateAlias;
     }
 
     // Umbraco.Code.MapAll -Id -Key -CreateDate -UpdateDate -DeleteDate

--- a/src/Umbraco.Cms.Api.Management/Mapping/Template/TemplateViewModelMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Template/TemplateViewModelMapDefinition.cs
@@ -1,0 +1,41 @@
+﻿using Umbraco.Cms.Api.Management.ViewModels.Template;
+using Umbraco.Cms.Core.Mapping;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Strings;
+
+namespace Umbraco.Cms.Api.Management.Mapping.Template;
+
+public class TemplateViewModelMapDefinition : IMapDefinition
+{
+    private readonly IShortStringHelper _shortStringHelper;
+
+    public TemplateViewModelMapDefinition(IShortStringHelper shortStringHelper)
+        => _shortStringHelper = shortStringHelper;
+
+    public void DefineMaps(IUmbracoMapper mapper)
+    {
+        mapper.Define<ITemplate, TemplateViewModel>((_, _) => new TemplateViewModel(), Map);
+        mapper.Define<TemplateUpdateModel, ITemplate>((source, _) => new Core.Models.Template(_shortStringHelper, source.Name, source.Alias), Map);
+    }
+
+    // Umbraco.Code.MapAll
+    private void Map(ITemplate source, TemplateViewModel target, MapperContext context)
+    {
+        target.Key = source.Key;
+        target.Name = source.Name ?? string.Empty;
+        target.Alias = source.Alias;
+        target.Content = source.Content;
+        target.VirtualPath = source.VirtualPath;
+        target.IsMasterTemplate = source.IsMasterTemplate;
+        target.MasterTemplateAlias = source.MasterTemplateAlias;
+    }
+
+    // Umbraco.Code.MapAll -Id -Key -CreateDate -UpdateDate -DeleteDate
+    // Umbraco.Code.MapAll -Path -VirtualPath -MasterTemplateId -IsMasterTemplate
+    private void Map(TemplateUpdateModel source, ITemplate target, MapperContext context)
+    {
+        target.Name = source.Name;
+        target.Alias = source.Alias;
+        target.Content = source.Content;
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -3875,6 +3875,240 @@
         }
       }
     },
+    "/umbraco/management/api/v1/template": {
+      "post": {
+        "tags": [
+          "Template"
+        ],
+        "operationId": "PostTemplate",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TemplateCreateModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/umbraco/management/api/v1/template/{key}": {
+      "get": {
+        "tags": [
+          "Template"
+        ],
+        "operationId": "GetTemplateByKey",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Template"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Template"
+        ],
+        "operationId": "DeleteTemplateByKey",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Template"
+        ],
+        "operationId": "PutTemplateByKey",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TemplateUpdateModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/umbraco/management/api/v1/template/query/execute": {
+      "post": {
+        "tags": [
+          "Template"
+        ],
+        "operationId": "PostTemplateQueryExecute",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TemplateQueryExecuteModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemplateQueryResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/umbraco/management/api/v1/template/query/settings": {
+      "get": {
+        "tags": [
+          "Template"
+        ],
+        "operationId": "GetTemplateQuerySettings",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemplateQuerySettings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/umbraco/management/api/v1/template/scaffold": {
+      "get": {
+        "tags": [
+          "Template"
+        ],
+        "operationId": "GetTemplateScaffold",
+        "parameters": [
+          {
+            "name": "masterTemplateAlias",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemplateScaffold"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/umbraco/management/api/v1/tree/template/children": {
       "get": {
         "tags": [
@@ -6441,6 +6675,20 @@
         },
         "additionalProperties": false
       },
+      "Operator": {
+        "enum": [
+          "Equals",
+          "NotEquals",
+          "Contains",
+          "NotContains",
+          "LessThan",
+          "LessThanEqualTo",
+          "GreaterThan",
+          "GreaterThanEqualTo"
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
       "OutOfDateStatus": {
         "type": "object",
         "properties": {
@@ -7346,6 +7594,257 @@
         ],
         "type": "integer",
         "format": "int32"
+      },
+      "Template": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "alias": {
+            "type": "string",
+            "nullable": true
+          },
+          "content": {
+            "type": "string",
+            "nullable": true
+          },
+          "masterTemplateAlias": {
+            "type": "string",
+            "nullable": true
+          },
+          "key": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "isMasterTemplate": {
+            "type": "boolean"
+          },
+          "virtualPath": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TemplateCreateModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "alias": {
+            "type": "string",
+            "nullable": true
+          },
+          "content": {
+            "type": "string",
+            "nullable": true
+          },
+          "masterTemplateAlias": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TemplateQueryExecuteFilterModel": {
+        "type": "object",
+        "properties": {
+          "propertyAlias": {
+            "type": "string",
+            "nullable": true
+          },
+          "constraintValue": {
+            "type": "string",
+            "nullable": true
+          },
+          "operator": {
+            "$ref": "#/components/schemas/Operator"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TemplateQueryExecuteModel": {
+        "type": "object",
+        "properties": {
+          "rootContentKey": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "contentTypeAlias": {
+            "type": "string",
+            "nullable": true
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TemplateQueryExecuteFilterModel"
+            },
+            "nullable": true
+          },
+          "sort": {
+            "$ref": "#/components/schemas/TemplateQueryExecuteSortModel"
+          },
+          "take": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TemplateQueryExecuteSortModel": {
+        "type": "object",
+        "properties": {
+          "propertyAlias": {
+            "type": "string",
+            "nullable": true
+          },
+          "direction": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TemplateQueryOperator": {
+        "type": "object",
+        "properties": {
+          "operator": {
+            "$ref": "#/components/schemas/Operator"
+          },
+          "applicableTypes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TemplateQueryPropertyType"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TemplateQueryProperty": {
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "$ref": "#/components/schemas/TemplateQueryPropertyType"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TemplateQueryPropertyType": {
+        "enum": [
+          "String",
+          "DateTime",
+          "Integer"
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "TemplateQueryResult": {
+        "type": "object",
+        "properties": {
+          "queryExpression": {
+            "type": "string",
+            "nullable": true
+          },
+          "sampleResults": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TemplateQueryResultItem"
+            },
+            "nullable": true
+          },
+          "resultCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "executionTime": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TemplateQueryResultItem": {
+        "type": "object",
+        "properties": {
+          "icon": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TemplateQuerySettings": {
+        "type": "object",
+        "properties": {
+          "contentTypeAliases": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "properties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TemplateQueryProperty"
+            },
+            "nullable": true
+          },
+          "operators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TemplateQueryOperator"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TemplateScaffold": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TemplateUpdateModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "alias": {
+            "type": "string",
+            "nullable": true
+          },
+          "content": {
+            "type": "string",
+            "nullable": true
+          },
+          "masterTemplateAlias": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
       },
       "Type": {
         "type": "object",

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -7610,20 +7610,9 @@
             "type": "string",
             "nullable": true
           },
-          "masterTemplateAlias": {
-            "type": "string",
-            "nullable": true
-          },
           "key": {
             "type": "string",
             "format": "uuid"
-          },
-          "isMasterTemplate": {
-            "type": "boolean"
-          },
-          "virtualPath": {
-            "type": "string",
-            "nullable": true
           }
         },
         "additionalProperties": false
@@ -7640,10 +7629,6 @@
             "nullable": true
           },
           "content": {
-            "type": "string",
-            "nullable": true
-          },
-          "masterTemplateAlias": {
             "type": "string",
             "nullable": true
           }
@@ -7836,10 +7821,6 @@
             "nullable": true
           },
           "content": {
-            "type": "string",
-            "nullable": true
-          },
-          "masterTemplateAlias": {
             "type": "string",
             "nullable": true
           }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Template/Query/TemplatePropertyViewModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Template/Query/TemplatePropertyViewModel.cs
@@ -1,0 +1,8 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Template.Query;
+
+public class TemplateQueryPropertyViewModel
+{
+    public required string Alias { get; init; }
+
+    public required string? Type { get; init; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Template/Query/TemplatePropertyViewModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Template/Query/TemplatePropertyViewModel.cs
@@ -4,5 +4,5 @@ public class TemplateQueryPropertyViewModel
 {
     public required string Alias { get; init; }
 
-    public required string? Type { get; init; }
+    public required TemplateQueryPropertyType Type { get; init; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Template/Query/TemplateQueryExecuteFilterModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Template/Query/TemplateQueryExecuteFilterModel.cs
@@ -1,0 +1,12 @@
+﻿using Umbraco.Cms.Core.Models.TemplateQuery;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.Template.Query;
+
+public class TemplateQueryExecuteFilterModel
+{
+    public string PropertyAlias { get; set; } = string.Empty;
+
+    public string ConstraintValue { get; set; } = string.Empty;
+
+    public Operator Operator { get; set; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Template/Query/TemplateQueryExecuteModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Template/Query/TemplateQueryExecuteModel.cs
@@ -1,0 +1,15 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Template.Query;
+
+public class TemplateQueryExecuteModel
+{
+    public Guid? RootContentKey { get; set; }
+
+    public string? ContentTypeAlias { get; set; }
+
+    public IEnumerable<TemplateQueryExecuteFilterModel>? Filters { get; set; }
+
+    public TemplateQueryExecuteSortModel? Sort { get; set; }
+
+    public int Take { get; set; }
+
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Template/Query/TemplateQueryExecuteSortModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Template/Query/TemplateQueryExecuteSortModel.cs
@@ -1,0 +1,8 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Template.Query;
+
+public class TemplateQueryExecuteSortModel
+{
+    public string PropertyAlias { get; set; } = string.Empty;
+
+    public string? Direction { get; set; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Template/Query/TemplateQueryOperatorViewModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Template/Query/TemplateQueryOperatorViewModel.cs
@@ -1,0 +1,10 @@
+﻿using Umbraco.Cms.Core.Models.TemplateQuery;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.Template.Query;
+
+public class TemplateQueryOperatorViewModel
+{
+    public required Operator Operator { get; init; }
+
+    public required IEnumerable<string> AppliesTo { get; init; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Template/Query/TemplateQueryOperatorViewModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Template/Query/TemplateQueryOperatorViewModel.cs
@@ -6,5 +6,5 @@ public class TemplateQueryOperatorViewModel
 {
     public required Operator Operator { get; init; }
 
-    public required IEnumerable<string> AppliesTo { get; init; }
+    public required IEnumerable<TemplateQueryPropertyType> ApplicableTypes { get; init; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Template/Query/TemplateQueryPropertyType.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Template/Query/TemplateQueryPropertyType.cs
@@ -1,0 +1,8 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Template.Query;
+
+public enum TemplateQueryPropertyType
+{
+    String,
+    DateTime,
+    Integer
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Template/Query/TemplateQueryResultItemViewModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Template/Query/TemplateQueryResultItemViewModel.cs
@@ -1,0 +1,8 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Template.Query;
+
+public class TemplateQueryResultItemViewModel
+{
+    public required string Icon { get; init; }
+
+    public required string Name { get; init; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Template/Query/TemplateQueryResultViewModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Template/Query/TemplateQueryResultViewModel.cs
@@ -1,0 +1,12 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Template.Query;
+
+public class TemplateQueryResultViewModel
+{
+    public required string QueryExpression { get; init; }
+
+    public required IEnumerable<TemplateQueryResultItemViewModel> SampleResults { get; init; }
+
+    public required int ResultCount { get; init; }
+
+    public required long ExecutionTime { get; init; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Template/Query/TemplateQuerySettingsViewModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Template/Query/TemplateQuerySettingsViewModel.cs
@@ -1,0 +1,10 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Template.Query;
+
+public class TemplateQuerySettingsViewModel
+{
+    public required IEnumerable<string> ContentTypeAliases { get; init; }
+
+    public required IEnumerable<TemplateQueryPropertyViewModel> Properties { get; init; }
+
+    public required IEnumerable<TemplateQueryOperatorViewModel> Operators { get; init; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Template/TemplateCreateModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Template/TemplateCreateModel.cs
@@ -1,0 +1,5 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Template;
+
+public class TemplateCreateModel : TemplateModelBase
+{
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Template/TemplateModelBase.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Template/TemplateModelBase.cs
@@ -7,6 +7,4 @@ public class TemplateModelBase
     public string Alias { get; set; } = string.Empty;
 
     public string? Content { get; set; }
-
-    public string? MasterTemplateAlias { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Template/TemplateModelBase.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Template/TemplateModelBase.cs
@@ -1,0 +1,12 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Template;
+
+public class TemplateModelBase
+{
+    public string Name { get; set; } = string.Empty;
+
+    public string Alias { get; set; } = string.Empty;
+
+    public string? Content { get; set; }
+
+    public string? MasterTemplateAlias { get; set; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Template/TemplateScaffoldViewModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Template/TemplateScaffoldViewModel.cs
@@ -1,0 +1,6 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Template;
+
+public class TemplateScaffoldViewModel
+{
+    public string Content { get; set; } = string.Empty;
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Template/TemplateUpdateModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Template/TemplateUpdateModel.cs
@@ -1,0 +1,5 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Template;
+
+public class TemplateUpdateModel : TemplateModelBase
+{
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Template/TemplateViewModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Template/TemplateViewModel.cs
@@ -1,0 +1,10 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Template;
+
+public class TemplateViewModel : TemplateModelBase
+{
+    public Guid Key { get; set; }
+
+    public bool IsMasterTemplate { get; set; }
+
+    public string? VirtualPath { get; set; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Template/TemplateViewModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Template/TemplateViewModel.cs
@@ -3,8 +3,4 @@
 public class TemplateViewModel : TemplateModelBase
 {
     public Guid Key { get; set; }
-
-    public bool IsMasterTemplate { get; set; }
-
-    public string? VirtualPath { get; set; }
 }

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -296,6 +296,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
             Services.AddUnique<IContentTypeBaseServiceProvider, ContentTypeBaseServiceProvider>();
             Services.AddUnique<IMediaTypeService, MediaTypeService>();
             Services.AddUnique<IFileService, FileService>();
+            Services.AddUnique<ITemplateService, TemplateService>();
             Services.AddUnique<IEntityService, EntityService>();
             Services.AddUnique<IRelationService, RelationService>();
             Services.AddUnique<IMemberTypeService, MemberTypeService>();

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -297,6 +297,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
             Services.AddUnique<IMediaTypeService, MediaTypeService>();
             Services.AddUnique<IFileService, FileService>();
             Services.AddUnique<ITemplateService, TemplateService>();
+            Services.AddUnique<ITemplateContentParserService, TemplateContentParserService>();
             Services.AddUnique<IEntityService, EntityService>();
             Services.AddUnique<IRelationService, RelationService>();
             Services.AddUnique<IMemberTypeService, MemberTypeService>();

--- a/src/Umbraco.Core/Models/ITemplate.cs
+++ b/src/Umbraco.Core/Models/ITemplate.cs
@@ -29,5 +29,6 @@ public interface ITemplate : IFile
     ///     Set the mastertemplate
     /// </summary>
     /// <param name="masterTemplate"></param>
+    [Obsolete("MasterTemplate is now calculated from the content. This will be removed in Umbraco 15.")]
     void SetMasterTemplate(ITemplate? masterTemplate);
 }

--- a/src/Umbraco.Core/Models/Template.cs
+++ b/src/Umbraco.Core/Models/Template.cs
@@ -64,6 +64,7 @@ public class Template : File, ITemplate
     /// </summary>
     public bool IsMasterTemplate { get; set; }
 
+    // FIXME: moving forward the master template is calculated from the actual template content; figure out how to get rid of this method, or at least *only* use it from TemplateService
     public void SetMasterTemplate(ITemplate? masterTemplate)
     {
         if (masterTemplate == null)

--- a/src/Umbraco.Core/Models/Template.cs
+++ b/src/Umbraco.Core/Models/Template.cs
@@ -65,6 +65,7 @@ public class Template : File, ITemplate
     public bool IsMasterTemplate { get; set; }
 
     // FIXME: moving forward the master template is calculated from the actual template content; figure out how to get rid of this method, or at least *only* use it from TemplateService
+    [Obsolete("MasterTemplate is now calculated from the content. This will be removed in Umbraco 15.")]
     public void SetMasterTemplate(ITemplate? masterTemplate)
     {
         if (masterTemplate == null)

--- a/src/Umbraco.Core/Services/FileService.cs
+++ b/src/Umbraco.Core/Services/FileService.cs
@@ -32,6 +32,7 @@ public class FileService : RepositoryService, IFileService
     private readonly IScriptRepository _scriptRepository;
     private readonly IStylesheetRepository _stylesheetRepository;
     private readonly ITemplateService _templateService;
+    private readonly IShortStringHelper _shortStringHelper;
 
     [Obsolete("Use other ctor - will be removed in Umbraco 15")]
     public FileService(
@@ -90,6 +91,7 @@ public class FileService : RepositoryService, IFileService
         _auditRepository = auditRepository;
         _hostingEnvironment = hostingEnvironment;
         _templateService = templateService;
+        _shortStringHelper = shortStringHelper;
     }
 
     #region Stylesheets
@@ -370,7 +372,7 @@ public class FileService : RepositoryService, IFileService
     [Obsolete("Please use ITemplateService for template operations - will be removed in Umbraco 15")]
     public Attempt<OperationResult<OperationResultType, ITemplate>?> CreateTemplateForContentType(
         string contentTypeAlias, string? contentTypeName, int userId = Constants.Security.SuperUserId)
-        => _templateService.CreateTemplateForContentType(contentTypeAlias, contentTypeName, userId);
+        => _templateService.CreateTemplateForContentTypeAsync(contentTypeAlias, contentTypeName, userId).GetAwaiter().GetResult();
 
     /// <summary>
     ///     Create a new template, setting the content if a view exists in the filesystem
@@ -388,7 +390,8 @@ public class FileService : RepositoryService, IFileService
         string? content,
         ITemplate? masterTemplate = null,
         int userId = Constants.Security.SuperUserId)
-        => _templateService.CreateTemplateWithIdentity(name, alias, content, masterTemplate, userId);
+        => _templateService.CreateTemplateWithIdentityAsync(name, alias, content, userId).GetAwaiter().GetResult()
+           ?? new Template(_shortStringHelper, name, alias);
 
     /// <summary>
     ///     Gets a list of all <see cref="ITemplate" /> objects
@@ -396,7 +399,7 @@ public class FileService : RepositoryService, IFileService
     /// <returns>An enumerable list of <see cref="ITemplate" /> objects</returns>
     [Obsolete("Please use ITemplateService for template operations - will be removed in Umbraco 15")]
     public IEnumerable<ITemplate> GetTemplates(params string[] aliases)
-        => _templateService.GetTemplates(aliases);
+        => _templateService.GetTemplatesAsync(aliases).GetAwaiter().GetResult();
 
     /// <summary>
     ///     Gets a list of all <see cref="ITemplate" /> objects
@@ -404,7 +407,7 @@ public class FileService : RepositoryService, IFileService
     /// <returns>An enumerable list of <see cref="ITemplate" /> objects</returns>
     [Obsolete("Please use ITemplateService for template operations - will be removed in Umbraco 15")]
     public IEnumerable<ITemplate> GetTemplates(int masterTemplateId)
-        => _templateService.GetTemplates(masterTemplateId);
+        => _templateService.GetTemplatesAsync(masterTemplateId).GetAwaiter().GetResult();
 
     /// <summary>
     ///     Gets a <see cref="ITemplate" /> object by its alias.
@@ -413,7 +416,7 @@ public class FileService : RepositoryService, IFileService
     /// <returns>The <see cref="ITemplate" /> object matching the alias, or null.</returns>
     [Obsolete("Please use ITemplateService for template operations - will be removed in Umbraco 15")]
     public ITemplate? GetTemplate(string? alias)
-        => _templateService.GetTemplate(alias);
+        => _templateService.GetTemplateAsync(alias).GetAwaiter().GetResult();
 
     /// <summary>
     ///     Gets a <see cref="ITemplate" /> object by its identifier.
@@ -422,7 +425,7 @@ public class FileService : RepositoryService, IFileService
     /// <returns>The <see cref="ITemplate" /> object matching the identifier, or null.</returns>
     [Obsolete("Please use ITemplateService for template operations - will be removed in Umbraco 15")]
     public ITemplate? GetTemplate(int id)
-        => _templateService.GetTemplate(id);
+        => _templateService.GetTemplateAsync(id).GetAwaiter().GetResult();
 
     /// <summary>
     ///     Gets a <see cref="ITemplate" /> object by its guid identifier.
@@ -431,7 +434,7 @@ public class FileService : RepositoryService, IFileService
     /// <returns>The <see cref="ITemplate" /> object matching the identifier, or null.</returns>
     [Obsolete("Please use ITemplateService for template operations - will be removed in Umbraco 15")]
     public ITemplate? GetTemplate(Guid id)
-        => _templateService.GetTemplate(id);
+        => _templateService.GetTemplateAsync(id).GetAwaiter().GetResult();
 
     /// <summary>
     ///     Gets the template descendants
@@ -440,7 +443,7 @@ public class FileService : RepositoryService, IFileService
     /// <returns></returns>
     [Obsolete("Please use ITemplateService for template operations - will be removed in Umbraco 15")]
     public IEnumerable<ITemplate> GetTemplateDescendants(int masterTemplateId)
-        => _templateService.GetTemplateDescendants(masterTemplateId);
+        => _templateService.GetTemplateDescendantsAsync(masterTemplateId).GetAwaiter().GetResult();
 
     /// <summary>
     ///     Saves a <see cref="Template" />
@@ -449,7 +452,7 @@ public class FileService : RepositoryService, IFileService
     /// <param name="userId"></param>
     [Obsolete("Please use ITemplateService for template operations - will be removed in Umbraco 15")]
     public void SaveTemplate(ITemplate template, int userId = Constants.Security.SuperUserId)
-        => _templateService.SaveTemplate(template, userId);
+        => _templateService.SaveTemplateAsync(template, userId).GetAwaiter().GetResult();
 
     /// <summary>
     ///     Saves a collection of <see cref="Template" /> objects
@@ -458,7 +461,7 @@ public class FileService : RepositoryService, IFileService
     /// <param name="userId">Optional id of the user</param>
     [Obsolete("Please use ITemplateService for template operations - will be removed in Umbraco 15")]
     public void SaveTemplate(IEnumerable<ITemplate> templates, int userId = Constants.Security.SuperUserId)
-        => _templateService.SaveTemplate(templates, userId);
+        => _templateService.SaveTemplateAsync(templates, userId).GetAwaiter().GetResult();
 
     /// <summary>
     ///     Deletes a template by its alias
@@ -467,22 +470,22 @@ public class FileService : RepositoryService, IFileService
     /// <param name="userId"></param>
     [Obsolete("Please use ITemplateService for template operations - will be removed in Umbraco 15")]
     public void DeleteTemplate(string alias, int userId = Constants.Security.SuperUserId)
-        => _templateService.DeleteTemplate(alias, userId);
+        => _templateService.DeleteTemplateAsync(alias, userId).GetAwaiter().GetResult();
 
     /// <inheritdoc />
     [Obsolete("Please use ITemplateService for template operations - will be removed in Umbraco 15")]
     public Stream GetTemplateFileContentStream(string filepath)
-        => _templateService.GetTemplateFileContentStream(filepath);
+        => _templateService.GetTemplateFileContentStreamAsync(filepath).GetAwaiter().GetResult();
 
     /// <inheritdoc />
     [Obsolete("Please use ITemplateService for template operations - will be removed in Umbraco 15")]
     public void SetTemplateFileContent(string filepath, Stream content)
-        => _templateService.SetTemplateFileContent(filepath, content);
+        => _templateService.SetTemplateFileContentAsync(filepath, content).GetAwaiter().GetResult();
 
     /// <inheritdoc />
     [Obsolete("Please use ITemplateService for template operations - will be removed in Umbraco 15")]
     public long GetTemplateFileSize(string filepath)
-        => _templateService.GetTemplateFileSize(filepath);
+        => _templateService.GetTemplateFileSizeAsync(filepath).GetAwaiter().GetResult();
 
     #endregion
 

--- a/src/Umbraco.Core/Services/ITemplateContentParserService.cs
+++ b/src/Umbraco.Core/Services/ITemplateContentParserService.cs
@@ -1,0 +1,6 @@
+﻿namespace Umbraco.Cms.Core.Services;
+
+public interface ITemplateContentParserService
+{
+    string? MasterTemplateAlias(string? viewContent);
+}

--- a/src/Umbraco.Core/Services/ITemplateService.cs
+++ b/src/Umbraco.Core/Services/ITemplateService.cs
@@ -1,0 +1,111 @@
+﻿using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Core.Services;
+
+public interface ITemplateService : IService
+{
+    /// <summary>
+    ///     Gets a list of all <see cref="ITemplate" /> objects
+    /// </summary>
+    /// <returns>An enumerable list of <see cref="ITemplate" /> objects</returns>
+    IEnumerable<ITemplate> GetTemplates(params string[] aliases);
+
+    /// <summary>
+    ///     Gets a list of all <see cref="ITemplate" /> objects
+    /// </summary>
+    /// <returns>An enumerable list of <see cref="ITemplate" /> objects</returns>
+    IEnumerable<ITemplate> GetTemplates(int masterTemplateId);
+
+    /// <summary>
+    ///     Gets a <see cref="ITemplate" /> object by its alias.
+    /// </summary>
+    /// <param name="alias">The alias of the template.</param>
+    /// <returns>The <see cref="ITemplate" /> object matching the alias, or null.</returns>
+    ITemplate? GetTemplate(string? alias);
+
+    /// <summary>
+    ///     Gets a <see cref="ITemplate" /> object by its identifier.
+    /// </summary>
+    /// <param name="id">The identifier of the template.</param>
+    /// <returns>The <see cref="ITemplate" /> object matching the identifier, or null.</returns>
+    ITemplate? GetTemplate(int id);
+
+    /// <summary>
+    ///     Gets a <see cref="ITemplate" /> object by its guid identifier.
+    /// </summary>
+    /// <param name="id">The guid identifier of the template.</param>
+    /// <returns>The <see cref="ITemplate" /> object matching the identifier, or null.</returns>
+    ITemplate? GetTemplate(Guid id);
+
+    /// <summary>
+    ///     Gets the template descendants
+    /// </summary>
+    /// <param name="masterTemplateId"></param>
+    /// <returns></returns>
+    IEnumerable<ITemplate> GetTemplateDescendants(int masterTemplateId);
+
+    /// <summary>
+    ///     Saves a <see cref="ITemplate" />
+    /// </summary>
+    /// <param name="template"><see cref="ITemplate" /> to save</param>
+    /// <param name="userId">Optional id of the user saving the template</param>
+    void SaveTemplate(ITemplate template, int userId = Constants.Security.SuperUserId);
+
+    /// <summary>
+    ///     Sets the master template of a <see cref="ITemplate" />
+    /// </summary>
+    /// <param name="template"><see cref="ITemplate" /> to set master template for.</param>
+    /// <param name="userId">The alias of the master template, or null if the template should not have a master template.</param>
+    void SetMasterTemplate(ITemplate template, string? masterTemplateAlias);
+
+    /// <summary>
+    ///     Creates a template for a content type
+    /// </summary>
+    /// <param name="contentTypeAlias"></param>
+    /// <param name="contentTypeName"></param>
+    /// <param name="userId"></param>
+    /// <returns>
+    ///     The template created
+    /// </returns>
+    Attempt<OperationResult<OperationResultType, ITemplate>?> CreateTemplateForContentType(
+        string contentTypeAlias,
+        string? contentTypeName,
+        int userId = Constants.Security.SuperUserId);
+
+    ITemplate CreateTemplateWithIdentity(string? name, string? alias, string? content, ITemplate? masterTemplate = null, int userId = Constants.Security.SuperUserId);
+
+    /// <summary>
+    ///     Deletes a template by its alias
+    /// </summary>
+    /// <param name="alias">Alias of the <see cref="ITemplate" /> to delete</param>
+    /// <param name="userId">Optional id of the user deleting the template</param>
+    void DeleteTemplate(string alias, int userId = Constants.Security.SuperUserId);
+
+    /// <summary>
+    ///     Saves a collection of <see cref="Template" /> objects
+    /// </summary>
+    /// <param name="templates">List of <see cref="Template" /> to save</param>
+    /// <param name="userId">Optional id of the user</param>
+    void SaveTemplate(IEnumerable<ITemplate> templates, int userId = Constants.Security.SuperUserId);
+
+    /// <summary>
+    ///     Gets the content of a template as a stream.
+    /// </summary>
+    /// <param name="filepath">The filesystem path to the template.</param>
+    /// <returns>The content of the template.</returns>
+    Stream GetTemplateFileContentStream(string filepath);
+
+    /// <summary>
+    ///     Sets the content of a template.
+    /// </summary>
+    /// <param name="filepath">The filesystem path to the template.</param>
+    /// <param name="content">The content of the template.</param>
+    void SetTemplateFileContent(string filepath, Stream content);
+
+    /// <summary>
+    ///     Gets the size of a template.
+    /// </summary>
+    /// <param name="filepath">The filesystem path to the template.</param>
+    /// <returns>The size of the template.</returns>
+    long GetTemplateFileSize(string filepath);
+}

--- a/src/Umbraco.Core/Services/ITemplateService.cs
+++ b/src/Umbraco.Core/Services/ITemplateService.cs
@@ -8,55 +8,49 @@ public interface ITemplateService : IService
     ///     Gets a list of all <see cref="ITemplate" /> objects
     /// </summary>
     /// <returns>An enumerable list of <see cref="ITemplate" /> objects</returns>
-    IEnumerable<ITemplate> GetTemplates(params string[] aliases);
+    Task<IEnumerable<ITemplate>> GetTemplatesAsync(params string[] aliases);
 
     /// <summary>
     ///     Gets a list of all <see cref="ITemplate" /> objects
     /// </summary>
     /// <returns>An enumerable list of <see cref="ITemplate" /> objects</returns>
-    IEnumerable<ITemplate> GetTemplates(int masterTemplateId);
+    Task<IEnumerable<ITemplate>> GetTemplatesAsync(int masterTemplateId);
 
     /// <summary>
     ///     Gets a <see cref="ITemplate" /> object by its alias.
     /// </summary>
     /// <param name="alias">The alias of the template.</param>
     /// <returns>The <see cref="ITemplate" /> object matching the alias, or null.</returns>
-    ITemplate? GetTemplate(string? alias);
+    Task<ITemplate?> GetTemplateAsync(string? alias);
 
     /// <summary>
     ///     Gets a <see cref="ITemplate" /> object by its identifier.
     /// </summary>
     /// <param name="id">The identifier of the template.</param>
     /// <returns>The <see cref="ITemplate" /> object matching the identifier, or null.</returns>
-    ITemplate? GetTemplate(int id);
+    Task<ITemplate?> GetTemplateAsync(int id);
 
     /// <summary>
     ///     Gets a <see cref="ITemplate" /> object by its guid identifier.
     /// </summary>
     /// <param name="id">The guid identifier of the template.</param>
     /// <returns>The <see cref="ITemplate" /> object matching the identifier, or null.</returns>
-    ITemplate? GetTemplate(Guid id);
+    Task<ITemplate?> GetTemplateAsync(Guid id);
 
     /// <summary>
     ///     Gets the template descendants
     /// </summary>
     /// <param name="masterTemplateId"></param>
     /// <returns></returns>
-    IEnumerable<ITemplate> GetTemplateDescendants(int masterTemplateId);
+    Task<IEnumerable<ITemplate>> GetTemplateDescendantsAsync(int masterTemplateId);
 
     /// <summary>
     ///     Saves a <see cref="ITemplate" />
     /// </summary>
     /// <param name="template"><see cref="ITemplate" /> to save</param>
     /// <param name="userId">Optional id of the user saving the template</param>
-    void SaveTemplate(ITemplate template, int userId = Constants.Security.SuperUserId);
-
-    /// <summary>
-    ///     Sets the master template of a <see cref="ITemplate" />
-    /// </summary>
-    /// <param name="template"><see cref="ITemplate" /> to set master template for.</param>
-    /// <param name="userId">The alias of the master template, or null if the template should not have a master template.</param>
-    void SetMasterTemplate(ITemplate template, string? masterTemplateAlias);
+    /// <returns>True if the template was saved, false otherwise.</returns>
+    Task<bool> SaveTemplateAsync(ITemplate template, int userId = Constants.Security.SuperUserId);
 
     /// <summary>
     ///     Creates a template for a content type
@@ -67,45 +61,55 @@ public interface ITemplateService : IService
     /// <returns>
     ///     The template created
     /// </returns>
-    Attempt<OperationResult<OperationResultType, ITemplate>?> CreateTemplateForContentType(
+    Task<Attempt<OperationResult<OperationResultType, ITemplate>?>> CreateTemplateForContentTypeAsync(
         string contentTypeAlias,
         string? contentTypeName,
         int userId = Constants.Security.SuperUserId);
 
-    ITemplate CreateTemplateWithIdentity(string? name, string? alias, string? content, ITemplate? masterTemplate = null, int userId = Constants.Security.SuperUserId);
+    Task<ITemplate?> CreateTemplateWithIdentityAsync(string? name, string? alias, string? content, int userId = Constants.Security.SuperUserId);
 
     /// <summary>
     ///     Deletes a template by its alias
     /// </summary>
     /// <param name="alias">Alias of the <see cref="ITemplate" /> to delete</param>
     /// <param name="userId">Optional id of the user deleting the template</param>
-    void DeleteTemplate(string alias, int userId = Constants.Security.SuperUserId);
+    /// <returns>True if the template was deleted, false otherwise</returns>
+    Task<bool> DeleteTemplateAsync(string alias, int userId = Constants.Security.SuperUserId);
+
+    /// <summary>
+    ///     Deletes a template by its key
+    /// </summary>
+    /// <param name="key">Key of the <see cref="ITemplate" /> to delete</param>
+    /// <param name="userId">Optional id of the user deleting the template</param>
+    /// <returns>True if the template was deleted, false otherwise</returns>
+    Task<bool> DeleteTemplateAsync(Guid key, int userId = Constants.Security.SuperUserId);
 
     /// <summary>
     ///     Saves a collection of <see cref="Template" /> objects
     /// </summary>
     /// <param name="templates">List of <see cref="Template" /> to save</param>
     /// <param name="userId">Optional id of the user</param>
-    void SaveTemplate(IEnumerable<ITemplate> templates, int userId = Constants.Security.SuperUserId);
+    /// <returns>True if the templates were saved, false otherwise</returns>
+    Task<bool> SaveTemplateAsync(IEnumerable<ITemplate> templates, int userId = Constants.Security.SuperUserId);
 
     /// <summary>
     ///     Gets the content of a template as a stream.
     /// </summary>
     /// <param name="filepath">The filesystem path to the template.</param>
     /// <returns>The content of the template.</returns>
-    Stream GetTemplateFileContentStream(string filepath);
+    Task<Stream> GetTemplateFileContentStreamAsync(string filepath);
 
     /// <summary>
     ///     Sets the content of a template.
     /// </summary>
     /// <param name="filepath">The filesystem path to the template.</param>
     /// <param name="content">The content of the template.</param>
-    void SetTemplateFileContent(string filepath, Stream content);
+    Task SetTemplateFileContentAsync(string filepath, Stream content);
 
     /// <summary>
     ///     Gets the size of a template.
     /// </summary>
     /// <param name="filepath">The filesystem path to the template.</param>
     /// <returns>The size of the template.</returns>
-    long GetTemplateFileSize(string filepath);
+    Task<long> GetTemplateFileSizeAsync(string filepath);
 }

--- a/src/Umbraco.Core/Services/TemplateContentParserService.cs
+++ b/src/Umbraco.Core/Services/TemplateContentParserService.cs
@@ -1,0 +1,30 @@
+﻿using System.Text.RegularExpressions;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Core.Services;
+
+public partial class TemplateContentParserService : ITemplateContentParserService
+{
+    public string? MasterTemplateAlias(string? viewContent)
+    {
+        if (viewContent.IsNullOrWhiteSpace())
+        {
+            return null;
+        }
+
+        Match match = LayoutRegex().Match(viewContent);
+
+        if (match.Success == false || match.Groups.ContainsKey("layout") == false)
+        {
+            return null;
+        }
+
+        var layout = match.Groups["layout"].Value;
+        return layout != "null"
+            ? layout.Replace(".cshtml", string.Empty, StringComparison.OrdinalIgnoreCase)
+            : null;
+    }
+
+    [GeneratedRegex("\\s*Layout\\s*=\\s*\"?(?<layout>[\\w\\s\\.]*)\"?;", RegexOptions.Compiled)]
+    private static partial Regex LayoutRegex();
+}

--- a/src/Umbraco.Core/Services/TemplateService.cs
+++ b/src/Umbraco.Core/Services/TemplateService.cs
@@ -1,0 +1,370 @@
+﻿using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Persistence.Querying;
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Strings;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Core.Services;
+
+public class TemplateService : RepositoryService, ITemplateService
+{
+    private readonly IShortStringHelper _shortStringHelper;
+    private readonly ITemplateRepository _templateRepository;
+    private readonly IAuditRepository _auditRepository;
+
+    public TemplateService(
+        ICoreScopeProvider provider,
+        ILoggerFactory loggerFactory,
+        IEventMessagesFactory eventMessagesFactory,
+        IShortStringHelper shortStringHelper,
+        ITemplateRepository templateRepository,
+        IAuditRepository auditRepository)
+        : base(provider, loggerFactory, eventMessagesFactory)
+    {
+        _shortStringHelper = shortStringHelper;
+        _templateRepository = templateRepository;
+        _auditRepository = auditRepository;
+    }
+
+    /// <inheritdoc />
+    public Attempt<OperationResult<OperationResultType, ITemplate>?> CreateTemplateForContentType(
+        string contentTypeAlias, string? contentTypeName, int userId = Constants.Security.SuperUserId)
+    {
+        var template = new Template(_shortStringHelper, contentTypeName,
+
+            // NOTE: We are NOT passing in the content type alias here, we want to use it's name since we don't
+            // want to save template file names as camelCase, the Template ctor will clean the alias as
+            // `alias.ToCleanString(CleanStringType.UnderscoreAlias)` which has been the default.
+            // This fixes: http://issues.umbraco.org/issue/U4-7953
+            contentTypeName);
+
+        EventMessages eventMessages = EventMessagesFactory.Get();
+
+        if (contentTypeAlias != null && contentTypeAlias.Length > 255)
+        {
+            throw new InvalidOperationException("Name cannot be more than 255 characters in length.");
+        }
+
+        // check that the template hasn't been created on disk before creating the content type
+        // if it exists, set the new template content to the existing file content
+        var content = GetViewContent(contentTypeAlias);
+        if (content != null)
+        {
+            template.Content = content;
+        }
+
+        using (ICoreScope scope = ScopeProvider.CreateCoreScope())
+        {
+            var savingEvent = new TemplateSavingNotification(template, eventMessages, true, contentTypeAlias!);
+            if (scope.Notifications.PublishCancelable(savingEvent))
+            {
+                scope.Complete();
+                return OperationResult.Attempt.Fail<OperationResultType, ITemplate>(
+                    OperationResultType.FailedCancelledByEvent, eventMessages, template);
+            }
+
+            _templateRepository.Save(template);
+            scope.Notifications.Publish(
+                new TemplateSavedNotification(template, eventMessages).WithStateFrom(savingEvent));
+
+            Audit(AuditType.Save, userId, template.Id, UmbracoObjectTypes.Template.GetName());
+            scope.Complete();
+        }
+
+        return OperationResult.Attempt.Succeed<OperationResultType, ITemplate>(
+            OperationResultType.Success,
+            eventMessages,
+            template);
+    }
+
+    /// <inheritdoc />
+    public ITemplate CreateTemplateWithIdentity(
+        string? name,
+        string? alias,
+        string? content,
+        ITemplate? masterTemplate = null,
+        int userId = Constants.Security.SuperUserId)
+    {
+        if (name == null)
+        {
+            throw new ArgumentNullException(nameof(name));
+        }
+
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("Name cannot be empty or contain only white-space characters", nameof(name));
+        }
+
+        if (name.Length > 255)
+        {
+            throw new ArgumentOutOfRangeException(nameof(name), "Name cannot be more than 255 characters in length.");
+        }
+
+        // file might already be on disk, if so grab the content to avoid overwriting
+        var template = new Template(_shortStringHelper, name, alias) { Content = GetViewContent(alias) ?? content };
+
+        if (masterTemplate != null)
+        {
+            template.SetMasterTemplate(masterTemplate);
+        }
+
+        SaveTemplate(template, userId);
+
+        return template;
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<ITemplate> GetTemplates(params string[] aliases)
+    {
+        using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            return _templateRepository.GetAll(aliases).OrderBy(x => x.Name);
+        }
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<ITemplate> GetTemplates(int masterTemplateId)
+    {
+        using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            return _templateRepository.GetChildren(masterTemplateId).OrderBy(x => x.Name);
+        }
+    }
+
+    /// <inheritdoc />
+    public ITemplate? GetTemplate(string? alias)
+    {
+        using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            return _templateRepository.Get(alias);
+        }
+    }
+
+    /// <inheritdoc />
+    public ITemplate? GetTemplate(int id)
+    {
+        using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            return _templateRepository.Get(id);
+        }
+    }
+
+    /// <inheritdoc />
+    public ITemplate? GetTemplate(Guid id)
+    {
+        using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            IQuery<ITemplate>? query = Query<ITemplate>().Where(x => x.Key == id);
+            return _templateRepository.Get(query)?.SingleOrDefault();
+        }
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<ITemplate> GetTemplateDescendants(int masterTemplateId)
+    {
+        using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            return _templateRepository.GetDescendants(masterTemplateId);
+        }
+    }
+
+    /// <inheritdoc />
+    public void SaveTemplate(ITemplate template, int userId = Constants.Security.SuperUserId)
+    {
+        if (template == null)
+        {
+            throw new ArgumentNullException(nameof(template));
+        }
+
+        if (string.IsNullOrWhiteSpace(template.Name) || template.Name.Length > 255)
+        {
+            throw new InvalidOperationException(
+                "Name cannot be null, empty, contain only white-space characters or be more than 255 characters in length.");
+        }
+
+        using (ICoreScope scope = ScopeProvider.CreateCoreScope())
+        {
+            EventMessages eventMessages = EventMessagesFactory.Get();
+            var savingNotification = new TemplateSavingNotification(template, eventMessages);
+            if (scope.Notifications.PublishCancelable(savingNotification))
+            {
+                scope.Complete();
+                return;
+            }
+
+            _templateRepository.Save(template);
+
+            scope.Notifications.Publish(
+                new TemplateSavedNotification(template, eventMessages).WithStateFrom(savingNotification));
+
+            Audit(AuditType.Save, userId, template.Id, UmbracoObjectTypes.Template.GetName());
+            scope.Complete();
+        }
+    }
+
+    /// <inheritdoc />
+    public void SaveTemplate(IEnumerable<ITemplate> templates, int userId = Constants.Security.SuperUserId)
+    {
+        ITemplate[] templatesA = templates.ToArray();
+        using (ICoreScope scope = ScopeProvider.CreateCoreScope())
+        {
+            EventMessages eventMessages = EventMessagesFactory.Get();
+            var savingNotification = new TemplateSavingNotification(templatesA, eventMessages);
+            if (scope.Notifications.PublishCancelable(savingNotification))
+            {
+                scope.Complete();
+                return;
+            }
+
+            foreach (ITemplate template in templatesA)
+            {
+                _templateRepository.Save(template);
+            }
+
+            scope.Notifications.Publish(
+                new TemplateSavedNotification(templatesA, eventMessages).WithStateFrom(savingNotification));
+
+            Audit(AuditType.Save, userId, -1, UmbracoObjectTypes.Template.GetName());
+            scope.Complete();
+        }
+    }
+
+    /// <inheritdoc />
+    public void DeleteTemplate(string alias, int userId = Constants.Security.SuperUserId)
+    {
+        using (ICoreScope scope = ScopeProvider.CreateCoreScope())
+        {
+            ITemplate? template = _templateRepository.Get(alias);
+            if (template == null)
+            {
+                scope.Complete();
+                return;
+            }
+
+            EventMessages eventMessages = EventMessagesFactory.Get();
+            var deletingNotification = new TemplateDeletingNotification(template, eventMessages);
+            if (scope.Notifications.PublishCancelable(deletingNotification))
+            {
+                scope.Complete();
+                return;
+            }
+
+            _templateRepository.Delete(template);
+
+            scope.Notifications.Publish(
+                new TemplateDeletedNotification(template, eventMessages).WithStateFrom(deletingNotification));
+
+            Audit(AuditType.Delete, userId, template.Id, UmbracoObjectTypes.Template.GetName());
+            scope.Complete();
+        }
+    }
+
+    /// <inheritdoc />
+    public Stream GetTemplateFileContentStream(string filepath)
+    {
+        using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            return _templateRepository.GetFileContentStream(filepath);
+        }
+    }
+
+    /// <inheritdoc />
+    public void SetTemplateFileContent(string filepath, Stream content)
+    {
+        using (ICoreScope scope = ScopeProvider.CreateCoreScope())
+        {
+            _templateRepository.SetFileContent(filepath, content);
+            scope.Complete();
+        }
+    }
+
+    /// <inheritdoc />
+    public long GetTemplateFileSize(string filepath)
+    {
+        using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            return _templateRepository.GetFileSize(filepath);
+        }
+    }
+
+    /// <inheritdoc />
+    public void SetMasterTemplate(ITemplate template, string? masterTemplateAlias)
+    {
+        if (template.MasterTemplateAlias == masterTemplateAlias)
+        {
+            return;
+        }
+
+        if (string.IsNullOrEmpty(masterTemplateAlias) == false)
+        {
+            ITemplate? master = GetTemplate(masterTemplateAlias);
+            if (master == null || master.Id == template.Id)
+            {
+                template.SetMasterTemplate(null);
+            }
+            else
+            {
+                template.SetMasterTemplate(master);
+
+                //After updating the master - ensure we update the path property if it has any children already assigned
+                IEnumerable<ITemplate> templateHasChildren = GetTemplateDescendants(template.Id);
+
+                foreach (ITemplate childTemplate in templateHasChildren)
+                {
+                    //template ID to find
+                    var templateIdInPath = "," + template.Id + ",";
+
+                    if (string.IsNullOrEmpty(childTemplate.Path))
+                    {
+                        continue;
+                    }
+
+                    //Find position in current comma separate string path (so we get the correct children path)
+                    var positionInPath = childTemplate.Path.IndexOf(templateIdInPath) + templateIdInPath.Length;
+
+                    //Get the substring of the child & any children (descendants it may have too)
+                    var childTemplatePath = childTemplate.Path.Substring(positionInPath);
+
+                    //As we are updating the template to be a child of a master
+                    //Set the path to the master's path + its current template id + the current child path substring
+                    childTemplate.Path = master.Path + "," + template.Id + "," + childTemplatePath;
+
+                    //Save the children with the updated path
+                    SaveTemplate(childTemplate);
+                }
+            }
+        }
+        else
+        {
+            //remove the master
+            template.SetMasterTemplate(null);
+        }
+    }
+
+    private string? GetViewContent(string? fileName)
+    {
+        if (fileName.IsNullOrWhiteSpace())
+        {
+            throw new ArgumentNullException(nameof(fileName));
+        }
+
+        if (!fileName!.EndsWith(".cshtml"))
+        {
+            fileName = $"{fileName}.cshtml";
+        }
+
+        Stream fs = _templateRepository.GetFileContentStream(fileName);
+
+        using (var view = new StreamReader(fs))
+        {
+            return view.ReadToEnd().Trim();
+        }
+    }
+
+    private void Audit(AuditType type, int userId, int objectId, string? entityType) =>
+        _auditRepository.Save(new AuditItem(objectId, type, userId, entityType));
+}

--- a/src/Umbraco.Core/Services/TemplateService.cs
+++ b/src/Umbraco.Core/Services/TemplateService.cs
@@ -361,7 +361,7 @@ public class TemplateService : RepositoryService, ITemplateService
 
         using (var view = new StreamReader(fs))
         {
-            return view.ReadToEnd().Trim();
+            return view.ReadToEnd().Trim().NullOrWhiteSpaceAsNull();
         }
     }
 

--- a/src/Umbraco.Web.BackOffice/Controllers/TemplateController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/TemplateController.cs
@@ -21,18 +21,18 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers;
 public class TemplateController : BackOfficeNotificationsController
 {
     private readonly IDefaultViewContentProvider _defaultViewContentProvider;
-    private readonly IFileService _fileService;
+    private readonly ITemplateService _templateService;
     private readonly IShortStringHelper _shortStringHelper;
     private readonly IUmbracoMapper _umbracoMapper;
 
     [ActivatorUtilitiesConstructor]
     public TemplateController(
-        IFileService fileService,
+        ITemplateService templateService,
         IUmbracoMapper umbracoMapper,
         IShortStringHelper shortStringHelper,
         IDefaultViewContentProvider defaultViewContentProvider)
     {
-        _fileService = fileService ?? throw new ArgumentNullException(nameof(fileService));
+        _templateService = templateService ?? throw new ArgumentNullException(nameof(templateService));
         _umbracoMapper = umbracoMapper ?? throw new ArgumentNullException(nameof(umbracoMapper));
         _shortStringHelper = shortStringHelper ?? throw new ArgumentNullException(nameof(shortStringHelper));
         _defaultViewContentProvider = defaultViewContentProvider ??
@@ -46,7 +46,7 @@ public class TemplateController : BackOfficeNotificationsController
         /// <returns></returns>
         public TemplateDisplay? GetByAlias(string alias)
         {
-            ITemplate? template = _fileService.GetTemplate(alias);
+            ITemplate? template = _templateService.GetTemplate(alias);
         return template == null ? null : _umbracoMapper.Map<ITemplate, TemplateDisplay>(template);
     }
 
@@ -54,7 +54,7 @@ public class TemplateController : BackOfficeNotificationsController
     ///     Get all templates
     /// </summary>
     /// <returns></returns>
-    public IEnumerable<EntityBasic>? GetAll() => _fileService.GetTemplates()
+    public IEnumerable<EntityBasic>? GetAll() => _templateService.GetTemplates()
         ?.Select(_umbracoMapper.Map<ITemplate, EntityBasic>).WhereNotNull();
 
     /// <summary>
@@ -64,7 +64,7 @@ public class TemplateController : BackOfficeNotificationsController
     /// <returns></returns>
     public ActionResult<TemplateDisplay?> GetById(int id)
     {
-        ITemplate? template = _fileService.GetTemplate(id);
+        ITemplate? template = _templateService.GetTemplate(id);
         if (template == null)
         {
             return NotFound();
@@ -81,7 +81,7 @@ public class TemplateController : BackOfficeNotificationsController
     /// <returns></returns>
     public ActionResult<TemplateDisplay?> GetById(Guid id)
     {
-        ITemplate? template = _fileService.GetTemplate(id);
+        ITemplate? template = _templateService.GetTemplate(id);
         if (template == null)
         {
             return NotFound();
@@ -103,7 +103,7 @@ public class TemplateController : BackOfficeNotificationsController
             return NotFound();
         }
 
-        ITemplate? template = _fileService.GetTemplate(guidUdi.Guid);
+        ITemplate? template = _templateService.GetTemplate(guidUdi.Guid);
         if (template == null)
         {
             return NotFound();
@@ -121,13 +121,13 @@ public class TemplateController : BackOfficeNotificationsController
     [HttpPost]
     public IActionResult DeleteById(int id)
     {
-        ITemplate? template = _fileService.GetTemplate(id);
+        ITemplate? template = _templateService.GetTemplate(id);
         if (template == null)
         {
             return NotFound();
         }
 
-        _fileService.DeleteTemplate(template.Alias);
+        _templateService.DeleteTemplate(template.Alias);
         return Ok();
     }
 
@@ -141,7 +141,7 @@ public class TemplateController : BackOfficeNotificationsController
 
         if (id > 0)
         {
-            ITemplate? master = _fileService.GetTemplate(id);
+            ITemplate? master = _templateService.GetTemplate(id);
             if (master != null)
             {
                 dt.SetMasterTemplate(master);
@@ -175,70 +175,23 @@ public class TemplateController : BackOfficeNotificationsController
         if (display.Id > 0)
         {
             // update
-            ITemplate? template = _fileService.GetTemplate(display.Id);
+            ITemplate? template = _templateService.GetTemplate(display.Id);
             if (template == null)
             {
                 return NotFound();
             }
 
-            var changeMaster = template.MasterTemplateAlias != display.MasterTemplateAlias;
             var changeAlias = template.Alias != display.Alias;
 
             _umbracoMapper.Map(display, template);
 
-            if (changeMaster)
-            {
-                if (string.IsNullOrEmpty(display.MasterTemplateAlias) == false)
-                {
-                    ITemplate? master = _fileService.GetTemplate(display.MasterTemplateAlias);
-                    if (master == null || master.Id == display.Id)
-                    {
-                        template.SetMasterTemplate(null);
-                    }
-                    else
-                    {
-                        template.SetMasterTemplate(master);
+            _templateService.SetMasterTemplate(template, display.MasterTemplateAlias);
 
-                        //After updating the master - ensure we update the path property if it has any children already assigned
-                        IEnumerable<ITemplate> templateHasChildren = _fileService.GetTemplateDescendants(display.Id);
-
-                        foreach (ITemplate childTemplate in templateHasChildren)
-                        {
-                            //template ID to find
-                            var templateIdInPath = "," + display.Id + ",";
-
-                            if (string.IsNullOrEmpty(childTemplate.Path))
-                            {
-                                continue;
-                            }
-
-                            //Find position in current comma separate string path (so we get the correct children path)
-                            var positionInPath = childTemplate.Path.IndexOf(templateIdInPath) + templateIdInPath.Length;
-
-                            //Get the substring of the child & any children (descendants it may have too)
-                            var childTemplatePath = childTemplate.Path.Substring(positionInPath);
-
-                            //As we are updating the template to be a child of a master
-                            //Set the path to the master's path + its current template id + the current child path substring
-                            childTemplate.Path = master.Path + "," + display.Id + "," + childTemplatePath;
-
-                            //Save the children with the updated path
-                            _fileService.SaveTemplate(childTemplate);
-                        }
-                    }
-                }
-                else
-                {
-                    //remove the master
-                    template.SetMasterTemplate(null);
-                }
-            }
-
-            _fileService.SaveTemplate(template);
+            _templateService.SaveTemplate(template);
 
             if (changeAlias)
             {
-                template = _fileService.GetTemplate(template.Id);
+                template = _templateService.GetTemplate(template.Id);
             }
 
             _umbracoMapper.Map(template, display);
@@ -249,7 +202,7 @@ public class TemplateController : BackOfficeNotificationsController
             ITemplate? master = null;
             if (string.IsNullOrEmpty(display.MasterTemplateAlias) == false)
             {
-                master = _fileService.GetTemplate(display.MasterTemplateAlias);
+                master = _templateService.GetTemplate(display.MasterTemplateAlias);
                 if (master == null)
                 {
                     return NotFound();
@@ -259,7 +212,7 @@ public class TemplateController : BackOfficeNotificationsController
             // we need to pass the template name as alias to keep the template file casing consistent with templates created with content
             // - see comment in FileService.CreateTemplateForContentType for additional details
             ITemplate template =
-                _fileService.CreateTemplateWithIdentity(display.Name, display.Name, display.Content, master);
+                _templateService.CreateTemplateWithIdentity(display.Name, display.Name, display.Content, master);
             _umbracoMapper.Map(template, display);
         }
 

--- a/src/Umbraco.Web.BackOffice/Controllers/TemplateController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/TemplateController.cs
@@ -25,12 +25,27 @@ public class TemplateController : BackOfficeNotificationsController
     private readonly IShortStringHelper _shortStringHelper;
     private readonly IUmbracoMapper _umbracoMapper;
 
+    public TemplateController(
+        IFileService fileService,
+        IUmbracoMapper umbracoMapper,
+        IShortStringHelper shortStringHelper,
+        IDefaultViewContentProvider defaultViewContentProvider)
+        : this(
+            StaticServiceProvider.Instance.GetRequiredService<ITemplateService>(),
+            umbracoMapper,
+            shortStringHelper,
+            defaultViewContentProvider,
+            fileService)
+    {
+    }
+
     [ActivatorUtilitiesConstructor]
     public TemplateController(
         ITemplateService templateService,
         IUmbracoMapper umbracoMapper,
         IShortStringHelper shortStringHelper,
-        IDefaultViewContentProvider defaultViewContentProvider)
+        IDefaultViewContentProvider defaultViewContentProvider,
+        IFileService fileService)
     {
         _templateService = templateService ?? throw new ArgumentNullException(nameof(templateService));
         _umbracoMapper = umbracoMapper ?? throw new ArgumentNullException(nameof(umbracoMapper));

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/FileServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/FileServiceTests.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using NUnit.Framework;
+using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
@@ -15,13 +16,24 @@ public class FileServiceTests : UmbracoIntegrationTest
 {
     private IFileService FileService => GetRequiredService<IFileService>();
 
+    [SetUp]
+    public void SetUp()
+    {
+        var fileSystems = GetRequiredService<FileSystems>();
+        var viewFileSystem = fileSystems.MvcViewsFileSystem!;
+        foreach (var file in viewFileSystem.GetFiles(string.Empty).ToArray())
+        {
+            viewFileSystem.DeleteFile(file);
+        }
+    }
+
     [Test]
     public void Create_Template_Then_Assign_Child()
     {
         var child = FileService.CreateTemplateWithIdentity("Child", "child", "test");
         var parent = FileService.CreateTemplateWithIdentity("Parent", "parent", "test");
 
-        child.SetMasterTemplate(parent);
+        child.Content = "Layout = \"Parent.cshtml\";";
         FileService.SaveTemplate(child);
 
         child = FileService.GetTemplate(child.Id);
@@ -33,22 +45,74 @@ public class FileServiceTests : UmbracoIntegrationTest
     public void Create_Template_With_Child_Then_Unassign()
     {
         var parent = FileService.CreateTemplateWithIdentity("Parent", "parent", "test");
-        var child = FileService.CreateTemplateWithIdentity("Child", "child", "test", parent);
+        var child = FileService.CreateTemplateWithIdentity("Child", "child", "Layout = \"Parent.cshtml\";");
 
-        child.SetMasterTemplate(null);
+        child = FileService.GetTemplate(child.Id);
+        Assert.NotNull(child);
+        Assert.AreEqual("parent", child.MasterTemplateAlias);
+
+        child.Content = "test";
         FileService.SaveTemplate(child);
 
         child = FileService.GetTemplate(child.Id);
-
+        Assert.NotNull(child);
         Assert.AreEqual(null, child.MasterTemplateAlias);
+    }
+
+    [Test]
+    public void Create_Template_With_Child_Then_Reassign()
+    {
+        var parent = FileService.CreateTemplateWithIdentity("Parent", "parent", "test");
+        var parent2 = FileService.CreateTemplateWithIdentity("Parent2", "parent2", "test");
+        var child = FileService.CreateTemplateWithIdentity("Child", "child", "Layout = \"Parent.cshtml\";");
+
+        child = FileService.GetTemplate(child.Id);
+        Assert.NotNull(child);
+        Assert.AreEqual("parent", child.MasterTemplateAlias);
+
+        child.Content = "Layout = \"Parent2.cshtml\";";
+        FileService.SaveTemplate(child);
+
+        child = FileService.GetTemplate(child.Id);
+        Assert.NotNull(child);
+        Assert.AreEqual("parent2", child.MasterTemplateAlias);
+    }
+
+    [Test]
+    public void Child_Template_Paths_Are_Updated_When_Reassigning_Master()
+    {
+        var parent = FileService.CreateTemplateWithIdentity("Parent", "parent", "test");
+        var parent2 = FileService.CreateTemplateWithIdentity("Parent2", "parent2", "test");
+        var child = FileService.CreateTemplateWithIdentity("Child", "child", "Layout = \"Parent.cshtml\";");
+        var childOfChild1 = FileService.CreateTemplateWithIdentity("Child1", "child1", "Layout = \"Child.cshtml\";");
+        var childOfChild2 = FileService.CreateTemplateWithIdentity("Child2", "child2", "Layout = \"Child.cshtml\";");
+
+        Assert.AreEqual($"child", childOfChild1.MasterTemplateAlias);
+        Assert.AreEqual($"{parent.Path},{child.Id},{childOfChild1.Id}", childOfChild1.Path);
+        Assert.AreEqual($"child", childOfChild2.MasterTemplateAlias);
+        Assert.AreEqual($"{parent.Path},{child.Id},{childOfChild2.Id}", childOfChild2.Path);
+
+        child.Content = "Layout = \"Parent2.cshtml\";";
+        FileService.SaveTemplate(child);
+
+        childOfChild1 = FileService.GetTemplate(childOfChild1.Id);
+        Assert.NotNull(childOfChild1);
+
+        childOfChild2 = FileService.GetTemplate(childOfChild2.Id);
+        Assert.NotNull(childOfChild2);
+
+        Assert.AreEqual($"child", childOfChild1.MasterTemplateAlias);
+        Assert.AreEqual($"{parent2.Path},{child.Id},{childOfChild1.Id}", childOfChild1.Path);
+        Assert.AreEqual($"child", childOfChild2.MasterTemplateAlias);
+        Assert.AreEqual($"{parent2.Path},{child.Id},{childOfChild2.Id}", childOfChild2.Path);
     }
 
     [Test]
     public void Can_Query_Template_Children()
     {
         var parent = FileService.CreateTemplateWithIdentity("Parent", "parent", "test");
-        var child1 = FileService.CreateTemplateWithIdentity("Child1", "child1", "test", parent);
-        var child2 = FileService.CreateTemplateWithIdentity("Child2", "child2", "test", parent);
+        var child1 = FileService.CreateTemplateWithIdentity("Child1", "child1", "Layout = \"Parent.cshtml\";");
+        var child2 = FileService.CreateTemplateWithIdentity("Child2", "child2", "Layout = \"Parent.cshtml\";");
 
         var children = FileService.GetTemplates(parent.Id).Select(x => x.Id).ToArray();
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR adds the template API for the new backoffice, featuring:

- Template CRUD operations.
- Template scaffolding.
- Query builder settings + query execution.

As part of this PR, all template operations have been moved from `FileService` to a new `TemplateService`. The `IFileService` interface remains intact for backwards compatibility - behind the scenes, `FileService` wraps `ITemplateService` to do the heavy lifting.

The current `TemplateController` has swapped its dependency on `IFileService` with the new `ITemplateService`. While we really don't need to maintain the current controllers as they will be deleted eventually for V13, this change will allow us to detect any necessary updates to master template assignment (which has been refactored by this PR), as we forward merge from the V12 branch. 

### Testing this PR

Get in touch with @kjac for a Postman collection 😄 

When testing the API, pay special attention to master template (re)assignment, as this has been refactored. 

The API is fully compatible with the current backoffice, so changes performed in the API can be validated in the backoffice.
