### PR TITLE
V12: Change nullability for the log searches

### DIFF
--- a/src/Umbraco.Core/Models/ILogViewerQuery.cs
+++ b/src/Umbraco.Core/Models/ILogViewerQuery.cs
@@ -4,7 +4,7 @@ namespace Umbraco.Cms.Core.Models;
 
 public interface ILogViewerQuery : IEntity
 {
-    string? Name { get; set; }
+    string Name { get; set; }
 
-    string? Query { get; set; }
+    string Query { get; set; }
 }

--- a/src/Umbraco.Core/Models/LogViewerQuery.cs
+++ b/src/Umbraco.Core/Models/LogViewerQuery.cs
@@ -7,26 +7,26 @@ namespace Umbraco.Cms.Core.Models;
 [DataContract(IsReference = true)]
 public class LogViewerQuery : EntityBase, ILogViewerQuery
 {
-    private string? _name;
-    private string? _query;
+    private string _name = string.Empty;
+    private string _query = string.Empty;
 
-    public LogViewerQuery(string? name, string? query)
+    public LogViewerQuery(string name, string query)
     {
         Name = name;
-        _query = query;
+        Query = query;
     }
 
     [DataMember]
-    public string? Name
+    public string Name
     {
         get => _name;
-        set => SetPropertyValueAndDetectChanges(value, ref _name, nameof(Name));
+        set => SetPropertyValueAndDetectChanges(value, ref _name!, nameof(Name));
     }
 
     [DataMember]
-    public string? Query
+    public string Query
     {
         get => _query;
-        set => SetPropertyValueAndDetectChanges(value, ref _query, nameof(Query));
+        set => SetPropertyValueAndDetectChanges(value, ref _query!, nameof(Query));
     }
 }

--- a/src/Umbraco.Infrastructure/Logging/Viewer/ILogViewer.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/ILogViewer.cs
@@ -14,12 +14,12 @@ public interface ILogViewer
     /// <summary>
     ///     Adds a new saved search to chosen data source and returns the updated searches
     /// </summary>
-    IReadOnlyList<SavedLogSearch> AddSavedSearch(string? name, string? query);
+    IReadOnlyList<SavedLogSearch> AddSavedSearch(string name, string query);
 
     /// <summary>
     ///     Deletes a saved search to chosen data source and returns the remaining searches
     /// </summary>
-    IReadOnlyList<SavedLogSearch> DeleteSavedSearch(string? name, string? query);
+    IReadOnlyList<SavedLogSearch> DeleteSavedSearch(string name, string query);
 
     /// <summary>
     ///     A count of number of errors

--- a/src/Umbraco.Infrastructure/Logging/Viewer/ILogViewer.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/ILogViewer.cs
@@ -19,6 +19,9 @@ public interface ILogViewer
     /// <summary>
     ///     Deletes a saved search to chosen data source and returns the remaining searches
     /// </summary>
+    IReadOnlyList<SavedLogSearch> DeleteSavedSearch(string name);
+
+    [Obsolete("Use the overload that only takes a 'name' parameter instead. This will be removed in Umbraco 14.")]
     IReadOnlyList<SavedLogSearch> DeleteSavedSearch(string name, string query);
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/Logging/Viewer/ILogViewerConfig.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/ILogViewerConfig.cs
@@ -4,7 +4,10 @@ public interface ILogViewerConfig
 {
     IReadOnlyList<SavedLogSearch> GetSavedSearches();
 
-    IReadOnlyList<SavedLogSearch> AddSavedSearch(string? name, string? query);
+    IReadOnlyList<SavedLogSearch> AddSavedSearch(string name, string query);
 
-    IReadOnlyList<SavedLogSearch> DeleteSavedSearch(string? name, string? query);
+    [Obsolete("Use the overload that only takes a 'name' parameter instead. This will be removed in Umbraco 14.")]
+    IReadOnlyList<SavedLogSearch> DeleteSavedSearch(string name, string query);
+
+    IReadOnlyList<SavedLogSearch> DeleteSavedSearch(string name);
 }

--- a/src/Umbraco.Infrastructure/Logging/Viewer/LogViewerConfig.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/LogViewerConfig.cs
@@ -24,7 +24,7 @@ public class LogViewerConfig : ILogViewerConfig
         return result;
     }
 
-    public IReadOnlyList<SavedLogSearch> AddSavedSearch(string? name, string? query)
+    public IReadOnlyList<SavedLogSearch> AddSavedSearch(string name, string query)
     {
         using IScope scope = _scopeProvider.CreateScope(autoComplete: true);
         _logViewerQueryRepository.Save(new LogViewerQuery(name, query));
@@ -32,10 +32,14 @@ public class LogViewerConfig : ILogViewerConfig
         return GetSavedSearches();
     }
 
-    public IReadOnlyList<SavedLogSearch> DeleteSavedSearch(string? name, string? query)
+    [Obsolete("Use the overload that only takes a 'name' parameter instead. This will be removed in Umbraco 14.")]
+    public IReadOnlyList<SavedLogSearch> DeleteSavedSearch(string name, string query) => DeleteSavedSearch(name);
+
+    public IReadOnlyList<SavedLogSearch> DeleteSavedSearch(string name)
     {
         using IScope scope = _scopeProvider.CreateScope(autoComplete: true);
-        ILogViewerQuery? item = name is null ? null : _logViewerQueryRepository.GetByName(name);
+        ILogViewerQuery? item = _logViewerQueryRepository.GetByName(name);
+
         if (item is not null)
         {
             _logViewerQueryRepository.Delete(item);

--- a/src/Umbraco.Infrastructure/Logging/Viewer/SavedLogSearch.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/SavedLogSearch.cs
@@ -5,8 +5,8 @@ namespace Umbraco.Cms.Core.Logging.Viewer;
 public class SavedLogSearch
 {
     [JsonProperty("name")]
-    public string? Name { get; set; }
+    public required string Name { get; set; }
 
     [JsonProperty("query")]
-    public string? Query { get; set; }
+    public required string Query { get; set; }
 }

--- a/src/Umbraco.Infrastructure/Logging/Viewer/SerilogLogViewerSourceBase.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/SerilogLogViewerSourceBase.cs
@@ -24,11 +24,15 @@ public abstract class SerilogLogViewerSourceBase : ILogViewer
     public virtual IReadOnlyList<SavedLogSearch> GetSavedSearches()
         => _logViewerConfig.GetSavedSearches();
 
-    public virtual IReadOnlyList<SavedLogSearch> AddSavedSearch(string? name, string? query)
+    public virtual IReadOnlyList<SavedLogSearch> AddSavedSearch(string name, string query)
         => _logViewerConfig.AddSavedSearch(name, query);
 
-    public virtual IReadOnlyList<SavedLogSearch> DeleteSavedSearch(string? name, string? query)
-        => _logViewerConfig.DeleteSavedSearch(name, query);
+    [Obsolete("Use the overload that only takes a 'name' parameter instead. This will be removed in Umbraco 14.")]
+    public virtual IReadOnlyList<SavedLogSearch> DeleteSavedSearch(string name, string query)
+        => DeleteSavedSearch(name);
+
+    public virtual IReadOnlyList<SavedLogSearch> DeleteSavedSearch(string name)
+        => _logViewerConfig.DeleteSavedSearch(name);
 
     public int GetNumberOfErrors(LogTimePeriod logTimePeriod)
     {

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/LogViewerQueryDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/LogViewerQueryDto.cs
@@ -15,8 +15,8 @@ internal class LogViewerQueryDto
 
     [Column("name")]
     [Index(IndexTypes.UniqueNonClustered, Name = "IX_LogViewerQuery_name")]
-    public string? Name { get; set; }
+    public required string Name { get; set; }
 
     [Column("query")]
-    public string? Query { get; set; }
+    public required string Query { get; set; }
 }

--- a/src/Umbraco.Web.BackOffice/Controllers/LogViewerController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/LogViewerController.cs
@@ -137,7 +137,7 @@ public class LogViewerController : BackOfficeNotificationsController
 
     [HttpPost]
     public IEnumerable<SavedLogSearch> DeleteSavedSearch(SavedLogSearch item) =>
-        _logViewer.DeleteSavedSearch(item.Name, item.Query);
+        _logViewer.DeleteSavedSearch(item.Name);
 
     [HttpGet]
     public ReadOnlyDictionary<string, LogEventLevel?> GetLogLevels() => _logLevelLoader.GetLogLevelsFromSinks();

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Logging/LogviewerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Logging/LogviewerTests.cs
@@ -223,7 +223,7 @@ public class LogviewerTests
         // Assert.That(searches, Contains.Item(savedSearch));
 
         // Remove the search from above & ensure it no longer exists
-        _logViewer.DeleteSavedSearch("Unit Test Example", "Has(UnitTest)");
+        _logViewer.DeleteSavedSearch("Unit Test Example");
 
         searches = _logViewer.GetSavedSearches();
         findItem = searches.Where(x => x.Name == "Unit Test Example" && x.Query == "Has(UnitTest)");


### PR DESCRIPTION
## Details
- Fixing nullability for the log searches since adding or deleting a saved search with a name being `null` is not the meant functionality;
- Obsoleting `DeleteSavedSearch(string name, string query);` as the `query` parameter is never used.


## Test
- Navigate to the Log Viewer dashboard;
- Make sure you are still getting the saved searches;
- Modify them - ex: delete or save new ones;
- Make sure that functionality still works as expected.