### PR TITLE
Only save selected variant for new content

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/save.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/save.controller.js
@@ -64,7 +64,6 @@
         function onInit() {
             vm.variants = $scope.model.variants;
             vm.availableVariants = vm.variants.filter(saveableVariantFilter);
-            vm.isNew = vm.variants.some(variant => variant.state === 'NotCreated');
 
             if (!$scope.model.title) {
                 localizationService.localize("content_readyToSave").then(value => {
@@ -78,7 +77,7 @@
                 variant.save = variant.publish = false;
                 variant.isMandatory = isMandatoryFilter(variant);
 
-                if(vm.isNew && hasAnyData(variant) && allowUpdate(variant)) {
+                if(variant.state === 'NotCreated' && hasAnyData(variant) && allowUpdate(variant)) {
                     variant.save = true;
                 }
             });


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/12033

### Description

As stated on #12033 there is a slight weirdness going on when creating new culture variant content "one culture at a time". 

Steps to reproduce:

1. Create a new content item that is allowed to vary by culture. 
2. Add a name for the first culture - do NOT select/edit another culture.
3. Save the content. A "content saved" notification will inform you, that the content has been saved in the given culture.
4. Stay on the same content item and select another culture.
5. Add a name for the other culture and save again. Notice the other culture is the only one available in the "Ready to Save?" dialog.
6. A "content saved" notification will inform you, that the content has been saved in _both_ cultures.

Turns out it's a logic error in the "Ready to Save?" dialog controller. This PR fixes that error. Once applied, the above outlined process goes like this:

![12033](https://user-images.githubusercontent.com/7405322/211315331-0cee6245-a223-4657-9f6c-41cd2456f622.gif)
