### PR TITLE
Use element type icon colors in block list catalogue

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umbBlockCard.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umbBlockCard.component.js
@@ -30,7 +30,11 @@
         };
 
         vm.$onChanges = function () {
-            vm.icon = vm.elementTypeModel ? vm.elementTypeModel.icon.split(" ")[0] : 'icon-block';
+            vm.icon = vm.elementTypeModel ? vm.elementTypeModel.icon : 'icon-block';
+            if (vm.blockConfigModel.iconColor) {
+                // enforce configured icon color for catalogue appearance instead of icon color from element type
+                vm.icon = vm.icon.split(" ")[0];
+            }
         };
 
         vm.$onDestroy = function () {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/12067

### Description

This PR ensures that we use the element type icon colors in the block list catalogue, unless a specific color has been defined for the catalogue appearance of said element.

### Testing this PR

1. Create a Block List datatype with at least two element types. Both element types must have colored icons.
2. Verify that the element type icon colors are reflected in the Block List datatype configuration:
![image](https://user-images.githubusercontent.com/7405322/211474177-f8e3d65d-d01e-41af-89d3-be0bc1456c85.png)
3. Verify that the element type icon colors are reflected in the Block List property catalogue:
![image](https://user-images.githubusercontent.com/7405322/211474488-f22a336a-cfd6-419c-8a5c-355b0107c470.png)
4. Configure an explicit icon color for one of the element types in the Block List datatype configuration:
![image](https://user-images.githubusercontent.com/7405322/211474703-5e8c487a-0af4-4aaa-b63d-ecab75c75024.png)
5. Verify that the configured icon color is applied in both the Block List datatype configuration and the Block List property catalogue.

### Limitations of this PR

This PR _only_ targets the Block List datatype configuration and the Block List property catalogue. The icons of the actual Block List property items remain unchanged, as the catalogue appearance is not supposed to affect the items.
