### PR TITLE
Use the client culture if available when rendering macro HTML

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/MacroRenderingController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MacroRenderingController.cs
@@ -125,13 +125,8 @@ public class MacroRenderingController : UmbracoAuthorizedJsonController
 
         // When rendering the macro in the backoffice the default setting would be to use the Culture of the logged in user.
         // Since a Macro might contain thing thats related to the culture of the "IPublishedContent" (ie Dictionary keys) we want
-        // to set the current culture to the culture related to the content item. This is hacky but it works.
-
-        // fixme
-        // in a 1:1 situation we do not handle the language being edited
-        // so the macro renders in the wrong language
-
-        var culture = DomainUtilities.GetCultureFromDomains(publishedContent.Id, publishedContent.Path, null,
+        // to set the current culture to the currently edited culture with fallback to the culture related to the content item.
+        var culture = Request.ClientCulture() ?? DomainUtilities.GetCultureFromDomains(publishedContent.Id, publishedContent.Path, null,
             umbracoContext, _siteDomainHelper);
 
         if (culture != null)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/11863

### Description

This PR ensures that we use the active client culture (if available) when we render macro HTML for the backoffice.

### Testing this PR

1. Create a macro with the following partial view (the macro must be configured to render in RTEs):
```html
@inherits Umbraco.Cms.Web.Common.Macros.PartialViewMacroPage
<b>Culture: @System.Threading.Thread.CurrentThread.CurrentCulture.Name</b>
```
2. Insert the macro in an RTE on a content page that varies by culture.
3. Verify that the macro out the correct culture within the RTE when swapping between cultures.

![11863-fix](https://user-images.githubusercontent.com/7405322/211554846-74fd7860-9f59-4785-8af6-5a88a12e2d45.gif)

### Limitations of this PR

This does not work with split views - there is generally issues with split views and culture bound property editors. See https://github.com/umbraco/Umbraco-CMS/issues/11862 and https://github.com/umbraco/Umbraco-CMS/issues/13461#issuecomment-1377190717.