### PR TITLE
Fix the content picker XPATH scope in infinite editing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -246,7 +246,7 @@ function contentPickerController($scope, $q, $routeParams, $location, entityReso
     }
     else if ($scope.model.config.startNode.query) {
         //if we have a query for the startnode, we will use that.
-        var rootId = $routeParams.id;
+        var rootId = editorState.current.id;
         entityResource.getByQuery($scope.model.config.startNode.query, rootId, "Document").then(function (ent) {
             dialogOptions.startNodeId = ($scope.model.config.idType === "udi" ? ent.udi : ent.id).toString();
         });


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/12121

### Description

When a content picker (MNTP) is configured with an XPATH query/scope, the scope is not applied in infinite editing; instead the parent scope is reused.

This means a content item in infinite editing will end up with an incorrect starting point when using scoped pickers.

### Steps to reproduce

1. Create an MNTP with a `$parent` XPATH scope and "Show open button" enabled:
![image](https://user-images.githubusercontent.com/7405322/211782878-5e35f1eb-e961-4fff-bddc-6c8c7eaebee4.png)
2. Add the MNTP to a content type and create a content structure based on this content type - at least three levels deep.
3. On a content item at level 2, use the MNTP to pick another content item at level 3. Note that the `$parent` scope is applied correctly when the picker opens.
4. Open the picked content item directly from the MNTP and then use the MNTP on the opened content item (in the infinite editor) to pick another content item.
5. The scope is wrong; it should be the `$parent` scope of the picked content item, but is the `$parent` of the original content item (at level 2).

Here's a screencast to demo the issue:

![12121-before](https://user-images.githubusercontent.com/7405322/211783758-0ef32b8f-b223-4548-856d-89a88f869938.gif)

This PR ensures that the content picker (MNTP) uses the current editor state (`editorState.current`) to resolve the ID of the currently edited content item rather than using the route ID (`$routeParams.id`). The ID of the currently editor content item is the basis for calculating the correct scope, because it is relative to the item being edited. Thus using the route ID will always resolve the "root" content item being edited, rather than the one being edited in the infinite editor.

Here's a screencast of this fix applied:

![12121-after](https://user-images.githubusercontent.com/7405322/211784384-1967c31c-03b4-474f-ba94-9adbfe0d8cd7.gif)





