### PR TITLE
Obsolete things broken in migrations refactor

### DIFF
--- a/src/Umbraco.Infrastructure/Install/PackageMigrationRunner.cs
+++ b/src/Umbraco.Infrastructure/Install/PackageMigrationRunner.cs
@@ -1,4 +1,7 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Migrations;
@@ -32,7 +35,8 @@ public class PackageMigrationRunner
         PackageMigrationPlanCollection packageMigrationPlans,
         IMigrationPlanExecutor migrationPlanExecutor,
         IKeyValueService keyValueService,
-        IEventAggregator eventAggregator)
+        IEventAggregator eventAggregator,
+        ILogger<PackageMigrationRunner> logger)
     {
         _profilingLogger = profilingLogger;
         _scopeProvider = scopeProvider;
@@ -41,6 +45,27 @@ public class PackageMigrationRunner
         _keyValueService = keyValueService;
         _eventAggregator = eventAggregator;
         _packageMigrationPlans = packageMigrationPlans.ToDictionary(x => x.Name);
+    }
+
+    [Obsolete("Use constructor that takes ILogger, this will be removed in V13")]
+    public PackageMigrationRunner(
+        IProfilingLogger profilingLogger,
+        ICoreScopeProvider scopeProvider,
+        PendingPackageMigrations pendingPackageMigrations,
+        PackageMigrationPlanCollection packageMigrationPlans,
+        IMigrationPlanExecutor migrationPlanExecutor,
+        IKeyValueService keyValueService,
+        IEventAggregator eventAggregator)
+        : this(
+            profilingLogger,
+            scopeProvider,
+            pendingPackageMigrations,
+            packageMigrationPlans,
+            migrationPlanExecutor,
+            keyValueService,
+            eventAggregator,
+            StaticServiceProvider.Instance.GetRequiredService<ILogger<PackageMigrationRunner>>())
+    {
     }
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/Migrations/IMigrationContext.cs
+++ b/src/Umbraco.Infrastructure/Migrations/IMigrationContext.cs
@@ -41,6 +41,7 @@ public interface IMigrationContext
     /// <summary>
     ///     Adds a post-migration.
     /// </summary>
+    [Obsolete("This will be removed in the V13, and replaced with a RebuildCache flag on the MigrationBase")]
     void AddPostMigration<TMigration>()
         where TMigration : MigrationBase;
 }

--- a/src/Umbraco.Infrastructure/Migrations/IMigrationPlanExecutor.cs
+++ b/src/Umbraco.Infrastructure/Migrations/IMigrationPlanExecutor.cs
@@ -4,5 +4,6 @@ namespace Umbraco.Cms.Core.Migrations;
 
 public interface IMigrationPlanExecutor
 {
+    [Obsolete("This will return an ExecutedMigrationPlan in V13")]
     string Execute(MigrationPlan plan, string fromState);
 }

--- a/src/Umbraco.Infrastructure/Migrations/IMigrationPlanExecutor.cs
+++ b/src/Umbraco.Infrastructure/Migrations/IMigrationPlanExecutor.cs
@@ -4,6 +4,12 @@ namespace Umbraco.Cms.Core.Migrations;
 
 public interface IMigrationPlanExecutor
 {
-    [Obsolete("This will return an ExecutedMigrationPlan in V13")]
+    [Obsolete("Use ExecutePlan instead.")]
     string Execute(MigrationPlan plan, string fromState);
+
+    ExecutedMigrationPlan ExecutePlan(MigrationPlan plan, string fromState)
+    {
+        var state = Execute(plan, fromState);
+        return new ExecutedMigrationPlan(plan, fromState, state);
+    }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseBuilder.cs
@@ -1,9 +1,12 @@
 using System.Data.Common;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Install;
 using Umbraco.Cms.Core.Install.Models;
 using Umbraco.Cms.Core.Migrations;
@@ -54,7 +57,8 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install
             IOptionsMonitor<ConnectionStrings> connectionStrings,
             IMigrationPlanExecutor migrationPlanExecutor,
             DatabaseSchemaCreatorFactory databaseSchemaCreatorFactory,
-            IEnumerable<IDatabaseProviderMetadata> databaseProviderMetadata)
+            IEnumerable<IDatabaseProviderMetadata> databaseProviderMetadata,
+            IEventAggregator eventAggregator)
         {
             _scopeProvider = scopeProvider;
             _scopeAccessor = scopeAccessor;
@@ -69,6 +73,40 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install
             _migrationPlanExecutor = migrationPlanExecutor;
             _databaseSchemaCreatorFactory = databaseSchemaCreatorFactory;
             _databaseProviderMetadata = databaseProviderMetadata;
+        }
+
+        [Obsolete("Use constructor that takes IEventAggregator, this will be removed in V13.")]
+        public DatabaseBuilder(
+            ICoreScopeProvider scopeProvider,
+            IScopeAccessor scopeAccessor,
+            IUmbracoDatabaseFactory databaseFactory,
+            IRuntimeState runtimeState,
+            ILoggerFactory loggerFactory,
+            IKeyValueService keyValueService,
+            IDbProviderFactoryCreator dbProviderFactoryCreator,
+            IConfigManipulator configManipulator,
+            IOptionsMonitor<GlobalSettings> globalSettings,
+            IOptionsMonitor<ConnectionStrings> connectionStrings,
+            IMigrationPlanExecutor migrationPlanExecutor,
+            DatabaseSchemaCreatorFactory databaseSchemaCreatorFactory,
+            IEnumerable<IDatabaseProviderMetadata> databaseProviderMetadata)
+            : this(
+                scopeProvider,
+                scopeAccessor,
+                databaseFactory,
+                runtimeState,
+                loggerFactory,
+                keyValueService,
+                dbProviderFactoryCreator,
+                configManipulator,
+                globalSettings,
+                connectionStrings,
+                migrationPlanExecutor,
+                databaseSchemaCreatorFactory,
+                databaseProviderMetadata,
+                StaticServiceProvider.Instance.GetRequiredService<IEventAggregator>()
+            )
+        {
         }
 
         #region Status

--- a/src/Umbraco.Infrastructure/Migrations/MigrationContext.cs
+++ b/src/Umbraco.Infrastructure/Migrations/MigrationContext.cs
@@ -22,6 +22,7 @@ internal class MigrationContext : IMigrationContext
     }
 
     // this is only internally exposed
+    [Obsolete("This will be removed in the V13, and replaced with a RebuildCache flag on the MigrationBase")]
     public IReadOnlyList<Type> PostMigrations => _postMigrations;
 
     /// <inheritdoc />
@@ -42,6 +43,7 @@ internal class MigrationContext : IMigrationContext
     public bool BuildingExpression { get; set; }
 
     /// <inheritdoc />
+    [Obsolete("This will be removed in the V13, and replaced with a RebuildCache flag on the MigrationBase")]
     public void AddPostMigration<TMigration>()
         where TMigration : MigrationBase =>
 

--- a/src/Umbraco.Infrastructure/Migrations/MigrationContext.cs
+++ b/src/Umbraco.Infrastructure/Migrations/MigrationContext.cs
@@ -43,7 +43,7 @@ internal class MigrationContext : IMigrationContext
     public bool BuildingExpression { get; set; }
 
     /// <inheritdoc />
-    [Obsolete("This will be removed in the V13, and replaced with a RebuildCache flag on the MigrationBase")]
+    [Obsolete("This will be removed in the V13, and replaced with a RebuildCache flag on the MigrationBase, and a UmbracoPlanExecutedNotification.")]
     public void AddPostMigration<TMigration>()
         where TMigration : MigrationBase =>
 

--- a/src/Umbraco.Infrastructure/Migrations/MigrationPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/MigrationPlan.cs
@@ -45,6 +45,7 @@ public class MigrationPlan
     /// </summary>
     public IReadOnlyDictionary<string, Transition?> Transitions => _transitions;
 
+    [Obsolete("This will be removed in the V13, and replaced with a RebuildCache flag on the MigrationBase")]
     public IReadOnlyList<Type> PostMigrationTypes => _postMigrationTypes;
 
     /// <summary>
@@ -296,6 +297,7 @@ public class MigrationPlan
     /// <summary>
     ///     Adds a post-migration to the plan.
     /// </summary>
+    [Obsolete("This will be removed in the V13, and replaced with a RebuildCache flag on the MigrationBase")]
     public virtual MigrationPlan AddPostMigration<TMigration>()
         where TMigration : MigrationBase
     {

--- a/src/Umbraco.Infrastructure/Migrations/MigrationPlanExecutor.cs
+++ b/src/Umbraco.Infrastructure/Migrations/MigrationPlanExecutor.cs
@@ -47,8 +47,7 @@ public class MigrationPlanExecutor : IMigrationPlanExecutor
             migrationBuilder,
             StaticServiceProvider.Instance.GetRequiredService<IUmbracoDatabaseFactory>(),
             StaticServiceProvider.Instance.GetRequiredService<IPublishedSnapshotService>(),
-            StaticServiceProvider.Instance.GetRequiredService<DistributedCache>()
-            )
+            StaticServiceProvider.Instance.GetRequiredService<DistributedCache>())
     {
     }
 

--- a/src/Umbraco.Infrastructure/Migrations/MigrationPlanExecutor.cs
+++ b/src/Umbraco.Infrastructure/Migrations/MigrationPlanExecutor.cs
@@ -1,6 +1,11 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Migrations;
+using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Infrastructure.Scoping;
 
 namespace Umbraco.Cms.Infrastructure.Migrations;
@@ -17,13 +22,34 @@ public class MigrationPlanExecutor : IMigrationPlanExecutor
         ICoreScopeProvider scopeProvider,
         IScopeAccessor scopeAccessor,
         ILoggerFactory loggerFactory,
-        IMigrationBuilder migrationBuilder)
+        IMigrationBuilder migrationBuilder,
+        IUmbracoDatabaseFactory databaseFactory,
+        IPublishedSnapshotService publishedSnapshotService,
+        DistributedCache distributedCache)
     {
         _scopeProvider = scopeProvider;
         _scopeAccessor = scopeAccessor;
         _loggerFactory = loggerFactory;
         _migrationBuilder = migrationBuilder;
         _logger = _loggerFactory.CreateLogger<MigrationPlanExecutor>();
+    }
+
+    [Obsolete("Use constructor with 7 parameters")]
+    public MigrationPlanExecutor(
+        ICoreScopeProvider scopeProvider,
+        IScopeAccessor scopeAccessor,
+        ILoggerFactory loggerFactory,
+        IMigrationBuilder migrationBuilder)
+        : this(
+            scopeProvider,
+            scopeAccessor,
+            loggerFactory,
+            migrationBuilder,
+            StaticServiceProvider.Instance.GetRequiredService<IUmbracoDatabaseFactory>(),
+            StaticServiceProvider.Instance.GetRequiredService<IPublishedSnapshotService>(),
+            StaticServiceProvider.Instance.GetRequiredService<DistributedCache>()
+            )
+    {
     }
 
     /// <summary>
@@ -36,6 +62,7 @@ public class MigrationPlanExecutor : IMigrationPlanExecutor
     /// <param name="loggerFactory"></param>
     /// <returns>The final state.</returns>
     /// <remarks>The plan executes within the scope, which must then be completed.</remarks>
+    [Obsolete("This will return an ExecutedMigrationPlan in V13")]
     public string Execute(MigrationPlan plan, string fromState)
     {
         plan.Validate();

--- a/src/Umbraco.Infrastructure/Migrations/PostMigrations/ClearCsrfCookies.cs
+++ b/src/Umbraco.Infrastructure/Migrations/PostMigrations/ClearCsrfCookies.cs
@@ -6,6 +6,7 @@ namespace Umbraco.Cms.Infrastructure.Migrations.PostMigrations;
 /// <summary>
 ///     Clears Csrf tokens.
 /// </summary>
+[Obsolete("Removed in the V13, and replaced with a notification handler")]
 public class ClearCsrfCookies : MigrationBase
 {
     private readonly ICookieManager _cookieManager;

--- a/src/Umbraco.Infrastructure/Migrations/PostMigrations/DeleteLogViewerQueryFile.cs
+++ b/src/Umbraco.Infrastructure/Migrations/PostMigrations/DeleteLogViewerQueryFile.cs
@@ -6,6 +6,7 @@ namespace Umbraco.Cms.Infrastructure.Migrations.PostMigrations;
 /// <summary>
 ///     Deletes the old file that saved log queries
 /// </summary>
+[Obsolete("This will be removed in the V13")]
 public class DeleteLogViewerQueryFile : MigrationBase
 {
     private readonly IHostingEnvironment _hostingEnvironment;
@@ -26,5 +27,6 @@ public class DeleteLogViewerQueryFile : MigrationBase
         // {
         //     File.Delete(logViewerQueryFile);
         // }
+        // }Rebuild
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/PostMigrations/RebuildPublishedSnapshot.cs
+++ b/src/Umbraco.Infrastructure/Migrations/PostMigrations/RebuildPublishedSnapshot.cs
@@ -3,6 +3,7 @@ namespace Umbraco.Cms.Infrastructure.Migrations.PostMigrations;
 /// <summary>
 ///     Rebuilds the published snapshot.
 /// </summary>
+[Obsolete("This will be removed in the V13, and replaced with a RebuildCache flag on the MigrationBase")]
 public class RebuildPublishedSnapshot : MigrationBase
 {
     private readonly IPublishedSnapshotRebuilder _rebuilder;

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/Upgrader.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/Upgrader.cs
@@ -70,7 +70,7 @@ public class Upgrader
             }
 
             // execute plan
-            var state = migrationPlanExecutor.Execute(Plan, currentState);
+            var state = migrationPlanExecutor.ExecutePlan(Plan, currentState).FinalState;
             if (string.IsNullOrWhiteSpace(state))
             {
                 throw new InvalidOperationException("Plan execution returned an invalid null or empty state.");

--- a/tests/Umbraco.Tests.UnitTests/AutoFixture/Customizations/UmbracoCustomizations.cs
+++ b/tests/Umbraco.Tests.UnitTests/AutoFixture/Customizations/UmbracoCustomizations.cs
@@ -39,7 +39,8 @@ internal class UmbracoCustomizations : ICustomization
             .Customize(new ConstructorCustomization(typeof(MemberManager), new GreedyConstructorQuery()))
             .Customize(new ConstructorCustomization(typeof(DatabaseSchemaCreatorFactory), new GreedyConstructorQuery()))
             .Customize(new ConstructorCustomization(typeof(BackOfficeServerVariables), new GreedyConstructorQuery()))
-            .Customize(new ConstructorCustomization(typeof(InstallHelper), new GreedyConstructorQuery()));
+            .Customize(new ConstructorCustomization(typeof(InstallHelper), new GreedyConstructorQuery()))
+            .Customize(new ConstructorCustomization(typeof(DatabaseBuilder), new GreedyConstructorQuery()));
 
         // When requesting an IUserStore ensure we actually uses a IUserLockoutStore
         fixture.Customize<IUserStore<BackOfficeIdentityUser>>(cc =>

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/MigrationPlanTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/MigrationPlanTests.cs
@@ -9,9 +9,12 @@ using Microsoft.Extensions.Options;
 using Moq;
 using NPoco;
 using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Infrastructure.Migrations;
 using Umbraco.Cms.Infrastructure.Migrations.Upgrade;
 using Umbraco.Cms.Infrastructure.Persistence;
@@ -59,7 +62,17 @@ public class MigrationPlanTests
                 }
             });
 
-        var executor = new MigrationPlanExecutor(scopeProvider, scopeProvider, loggerFactory, migrationBuilder);
+        var databaseFactory = Mock.Of<IUmbracoDatabaseFactory>();
+        var publishedSnapshotService = Mock.Of<IPublishedSnapshotService>();
+        var distributedCache = new DistributedCache(Mock.Of<IServerMessenger>(), new CacheRefresherCollection(Enumerable.Empty<ICacheRefresher>));
+        var executor = new MigrationPlanExecutor(
+            scopeProvider,
+            scopeProvider,
+            loggerFactory,
+            migrationBuilder,
+            databaseFactory,
+            publishedSnapshotService,
+            distributedCache);
 
         var plan = new MigrationPlan("default")
             .From(string.Empty)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/PostMigrationTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/PostMigrationTests.cs
@@ -8,11 +8,14 @@ using Microsoft.Extensions.Options;
 using Moq;
 using NPoco;
 using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Migrations;
+using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Infrastructure.Migrations;
 using Umbraco.Cms.Infrastructure.Migrations.Upgrade;
 using Umbraco.Cms.Infrastructure.Persistence;
@@ -32,7 +35,12 @@ public class PostMigrationTests
         ICoreScopeProvider scopeProvider,
         IScopeAccessor scopeAccessor,
         IMigrationBuilder builder)
-        => new MigrationPlanExecutor(scopeProvider, scopeAccessor, s_loggerFactory, builder);
+    {
+        var databaseFactory = Mock.Of<IUmbracoDatabaseFactory>();
+        var publishedSnapshotService = Mock.Of<IPublishedSnapshotService>();
+        var distributedCache = new DistributedCache(Mock.Of<IServerMessenger>(), new CacheRefresherCollection(Enumerable.Empty<ICacheRefresher>));
+        return new MigrationPlanExecutor(scopeProvider, scopeAccessor, s_loggerFactory, builder, databaseFactory, publishedSnapshotService, distributedCache);
+    }
 
     [Test]
     public void ExecutesPlanPostMigration()


### PR DESCRIPTION
This PR obsoletes the things broken in #13654.

Where possible I've tried to provide alternatives, but for some, like `DeleteLogViewerQueryFile` there isn't really an alternative, it'll be removed because it isn't used. 