### PR TITLE
Re-introduce the option to conditionally login members after registration

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Snippets/RegisterMember.cshtml
+++ b/src/Umbraco.Core/EmbeddedResources/Snippets/RegisterMember.cshtml
@@ -18,6 +18,9 @@
         // Set to true if you want the member editable properties shown.
         // It will only displays properties marked as "Member can edit" on the "Info" tab of the Member Type.
         .WithCustomProperties(false)
+        // By default the member will be logged in automatically after registration.
+        // Set this to false if the member should not be logged in automatically.
+        .WithAutomaticLogIn(true)
         .Build();
 
     var success = TempData["FormSuccess"] != null;
@@ -39,7 +42,8 @@ else
             new {
                 MemberTypeAlias = registerModel.MemberTypeAlias,
                 UsernameIsEmail = registerModel.UsernameIsEmail,
-                RedirectUrl = registerModel.RedirectUrl
+                RedirectUrl = registerModel.RedirectUrl,
+                AutomaticLogIn = registerModel.AutomaticLogIn
             }))
     {
         <h2>Create a new account.</h2>

--- a/src/Umbraco.Web.Website/Controllers/UmbRegisterController.cs
+++ b/src/Umbraco.Web.Website/Controllers/UmbRegisterController.cs
@@ -95,6 +95,12 @@ public class UmbRegisterController : SurfaceController
         {
             model.UsernameIsEmail = usernameIsEmail.ToString() == "True";
         }
+
+        if (RouteData.Values.TryGetValue(nameof(RegisterModel.AutomaticLogIn), out var automaticLogin) &&
+            automaticLogin != null)
+        {
+            model.AutomaticLogIn = automaticLogin.ToString() == "True";
+        }
     }
 
     private void AddErrors(IdentityResult result)
@@ -109,9 +115,8 @@ public class UmbRegisterController : SurfaceController
     ///     Registers a new member.
     /// </summary>
     /// <param name="model">Register member model.</param>
-    /// <param name="logMemberIn">Flag for whether to log the member in upon successful registration.</param>
     /// <returns>Result of registration operation.</returns>
-    private async Task<IdentityResult> RegisterMemberAsync(RegisterModel model, bool logMemberIn = true)
+    private async Task<IdentityResult> RegisterMemberAsync(RegisterModel model)
     {
         using ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true);
 
@@ -149,7 +154,7 @@ public class UmbRegisterController : SurfaceController
 
             _memberService.Save(member);
 
-            if (logMemberIn)
+            if (model.AutomaticLogIn)
             {
                 await _memberSignInManager.SignInAsync(identityUser, false);
             }

--- a/src/Umbraco.Web.Website/Models/RegisterModel.cs
+++ b/src/Umbraco.Web.Website/Models/RegisterModel.cs
@@ -13,6 +13,7 @@ public class RegisterModel : PostRedirectModel
         MemberTypeAlias = Constants.Conventions.MemberTypes.DefaultAlias;
         UsernameIsEmail = true;
         MemberProperties = new List<MemberPropertyModel>();
+        AutomaticLogIn = true;
     }
 
     [Required]
@@ -59,4 +60,9 @@ public class RegisterModel : PostRedirectModel
     ///     Flag to determine if the username should be the email address, if true then the Username property is ignored
     /// </summary>
     public bool UsernameIsEmail { get; set; }
+
+    /// <summary>
+    ///     Flag to determine if the member should be logged in automatically after successful registration
+    /// </summary>
+    public bool AutomaticLogIn { get; set; }
 }

--- a/src/Umbraco.Web.Website/Models/RegisterModelBuilder.cs
+++ b/src/Umbraco.Web.Website/Models/RegisterModelBuilder.cs
@@ -14,7 +14,7 @@ public class RegisterModelBuilder : MemberModelBuilderBase
     private string? _memberTypeAlias;
     private string? _redirectUrl;
     private bool _usernameIsEmail;
-    private bool _automaticLogIn;
+    private bool _automaticLogIn = true;
 
     public RegisterModelBuilder(IMemberTypeService memberTypeService, IShortStringHelper shortStringHelper)
         : base(memberTypeService, shortStringHelper)

--- a/src/Umbraco.Web.Website/Models/RegisterModelBuilder.cs
+++ b/src/Umbraco.Web.Website/Models/RegisterModelBuilder.cs
@@ -14,6 +14,7 @@ public class RegisterModelBuilder : MemberModelBuilderBase
     private string? _memberTypeAlias;
     private string? _redirectUrl;
     private bool _usernameIsEmail;
+    private bool _automaticLogIn;
 
     public RegisterModelBuilder(IMemberTypeService memberTypeService, IShortStringHelper shortStringHelper)
         : base(memberTypeService, shortStringHelper)
@@ -44,6 +45,12 @@ public class RegisterModelBuilder : MemberModelBuilderBase
         return this;
     }
 
+    public RegisterModelBuilder WithAutomaticLogIn(bool automaticLogIn = true)
+    {
+        _automaticLogIn = automaticLogIn;
+        return this;
+    }
+
     public RegisterModel Build()
     {
         var providedOrDefaultMemberTypeAlias = _memberTypeAlias ?? Constants.Conventions.MemberTypes.DefaultAlias;
@@ -62,6 +69,7 @@ public class RegisterModelBuilder : MemberModelBuilderBase
             MemberProperties = _lookupProperties
                 ? GetMemberPropertiesViewModel(memberType)
                 : Enumerable.Empty<MemberPropertyModel>().ToList(),
+            AutomaticLogIn = _automaticLogIn
         };
         return model;
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/11923

### Description

This PR re-introduces the option to conditionally log in members after registration using the built-in macro templates and controllers. Today they are always logged in with no option to bypass that - previously that was configurable in the template.

The default remains as members being automatically logged in.

### Testing this PR

1. Create three macro using the built-in templates:
   - "Register Member"
   - "Login"
   - "Login Status"  
![image](https://user-images.githubusercontent.com/7405322/211826969-ce69a326-5cc3-4f27-9226-0aad3515b6ba.png)
2. Make sure the macros are allowed in RTEs.
![image](https://user-images.githubusercontent.com/7405322/211827103-de8a5118-4250-4976-8239-23c61dedab52.png)
3. Add all macros to an RTE.
![image](https://user-images.githubusercontent.com/7405322/211827269-d92ab372-f5ad-42b7-9212-594be63ef1f3.png)
4. Render the RTE in the template with something like this:
```html
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
@{
	Layout = null;
}
<html>
<body>
@Model.Value("text")
</body>
</html>
```
5. Register a new member and verify that newly registered member is logged in automatically.
   - You may want to do this in an incognito browser to make testing easier.
6. Log the member out.
7. Go to the "Register Member" template and change `.WithAutomaticLogIn(true)` from `true` to `false`.
![image](https://user-images.githubusercontent.com/7405322/211828153-c2cda5d2-3a20-4768-b3f4-56ef0f841dca.png)
8. Register a new member and verify that newly registered member is *not* logged in automatically. 
9. Verify that you can log the newly registered member in explicitly.
