### PR TITLE
Make sure the expand icon is never faded in mini list views

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/listview.less
+++ b/src/Umbraco.Web.UI.Client/src/less/listview.less
@@ -153,8 +153,10 @@
 
 .umb-minilistview {
     .umb-table-row.not-allowed {
+      cursor: not-allowed;
+      .umb-minilistview__fade-not-allowed {
         opacity: 0.6;
-        cursor: not-allowed;
+      }
     }
 
     div.umb-mini-list-view__breadcrumb {

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-mini-list-view.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-mini-list-view.html
@@ -64,12 +64,12 @@
                     ng-class="{'-selected':child.selected, 'not-allowed':!child.allowed}">
                     <div class="umb-table-cell umb-table-cell--auto-width" ng-class="{'umb-table-cell--faded':child.published === false}">
                         <div class="flex items-center">
-                            <umb-icon icon="icon-navigation-right" class="umb-table__row-expand" ng-click="openNode($event, child)" ng-class="{'umb-table__row-expand--hidden': child.metaData.hasChildren !== true}">&nbsp;</umb-icon>
-                            <umb-icon icon="{{child.icon}}" class="umb-table-body__icon umb-table-body__fileicon"></umb-icon>
+                            <umb-icon icon="icon-navigation-right" class="umb-table__row-expand cursor-pointer" ng-click="openNode($event, child)" ng-class="{'umb-table__row-expand--hidden': child.metaData.hasChildren !== true}">&nbsp;</umb-icon>
+                            <umb-icon icon="{{child.icon}}" class="umb-table-body__icon umb-table-body__fileicon umb-minilistview__fade-not-allowed"></umb-icon>
                             <umb-icon icon="icon-check" class="umb-table-body__icon umb-table-body__checkicon"></umb-icon>
                         </div>
                     </div>
-                    <div class="umb-table-cell black" ng-class="{'umb-table-cell--faded':child.published === false}">{{ child.name }}</div>
+                    <div class="umb-table-cell black umb-minilistview__fade-not-allowed" ng-class="{'umb-table-cell--faded':child.published === false}">{{ child.name }}</div>
                 </div>
 
                 <!-- Show a message when no items are found, depending on whether you searched or the list was empty anyway -->


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/11741

### Description

If items in the mini list view are un-selectable, the item gets dimmed down (opacity 0.6) and a not-allowed cursor is applied. Unfortunately this also affects the right-arrow icon that indicates one can expand the un-selectable item. Thus it's not entirely obvious that one can expand the item, as the expand icon is dimmed down and has a not-allowed cursor. But you actually can expand it (and rightfully so!).

Here's how it plays out:

![11741-before](https://user-images.githubusercontent.com/7405322/211872739-5f1bff3e-806a-44c3-93b5-c7bc7ba00243.gif)

This PR fixes it by making the CSS a tad more deliberate/specific. Here's another screencast with this PR applied:

![11741-fix](https://user-images.githubusercontent.com/7405322/211872131-b45b0586-bf99-4fab-a631-d10ad83a6378.gif)
