### PR TITLE
Fix broken buttons for properties with alias "navigation"

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umb-block-list-property-editor.html
@@ -31,7 +31,7 @@
 
         <div class="umb-block-list__actions" ng-if="vm.loading !== true && !vm.singleBlockMode">
             <button
-                    id="{{vm.model.alias}}"
+                    id="button_{{vm.model.alias}}"
                     type="button"
                     class="btn-reset umb-block-list__create-button umb-outline"
                     ng-disabled="vm.availableBlockTypes.length === 0 || vm.readonly"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umb-media-picker3-property-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umb-media-picker3-property-editor.html
@@ -100,7 +100,7 @@
             </div>
 
             <button ng-if="vm.loading !== true && ((vm.singleMode === true && vm.model.value.length === 0) || vm.singleMode !== true)"
-                    id="{{vm.model.alias}}"
+                    id="button_{{vm.model.alias}}"
                     type="button"
                     class="btn-reset umb-media-card-grid__create-button umb-outline"
                     ng-disabled="!vm.allowAddMedia"


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/11688

### Description

As mentioned on the linked issue there are some problems when certain property editors have the alias `navigation`:

**Block list**

![image](https://user-images.githubusercontent.com/7405322/212010174-bd0ba6c5-ddf4-479b-b9e8-3bbd0a2ca12b.png)

**Media picker 3**

![image](https://user-images.githubusercontent.com/7405322/212010410-312b25e0-150c-4350-a4f5-928c8f645643.png)

With this PR applied the property editor add/create buttons look as they should:

**Block list**

![image](https://user-images.githubusercontent.com/7405322/212010693-a51292b5-af1d-4174-a53f-dbc204b90ee4.png)

**Media picker 3**

![image](https://user-images.githubusercontent.com/7405322/212010747-086c8729-bd0a-4448-b2cb-51bf3527d856.png)
