### PR TITLE
New backoffice: Obsolete ReadOnlyUserGroup constructor.

### DIFF
--- a/src/Umbraco.Core/Models/Membership/ReadOnlyUserGroup.cs
+++ b/src/Umbraco.Core/Models/Membership/ReadOnlyUserGroup.cs
@@ -29,7 +29,7 @@ public class ReadOnlyUserGroup : IReadOnlyUserGroup, IEquatable<ReadOnlyUserGrou
         HasAccessToAllLanguages = hasAccessToAllLanguages;
     }
 
-    [Obsolete("Please use constructor that takes a guid.")]
+    [Obsolete("Please use constructor that takes a Guid key. Scheduled for removal in v13")]
     public ReadOnlyUserGroup(
         int id,
         string? name,

--- a/src/Umbraco.Core/Models/Membership/ReadOnlyUserGroup.cs
+++ b/src/Umbraco.Core/Models/Membership/ReadOnlyUserGroup.cs
@@ -4,6 +4,7 @@ public class ReadOnlyUserGroup : IReadOnlyUserGroup, IEquatable<ReadOnlyUserGrou
 {
     public ReadOnlyUserGroup(
         int id,
+        Guid key, // This is not used for anything now, but will be in v13
         string? name,
         string? icon,
         int? startContentId,
@@ -28,6 +29,33 @@ public class ReadOnlyUserGroup : IReadOnlyUserGroup, IEquatable<ReadOnlyUserGrou
         HasAccessToAllLanguages = hasAccessToAllLanguages;
     }
 
+    [Obsolete("Please use constructor that takes a guid.")]
+    public ReadOnlyUserGroup(
+        int id,
+        string? name,
+        string? icon,
+        int? startContentId,
+        int? startMediaId,
+        string? alias,
+        IEnumerable<int> allowedLanguages,
+        IEnumerable<string> allowedSections,
+        IEnumerable<string>? permissions,
+        bool hasAccessToAllLanguages)
+    : this(
+        id,
+        Guid.NewGuid(),
+        name,
+        icon,
+        startContentId,
+        startMediaId,
+        alias,
+        allowedLanguages,
+        allowedSections,
+        permissions,
+        hasAccessToAllLanguages)
+    {
+    }
+
     [Obsolete("please use ctor that takes allowedActions & hasAccessToAllLanguages instead, scheduled for removal in v12")]
     public ReadOnlyUserGroup(
         int id,
@@ -38,7 +66,7 @@ public class ReadOnlyUserGroup : IReadOnlyUserGroup, IEquatable<ReadOnlyUserGrou
         string? alias,
         IEnumerable<string> allowedSections,
         IEnumerable<string>? permissions)
-    : this(id, name, icon, startContentId, startMediaId, alias, Enumerable.Empty<int>(), allowedSections, permissions, true)
+    : this(id, Guid.NewGuid(), name, icon, startContentId, startMediaId, alias, Enumerable.Empty<int>(), allowedSections, permissions, true)
     {
     }
 

--- a/src/Umbraco.Core/Models/Membership/UserGroupExtensions.cs
+++ b/src/Umbraco.Core/Models/Membership/UserGroupExtensions.cs
@@ -14,7 +14,7 @@ public static class UserGroupExtensions
         }
 
         // otherwise create one
-        return new ReadOnlyUserGroup(group.Id, group.Name, group.Icon, group.StartContentId, group.StartMediaId, group.Alias, group.AllowedLanguages, group.AllowedSections, group.Permissions, group.HasAccessToAllLanguages);
+        return new ReadOnlyUserGroup(group.Id, group.Key, group.Name, group.Icon, group.StartContentId, group.StartMediaId, group.Alias, group.AllowedLanguages, group.AllowedSections, group.Permissions, group.HasAccessToAllLanguages);
     }
 
     public static bool IsSystemUserGroup(this IUserGroup group) =>

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Editors/UserEditorAuthorizationHelperTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Editors/UserEditorAuthorizationHelperTests.cs
@@ -116,7 +116,7 @@ public class UserEditorAuthorizationHelperTests
     {
         var currentUser = Mock.Of<IUser>(user => user.Groups == new[]
         {
-            new ReadOnlyUserGroup(1, "CurrentUser", "icon-user", null, null, groupAlias, new int[0], new string[0], new string[0], true),
+            new ReadOnlyUserGroup(1, Guid.NewGuid(),  "CurrentUser", "icon-user", null, null, groupAlias, new int[0], new string[0], new string[0], true),
         });
         IUser savingUser = null; // This means it is a new created user
 


### PR DESCRIPTION
This obsoletes the `ReadOnlyUserGroup` constructor broken by #13672