### PR TITLE
V11: Add improved log message on compilation failure using InMemoryAuto

### DIFF
--- a/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/CollectibleRuntimeViewCompiler.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/CollectibleRuntimeViewCompiler.cs
@@ -401,18 +401,16 @@ internal class CollectibleRuntimeViewCompiler : IViewCompiler
 
     private void LogCompilationFailure(UmbracoCompilationException compilationException)
     {
-        IEnumerable<DiagnosticMessage?>? diagnosticMessages = compilationException.CompilationFailures?
+        IEnumerable<string>? messages = compilationException.CompilationFailures?
             .WhereNotNull()
-            .SelectMany(x => x.Messages!);
+            .SelectMany(x => x.Messages!)
+            .WhereNotNull()
+            .Select(x => x.FormattedMessage)
+            .WhereNotNull();
 
-        foreach (DiagnosticMessage? diagnosticMessage in diagnosticMessages ?? Enumerable.Empty<DiagnosticMessage>())
+        foreach (var message in messages ?? Enumerable.Empty<string>())
         {
-            if (diagnosticMessage?.FormattedMessage is null)
-            {
-                continue;
-            }
-
-            _logger.LogError(compilationException, "Compilation error occured with message: {ErrorMessage}", diagnosticMessage.FormattedMessage);
+            _logger.LogError(compilationException, "Compilation error occured with message: {ErrorMessage}", message);
         }
     }
 

--- a/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/CollectibleRuntimeViewCompiler.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/CollectibleRuntimeViewCompiler.cs
@@ -384,23 +384,7 @@ internal class CollectibleRuntimeViewCompiler : IViewCompiler
                     assemblyName,
                     result.Diagnostics);
 
-                foreach (CompilationFailure? compilationFailure in compilationException.CompilationFailures ?? Enumerable.Empty<CompilationFailure>())
-                {
-                    if (compilationFailure?.Messages is null)
-                    {
-                        continue;
-                    }
-
-                    foreach (DiagnosticMessage? message in compilationFailure.Messages)
-                    {
-                        if (message?.FormattedMessage is null)
-                        {
-                            continue;
-                        }
-
-                        _logger.LogError(compilationException, "Compilation error occured with message: {ErrorMessage}", message.FormattedMessage);
-                    }
-                }
+                LogCompilationFailure(compilationException);
 
                 throw compilationException;
             }
@@ -411,6 +395,27 @@ internal class CollectibleRuntimeViewCompiler : IViewCompiler
             Assembly assembly = _loadContextManager.LoadCollectibleAssemblyFromStream(assemblyStream, pdbStream);
 
             return assembly;
+        }
+    }
+
+    private void LogCompilationFailure(UmbracoCompilationException compilationException)
+    {
+        foreach (CompilationFailure? compilationFailure in compilationException.CompilationFailures ?? Enumerable.Empty<CompilationFailure>())
+        {
+            if (compilationFailure?.Messages is null)
+            {
+                continue;
+            }
+
+            foreach (DiagnosticMessage? message in compilationFailure.Messages)
+            {
+                if (message?.FormattedMessage is null)
+                {
+                    continue;
+                }
+
+                _logger.LogError(compilationException, "Compilation error occured with message: {ErrorMessage}", message.FormattedMessage);
+            }
         }
     }
 


### PR DESCRIPTION
We got a report internally that the log message has changed as part of the InMemory fix for V11. 

Previously the specific compilation error would be displayed on the front end if development was enabled, AND logged in the backoffice regardless of development status.

After the changes in #13107 this log message changed to a generic unhelpful message.

Unfortunately, this is logged from the `DeveloperExceptionPageMiddleware` which is dotnet thing, so we can't really change that. 

Instead, I've added a log message in the `CollectibleRuntimeViewCompiler` which will display the helpful message. 

## Testing 

To test this make sure your site is using InMemoryAuto.

Now create a view with a compilation exception, for instance by adding `@Model.ThisPropertyDoesntExist`, and ensure that a helpful message is logged in the backoffice like so: 

![image](https://user-images.githubusercontent.com/16456704/212701645-af83074b-d89d-4b02-8967-a91cb691703d.png)
