### PR TITLE
Turn the indexer health status into an enum

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Indexer/AllIndexerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Indexer/AllIndexerController.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
-using Umbraco.Cms.Api.Management.ViewModels.Search;
+using Umbraco.Cms.Api.Management.ViewModels.Indexer;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Indexer;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Indexer/DetailsIndexerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Indexer/DetailsIndexerController.cs
@@ -2,7 +2,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
-using Umbraco.Cms.Api.Management.ViewModels.Search;
+using Umbraco.Cms.Api.Management.ViewModels.Indexer;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Indexer;
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Searcher/AllSearcherController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Searcher/AllSearcherController.cs
@@ -2,7 +2,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
-using Umbraco.Cms.Api.Management.ViewModels.Search;
+using Umbraco.Cms.Api.Management.ViewModels.Searcher;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Searcher;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Searcher/QuerySearcherController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Searcher/QuerySearcherController.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Services;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
-using Umbraco.Cms.Api.Management.ViewModels.Search;
+using Umbraco.Cms.Api.Management.ViewModels.Searcher;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Searcher;

--- a/src/Umbraco.Cms.Api.Management/Factories/IIndexViewModelFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IIndexViewModelFactory.cs
@@ -1,5 +1,5 @@
 ﻿using Examine;
-using Umbraco.Cms.Api.Management.ViewModels.Search;
+using Umbraco.Cms.Api.Management.ViewModels.Indexer;
 
 namespace Umbraco.Cms.Api.Management.Factories;
 

--- a/src/Umbraco.Cms.Api.Management/Factories/IndexViewModelFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IndexViewModelFactory.cs
@@ -1,7 +1,7 @@
 ﻿using Examine;
+using Umbraco.Cms.Api.Management.ViewModels.Indexer;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Infrastructure.Examine;
-using Umbraco.Cms.Api.Management.ViewModels.Search;
 using Umbraco.New.Cms.Infrastructure.Services;
 
 namespace Umbraco.Cms.Api.Management.Factories;
@@ -26,7 +26,7 @@ public class IndexViewModelFactory : IIndexViewModelFactory
             return new IndexViewModel
             {
                 Name = index.Name,
-                HealthStatus = "Rebuilding",
+                HealthStatus = HealthStatus.Rebuilding,
                 SearcherName = index.Searcher.Name,
                 DocumentCount = 0,
                 FieldCount = 0,
@@ -55,7 +55,7 @@ public class IndexViewModelFactory : IIndexViewModelFactory
         var indexerModel = new IndexViewModel
         {
             Name = index.Name,
-            HealthStatus = isHealthy.Success ? isHealthy.Result ?? "Healthy" : isHealthy.Result ?? "Unhealthy",
+            HealthStatus = isHealthy.Success ? HealthStatus.Healthy : HealthStatus.Unhealthy,
             CanRebuild = _indexRebuilder.CanRebuild(index.Name),
             SearcherName = index.Searcher.Name,
             DocumentCount = indexDiag.GetDocumentCount(),

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -815,7 +815,7 @@
         ],
         "operationId": "PostDictionaryUpload",
         "requestBody": {
-          "content": { }
+          "content": {}
         },
         "responses": {
           "200": {
@@ -1216,22 +1216,22 @@
           }
         ],
         "responses": {
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PagedRecycleBinItem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -1266,22 +1266,22 @@
           }
         ],
         "responses": {
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PagedRecycleBinItem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -1515,22 +1515,22 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundResult"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/HealthCheckGroupWithResult"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResult"
                 }
               }
             }
@@ -1554,22 +1554,22 @@
           }
         },
         "responses": {
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/HealthCheckResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -1624,22 +1624,22 @@
           }
         ],
         "responses": {
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PagedHelpPage"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -1702,22 +1702,22 @@
           }
         ],
         "responses": {
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Index"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -1742,22 +1742,22 @@
           }
         ],
         "responses": {
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OkResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -1772,6 +1772,16 @@
         ],
         "operationId": "GetInstallSettings",
         "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstallSettings"
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -1788,16 +1798,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InstallSettings"
                 }
               }
             }
@@ -1821,6 +1821,9 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "Success"
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -1840,9 +1843,6 @@
                 }
               }
             }
-          },
-          "200": {
-            "description": "Success"
           }
         }
       }
@@ -1863,6 +1863,9 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "Success"
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -1872,9 +1875,6 @@
                 }
               }
             }
-          },
-          "200": {
-            "description": "Success"
           }
         }
       }
@@ -1895,6 +1895,9 @@
           }
         },
         "responses": {
+          "201": {
+            "description": "Created"
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -1904,9 +1907,6 @@
                 }
               }
             }
-          },
-          "201": {
-            "description": "Created"
           }
         }
       },
@@ -1965,22 +1965,22 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundResult"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Language"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResult"
                 }
               }
             }
@@ -2004,6 +2004,9 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Success"
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2023,9 +2026,6 @@
                 }
               }
             }
-          },
-          "200": {
-            "description": "Success"
           }
         }
       },
@@ -2055,15 +2055,8 @@
           }
         },
         "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundResult"
-                }
-              }
-            }
+          "200": {
+            "description": "Success"
           },
           "400": {
             "description": "Bad Request",
@@ -2075,8 +2068,15 @@
               }
             }
           },
-          "200": {
-            "description": "Success"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResult"
+                }
+              }
+            }
           }
         }
       }
@@ -2256,22 +2256,22 @@
           }
         ],
         "responses": {
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PagedRecycleBinItem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -2306,22 +2306,22 @@
           }
         ],
         "responses": {
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PagedRecycleBinItem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -2932,22 +2932,22 @@
           }
         ],
         "responses": {
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PagedRedirectUrl"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -3490,22 +3490,22 @@
         ],
         "operationId": "GetServerStatus",
         "responses": {
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ServerStatus"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -3520,22 +3520,22 @@
         ],
         "operationId": "GetServerVersion",
         "responses": {
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Version"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -3859,6 +3859,9 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "Success"
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -3868,9 +3871,6 @@
                 }
               }
             }
-          },
-          "200": {
-            "description": "Success"
           }
         }
       }
@@ -5990,6 +5990,15 @@
         },
         "additionalProperties": false
       },
+      "HealthStatus": {
+        "enum": [
+          "Healthy",
+          "Unhealthy",
+          "Rebuilding"
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
       "HelpPage": {
         "type": "object",
         "properties": {
@@ -6025,7 +6034,6 @@
           "canRebuild",
           "documentCount",
           "fieldCount",
-          "isHealthy",
           "name"
         ],
         "type": "object",
@@ -6035,12 +6043,7 @@
             "type": "string"
           },
           "healthStatus": {
-            "type": "string",
-            "nullable": true
-          },
-          "isHealthy": {
-            "type": "boolean",
-            "readOnly": true
+            "$ref": "#/components/schemas/HealthStatus"
           },
           "canRebuild": {
             "type": "boolean"
@@ -6059,7 +6062,7 @@
           },
           "providerProperties": {
             "type": "object",
-            "additionalProperties": { },
+            "additionalProperties": {},
             "nullable": true
           }
         },
@@ -7219,7 +7222,7 @@
             "nullable": true
           }
         },
-        "additionalProperties": { }
+        "additionalProperties": {}
       },
       "ProfilingStatus": {
         "type": "object",
@@ -8617,7 +8620,7 @@
           "authorizationCode": {
             "authorizationUrl": "/umbraco/management/api/v1.0/security/back-office/authorize",
             "tokenUrl": "/umbraco/management/api/v1.0/security/back-office/token",
-            "scopes": { }
+            "scopes": {}
           }
         }
       }
@@ -8625,7 +8628,7 @@
   },
   "security": [
     {
-      "OAuth": [ ]
+      "OAuth": []
     }
   ]
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Indexer/HealthStatus.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Indexer/HealthStatus.cs
@@ -1,0 +1,8 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Indexer;
+
+public enum HealthStatus
+{
+    Healthy,
+    Unhealthy,
+    Rebuilding
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Indexer/IndexViewModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Indexer/IndexViewModel.cs
@@ -1,16 +1,13 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace Umbraco.Cms.Api.Management.ViewModels.Search;
+namespace Umbraco.Cms.Api.Management.ViewModels.Indexer;
 
 public class IndexViewModel
 {
     [Required]
     public string Name { get; init; } = null!;
 
-    public string? HealthStatus { get; init; }
-
-    [Required]
-    public bool IsHealthy => HealthStatus == "Healthy";
+    public HealthStatus HealthStatus { get; init; }
 
     [Required]
     public bool CanRebuild { get; init; }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Searcher/FieldViewModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Searcher/FieldViewModel.cs
@@ -1,4 +1,4 @@
-﻿namespace Umbraco.Cms.Api.Management.ViewModels.Search;
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Searcher;
 
 public class FieldViewModel
 {

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Searcher/SearchResultViewModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Searcher/SearchResultViewModel.cs
@@ -1,4 +1,4 @@
-﻿namespace Umbraco.Cms.Api.Management.ViewModels.Search;
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Searcher;
 
 public class SearchResultViewModel
 {

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Searcher/SearcherViewModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Searcher/SearcherViewModel.cs
@@ -1,4 +1,4 @@
-﻿namespace Umbraco.Cms.Api.Management.ViewModels.Search;
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Searcher;
 
 public class SearcherViewModel
 {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR changes the indexer health status to an enum rather than a string. 

This *may* result in less detailed index health status reports to the client, but this is preferable over the hardcoded magic strings otherwise required to recognize index health status. If the client really needs the detailed index health status reported by the index diagnostics, we can add a dedicated property for that later on.

A while ago the then-called "examine management" endpoint was split into dedicated endpoints for indexers and searchers. It seems we forgot to move the related view models to similar namespaces back then, so I have done that now 😄 

### Testing this PR

Validate that Swagger reports the index health status as an enum rather than a string:

![image](https://user-images.githubusercontent.com/7405322/212841117-3d61ce91-ad2b-48d0-934c-9af36ac5ee12.png)
