### PR TITLE
Uses URL path separator when generating UDIs for files nested in folders.

### DIFF
--- a/src/Umbraco.Core/Extensions/UdiGetterExtensions.cs
+++ b/src/Umbraco.Core/Extensions/UdiGetterExtensions.cs
@@ -232,9 +232,7 @@ public static class UdiGetterExtensions
             throw new ArgumentNullException("entity");
         }
 
-        return new StringUdi(
-            Constants.UdiEntityType.Stylesheet,
-            entity.Path.TrimStart(Constants.CharArrays.ForwardSlash)).EnsureClosed();
+        return GetUdiFromPath(Constants.UdiEntityType.Stylesheet, entity.Path);
     }
 
     /// <summary>
@@ -249,8 +247,15 @@ public static class UdiGetterExtensions
             throw new ArgumentNullException("entity");
         }
 
-        return new StringUdi(Constants.UdiEntityType.Script, entity.Path.TrimStart(Constants.CharArrays.ForwardSlash))
-            .EnsureClosed();
+        return GetUdiFromPath(Constants.UdiEntityType.Script, entity.Path);
+    }
+
+    private static StringUdi GetUdiFromPath(string entityType, string path)
+    {
+        var id = path
+            .TrimStart(Constants.CharArrays.ForwardSlash)
+            .Replace("\\", "/");
+        return new StringUdi(entityType, id).EnsureClosed();
     }
 
     /// <summary>
@@ -300,7 +305,7 @@ public static class UdiGetterExtensions
             ? Constants.UdiEntityType.PartialViewMacro
             : Constants.UdiEntityType.PartialView;
 
-        return new StringUdi(entityType, entity.Path.TrimStart(Constants.CharArrays.ForwardSlash)).EnsureClosed();
+        return GetUdiFromPath(entityType, entity.Path);
     }
 
     /// <summary>

--- a/tests/Umbraco.Tests.Common/Builders/PartialViewBuilder.cs
+++ b/tests/Umbraco.Tests.Common/Builders/PartialViewBuilder.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Tests.Common.Builders;
+
+public class PartialViewBuilder
+    : BuilderBase<IPartialView>
+{
+    private string _path;
+    private string _content;
+    private PartialViewType _viewType = PartialViewType.Unknown;
+
+    public PartialViewBuilder WithPath(string path)
+    {
+        _path = path;
+        return this;
+    }
+
+    public PartialViewBuilder WithContent(string content)
+    {
+        _content = content;
+        return this;
+    }
+
+    public PartialViewBuilder WithViewType(PartialViewType viewType)
+    {
+        _viewType = viewType;
+        return this;
+    }
+
+    public override IPartialView Build()
+    {
+        var path = _path ?? string.Empty;
+        var content = _content ?? string.Empty;
+        var viewType = _viewType;
+
+        return new PartialView(viewType, path) { Content = content };
+    }
+}

--- a/tests/Umbraco.Tests.Common/Builders/ScriptBuilder.cs
+++ b/tests/Umbraco.Tests.Common/Builders/ScriptBuilder.cs
@@ -5,29 +5,29 @@ using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Tests.Common.Builders;
 
-public class StylesheetBuilder
-    : BuilderBase<Stylesheet>
+public class ScriptBuilder
+    : BuilderBase<Script>
 {
     private string _path;
     private string _content;
 
-    public StylesheetBuilder WithPath(string path)
+    public ScriptBuilder WithPath(string path)
     {
         _path = path;
         return this;
     }
 
-    public StylesheetBuilder WithContent(string content)
+    public ScriptBuilder WithContent(string content)
     {
         _content = content;
         return this;
     }
 
-    public override Stylesheet Build()
+    public override Script Build()
     {
         var path = _path ?? string.Empty;
         var content = _content ?? string.Empty;
 
-        return new Stylesheet(path) { Content = content };
+        return new Script(path) { Content = content };
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/UdiGetterExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/UdiGetterExtensionsTests.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using NUnit.Framework;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Extensions;
+
+[TestFixture]
+public class UdiGetterExtensionsTests
+{
+    [TestCase("style.css", "umb://stylesheet/style.css")]
+    [TestCase("editor\\style.css", "umb://stylesheet/editor/style.css")]
+    [TestCase("editor/style.css", "umb://stylesheet/editor/style.css")]
+    public void GetUdiForStylesheet(string path, string expected)
+    {
+        var builder = new StylesheetBuilder();
+        var stylesheet = builder.WithPath(path).Build();
+        var result = stylesheet.GetUdi();
+        Assert.AreEqual(expected, result.ToString());
+    }
+
+    [TestCase("script.js", "umb://script/script.js")]
+    [TestCase("editor\\script.js", "umb://script/editor/script.js")]
+    [TestCase("editor/script.js", "umb://script/editor/script.js")]
+    public void GetUdiForScript(string path, string expected)
+    {
+        var builder = new ScriptBuilder();
+        var script = builder.WithPath(path).Build();
+        var result = script.GetUdi();
+        Assert.AreEqual(expected, result.ToString());
+    }
+
+    [TestCase("test.cshtml", PartialViewType.PartialView, "umb://partial-view/test.cshtml")]
+    [TestCase("editor\\test.cshtml", PartialViewType.PartialView, "umb://partial-view/editor/test.cshtml")]
+    [TestCase("editor/test.cshtml", PartialViewType.PartialView, "umb://partial-view/editor/test.cshtml")]
+    [TestCase("test.cshtml", PartialViewType.PartialViewMacro, "umb://partial-view-macro/test.cshtml")]
+    [TestCase("editor\\test.cshtml", PartialViewType.PartialViewMacro, "umb://partial-view-macro/editor/test.cshtml")]
+    [TestCase("editor/test.cshtml", PartialViewType.PartialViewMacro, "umb://partial-view-macro/editor/test.cshtml")]
+    public void GetUdiForPartialView(string path, PartialViewType viewType, string expected)
+    {
+        var builder = new PartialViewBuilder();
+        var partialView = builder
+            .WithPath(path)
+            .WithViewType(viewType)
+            .Build();
+        var result = partialView.GetUdi();
+        Assert.AreEqual(expected, result.ToString());
+    }
+}


### PR DESCRIPTION
We had [this issue](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/153) reported on the Deploy tracker, noting an problem when restoring from Windows into a Mac environment, when there were stylesheets held in a folder.

I think cause is how we are generating UDIs for these types of files (stylesheets, scripts and partial views).  We base this off the path, but don't normalize for the different path separators (`\` and `/`) used on Windows and Mac/Linux.  Given we are generating UDIs, which are URI-like, seems we should really be using the `/` here.

So this PR does and verifies this.

- Currently we have e.g. `umb://stylesheet/styles%5Ceditor.css`
- With this update we'd have e.g. `umb://stylesheet/styles/editor.css`

I've tested Deploy having done this, and don't find any issues in transferring files in folders when using this new separator.  So from that perspective it seems safe to correct this.

I'll leave to the reviewer though to consider if this is a safe correction to make for any other uses of these UDIs.

@ronaldbarendse - just pinging you for any comment too, but the CMS team should review.