### PR TITLE
Make it possible to keep focus on a parent Block

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridui.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridui.less
@@ -20,18 +20,6 @@
 
 .umb-block-grid__layout-item {
     position: relative;
-    &:hover {
-
-        > ng-form > .umb-block-grid__block--context {
-            z-index: 4;
-        }
-
-        > ng-form > .umb-block-grid__block--inline-create-button, 
-        > ng-form > .umb-block-grid__block--validation-border,
-        > ng-form > .umb-block-grid__block--actions {
-            z-index: 3;
-        }
-    }
 }
 
 .umb-block-grid__block--validation-border {
@@ -191,6 +179,7 @@ ng-form.ng-invalid-val-server-match-content > .umb-block-grid__block:not(.--acti
         }
         &:not(.--scale-mode) {
             > .umb-block-grid__block--actions {
+                z-index: 4;
                 opacity: var(--umb-block-grid--block-ui-opacity);
             }
     


### PR DESCRIPTION
This fix makes it possible to keep the focus on a parent block, though a child block is 'overlapping' with the action bar.

Enables to move the mouse to this position without the child getting focused.
<img width="170" alt="image" src="https://user-images.githubusercontent.com/6791648/213132858-fb18efc4-2522-4bd0-8793-bc4ae9ed3b18.png">

Previously this would have happened:
<img width="245" alt="image" src="https://user-images.githubusercontent.com/6791648/213133230-11203958-5a57-4a01-b000-51b1d2679773.png">

This will still happen but it depends on how your mouse navigated here.

Main reason for this change is to make an acceptable solution for setups like this seen above where the is enough space to see the actions of the parent, but not enough space to actually get to them.

I also removed some CSS that did not have a valid selector, must have been some left over from development period.

**Test steps:**

* Setup a new document type
* Add a property with a Data Type using the Block Grid Editor.
* Setup the demo blocks in the Block Grid Editor Data Type configuration.
* Create a content node using the new Document Type.
* Add a two column layout block
* Add a image block in the right area.
* Experience that the focus is given to the Image Block when mouse is in the position from the above screenshot(Moving mouse from top down to hover the edit button).
* Test that this PR changes that so its easier to give focus to the parent Block, aka. the Two Column Layout Block.