### PR TITLE
V11: fix issue where editing a macro was not possible

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -726,7 +726,6 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
     createInsertMacro: function (editor, callback) {
 
       let self = this;
-      let activeMacroElement = null; //track an active macro element
 
       /** Adds custom rules for the macro plugin and custom serialization */
       editor.on('preInit', function (args) {
@@ -755,11 +754,17 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
       });
 
       /**
-       * Because the macro gets wrapped in a P tag because of the way 'enter' works, this
+       * Because the macro got wrapped in a P tag because of the way 'enter' works in older versions of Umbraco, this
        * method will return the macro element if not wrapped in a p, or the p if the macro
        * element is the only one inside of it even if we are deep inside an element inside the macro
        */
-      function getRealMacroElem(element) {
+      function getRealMacroElem() {
+        // Ask the editor for the currently selected element
+        const element = editor.selection.getNode();
+        if (!element) {
+          return null;
+        }
+
         var e = $(element).closest(".umb-macro-holder");
         if (e.length > 0) {
           if (e.get(0).parentNode.nodeName === "P") {
@@ -780,7 +785,6 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
 
         /** The insert macro button click event handler */
         onAction: function () {
-
           var dialogData = {
             //flag for use in rte so we only show macros flagged for the editor
             richTextEditor: true
@@ -788,6 +792,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
 
           //when we click we could have a macro already selected and in that case we'll want to edit the current parameters
           //so we'll need to extract them and submit them to the dialog.
+          const activeMacroElement = getRealMacroElem();
           if (activeMacroElement) {
             //we have a macro selected so we'll need to parse it's alias and parameters
             var contents = $(activeMacroElement).contents();
@@ -801,7 +806,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
             var parsed = macroService.parseMacroSyntax(syntax);
             dialogData = {
               macroData: parsed,
-              activeMacroElement: activeMacroElement //pass the active element along so we can retrieve it later
+              activeMacroElement //pass the active element along so we can retrieve it later
             };
           }
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -777,28 +777,6 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
       editor.ui.registry.addButton('umbmacro', {
         icon: 'preferences',
         tooltip: 'Insert macro',
-        onSetup: function (buttonApi) {
-          /**
-           * Check if the macro is currently selected and toggle the menu button
-           */
-          function onNodeChanged(evt) {
-
-            //set our macro button active when on a node of class umb-macro-holder
-            activeMacroElement = getRealMacroElem(evt.element);
-
-            //set the button active/inactive
-            buttonApi.setEnabled(activeMacroElement === null);
-          }
-
-          //set onNodeChanged event listener
-          editor.on('NodeChange', onNodeChanged);
-
-          return function () {
-            //remove the event listener
-            editor.off('NodeChange', onNodeChanged);
-          }
-
-        },
 
         /** The insert macro button click event handler */
         onAction: function () {


### PR DESCRIPTION
### Prerequisites

Fixes #13603

### Description
Due to how TinyMCE 6 changed the way it works with buttons, we initially failed to replicate the same logic from Umbraco 10 (TinyMCE 4) as to the macro button. We relied too much on the NodeChange event, which is not very performant for one and is not what we need at all. This PR changes the way we detect and work with macros in the following way:

1. We now no longer check if you selected a macro element or not before activating the macro insert button (it is now always active), which allows you to select a macro and then click the button (to edit the parameters)
2. We no longer save each selected element through the NodeChange event but now instead look it up only when you click the "Insert Macro" button
    1. We need to do this since you can edit the parameters of an existing macro
    2. Idea for the future: Check if a macro has parameters before activating the button if that somehow can be cached

