### PR TITLE
Add .woff2 to BrowsableFileExtensions

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/UmbracoPluginSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/UmbracoPluginSettings.cs
@@ -19,7 +19,7 @@ public class UmbracoPluginSettings
         ".css", // styles
         ".js", // scripts
         ".jpg", ".jpeg", ".gif", ".png", ".svg", // images
-        ".eot", ".ttf", ".woff", // fonts
+        ".eot", ".ttf", ".woff", ".woff2", // fonts
         ".xml", ".json", ".config", // configurations
         ".lic", // license
         ".map", // js map files


### PR DESCRIPTION
The UmbracoPluginPhysicalFileProvider - https://github.com/umbraco/Umbraco-CMS/blob/v11/contrib/src/Umbraco.Web.Common/Plugins/UmbracoPluginPhysicalFileProvider.cs

Reads in browsable File Extensions from configuration, and the default plugin settings that Umbraco ships with have the usual sort of web file extensions you'd expect...

![image](https://user-images.githubusercontent.com/260802/213439845-c5547f77-2aa1-4c19-8612-3d804d7b1252.png)

This governs what can be loaded from the App_Plugins folder above wwwroot, eg files shipped with an Umbraco package or perhaps in some customer development

And people can augment this list of files extensions via their own AppSettings...

... but I just noticed that packages and plugins that ship .woff2 files in their App_Plugins folder eg Vendr, end up with a 404 for the .woff2 file...

I mean people can always configure to avoid this, to add woff2 in AppSettings and the package developers can probably make the fix as part of the package to make sure it gets added in if it contains a woff2 file... but I was wondering since we've got .eot, .ttf, .woff // fonts - listed in the default shipped plugin settings as 'browsable', should we dare to add .woff2 too??

If so, this PR does that very thing.

In terms of testing, you could install latest Umbraco, install Vendr, click around backoffice, see 404 in trying to load /app_plugins/vendr/backoffice/assets/fonts/vendr.woff2 (but see that vendr.woff is fine).

Then add this PR in and you'd see no 404, the woff2 loads super fine and dandy!