### PR TITLE
fix: Prevents Umbraco install from throwing when a connectionstring is already configured

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/UmbracoDatabaseFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/UmbracoDatabaseFactory.cs
@@ -173,7 +173,7 @@ public class UmbracoDatabaseFactory : DisposableObjectSlim, IUmbracoDatabaseFact
 
         lock (_lock)
         {
-            if (Volatile.Read(ref _initialized))
+            if (_umbracoConnectionString is null && Volatile.Read(ref _initialized))
             {
                 throw new InvalidOperationException("Already initialized.");
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

This solves a problem where if you have a sqlite connection registered but no sqlite database in the file system the setup install would throw `Already initialized`.

## Reproduce problem (Before this change)

1. Create an Umbraco instance with a sqlite database
2. Delete the `Umbraco/Data` folder where the sqlite database resides
3. Start Umbraco again (Here you'll see the install screen because the site no longer has a database)
4. When pressing install the process will throw `Already initialized`

## To test pr

1. Create an Umbraco instance with a sqlite database
2. Delete the `Umbraco/Data` folder where the sqlite database resides
3. Start Umbraco again (Here you'll see the install screen because the site no longer has a database)
4. When pressing install the process will install Umbraco as usual and not throw an error.

<!-- Thanks for contributing to Umbraco CMS! -->
