### PR TITLE
V11: Prevalues as toggles have problems in datatype settings view

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypesettings/datatypesettings.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypesettings/datatypesettings.controller.js
@@ -107,9 +107,7 @@
 
       vm.saveButtonState = "busy";
 
-      var preValues = dataTypeHelper.createPreValueProps(vm.dataType.preValues);
-
-      dataTypeResource.save(vm.dataType, preValues, $scope.model.create).then(
+      dataTypeResource.save(vm.dataType, vm.dataType.preValues, $scope.model.create).then(
         function(newDataType) {
           $scope.model.dataType = newDataType;
 

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypesettings/datatypesettings.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypesettings/datatypesettings.controller.js
@@ -76,7 +76,7 @@
 
         // get pre values
         dataTypeResource.getPreValues(newDataType.selectedEditor).then(function(preValues) {
-          newDataType.preValues = preValues;
+          newDataType.preValues = dataTypeHelper.createPreValueProps(preValues);
           vm.dataType = newDataType;
           vm.loadingDataType = false;
         });
@@ -89,6 +89,7 @@
       vm.loadingDataType = true;
       dataTypeResource.getById($scope.model.id).then(function (dataType) {
         vm.dataType = dataType;
+        vm.dataType.preValues = dataTypeHelper.createPreValueProps(dataType.preValues);
         vm.loadingDataType = false;
       });
     }


### PR DESCRIPTION
### Prerequisites

Fixes #13694 

Partly introduced with #13108 since input-id was not generated correctly because the prevalues in one case were not being run through the `DataTypeHelper::createPreValueProps` function.

### Description

Prevalues need to have an "alias" key to work properly with the EventsService, which they do not get directly from the server but is instead generated by the client. In one case, this generation did not find place before the prevalues were submitted back to the server (where we also require the "alias" property). This fix ensures that prevalues are always formatted for the display models used in views.

The same logic is already being applied in datatype prevalue configuration (when you open a datatype directly and edit there), so no need to change anything there.
