### PR TITLE
Fixes issue with nucache slow on linux, when cold-booting

### DIFF
--- a/src/Umbraco.PublishedCache.NuCache/DataSource/BTree.cs
+++ b/src/Umbraco.PublishedCache.NuCache/DataSource/BTree.cs
@@ -22,11 +22,6 @@ public class BTree
             // default is 4096, min 2^9 = 512, max 2^16 = 64K
             FileBlockSize = GetBlockSize(settings),
 
-            // Since .NET 5, we can use the fastest cross-platform Storage Performance Mode.
-            // This is safer but a bit slower then what was used in Umbraco 8 (LogFileInCache (Windows only)).
-            // But much faster than what was used in Umbraco 9 (CommitToDisk), Especially on Linux for some reason..
-            StoragePerformance = StoragePerformance.CommitToCache,
-
             // other options?
         };
 

--- a/src/Umbraco.PublishedCache.NuCache/DataSource/BTree.cs
+++ b/src/Umbraco.PublishedCache.NuCache/DataSource/BTree.cs
@@ -22,9 +22,10 @@ public class BTree
             // default is 4096, min 2^9 = 512, max 2^16 = 64K
             FileBlockSize = GetBlockSize(settings),
 
-            // HACK: Forces FileOptions to be WriteThrough here: https://github.com/mamift/CSharpTest.Net.Collections/blob/9f93733b3af7ee0e2de353e822ff54d908209b0b/src/CSharpTest.Net.Collections/IO/TransactedCompoundFile.cs#L316-L327,
-            // as the reflection uses otherwise will failed in .NET Core as the "_handle" field in FileStream is renamed to "_fileHandle".
-            StoragePerformance = StoragePerformance.CommitToDisk,
+            // Since .NET 5, we can use the fastest cross-platform Storage Performance Mode.
+            // This is safer but a bit slower then what was used in Umbraco 8 (LogFileInCache (Windows only)).
+            // But much faster than what was used in Umbraco 9 (CommitToDisk), Especially on Linux for some reason..
+            StoragePerformance = StoragePerformance.CommitToCache,
 
             // other options?
         };

--- a/src/Umbraco.PublishedCache.NuCache/Umbraco.PublishedCache.NuCache.csproj
+++ b/src/Umbraco.PublishedCache.NuCache/Umbraco.PublishedCache.NuCache.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CSharpTest.Net.Collections-NetStd2" Version="14.906.1403.1084" />
+    <PackageReference Include="Umbraco.CSharpTest.Net.Collections" Version="14.906.1403.1085" />
     <PackageReference Include="MessagePack" Version="2.3.85" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.2.16" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/12159

The previous hack was only nescessary because the BPlusTree Package did some wrong reflection. 
We now use same mode as Umbraco 8 (default), since we forked the project, and (hopefully) fixed the issues related to that mode.

The info on the enum explains most:
```cs
    public enum StoragePerformance
    {
        /// <summary> (100k rps) Uncommitted changes will be lost, a crash durring commit may corrupt state. </summary>
        /// <remarks> 
        /// No changes are committed until a call to Commit is made, durring the commit a partial write may corrupt the store.
        /// </remarks>
        Fastest = 1,
        /// <summary> (30k rps) Uses a system-cached transaction log to recover uncommitted changes after a process crash. </summary>
        /// <remarks> Will not corrupt state; however, in a power outage or system failure it may loose some comitted records. </remarks>
        LogFileInCache = 2,
        /// <summary> (8k rps) Every write will commit changes to the storage file immediately into system cache </summary>
        /// <remarks> May corrupt state and/or loose data in the event of a power outage </remarks>
        CommitToCache = 3,
        /// <summary> (2k rps) Uses a cache-writethrough transaction log to recover uncommitted changes after a power outage or system crash. </summary>
        /// <remarks> Complies with ACID durability requirements, can be expensive to recover from the log. </remarks>
        LogFileNoCache = 4,
        /// <summary> (1k rps) Every write will commit changes to the storage file immediately bypassing system cache (Slowest/Safest) </summary>
        /// <remarks> Complies with ACID durability requirements </remarks>
        CommitToDisk = 5,

        /// <summary> Defaults to using a transaction log in system cache for best performance/durability. </summary>
        Default = LogFileInCache,
    }
```

# Test
- Go make a site with lots of content and ensure publish, preview and publish with descendants works as expected on each platform