### PR TITLE
Content API: Add start-node header value to deal with url collisions

### DIFF
--- a/src/Umbraco.Cms.Api.Content/Controllers/ByRouteContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Content/Controllers/ByRouteContentApiController.cs
@@ -27,15 +27,15 @@ public class ByRouteContentApiController : ContentApiControllerBase
     /// <summary>
     ///     Gets a content item by route.
     /// </summary>
-    /// <param name="url">The path to the content item.</param>
+    /// <param name="path">The path to the content item.</param>
     /// <param name="startNode">Optional path for the start node of the content item.</param>
     /// <returns>The content item or not found result.</returns>
-    [HttpGet("{url}")]
+    [HttpGet("{path}")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IApiContent), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> ByRoute(string url, [FromHeader(Name = "start-node")] string? startNode = null)
+    public async Task<IActionResult> ByRoute(string path, [FromHeader(Name = "start-node")] string? startNode = null)
     {
         IPublishedContentCache? contentCache = GetContentCache();
 
@@ -44,7 +44,7 @@ public class ByRouteContentApiController : ContentApiControllerBase
             return BadRequest(ContentCacheNotFoundProblemDetails());
         }
 
-        var decodedPath = ConstructRoute(url, startNode);
+        var decodedPath = ConstructRoute(path, startNode);
 
         IPublishedContent? contentItem = contentCache.GetByRoute(decodedPath);
 
@@ -56,10 +56,10 @@ public class ByRouteContentApiController : ContentApiControllerBase
         return await Task.FromResult(Ok(ApiContentBuilder.Build(contentItem)));
     }
 
-    // Decode the node url and check "start-node" header if the top level node is not hidden
-    private string ConstructRoute(string url, string? startNodePath)
+    // Decode the node path and check "start-node" header if the top level node is not hidden
+    private string ConstructRoute(string path, string? startNodePath)
     {
-        var decodedPath = $"/{WebUtility.UrlDecode(url).TrimStart(Constants.CharArrays.ForwardSlash)}";
+        var decodedPath = $"/{WebUtility.UrlDecode(path).TrimStart(Constants.CharArrays.ForwardSlash)}";
 
         if (_globalSettings.HideTopLevelNodeFromPath == false)
         {

--- a/src/Umbraco.Cms.Api.Content/Controllers/ByRouteContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Content/Controllers/ByRouteContentApiController.cs
@@ -2,7 +2,6 @@ using System.Net;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Primitives;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.ContentApi;

--- a/src/Umbraco.Cms.Api.Content/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Content/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -1,10 +1,12 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Api.Common.Configuration;
 using Umbraco.Cms.Api.Common.DependencyInjection;
 using Umbraco.Cms.Api.Content.Filters;
+using Umbraco.Cms.Api.Content.Services;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.ContentApi;
 using Umbraco.Cms.Core.DependencyInjection;
 
 namespace Umbraco.Cms.Api.Content.DependencyInjection;
@@ -13,6 +15,8 @@ public static class UmbracoBuilderExtensions
 {
     public static IUmbracoBuilder AddContentApi(this IUmbracoBuilder builder)
     {
+        builder.Services.AddScoped<IStartNodeService, StartNodeService>();
+
         builder
             .Services
             .ConfigureOptions<ConfigureMvcOptions>()

--- a/src/Umbraco.Cms.Api.Content/Services/StartNodeService.cs
+++ b/src/Umbraco.Cms.Api.Content/Services/StartNodeService.cs
@@ -24,7 +24,7 @@ public class StartNodeService : IStartNodeService
         if (context is not null && context.Request.Headers.TryGetValue(StartNodeHeaderName, out StringValues headerValue))
         {
             var startNodeHeader = headerValue.ToString();
-            return WebUtility.UrlDecode(startNodeHeader).TrimStart(Constants.CharArrays.ForwardSlash);
+            return WebUtility.UrlDecode(startNodeHeader).Trim(Constants.CharArrays.ForwardSlash);
         }
 
         return null;

--- a/src/Umbraco.Cms.Api.Content/Services/StartNodeService.cs
+++ b/src/Umbraco.Cms.Api.Content/Services/StartNodeService.cs
@@ -1,0 +1,32 @@
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.ContentApi;
+
+namespace Umbraco.Cms.Api.Content.Services;
+
+public class StartNodeService : IStartNodeService
+{
+    private const string StartNodeHeaderName = "start-node";
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public StartNodeService(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    /// <inheritdoc/>
+    public string? GetStartNode()
+    {
+        HttpContext? context = _httpContextAccessor.HttpContext;
+
+        if (context is not null && context.Request.Headers.TryGetValue(StartNodeHeaderName, out StringValues headerValue))
+        {
+            var startNodeHeader = headerValue.ToString();
+            return WebUtility.UrlDecode(startNodeHeader).TrimStart(Constants.CharArrays.ForwardSlash);
+        }
+
+        return null;
+    }
+}

--- a/src/Umbraco.Core/ContentApi/IStartNodeService.cs
+++ b/src/Umbraco.Core/ContentApi/IStartNodeService.cs
@@ -1,0 +1,9 @@
+namespace Umbraco.Cms.Core.ContentApi;
+
+public interface IStartNodeService
+{
+    /// <summary>
+    ///     Gets the start node from "start-node" header, if present.
+    /// </summary>
+    string? GetStartNode();
+}


### PR DESCRIPTION
## Details
- Adding a `start-node` header for the GET `/content/{url`;
  - Its value will be considered only when `Umbraco:CMS:Global:HideTopLevelNodeFromPath` is set to `false`.
- This also helps resolve url collisions.

## Test	
- Set up a "_Root_" and a "Child" document types;
- Create a "_Sports_" root content node;
- Create the following child content nodes:
  - "_Tennis_";
  - "_Dancing_".
- Create another root content node, called "_Competitions_";
- Create the following child content nodes:
  - "_Tennis_";
  - "_Dancing_".
- Pass "/tennis" to GET `/content/{url`;
  - Verify that you get the details for the content node with that path.
- Set `Umbraco:CMS:Global:HideTopLevelNodeFromPath` to `false` in appsettings.json;
- Pass "/tennis" to GET `/content/{url` again;
  - Verify that you get a **Not Found** response because you now have to pass a value to a `start-node` header.
- Add "sports" or "competitions" to a `start-node` header;
  - Verify that you get the details for the content node with that path.
- Pass "/sports" to GET `/content/{url` **without** a value to a `start-node` header;
  - Verify that you get the correct details for this root node.