### PR TITLE
Fixes #13715 Simple LogViewer queries not returning results

### DIFF
--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Logging/LogviewerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Logging/LogviewerTests.cs
@@ -197,6 +197,8 @@ public class LogviewerTests
     [TestCase("@mt = '{EndMessage} ({Duration}ms) [Timing {TimingId}]'", 26)]
     [TestCase("SortedComponentTypes[?] = 'Umbraco.Web.Search.ExamineComponent'", 1)]
     [TestCase("Contains(SortedComponentTypes[?], 'DatabaseServer')", 1)]
+    [TestCase("@Message like '%definition%'", 6)]
+    [TestCase("definition", 6)]
     [Test]
     public void Logs_Can_Query_With_Expressions(string queryToVerify, int expectedCount)
     {


### PR DESCRIPTION
Fixes #13715 

## Test Notes
* Ensure unit tests pass
* Search for `index` and ensure it returns results
* Search for `@Message like '%index%'` and ensure it returns the same results as above

