### PR TITLE
Make methods virtual so they can be redefined in derived classes.

### DIFF
--- a/src/Umbraco.Web.Common/Security/MemberManager.cs
+++ b/src/Umbraco.Web.Common/Security/MemberManager.cs
@@ -50,7 +50,7 @@ public class MemberManager : UmbracoUserManager<MemberIdentityUser, MemberPasswo
     }
 
     /// <inheritdoc />
-    public async Task<bool> IsMemberAuthorizedAsync(
+    public virtual async Task<bool> IsMemberAuthorizedAsync(
         IEnumerable<string>? allowTypes = null,
         IEnumerable<string>? allowGroups = null,
         IEnumerable<int>? allowMembers = null)
@@ -122,14 +122,14 @@ public class MemberManager : UmbracoUserManager<MemberIdentityUser, MemberPasswo
     }
 
     /// <inheritdoc />
-    public bool IsLoggedIn()
+    public virtual bool IsLoggedIn()
     {
         HttpContext? httpContext = _httpContextAccessor.HttpContext;
         return httpContext?.User.Identity?.IsAuthenticated ?? false;
     }
 
     /// <inheritdoc />
-    public async Task<bool> MemberHasAccessAsync(string path)
+    public virtual async Task<bool> MemberHasAccessAsync(string path)
     {
         if (await IsProtectedAsync(path))
         {
@@ -140,7 +140,7 @@ public class MemberManager : UmbracoUserManager<MemberIdentityUser, MemberPasswo
     }
 
     /// <inheritdoc />
-    public async Task<IReadOnlyDictionary<string, bool>> MemberHasAccessAsync(IEnumerable<string> paths)
+    public virtual async Task<IReadOnlyDictionary<string, bool>> MemberHasAccessAsync(IEnumerable<string> paths)
     {
         IReadOnlyDictionary<string, bool> protectedPaths = await IsProtectedAsync(paths);
 
@@ -163,10 +163,10 @@ public class MemberManager : UmbracoUserManager<MemberIdentityUser, MemberPasswo
     /// <remarks>
     ///     this is a cached call
     /// </remarks>
-    public Task<bool> IsProtectedAsync(string path) => Task.FromResult(_publicAccessService.IsProtected(path).Success);
+    public virtual Task<bool> IsProtectedAsync(string path) => Task.FromResult(_publicAccessService.IsProtected(path).Success);
 
     /// <inheritdoc />
-    public Task<IReadOnlyDictionary<string, bool>> IsProtectedAsync(IEnumerable<string> paths)
+    public virtual Task<IReadOnlyDictionary<string, bool>> IsProtectedAsync(IEnumerable<string> paths)
     {
         var result = new Dictionary<string, bool>();
         foreach (var path in paths)
@@ -179,7 +179,7 @@ public class MemberManager : UmbracoUserManager<MemberIdentityUser, MemberPasswo
     }
 
     /// <inheritdoc />
-    public async Task<MemberIdentityUser?> GetCurrentMemberAsync()
+    public virtual async Task<MemberIdentityUser?> GetCurrentMemberAsync()
     {
         if (_currentMember == null)
         {
@@ -194,7 +194,7 @@ public class MemberManager : UmbracoUserManager<MemberIdentityUser, MemberPasswo
         return _currentMember;
     }
 
-    public IPublishedContent? AsPublishedMember(MemberIdentityUser user) => _store.GetPublishedMember(user);
+    public virtual IPublishedContent? AsPublishedMember(MemberIdentityUser user) => _store.GetPublishedMember(user);
 
     /// <summary>
     ///     This will check if the member has access to this path

--- a/src/Umbraco.Web.Common/Security/MemberSignInManager.cs
+++ b/src/Umbraco.Web.Common/Security/MemberSignInManager.cs
@@ -126,7 +126,7 @@ public class MemberSignInManager : UmbracoSignInManager<MemberIdentityUser>, IMe
     /// <summary>
     ///     Custom ExternalLoginSignInAsync overload for handling external sign in with auto-linking
     /// </summary>
-    public async Task<SignInResult> ExternalLoginSignInAsync(ExternalLoginInfo loginInfo, bool isPersistent, bool bypassTwoFactor = false)
+    public virtual async Task<SignInResult> ExternalLoginSignInAsync(ExternalLoginInfo loginInfo, bool isPersistent, bool bypassTwoFactor = false)
     {
         // borrowed from https://github.com/dotnet/aspnetcore/blob/master/src/Identity/Core/src/SignInManager.cs
         // to be able to deal with auto-linking and reduce duplicate lookups


### PR DESCRIPTION
### Prerequisites

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

When you're using external login providers you sometimes want to override the MemberManager and MemberSignInManager classes with custom implementations. By making the methods of these classes virtual you can inherit from those classes and only override what you need to.

This is an example of the CustomMemberSignInManager where I override the virtual ExternalLoginSignInAsync method:

```
using System.Security.Claims;
using Microsoft.AspNetCore.Authentication;
using Microsoft.AspNetCore.Http;
using Microsoft.AspNetCore.Identity;
using Microsoft.Extensions.DependencyInjection;
using Microsoft.Extensions.Logging;
using Microsoft.Extensions.Options;
using Umbraco_OpenIdConnect_Example.Core.Extensions;
using Umbraco.Cms.Core.DependencyInjection;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Security;
using Umbraco.Cms.Web.Common.Security;

namespace Umbraco_OpenIdConnect_Example.Core.Member;

public class CustomMemberSignInManager : MemberSignInManager
{
    private readonly IMemberManager _memberManager;

    public CustomMemberSignInManager(
        UserManager<MemberIdentityUser> memberManager,
        IHttpContextAccessor contextAccessor,
        IUserClaimsPrincipalFactory<MemberIdentityUser> claimsFactory,
        IOptions<IdentityOptions> optionsAccessor,
        ILogger<SignInManager<MemberIdentityUser>> logger,
        IAuthenticationSchemeProvider schemes,
        IUserConfirmation<MemberIdentityUser> confirmation,
        IMemberExternalLoginProviders memberExternalLoginProviders,
        IEventAggregator eventAggregator)
        : base(memberManager, contextAccessor, claimsFactory, optionsAccessor, logger, schemes, confirmation)
    {
        _memberManager = (IMemberManager)memberManager;
    }

    [Obsolete("Use ctor with all params")]
    public CustomMemberSignInManager(
        UserManager<MemberIdentityUser> memberManager,
        IHttpContextAccessor contextAccessor,
        IUserClaimsPrincipalFactory<MemberIdentityUser> claimsFactory,
        IOptions<IdentityOptions> optionsAccessor,
        ILogger<SignInManager<MemberIdentityUser>> logger,
        IAuthenticationSchemeProvider schemes,
        IUserConfirmation<MemberIdentityUser> confirmation)
        : this(
            memberManager,
            contextAccessor,
            claimsFactory,
            optionsAccessor,
            logger,
            schemes,
            confirmation,
            StaticServiceProvider.Instance.GetRequiredService<IMemberExternalLoginProviders>(),
            StaticServiceProvider.Instance.GetRequiredService<IEventAggregator>())
    {
    }
    
    public override async Task<SignInResult> ExternalLoginSignInAsync(ExternalLoginInfo loginInfo, bool isPersistent, bool bypassTwoFactor = false)
    {
        // In the default implementation, the member is fetched from the database.
        // The default implementation also tries to create the member with the auto link feature if it doesn't exist.
        // The auto link feature has been removed here because the member is from an external login provider.
        // We just build a virtual member from the external login info.
        var claims = loginInfo.Principal.Claims;
        var id = claims.FirstOrDefault(x => x.Type == "sid")?.Value;
        var user = _memberManager.CreateVirtualUser(id, loginInfo.Principal.Claims);
        
        // For now hard code the role. These could be claims from the external login provider.
        user.Claims.Add(new IdentityUserClaim<string>() { ClaimType = ClaimTypes.Role, ClaimValue = "example-group" });

        return await SignInOrTwoFactorAsync(user, isPersistent, loginInfo.LoginProvider, bypassTwoFactor);
    }
}

```

<!-- Thanks for contributing to Umbraco CMS! -->
