### PR TITLE
Obsolete language ID related properties and methods for V13

### DIFF
--- a/src/Umbraco.Core/Models/ContentEditing/Language.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/Language.cs
@@ -22,6 +22,7 @@ public class Language
     [DataMember(Name = "isMandatory")]
     public bool IsMandatory { get; set; }
 
+    [Obsolete("This will be replaced by fallback language ISO code in V13.")]
     [DataMember(Name = "fallbackLanguageId")]
     public int? FallbackLanguageId { get; set; }
 }

--- a/src/Umbraco.Core/Models/DictionaryItem.cs
+++ b/src/Umbraco.Core/Models/DictionaryItem.cs
@@ -34,6 +34,7 @@ public class DictionaryItem : EntityBase, IDictionaryItem
         _translations = new List<IDictionaryTranslation>();
     }
 
+    [Obsolete("This will be removed in V13.")]
     public Func<int, ILanguage?>? GetLanguage { get; set; }
 
     /// <summary>

--- a/src/Umbraco.Core/Models/DictionaryItemExtensions.cs
+++ b/src/Umbraco.Core/Models/DictionaryItemExtensions.cs
@@ -10,6 +10,7 @@ public static class DictionaryItemExtensions
     /// <param name="d"></param>
     /// <param name="languageId"></param>
     /// <returns></returns>
+    [Obsolete("This will be replaced in V13 by a corresponding method accepting language ISO code instead of language ID.")]
     public static string? GetTranslatedValue(this IDictionaryItem d, int languageId)
     {
         IDictionaryTranslation? trans = d.Translations.FirstOrDefault(x => x.LanguageId == languageId);
@@ -21,6 +22,7 @@ public static class DictionaryItemExtensions
     /// </summary>
     /// <param name="d"></param>
     /// <returns></returns>
+    [Obsolete("Warning: This method ONLY works in very specific scenarios. It will be removed in V13.")]
     public static string? GetDefaultValue(this IDictionaryItem d)
     {
         IDictionaryTranslation? defaultTranslation = d.Translations.FirstOrDefault(x => x.Language?.Id == 1);

--- a/src/Umbraco.Core/Models/DictionaryTranslation.cs
+++ b/src/Umbraco.Core/Models/DictionaryTranslation.cs
@@ -30,12 +30,14 @@ public class DictionaryTranslation : EntityBase, IDictionaryTranslation
         Key = uniqueId;
     }
 
+    [Obsolete("Please use constructor that accepts ILanguage. This will be removed in V13.")]
     public DictionaryTranslation(int languageId, string value)
     {
         LanguageId = languageId;
         _value = value;
     }
 
+    [Obsolete("Please use constructor that accepts ILanguage. This will be removed in V13.")]
     public DictionaryTranslation(int languageId, string value, Guid uniqueId)
     {
         LanguageId = languageId;
@@ -56,6 +58,7 @@ public class DictionaryTranslation : EntityBase, IDictionaryTranslation
     ///     returned
     ///     on a callback.
     /// </remarks>
+    [Obsolete("This will be removed in V13. From V13 onwards you should get languages by ISO code from ILanguageService.")]
     [DataMember]
     [DoNotClone]
     public ILanguage? Language
@@ -83,6 +86,7 @@ public class DictionaryTranslation : EntityBase, IDictionaryTranslation
         }
     }
 
+    [Obsolete("This will be replaced by language ISO code in V13.")]
     public int LanguageId { get; private set; }
 
     /// <summary>

--- a/src/Umbraco.Core/Models/IDictionaryTranslation.cs
+++ b/src/Umbraco.Core/Models/IDictionaryTranslation.cs
@@ -8,9 +8,11 @@ public interface IDictionaryTranslation : IEntity, IRememberBeingDirty
     /// <summary>
     ///     Gets or sets the <see cref="Language" /> for the translation
     /// </summary>
+    [Obsolete("This will be removed in V13. From V13 onwards you should get languages by ISO code from ILanguageService.")]
     [DataMember]
     ILanguage? Language { get; set; }
 
+    [Obsolete("This will be replaced by language ISO code in V13.")]
     int LanguageId { get; }
 
     /// <summary>

--- a/src/Umbraco.Core/Models/ILanguage.cs
+++ b/src/Umbraco.Core/Models/ILanguage.cs
@@ -55,6 +55,7 @@ public interface ILanguage : IEntity, IRememberBeingDirty
     ///         define fallback strategies when a value does not exist for a requested language.
     ///     </para>
     /// </remarks>
+    [Obsolete("This will be replaced by fallback language ISO code in V13.")]
     [DataMember]
     int? FallbackLanguageId { get; set; }
 }

--- a/src/Umbraco.Core/Models/Language.cs
+++ b/src/Umbraco.Core/Models/Language.cs
@@ -74,6 +74,7 @@ public class Language : EntityBase, ILanguage
     }
 
     /// <inheritdoc />
+    [Obsolete("This will be replaced by fallback language ISO code in V13.")]
     public int? FallbackLanguageId
     {
         get => _fallbackLanguageId;

--- a/tests/Umbraco.Tests.Common/Builders/LanguageBuilder.cs
+++ b/tests/Umbraco.Tests.Common/Builders/LanguageBuilder.cs
@@ -95,6 +95,7 @@ public class LanguageBuilder<TParent>
         return this;
     }
 
+    [Obsolete("This will be replaced in V13 by a corresponding method accepting language ISO code instead of language ID.")]
     public LanguageBuilder<TParent> WithFallbackLanguageId(int fallbackLanguageId)
     {
         _fallbackLanguageId = fallbackLanguageId;


### PR DESCRIPTION
### Description

This PR obsoletes all breakage introduced by refactoring language IDs in favor of language ISO codes for V13. 

See https://github.com/umbraco/Umbraco-CMS/pull/13751 for details.

This PR should **NOT** be merged before https://github.com/umbraco/Umbraco-CMS/pull/13751 is merged.