### PR TITLE
Send email notification on password reset

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/AuthenticationController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/AuthenticationController.cs
@@ -421,7 +421,7 @@ public class AuthenticationController : UmbracoApiControllerBase
 
                 var mailMessage = new EmailMessage(from, user.Email, subject, message, true);
 
-                await _emailSender.SendAsync(mailMessage, Constants.Web.EmailTypes.PasswordReset);
+                await _emailSender.SendAsync(mailMessage, Constants.Web.EmailTypes.PasswordReset, true);
 
                 _userManager.NotifyForgotPasswordRequested(User, user.Id.ToString());
             }


### PR DESCRIPTION
When a user requests password reset, the SendEmailNotification is not fired.

This PR fires the notification