### PR TITLE
Align the data type API

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/ByKeyDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/ByKeyDataTypeController.cs
@@ -24,12 +24,12 @@ public class ByKeyDataTypeController : DataTypeControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<DataTypeViewModel>> ByKey(Guid key)
     {
-        IDataType? dataType = _dataTypeService.GetDataType(key);
+        IDataType? dataType = await _dataTypeService.GetAsync(key);
         if (dataType == null)
         {
             return NotFound();
         }
 
-        return await Task.FromResult(Ok(_umbracoMapper.Map<DataTypeViewModel>(dataType)));
+        return Ok(_umbracoMapper.Map<DataTypeViewModel>(dataType));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/DataTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/DataTypeControllerBase.cs
@@ -1,12 +1,9 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Models.Membership;
-using Umbraco.Cms.Core.Security;
-using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType;
 
@@ -16,19 +13,22 @@ namespace Umbraco.Cms.Api.Management.Controllers.DataType;
 [ApiVersion("1.0")]
 public abstract class DataTypeControllerBase : ManagementApiControllerBase
 {
-    protected static ProblemDetails? Save(IDataType dataType, IDataTypeService dataTypeService, IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
-    {
-        ValidationResult[] validationResults = dataTypeService.ValidateConfigurationData(dataType).ToArray();
-        if (validationResults.Any())
+    protected IActionResult DataTypeOperationStatusResult(DataTypeOperationStatus status) =>
+        status switch
         {
-            return new ProblemDetailsBuilder()
+            DataTypeOperationStatus.InvalidConfiguration => BadRequest(new ProblemDetailsBuilder()
                 .WithTitle("Invalid data type configuration")
-                .WithDetail(string.Join(Environment.NewLine, validationResults.Select(r => r.ErrorMessage)))
-                .Build();
-        }
-
-        dataTypeService.Save(dataType, CurrentUserId(backOfficeSecurityAccessor));
-
-        return null;
-    }
+                .WithDetail("The supplied data type configuration was not valid. Please see the log for more details.")
+                .Build()),
+            DataTypeOperationStatus.NotFound => NotFound("The data type could not be found"),
+            DataTypeOperationStatus.InvalidName => BadRequest(new ProblemDetailsBuilder()
+                .WithTitle("Invalid data type name")
+                .WithDetail("The data type name must be non-empty and no longer than 255 characters.")
+                .Build()),
+            DataTypeOperationStatus.CancelledByNotification => BadRequest(new ProblemDetailsBuilder()
+                .WithTitle("Cancelled by notification")
+                .WithDetail("A notification handler prevented the data type operation.")
+                .Build()),
+            _ => StatusCode(StatusCodes.Status500InternalServerError, "Unknown data type operation status")
+        };
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/ByKeyDataTypeFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/ByKeyDataTypeFolderController.cs
@@ -8,8 +8,8 @@ namespace Umbraco.Cms.Api.Management.Controllers.DataType.Folder;
 
 public class ByKeyDataTypeFolderController : DataTypeFolderControllerBase
 {
-    public ByKeyDataTypeFolderController(IBackOfficeSecurityAccessor backOfficeSecurityAccessor, IDataTypeService dataTypeService)
-        : base(backOfficeSecurityAccessor, dataTypeService)
+    public ByKeyDataTypeFolderController(IBackOfficeSecurityAccessor backOfficeSecurityAccessor, IDataTypeContainerService dataTypeContainerService)
+        : base(backOfficeSecurityAccessor, dataTypeContainerService)
     {
     }
 
@@ -17,6 +17,5 @@ public class ByKeyDataTypeFolderController : DataTypeFolderControllerBase
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(FolderViewModel), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<FolderViewModel>> ByKey(Guid key)
-        => await Task.FromResult(GetFolder(key));
+    public async Task<IActionResult> ByKey(Guid key) => await GetFolderAsync(key);
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/CreateDataTypeFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/CreateDataTypeFolderController.cs
@@ -8,14 +8,14 @@ namespace Umbraco.Cms.Api.Management.Controllers.DataType.Folder;
 
 public class CreateDataTypeFolderController : DataTypeFolderControllerBase
 {
-    public CreateDataTypeFolderController(IBackOfficeSecurityAccessor backOfficeSecurityAccessor, IDataTypeService dataTypeService)
-        : base(backOfficeSecurityAccessor, dataTypeService)
+    public CreateDataTypeFolderController(IBackOfficeSecurityAccessor backOfficeSecurityAccessor, IDataTypeContainerService dataTypeContainerService)
+        : base(backOfficeSecurityAccessor, dataTypeContainerService)
     {
     }
 
     [HttpPost]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status201Created)]
-    public async Task<ActionResult> Create(FolderCreateModel folderCreateModel)
-        => await Task.FromResult(CreateFolder<ByKeyDataTypeFolderController>(folderCreateModel, controller => nameof(controller.ByKey)));
+    public async Task<IActionResult> Create(FolderCreateModel folderCreateModel)
+        => await CreateFolderAsync<ByKeyDataTypeFolderController>(folderCreateModel, controller => nameof(controller.ByKey));
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DeleteDataTypeFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DeleteDataTypeFolderController.cs
@@ -8,8 +8,8 @@ namespace Umbraco.Cms.Api.Management.Controllers.DataType.Folder;
 
 public class DeleteDataTypeFolderController : DataTypeFolderControllerBase
 {
-    public DeleteDataTypeFolderController(IBackOfficeSecurityAccessor backOfficeSecurityAccessor, IDataTypeService dataTypeService)
-        : base(backOfficeSecurityAccessor, dataTypeService)
+    public DeleteDataTypeFolderController(IBackOfficeSecurityAccessor backOfficeSecurityAccessor, IDataTypeContainerService dataTypeContainerService)
+        : base(backOfficeSecurityAccessor, dataTypeContainerService)
     {
     }
 
@@ -17,6 +17,5 @@ public class DeleteDataTypeFolderController : DataTypeFolderControllerBase
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult> Delete(Guid key)
-        => await Task.FromResult(DeleteFolder(key));
+    public async Task<IActionResult> Delete(Guid key) => await DeleteFolderAsync(key);
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/UpdateDataTypeFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/UpdateDataTypeFolderController.cs
@@ -8,8 +8,8 @@ namespace Umbraco.Cms.Api.Management.Controllers.DataType.Folder;
 
 public class UpdateDataTypeFolderController : DataTypeFolderControllerBase
 {
-    public UpdateDataTypeFolderController(IBackOfficeSecurityAccessor backOfficeSecurityAccessor, IDataTypeService dataTypeService)
-        : base(backOfficeSecurityAccessor, dataTypeService)
+    public UpdateDataTypeFolderController(IBackOfficeSecurityAccessor backOfficeSecurityAccessor, IDataTypeContainerService dataTypeContainerService)
+        : base(backOfficeSecurityAccessor, dataTypeContainerService)
     {
     }
 
@@ -17,6 +17,5 @@ public class UpdateDataTypeFolderController : DataTypeFolderControllerBase
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult> Update(Guid key, FolderUpdateModel folderUpdateModel)
-        => await Task.FromResult(UpdateFolder(key, folderUpdateModel));
+    public async Task<IActionResult> Update(Guid key, FolderUpdateModel folderUpdateModel) => await UpdateFolderAsync(key, folderUpdateModel);
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Language/LanguageControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Language/LanguageControllerBase.cs
@@ -36,6 +36,6 @@ public abstract class LanguageControllerBase : ManagementApiControllerBase
                 .WithTitle("Cancelled by notification")
                 .WithDetail("A notification handler prevented the language operation.")
                 .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, "Unknown dictionary operation status")
+            _ => StatusCode(StatusCodes.Status500InternalServerError, "Unknown language operation status")
         };
 }

--- a/src/Umbraco.Core/CompatibilitySuppressions.xml
+++ b/src/Umbraco.Core/CompatibilitySuppressions.xml
@@ -204,6 +204,13 @@
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Umbraco.Cms.Core.Services.Implement.DataTypeService.#ctor(Umbraco.Cms.Core.PropertyEditors.IDataValueEditorFactory,Umbraco.Cms.Core.Scoping.ICoreScopeProvider,Microsoft.Extensions.Logging.ILoggerFactory,Umbraco.Cms.Core.Events.IEventMessagesFactory,Umbraco.Cms.Core.Persistence.Repositories.IDataTypeRepository,Umbraco.Cms.Core.Persistence.Repositories.IDataTypeContainerRepository,Umbraco.Cms.Core.Persistence.Repositories.IAuditRepository,Umbraco.Cms.Core.Persistence.Repositories.IEntityRepository,Umbraco.Cms.Core.Persistence.Repositories.IContentTypeRepository,Umbraco.Cms.Core.IO.IIOHelper,Umbraco.Cms.Core.Services.ILocalizedTextService,Umbraco.Cms.Core.Services.ILocalizationService,Umbraco.Cms.Core.Strings.IShortStringHelper,Umbraco.Cms.Core.Serialization.IJsonSerializer)</Target>
+    <Left>lib/net7.0/Umbraco.Core.dll</Left>
+    <Right>lib/net7.0/Umbraco.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
     <Target>M:Umbraco.Cms.Core.Deploy.IDataTypeConfigurationConnector.FromArtifact(Umbraco.Cms.Core.Models.IDataType,System.String,Umbraco.Cms.Core.Deploy.IContextCache)</Target>
     <Left>lib/net7.0/Umbraco.Core.dll</Left>
@@ -290,6 +297,55 @@
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
     <Target>M:Umbraco.Cms.Core.PropertyEditors.IConfigurationEditor.Validate(System.Collections.Generic.IDictionary{System.String,System.Object})</Target>
+    <Left>lib/net7.0/Umbraco.Core.dll</Left>
+    <Right>lib/net7.0/Umbraco.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Umbraco.Cms.Core.Services.IDataTypeService.CreateAsync(Umbraco.Cms.Core.Models.IDataType,System.Int32)</Target>
+    <Left>lib/net7.0/Umbraco.Core.dll</Left>
+    <Right>lib/net7.0/Umbraco.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Umbraco.Cms.Core.Services.IDataTypeService.DeleteAsync(System.Guid,System.Int32)</Target>
+    <Left>lib/net7.0/Umbraco.Core.dll</Left>
+    <Right>lib/net7.0/Umbraco.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Umbraco.Cms.Core.Services.IDataTypeService.GetAsync(System.Guid)</Target>
+    <Left>lib/net7.0/Umbraco.Core.dll</Left>
+    <Right>lib/net7.0/Umbraco.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Umbraco.Cms.Core.Services.IDataTypeService.GetAsync(System.String)</Target>
+    <Left>lib/net7.0/Umbraco.Core.dll</Left>
+    <Right>lib/net7.0/Umbraco.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Umbraco.Cms.Core.Services.IDataTypeService.GetByEditorAliasAsync(System.String)</Target>
+    <Left>lib/net7.0/Umbraco.Core.dll</Left>
+    <Right>lib/net7.0/Umbraco.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Umbraco.Cms.Core.Services.IDataTypeService.GetReferencesAsync(System.Guid)</Target>
+    <Left>lib/net7.0/Umbraco.Core.dll</Left>
+    <Right>lib/net7.0/Umbraco.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Umbraco.Cms.Core.Services.IDataTypeService.UpdateAsync(Umbraco.Cms.Core.Models.IDataType,System.Int32)</Target>
     <Left>lib/net7.0/Umbraco.Core.dll</Left>
     <Right>lib/net7.0/Umbraco.Core.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -282,6 +282,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
             Services.AddUnique<IUserService, UserService>();
             Services.AddUnique<ILocalizationService, LocalizationService>();
             Services.AddUnique<IDictionaryItemService, DictionaryItemService>();
+            Services.AddUnique<IDataTypeContainerService, DataTypeContainerService>();
             Services.AddUnique<ILanguageService, LanguageService>();
             Services.AddUnique<IMacroService, MacroService>();
             Services.AddUnique<IMemberGroupService, MemberGroupService>();

--- a/src/Umbraco.Core/Services/DataTypeContainerService.cs
+++ b/src/Umbraco.Core/Services/DataTypeContainerService.cs
@@ -1,0 +1,180 @@
+﻿using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Entities;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Core.Services;
+
+internal sealed class DataTypeContainerService : RepositoryService, IDataTypeContainerService
+{
+    private readonly IDataTypeContainerRepository _dataTypeContainerRepository;
+    private readonly IAuditRepository _auditRepository;
+    private readonly IEntityRepository _entityRepository;
+
+    public DataTypeContainerService(
+        ICoreScopeProvider provider,
+        ILoggerFactory loggerFactory,
+        IEventMessagesFactory eventMessagesFactory,
+        IDataTypeContainerRepository dataTypeContainerRepository,
+        IAuditRepository auditRepository,
+        IEntityRepository entityRepository)
+        : base(provider, loggerFactory, eventMessagesFactory)
+    {
+        _dataTypeContainerRepository = dataTypeContainerRepository;
+        _auditRepository = auditRepository;
+        _entityRepository = entityRepository;
+    }
+
+    /// <inheritdoc />
+    public async Task<EntityContainer?> GetAsync(Guid id)
+    {
+        using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
+        return await Task.FromResult(_dataTypeContainerRepository.Get(id));
+    }
+
+    /// <inheritdoc />
+    public async Task<EntityContainer?> GetParentAsync(EntityContainer container)
+        => await Task.FromResult(GetParent(container));
+
+    /// <inheritdoc />
+    public async Task<EntityContainer?> GetParentAsync(IDataType dataType)
+        => await Task.FromResult(GetParent(dataType));
+
+    /// <inheritdoc />
+    public async Task<Attempt<EntityContainer, DataTypeContainerOperationStatus>> CreateAsync(EntityContainer container, Guid? parentId = null, int userId = Constants.Security.SuperUserId)
+        => await SaveAsync(
+            container,
+            userId,
+            () =>
+            {
+                if (container.Id > 0)
+                {
+                    return DataTypeContainerOperationStatus.InvalidId;
+                }
+
+                EntityContainer? parentContainer = parentId.HasValue
+                    ? _dataTypeContainerRepository.Get(parentId.Value)
+                    : null;
+
+                if (parentId.HasValue && parentContainer == null)
+                {
+                    return DataTypeContainerOperationStatus.ParentNotFound;
+                }
+
+                container.ParentId = parentContainer?.Id ?? Constants.System.Root;
+                return DataTypeContainerOperationStatus.Success;
+            },
+            AuditType.New);
+
+    /// <inheritdoc />
+    public async Task<Attempt<EntityContainer, DataTypeContainerOperationStatus>> UpdateAsync(EntityContainer container, int userId = Constants.Security.SuperUserId)
+        => await SaveAsync(
+            container,
+            userId,
+            () =>
+            {
+                if (container.Id == 0)
+                {
+                    return DataTypeContainerOperationStatus.InvalidId;
+                }
+
+                if (container.IsPropertyDirty(nameof(EntityContainer.ParentId)))
+                {
+                    LoggerFactory.CreateLogger<DataTypeContainerService>().LogWarning($"Cannot use {nameof(UpdateAsync)} to change the container parent. Move the container instead.");
+                    return DataTypeContainerOperationStatus.ParentNotFound;
+                }
+
+                return DataTypeContainerOperationStatus.Success;
+            },
+            AuditType.New);
+
+    /// <inheritdoc />
+    public async Task<Attempt<EntityContainer?, DataTypeContainerOperationStatus>> DeleteAsync(Guid id, int userId = Constants.Security.SuperUserId)
+    {
+        using ICoreScope scope = ScopeProvider.CreateCoreScope();
+
+        EntityContainer? container = _dataTypeContainerRepository.Get(id);
+        if (container == null)
+        {
+            return Attempt.FailWithStatus<EntityContainer?, DataTypeContainerOperationStatus>(DataTypeContainerOperationStatus.NotFound, null);
+        }
+
+        // 'container' here does not know about its children, so we need
+        // to get it again from the entity repository, as a light entity
+        IEntitySlim? entity = _entityRepository.Get(container.Id);
+        if (entity?.HasChildren is true)
+        {
+            scope.Complete();
+            return Attempt.FailWithStatus<EntityContainer?, DataTypeContainerOperationStatus>(DataTypeContainerOperationStatus.NotEmpty, container);
+        }
+
+        EventMessages eventMessages = EventMessagesFactory.Get();
+
+        var deletingEntityContainerNotification = new EntityContainerDeletingNotification(container, eventMessages);
+        if (await scope.Notifications.PublishCancelableAsync(deletingEntityContainerNotification))
+        {
+            scope.Complete();
+            return Attempt.FailWithStatus<EntityContainer?, DataTypeContainerOperationStatus>(DataTypeContainerOperationStatus.CancelledByNotification, container);
+        }
+
+        _dataTypeContainerRepository.Delete(container);
+
+        Audit(AuditType.Delete, userId, container.Id);
+        scope.Complete();
+
+        scope.Notifications.Publish(new EntityContainerDeletedNotification(container, eventMessages).WithStateFrom(deletingEntityContainerNotification));
+
+        return Attempt.SucceedWithStatus<EntityContainer?, DataTypeContainerOperationStatus>(DataTypeContainerOperationStatus.Success, container);
+    }
+
+    private async Task<Attempt<EntityContainer, DataTypeContainerOperationStatus>> SaveAsync(EntityContainer container, int userId, Func<DataTypeContainerOperationStatus> operationValidation, AuditType auditType)
+    {
+        if (container.ContainedObjectType != Constants.ObjectTypes.DataType)
+        {
+            return Attempt.FailWithStatus(DataTypeContainerOperationStatus.InvalidObjectType, container);
+        }
+
+        using ICoreScope scope = ScopeProvider.CreateCoreScope();
+
+        DataTypeContainerOperationStatus operationValidationStatus = operationValidation();
+        if (operationValidationStatus != DataTypeContainerOperationStatus.Success)
+        {
+            return Attempt.FailWithStatus(operationValidationStatus, container);
+        }
+
+        EventMessages eventMessages = EventMessagesFactory.Get();
+        var savingEntityContainerNotification = new EntityContainerSavingNotification(container, eventMessages);
+        if (await scope.Notifications.PublishCancelableAsync(savingEntityContainerNotification))
+        {
+            scope.Complete();
+            return Attempt.FailWithStatus(DataTypeContainerOperationStatus.CancelledByNotification, container);
+        }
+
+        _dataTypeContainerRepository.Save(container);
+
+        Audit(auditType, userId, container.Id);
+        scope.Complete();
+
+        scope.Notifications.Publish(new EntityContainerSavedNotification(container, eventMessages).WithStateFrom(savingEntityContainerNotification));
+
+        return Attempt.SucceedWithStatus(DataTypeContainerOperationStatus.Success, container);
+    }
+
+    private EntityContainer? GetParent(ITreeEntity treeEntity)
+    {
+        if (treeEntity.ParentId == Constants.System.Root)
+        {
+            return null;
+        }
+
+        using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
+        return _dataTypeContainerRepository.Get(treeEntity.ParentId);
+    }
+
+    private void Audit(AuditType type, int userId, int objectId)
+        => _auditRepository.Save(new AuditItem(objectId, type, userId, UmbracoObjectTypes.DataTypeContainer.GetName()));
+}

--- a/src/Umbraco.Core/Services/IDataTypeContainerService.cs
+++ b/src/Umbraco.Core/Services/IDataTypeContainerService.cs
@@ -1,0 +1,47 @@
+﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Core.Services;
+
+public interface IDataTypeContainerService
+{
+    /// <summary>
+    /// Gets a data type container
+    /// </summary>
+    /// <param name="id">The ID of the data type container to get.</param>
+    /// <returns></returns>
+    Task<EntityContainer?> GetAsync(Guid id);
+
+    /// <summary>
+    /// Gets the parent container of a data type container
+    /// </summary>
+    /// <param name="container">The container whose parent container to get.</param>
+    /// <returns></returns>
+    Task<EntityContainer?> GetParentAsync(EntityContainer container);
+
+    /// <summary>
+    /// Creates a new data type container
+    /// </summary>
+    /// <param name="container">The container to create.</param>
+    /// <param name="parentId">The ID of the parent container to create the new container under.</param>
+    /// <param name="userId">The ID of the user issuing the creation.</param>
+    /// <returns></returns>
+    /// <remarks>If no parent ID is supplied, the container will be created at the data type tree root.</remarks>
+    Task<Attempt<EntityContainer, DataTypeContainerOperationStatus>> CreateAsync(EntityContainer container, Guid? parentId = null, int userId = Constants.Security.SuperUserId);
+
+    /// <summary>
+    /// Updates an existing data type container
+    /// </summary>
+    /// <param name="container">The container to create.</param>
+    /// <param name="userId">The ID of the user issuing the update.</param>
+    /// <returns></returns>
+    Task<Attempt<EntityContainer, DataTypeContainerOperationStatus>> UpdateAsync(EntityContainer container, int userId = Constants.Security.SuperUserId);
+
+    /// <summary>
+    /// Deletes a data type container
+    /// </summary>
+    /// <param name="id">The ID of the container to delete.</param>
+    /// <param name="userId">The ID of the user issuing the deletion.</param>
+    /// <returns></returns>
+    Task<Attempt<EntityContainer?, DataTypeContainerOperationStatus>> DeleteAsync(Guid id, int userId = Constants.Security.SuperUserId);
+}

--- a/src/Umbraco.Core/Services/IDataTypeService.cs
+++ b/src/Umbraco.Core/Services/IDataTypeService.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Core.Services;
 
@@ -14,7 +15,15 @@ public interface IDataTypeService : IService
     /// </summary>
     /// <param name="id"></param>
     /// <returns></returns>
+    [Obsolete("Please use GetReferencesAsync. Will be deleted in V15.")]
     IReadOnlyDictionary<Udi, IEnumerable<string>> GetReferences(int id);
+
+    /// <summary>
+    ///     Returns a dictionary of content type <see cref="Udi" />s and the property type aliases that use a <see cref="IDataType" />
+    /// </summary>
+    /// <param name="id">The guid Id of the <see cref="IDataType" /></param>
+    /// <returns></returns>
+    Task<Attempt<IReadOnlyDictionary<Udi, IEnumerable<string>>, DataTypeOperationStatus>> GetReferencesAsync(Guid id);
 
     Attempt<OperationResult<OperationResultType, EntityContainer>?> CreateContainer(int parentId, Guid key, string name, int userId = Constants.Security.SuperUserId);
 
@@ -41,6 +50,7 @@ public interface IDataTypeService : IService
     /// <returns>
     ///     <see cref="IDataType" />
     /// </returns>
+    [Obsolete("Please use GetAsync. Will be removed in V15.")]
     IDataType? GetDataType(string name);
 
     /// <summary>
@@ -50,6 +60,7 @@ public interface IDataTypeService : IService
     /// <returns>
     ///     <see cref="IDataType" />
     /// </returns>
+    [Obsolete("Please use GetAsync. Will be removed in V15.")]
     IDataType? GetDataType(int id);
 
     /// <summary>
@@ -59,7 +70,26 @@ public interface IDataTypeService : IService
     /// <returns>
     ///     <see cref="IDataType" />
     /// </returns>
+    [Obsolete("Please use GetAsync. Will be removed in V15.")]
     IDataType? GetDataType(Guid id);
+
+    /// <summary>
+    ///     Gets an <see cref="IDataType" /> by its Name
+    /// </summary>
+    /// <param name="name">Name of the <see cref="IDataType" /></param>
+    /// <returns>
+    ///     <see cref="IDataType" />
+    /// </returns>
+    Task<IDataType?> GetAsync(string name);
+
+    /// <summary>
+    ///     Gets an <see cref="IDataType" /> by its unique guid Id
+    /// </summary>
+    /// <param name="id">Unique guid Id of the DataType</param>
+    /// <returns>
+    ///     <see cref="IDataType" />
+    /// </returns>
+    Task<IDataType?> GetAsync(Guid id);
 
     /// <summary>
     ///     Gets all <see cref="IDataType" /> objects or those with the ids passed in
@@ -73,6 +103,7 @@ public interface IDataTypeService : IService
     /// </summary>
     /// <param name="dataType"><see cref="IDataType" /> to save</param>
     /// <param name="userId">Id of the user issuing the save</param>
+    [Obsolete("Please use CreateAsync or UpdateAsync. Will be removed in V15.")]
     void Save(IDataType dataType, int userId = Constants.Security.SuperUserId);
 
     /// <summary>
@@ -80,7 +111,22 @@ public interface IDataTypeService : IService
     /// </summary>
     /// <param name="dataTypeDefinitions"><see cref="IDataType" /> to save</param>
     /// <param name="userId">Id of the user issuing the save</param>
+    [Obsolete("Please use CreateAsync or UpdateAsync. Will be removed in V15.")]
     void Save(IEnumerable<IDataType> dataTypeDefinitions, int userId = Constants.Security.SuperUserId);
+
+    /// <summary>
+    ///     Creates a new <see cref="IDataType" />
+    /// </summary>
+    /// <param name="dataType"><see cref="IDataType" /> to create</param>
+    /// <param name="userId">Id of the user issuing the creation</param>
+    Task<Attempt<IDataType, DataTypeOperationStatus>> CreateAsync(IDataType dataType, int userId = Constants.Security.SuperUserId);
+
+    /// <summary>
+    ///     Updates an existing <see cref="IDataType" />
+    /// </summary>
+    /// <param name="dataType"><see cref="IDataType" /> to update</param>
+    /// <param name="userId">Id of the user issuing the update</param>
+    Task<Attempt<IDataType, DataTypeOperationStatus>> UpdateAsync(IDataType dataType, int userId = Constants.Security.SuperUserId);
 
     /// <summary>
     ///     Deletes an <see cref="IDataType" />
@@ -91,14 +137,34 @@ public interface IDataTypeService : IService
     /// </remarks>
     /// <param name="dataType"><see cref="IDataType" /> to delete</param>
     /// <param name="userId">Id of the user issuing the deletion</param>
+    [Obsolete("Please use DeleteAsync. Will be removed in V15.")]
     void Delete(IDataType dataType, int userId = Constants.Security.SuperUserId);
+
+    /// <summary>
+    ///     Deletes an <see cref="IDataType" />
+    /// </summary>
+    /// <remarks>
+    ///     Please note that deleting a <see cref="IDataType" /> will remove
+    ///     all the <see cref="IPropertyType" /> data that references this <see cref="IDataType" />.
+    /// </remarks>
+    /// <param name="id">The guid Id of the <see cref="IDataType" /> to delete</param>
+    /// <param name="userId">Id of the user issuing the deletion</param>
+    Task<Attempt<IDataType?, DataTypeOperationStatus>> DeleteAsync(Guid id, int userId = Constants.Security.SuperUserId);
 
     /// <summary>
     ///     Gets a <see cref="IDataType" /> by its control Id
     /// </summary>
     /// <param name="propertyEditorAlias">Alias of the property editor</param>
     /// <returns>Collection of <see cref="IDataType" /> objects with a matching control id</returns>
+    [Obsolete("Please use GetByEditorAliasAsync. Will be removed in V15.")]
     IEnumerable<IDataType> GetByEditorAlias(string propertyEditorAlias);
+
+    /// <summary>
+    ///     Gets all <see cref="IDataType" /> for a given property editor
+    /// </summary>
+    /// <param name="propertyEditorAlias">Alias of the property editor</param>
+    /// <returns>Collection of <see cref="IDataType" /> configured for the property editor</returns>
+    Task<IEnumerable<IDataType>> GetByEditorAliasAsync(string propertyEditorAlias);
 
     Attempt<OperationResult<MoveOperationStatusType>?> Move(IDataType toMove, int parentId);
 

--- a/src/Umbraco.Core/Services/IDataTypeService.cs
+++ b/src/Umbraco.Core/Services/IDataTypeService.cs
@@ -25,22 +25,31 @@ public interface IDataTypeService : IService
     /// <returns></returns>
     Task<Attempt<IReadOnlyDictionary<Udi, IEnumerable<string>>, DataTypeOperationStatus>> GetReferencesAsync(Guid id);
 
+    [Obsolete("Please use IDataTypeContainerService for all data type container operations. Will be removed in V15.")]
     Attempt<OperationResult<OperationResultType, EntityContainer>?> CreateContainer(int parentId, Guid key, string name, int userId = Constants.Security.SuperUserId);
 
+    [Obsolete("Please use IDataTypeContainerService for all data type container operations. Will be removed in V15.")]
     Attempt<OperationResult?> SaveContainer(EntityContainer container, int userId = Constants.Security.SuperUserId);
 
+    [Obsolete("Please use IDataTypeContainerService for all data type container operations. Will be removed in V15.")]
     EntityContainer? GetContainer(int containerId);
 
+    [Obsolete("Please use IDataTypeContainerService for all data type container operations. Will be removed in V15.")]
     EntityContainer? GetContainer(Guid containerId);
 
+    [Obsolete("Please use IDataTypeContainerService for all data type container operations. Will be removed in V15.")]
     IEnumerable<EntityContainer> GetContainers(string folderName, int level);
 
+    [Obsolete("Please use IDataTypeContainerService for all data type container operations. Will be removed in V15.")]
     IEnumerable<EntityContainer> GetContainers(IDataType dataType);
 
+    [Obsolete("Please use IDataTypeContainerService for all data type container operations. Will be removed in V15.")]
     IEnumerable<EntityContainer> GetContainers(int[] containerIds);
 
+    [Obsolete("Please use IDataTypeContainerService for all data type container operations. Will be removed in V15.")]
     Attempt<OperationResult?> DeleteContainer(int containerId, int userId = Constants.Security.SuperUserId);
 
+    [Obsolete("Please use IDataTypeContainerService for all data type container operations. Will be removed in V15.")]
     Attempt<OperationResult<OperationResultType, EntityContainer>?> RenameContainer(int id, string name, int userId = Constants.Security.SuperUserId);
 
     /// <summary>

--- a/src/Umbraco.Core/Services/OperationStatus/DataTypeContainerOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/DataTypeContainerOperationStatus.cs
@@ -1,0 +1,12 @@
+﻿namespace Umbraco.Cms.Core.Services.OperationStatus;
+
+public enum DataTypeContainerOperationStatus
+{
+    Success,
+    CancelledByNotification,
+    InvalidObjectType,
+    InvalidId,
+    NotFound,
+    ParentNotFound,
+    NotEmpty
+}

--- a/src/Umbraco.Core/Services/OperationStatus/DataTypeOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/DataTypeOperationStatus.cs
@@ -1,0 +1,11 @@
+﻿namespace Umbraco.Cms.Core.Services.OperationStatus;
+
+public enum DataTypeOperationStatus
+{
+    Success,
+    CancelledByNotification,
+    InvalidConfiguration,
+    InvalidName,
+    InvalidId,
+    NotFound
+}

--- a/tests/Umbraco.Tests.Integration/CompatibilitySuppressions.xml
+++ b/tests/Umbraco.Tests.Integration/CompatibilitySuppressions.xml
@@ -2,6 +2,13 @@
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services.DataTypeServiceTests.DataTypeService_Can_Persist_New_DataTypeDefinition</Target>
+    <Left>lib/net7.0/Umbraco.Tests.Integration.dll</Left>
+    <Right>lib/net7.0/Umbraco.Tests.Integration.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services.LocalizationServiceTests.Can_Create_DictionaryItem_At_Root_With_Identity</Target>
     <Left>lib/net7.0/Umbraco.Tests.Integration.dll</Left>
     <Right>lib/net7.0/Umbraco.Tests.Integration.dll</Right>

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/DataTypeContainerServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/DataTypeContainerServiceTests.cs
@@ -1,0 +1,281 @@
+﻿using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Infrastructure.Services;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
+
+/// <summary>
+///     Tests covering the DataTypeContainerService
+/// </summary>
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+public class DataTypeContainerServiceTests : UmbracoIntegrationTest
+{
+    private IDataTypeContainerService DataTypeContainerService => GetRequiredService<IDataTypeContainerService>();
+
+    private IDataTypeService DataTypeService => GetRequiredService<IDataTypeService>();
+
+    private IDataValueEditorFactory DataValueEditorFactory => GetRequiredService<IDataValueEditorFactory>();
+
+    private IConfigurationEditorJsonSerializer ConfigurationEditorJsonSerializer => GetRequiredService<IConfigurationEditorJsonSerializer>();
+
+    private IEditorConfigurationParser EditorConfigurationParser => GetRequiredService<IEditorConfigurationParser>();
+
+    [Test]
+    public async Task Can_Create_Container_At_Root()
+    {
+        EntityContainer toCreate = new EntityContainer(Constants.ObjectTypes.DataType) { Name = "Root Container" };
+
+        var result = await DataTypeContainerService.CreateAsync(toCreate);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(DataTypeContainerOperationStatus.Success, result.Status);
+
+        var created = await DataTypeContainerService.GetAsync(toCreate.Key);
+        Assert.NotNull(created);
+        Assert.AreEqual("Root Container", created.Name);
+        Assert.AreEqual(Constants.System.Root, created.ParentId);
+    }
+
+    [Test]
+    public async Task Can_Create_Child_Container()
+    {
+        EntityContainer root = new EntityContainer(Constants.ObjectTypes.DataType) { Name = "Root Container" };
+        await DataTypeContainerService.CreateAsync(root);
+
+        EntityContainer child = new EntityContainer(Constants.ObjectTypes.DataType) { Name = "Child Container" };
+        var result = await DataTypeContainerService.CreateAsync(child, root.Key);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(DataTypeContainerOperationStatus.Success, result.Status);
+
+        var created = await DataTypeContainerService.GetAsync(child.Key);
+        Assert.NotNull(created);
+        Assert.AreEqual("Child Container", created.Name);
+        Assert.AreEqual(root.Id, child.ParentId);
+    }
+
+    [Test]
+    public async Task Can_Update_Container_At_Root()
+    {
+        EntityContainer root = new EntityContainer(Constants.ObjectTypes.DataType) { Name = "Root Container" };
+        await DataTypeContainerService.CreateAsync(root);
+
+        EntityContainer toUpdate = await DataTypeContainerService.GetAsync(root.Key);
+        Assert.NotNull(toUpdate);
+
+        toUpdate.Name += " UPDATED";
+        var result = await DataTypeContainerService.UpdateAsync(toUpdate);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(DataTypeContainerOperationStatus.Success, result.Status);
+
+        var updated = await DataTypeContainerService.GetAsync(toUpdate.Key);
+        Assert.NotNull(updated);
+        Assert.AreEqual("Root Container UPDATED", updated.Name);
+        Assert.AreEqual(Constants.System.Root, updated.ParentId);
+    }
+
+    [Test]
+    public async Task Can_Update_Child_Container()
+    {
+        EntityContainer root = new EntityContainer(Constants.ObjectTypes.DataType) { Name = "Root Container" };
+        await DataTypeContainerService.CreateAsync(root);
+
+        EntityContainer child = new EntityContainer(Constants.ObjectTypes.DataType) { Name = "Child Container" };
+        await DataTypeContainerService.CreateAsync(child, root.Key);
+
+        EntityContainer toUpdate = await DataTypeContainerService.GetAsync(child.Key);
+        Assert.NotNull(toUpdate);
+
+        toUpdate.Name += " UPDATED";
+        var result = await DataTypeContainerService.UpdateAsync(toUpdate);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(DataTypeContainerOperationStatus.Success, result.Status);
+
+        var updated = await DataTypeContainerService.GetAsync(toUpdate.Key);
+        Assert.NotNull(updated);
+        Assert.AreEqual("Child Container UPDATED", updated.Name);
+        Assert.AreEqual(root.Id, updated.ParentId);
+    }
+
+    [Test]
+    public async Task Can_Get_Container_At_Root()
+    {
+        EntityContainer root = new EntityContainer(Constants.ObjectTypes.DataType) { Name = "Root Container" };
+        await DataTypeContainerService.CreateAsync(root);
+
+        var created = await DataTypeContainerService.GetAsync(root.Key);
+        Assert.NotNull(created);
+        Assert.AreEqual("Root Container", created.Name);
+        Assert.AreEqual(Constants.System.Root, created.ParentId);
+    }
+
+    [Test]
+    public async Task Can_Get_Child_Container()
+    {
+        EntityContainer root = new EntityContainer(Constants.ObjectTypes.DataType) { Name = "Root Container" };
+        await DataTypeContainerService.CreateAsync(root);
+
+        EntityContainer child = new EntityContainer(Constants.ObjectTypes.DataType) { Name = "Child Container" };
+        await DataTypeContainerService.CreateAsync(child, root.Key);
+
+        var created = await DataTypeContainerService.GetAsync(child.Key);
+        Assert.IsNotNull(created);
+        Assert.AreEqual("Child Container", created.Name);
+        Assert.AreEqual(root.Id, child.ParentId);
+    }
+
+    [Test]
+    public async Task Can_Delete_Container_At_Root()
+    {
+        EntityContainer root = new EntityContainer(Constants.ObjectTypes.DataType) { Name = "Root Container" };
+        await DataTypeContainerService.CreateAsync(root);
+
+        var result = await DataTypeContainerService.DeleteAsync(root.Key);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(DataTypeContainerOperationStatus.Success, result.Status);
+
+        var current = await DataTypeContainerService.GetAsync(root.Key);
+        Assert.IsNull(current);
+    }
+
+    [Test]
+    public async Task Can_Delete_Child_Container()
+    {
+        EntityContainer root = new EntityContainer(Constants.ObjectTypes.DataType) { Name = "Root Container" };
+        await DataTypeContainerService.CreateAsync(root);
+
+        EntityContainer child = new EntityContainer(Constants.ObjectTypes.DataType) { Name = "Child Container" };
+        await DataTypeContainerService.CreateAsync(child, root.Key);
+
+        var result = await DataTypeContainerService.DeleteAsync(child.Key);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(DataTypeContainerOperationStatus.Success, result.Status);
+
+        var current = await DataTypeContainerService.GetAsync(child.Key);
+        Assert.IsNull(current);
+
+        current = await DataTypeContainerService.GetAsync(root.Key);
+        Assert.IsNotNull(current);
+    }
+
+    [Test]
+    public async Task Cannot_Create_Child_Container_Below_Invalid_Parent()
+    {
+        EntityContainer child = new EntityContainer(Constants.ObjectTypes.DataType) { Name = "Child Container" };
+        var result = await DataTypeContainerService.CreateAsync(child, Guid.NewGuid());
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(DataTypeContainerOperationStatus.ParentNotFound, result.Status);
+
+        var created = await DataTypeContainerService.GetAsync(child.Key);
+        Assert.IsNull(created);
+    }
+
+    [Test]
+    public async Task Cannot_Create_Child_Container_With_Explicit_Id()
+    {
+        EntityContainer toCreate = new EntityContainer(Constants.ObjectTypes.DataType) { Name = "Root Container", Id = 1234 };
+
+        var result = await DataTypeContainerService.CreateAsync(toCreate);
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(DataTypeContainerOperationStatus.InvalidId, result.Status);
+
+        var created = await DataTypeContainerService.GetAsync(toCreate.Key);
+        Assert.IsNull(created);
+    }
+
+    [TestCase(Constants.ObjectTypes.Strings.DocumentType)]
+    [TestCase(Constants.ObjectTypes.Strings.MediaType)]
+    public async Task Cannot_Create_Container_With_Invalid_Contained_Type(string containedObjectType)
+    {
+        EntityContainer toCreate = new EntityContainer(new Guid(containedObjectType)) { Name = "Root Container" };
+
+        var result = await DataTypeContainerService.CreateAsync(toCreate);
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(DataTypeContainerOperationStatus.InvalidObjectType, result.Status);
+
+        var created = await DataTypeContainerService.GetAsync(toCreate.Key);
+        Assert.IsNull(created);
+    }
+
+    [Test]
+    public async Task Cannot_Update_Container_Parent()
+    {
+        EntityContainer root = new EntityContainer(Constants.ObjectTypes.DataType) { Name = "Root Container" };
+        await DataTypeContainerService.CreateAsync(root);
+
+        EntityContainer root2 = new EntityContainer(Constants.ObjectTypes.DataType) { Name = "Root Container 2" };
+        await DataTypeContainerService.CreateAsync(root2);
+
+        EntityContainer child = new EntityContainer(Constants.ObjectTypes.DataType) { Name = "Child Container" };
+        await DataTypeContainerService.CreateAsync(child, root.Key);
+
+        EntityContainer toUpdate = await DataTypeContainerService.GetAsync(child.Key);
+        Assert.IsNotNull(toUpdate);
+
+        toUpdate.ParentId = root2.Id;
+        var result = await DataTypeContainerService.UpdateAsync(toUpdate);
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(DataTypeContainerOperationStatus.ParentNotFound, result.Status);
+
+        var current = await DataTypeContainerService.GetAsync(child.Key);
+        Assert.IsNotNull(current);
+        Assert.AreEqual(root.Id, child.ParentId);
+    }
+
+    [Test]
+    public async Task Cannot_Delete_Container_With_Child_Container()
+    {
+        EntityContainer root = new EntityContainer(Constants.ObjectTypes.DataType) { Name = "Root Container" };
+        await DataTypeContainerService.CreateAsync(root);
+
+        EntityContainer child = new EntityContainer(Constants.ObjectTypes.DataType) { Name = "Child Container" };
+        await DataTypeContainerService.CreateAsync(child, root.Key);
+
+        var result = await DataTypeContainerService.DeleteAsync(root.Key);
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(DataTypeContainerOperationStatus.NotEmpty, result.Status);
+
+        var current = await DataTypeContainerService.GetAsync(root.Key);
+        Assert.IsNotNull(current);
+    }
+
+    [Test]
+    public async Task Cannot_Delete_Container_With_Child_DataType()
+    {
+        EntityContainer container = new EntityContainer(Constants.ObjectTypes.DataType) { Name = "Root Container" };
+        await DataTypeContainerService.CreateAsync(container);
+
+        IDataType dataType =
+            new DataType(new TextboxPropertyEditor(DataValueEditorFactory, IOHelper, EditorConfigurationParser), ConfigurationEditorJsonSerializer)
+            {
+                Name = Guid.NewGuid().ToString(),
+                DatabaseType = ValueStorageType.Nvarchar,
+                ParentId = container.Id
+            };
+        await DataTypeService.CreateAsync(dataType);
+
+        var result = await DataTypeContainerService.DeleteAsync(container.Key);
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(DataTypeContainerOperationStatus.NotEmpty, result.Status);
+
+        var currentContainer = await DataTypeContainerService.GetAsync(container.Key);
+        Assert.IsNotNull(currentContainer);
+
+        var currentDataType = await DataTypeService.GetAsync(dataType.Key);
+        Assert.IsNotNull(currentDataType);
+    }
+
+    [Test]
+    public async Task Cannot_Delete_Non_Existing_Container()
+    {
+        var result = await DataTypeContainerService.DeleteAsync(Guid.NewGuid());
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(DataTypeContainerOperationStatus.NotFound, result.Status);
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/DataTypeServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/DataTypeServiceTests.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using System;
-using System.Linq;
 using NUnit.Framework;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
@@ -31,8 +31,10 @@ public class DataTypeServiceTests : UmbracoIntegrationTest
     private IConfigurationEditorJsonSerializer ConfigurationEditorJsonSerializer =>
         GetRequiredService<IConfigurationEditorJsonSerializer>();
 
+    private IEditorConfigurationParser EditorConfigurationParser => GetRequiredService<IEditorConfigurationParser>();
+
     [Test]
-    public void DataTypeService_Can_Persist_New_DataTypeDefinition()
+    public async Task Can_Create_New_DataTypeDefinition()
     {
         // Act
         IDataType dataType =
@@ -41,22 +43,104 @@ public class DataTypeServiceTests : UmbracoIntegrationTest
                 Name = "Testing Textfield",
                 DatabaseType = ValueStorageType.Ntext
             };
-        DataTypeService.Save(dataType);
+        var result = await DataTypeService.CreateAsync(dataType);
+        Assert.True(result.Success);
+        Assert.AreEqual(DataTypeOperationStatus.Success, result.Status);
 
         // Assert
         Assert.That(dataType, Is.Not.Null);
         Assert.That(dataType.HasIdentity, Is.True);
 
-        dataType = DataTypeService.GetDataType(dataType.Id);
+        dataType = await DataTypeService.GetAsync(dataType.Key);
         Assert.That(dataType, Is.Not.Null);
     }
 
     [Test]
-    public void DataTypeService_Can_Delete_Textfield_DataType_And_Clear_Usages()
+    public async Task Can_Update_Existing_DataTypeDefinition()
     {
         // Arrange
-        var textfieldId = "Umbraco.Textbox";
-        var dataTypeDefinitions = DataTypeService.GetByEditorAlias(textfieldId);
+        IDataType? dataType = (await DataTypeService.GetByEditorAliasAsync(Constants.PropertyEditors.Aliases.TextBox)).FirstOrDefault();
+        Assert.NotNull(dataType);
+
+        // Act
+        dataType.Name += " UPDATED";
+        var result = await DataTypeService.UpdateAsync(dataType);
+        Assert.True(result.Success);
+        Assert.AreEqual(DataTypeOperationStatus.Success, result.Status);
+
+        // Assert
+        dataType = await DataTypeService.GetAsync(dataType.Key);
+        Assert.NotNull(dataType);
+        Assert.True(dataType.Name.EndsWith(" UPDATED"));
+    }
+
+    [Test]
+    public async Task Can_Get_All_By_Editor_Alias()
+    {
+        // Arrange
+        async Task<IDataType> CreateTextBoxDataType()
+        {
+            IDataType dataType =
+                new DataType(new TextboxPropertyEditor(DataValueEditorFactory, IOHelper, EditorConfigurationParser), ConfigurationEditorJsonSerializer)
+                {
+                    Name = Guid.NewGuid().ToString(),
+                    DatabaseType = ValueStorageType.Nvarchar
+                };
+            var result = await DataTypeService.CreateAsync(dataType);
+            Assert.True(result.Success);
+            return result.Result;
+        }
+
+        IDataType dataType1 = await CreateTextBoxDataType();
+        IDataType dataType2 = await CreateTextBoxDataType();
+        IDataType dataType3 = await CreateTextBoxDataType();
+
+        // Act
+        IEnumerable<IDataType> dataTypes = await DataTypeService.GetByEditorAliasAsync(Constants.PropertyEditors.Aliases.TextBox);
+
+        // Assert
+        Assert.True(dataTypes.Count() >= 3);
+        Assert.True(dataTypes.All(dataType => dataType.EditorAlias == Constants.PropertyEditors.Aliases.TextBox));
+        Assert.NotNull(dataTypes.FirstOrDefault(dataType => dataType.Key == dataType1.Key));
+        Assert.NotNull(dataTypes.FirstOrDefault(dataType => dataType.Key == dataType2.Key));
+        Assert.NotNull(dataTypes.FirstOrDefault(dataType => dataType.Key == dataType3.Key));
+    }
+
+    [Test]
+    public async Task Can_Get_By_Id()
+    {
+        // Arrange
+        IDataType? dataType = (await DataTypeService.GetByEditorAliasAsync(Constants.PropertyEditors.Aliases.TextBox)).FirstOrDefault();
+        Assert.NotNull(dataType);
+
+        // Act
+        IDataType? actual = await DataTypeService.GetAsync(dataType.Key);
+
+        // Assert
+        Assert.NotNull(actual);
+        Assert.AreEqual(dataType.Key, actual.Key);
+    }
+
+    [Test]
+    public async Task Can_Get_By_Name()
+    {
+        // Arrange
+        IDataType? dataType = (await DataTypeService.GetByEditorAliasAsync(Constants.PropertyEditors.Aliases.TextBox)).FirstOrDefault();
+        Assert.NotNull(dataType);
+
+        // Act
+        IDataType? actual = await DataTypeService.GetAsync(dataType.Name);
+
+        // Assert
+        Assert.NotNull(actual);
+        Assert.AreEqual(dataType.Key, actual.Key);
+    }
+
+    [Test]
+    public async Task DataTypeService_Can_Delete_Textfield_DataType_And_Clear_Usages()
+    {
+        // Arrange
+        var dataTypeDefinitions = await DataTypeService.GetByEditorAliasAsync(Constants.PropertyEditors.Aliases.TextBox);
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
         var doctype =
@@ -65,10 +149,14 @@ public class DataTypeServiceTests : UmbracoIntegrationTest
 
         // Act
         var definition = dataTypeDefinitions.First();
-        var definitionId = definition.Id;
-        DataTypeService.Delete(definition);
+        var definitionKey = definition.Key;
+        var result = await DataTypeService.DeleteAsync(definitionKey);
+        Assert.True(result.Success);
+        Assert.AreEqual(DataTypeOperationStatus.Success, result.Status);
+        Assert.NotNull(result.Result);
+        Assert.AreEqual(definitionKey, result.Result.Key);
 
-        var deletedDefinition = DataTypeService.GetDataType(definitionId);
+        var deletedDefinition = await DataTypeService.GetAsync(definitionKey);
 
         // Assert
         Assert.That(deletedDefinition, Is.Null);
@@ -77,6 +165,44 @@ public class DataTypeServiceTests : UmbracoIntegrationTest
         var contentType = ContentTypeService.Get(doctype.Id);
         Assert.That(contentType.Alias, Is.EqualTo("umbTextpage"));
         Assert.That(contentType.PropertyTypes.Count(), Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Cannot_Create_DataType_With_Empty_Name()
+    {
+        // Act
+        var dataTypeDefinition =
+            new DataType(new LabelPropertyEditor(DataValueEditorFactory, IOHelper), ConfigurationEditorJsonSerializer)
+            {
+                Name = string.Empty,
+                DatabaseType = ValueStorageType.Ntext
+            };
+
+        // Act
+        var result = await DataTypeService.CreateAsync(dataTypeDefinition);
+
+        // Assert
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(DataTypeOperationStatus.InvalidName, result.Status);
+    }
+
+    [Test]
+    public async Task Cannot_Create_DataType_With_Too_Long_Name()
+    {
+        // Act
+        var dataTypeDefinition =
+            new DataType(new LabelPropertyEditor(DataValueEditorFactory, IOHelper), ConfigurationEditorJsonSerializer)
+            {
+                Name = new string('a', 256),
+                DatabaseType = ValueStorageType.Ntext
+            };
+
+        // Act
+        var result = await DataTypeService.CreateAsync(dataTypeDefinition);
+
+        // Assert
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(DataTypeOperationStatus.InvalidName, result.Status);
     }
 
     [Test]


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR aligns the data type API with the current standards for CRUD operations, including:
- async interface methods
- explicit create/update instead of generic save
- attempt pattern for operations

The data type container (folder) handling has been split into its own dedicated service, as this really has no place in the data type service. This in turn has an impact on the folder API base controller, which now has to support the current way of doing things. 

Unit tests have been updated to cover the new data type service operations as well as the data type container operations -which, as it turns out, currently aren't covered by any unit tests.

One of the constructors on the data type service has been obsoleted since V10, but has no indication of removal version in the obsolete message. That constructor has been removed in this PR, and the message has been amended in https://github.com/umbraco/Umbraco-CMS/pull/13761