### PR TITLE
IScopeProvider" is now used from Umbraco.Cms.Infrastructure.Scoping

### DIFF
--- a/src/Umbraco.Infrastructure/Examine/ContentValueSetValidator.cs
+++ b/src/Umbraco.Infrastructure/Examine/ContentValueSetValidator.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using Examine;
 using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
 

--- a/src/Umbraco.Infrastructure/Examine/UmbracoIndexConfig.cs
+++ b/src/Umbraco.Infrastructure/Examine/UmbracoIndexConfig.cs
@@ -1,5 +1,5 @@
 using Examine;
-using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Infrastructure.Examine;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/ExamineBaseTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/ExamineBaseTest.cs
@@ -9,11 +9,12 @@ using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Querying;
-using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Examine;
 using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Tests.Integration.Testing;
+using RepositoryCacheMode = Umbraco.Cms.Core.Scoping.RepositoryCacheMode;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Examine.Lucene.UmbracoExamine;
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Examine/UmbracoContentValueSetValidatorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Examine/UmbracoContentValueSetValidatorTests.cs
@@ -9,7 +9,7 @@ using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Examine;
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This PR fixes #13729

### Description

- Changed the namespace of the "IScopeProvider" from Umbraco.Cms.Core.Scoping to Umbraco.Cms.Infrastructure.Scoping 

<!-- Thanks for contributing to Umbraco CMS! -->
