### PR TITLE
Remove special characters in avatar

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbavatar.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbavatar.directive.js
@@ -69,8 +69,9 @@ Use this directive to render an avatar.
             }
 
             function getNameInitials(name) {
-                if(name) {
-                    var names = name.replace(/[^a-zA-Z0-9 ]/g,'').split(' '),
+                if (name) {
+                    const notAllowed = /[\[\]\{\}\*\?\&\$\@\!\(\)\%\#]+/g;
+                    var names = name.replace(notAllowed,'').trim().split(' '),
                         initials = names[0].substring(0, 1);
 
                     if (names.length > 1) {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbavatar.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbavatar.directive.js
@@ -70,7 +70,7 @@ Use this directive to render an avatar.
 
             function getNameInitials(name) {
                 if(name) {
-                    var names = name.split(' '),
+                    var names = name.replace(/[^a-zA-Z0-9 ]/g,'').split(' '),
                         initials = names[0].substring(0, 1);
 
                     if (names.length > 1) {


### PR DESCRIPTION
One of our customers asked us if it was possible to remove special characters in the initials used in the umbavatar.directive.js.

Of course it is possible to rename the user to prevent special chars will shown but in this case users are created by using auto linking (Active Directory). It would be nice if they don't have to edit each user manually. 

Before: 
![image](https://user-images.githubusercontent.com/7831614/215995834-7807943b-b4a0-4093-9c08-45b382484f30.png)


After: 
![image](https://user-images.githubusercontent.com/7831614/215996042-34322082-de89-4cf1-931e-5877a0059639.png)
