### PR TITLE
Isolate maintenance page from published content cache

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Dtos/KeyValueDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/KeyValueDto.cs
@@ -5,6 +5,7 @@ using Umbraco.Cms.Infrastructure.Persistence.DatabaseModelDefinitions;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 
+
 [TableName(Constants.DatabaseSchema.Tables.KeyValue)]
 [PrimaryKey("key", AutoIncrement = false)]
 [ExplicitColumns]
@@ -22,4 +23,6 @@ internal class KeyValueDto
     [Column("updated")]
     [Constraint(Default = SystemMethods.CurrentDateTime)]
     public DateTime UpdateDate { get; set; }
+
+    //NOTE that changes to this file needs to be backward compatible. Otherwise our upgrader cannot work, as it uses this to read from the db
 }

--- a/src/Umbraco.Web.Common/Controllers/MaintenanceModeActionFilterAttribute.cs
+++ b/src/Umbraco.Web.Common/Controllers/MaintenanceModeActionFilterAttribute.cs
@@ -10,9 +10,8 @@ namespace Umbraco.Cms.Web.Common.Controllers;
 
 internal sealed class MaintenanceModeActionFilterAttribute : TypeFilterAttribute
 {
-    public MaintenanceModeActionFilterAttribute() : base(typeof(MaintenanceModeActionFilter))
-    {
-    }
+
+    public MaintenanceModeActionFilterAttribute() : base(typeof(MaintenanceModeActionFilter)) => Order = int.MinValue; // Ensures this run as the first filter.
 
     private sealed class MaintenanceModeActionFilter : IActionFilter
     {

--- a/src/Umbraco.Web.Common/Controllers/PublishedRequestFilterAttribute.cs
+++ b/src/Umbraco.Web.Common/Controllers/PublishedRequestFilterAttribute.cs
@@ -15,6 +15,12 @@ internal class PublishedRequestFilterAttribute : ResultFilterAttribute
     /// </summary>
     public override void OnResultExecuting(ResultExecutingContext context)
     {
+        if (context.Result is not null)
+        {
+            // If the result is already set, we just skip the execution
+            return;
+        }
+
         UmbracoRouteValues routeVals = GetUmbracoRouteValues(context);
         IPublishedRequest pcr = routeVals.PublishedRequest;
 

--- a/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Services;
@@ -55,7 +56,8 @@ public static partial class UmbracoBuilderExtensions
             x.GetRequiredService<IDataProtectionProvider>(),
             x.GetRequiredService<IControllerActionSearcher>(),
             x.GetRequiredService<IPublicAccessRequestHandler>(),
-            x.GetRequiredService<IUmbracoVirtualPageRoute>()
+            x.GetRequiredService<IUmbracoVirtualPageRoute>(),
+            x.GetRequiredService<IOptionsMonitor<GlobalSettings>>()
             ));
         builder.Services.AddSingleton<IControllerActionSearcher, ControllerActionSearcher>();
         builder.Services.TryAddEnumerable(Singleton<MatcherPolicy, NotFoundSelectorPolicy>());

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformerTests.cs
@@ -67,7 +67,8 @@ public class UmbracoRouteValueTransformerTests
             Mock.Of<IDataProtectionProvider>(),
             Mock.Of<IControllerActionSearcher>(),
             publicAccessRequestHandler.Object,
-            Mock.Of<IUmbracoVirtualPageRoute>()
+            Mock.Of<IUmbracoVirtualPageRoute>(),
+            Mock.Of<IOptionsMonitor<GlobalSettings>>()
             );
         return transformer;
     }


### PR DESCRIPTION
### Description
This PR changes the behaviour so the maintenance page is presented in cases where there are migrations in tables needed to build the published content cache.

This also means 404 pages cannot be shown when presenting the Maintenance page (because the  published content cache is required).

### Tests
Use steps from https://github.com/umbraco/Umbraco-CMS/pull/13551 with the following modifications
- With the change that 404 is not available when the maintenance page should be showed (as that requires the content cache)
- Also try to add a new property on DataTypeDto and make a migration 
  - This tests that the content cache is not used 