### PR TITLE
Listview batch publishing on multi language site, publishes all variants #13755 - Fix

### DIFF
--- a/src/Umbraco.Core/Models/ContentEditing/PublishContent.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/PublishContent.cs
@@ -1,0 +1,16 @@
+using System.Runtime.Serialization;
+
+namespace Umbraco.Cms.Core.Models.ContentEditing;
+
+/// <summary>
+///     Used to publish content and variants
+/// </summary>
+[DataContract(Name = "publish", Namespace = "")]
+public class PublishContent
+{
+    [DataMember(Name = "id")]
+    public int Id { get; set; }
+
+    [DataMember(Name = "cultures")]
+    public string[]? Cultures { get; set; }
+}

--- a/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
@@ -278,7 +278,8 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
           *      alert("node wasnt unpublished:" + err.data.Message);
          *    });
           * </pre>
-         * @param {Int} id the ID of the node to unpublish
+         * @param {Int} id the ID of the node to unpublish.
+         * @param {array} cultures the cultures to unpublish.
          * @returns {Promise} resourcePromise object.
          *
          */
@@ -1086,6 +1087,7 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
           * </pre>
           *
          * @param {Int} id The ID of the conten to publish
+         * @param {array} cultures the cultures to publish.
          * @returns {Promise} resourcePromise object containing the published content item.
          *
          */

--- a/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
@@ -1090,21 +1090,26 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
          *
          */
         publishById: function (id, cultures) {
-
             if (!id) {
                 throw "id cannot be null";
             }
 
             if (!cultures) {
-                cultures = [];
+                return umbRequestHelper.resourcePromise(
+                  $http.post(
+                    umbRequestHelper.getApiUrl(
+                      "contentApiBaseUrl",
+                      "PostPublishById"), { id: id }),
+                  'Failed to publish content with id ' + id);
             }
-
-          return umbRequestHelper.resourcePromise(
-            $http.post(
-              umbRequestHelper.getApiUrl(
-                "contentApiBaseUrl",
-                "PostPublishById"), { id: id, cultures: cultures }),
-                'Failed to publish content with id ' + id);
+            else {
+                return umbRequestHelper.resourcePromise(
+                  $http.post(
+                    umbRequestHelper.getApiUrl(
+                      "contentApiBaseUrl",
+                      "PostPublishByIdAndCulture"), { id: id, cultures: cultures }),
+                  'Failed to publish content with id ' + id);
+            }
         },
 
         /**

--- a/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
@@ -1089,20 +1089,22 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
          * @returns {Promise} resourcePromise object containing the published content item.
          *
          */
-        publishById: function (id) {
+        publishById: function (id, cultures) {
 
             if (!id) {
                 throw "id cannot be null";
             }
 
-            return umbRequestHelper.resourcePromise(
-                $http.post(
-                    umbRequestHelper.getApiUrl(
-                        "contentApiBaseUrl",
-                        "PostPublishById",
-                        [{ id: id }])),
-                'Failed to publish content with id ' + id);
+            if (!cultures) {
+                cultures = [];
+            }
 
+          return umbRequestHelper.resourcePromise(
+            $http.post(
+              umbRequestHelper.getApiUrl(
+                "contentApiBaseUrl",
+                "PostPublishById"), { id: id, cultures: cultures }),
+                'Failed to publish content with id ' + id);
         },
 
         /**


### PR DESCRIPTION
### Prerequisites

Link to issue: https://github.com/umbraco/Umbraco-CMS/issues/13755

### Description
Modified `PostPublishById` to handle content that is culture variant. Added a new model for the endpoint and modified the JavaScript function that calls said endpoint.

I've tested these changes by creating a new doctype with list view enabled. I've allowed another doctype as it's child. Both doctypes are culture variant. After these changes you can publish one culture from the list view and the other culture will remain unpublished. **I'd like someone else to test these changes as well.** There were a few occasions where it looked like it wasn't working but I wasn't really able to replicate that. 

See gif below for the result:
![listviewsave](https://user-images.githubusercontent.com/77411834/216177492-128baa8b-2e90-4b96-b7a1-22402cfded89.gif)
