### PR TITLE
Add option to disable CheckCertificateRevocation for smtp client

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/SmtpSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/SmtpSettings.cs
@@ -83,6 +83,15 @@ public class SmtpSettings : ValidatableEntryBase
     public string? PickupDirectoryLocation { get; set; }
 
     /// <summary>
+    ///     Gets or sets a value indicating whether connecting via SSL/TLS should check certificate revocation.
+    /// </summary>
+    /// <remarks>
+    ///     Normally, the value of this property should be set to true (the default) for
+    ///     security reasons, but there are times when it may be necessary to set it to false.
+    /// </remarks>
+    public bool CheckCertificateRevocation { get; set; } = true;
+
+    /// <summary>
     ///     Gets or sets a value for the SMTP delivery method.
     /// </summary>
     [DefaultValue(StaticDeliveryMethod)]

--- a/src/Umbraco.Infrastructure/Mail/EmailSender.cs
+++ b/src/Umbraco.Infrastructure/Mail/EmailSender.cs
@@ -148,6 +148,8 @@ public class EmailSender : IEmailSender
 
         using var client = new SmtpClient();
 
+        client.CheckCertificateRevocation = _globalSettings.Smtp?.CheckCertificateRevocation ?? true;
+
         await client.ConnectAsync(
             _globalSettings.Smtp!.Host,
             _globalSettings.Smtp.Port,


### PR DESCRIPTION
### Prerequisites

- [x ] I have added steps to test this contribution in the description below

### Description

On one of our customer servers, where Umbraco is running behind a company firewall, it is impossible to check the revocation status of one of the certificates. This result in an SslHandshakeException. With the option to configuring the CheckCertificateRevocation on the SmtpClient we can prevent this problem.
The only problem is that this cannot be configured at the moment via the umbraco smtp settings. That's what this small change does.

It is difficult to name steps to fully test this. Perhaps putting a debug point on the modified line in the EmailSender.cs is the easiest option. And then change the appsettings and invite a new user via the cms.
