### PR TITLE
V11: Fix for media library type dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
@@ -136,7 +136,7 @@ angular.module("umbraco.directives")
           function _upload(file) {
 
             scope.propertyAlias = scope.propertyAlias ? scope.propertyAlias : "umbracoFile";
-            scope.contentTypeAlias = scope.contentTypeAlias ? scope.contentTypeAlias : "Image";
+            scope.contentTypeAlias = scope.contentTypeAlias ? scope.contentTypeAlias : "umbracoAutoSelect";
 
             scope.processingCount++;
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
@@ -75,6 +75,10 @@ angular.module("umbraco.directives")
               }
             });
 
+            // Add all of the processing and processed files to account for uploading
+            // files in stages (dragging files X at a time into the dropzone).
+            scope.totalQueued = scope.queue.length + scope.processingCount + scope.processed.length;
+
             // Upload not allowed
             if (!scope.acceptedMediatypes || !scope.acceptedMediatypes.length) {
               files.map(file => {
@@ -82,16 +86,19 @@ angular.module("umbraco.directives")
               });
             }
 
-            // If we have Accepted Media Types, we will ask to choose Media Type, if
-            // Choose Media Type returns false, it only had one choice and therefor no reason to
-            if (scope.acceptedMediatypes && _requestChooseMediaTypeDialog() === false) {
-              scope.contentTypeAlias = "umbracoAutoSelect";
+            // If we have Accepted Media Types, we will ask to choose Media Type
+            if (scope.acceptedMediatypes) {
+
+              // If the media type dialog returns a positive answer, it is safe to assume that the
+              // contentTypeAlias has been chosen and we can return early because the dialog will start processing
+              // the queue automatically
+              if (_requestChooseMediaTypeDialog()) {
+                return;
+              }
             }
 
-            // Add all of the processing and processed files to account for uploading
-            // files in stages (dragging files X at a time into the dropzone).
-            scope.totalQueued = scope.queue.length + scope.processingCount + scope.processed.length;
-
+            // Start the processing of the queue here because the media type dialog was not shown and therefore
+            // did not do it earlier
             _processQueueItems();
           }
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
@@ -3,21 +3,8 @@
 * @name umbraco.directives.directive:umbFileDropzone
 * @restrict E
 * @function
-* @description
+* @description Show a dropzone that allows the user to drag files and have them be uploaded to the media library
 **/
-
-/*
-TODO
-.directive("umbFileDrop", function ($timeout, $upload, localizationService, umbRequestHelper){
-    return{
-        restrict: "A",
-        link: function(scope, element, attrs){
-            //load in the options model
-        }
-    }
-})
-*/
-
 angular.module("umbraco.directives")
   .directive('umbFileDropzone',
     function ($timeout, Upload, localizationService, umbRequestHelper, overlayService, mediaHelper, mediaTypeHelper) {
@@ -65,6 +52,14 @@ angular.module("umbraco.directives")
             }
           }
 
+          /**
+           * Initial entrypoint to handle the queued files. It will determine if the files are acceptable
+           * and determine if the user needs to pick a media type
+           * @param files
+           * @param event
+           * @returns void
+           * @private
+           */
           function _filesQueued(files, event) {
             //Push into the queue
             Utilities.forEach(files, file => {
@@ -101,6 +96,11 @@ angular.module("umbraco.directives")
             _processQueueItems();
           }
 
+          /**
+           * Run through the queue and start processing files
+           * @returns void
+           * @private
+           */
           function _processQueueItems() {
 
             if (scope.processingCount === scope.batchSize) {
@@ -139,6 +139,13 @@ angular.module("umbraco.directives")
             }
           }
 
+          /**
+           * Upload a specific file and use the scope.contentTypeAlias for the type or fall back to letting
+           * the backend auto select a type.
+           * @param file
+           * @returns void
+           * @private
+           */
           function _upload(file) {
 
             scope.propertyAlias = scope.propertyAlias ? scope.propertyAlias : "umbracoFile";
@@ -201,6 +208,11 @@ angular.module("umbraco.directives")
               });
           }
 
+          /**
+           * Opens the media type dialog and lets the user choose a media type. If the queue is empty it will not show.
+           * @returns {boolean}
+           * @private
+           */
           function _requestChooseMediaTypeDialog() {
 
             if (scope.queue.length === 0) {
@@ -223,7 +235,6 @@ angular.module("umbraco.directives")
               // if only one  or less accepted types when we have filtered type 'file' out, then we wont ask to choose.
               return false;
             }
-
 
             localizationService.localizeMany(["defaultdialogs_selectMediaType", "mediaType_autoPickMediaType"]).then(function (translations) {
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
@@ -34,11 +34,10 @@ angular.module("umbraco.directives")
 
           compact: '@',
           hideDropzone: '@',
-          acceptedMediatypes: '=',
+          acceptedMediatypes: '<',
 
-          filesQueued: '=',
-          handleFile: '=',
-          filesUploaded: '='
+          filesQueued: '<',
+          filesUploaded: '<'
         },
         link: function (scope, element, attrs) {
           scope.queue = [];


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #13210, #13774

### Description

This aims to fix an issue where the user would be prompted to choose a media type in a dialog, but in the background, the files were already uploaded and assumed to be of the Image type.

Another fix included here is that some files would not be auto-detected correctly, e.g. SVG files were uploaded as images since that would be the default. The goal is now to let the server deduct what the best fitting media type is for a given file if the user was not prompted to choose one and if the dropzone directive was not instructed otherwise with a specific media type alias.

Lastly, I have added jsdocs to the functions in the dropzone directive to improve my understanding of what they do.

Note: At some point we should migrate the upload logic in the Dropzone directive to the newer Utilities.MediaUploader function.

### How to test

1. Open a default Umbraco 11 installation
    1. Drag an image type (jpg, png) => Check that media type is Image
    2. Drag a document (pdf) => Check that media type is Article
    3. Drag a vector graphic file (SVG) => Check that media type is Vector Graphics (SVG)
2. Make a copy of the media type "Vector Graphics (SVG)"
    1. Drag another vector graphic file (SVG) => Choose the new copied media type in the dialog => Check that the entry ends up with that type
    2. Drag another vector graphic file (SVG) => Choose "Autopick" in the dialog => Check that it defaulted back to the first media type (most likely "Vector Graphics (SVG)"
