### PR TITLE
V10: fix content version cleanup dto migration

### DIFF
--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerSyntaxProvider.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerSyntaxProvider.cs
@@ -272,6 +272,8 @@ where tbl.[name]=@0 and col.[name]=@1;",
         return !constraintName.IsNullOrWhiteSpace();
     }
 
+    public override bool DoesPrimaryKeyExists(IDatabase db, string tableName, string primaryKeyName) => false;
+
     public override bool DoesTableExist(IDatabase db, string tableName)
     {
         var result =

--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerSyntaxProvider.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerSyntaxProvider.cs
@@ -272,7 +272,12 @@ where tbl.[name]=@0 and col.[name]=@1;",
         return !constraintName.IsNullOrWhiteSpace();
     }
 
-    public override bool DoesPrimaryKeyExists(IDatabase db, string tableName, string primaryKeyName) => false;
+    public override bool DoesPrimaryKeyExists(IDatabase db, string tableName, string primaryKeyName)
+    {
+        IEnumerable<SqlPrimaryKey>? keys = db.Fetch<SqlPrimaryKey>($"select * from sysobjects where xtype='pk' and  parent_obj in (select id from sysobjects where name='{tableName}')")
+            .Where(x => x.Name == primaryKeyName);
+        return keys.FirstOrDefault() is not null;
+    }
 
     public override bool DoesTableExist(IDatabase db, string tableName)
     {
@@ -455,4 +460,9 @@ _sqlInspector ??= new SqlInspectionUtilities();
     }
 
     #endregion
+
+    private class SqlPrimaryKey
+    {
+        public string Name { get; set; } = null!;
+    }
 }

--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerSyntaxProvider.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerSyntaxProvider.cs
@@ -272,7 +272,7 @@ where tbl.[name]=@0 and col.[name]=@1;",
         return !constraintName.IsNullOrWhiteSpace();
     }
 
-    public override bool DoesPrimaryKeyExists(IDatabase db, string tableName, string primaryKeyName)
+    public override bool DoesPrimaryKeyExist(IDatabase db, string tableName, string primaryKeyName)
     {
         IEnumerable<SqlPrimaryKey>? keys = db.Fetch<SqlPrimaryKey>($"select * from sysobjects where xtype='pk' and  parent_obj in (select id from sysobjects where name='{tableName}')")
             .Where(x => x.Name == primaryKeyName);

--- a/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
@@ -176,9 +176,9 @@ public class SqliteSyntaxProvider : SqlSyntaxProviderBase<SqliteSyntaxProvider>
 
     public override bool DoesPrimaryKeyExist(IDatabase db, string tableName, string primaryKeyName)
     {
-        IEnumerable<string> items = db
-            .Fetch<string>($"SELECT l.name FROM pragma_table_info('{tableName}') as l WHERE l.pk = 1;")
-            .Where(x => x == primaryKeyName);
+        IEnumerable<SqliteMaster> items = db.Fetch<SqliteMaster>("select * from sqlite_master where type = 'table'")
+            .Where(x => x.Name == tableName)
+            .Where(x => x.Sql.Contains($"CONSTRAINT {primaryKeyName} PRIMARY KEY"));
 
         return items.Any();
     }

--- a/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
@@ -176,7 +176,7 @@ public class SqliteSyntaxProvider : SqlSyntaxProviderBase<SqliteSyntaxProvider>
 
     public override bool DoesPrimaryKeyExist(IDatabase db, string tableName, string primaryKeyName)
     {
-        IEnumerable<SqliteMaster> items = db.Fetch<SqliteMaster>("select * from sqlite_master where type = 'table'")
+        IEnumerable<SqliteMaster> items = db.Fetch<SqliteMaster>($"select * from sqlite_master where type = 'table' and name = '{tableName}'")
             .Where(x => x.Name == tableName)
             .Where(x => x.Sql.Contains($"CONSTRAINT {primaryKeyName} PRIMARY KEY"));
 
@@ -448,11 +448,6 @@ public class SqliteSyntaxProvider : SqlSyntaxProviderBase<SqliteSyntaxProvider>
         }
 
         public override string ToString() => ConstraintName;
-    }
-
-    private class SqlitePrimaryKey
-    {
-        public string Name { get; set; } = null!;
     }
 
     private class SqliteMaster

--- a/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
@@ -174,6 +174,15 @@ public class SqliteSyntaxProvider : SqlSyntaxProviderBase<SqliteSyntaxProvider>
         return false;
     }
 
+    public override bool DoesPrimaryKeyExists(IDatabase db, string tableName, string primaryKeyName)
+    {
+        IEnumerable<SqliteMaster> items = db
+            .Fetch<SqliteMaster>($"SELECT l.name FROM pragma_table_info('{tableName}') as l WHERE l.pk = 1;")
+            .Where(x => x.Name == primaryKeyName);
+
+        return items.Any();
+    }
+
     public override string GetFieldNameForUpdate<TDto>(Expression<Func<TDto, object?>> fieldSelector, string? tableAlias = null)
     {
         var field = ExpressionHelper.FindProperty(fieldSelector).Item1 as PropertyInfo;

--- a/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
@@ -176,9 +176,9 @@ public class SqliteSyntaxProvider : SqlSyntaxProviderBase<SqliteSyntaxProvider>
 
     public override bool DoesPrimaryKeyExists(IDatabase db, string tableName, string primaryKeyName)
     {
-        IEnumerable<SqliteMaster> items = db
-            .Fetch<SqliteMaster>($"SELECT l.name FROM pragma_table_info('{tableName}') as l WHERE l.pk = 1;")
-            .Where(x => x.Name == primaryKeyName);
+        IEnumerable<string> items = db
+            .Fetch<string>($"SELECT l.name FROM pragma_table_info('{tableName}') as l WHERE l.pk = 1;")
+            .Where(x => x == primaryKeyName);
 
         return items.Any();
     }
@@ -448,6 +448,11 @@ public class SqliteSyntaxProvider : SqlSyntaxProviderBase<SqliteSyntaxProvider>
         }
 
         public override string ToString() => ConstraintName;
+    }
+
+    private class SqlitePrimaryKey
+    {
+        public string Name { get; set; } = null!;
     }
 
     private class SqliteMaster

--- a/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
@@ -174,7 +174,7 @@ public class SqliteSyntaxProvider : SqlSyntaxProviderBase<SqliteSyntaxProvider>
         return false;
     }
 
-    public override bool DoesPrimaryKeyExists(IDatabase db, string tableName, string primaryKeyName)
+    public override bool DoesPrimaryKeyExist(IDatabase db, string tableName, string primaryKeyName)
     {
         IEnumerable<string> items = db
             .Fetch<string>($"SELECT l.name FROM pragma_table_info('{tableName}') as l WHERE l.pk = 1;")

--- a/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
@@ -176,8 +176,8 @@ public class SqliteSyntaxProvider : SqlSyntaxProviderBase<SqliteSyntaxProvider>
 
     public override bool DoesPrimaryKeyExist(IDatabase db, string tableName, string primaryKeyName)
     {
-        IEnumerable<SqliteMaster> items = db.Fetch<SqliteMaster>($"select * from sqlite_master where type = 'table' and name = '{tableName}'")
-            .Where(x => x.Sql.Contains($"CONSTRAINT {primaryKeyName} PRIMARY KEY"));
+        IEnumerable<string> items = db.Fetch<string>($"select sql from sqlite_master where type = 'table' and name = '{tableName}'")
+            .Where(x => x.Contains($"CONSTRAINT {primaryKeyName} PRIMARY KEY"));
 
         return items.Any();
     }

--- a/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
@@ -177,7 +177,6 @@ public class SqliteSyntaxProvider : SqlSyntaxProviderBase<SqliteSyntaxProvider>
     public override bool DoesPrimaryKeyExist(IDatabase db, string tableName, string primaryKeyName)
     {
         IEnumerable<SqliteMaster> items = db.Fetch<SqliteMaster>($"select * from sqlite_master where type = 'table' and name = '{tableName}'")
-            .Where(x => x.Name == tableName)
             .Where(x => x.Sql.Contains($"CONSTRAINT {primaryKeyName} PRIMARY KEY"));
 
         return items.Any();

--- a/src/Umbraco.Infrastructure/Migrations/MigrationBase_Extra.cs
+++ b/src/Umbraco.Infrastructure/Migrations/MigrationBase_Extra.cs
@@ -110,6 +110,11 @@ namespace Umbraco.Cms.Infrastructure.Migrations
             return indexes.Any(x => x.Item2.InvariantEquals(indexName));
         }
 
+        protected bool PrimaryKeyExists(string tableName, string primaryKeyName)
+        {
+            return SqlSyntax.DoesPrimaryKeyExists(Context.Database, tableName, primaryKeyName);
+        }
+
         protected bool ColumnExists(string tableName, string columnName)
         {
             ColumnInfo[]? columns = SqlSyntax.GetColumnsInSchema(Context.Database).Distinct().ToArray();

--- a/src/Umbraco.Infrastructure/Migrations/MigrationBase_Extra.cs
+++ b/src/Umbraco.Infrastructure/Migrations/MigrationBase_Extra.cs
@@ -112,7 +112,7 @@ namespace Umbraco.Cms.Infrastructure.Migrations
 
         protected bool PrimaryKeyExists(string tableName, string primaryKeyName)
         {
-            return SqlSyntax.DoesPrimaryKeyExists(Context.Database, tableName, primaryKeyName);
+            return SqlSyntax.DoesPrimaryKeyExist(Context.Database, tableName, primaryKeyName);
         }
 
         protected bool ColumnExists(string tableName, string columnName)

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_10_5_0/AddPrimaryKeyConstrainToContentVersionCleanupDtos.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_10_5_0/AddPrimaryKeyConstrainToContentVersionCleanupDtos.cs
@@ -10,18 +10,28 @@ public class AddPrimaryKeyConstrainToContentVersionCleanupDtos : MigrationBase
 
     protected override void Migrate()
     {
-        IEnumerable<ContentVersionCleanupPolicyDto> contentVersionCleanupPolicyDtos =
-            Database
-                .Fetch<ContentVersionCleanupPolicyDto>()
-                .OrderByDescending(x => x.Updated)
-                .DistinctBy(x => x.ContentTypeId);
-
+        IEnumerable<ContentVersionCleanupPolicyDto>? contentVersionCleanupPolicyDtos = null;
         if (TableExists(ContentVersionCleanupPolicyDto.TableName))
         {
+            if (PrimaryKeyExists(ContentVersionCleanupPolicyDto.TableName, "PK_umbracoContentVersionCleanupPolicy"))
+            {
+                return;
+            }
+
+            contentVersionCleanupPolicyDtos =
+                Database
+                    .Fetch<ContentVersionCleanupPolicyDto>()
+                    .OrderByDescending(x => x.Updated)
+                    .DistinctBy(x => x.ContentTypeId);
+
             Delete.Table(ContentVersionCleanupPolicyDto.TableName).Do();
         }
 
         Create.Table<ContentVersionCleanupPolicyDto>().Do();
-        Database.InsertBatch(contentVersionCleanupPolicyDtos);
+
+        if (contentVersionCleanupPolicyDtos is not null)
+        {
+            Database.InsertBatch(contentVersionCleanupPolicyDtos);
+        }
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_10_5_0/AddPrimaryKeyConstrainToContentVersionCleanupDtos.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_10_5_0/AddPrimaryKeyConstrainToContentVersionCleanupDtos.cs
@@ -13,7 +13,7 @@ public class AddPrimaryKeyConstrainToContentVersionCleanupDtos : MigrationBase
         IEnumerable<ContentVersionCleanupPolicyDto>? contentVersionCleanupPolicyDtos = null;
         if (TableExists(ContentVersionCleanupPolicyDto.TableName))
         {
-            if (PrimaryKeyExists(ContentVersionCleanupPolicyDto.TableName, "PK_umbracoContentVersionCleanupPolicy"))
+            if (PrimaryKeyExists(ContentVersionCleanupPolicyDto.TableName, "contentTypeId"))
             {
                 return;
             }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_10_5_0/AddPrimaryKeyConstrainToContentVersionCleanupDtos.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_10_5_0/AddPrimaryKeyConstrainToContentVersionCleanupDtos.cs
@@ -13,7 +13,7 @@ public class AddPrimaryKeyConstrainToContentVersionCleanupDtos : MigrationBase
         IEnumerable<ContentVersionCleanupPolicyDto>? contentVersionCleanupPolicyDtos = null;
         if (TableExists(ContentVersionCleanupPolicyDto.TableName))
         {
-            if (PrimaryKeyExists(ContentVersionCleanupPolicyDto.TableName, "contentTypeId"))
+            if (PrimaryKeyExists(ContentVersionCleanupPolicyDto.TableName, "PK_umbracoContentVersionCleanupPolicy"))
             {
                 return;
             }

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/ContentVersionCleanupPolicyDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/ContentVersionCleanupPolicyDto.cs
@@ -1,4 +1,3 @@
-using System.Data;
 using NPoco;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Infrastructure.Persistence.DatabaseAnnotations;
@@ -6,6 +5,7 @@ using Umbraco.Cms.Infrastructure.Persistence.DatabaseAnnotations;
 namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 
 [TableName(TableName)]
+[PrimaryKey("contentTypeId", AutoIncrement = false)]
 [ExplicitColumns]
 internal class ContentVersionCleanupPolicyDto
 {

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/ContentVersionCleanupPolicyDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/ContentVersionCleanupPolicyDto.cs
@@ -6,14 +6,13 @@ using Umbraco.Cms.Infrastructure.Persistence.DatabaseAnnotations;
 namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 
 [TableName(TableName)]
-[PrimaryKey("contentTypeId", AutoIncrement = false)]
 [ExplicitColumns]
 internal class ContentVersionCleanupPolicyDto
 {
     public const string TableName = Constants.DatabaseSchema.Tables.ContentVersionCleanupPolicy;
 
     [Column("contentTypeId")]
-    [PrimaryKeyColumn(AutoIncrement = false)]
+    [PrimaryKeyColumn(AutoIncrement = false, Name = "PK_umbracoContentVersionCleanupPolicy")]
     [ForeignKey(typeof(ContentTypeDto), Column = "nodeId")]
     public int ContentTypeId { get; set; }
 

--- a/src/Umbraco.Infrastructure/Persistence/SqlSyntax/ISqlSyntaxProvider.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SqlSyntax/ISqlSyntaxProvider.cs
@@ -187,6 +187,7 @@ public interface ISqlSyntaxProvider
     ///     </para>
     /// </remarks>
     bool TryGetDefaultConstraint(IDatabase db, string? tableName, string columnName, [MaybeNullWhen(false)] out string constraintName);
+    bool DoesPrimaryKeyExists(IDatabase db, string tableName, string primaryKeyName);
 
     string GetFieldNameForUpdate<TDto>(Expression<Func<TDto, object?>> fieldSelector, string? tableAlias = null);
 

--- a/src/Umbraco.Infrastructure/Persistence/SqlSyntax/ISqlSyntaxProvider.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SqlSyntax/ISqlSyntaxProvider.cs
@@ -187,7 +187,8 @@ public interface ISqlSyntaxProvider
     ///     </para>
     /// </remarks>
     bool TryGetDefaultConstraint(IDatabase db, string? tableName, string columnName, [MaybeNullWhen(false)] out string constraintName);
-    bool DoesPrimaryKeyExist(IDatabase db, string tableName, string primaryKeyName);
+
+    bool DoesPrimaryKeyExist(IDatabase db, string tableName, string primaryKeyName) => throw new NotImplementedException();
 
     string GetFieldNameForUpdate<TDto>(Expression<Func<TDto, object?>> fieldSelector, string? tableAlias = null);
 

--- a/src/Umbraco.Infrastructure/Persistence/SqlSyntax/ISqlSyntaxProvider.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SqlSyntax/ISqlSyntaxProvider.cs
@@ -187,7 +187,7 @@ public interface ISqlSyntaxProvider
     ///     </para>
     /// </remarks>
     bool TryGetDefaultConstraint(IDatabase db, string? tableName, string columnName, [MaybeNullWhen(false)] out string constraintName);
-    bool DoesPrimaryKeyExists(IDatabase db, string tableName, string primaryKeyName);
+    bool DoesPrimaryKeyExist(IDatabase db, string tableName, string primaryKeyName);
 
     string GetFieldNameForUpdate<TDto>(Expression<Func<TDto, object?>> fieldSelector, string? tableAlias = null);
 

--- a/src/Umbraco.Infrastructure/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
@@ -209,6 +209,8 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
 
     public abstract bool TryGetDefaultConstraint(IDatabase db, string? tableName, string columnName, [MaybeNullWhen(false)] out string constraintName);
 
+    public abstract bool DoesPrimaryKeyExists(IDatabase db, string tableName, string primaryKeyName);
+
     public virtual string GetFieldNameForUpdate<TDto>(
         Expression<Func<TDto, object?>> fieldSelector,
         string? tableAlias = null) => this.GetFieldName(fieldSelector, tableAlias);

--- a/src/Umbraco.Infrastructure/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
@@ -209,7 +209,7 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
 
     public abstract bool TryGetDefaultConstraint(IDatabase db, string? tableName, string columnName, [MaybeNullWhen(false)] out string constraintName);
 
-    public abstract bool DoesPrimaryKeyExist(IDatabase db, string tableName, string primaryKeyName);
+    public virtual bool DoesPrimaryKeyExist(IDatabase db, string tableName, string primaryKeyName) => throw new NotImplementedException();
 
     public virtual string GetFieldNameForUpdate<TDto>(
         Expression<Func<TDto, object?>> fieldSelector,

--- a/src/Umbraco.Infrastructure/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
@@ -209,7 +209,7 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
 
     public abstract bool TryGetDefaultConstraint(IDatabase db, string? tableName, string columnName, [MaybeNullWhen(false)] out string constraintName);
 
-    public abstract bool DoesPrimaryKeyExists(IDatabase db, string tableName, string primaryKeyName);
+    public abstract bool DoesPrimaryKeyExist(IDatabase db, string tableName, string primaryKeyName);
 
     public virtual string GetFieldNameForUpdate<TDto>(
         Expression<Func<TDto, object?>> fieldSelector,


### PR DESCRIPTION
Fixes comments from https://github.com/umbraco/Umbraco-CMS/pull/12684#discussion_r1095655597

# Notes
- Move guarding TableExist clause up to prevent explosion of migration.
- Added PrimaryKeyExist to ISqlSyntaxProvider
- Added PrimaryKeyExist overrides for SqlServerSyntaxProvicer & SqliteSyntaxProvider

# How to test
- Run and install umbraco
- Stop umbraco
- Add `To<AddPrimaryKeyConstrainToContentVersionCleanupDtos>("{67CF5353-82A4-4C08-AB7D-99EB0A49715E}");` to last line of UmbracoPlan.DefinePlan()
- Run umbraco and go to /install
- Set a breakpoint in `AddPrimaryKeyConstrainToContentVersionCleanupDtos` on line 16
- PrimaryKeyExists Should return true