### PR TITLE
potential fix for #13799

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbraco-blockgridlayout.css
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbraco-blockgridlayout.css
@@ -21,7 +21,7 @@
     display: grid;
     grid-template-columns: repeat(var(--umb-block-grid--area-grid-columns, var(--umb-block-grid--grid-columns, 1)), minmax(0, 1fr));
     grid-auto-flow: row;
-    grid-auto-rows: minmax(50px, min-content);
+    grid-auto-rows: minmax(max-content, min-content);
 
     column-gap: var(--umb-block-grid--areas-column-gap, 0);
     row-gap: var(--umb-block-grid--areas-row-gap, 0);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes #13799 

### Description
Fixes block grid layout for 2-column layouts on Safari mobile (<640px) views
