### PR TITLE
v11: npm updates for february

### DIFF
--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -9,7 +9,7 @@
         "@microsoft/signalr": "7.0.2",
         "@umbraco-ui/uui": "1.1.0",
         "@umbraco-ui/uui-css": "1.1.0",
-        "ace-builds": "1.14.0",
+        "ace-builds": "1.15.0",
         "angular": "1.8.3",
         "angular-animate": "1.8.3",
         "angular-aria": "1.8.3",
@@ -2877,9 +2877,9 @@
       }
     },
     "node_modules/ace-builds": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.14.0.tgz",
-      "integrity": "sha512-3q8LvawomApRCt4cC0OzxVjDsZ609lDbm8l0Xl9uqG06dKEq4RT0YXLUyk7J2SxmqIp5YXzZNw767Dr8GKUruw=="
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.15.0.tgz",
+      "integrity": "sha512-L1RXgqxDvzbJ7H8Y2v9lb4kHaZRn5JNTECG+oZTH2EDewMmpQMLDC4GnFKIh3+xb/gk2nVPO7gGwpTYPw91QzA=="
     },
     "node_modules/acorn": {
       "version": "8.8.1",
@@ -19612,9 +19612,9 @@
       }
     },
     "ace-builds": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.14.0.tgz",
-      "integrity": "sha512-3q8LvawomApRCt4cC0OzxVjDsZ609lDbm8l0Xl9uqG06dKEq4RT0YXLUyk7J2SxmqIp5YXzZNw767Dr8GKUruw=="
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.15.0.tgz",
+      "integrity": "sha512-L1RXgqxDvzbJ7H8Y2v9lb4kHaZRn5JNTECG+oZTH2EDewMmpQMLDC4GnFKIh3+xb/gk2nVPO7gGwpTYPw91QzA=="
     },
     "acorn": {
       "version": "8.8.1",

--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -69,7 +69,7 @@
         "gulp-wrap": "0.15.0",
         "gulp-wrap-js": "0.4.1",
         "jasmine-core": "4.5.0",
-        "jsdom": "21.0.0",
+        "jsdom": "21.1.0",
         "karma": "6.4.1",
         "karma-jasmine": "5.1.0",
         "karma-jsdom-launcher": "14.0.0",
@@ -10638,9 +10638,9 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-21.0.0.tgz",
-      "integrity": "sha512-AIw+3ZakSUtDYvhwPwWHiZsUi3zHugpMEKlNPaurviseYoBqo0zBd3zqoUi3LPCNtPFlEP8FiW9MqCZdjb2IYA==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-21.1.0.tgz",
+      "integrity": "sha512-m0lzlP7qOtthD918nenK3hdItSd2I+V3W9IrBcB36sqDwG+KnUs66IF5GY7laGWUnlM9vTsD0W1QwSEBYWWcJg==",
       "dev": true,
       "dependencies": {
         "abab": "^2.0.6",
@@ -25756,9 +25756,9 @@
       }
     },
     "jsdom": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-21.0.0.tgz",
-      "integrity": "sha512-AIw+3ZakSUtDYvhwPwWHiZsUi3zHugpMEKlNPaurviseYoBqo0zBd3zqoUi3LPCNtPFlEP8FiW9MqCZdjb2IYA==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-21.1.0.tgz",
+      "integrity": "sha512-m0lzlP7qOtthD918nenK3hdItSd2I+V3W9IrBcB36sqDwG+KnUs66IF5GY7laGWUnlM9vTsD0W1QwSEBYWWcJg==",
       "dev": true,
       "requires": {
         "abab": "^2.0.6",

--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -49,7 +49,7 @@
         "@babel/preset-env": "7.20.2",
         "autoprefixer": "10.4.13",
         "cssnano": "5.1.14",
-        "eslint": "8.32.0",
+        "eslint": "8.33.0",
         "gulp": "4.0.2",
         "gulp-angular-embed-templates": "2.3.0",
         "gulp-babel": "8.0.0",
@@ -6434,9 +6434,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.32.0.tgz",
-      "integrity": "sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.33.0.tgz",
+      "integrity": "sha512-WjOpFQgKK8VrCnAtl8We0SUOy/oVZ5NHykyMiagV1M9r8IFpIJX7DduK6n1mpfhlG7T1NLWm2SuD8QB7KFySaA==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.4.1",
@@ -22503,9 +22503,9 @@
       }
     },
     "eslint": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.32.0.tgz",
-      "integrity": "sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.33.0.tgz",
+      "integrity": "sha512-WjOpFQgKK8VrCnAtl8We0SUOy/oVZ5NHykyMiagV1M9r8IFpIJX7DduK6n1mpfhlG7T1NLWm2SuD8QB7KFySaA==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.4.1",

--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -37,7 +37,7 @@
         "lazyload-js": "1.0.0",
         "moment": "2.29.4",
         "ng-file-upload": "12.2.13",
-        "nouislider": "15.6.1",
+        "nouislider": "15.7.0",
         "spectrum-colorpicker2": "2.0.9",
         "tinymce": "6.3.1",
         "typeahead.js": "0.11.1",
@@ -12543,9 +12543,9 @@
       }
     },
     "node_modules/nouislider": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/nouislider/-/nouislider-15.6.1.tgz",
-      "integrity": "sha512-1T5AfeEMGrGM87UJ+qAHvauPfCe/woOjYV/o29fp21+XgGuGpkM1Udo7mPHnidu4+cxlj35rDBWKiA6Mefemrg=="
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/nouislider/-/nouislider-15.7.0.tgz",
+      "integrity": "sha512-aJVEULBPOUwq32/s7xnLNyLvo4kuzYJJsNp2PNGW932AQ0uuDAbLShAqswtxRzJc5n/dLJXNlYSLOZ57bcUg1w=="
     },
     "node_modules/now-and-later": {
       "version": "2.0.1",
@@ -27241,9 +27241,9 @@
       "dev": true
     },
     "nouislider": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/nouislider/-/nouislider-15.6.1.tgz",
-      "integrity": "sha512-1T5AfeEMGrGM87UJ+qAHvauPfCe/woOjYV/o29fp21+XgGuGpkM1Udo7mPHnidu4+cxlj35rDBWKiA6Mefemrg=="
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/nouislider/-/nouislider-15.7.0.tgz",
+      "integrity": "sha512-aJVEULBPOUwq32/s7xnLNyLvo4kuzYJJsNp2PNGW932AQ0uuDAbLShAqswtxRzJc5n/dLJXNlYSLOZ57bcUg1w=="
     },
     "now-and-later": {
       "version": "2.0.1",

--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -21,7 +21,7 @@
     "@microsoft/signalr": "7.0.2",
     "@umbraco-ui/uui": "1.1.0",
     "@umbraco-ui/uui-css": "1.1.0",
-    "ace-builds": "1.14.0",
+    "ace-builds": "1.15.0",
     "angular": "1.8.3",
     "angular-animate": "1.8.3",
     "angular-aria": "1.8.3",

--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -49,7 +49,7 @@
     "lazyload-js": "1.0.0",
     "moment": "2.29.4",
     "ng-file-upload": "12.2.13",
-    "nouislider": "15.6.1",
+    "nouislider": "15.7.0",
     "spectrum-colorpicker2": "2.0.9",
     "tinymce": "6.3.1",
     "typeahead.js": "0.11.1",

--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -81,7 +81,7 @@
     "gulp-wrap": "0.15.0",
     "gulp-wrap-js": "0.4.1",
     "jasmine-core": "4.5.0",
-    "jsdom": "21.0.0",
+    "jsdom": "21.1.0",
     "karma": "6.4.1",
     "karma-jasmine": "5.1.0",
     "karma-jsdom-launcher": "14.0.0",

--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -61,7 +61,7 @@
     "@babel/preset-env": "7.20.2",
     "autoprefixer": "10.4.13",
     "cssnano": "5.1.14",
-    "eslint": "8.32.0",
+    "eslint": "8.33.0",
     "gulp": "4.0.2",
     "gulp-angular-embed-templates": "2.3.0",
     "gulp-babel": "8.0.0",


### PR DESCRIPTION
* update ace-builds from 1.14.0 to 1.15.0
* update eslint from 8.32.0 to 8.33.0
* update jsdom from 21.0.0 to 21.1.0
* update nouislider from 15.6.1 to 15.7.0