### PR TITLE
Add "Model" postfix for all models in the Swagger output

### DIFF
--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -38,7 +38,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedCulture"
+                  "$ref": "#/components/schemas/PagedCultureModel"
                 }
               }
             }
@@ -65,12 +65,22 @@
           "201": {
             "description": "Created"
           },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -101,7 +111,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DataType"
+                  "$ref": "#/components/schemas/DataTypeModel"
                 }
               }
             }
@@ -111,7 +121,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -138,12 +148,22 @@
           "200": {
             "description": "Success"
           },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -179,12 +199,22 @@
           "200": {
             "description": "Success"
           },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -217,7 +247,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DataTypeReference"
+                    "$ref": "#/components/schemas/DataTypeReferenceModel"
                   }
                 }
               }
@@ -228,7 +258,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -281,7 +311,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Folder"
+                  "$ref": "#/components/schemas/FolderModel"
                 }
               }
             }
@@ -291,7 +321,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -323,7 +353,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -364,7 +394,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -420,7 +450,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedFolderTreeItem"
+                  "$ref": "#/components/schemas/PagedFolderTreeItemModel"
                 }
               }
             }
@@ -455,7 +485,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/FolderTreeItem"
+                    "$ref": "#/components/schemas/FolderTreeItemModel"
                   }
                 }
               }
@@ -504,7 +534,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedFolderTreeItem"
+                  "$ref": "#/components/schemas/PagedFolderTreeItemModel"
                 }
               }
             }
@@ -544,7 +574,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedDictionaryOverview"
+                  "$ref": "#/components/schemas/PagedDictionaryOverviewModel"
                 }
               }
             }
@@ -574,7 +604,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -584,7 +614,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -594,7 +624,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -625,7 +655,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DictionaryItem"
+                  "$ref": "#/components/schemas/DictionaryItemModel"
                 }
               }
             }
@@ -635,7 +665,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -667,7 +697,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -677,7 +707,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -718,7 +748,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -728,7 +758,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -778,7 +808,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotFoundResult"
+                  "$ref": "#/components/schemas/NotFoundResultModel"
                 }
               }
             }
@@ -815,7 +845,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ContentResult"
+                  "$ref": "#/components/schemas/ContentResultModel"
                 }
               }
             }
@@ -825,7 +855,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotFoundResult"
+                  "$ref": "#/components/schemas/NotFoundResultModel"
                 }
               }
             }
@@ -840,7 +870,7 @@
         ],
         "operationId": "PostDictionaryUpload",
         "requestBody": {
-          "content": {}
+          "content": { }
         },
         "responses": {
           "200": {
@@ -848,7 +878,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DictionaryImport"
+                  "$ref": "#/components/schemas/DictionaryImportModel"
                 }
               }
             }
@@ -858,7 +888,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -906,7 +936,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedEntityTreeItem"
+                  "$ref": "#/components/schemas/PagedEntityTreeItemModel"
                 }
               }
             }
@@ -941,7 +971,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/FolderTreeItem"
+                    "$ref": "#/components/schemas/FolderTreeItemModel"
                   }
                 }
               }
@@ -982,7 +1012,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedEntityTreeItem"
+                  "$ref": "#/components/schemas/PagedEntityTreeItemModel"
                 }
               }
             }
@@ -1017,7 +1047,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DocumentBlueprintTreeItem"
+                    "$ref": "#/components/schemas/DocumentBlueprintTreeItemModel"
                   }
                 }
               }
@@ -1058,7 +1088,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedDocumentBlueprintTreeItem"
+                  "$ref": "#/components/schemas/PagedDocumentBlueprintTreeItemModel"
                 }
               }
             }
@@ -1114,7 +1144,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedDocumentTypeTreeItem"
+                  "$ref": "#/components/schemas/PagedDocumentTypeTreeItemModel"
                 }
               }
             }
@@ -1149,7 +1179,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DocumentTypeTreeItem"
+                    "$ref": "#/components/schemas/DocumentTypeTreeItemModel"
                   }
                 }
               }
@@ -1198,7 +1228,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedDocumentTypeTreeItem"
+                  "$ref": "#/components/schemas/PagedDocumentTypeTreeItemModel"
                 }
               }
             }
@@ -1246,7 +1276,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -1256,7 +1286,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedRecycleBinItem"
+                  "$ref": "#/components/schemas/PagedRecycleBinItemModel"
                 }
               }
             }
@@ -1296,7 +1326,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -1306,7 +1336,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedRecycleBinItem"
+                  "$ref": "#/components/schemas/PagedRecycleBinItemModel"
                 }
               }
             }
@@ -1369,7 +1399,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedDocumentTreeItem"
+                  "$ref": "#/components/schemas/PagedDocumentTreeItemModel"
                 }
               }
             }
@@ -1419,7 +1449,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DocumentTreeItem"
+                    "$ref": "#/components/schemas/DocumentTreeItemModel"
                   }
                 }
               }
@@ -1475,7 +1505,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedDocumentTreeItem"
+                  "$ref": "#/components/schemas/PagedDocumentTreeItemModel"
                 }
               }
             }
@@ -1515,7 +1545,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedHealthCheckGroup"
+                  "$ref": "#/components/schemas/PagedHealthCheckGroupModel"
                 }
               }
             }
@@ -1545,7 +1575,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotFoundResult"
+                  "$ref": "#/components/schemas/NotFoundResultModel"
                 }
               }
             }
@@ -1555,7 +1585,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HealthCheckGroupWithResult"
+                  "$ref": "#/components/schemas/HealthCheckGroupWithResultModel"
                 }
               }
             }
@@ -1573,7 +1603,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/HealthCheckAction"
+                "$ref": "#/components/schemas/HealthCheckActionModel"
               }
             }
           }
@@ -1584,7 +1614,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -1594,7 +1624,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HealthCheckResult"
+                  "$ref": "#/components/schemas/HealthCheckResultModel"
                 }
               }
             }
@@ -1654,7 +1684,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -1664,7 +1694,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedHelpPage"
+                  "$ref": "#/components/schemas/PagedHelpPageModel"
                 }
               }
             }
@@ -1702,7 +1732,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedIndex"
+                  "$ref": "#/components/schemas/PagedIndexModel"
                 }
               }
             }
@@ -1732,7 +1762,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -1742,7 +1772,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Index"
+                  "$ref": "#/components/schemas/IndexModel"
                 }
               }
             }
@@ -1772,7 +1802,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -1782,7 +1812,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/OkResult"
+                  "$ref": "#/components/schemas/OkResultModel"
                 }
               }
             }
@@ -1802,7 +1832,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -1812,7 +1842,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -1822,7 +1852,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/InstallSettings"
+                  "$ref": "#/components/schemas/InstallSettingsModel"
                 }
               }
             }
@@ -1840,7 +1870,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Install"
+                "$ref": "#/components/schemas/InstallModel"
               }
             }
           }
@@ -1851,7 +1881,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -1861,7 +1891,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -1882,7 +1912,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/DatabaseInstall"
+                "$ref": "#/components/schemas/DatabaseInstallModel"
               }
             }
           }
@@ -1893,7 +1923,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -1936,7 +1966,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedLanguage"
+                  "$ref": "#/components/schemas/PagedLanguageModel"
                 }
               }
             }
@@ -1963,7 +1993,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -1973,7 +2003,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -2006,7 +2036,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -2016,7 +2046,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Language"
+                  "$ref": "#/components/schemas/LanguageModel"
                 }
               }
             }
@@ -2044,7 +2074,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -2054,7 +2084,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -2094,7 +2124,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotFoundResult"
+                  "$ref": "#/components/schemas/NotFoundResultModel"
                 }
               }
             }
@@ -2104,7 +2134,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -2147,7 +2177,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedLogger"
+                  "$ref": "#/components/schemas/PagedLoggerModel"
                 }
               }
             }
@@ -2185,7 +2215,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -2225,7 +2255,7 @@
             "name": "orderDirection",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Direction"
+              "$ref": "#/components/schemas/DirectionModel"
             }
           },
           {
@@ -2241,7 +2271,7 @@
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/components/schemas/LogLevel"
+                "$ref": "#/components/schemas/LogLevelModel"
               }
             }
           },
@@ -2268,7 +2298,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedLogMessage"
+                  "$ref": "#/components/schemas/PagedLogMessageModel"
                 }
               }
             }
@@ -2324,7 +2354,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -2334,7 +2364,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedLogTemplate"
+                  "$ref": "#/components/schemas/PagedLogTemplateModel"
                 }
               }
             }
@@ -2374,7 +2404,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedSavedLogSearch"
+                  "$ref": "#/components/schemas/PagedSavedLogSearchModel"
                 }
               }
             }
@@ -2390,7 +2420,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SavedLogSearch"
+                "$ref": "#/components/schemas/SavedLogSearchModel"
               }
             }
           }
@@ -2401,7 +2431,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -2434,7 +2464,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotFoundResult"
+                  "$ref": "#/components/schemas/NotFoundResultModel"
                 }
               }
             }
@@ -2444,7 +2474,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SavedLogSearch"
+                  "$ref": "#/components/schemas/SavedLogSearchModel"
                 }
               }
             }
@@ -2472,7 +2502,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotFoundResult"
+                  "$ref": "#/components/schemas/NotFoundResultModel"
                 }
               }
             }
@@ -2513,7 +2543,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -2572,7 +2602,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedFolderTreeItem"
+                  "$ref": "#/components/schemas/PagedFolderTreeItemModel"
                 }
               }
             }
@@ -2607,7 +2637,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/FolderTreeItem"
+                    "$ref": "#/components/schemas/FolderTreeItemModel"
                   }
                 }
               }
@@ -2656,7 +2686,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedFolderTreeItem"
+                  "$ref": "#/components/schemas/PagedFolderTreeItemModel"
                 }
               }
             }
@@ -2704,7 +2734,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -2714,7 +2744,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedRecycleBinItem"
+                  "$ref": "#/components/schemas/PagedRecycleBinItemModel"
                 }
               }
             }
@@ -2754,7 +2784,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -2764,7 +2794,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedRecycleBinItem"
+                  "$ref": "#/components/schemas/PagedRecycleBinItemModel"
                 }
               }
             }
@@ -2820,7 +2850,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedContentTreeItem"
+                  "$ref": "#/components/schemas/PagedContentTreeItemModel"
                 }
               }
             }
@@ -2863,7 +2893,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/ContentTreeItem"
+                    "$ref": "#/components/schemas/ContentTreeItemModel"
                   }
                 }
               }
@@ -2912,7 +2942,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedContentTreeItem"
+                  "$ref": "#/components/schemas/PagedContentTreeItemModel"
                 }
               }
             }
@@ -2947,7 +2977,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/EntityTreeItem"
+                    "$ref": "#/components/schemas/EntityTreeItemModel"
                   }
                 }
               }
@@ -2988,7 +3018,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedEntityTreeItem"
+                  "$ref": "#/components/schemas/PagedEntityTreeItemModel"
                 }
               }
             }
@@ -3023,7 +3053,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/EntityTreeItem"
+                    "$ref": "#/components/schemas/EntityTreeItemModel"
                   }
                 }
               }
@@ -3064,7 +3094,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedEntityTreeItem"
+                  "$ref": "#/components/schemas/PagedEntityTreeItemModel"
                 }
               }
             }
@@ -3084,7 +3114,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreatedResult"
+                  "$ref": "#/components/schemas/CreatedResultModel"
                 }
               }
             }
@@ -3094,7 +3124,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -3114,7 +3144,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ModelsBuilder"
+                  "$ref": "#/components/schemas/ModelsBuilderModel"
                 }
               }
             }
@@ -3134,7 +3164,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/OutOfDateStatus"
+                  "$ref": "#/components/schemas/OutOfDateStatusModel"
                 }
               }
             }
@@ -3181,7 +3211,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedFileSystemTreeItem"
+                  "$ref": "#/components/schemas/PagedFileSystemTreeItemModel"
                 }
               }
             }
@@ -3215,7 +3245,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/FileSystemTreeItem"
+                    "$ref": "#/components/schemas/FileSystemTreeItemModel"
                   }
                 }
               }
@@ -3256,7 +3286,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedFileSystemTreeItem"
+                  "$ref": "#/components/schemas/PagedFileSystemTreeItemModel"
                 }
               }
             }
@@ -3276,7 +3306,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProfilingStatus"
+                  "$ref": "#/components/schemas/ProfilingStatusModel"
                 }
               }
             }
@@ -3380,7 +3410,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -3390,7 +3420,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedRedirectUrl"
+                  "$ref": "#/components/schemas/PagedRedirectUrlModel"
                 }
               }
             }
@@ -3437,7 +3467,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedRedirectUrl"
+                  "$ref": "#/components/schemas/PagedRedirectUrlModel"
                 }
               }
             }
@@ -3479,7 +3509,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RedirectUrlStatus"
+                  "$ref": "#/components/schemas/RedirectUrlStatusModel"
                 }
               }
             }
@@ -3496,7 +3526,7 @@
             "name": "status",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/RedirectStatus"
+              "$ref": "#/components/schemas/RedirectStatusModel"
             }
           }
         ],
@@ -3534,7 +3564,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/FolderTreeItem"
+                    "$ref": "#/components/schemas/FolderTreeItemModel"
                   }
                 }
               }
@@ -3575,7 +3605,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedEntityTreeItem"
+                  "$ref": "#/components/schemas/PagedEntityTreeItemModel"
                 }
               }
             }
@@ -3606,7 +3636,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Relation"
+                  "$ref": "#/components/schemas/RelationModel"
                 }
               }
             }
@@ -3616,7 +3646,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotFoundResult"
+                  "$ref": "#/components/schemas/NotFoundResultModel"
                 }
               }
             }
@@ -3671,7 +3701,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedRelation"
+                  "$ref": "#/components/schemas/PagedRelationModel"
                 }
               }
             }
@@ -3718,7 +3748,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedFileSystemTreeItem"
+                  "$ref": "#/components/schemas/PagedFileSystemTreeItemModel"
                 }
               }
             }
@@ -3752,7 +3782,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/FileSystemTreeItem"
+                    "$ref": "#/components/schemas/FileSystemTreeItemModel"
                   }
                 }
               }
@@ -3793,7 +3823,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedFileSystemTreeItem"
+                  "$ref": "#/components/schemas/PagedFileSystemTreeItemModel"
                 }
               }
             }
@@ -3831,7 +3861,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedSearcher"
+                  "$ref": "#/components/schemas/PagedSearcherModel"
                 }
               }
             }
@@ -3884,7 +3914,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedSearchResult"
+                  "$ref": "#/components/schemas/PagedSearchResultModel"
                 }
               }
             }
@@ -3894,7 +3924,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -3938,7 +3968,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -3948,7 +3978,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ServerStatus"
+                  "$ref": "#/components/schemas/ServerStatusModel"
                 }
               }
             }
@@ -3968,7 +3998,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -3978,7 +4008,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Version"
+                  "$ref": "#/components/schemas/VersionModel"
                 }
               }
             }
@@ -4025,7 +4055,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedFileSystemTreeItem"
+                  "$ref": "#/components/schemas/PagedFileSystemTreeItemModel"
                 }
               }
             }
@@ -4059,7 +4089,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/FileSystemTreeItem"
+                    "$ref": "#/components/schemas/FileSystemTreeItemModel"
                   }
                 }
               }
@@ -4100,7 +4130,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedFileSystemTreeItem"
+                  "$ref": "#/components/schemas/PagedFileSystemTreeItemModel"
                 }
               }
             }
@@ -4147,7 +4177,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedFileSystemTreeItem"
+                  "$ref": "#/components/schemas/PagedFileSystemTreeItemModel"
                 }
               }
             }
@@ -4181,7 +4211,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/FileSystemTreeItem"
+                    "$ref": "#/components/schemas/FileSystemTreeItemModel"
                   }
                 }
               }
@@ -4222,7 +4252,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedFileSystemTreeItem"
+                  "$ref": "#/components/schemas/PagedFileSystemTreeItemModel"
                 }
               }
             }
@@ -4260,7 +4290,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedTelemetry"
+                  "$ref": "#/components/schemas/PagedTelemetryModel"
                 }
               }
             }
@@ -4280,7 +4310,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Telemetry"
+                  "$ref": "#/components/schemas/TelemetryModel"
                 }
               }
             }
@@ -4296,7 +4326,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Telemetry"
+                "$ref": "#/components/schemas/TelemetryModel"
               }
             }
           }
@@ -4307,7 +4337,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -4342,7 +4372,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -4352,7 +4382,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -4383,7 +4413,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Template"
+                  "$ref": "#/components/schemas/TemplateModel"
                 }
               }
             }
@@ -4393,7 +4423,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -4425,7 +4455,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -4435,7 +4465,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -4476,7 +4506,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -4486,7 +4516,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -4515,7 +4545,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TemplateQueryResult"
+                  "$ref": "#/components/schemas/TemplateQueryResultModel"
                 }
               }
             }
@@ -4535,7 +4565,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TemplateQuerySettings"
+                  "$ref": "#/components/schemas/TemplateQuerySettingsModel"
                 }
               }
             }
@@ -4555,7 +4585,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TemplateScaffold"
+                  "$ref": "#/components/schemas/TemplateScaffoldModel"
                 }
               }
             }
@@ -4565,7 +4595,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -4613,7 +4643,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedEntityTreeItem"
+                  "$ref": "#/components/schemas/PagedEntityTreeItemModel"
                 }
               }
             }
@@ -4648,7 +4678,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/EntityTreeItem"
+                    "$ref": "#/components/schemas/EntityTreeItemModel"
                   }
                 }
               }
@@ -4689,7 +4719,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedEntityTreeItem"
+                  "$ref": "#/components/schemas/PagedEntityTreeItemModel"
                 }
               }
             }
@@ -4743,7 +4773,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedRelationItem"
+                  "$ref": "#/components/schemas/PagedRelationItemModel"
                 }
               }
             }
@@ -4797,7 +4827,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedRelationItem"
+                  "$ref": "#/components/schemas/PagedRelationItemModel"
                 }
               }
             }
@@ -4853,7 +4883,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedRelationItem"
+                  "$ref": "#/components/schemas/PagedRelationItemModel"
                 }
               }
             }
@@ -4876,7 +4906,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -4886,7 +4916,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -4906,7 +4936,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UpgradeSettings"
+                  "$ref": "#/components/schemas/UpgradeSettingsModel"
                 }
               }
             }
@@ -4916,7 +4946,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -4927,20 +4957,20 @@
   },
   "components": {
     "schemas": {
-      "Assembly": {
+      "AssemblyModel": {
         "type": "object",
         "properties": {
           "definedTypes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TypeInfo"
+              "$ref": "#/components/schemas/TypeInfoModel"
             },
             "readOnly": true
           },
           "exportedTypes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Type"
+              "$ref": "#/components/schemas/TypeModel"
             },
             "readOnly": true
           },
@@ -4951,7 +4981,7 @@
             "deprecated": true
           },
           "entryPoint": {
-            "$ref": "#/components/schemas/MethodInfo"
+            "$ref": "#/components/schemas/MethodInfoModel"
           },
           "fullName": {
             "type": "string",
@@ -4985,7 +5015,7 @@
           "customAttributes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CustomAttributeData"
+              "$ref": "#/components/schemas/CustomAttributeDataModel"
             },
             "readOnly": true
           },
@@ -4995,12 +5025,12 @@
             "deprecated": true
           },
           "manifestModule": {
-            "$ref": "#/components/schemas/Module"
+            "$ref": "#/components/schemas/ModuleModel"
           },
           "modules": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Module"
+              "$ref": "#/components/schemas/ModuleModel"
             },
             "readOnly": true
           },
@@ -5015,12 +5045,12 @@
             "readOnly": true
           },
           "securityRuleSet": {
-            "$ref": "#/components/schemas/SecurityRuleSet"
+            "$ref": "#/components/schemas/SecurityRuleSetModel"
           }
         },
         "additionalProperties": false
       },
-      "CallingConventions": {
+      "CallingConventionsModel": {
         "enum": [
           "Standard",
           "VarArgs",
@@ -5031,11 +5061,11 @@
         "type": "integer",
         "format": "int32"
       },
-      "ConsentLevel": {
+      "ConsentLevelModel": {
         "type": "object",
         "properties": {
           "level": {
-            "$ref": "#/components/schemas/TelemetryLevel"
+            "$ref": "#/components/schemas/TelemetryLevelModel"
           },
           "description": {
             "type": "string"
@@ -5043,7 +5073,7 @@
         },
         "additionalProperties": false
       },
-      "ConstructorInfo": {
+      "ConstructorInfoModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -5051,18 +5081,18 @@
             "readOnly": true
           },
           "declaringType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "reflectedType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "module": {
-            "$ref": "#/components/schemas/Module"
+            "$ref": "#/components/schemas/ModuleModel"
           },
           "customAttributes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CustomAttributeData"
+              "$ref": "#/components/schemas/CustomAttributeDataModel"
             },
             "readOnly": true
           },
@@ -5076,13 +5106,13 @@
             "readOnly": true
           },
           "attributes": {
-            "$ref": "#/components/schemas/MethodAttributes"
+            "$ref": "#/components/schemas/MethodAttributesModel"
           },
           "methodImplementationFlags": {
-            "$ref": "#/components/schemas/MethodImplAttributes"
+            "$ref": "#/components/schemas/MethodImplAttributesModel"
           },
           "callingConvention": {
-            "$ref": "#/components/schemas/CallingConventions"
+            "$ref": "#/components/schemas/CallingConventionsModel"
           },
           "isAbstract": {
             "type": "boolean",
@@ -5153,7 +5183,7 @@
             "readOnly": true
           },
           "methodHandle": {
-            "$ref": "#/components/schemas/RuntimeMethodHandle"
+            "$ref": "#/components/schemas/RuntimeMethodHandleModel"
           },
           "isSecurityCritical": {
             "type": "boolean",
@@ -5168,12 +5198,12 @@
             "readOnly": true
           },
           "memberType": {
-            "$ref": "#/components/schemas/MemberTypes"
+            "$ref": "#/components/schemas/MemberTypesModel"
           }
         },
         "additionalProperties": false
       },
-      "ContentResult": {
+      "ContentResultModel": {
         "type": "object",
         "properties": {
           "content": {
@@ -5192,7 +5222,7 @@
         },
         "additionalProperties": false
       },
-      "ContentTreeItem": {
+      "ContentTreeItemModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -5228,7 +5258,7 @@
         },
         "additionalProperties": false
       },
-      "CreatedResult": {
+      "CreatedResultModel": {
         "type": "object",
         "properties": {
           "value": {
@@ -5237,7 +5267,7 @@
           "formatters": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/IOutputFormatter"
+              "$ref": "#/components/schemas/IOutputFormatterModel"
             }
           },
           "contentTypes": {
@@ -5247,7 +5277,7 @@
             }
           },
           "declaredType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "statusCode": {
             "type": "integer",
@@ -5260,7 +5290,7 @@
         },
         "additionalProperties": false
       },
-      "Culture": {
+      "CultureModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -5272,40 +5302,40 @@
         },
         "additionalProperties": false
       },
-      "CustomAttributeData": {
+      "CustomAttributeDataModel": {
         "type": "object",
         "properties": {
           "attributeType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "constructor": {
-            "$ref": "#/components/schemas/ConstructorInfo"
+            "$ref": "#/components/schemas/ConstructorInfoModel"
           },
           "constructorArguments": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CustomAttributeTypedArgument"
+              "$ref": "#/components/schemas/CustomAttributeTypedArgumentModel"
             },
             "readOnly": true
           },
           "namedArguments": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CustomAttributeNamedArgument"
+              "$ref": "#/components/schemas/CustomAttributeNamedArgumentModel"
             },
             "readOnly": true
           }
         },
         "additionalProperties": false
       },
-      "CustomAttributeNamedArgument": {
+      "CustomAttributeNamedArgumentModel": {
         "type": "object",
         "properties": {
           "memberInfo": {
-            "$ref": "#/components/schemas/MemberInfo"
+            "$ref": "#/components/schemas/MemberInfoModel"
           },
           "typedValue": {
-            "$ref": "#/components/schemas/CustomAttributeTypedArgument"
+            "$ref": "#/components/schemas/CustomAttributeTypedArgumentModel"
           },
           "memberName": {
             "type": "string",
@@ -5318,44 +5348,13 @@
         },
         "additionalProperties": false
       },
-      "CustomAttributeTypedArgument": {
+      "CustomAttributeTypedArgumentModel": {
         "type": "object",
         "properties": {
           "argumentType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "value": {
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "DataType": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "propertyEditorAlias": {
-            "type": "string"
-          },
-          "propertyEditorUiAlias": {
-            "type": "string",
-            "nullable": true
-          },
-          "data": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DataTypeProperty"
-            }
-          },
-          "key": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "parentKey": {
-            "type": "string",
-            "format": "uuid",
             "nullable": true
           }
         },
@@ -5377,7 +5376,7 @@
           "data": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DataTypeProperty"
+              "$ref": "#/components/schemas/DataTypePropertyModel"
             }
           },
           "parentKey": {
@@ -5388,7 +5387,38 @@
         },
         "additionalProperties": false
       },
-      "DataTypeProperty": {
+      "DataTypeModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "propertyEditorAlias": {
+            "type": "string"
+          },
+          "propertyEditorUiAlias": {
+            "type": "string",
+            "nullable": true
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataTypePropertyModel"
+            }
+          },
+          "key": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "parentKey": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DataTypePropertyModel": {
         "type": "object",
         "properties": {
           "alias": {
@@ -5400,7 +5430,7 @@
         },
         "additionalProperties": false
       },
-      "DataTypePropertyReference": {
+      "DataTypePropertyReferenceModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -5412,7 +5442,7 @@
         },
         "additionalProperties": false
       },
-      "DataTypeReference": {
+      "DataTypeReferenceModel": {
         "type": "object",
         "properties": {
           "key": {
@@ -5425,7 +5455,7 @@
           "properties": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DataTypePropertyReference"
+              "$ref": "#/components/schemas/DataTypePropertyReferenceModel"
             }
           }
         },
@@ -5447,13 +5477,13 @@
           "data": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DataTypeProperty"
+              "$ref": "#/components/schemas/DataTypePropertyModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "DatabaseInstall": {
+      "DatabaseInstallModel": {
         "required": [
           "id",
           "providerName"
@@ -5494,7 +5524,7 @@
         },
         "additionalProperties": false
       },
-      "DatabaseSettings": {
+      "DatabaseSettingsModel": {
         "type": "object",
         "properties": {
           "id": {
@@ -5535,37 +5565,18 @@
         },
         "additionalProperties": false
       },
-      "DictionaryImport": {
+      "DictionaryImportModel": {
         "type": "object",
         "properties": {
           "dictionaryItems": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DictionaryItemsImport"
+              "$ref": "#/components/schemas/DictionaryItemsImportModel"
             }
           },
           "tempFileName": {
             "type": "string",
             "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "DictionaryItem": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "translations": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DictionaryItemTranslationModel"
-            }
-          },
-          "key": {
-            "type": "string",
-            "format": "uuid"
           }
         },
         "additionalProperties": false
@@ -5586,6 +5597,25 @@
             "type": "string",
             "format": "uuid",
             "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DictionaryItemModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "translations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DictionaryItemTranslationModel"
+            }
+          },
+          "key": {
+            "type": "string",
+            "format": "uuid"
           }
         },
         "additionalProperties": false
@@ -5617,7 +5647,7 @@
         },
         "additionalProperties": false
       },
-      "DictionaryItemsImport": {
+      "DictionaryItemsImportModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -5631,7 +5661,7 @@
         },
         "additionalProperties": false
       },
-      "DictionaryOverview": {
+      "DictionaryOverviewModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -5655,7 +5685,7 @@
         },
         "additionalProperties": false
       },
-      "Direction": {
+      "DirectionModel": {
         "enum": [
           "Ascending",
           "Descending"
@@ -5663,7 +5693,7 @@
         "type": "integer",
         "format": "int32"
       },
-      "DocumentBlueprintTreeItem": {
+      "DocumentBlueprintTreeItemModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -5704,7 +5734,7 @@
         },
         "additionalProperties": false
       },
-      "DocumentTreeItem": {
+      "DocumentTreeItemModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -5749,7 +5779,7 @@
         },
         "additionalProperties": false
       },
-      "DocumentTypeTreeItem": {
+      "DocumentTypeTreeItemModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -5785,7 +5815,7 @@
         },
         "additionalProperties": false
       },
-      "EntityTreeItem": {
+      "EntityTreeItemModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -5815,7 +5845,7 @@
         },
         "additionalProperties": false
       },
-      "EventAttributes": {
+      "EventAttributesModel": {
         "enum": [
           "None",
           "SpecialName",
@@ -5825,7 +5855,7 @@
         "type": "integer",
         "format": "int32"
       },
-      "EventInfo": {
+      "EventInfoModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -5833,18 +5863,18 @@
             "readOnly": true
           },
           "declaringType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "reflectedType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "module": {
-            "$ref": "#/components/schemas/Module"
+            "$ref": "#/components/schemas/ModuleModel"
           },
           "customAttributes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CustomAttributeData"
+              "$ref": "#/components/schemas/CustomAttributeDataModel"
             },
             "readOnly": true
           },
@@ -5858,50 +5888,35 @@
             "readOnly": true
           },
           "memberType": {
-            "$ref": "#/components/schemas/MemberTypes"
+            "$ref": "#/components/schemas/MemberTypesModel"
           },
           "attributes": {
-            "$ref": "#/components/schemas/EventAttributes"
+            "$ref": "#/components/schemas/EventAttributesModel"
           },
           "isSpecialName": {
             "type": "boolean",
             "readOnly": true
           },
           "addMethod": {
-            "$ref": "#/components/schemas/MethodInfo"
+            "$ref": "#/components/schemas/MethodInfoModel"
           },
           "removeMethod": {
-            "$ref": "#/components/schemas/MethodInfo"
+            "$ref": "#/components/schemas/MethodInfoModel"
           },
           "raiseMethod": {
-            "$ref": "#/components/schemas/MethodInfo"
+            "$ref": "#/components/schemas/MethodInfoModel"
           },
           "isMulticast": {
             "type": "boolean",
             "readOnly": true
           },
           "eventHandlerType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           }
         },
         "additionalProperties": false
       },
-      "Field": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "values": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "additionalProperties": false
-      },
-      "FieldAttributes": {
+      "FieldAttributesModel": {
         "enum": [
           "PrivateScope",
           "Private",
@@ -5926,7 +5941,7 @@
         "type": "integer",
         "format": "int32"
       },
-      "FieldInfo": {
+      "FieldInfoModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -5934,18 +5949,18 @@
             "readOnly": true
           },
           "declaringType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "reflectedType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "module": {
-            "$ref": "#/components/schemas/Module"
+            "$ref": "#/components/schemas/ModuleModel"
           },
           "customAttributes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CustomAttributeData"
+              "$ref": "#/components/schemas/CustomAttributeDataModel"
             },
             "readOnly": true
           },
@@ -5959,13 +5974,13 @@
             "readOnly": true
           },
           "memberType": {
-            "$ref": "#/components/schemas/MemberTypes"
+            "$ref": "#/components/schemas/MemberTypesModel"
           },
           "attributes": {
-            "$ref": "#/components/schemas/FieldAttributes"
+            "$ref": "#/components/schemas/FieldAttributesModel"
           },
           "fieldType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "isInitOnly": {
             "type": "boolean",
@@ -6028,12 +6043,27 @@
             "readOnly": true
           },
           "fieldHandle": {
-            "$ref": "#/components/schemas/RuntimeFieldHandle"
+            "$ref": "#/components/schemas/RuntimeFieldHandleModel"
           }
         },
         "additionalProperties": false
       },
-      "FileSystemTreeItem": {
+      "FieldModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "FileSystemTreeItemModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -6057,7 +6087,21 @@
         },
         "additionalProperties": false
       },
-      "Folder": {
+      "FolderCreateModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "parentKey": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "FolderModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -6075,21 +6119,7 @@
         },
         "additionalProperties": false
       },
-      "FolderCreateModel": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "parentKey": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "FolderTreeItem": {
+      "FolderTreeItemModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -6131,7 +6161,7 @@
         },
         "additionalProperties": false
       },
-      "GenericParameterAttributes": {
+      "GenericParameterAttributesModel": {
         "enum": [
           "None",
           "Covariant",
@@ -6145,24 +6175,7 @@
         "type": "integer",
         "format": "int32"
       },
-      "HealthCheck": {
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "HealthCheckAction": {
+      "HealthCheckActionModel": {
         "type": "object",
         "properties": {
           "healthCheckKey": {
@@ -6199,7 +6212,7 @@
         },
         "additionalProperties": false
       },
-      "HealthCheckGroup": {
+      "HealthCheckGroupModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -6209,13 +6222,13 @@
           "checks": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/HealthCheck"
+              "$ref": "#/components/schemas/HealthCheckModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "HealthCheckGroupWithResult": {
+      "HealthCheckGroupWithResultModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -6225,25 +6238,42 @@
           "checks": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/HealthCheckWithResult"
+              "$ref": "#/components/schemas/HealthCheckWithResultModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "HealthCheckResult": {
+      "HealthCheckModel": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "HealthCheckResultModel": {
         "type": "object",
         "properties": {
           "message": {
             "type": "string"
           },
           "resultType": {
-            "$ref": "#/components/schemas/StatusResultType"
+            "$ref": "#/components/schemas/StatusResultTypeModel"
           },
           "actions": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/HealthCheckAction"
+              "$ref": "#/components/schemas/HealthCheckActionModel"
             },
             "nullable": true
           },
@@ -6254,7 +6284,7 @@
         },
         "additionalProperties": false
       },
-      "HealthCheckWithResult": {
+      "HealthCheckWithResultModel": {
         "type": "object",
         "properties": {
           "key": {
@@ -6271,14 +6301,14 @@
           "results": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/HealthCheckResult"
+              "$ref": "#/components/schemas/HealthCheckResultModel"
             },
             "nullable": true
           }
         },
         "additionalProperties": false
       },
-      "HealthStatus": {
+      "HealthStatusModel": {
         "enum": [
           "Healthy",
           "Unhealthy",
@@ -6287,7 +6317,7 @@
         "type": "integer",
         "format": "int32"
       },
-      "HelpPage": {
+      "HelpPageModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -6309,15 +6339,15 @@
         },
         "additionalProperties": false
       },
-      "ICustomAttributeProvider": {
+      "ICustomAttributeProviderModel": {
         "type": "object",
         "additionalProperties": false
       },
-      "IOutputFormatter": {
+      "IOutputFormatterModel": {
         "type": "object",
         "additionalProperties": false
       },
-      "Index": {
+      "IndexModel": {
         "required": [
           "canRebuild",
           "documentCount",
@@ -6331,7 +6361,7 @@
             "type": "string"
           },
           "healthStatus": {
-            "$ref": "#/components/schemas/HealthStatus"
+            "$ref": "#/components/schemas/HealthStatusModel"
           },
           "canRebuild": {
             "type": "boolean"
@@ -6349,13 +6379,13 @@
           },
           "providerProperties": {
             "type": "object",
-            "additionalProperties": {},
+            "additionalProperties": { },
             "nullable": true
           }
         },
         "additionalProperties": false
       },
-      "Install": {
+      "InstallModel": {
         "required": [
           "database",
           "user"
@@ -6363,37 +6393,37 @@
         "type": "object",
         "properties": {
           "user": {
-            "$ref": "#/components/schemas/UserInstall"
+            "$ref": "#/components/schemas/UserInstallModel"
           },
           "database": {
-            "$ref": "#/components/schemas/DatabaseInstall"
+            "$ref": "#/components/schemas/DatabaseInstallModel"
           },
           "telemetryLevel": {
-            "$ref": "#/components/schemas/TelemetryLevel"
+            "$ref": "#/components/schemas/TelemetryLevelModel"
           }
         },
         "additionalProperties": false
       },
-      "InstallSettings": {
+      "InstallSettingsModel": {
         "type": "object",
         "properties": {
           "user": {
-            "$ref": "#/components/schemas/UserSettings"
+            "$ref": "#/components/schemas/UserSettingsModel"
           },
           "databases": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DatabaseSettings"
+              "$ref": "#/components/schemas/DatabaseSettingsModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "IntPtr": {
+      "IntPtrModel": {
         "type": "object",
         "additionalProperties": false
       },
-      "Language": {
+      "LanguageCreateModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -6415,7 +6445,7 @@
         },
         "additionalProperties": false
       },
-      "LanguageCreateModel": {
+      "LanguageModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -6456,7 +6486,7 @@
         },
         "additionalProperties": false
       },
-      "LayoutKind": {
+      "LayoutKindModel": {
         "enum": [
           "Sequential",
           "Explicit",
@@ -6465,7 +6495,7 @@
         "type": "integer",
         "format": "int32"
       },
-      "LogLevel": {
+      "LogLevelModel": {
         "enum": [
           "Verbose",
           "Debug",
@@ -6477,7 +6507,7 @@
         "type": "integer",
         "format": "int32"
       },
-      "LogMessage": {
+      "LogMessageModel": {
         "type": "object",
         "properties": {
           "timestamp": {
@@ -6485,7 +6515,7 @@
             "format": "date-time"
           },
           "level": {
-            "$ref": "#/components/schemas/LogLevel"
+            "$ref": "#/components/schemas/LogLevelModel"
           },
           "messageTemplate": {
             "type": "string",
@@ -6498,7 +6528,7 @@
           "properties": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/LogMessageProperty"
+              "$ref": "#/components/schemas/LogMessagePropertyModel"
             }
           },
           "exception": {
@@ -6508,7 +6538,7 @@
         },
         "additionalProperties": false
       },
-      "LogMessageProperty": {
+      "LogMessagePropertyModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -6521,7 +6551,7 @@
         },
         "additionalProperties": false
       },
-      "LogTemplate": {
+      "LogTemplateModel": {
         "type": "object",
         "properties": {
           "messageTemplate": {
@@ -6535,41 +6565,41 @@
         },
         "additionalProperties": false
       },
-      "Logger": {
+      "LoggerModel": {
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
           "level": {
-            "$ref": "#/components/schemas/LogLevel"
+            "$ref": "#/components/schemas/LogLevelModel"
           }
         },
         "additionalProperties": false
       },
-      "MemberInfo": {
+      "MemberInfoModel": {
         "type": "object",
         "properties": {
           "memberType": {
-            "$ref": "#/components/schemas/MemberTypes"
+            "$ref": "#/components/schemas/MemberTypesModel"
           },
           "name": {
             "type": "string",
             "readOnly": true
           },
           "declaringType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "reflectedType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "module": {
-            "$ref": "#/components/schemas/Module"
+            "$ref": "#/components/schemas/ModuleModel"
           },
           "customAttributes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CustomAttributeData"
+              "$ref": "#/components/schemas/CustomAttributeDataModel"
             },
             "readOnly": true
           },
@@ -6585,7 +6615,7 @@
         },
         "additionalProperties": false
       },
-      "MemberTypes": {
+      "MemberTypesModel": {
         "enum": [
           "Constructor",
           "Event",
@@ -6600,7 +6630,7 @@
         "type": "integer",
         "format": "int32"
       },
-      "MethodAttributes": {
+      "MethodAttributesModel": {
         "enum": [
           "ReuseSlot",
           "PrivateScope",
@@ -6630,29 +6660,29 @@
         "type": "integer",
         "format": "int32"
       },
-      "MethodBase": {
+      "MethodBaseModel": {
         "type": "object",
         "properties": {
           "memberType": {
-            "$ref": "#/components/schemas/MemberTypes"
+            "$ref": "#/components/schemas/MemberTypesModel"
           },
           "name": {
             "type": "string",
             "readOnly": true
           },
           "declaringType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "reflectedType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "module": {
-            "$ref": "#/components/schemas/Module"
+            "$ref": "#/components/schemas/ModuleModel"
           },
           "customAttributes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CustomAttributeData"
+              "$ref": "#/components/schemas/CustomAttributeDataModel"
             },
             "readOnly": true
           },
@@ -6666,13 +6696,13 @@
             "readOnly": true
           },
           "attributes": {
-            "$ref": "#/components/schemas/MethodAttributes"
+            "$ref": "#/components/schemas/MethodAttributesModel"
           },
           "methodImplementationFlags": {
-            "$ref": "#/components/schemas/MethodImplAttributes"
+            "$ref": "#/components/schemas/MethodImplAttributesModel"
           },
           "callingConvention": {
-            "$ref": "#/components/schemas/CallingConventions"
+            "$ref": "#/components/schemas/CallingConventionsModel"
           },
           "isAbstract": {
             "type": "boolean",
@@ -6743,7 +6773,7 @@
             "readOnly": true
           },
           "methodHandle": {
-            "$ref": "#/components/schemas/RuntimeMethodHandle"
+            "$ref": "#/components/schemas/RuntimeMethodHandleModel"
           },
           "isSecurityCritical": {
             "type": "boolean",
@@ -6760,7 +6790,7 @@
         },
         "additionalProperties": false
       },
-      "MethodImplAttributes": {
+      "MethodImplAttributesModel": {
         "enum": [
           "IL",
           "Managed",
@@ -6783,7 +6813,7 @@
         "type": "integer",
         "format": "int32"
       },
-      "MethodInfo": {
+      "MethodInfoModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -6791,18 +6821,18 @@
             "readOnly": true
           },
           "declaringType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "reflectedType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "module": {
-            "$ref": "#/components/schemas/Module"
+            "$ref": "#/components/schemas/ModuleModel"
           },
           "customAttributes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CustomAttributeData"
+              "$ref": "#/components/schemas/CustomAttributeDataModel"
             },
             "readOnly": true
           },
@@ -6816,13 +6846,13 @@
             "readOnly": true
           },
           "attributes": {
-            "$ref": "#/components/schemas/MethodAttributes"
+            "$ref": "#/components/schemas/MethodAttributesModel"
           },
           "methodImplementationFlags": {
-            "$ref": "#/components/schemas/MethodImplAttributes"
+            "$ref": "#/components/schemas/MethodImplAttributesModel"
           },
           "callingConvention": {
-            "$ref": "#/components/schemas/CallingConventions"
+            "$ref": "#/components/schemas/CallingConventionsModel"
           },
           "isAbstract": {
             "type": "boolean",
@@ -6893,7 +6923,7 @@
             "readOnly": true
           },
           "methodHandle": {
-            "$ref": "#/components/schemas/RuntimeMethodHandle"
+            "$ref": "#/components/schemas/RuntimeMethodHandleModel"
           },
           "isSecurityCritical": {
             "type": "boolean",
@@ -6908,25 +6938,25 @@
             "readOnly": true
           },
           "memberType": {
-            "$ref": "#/components/schemas/MemberTypes"
+            "$ref": "#/components/schemas/MemberTypesModel"
           },
           "returnParameter": {
-            "$ref": "#/components/schemas/ParameterInfo"
+            "$ref": "#/components/schemas/ParameterInfoModel"
           },
           "returnType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "returnTypeCustomAttributes": {
-            "$ref": "#/components/schemas/ICustomAttributeProvider"
+            "$ref": "#/components/schemas/ICustomAttributeProviderModel"
           }
         },
         "additionalProperties": false
       },
-      "ModelsBuilder": {
+      "ModelsBuilderModel": {
         "type": "object",
         "properties": {
           "mode": {
-            "$ref": "#/components/schemas/ModelsMode"
+            "$ref": "#/components/schemas/ModelsModeModel"
           },
           "canGenerate": {
             "type": "boolean"
@@ -6952,7 +6982,7 @@
         },
         "additionalProperties": false
       },
-      "ModelsMode": {
+      "ModelsModeModel": {
         "enum": [
           "Nothing",
           "InMemoryAuto",
@@ -6962,11 +6992,22 @@
         "type": "integer",
         "format": "int32"
       },
-      "Module": {
+      "ModuleHandleModel": {
+        "type": "object",
+        "properties": {
+          "mdStreamVersion": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ModuleModel": {
         "type": "object",
         "properties": {
           "assembly": {
-            "$ref": "#/components/schemas/Assembly"
+            "$ref": "#/components/schemas/AssemblyModel"
           },
           "fullyQualifiedName": {
             "type": "string",
@@ -6991,12 +7032,12 @@
             "readOnly": true
           },
           "moduleHandle": {
-            "$ref": "#/components/schemas/ModuleHandle"
+            "$ref": "#/components/schemas/ModuleHandleModel"
           },
           "customAttributes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CustomAttributeData"
+              "$ref": "#/components/schemas/CustomAttributeDataModel"
             },
             "readOnly": true
           },
@@ -7008,18 +7049,7 @@
         },
         "additionalProperties": false
       },
-      "ModuleHandle": {
-        "type": "object",
-        "properties": {
-          "mdStreamVersion": {
-            "type": "integer",
-            "format": "int32",
-            "readOnly": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "NotFoundResult": {
+      "NotFoundResultModel": {
         "type": "object",
         "properties": {
           "statusCode": {
@@ -7029,7 +7059,7 @@
         },
         "additionalProperties": false
       },
-      "OkResult": {
+      "OkResultModel": {
         "type": "object",
         "properties": {
           "statusCode": {
@@ -7039,7 +7069,7 @@
         },
         "additionalProperties": false
       },
-      "Operator": {
+      "OperatorModel": {
         "enum": [
           "Equals",
           "NotEquals",
@@ -7053,16 +7083,16 @@
         "type": "integer",
         "format": "int32"
       },
-      "OutOfDateStatus": {
+      "OutOfDateStatusModel": {
         "type": "object",
         "properties": {
           "status": {
-            "$ref": "#/components/schemas/OutOfDateType"
+            "$ref": "#/components/schemas/OutOfDateTypeModel"
           }
         },
         "additionalProperties": false
       },
-      "OutOfDateType": {
+      "OutOfDateTypeModel": {
         "enum": [
           "OutOfDate",
           "Current",
@@ -7071,7 +7101,7 @@
         "type": "integer",
         "format": "int32"
       },
-      "PagedContentTreeItem": {
+      "PagedContentTreeItemModel": {
         "required": [
           "items",
           "total"
@@ -7085,13 +7115,13 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ContentTreeItem"
+              "$ref": "#/components/schemas/ContentTreeItemModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "PagedCulture": {
+      "PagedCultureModel": {
         "required": [
           "items",
           "total"
@@ -7105,13 +7135,13 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Culture"
+              "$ref": "#/components/schemas/CultureModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "PagedDictionaryOverview": {
+      "PagedDictionaryOverviewModel": {
         "required": [
           "items",
           "total"
@@ -7125,13 +7155,13 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DictionaryOverview"
+              "$ref": "#/components/schemas/DictionaryOverviewModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "PagedDocumentBlueprintTreeItem": {
+      "PagedDocumentBlueprintTreeItemModel": {
         "required": [
           "items",
           "total"
@@ -7145,13 +7175,13 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DocumentBlueprintTreeItem"
+              "$ref": "#/components/schemas/DocumentBlueprintTreeItemModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "PagedDocumentTreeItem": {
+      "PagedDocumentTreeItemModel": {
         "required": [
           "items",
           "total"
@@ -7165,13 +7195,13 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DocumentTreeItem"
+              "$ref": "#/components/schemas/DocumentTreeItemModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "PagedDocumentTypeTreeItem": {
+      "PagedDocumentTypeTreeItemModel": {
         "required": [
           "items",
           "total"
@@ -7185,13 +7215,13 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DocumentTypeTreeItem"
+              "$ref": "#/components/schemas/DocumentTypeTreeItemModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "PagedEntityTreeItem": {
+      "PagedEntityTreeItemModel": {
         "required": [
           "items",
           "total"
@@ -7205,13 +7235,13 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/EntityTreeItem"
+              "$ref": "#/components/schemas/EntityTreeItemModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "PagedFileSystemTreeItem": {
+      "PagedFileSystemTreeItemModel": {
         "required": [
           "items",
           "total"
@@ -7225,13 +7255,13 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/FileSystemTreeItem"
+              "$ref": "#/components/schemas/FileSystemTreeItemModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "PagedFolderTreeItem": {
+      "PagedFolderTreeItemModel": {
         "required": [
           "items",
           "total"
@@ -7245,13 +7275,13 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/FolderTreeItem"
+              "$ref": "#/components/schemas/FolderTreeItemModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "PagedHealthCheckGroup": {
+      "PagedHealthCheckGroupModel": {
         "required": [
           "items",
           "total"
@@ -7265,13 +7295,13 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/HealthCheckGroup"
+              "$ref": "#/components/schemas/HealthCheckGroupModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "PagedHelpPage": {
+      "PagedHelpPageModel": {
         "required": [
           "items",
           "total"
@@ -7285,13 +7315,13 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/HelpPage"
+              "$ref": "#/components/schemas/HelpPageModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "PagedIndex": {
+      "PagedIndexModel": {
         "required": [
           "items",
           "total"
@@ -7305,13 +7335,13 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Index"
+              "$ref": "#/components/schemas/IndexModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "PagedLanguage": {
+      "PagedLanguageModel": {
         "required": [
           "items",
           "total"
@@ -7325,13 +7355,13 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Language"
+              "$ref": "#/components/schemas/LanguageModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "PagedLogMessage": {
+      "PagedLogMessageModel": {
         "required": [
           "items",
           "total"
@@ -7345,13 +7375,13 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/LogMessage"
+              "$ref": "#/components/schemas/LogMessageModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "PagedLogTemplate": {
+      "PagedLogTemplateModel": {
         "required": [
           "items",
           "total"
@@ -7365,13 +7395,13 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/LogTemplate"
+              "$ref": "#/components/schemas/LogTemplateModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "PagedLogger": {
+      "PagedLoggerModel": {
         "required": [
           "items",
           "total"
@@ -7385,13 +7415,13 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Logger"
+              "$ref": "#/components/schemas/LoggerModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "PagedRecycleBinItem": {
+      "PagedRecycleBinItemModel": {
         "required": [
           "items",
           "total"
@@ -7405,13 +7435,13 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/RecycleBinItem"
+              "$ref": "#/components/schemas/RecycleBinItemModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "PagedRedirectUrl": {
+      "PagedRedirectUrlModel": {
         "required": [
           "items",
           "total"
@@ -7425,13 +7455,13 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/RedirectUrl"
+              "$ref": "#/components/schemas/RedirectUrlModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "PagedRelation": {
+      "PagedRelationItemModel": {
         "required": [
           "items",
           "total"
@@ -7445,13 +7475,13 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Relation"
+              "$ref": "#/components/schemas/RelationItemModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "PagedRelationItem": {
+      "PagedRelationModel": {
         "required": [
           "items",
           "total"
@@ -7465,13 +7495,13 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/RelationItem"
+              "$ref": "#/components/schemas/RelationModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "PagedSavedLogSearch": {
+      "PagedSavedLogSearchModel": {
         "required": [
           "items",
           "total"
@@ -7485,13 +7515,13 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/SavedLogSearch"
+              "$ref": "#/components/schemas/SavedLogSearchModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "PagedSearchResult": {
+      "PagedSearchResultModel": {
         "required": [
           "items",
           "total"
@@ -7505,13 +7535,13 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/SearchResult"
+              "$ref": "#/components/schemas/SearchResultModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "PagedSearcher": {
+      "PagedSearcherModel": {
         "required": [
           "items",
           "total"
@@ -7525,13 +7555,13 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Searcher"
+              "$ref": "#/components/schemas/SearcherModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "PagedTelemetry": {
+      "PagedTelemetryModel": {
         "required": [
           "items",
           "total"
@@ -7545,13 +7575,13 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Telemetry"
+              "$ref": "#/components/schemas/TelemetryModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "ParameterAttributes": {
+      "ParameterAttributesModel": {
         "enum": [
           "None",
           "In",
@@ -7568,14 +7598,14 @@
         "type": "integer",
         "format": "int32"
       },
-      "ParameterInfo": {
+      "ParameterInfoModel": {
         "type": "object",
         "properties": {
           "attributes": {
-            "$ref": "#/components/schemas/ParameterAttributes"
+            "$ref": "#/components/schemas/ParameterAttributesModel"
           },
           "member": {
-            "$ref": "#/components/schemas/MemberInfo"
+            "$ref": "#/components/schemas/MemberInfoModel"
           },
           "name": {
             "type": "string",
@@ -7583,7 +7613,7 @@
             "readOnly": true
           },
           "parameterType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "position": {
             "type": "integer",
@@ -7625,7 +7655,7 @@
           "customAttributes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CustomAttributeData"
+              "$ref": "#/components/schemas/CustomAttributeDataModel"
             },
             "readOnly": true
           },
@@ -7637,7 +7667,7 @@
         },
         "additionalProperties": false
       },
-      "ProblemDetails": {
+      "ProblemDetailsModel": {
         "type": "object",
         "properties": {
           "type": {
@@ -7662,9 +7692,9 @@
             "nullable": true
           }
         },
-        "additionalProperties": {}
+        "additionalProperties": { }
       },
-      "ProfilingStatus": {
+      "ProfilingStatusModel": {
         "type": "object",
         "properties": {
           "enabled": {
@@ -7673,7 +7703,7 @@
         },
         "additionalProperties": false
       },
-      "PropertyAttributes": {
+      "PropertyAttributesModel": {
         "enum": [
           "None",
           "SpecialName",
@@ -7687,7 +7717,7 @@
         "type": "integer",
         "format": "int32"
       },
-      "PropertyInfo": {
+      "PropertyInfoModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -7695,18 +7725,18 @@
             "readOnly": true
           },
           "declaringType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "reflectedType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "module": {
-            "$ref": "#/components/schemas/Module"
+            "$ref": "#/components/schemas/ModuleModel"
           },
           "customAttributes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CustomAttributeData"
+              "$ref": "#/components/schemas/CustomAttributeDataModel"
             },
             "readOnly": true
           },
@@ -7720,13 +7750,13 @@
             "readOnly": true
           },
           "memberType": {
-            "$ref": "#/components/schemas/MemberTypes"
+            "$ref": "#/components/schemas/MemberTypesModel"
           },
           "propertyType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "attributes": {
-            "$ref": "#/components/schemas/PropertyAttributes"
+            "$ref": "#/components/schemas/PropertyAttributesModel"
           },
           "isSpecialName": {
             "type": "boolean",
@@ -7741,15 +7771,15 @@
             "readOnly": true
           },
           "getMethod": {
-            "$ref": "#/components/schemas/MethodInfo"
+            "$ref": "#/components/schemas/MethodInfoModel"
           },
           "setMethod": {
-            "$ref": "#/components/schemas/MethodInfo"
+            "$ref": "#/components/schemas/MethodInfoModel"
           }
         },
         "additionalProperties": false
       },
-      "RecycleBinItem": {
+      "RecycleBinItemModel": {
         "type": "object",
         "properties": {
           "key": {
@@ -7779,7 +7809,7 @@
         },
         "additionalProperties": false
       },
-      "RedirectStatus": {
+      "RedirectStatusModel": {
         "enum": [
           "Enabled",
           "Disabled"
@@ -7787,7 +7817,7 @@
         "type": "integer",
         "format": "int32"
       },
-      "RedirectUrl": {
+      "RedirectUrlModel": {
         "type": "object",
         "properties": {
           "key": {
@@ -7815,11 +7845,11 @@
         },
         "additionalProperties": false
       },
-      "RedirectUrlStatus": {
+      "RedirectUrlStatusModel": {
         "type": "object",
         "properties": {
           "status": {
-            "$ref": "#/components/schemas/RedirectStatus"
+            "$ref": "#/components/schemas/RedirectStatusModel"
           },
           "userIsAdmin": {
             "type": "boolean"
@@ -7827,37 +7857,7 @@
         },
         "additionalProperties": false
       },
-      "Relation": {
-        "type": "object",
-        "properties": {
-          "parentId": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "parentName": {
-            "type": "string",
-            "nullable": true
-          },
-          "childId": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "childName": {
-            "type": "string",
-            "nullable": true
-          },
-          "createDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "comment": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "RelationItem": {
+      "RelationItemModel": {
         "type": "object",
         "properties": {
           "nodeKey": {
@@ -7897,16 +7897,46 @@
         },
         "additionalProperties": false
       },
-      "RuntimeFieldHandle": {
+      "RelationModel": {
         "type": "object",
         "properties": {
-          "value": {
-            "$ref": "#/components/schemas/IntPtr"
+          "parentId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "parentName": {
+            "type": "string",
+            "nullable": true
+          },
+          "childId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "childName": {
+            "type": "string",
+            "nullable": true
+          },
+          "createDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "comment": {
+            "type": "string",
+            "nullable": true
           }
         },
         "additionalProperties": false
       },
-      "RuntimeLevel": {
+      "RuntimeFieldHandleModel": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/IntPtrModel"
+          }
+        },
+        "additionalProperties": false
+      },
+      "RuntimeLevelModel": {
         "enum": [
           "Unknown",
           "Boot",
@@ -7918,25 +7948,25 @@
         "type": "integer",
         "format": "int32"
       },
-      "RuntimeMethodHandle": {
+      "RuntimeMethodHandleModel": {
         "type": "object",
         "properties": {
           "value": {
-            "$ref": "#/components/schemas/IntPtr"
+            "$ref": "#/components/schemas/IntPtrModel"
           }
         },
         "additionalProperties": false
       },
-      "RuntimeTypeHandle": {
+      "RuntimeTypeHandleModel": {
         "type": "object",
         "properties": {
           "value": {
-            "$ref": "#/components/schemas/IntPtr"
+            "$ref": "#/components/schemas/IntPtrModel"
           }
         },
         "additionalProperties": false
       },
-      "SavedLogSearch": {
+      "SavedLogSearchModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -7948,7 +7978,7 @@
         },
         "additionalProperties": false
       },
-      "SearchResult": {
+      "SearchResultModel": {
         "type": "object",
         "properties": {
           "id": {
@@ -7966,13 +7996,13 @@
           "fields": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Field"
+              "$ref": "#/components/schemas/FieldModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "Searcher": {
+      "SearcherModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -7981,7 +8011,7 @@
         },
         "additionalProperties": false
       },
-      "SecurityRuleSet": {
+      "SecurityRuleSetModel": {
         "enum": [
           "None",
           "Level1",
@@ -7990,16 +8020,16 @@
         "type": "integer",
         "format": "int32"
       },
-      "ServerStatus": {
+      "ServerStatusModel": {
         "type": "object",
         "properties": {
           "serverStatus": {
-            "$ref": "#/components/schemas/RuntimeLevel"
+            "$ref": "#/components/schemas/RuntimeLevelModel"
           }
         },
         "additionalProperties": false
       },
-      "StatusResultType": {
+      "StatusResultTypeModel": {
         "enum": [
           "Success",
           "Warning",
@@ -8009,28 +8039,19 @@
         "type": "integer",
         "format": "int32"
       },
-      "StructLayoutAttribute": {
+      "StructLayoutAttributeModel": {
         "type": "object",
         "properties": {
           "typeId": {
             "readOnly": true
           },
           "value": {
-            "$ref": "#/components/schemas/LayoutKind"
+            "$ref": "#/components/schemas/LayoutKindModel"
           }
         },
         "additionalProperties": false
       },
-      "Telemetry": {
-        "type": "object",
-        "properties": {
-          "telemetryLevel": {
-            "$ref": "#/components/schemas/TelemetryLevel"
-          }
-        },
-        "additionalProperties": false
-      },
-      "TelemetryLevel": {
+      "TelemetryLevelModel": {
         "enum": [
           "Minimal",
           "Basic",
@@ -8039,22 +8060,11 @@
         "type": "integer",
         "format": "int32"
       },
-      "Template": {
+      "TelemetryModel": {
         "type": "object",
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "alias": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string",
-            "nullable": true
-          },
-          "key": {
-            "type": "string",
-            "format": "uuid"
+          "telemetryLevel": {
+            "$ref": "#/components/schemas/TelemetryLevelModel"
           }
         },
         "additionalProperties": false
@@ -8075,6 +8085,26 @@
         },
         "additionalProperties": false
       },
+      "TemplateModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string",
+            "nullable": true
+          },
+          "key": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
       "TemplateQueryExecuteFilterModel": {
         "type": "object",
         "properties": {
@@ -8085,7 +8115,7 @@
             "type": "string"
           },
           "operator": {
-            "$ref": "#/components/schemas/Operator"
+            "$ref": "#/components/schemas/OperatorModel"
           }
         },
         "additionalProperties": false
@@ -8132,34 +8162,34 @@
         },
         "additionalProperties": false
       },
-      "TemplateQueryOperator": {
+      "TemplateQueryOperatorModel": {
         "type": "object",
         "properties": {
           "operator": {
-            "$ref": "#/components/schemas/Operator"
+            "$ref": "#/components/schemas/OperatorModel"
           },
           "applicableTypes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TemplateQueryPropertyType"
+              "$ref": "#/components/schemas/TemplateQueryPropertyTypeModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "TemplateQueryProperty": {
+      "TemplateQueryPropertyModel": {
         "type": "object",
         "properties": {
           "alias": {
             "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/TemplateQueryPropertyType"
+            "$ref": "#/components/schemas/TemplateQueryPropertyTypeModel"
           }
         },
         "additionalProperties": false
       },
-      "TemplateQueryPropertyType": {
+      "TemplateQueryPropertyTypeModel": {
         "enum": [
           "String",
           "DateTime",
@@ -8168,7 +8198,19 @@
         "type": "integer",
         "format": "int32"
       },
-      "TemplateQueryResult": {
+      "TemplateQueryResultItemModel": {
+        "type": "object",
+        "properties": {
+          "icon": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TemplateQueryResultModel": {
         "type": "object",
         "properties": {
           "queryExpression": {
@@ -8177,7 +8219,7 @@
           "sampleResults": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TemplateQueryResultItem"
+              "$ref": "#/components/schemas/TemplateQueryResultItemModel"
             }
           },
           "resultCount": {
@@ -8191,19 +8233,7 @@
         },
         "additionalProperties": false
       },
-      "TemplateQueryResultItem": {
-        "type": "object",
-        "properties": {
-          "icon": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "TemplateQuerySettings": {
+      "TemplateQuerySettingsModel": {
         "type": "object",
         "properties": {
           "contentTypeAliases": {
@@ -8215,19 +8245,19 @@
           "properties": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TemplateQueryProperty"
+              "$ref": "#/components/schemas/TemplateQueryPropertyModel"
             }
           },
           "operators": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TemplateQueryOperator"
+              "$ref": "#/components/schemas/TemplateQueryOperatorModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "TemplateScaffold": {
+      "TemplateScaffoldModel": {
         "type": "object",
         "properties": {
           "content": {
@@ -8252,296 +8282,7 @@
         },
         "additionalProperties": false
       },
-      "Type": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "readOnly": true
-          },
-          "customAttributes": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CustomAttributeData"
-            },
-            "readOnly": true
-          },
-          "isCollectible": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "metadataToken": {
-            "type": "integer",
-            "format": "int32",
-            "readOnly": true
-          },
-          "isInterface": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "memberType": {
-            "$ref": "#/components/schemas/MemberTypes"
-          },
-          "namespace": {
-            "type": "string",
-            "nullable": true,
-            "readOnly": true
-          },
-          "assemblyQualifiedName": {
-            "type": "string",
-            "nullable": true,
-            "readOnly": true
-          },
-          "fullName": {
-            "type": "string",
-            "nullable": true,
-            "readOnly": true
-          },
-          "assembly": {
-            "$ref": "#/components/schemas/Assembly"
-          },
-          "module": {
-            "$ref": "#/components/schemas/Module"
-          },
-          "isNested": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "declaringType": {
-            "$ref": "#/components/schemas/Type"
-          },
-          "declaringMethod": {
-            "$ref": "#/components/schemas/MethodBase"
-          },
-          "reflectedType": {
-            "$ref": "#/components/schemas/Type"
-          },
-          "underlyingSystemType": {
-            "$ref": "#/components/schemas/Type"
-          },
-          "isTypeDefinition": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isArray": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isByRef": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isPointer": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isConstructedGenericType": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isGenericParameter": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isGenericTypeParameter": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isGenericMethodParameter": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isGenericType": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isGenericTypeDefinition": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isSZArray": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isVariableBoundArray": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isByRefLike": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "hasElementType": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "genericTypeArguments": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Type"
-            },
-            "readOnly": true
-          },
-          "genericParameterPosition": {
-            "type": "integer",
-            "format": "int32",
-            "readOnly": true
-          },
-          "genericParameterAttributes": {
-            "$ref": "#/components/schemas/GenericParameterAttributes"
-          },
-          "attributes": {
-            "$ref": "#/components/schemas/TypeAttributes"
-          },
-          "isAbstract": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isImport": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isSealed": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isSpecialName": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isClass": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isNestedAssembly": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isNestedFamANDAssem": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isNestedFamily": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isNestedFamORAssem": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isNestedPrivate": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isNestedPublic": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isNotPublic": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isPublic": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isAutoLayout": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isExplicitLayout": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isLayoutSequential": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isAnsiClass": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isAutoClass": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isUnicodeClass": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isCOMObject": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isContextful": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isEnum": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isMarshalByRef": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isPrimitive": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isValueType": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isSignatureType": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isSecurityCritical": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isSecuritySafeCritical": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isSecurityTransparent": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "structLayoutAttribute": {
-            "$ref": "#/components/schemas/StructLayoutAttribute"
-          },
-          "typeInitializer": {
-            "$ref": "#/components/schemas/ConstructorInfo"
-          },
-          "typeHandle": {
-            "$ref": "#/components/schemas/RuntimeTypeHandle"
-          },
-          "guid": {
-            "type": "string",
-            "format": "uuid",
-            "readOnly": true
-          },
-          "baseType": {
-            "$ref": "#/components/schemas/Type"
-          },
-          "isSerializable": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "containsGenericParameters": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "isVisible": {
-            "type": "boolean",
-            "readOnly": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "TypeAttributes": {
+      "TypeAttributesModel": {
         "enum": [
           "NotPublic",
           "AutoLayout",
@@ -8579,7 +8320,7 @@
         "type": "integer",
         "format": "int32"
       },
-      "TypeInfo": {
+      "TypeInfoModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -8589,7 +8330,7 @@
           "customAttributes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CustomAttributeData"
+              "$ref": "#/components/schemas/CustomAttributeDataModel"
             },
             "readOnly": true
           },
@@ -8607,7 +8348,7 @@
             "readOnly": true
           },
           "memberType": {
-            "$ref": "#/components/schemas/MemberTypes"
+            "$ref": "#/components/schemas/MemberTypesModel"
           },
           "namespace": {
             "type": "string",
@@ -8625,26 +8366,26 @@
             "readOnly": true
           },
           "assembly": {
-            "$ref": "#/components/schemas/Assembly"
+            "$ref": "#/components/schemas/AssemblyModel"
           },
           "module": {
-            "$ref": "#/components/schemas/Module"
+            "$ref": "#/components/schemas/ModuleModel"
           },
           "isNested": {
             "type": "boolean",
             "readOnly": true
           },
           "declaringType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "declaringMethod": {
-            "$ref": "#/components/schemas/MethodBase"
+            "$ref": "#/components/schemas/MethodBaseModel"
           },
           "reflectedType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "underlyingSystemType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "isTypeDefinition": {
             "type": "boolean",
@@ -8705,7 +8446,7 @@
           "genericTypeArguments": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Type"
+              "$ref": "#/components/schemas/TypeModel"
             },
             "readOnly": true
           },
@@ -8715,10 +8456,10 @@
             "readOnly": true
           },
           "genericParameterAttributes": {
-            "$ref": "#/components/schemas/GenericParameterAttributes"
+            "$ref": "#/components/schemas/GenericParameterAttributesModel"
           },
           "attributes": {
-            "$ref": "#/components/schemas/TypeAttributes"
+            "$ref": "#/components/schemas/TypeAttributesModel"
           },
           "isAbstract": {
             "type": "boolean",
@@ -8837,13 +8578,13 @@
             "readOnly": true
           },
           "structLayoutAttribute": {
-            "$ref": "#/components/schemas/StructLayoutAttribute"
+            "$ref": "#/components/schemas/StructLayoutAttributeModel"
           },
           "typeInitializer": {
-            "$ref": "#/components/schemas/ConstructorInfo"
+            "$ref": "#/components/schemas/ConstructorInfoModel"
           },
           "typeHandle": {
-            "$ref": "#/components/schemas/RuntimeTypeHandle"
+            "$ref": "#/components/schemas/RuntimeTypeHandleModel"
           },
           "guid": {
             "type": "string",
@@ -8851,7 +8592,7 @@
             "readOnly": true
           },
           "baseType": {
-            "$ref": "#/components/schemas/Type"
+            "$ref": "#/components/schemas/TypeModel"
           },
           "isSerializable": {
             "type": "boolean",
@@ -8868,70 +8609,359 @@
           "genericTypeParameters": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Type"
+              "$ref": "#/components/schemas/TypeModel"
             },
             "readOnly": true
           },
           "declaredConstructors": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ConstructorInfo"
+              "$ref": "#/components/schemas/ConstructorInfoModel"
             },
             "readOnly": true
           },
           "declaredEvents": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/EventInfo"
+              "$ref": "#/components/schemas/EventInfoModel"
             },
             "readOnly": true
           },
           "declaredFields": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/FieldInfo"
+              "$ref": "#/components/schemas/FieldInfoModel"
             },
             "readOnly": true
           },
           "declaredMembers": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/MemberInfo"
+              "$ref": "#/components/schemas/MemberInfoModel"
             },
             "readOnly": true
           },
           "declaredMethods": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/MethodInfo"
+              "$ref": "#/components/schemas/MethodInfoModel"
             },
             "readOnly": true
           },
           "declaredNestedTypes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TypeInfo"
+              "$ref": "#/components/schemas/TypeInfoModel"
             },
             "readOnly": true
           },
           "declaredProperties": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/PropertyInfo"
+              "$ref": "#/components/schemas/PropertyInfoModel"
             },
             "readOnly": true
           },
           "implementedInterfaces": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Type"
+              "$ref": "#/components/schemas/TypeModel"
             },
             "readOnly": true
           }
         },
         "additionalProperties": false
       },
-      "UpgradeSettings": {
+      "TypeModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "readOnly": true
+          },
+          "customAttributes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomAttributeDataModel"
+            },
+            "readOnly": true
+          },
+          "isCollectible": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "metadataToken": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "isInterface": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "memberType": {
+            "$ref": "#/components/schemas/MemberTypesModel"
+          },
+          "namespace": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "assemblyQualifiedName": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "fullName": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "assembly": {
+            "$ref": "#/components/schemas/AssemblyModel"
+          },
+          "module": {
+            "$ref": "#/components/schemas/ModuleModel"
+          },
+          "isNested": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "declaringType": {
+            "$ref": "#/components/schemas/TypeModel"
+          },
+          "declaringMethod": {
+            "$ref": "#/components/schemas/MethodBaseModel"
+          },
+          "reflectedType": {
+            "$ref": "#/components/schemas/TypeModel"
+          },
+          "underlyingSystemType": {
+            "$ref": "#/components/schemas/TypeModel"
+          },
+          "isTypeDefinition": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isArray": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isByRef": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isPointer": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isConstructedGenericType": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isGenericParameter": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isGenericTypeParameter": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isGenericMethodParameter": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isGenericType": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isGenericTypeDefinition": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isSZArray": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isVariableBoundArray": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isByRefLike": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasElementType": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "genericTypeArguments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TypeModel"
+            },
+            "readOnly": true
+          },
+          "genericParameterPosition": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "genericParameterAttributes": {
+            "$ref": "#/components/schemas/GenericParameterAttributesModel"
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/TypeAttributesModel"
+          },
+          "isAbstract": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isImport": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isSealed": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isSpecialName": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isClass": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isNestedAssembly": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isNestedFamANDAssem": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isNestedFamily": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isNestedFamORAssem": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isNestedPrivate": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isNestedPublic": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isNotPublic": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isPublic": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isAutoLayout": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isExplicitLayout": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isLayoutSequential": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isAnsiClass": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isAutoClass": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isUnicodeClass": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isCOMObject": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isContextful": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isEnum": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isMarshalByRef": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isPrimitive": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isValueType": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isSignatureType": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isSecurityCritical": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isSecuritySafeCritical": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isSecurityTransparent": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "structLayoutAttribute": {
+            "$ref": "#/components/schemas/StructLayoutAttributeModel"
+          },
+          "typeInitializer": {
+            "$ref": "#/components/schemas/ConstructorInfoModel"
+          },
+          "typeHandle": {
+            "$ref": "#/components/schemas/RuntimeTypeHandleModel"
+          },
+          "guid": {
+            "type": "string",
+            "format": "uuid",
+            "readOnly": true
+          },
+          "baseType": {
+            "$ref": "#/components/schemas/TypeModel"
+          },
+          "isSerializable": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "containsGenericParameters": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isVisible": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpgradeSettingsModel": {
         "type": "object",
         "properties": {
           "currentState": {
@@ -8953,7 +8983,7 @@
         },
         "additionalProperties": false
       },
-      "UserInstall": {
+      "UserInstallModel": {
         "required": [
           "email",
           "name",
@@ -8982,7 +9012,7 @@
         },
         "additionalProperties": false
       },
-      "UserSettings": {
+      "UserSettingsModel": {
         "type": "object",
         "properties": {
           "minCharLength": {
@@ -8996,13 +9026,13 @@
           "consentLevels": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ConsentLevel"
+              "$ref": "#/components/schemas/ConsentLevelModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "Version": {
+      "VersionModel": {
         "type": "object",
         "properties": {
           "version": {
@@ -9020,7 +9050,7 @@
           "authorizationCode": {
             "authorizationUrl": "/umbraco/management/api/v1.0/security/back-office/authorize",
             "tokenUrl": "/umbraco/management/api/v1.0/security/back-office/token",
-            "scopes": {}
+            "scopes": { }
           }
         }
       }
@@ -9028,7 +9058,7 @@
   },
   "security": [
     {
-      "OAuth": []
+      "OAuth": [ ]
     }
   ]
 }

--- a/src/Umbraco.Cms.Api.Management/OpenApi/SchemaIdGenerator.cs
+++ b/src/Umbraco.Cms.Api.Management/OpenApi/SchemaIdGenerator.cs
@@ -17,7 +17,14 @@ internal static class SchemaIdGenerator
         if (type.IsGenericType)
         {
             // append the generic type names, ultimately turning i.e. "PagedViewModel<RelationItemViewModel>" into "PagedRelationItem"
-            name += string.Join(string.Empty, type.GenericTypeArguments.Select(SanitizedTypeName));
+            name = $"{name}{string.Join(string.Empty, type.GenericTypeArguments.Select(SanitizedTypeName))}";
+        }
+
+        if (name.EndsWith("Model") == false)
+        {
+            // because some models names clash with common classes in TypeScript (i.e. Document),
+            // we need to add a "Model" postfix to all models
+            name = $"{name}Model";
         }
 
         // make absolutely sure we don't pass any invalid named by removing all non-word chars


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR adds "Model" as postfix for all models in the Swagger output. This is necessary because some models have unfortunate name clashes with core TypeScript/JavaScript classes (like `Document`).

### Testing this PR

Verify that the Swagger UI displats both request and return models with a "Model" postfix:

![image](https://user-images.githubusercontent.com/7405322/217505586-ba35d57b-9377-4c57-857c-b76401329c95.png)

![image](https://user-images.githubusercontent.com/7405322/217505732-043215f9-35d7-4f22-951d-987041a236c4.png)
