### PR TITLE
Make the default lockout time configurable for users and members

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/SecuritySettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/SecuritySettings.cs
@@ -22,6 +22,9 @@ public class SecuritySettings
     internal const string StaticAllowedUserNameCharacters =
         "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+\\";
 
+    internal const int StaticMemberDefaultLockoutTimeInMinutes = 30 * 24 * 60;
+    internal const int StaticUserDefaultLockoutTimeInMinutes = 30 * 24 * 60;
+
     /// <summary>
     ///     Gets or sets a value indicating whether to keep the user logged in.
     /// </summary>
@@ -85,6 +88,18 @@ public class SecuritySettings
     /// </summary>
     [DefaultValue(StaticUserBypassTwoFactorForExternalLogins)]
     public bool UserBypassTwoFactorForExternalLogins { get; set; } = StaticUserBypassTwoFactorForExternalLogins;
+
+    /// <summary>
+    ///     Gets or sets a value for how long (in minutes) a member is locked out when a lockout occurs.
+    /// </summary>
+    [DefaultValue(StaticMemberDefaultLockoutTimeInMinutes)]
+    public int MemberDefaultLockoutTimeInMinutes { get; set; } = StaticMemberDefaultLockoutTimeInMinutes;
+
+    /// <summary>
+    ///     Gets or sets a value for how long (in minutes) a user is locked out when a lockout occurs.
+    /// </summary>
+    [DefaultValue(StaticUserDefaultLockoutTimeInMinutes)]
+    public int UserDefaultLockoutTimeInMinutes { get; set; } = StaticUserDefaultLockoutTimeInMinutes;
 
     /// <summary>
     /// Gets or sets a value indicating whether to allow editing invariant properties from a non-default language variation.

--- a/src/Umbraco.Web.BackOffice/Security/ConfigureBackOfficeIdentityOptions.cs
+++ b/src/Umbraco.Web.BackOffice/Security/ConfigureBackOfficeIdentityOptions.cs
@@ -1,8 +1,10 @@
 using System.Security.Claims;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Web.BackOffice.Security;
@@ -13,9 +15,21 @@ namespace Umbraco.Cms.Web.BackOffice.Security;
 public sealed class ConfigureBackOfficeIdentityOptions : IConfigureOptions<BackOfficeIdentityOptions>
 {
     private readonly UserPasswordConfigurationSettings _userPasswordConfiguration;
+    private readonly SecuritySettings _securitySettings;
 
-    public ConfigureBackOfficeIdentityOptions(IOptions<UserPasswordConfigurationSettings> userPasswordConfiguration) =>
+    [Obsolete("Use the constructor that accepts SecuritySettings. Will be removed in V12.")]
+    public ConfigureBackOfficeIdentityOptions(IOptions<UserPasswordConfigurationSettings> userPasswordConfiguration)
+        : this(userPasswordConfiguration, StaticServiceProvider.Instance.GetRequiredService<IOptions<SecuritySettings>>())
+    {
+    }
+
+    public ConfigureBackOfficeIdentityOptions(
+        IOptions<UserPasswordConfigurationSettings> userPasswordConfiguration,
+        IOptions<SecuritySettings> securitySettings)
+    {
         _userPasswordConfiguration = userPasswordConfiguration.Value;
+        _securitySettings = securitySettings.Value;
+    }
 
     public void Configure(BackOfficeIdentityOptions options)
     {
@@ -31,8 +45,7 @@ public sealed class ConfigureBackOfficeIdentityOptions : IConfigureOptions<BackO
         options.ClaimsIdentity.SecurityStampClaimType = Constants.Security.SecurityStampClaimType;
 
         options.Lockout.AllowedForNewUsers = true;
-        // TODO: Implement this
-        options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromDays(30);
+        options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(_securitySettings.UserDefaultLockoutTimeInMinutes);
 
         options.Password.ConfigurePasswordOptions(_userPasswordConfiguration);
 

--- a/src/Umbraco.Web.BackOffice/Security/ConfigureBackOfficeIdentityOptions.cs
+++ b/src/Umbraco.Web.BackOffice/Security/ConfigureBackOfficeIdentityOptions.cs
@@ -17,7 +17,7 @@ public sealed class ConfigureBackOfficeIdentityOptions : IConfigureOptions<BackO
     private readonly UserPasswordConfigurationSettings _userPasswordConfiguration;
     private readonly SecuritySettings _securitySettings;
 
-    [Obsolete("Use the constructor that accepts SecuritySettings. Will be removed in V12.")]
+    [Obsolete("Use the constructor that accepts SecuritySettings. Will be removed in V13.")]
     public ConfigureBackOfficeIdentityOptions(IOptions<UserPasswordConfigurationSettings> userPasswordConfiguration)
         : this(userPasswordConfiguration, StaticServiceProvider.Instance.GetRequiredService<IOptions<SecuritySettings>>())
     {

--- a/src/Umbraco.Web.Common/Security/ConfigureMemberIdentityOptions.cs
+++ b/src/Umbraco.Web.Common/Security/ConfigureMemberIdentityOptions.cs
@@ -31,8 +31,7 @@ public sealed class ConfigureMemberIdentityOptions : IConfigureOptions<IdentityO
 
         options.Lockout.AllowedForNewUsers = true;
 
-        // TODO: Implement this
-        options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromDays(30);
+        options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(_securitySettings.MemberDefaultLockoutTimeInMinutes);
 
         options.Password.ConfigurePasswordOptions(_memberPasswordConfiguration);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/12985

### Description

The default lockout time for users and members is currently hardcoded to 30 days. This PR makes those lockout times configurable by introducing two new configuration options under `Security` - one for members and one for users:

![image](https://user-images.githubusercontent.com/7405322/217521963-b4c8ffd3-55c7-46d1-b923-4be3026ff917.png)

The default values for these configuration options remain as 30 days (43200 minutes).

### Testing this PR

1. Delete `appsettings-schema.json` under `Umbraco.Cms` if it exists (it is a built-time auto generated file that will only be created if it does not exist).
![image](https://user-images.githubusercontent.com/7405322/217522446-e6c4d10f-49dc-4e33-a49a-a6a85f231ba9.png)
2. Build the solution. The schema file should be generated by the build.
3. Verify that `appsettings.json` supports auto completion for the two new settings:
![image](https://user-images.githubusercontent.com/7405322/217522676-58ea2a16-f88d-4648-88c5-5eeea7c5a250.png)
4. Configure the settings in `appsettings.json`
5. Restart the site if it's running.
6. Render any page with the template snippet below and verify that the correct configuration is rendered by the template.
7. Remove the configuration settings.
8. Restart the site if it's running.
9. Render any page with the template snippet below and verify that the default configuration (43200) now is rendered by the template.

### Test template
 
_Disclaimer: Please don't ever ever use this kind of templating in real life. Ever._

```cshtml
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
@inject IBackOfficeUserManager BackOfficeUserManager
@inject IMemberManager MemberManager
@using Umbraco.Cms.Core.Security
@using Microsoft.AspNetCore.Identity
@{
    Layout = null;
    var memberOptions = ((UserManager<MemberIdentityUser>)MemberManager).Options;
    var userOptions = ((UserManager<BackOfficeIdentityUser>)BackOfficeUserManager).Options;
}
<html>
<body>

<ul>
    <li>Members: @memberOptions.Lockout.DefaultLockoutTimeSpan.TotalMinutes minutes</li>
    <li>Users: @userOptions.Lockout.DefaultLockoutTimeSpan.TotalMinutes minutes</li>
</ul>

</body>
</html>
```