### PR TITLE
Don't show DB details on install screen when using a pre-configured c…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.html
@@ -101,11 +101,14 @@
           <div class="control-group">
             <label class="control-label" for="dbType">Database</label>
             <div class="controls -with-border">
-              <div class="input-readonly-text">
+              <div class="input-readonly-text" ng-if="installer.current.model.customInstallAvailable">
                 <strong>Provider:</strong>
                 {{installer.current.model.quickInstallSettings.displayName}}
                 <br /><strong>Name:</strong>
                 {{installer.current.model.quickInstallSettings.defaultDatabaseName}}
+              </div>
+              <div class="input-readonly-text" ng-if="!installer.current.model.customInstallAvailable">
+                A database has been pre-configured for your installation.
               </div>
             </div>
           </div>


### PR DESCRIPTION
…onnection string

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/12824

### Description

The first step in the installer shows incorrectly assumes the default setup for the target database when a connection string is pre-configured (i.e. lists the DB provider as "SQLite" and the DB name as "Umbraco" when in fact they might be something entirely different).

It looks something like this (notice you can't change the DB, which means the connection string is pre-configured):

![image](https://user-images.githubusercontent.com/7405322/217529089-336fdccf-a768-4b51-9f06-84303ec6ba50.png)

To fix that I have opted to remove the DB provider and DB name entirely in the case of a pre-configured connection string. Since one can't change the DB anyway, the provider and name is excess information at best, noise at worst. Instead a message is shown, indicating the pre-configured state:

![image](https://user-images.githubusercontent.com/7405322/217528157-a39867ec-a340-4dec-aaa6-1378efef0f94.png)

For comparison, here'sis how the installer appears without a pre-configured connection string (this PR does not change that):

![image](https://user-images.githubusercontent.com/7405322/217528340-64c4a01a-d97c-4cdf-96ba-9ba6f499d0f6.png)

### Testing this PR

Add a valid connection string that points to a non-existing SQLite DB and verify that the new message is displayed in the installer.