### PR TITLE
Add DefaultLanguage fallback policy for published values

### DIFF
--- a/src/Umbraco.Core/Models/PublishedContent/Fallback.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/Fallback.cs
@@ -3,56 +3,82 @@ using System.Collections;
 namespace Umbraco.Cms.Core.Models.PublishedContent;
 
 /// <summary>
-///     Manages the built-in fallback policies.
+/// Manages the built-in fallback policies.
 /// </summary>
 public struct Fallback : IEnumerable<int>
 {
     /// <summary>
-    ///     Do not fallback.
+    /// Do not fallback.
     /// </summary>
     public const int None = 0;
 
     private readonly int[] _values;
 
     /// <summary>
-    ///     Initializes a new instance of the <see cref="Fallback" /> struct with values.
+    /// Initializes a new instance of the <see cref="Fallback" /> struct with values.
     /// </summary>
+    /// <param name="values">The values.</param>
     private Fallback(int[] values) => _values = values;
 
     /// <summary>
-    ///     Gets an ordered set of fallback policies.
+    /// Gets an ordered set of fallback policies.
     /// </summary>
-    /// <param name="values"></param>
+    /// <param name="values">The values.</param>
+    /// <returns>
+    /// The fallback policy.
+    /// </returns>
     public static Fallback To(params int[] values) => new(values);
 
     /// <summary>
-    ///     Fallback to default value.
+    /// Fallback to the default value.
     /// </summary>
     public const int DefaultValue = 1;
 
     /// <summary>
-    ///     Fallback to other languages.
+    /// Fallback to other languages.
     /// </summary>
     public const int Language = 2;
 
     /// <summary>
-    ///     Fallback to tree ancestors.
+    /// Fallback to tree ancestors.
     /// </summary>
     public const int Ancestors = 3;
 
     /// <summary>
-    ///     Gets the fallback to default value policy.
+    /// Fallback to the default language.
     /// </summary>
+    public const int DefaultLanguage = 4;
+
+    /// <summary>
+    /// Gets the fallback to the default language policy.
+    /// </summary>
+    /// <value>
+    /// The default language fallback policy.
+    /// </value>
+    public static Fallback ToDefaultLanguage => new Fallback(new[] { DefaultLanguage });
+
+    /// <summary>
+    /// Gets the fallback to the default value policy.
+    /// </summary>
+    /// <value>
+    /// The default value fallback policy.
+    /// </value>
     public static Fallback ToDefaultValue => new(new[] { DefaultValue });
 
     /// <summary>
-    ///     Gets the fallback to language policy.
+    /// Gets the fallback to language policy.
     /// </summary>
+    /// <value>
+    /// The language fallback policy.
+    /// </value>
     public static Fallback ToLanguage => new(new[] { Language });
 
     /// <summary>
-    ///     Gets the fallback to tree ancestors policy.
+    /// Gets the fallback to tree ancestors policy.
     /// </summary>
+    /// <value>
+    /// The tree ancestors fallback policy.
+    /// </value>
     public static Fallback ToAncestors => new(new[] { Ancestors });
 
     /// <inheritdoc />

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedValueFallback.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedValueFallback.cs
@@ -45,6 +45,13 @@ public class PublishedValueFallback : IPublishedValueFallback
                     }
 
                     break;
+                case Fallback.DefaultLanguage:
+                    if (TryGetValueWithDefaultLanguageFallback(property, culture, segment, out value))
+                    {
+                        return true;
+                    }
+
+                    break;
                 default:
                     throw NotSupportedFallbackMethod(f, "property");
             }
@@ -81,6 +88,13 @@ public class PublishedValueFallback : IPublishedValueFallback
                     return true;
                 case Fallback.Language:
                     if (TryGetValueWithLanguageFallback(content, alias, culture, segment, out value))
+                    {
+                        return true;
+                    }
+
+                    break;
+                case Fallback.DefaultLanguage:
+                    if (TryGetValueWithDefaultLanguageFallback(content, alias, culture, segment, out value))
                     {
                         return true;
                     }
@@ -137,6 +151,13 @@ public class PublishedValueFallback : IPublishedValueFallback
                     break;
                 case Fallback.Ancestors:
                     if (TryGetValueWithAncestorsFallback(content, alias, culture, segment, out value, ref noValueProperty))
+                    {
+                        return true;
+                    }
+
+                    break;
+                case Fallback.DefaultLanguage:
+                    if (TryGetValueWithDefaultLanguageFallback(content, alias, culture, segment, out value))
                     {
                         return true;
                     }
@@ -346,5 +367,43 @@ public class PublishedValueFallback : IPublishedValueFallback
 
             language = language2;
         }
+    }
+
+    private bool TryGetValueWithDefaultLanguageFallback<T>(IPublishedProperty property, string? culture, string? segment, out T? value)
+    {
+        value = default;
+
+        if (culture.IsNullOrWhiteSpace())
+        {
+            return false;
+        }
+
+        string? defaultCulture = _localizationService?.GetDefaultLanguageIsoCode();
+        if (culture.InvariantEquals(defaultCulture) == false && property.HasValue(defaultCulture, segment))
+        {
+            value = property.Value<T>(this, defaultCulture, segment);
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool TryGetValueWithDefaultLanguageFallback<T>(IPublishedElement element, string alias, string? culture, string? segment, out T? value)
+    {
+        value = default;
+
+        if (culture.IsNullOrWhiteSpace())
+        {
+            return false;
+        }
+
+        string? defaultCulture = _localizationService?.GetDefaultLanguageIsoCode();
+        if (culture.InvariantEquals(defaultCulture) == false && element.HasValue(alias, defaultCulture, segment))
+        {
+            value = element.Value<T>(this, alias, defaultCulture, segment);
+            return true;
+        }
+
+        return false;
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/PublishedCache/PublishedContentLanguageVariantTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/PublishedCache/PublishedContentLanguageVariantTests.cs
@@ -243,6 +243,15 @@ public class PublishedContentLanguageVariantTests : PublishedSnapshotServiceTest
     }
 
     [Test]
+    public void Can_Get_Content_For_Unpopulated_Requested_DefaultLanguage_With_Fallback()
+    {
+        var snapshot = GetPublishedSnapshot();
+        var content = snapshot.Content.GetAtRoot().First();
+        var value = content.Value(PublishedValueFallback, "welcomeText", "fr", fallback: Fallback.ToDefaultLanguage);
+        Assert.AreEqual("Welcome", value);
+    }
+
+    [Test]
     public void Do_Not_Get_Content_Recursively_Unless_Requested()
     {
         var snapshot = GetPublishedSnapshot();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/8349.

This includes most changes done in PR https://github.com/umbraco/Umbraco-CMS/pull/8350 that targeted v8.

### Description
This PR adds a new `Fallback.DefaultLanguage` value to get the content/property value from the default language, instead of the configured language fallback chain.

Previously, you had to either configure the fallback language to the default one and/or use very verbose, nested fallback chains:
```cshtml
<h1>@Model.Value("title", fallback: Fallback.To(Fallback.DefaultValue), defaultValue: Model.Value("title", culture: UmbracoContext?.Domains?.DefaultCulture, fallback: Fallback.ToDefaultValue, defaultValue: Model.Name))</h1>
@Model.Value("text", fallback: Fallback.To(Fallback.Language, Fallback.DefaultValue), defaultValue: Model.Value("text", UmbracoContext?.Domains?.DefaultCulture))
```

With this new fallback value/policy, you don't have to configure the language fallbacks (so you can use that when you actually want to fallback from e.g. `en-US` to `en`), the code is much more compact and because fallback values are only retrieved when they need to, is more performant as well:
```cshtml
<h1>@Model.Value("title", fallback: Fallback.To(Fallback.DefaultLanguage, Fallback.DefaultValue), defaultValue: Model.Name)</h1>
@Model.Value("text", fallback: Fallback.To(Fallback.Language, Fallback.DefaultLanguage))
```

And in its simplest form, you can also use the helper property: `Model.Value("text", fallback: Fallback.ToDefaultLanguage)`.

I've added a test that shows it can get the correct value from the default language, but you can also test this manually by:
1. Adding multiple languages:
   - English - Default
   - Danish
   - Dutch
   - German - Fallback to Dutch
2. Creating a document type that varies by culture with 2 properties: `title` and `text`
3. Create and publish a content node with the following values per language:
   - English:
      - Name: `Home`
      - Title:
      - Text: `This is the English content...`
   - Danish:
      - Name: `Hjem`
      - Title:
      - Text:
   - Dutch:
      - Name: `Thuis`
      - Title: `Voorpagina`
      - Text: `Dit is de Nederlandse inhoud...`
   - German:
      - Name: `Startseite`
      - Title:
      - Text:
4. Add both of the above code snippets to the template of this document type (to verify they return the same results)
5. This should return the following results:
   - English: `Home` / `This is the English content...`
   - Danish: `Hjem` / `This is the English content...`
   - Dutch: `Thuis` / `Dit is de Nederlandse inhoud...`
   - German: `Startseite` / `Dit is de Nederlandse inhoud...`