### PR TITLE
Improvement to JITOptimizerValidator exception message.

### DIFF
--- a/src/Umbraco.Infrastructure/Runtime/RuntimeModeValidators/JITOptimizerValidator.cs
+++ b/src/Umbraco.Infrastructure/Runtime/RuntimeModeValidators/JITOptimizerValidator.cs
@@ -19,7 +19,7 @@ public class JITOptimizerValidator : RuntimeModeProductionValidatorBase
         DebuggableAttribute? debuggableAttribute = Assembly.GetEntryAssembly()?.GetCustomAttribute<DebuggableAttribute>();
         if (debuggableAttribute != null && debuggableAttribute.IsJITOptimizerDisabled)
         {
-            validationErrorMessage = "The JIT/runtime optimizer of the entry assembly needs to be enabled in production mode.";
+            validationErrorMessage = "The JIT/runtime optimizer of the entry assembly needs to be enabled in production mode.  The project should be built/published in Release (or similar) configuration in production mode.";
             return false;
         }
 


### PR DESCRIPTION
### Description
When setting the Runtime mode to `Production`, the project should be built/published in Release mode, and the `JITOptimizerValidator` enforces this.  

However, if you don't build/publish in release mode, then you get the following exception rmessage which doesn't help you understand how to fix the problem:
```
The JIT/runtime optimizer of the entry assembly needs to be enabled in production mode.
```

I recently came across this error message when I didn't realise that my my build server was publishing the using "Debug" configuration.  It took me a couple of hours to figure out that this was the problem, so I figured adding a bit of info to the exception would have helped me and might help others!