### PR TITLE
Fixup: Handle converting from slider to single value

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/SliderValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/SliderValueConverter.cs
@@ -52,20 +52,19 @@ public class SliderValueConverter : PropertyValueConverterBase
         bool isRange = IsRange(propertyType);
 
         var sourceString = source?.ToString();
-        if (string.IsNullOrEmpty(sourceString))
-        {
-            return isRange
-                ? new Range<decimal>()
-                : default(decimal);
-        }
 
         return isRange
             ? HandleRange(sourceString)
             : HandleDecimal(sourceString);
     }
 
-    private static object? HandleRange(string sourceString)
+    private static Range<decimal> HandleRange(string? sourceString)
     {
+        if (sourceString is null)
+        {
+            return new Range<decimal>();
+        }
+
         string[] rangeRawValues = sourceString.Split(Constants.CharArrays.Comma);
 
         if (TryParseDecimal(rangeRawValues[0], out var minimum))
@@ -93,8 +92,12 @@ public class SliderValueConverter : PropertyValueConverterBase
         return new Range<decimal>();
     }
 
-    private static object? HandleDecimal(string sourceString)
+    private static decimal HandleDecimal(string? sourceString)
     {
+        if (string.IsNullOrEmpty(sourceString))
+        {
+            return default;
+        }
 
         // This used to be a range slider, so we'll assign the minimum value as the new value
         if (sourceString.Contains(','))
@@ -111,7 +114,7 @@ public class SliderValueConverter : PropertyValueConverterBase
             return value;
         }
 
-        return default(decimal);
+        return default;
     }
 
     /// <summary>


### PR DESCRIPTION
This is a proposed amend to #13782 


During testing, I noticed that if you went from a range slider to a non-range slider, the slider value changed to the two values combined and parsed to a double. 

This PR fixes this by using the same approach as when going from a non-range slider to a range slider, that is we check if there is a `,` in the value, and if there is we assume we're going from a ranger slider to a non-range slider, and pick the minimum level.

While I was at it, I also refactored the code a bit to make it easier to work with and understand.


### Testing

Follow the testing steps from the PR, but try and go from a range slider to a non-range slider, the value presented should be the minimum value. 