### PR TITLE
Updated OpenIddict to v4

### DIFF
--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeAuthBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeAuthBuilderExtensions.cs
@@ -59,8 +59,8 @@ public static class BackOfficeAuthBuilderExtensions
             {
                 // Enable the authorization and token endpoints.
                 options
-                    .SetAuthorizationEndpointUris(Controllers.Security.Paths.BackOfficeApiAuthorizationEndpoint)
-                    .SetTokenEndpointUris(Controllers.Security.Paths.BackOfficeApiTokenEndpoint);
+                    .SetAuthorizationEndpointUris(Controllers.Security.Paths.BackOfficeApiAuthorizationEndpoint.TrimStart('/'))
+                    .SetTokenEndpointUris(Controllers.Security.Paths.BackOfficeApiTokenEndpoint.TrimStart('/'));
 
                 // Enable authorization code flow with PKCE
                 options

--- a/src/Umbraco.Cms.Api.Management/Umbraco.Cms.Api.Management.csproj
+++ b/src/Umbraco.Cms.Api.Management/Umbraco.Cms.Api.Management.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.2" />
-    <PackageReference Include="OpenIddict.AspNetCore" Version="3.1.1" />
-    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="3.1.1" />
+    <PackageReference Include="OpenIddict.AspNetCore" Version="4.0.0" />
+    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="4.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/src/Umbraco.Cms.StaticAssets/Umbraco.Cms.StaticAssets.csproj
+++ b/src/Umbraco.Cms.StaticAssets/Umbraco.Cms.StaticAssets.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <BellePath>$(ProjectDir)wwwroot\umbraco</BellePath>
+    <BellePath>$(ProjectDir)wwwroot\umbraco\backoffice</BellePath>
   </PropertyGroup>
 
   <Target Name="BuildBellePreconditions" BeforeTargets="Build">
@@ -27,6 +27,11 @@
   </Target>
 
   <Target Name="BuildBelle">
+<!--    TODO remove these when the old backoffice is not used anymore-->
+    <Exec WorkingDirectory="$(ProjectDir)..\Umbraco.Web.UI.Client\" Command="npm ci --no-fund --no-audit --prefer-offline" />
+    <Exec WorkingDirectory="$(ProjectDir)..\Umbraco.Web.UI.Client\" Command="npm run build:skip-tests" />
+
+
     <Exec WorkingDirectory="$(ProjectDir)..\Umbraco.Web.UI.New.Client\" Command="npm ci --no-fund --no-audit --prefer-offline" />
     <Exec WorkingDirectory="$(ProjectDir)..\Umbraco.Web.UI.New.Client\" Command="npm run build:for:cms" />
   </Target>

--- a/src/Umbraco.New.Cms.Infrastructure/Umbraco.New.Cms.Infrastructure.csproj
+++ b/src/Umbraco.New.Cms.Infrastructure/Umbraco.New.Cms.Infrastructure.csproj
@@ -12,6 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenIddict.Abstractions" Version="3.1.1" />
+    <PackageReference Include="OpenIddict.Abstractions" Version="4.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updated the OpenIddict to the new v4
- Followed [migration guide](https://documentation.openiddict.com/guides/migration/30-to-40.html).
  - Updated endpoint urls 
    -  https://documentation.openiddict.com/guides/migration/30-to-40.html#update-your-endpoint-uris
 
 - Fixed issue where the old backoffice did not work anymore.
 
 # Tests
 - Go to swagger in old backoffice and use the authorise button.
   - Keep the client_id
   - keep the cliense_secret  empty
  -  Verify you now have a token.