### PR TITLE
Content API: Support Accept-Language header

### DIFF
--- a/src/Umbraco.Cms.Api.Content/Controllers/ContentApiControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Content/Controllers/ContentApiControllerBase.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Common.Filters;
+using Umbraco.Cms.Api.Content.Filters;
 using Umbraco.Cms.Api.Content.Routing;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.ContentApi;
@@ -13,6 +14,7 @@ namespace Umbraco.Cms.Api.Content.Controllers;
 [ApiExplorerSettings(GroupName = "Content")]
 [ApiVersion("1.0")]
 [JsonOptionsName(Constants.JsonOptionsNames.ContentApi)]
+[LocalizeFromAcceptLanguageHeader]
 public abstract class ContentApiControllerBase : Controller
 {
     private readonly IPublishedSnapshotAccessor _publishedSnapshotAccessor;

--- a/src/Umbraco.Cms.Api.Content/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Content/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Api.Common.Configuration;
 using Umbraco.Cms.Api.Common.DependencyInjection;
-using Umbraco.Cms.Api.Content.Filters;
+using Umbraco.Cms.Api.Content.Json;
 using Umbraco.Cms.Api.Content.Services;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.ContentApi;

--- a/src/Umbraco.Cms.Api.Content/Filters/LocalizeFromAcceptLanguageHeaderAttribute.cs
+++ b/src/Umbraco.Cms.Api.Content/Filters/LocalizeFromAcceptLanguageHeaderAttribute.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Content.Filters;
+
+public class LocalizeFromAcceptLanguageHeaderAttribute : TypeFilterAttribute
+{
+    public LocalizeFromAcceptLanguageHeaderAttribute()
+        : base(typeof(LocalizeFromAcceptLanguageHeaderAttributeFilter))
+    {
+    }
+
+    private class LocalizeFromAcceptLanguageHeaderAttributeFilter : IActionFilter
+    {
+        private readonly IVariationContextAccessor _variationContextAccessor;
+
+        public LocalizeFromAcceptLanguageHeaderAttributeFilter(IVariationContextAccessor variationContextAccessor)
+            => _variationContextAccessor = variationContextAccessor;
+
+        public void OnActionExecuting(ActionExecutingContext context)
+        {
+            var acceptLanguage = context.HttpContext.Request.Headers.AcceptLanguage.ToString();
+            if (acceptLanguage.IsNullOrWhiteSpace() || _variationContextAccessor.VariationContext?.Culture == acceptLanguage)
+            {
+                return;
+            }
+
+            _variationContextAccessor.VariationContext = new VariationContext(acceptLanguage);
+        }
+
+        public void OnActionExecuted(ActionExecutedContext context)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Cms.Api.Content/Json/ContentApiJsonTypeResolver.cs
+++ b/src/Umbraco.Cms.Api.Content/Json/ContentApiJsonTypeResolver.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using Umbraco.Cms.Core.Models.ContentApi;
 
-namespace Umbraco.Cms.Api.Content.Filters;
+namespace Umbraco.Cms.Api.Content.Json;
 
 // see https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/polymorphism?pivots=dotnet-7-0
 // TODO: if this type resolver is to be used for extendable content models (custom IApiContent implementations) we need to work out an extension model for known derived types


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Adds support for passing in an Accept-Language header with a culture code to the Content API.

I have also moved the `ContentApiJsonTypeResolver` to the `Json` namespace where it rightfully belongs - not sure why it was placed under `Filters` to begin with 😆 

### Testing this PR

At the time of writing we seem to have an issue fetching culture variant content by path, so for now this can only be tested when fetching culture variant content by key:

![image](https://user-images.githubusercontent.com/7405322/218951126-4ddc69b7-003d-4fd4-be23-924ae874d872.png)
