### PR TITLE
V13: Add parentkey to notifications

### DIFF
--- a/src/Umbraco.Core/Events/MoveEventInfo.cs
+++ b/src/Umbraco.Core/Events/MoveEventInfo.cs
@@ -22,7 +22,7 @@ public class MoveEventInfo<TEntity> : MoveEventInfoBase<TEntity>
 
     public override bool Equals(object? obj) => Equals((MoveEventInfo<TEntity>?)obj) && base.Equals(obj);
 
-    private bool Equals(MoveEventInfo<TEntity>? other) => NewParentId == other?.NewParentId && NewParentKey == other.NewParentKey;
+    public bool Equals(MoveEventInfo<TEntity>? other) => NewParentId == other?.NewParentId && NewParentKey == other.NewParentKey && base.Equals(other);
 
     public override int GetHashCode()
     {

--- a/src/Umbraco.Core/Events/MoveEventInfo.cs
+++ b/src/Umbraco.Core/Events/MoveEventInfo.cs
@@ -9,8 +9,7 @@ public class MoveEventInfo<TEntity> : MoveEventInfoBase<TEntity>
         NewParentKey = newParentKey;
     }
 
-    public MoveEventInfo(TEntity entity, string originalPath, int newParentId) : this(entity, originalPath, newParentId,
-        null)
+    public MoveEventInfo(TEntity entity, string originalPath, int newParentId) : this(entity, originalPath, newParentId, null)
     {
     }
 

--- a/src/Umbraco.Core/Events/MoveEventInfo.cs
+++ b/src/Umbraco.Core/Events/MoveEventInfo.cs
@@ -20,9 +20,9 @@ public class MoveEventInfo<TEntity> : MoveEventInfoBase<TEntity>
 
     public static bool operator ==(MoveEventInfo<TEntity> left, MoveEventInfo<TEntity> right) => Equals(left, right);
 
-    public override bool Equals(object? obj) => Equals((MoveEventInfoBase<TEntity>?)obj) && base.Equals(obj);
+    public override bool Equals(object? obj) => Equals((MoveEventInfo<TEntity>?)obj) && base.Equals(obj);
 
-    public bool Equals(MoveEventInfo<TEntity>? other) => NewParentId == other?.NewParentId && NewParentKey == other.NewParentKey;
+    private bool Equals(MoveEventInfo<TEntity>? other) => NewParentId == other?.NewParentId && NewParentKey == other.NewParentKey;
 
     public override int GetHashCode()
     {

--- a/src/Umbraco.Core/Events/MoveEventInfo.cs
+++ b/src/Umbraco.Core/Events/MoveEventInfo.cs
@@ -20,7 +20,7 @@ public class MoveEventInfo<TEntity> : MoveEventInfoBase<TEntity>
 
     public static bool operator ==(MoveEventInfo<TEntity> left, MoveEventInfo<TEntity> right) => Equals(left, right);
 
-    public override bool Equals(object? obj) => Equals((MoveEventInfo<TEntity>?)obj) && base.Equals(obj);
+    public override bool Equals(object? obj) => Equals((MoveEventInfo<TEntity>?)obj);
 
     public bool Equals(MoveEventInfo<TEntity>? other) => NewParentId == other?.NewParentId && NewParentKey == other.NewParentKey && base.Equals(other);
 

--- a/src/Umbraco.Core/Events/MoveEventInfo.cs
+++ b/src/Umbraco.Core/Events/MoveEventInfo.cs
@@ -1,19 +1,23 @@
 namespace Umbraco.Cms.Core.Events;
 
-public class MoveEventInfo<TEntity> : IEquatable<MoveEventInfo<TEntity>>
+public class MoveEventInfo<TEntity> : MoveEventInfoBase<TEntity>
 {
-    public MoveEventInfo(TEntity entity, string originalPath, int newParentId)
+    public MoveEventInfo(TEntity entity, string originalPath, int newParentId, Guid? newParentKey)
+        : base(entity, originalPath)
     {
-        Entity = entity;
-        OriginalPath = originalPath;
         NewParentId = newParentId;
+        NewParentKey = newParentKey;
     }
 
-    public TEntity Entity { get; set; }
+    public MoveEventInfo(TEntity entity, string originalPath, int newParentId) : this(entity, originalPath, newParentId,
+        null)
+    {
+    }
 
-    public string OriginalPath { get; set; }
-
+    [Obsolete("Please use NewParentKey instead, scheduled for removal in V15")]
     public int NewParentId { get; set; }
+
+    public Guid? NewParentKey { get; }
 
     public static bool operator ==(MoveEventInfo<TEntity> left, MoveEventInfo<TEntity> right) => Equals(left, right);
 
@@ -29,7 +33,11 @@ public class MoveEventInfo<TEntity> : IEquatable<MoveEventInfo<TEntity>>
             return true;
         }
 
-        return EqualityComparer<TEntity>.Default.Equals(Entity, other.Entity) && NewParentId == other.NewParentId &&
+        return EqualityComparer<TEntity>.Default.Equals(
+                   Entity,
+                   other.Entity) &&
+               NewParentId == other.NewParentId &&
+               NewParentKey == other.NewParentKey &&
                string.Equals(OriginalPath, other.OriginalPath);
     }
 

--- a/src/Umbraco.Core/Events/MoveEventInfo.cs
+++ b/src/Umbraco.Core/Events/MoveEventInfo.cs
@@ -20,43 +20,9 @@ public class MoveEventInfo<TEntity> : MoveEventInfoBase<TEntity>
 
     public static bool operator ==(MoveEventInfo<TEntity> left, MoveEventInfo<TEntity> right) => Equals(left, right);
 
-    public bool Equals(MoveEventInfo<TEntity>? other)
-    {
-        if (ReferenceEquals(null, other))
-        {
-            return false;
-        }
+    public override bool Equals(object? obj) => Equals((MoveEventInfoBase<TEntity>?)obj) && base.Equals(obj);
 
-        if (ReferenceEquals(this, other))
-        {
-            return true;
-        }
-
-        return EqualityComparer<TEntity>.Default.Equals(Entity, other.Entity)
-               && NewParentId == other.NewParentId
-               && NewParentKey == other.NewParentKey
-               && string.Equals(OriginalPath, other.OriginalPath);
-    }
-
-    public override bool Equals(object? obj)
-    {
-        if (ReferenceEquals(null, obj))
-        {
-            return false;
-        }
-
-        if (ReferenceEquals(this, obj))
-        {
-            return true;
-        }
-
-        if (obj.GetType() != GetType())
-        {
-            return false;
-        }
-
-        return Equals((MoveEventInfo<TEntity>)obj);
-    }
+    public bool Equals(MoveEventInfo<TEntity>? other) => NewParentId == other?.NewParentId && NewParentKey == other.NewParentKey;
 
     public override int GetHashCode()
     {

--- a/src/Umbraco.Core/Events/MoveEventInfo.cs
+++ b/src/Umbraco.Core/Events/MoveEventInfo.cs
@@ -32,12 +32,10 @@ public class MoveEventInfo<TEntity> : MoveEventInfoBase<TEntity>
             return true;
         }
 
-        return EqualityComparer<TEntity>.Default.Equals(
-                   Entity,
-                   other.Entity) &&
-               NewParentId == other.NewParentId &&
-               NewParentKey == other.NewParentKey &&
-               string.Equals(OriginalPath, other.OriginalPath);
+        return EqualityComparer<TEntity>.Default.Equals(Entity, other.Entity)
+               && NewParentId == other.NewParentId
+               && NewParentKey == other.NewParentKey
+               && string.Equals(OriginalPath, other.OriginalPath);
     }
 
     public override bool Equals(object? obj)

--- a/src/Umbraco.Core/Events/MoveEventInfoBase.cs
+++ b/src/Umbraco.Core/Events/MoveEventInfoBase.cs
@@ -1,0 +1,51 @@
+﻿namespace Umbraco.Cms.Core.Events;
+
+public abstract class MoveEventInfoBase<TEntity> : IEquatable<MoveEventInfoBase<TEntity>>
+{
+    public MoveEventInfoBase(TEntity entity, string originalPath)
+    {
+        Entity = entity;
+        OriginalPath = originalPath;
+    }
+
+    public TEntity Entity { get; set; }
+
+    public string OriginalPath { get; set; }
+
+    public bool Equals(MoveEventInfoBase<TEntity>? other)
+    {
+        if (ReferenceEquals(null, other))
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        return EqualityComparer<TEntity>.Default.Equals(Entity, other.Entity) && OriginalPath == other.OriginalPath;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (ReferenceEquals(null, obj))
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+
+        if (obj.GetType() != this.GetType())
+        {
+            return false;
+        }
+
+        return Equals((MoveEventInfoBase<TEntity>) obj);
+    }
+
+    public override int GetHashCode() => HashCode.Combine(Entity, OriginalPath);
+}

--- a/src/Umbraco.Core/Events/MoveEventInfoBase.cs
+++ b/src/Umbraco.Core/Events/MoveEventInfoBase.cs
@@ -24,27 +24,17 @@ public abstract class MoveEventInfoBase<TEntity> : IEquatable<MoveEventInfoBase<
             return true;
         }
 
+        if (other.GetType() != this.GetType())
+        {
+            return false;
+        }
+
         return EqualityComparer<TEntity>.Default.Equals(Entity, other.Entity) && OriginalPath == other.OriginalPath;
     }
 
     public override bool Equals(object? obj)
     {
-        if (ReferenceEquals(null, obj))
-        {
-            return false;
-        }
-
-        if (ReferenceEquals(this, obj))
-        {
-            return true;
-        }
-
-        if (obj.GetType() != this.GetType())
-        {
-            return false;
-        }
-
-        return Equals((MoveEventInfoBase<TEntity>) obj);
+        return Equals((MoveEventInfoBase<TEntity>?) obj);
     }
 
     public override int GetHashCode() => HashCode.Combine(Entity, OriginalPath);

--- a/src/Umbraco.Core/Events/MoveEventInfoBase.cs
+++ b/src/Umbraco.Core/Events/MoveEventInfoBase.cs
@@ -32,10 +32,7 @@ public abstract class MoveEventInfoBase<TEntity> : IEquatable<MoveEventInfoBase<
         return EqualityComparer<TEntity>.Default.Equals(Entity, other.Entity) && OriginalPath == other.OriginalPath;
     }
 
-    public override bool Equals(object? obj)
-    {
-        return Equals((MoveEventInfoBase<TEntity>?) obj);
-    }
+    public override bool Equals(object? obj) => Equals((MoveEventInfoBase<TEntity>?) obj);
 
     public override int GetHashCode() => HashCode.Combine(Entity, OriginalPath);
 }

--- a/src/Umbraco.Core/Events/MoveToRecycleBinEventInfo.cs
+++ b/src/Umbraco.Core/Events/MoveToRecycleBinEventInfo.cs
@@ -1,0 +1,8 @@
+﻿namespace Umbraco.Cms.Core.Events;
+
+public class MoveToRecycleBinEventInfo<TEntity> : MoveEventInfoBase<TEntity>
+{
+    public MoveToRecycleBinEventInfo(TEntity entity, string originalPath) : base(entity, originalPath)
+    {
+    }
+}

--- a/src/Umbraco.Core/Notifications/ContentCopiedNotification.cs
+++ b/src/Umbraco.Core/Notifications/ContentCopiedNotification.cs
@@ -8,8 +8,13 @@ namespace Umbraco.Cms.Core.Notifications;
 
 public sealed class ContentCopiedNotification : CopiedNotification<IContent>
 {
+    public ContentCopiedNotification(IContent original, IContent copy, int parentId, Guid? parentKey, bool relateToOriginal, EventMessages messages)
+        : base(original, copy, parentId, parentKey, relateToOriginal, messages)
+    {
+    }
+
     public ContentCopiedNotification(IContent original, IContent copy, int parentId, bool relateToOriginal, EventMessages messages)
-        : base(original, copy, parentId, relateToOriginal, messages)
+        : this(original, copy, parentId, null, relateToOriginal, messages)
     {
     }
 }

--- a/src/Umbraco.Core/Notifications/ContentCopiedNotification.cs
+++ b/src/Umbraco.Core/Notifications/ContentCopiedNotification.cs
@@ -13,6 +13,7 @@ public sealed class ContentCopiedNotification : CopiedNotification<IContent>
     {
     }
 
+    [Obsolete("Please use constructor that takes a parent key as well, scheduled for removal in v15")]
     public ContentCopiedNotification(IContent original, IContent copy, int parentId, bool relateToOriginal, EventMessages messages)
         : this(original, copy, parentId, null, relateToOriginal, messages)
     {

--- a/src/Umbraco.Core/Notifications/ContentCopyingNotification.cs
+++ b/src/Umbraco.Core/Notifications/ContentCopyingNotification.cs
@@ -14,7 +14,7 @@ public sealed class ContentCopyingNotification : CopyingNotification<IContent>
     }
 
     public ContentCopyingNotification(IContent original, IContent copy, int parentId, EventMessages messages)
-        : base(original, copy, parentId, messages)
+        : this(original, copy, parentId, null, messages)
     {
     }
 }

--- a/src/Umbraco.Core/Notifications/ContentCopyingNotification.cs
+++ b/src/Umbraco.Core/Notifications/ContentCopyingNotification.cs
@@ -8,6 +8,11 @@ namespace Umbraco.Cms.Core.Notifications;
 
 public sealed class ContentCopyingNotification : CopyingNotification<IContent>
 {
+    public ContentCopyingNotification(IContent original, IContent copy, int parentId, Guid parentKey, EventMessages messages)
+        : base(original, copy, parentId, parentKey, messages)
+    {
+    }
+
     public ContentCopyingNotification(IContent original, IContent copy, int parentId, EventMessages messages)
         : base(original, copy, parentId, messages)
     {

--- a/src/Umbraco.Core/Notifications/ContentCopyingNotification.cs
+++ b/src/Umbraco.Core/Notifications/ContentCopyingNotification.cs
@@ -13,6 +13,7 @@ public sealed class ContentCopyingNotification : CopyingNotification<IContent>
     {
     }
 
+    [Obsolete("Please use constructor that takes a parent key as well, scheduled for removal in v15")]
     public ContentCopyingNotification(IContent original, IContent copy, int parentId, EventMessages messages)
         : this(original, copy, parentId, null, messages)
     {

--- a/src/Umbraco.Core/Notifications/ContentCopyingNotification.cs
+++ b/src/Umbraco.Core/Notifications/ContentCopyingNotification.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Core.Notifications;
 
 public sealed class ContentCopyingNotification : CopyingNotification<IContent>
 {
-    public ContentCopyingNotification(IContent original, IContent copy, int parentId, Guid parentKey, EventMessages messages)
+    public ContentCopyingNotification(IContent original, IContent copy, int parentId, Guid? parentKey, EventMessages messages)
         : base(original, copy, parentId, parentKey, messages)
     {
     }

--- a/src/Umbraco.Core/Notifications/ContentMovedToRecycleBinNotification.cs
+++ b/src/Umbraco.Core/Notifications/ContentMovedToRecycleBinNotification.cs
@@ -8,14 +8,14 @@ namespace Umbraco.Cms.Core.Notifications;
 
 public sealed class ContentMovedToRecycleBinNotification : MovedToRecycleBinNotification<IContent>
 {
-    public ContentMovedToRecycleBinNotification(MoveEventInfo<IContent> target, EventMessages messages)
+    public ContentMovedToRecycleBinNotification(MoveToRecycleBinEventInfo<IContent> target, EventMessages messages)
         : base(
         target,
         messages)
     {
     }
 
-    public ContentMovedToRecycleBinNotification(IEnumerable<MoveEventInfo<IContent>> target, EventMessages messages)
+    public ContentMovedToRecycleBinNotification(IEnumerable<MoveToRecycleBinEventInfo<IContent>> target, EventMessages messages)
         : base(target, messages)
     {
     }

--- a/src/Umbraco.Core/Notifications/ContentMovingToRecycleBinNotification.cs
+++ b/src/Umbraco.Core/Notifications/ContentMovingToRecycleBinNotification.cs
@@ -8,14 +8,14 @@ namespace Umbraco.Cms.Core.Notifications;
 
 public sealed class ContentMovingToRecycleBinNotification : MovingToRecycleBinNotification<IContent>
 {
-    public ContentMovingToRecycleBinNotification(MoveEventInfo<IContent> target, EventMessages messages)
+    public ContentMovingToRecycleBinNotification(MoveToRecycleBinEventInfo<IContent> target, EventMessages messages)
         : base(
         target,
         messages)
     {
     }
 
-    public ContentMovingToRecycleBinNotification(IEnumerable<MoveEventInfo<IContent>> target, EventMessages messages)
+    public ContentMovingToRecycleBinNotification(IEnumerable<MoveToRecycleBinEventInfo<IContent>> target, EventMessages messages)
         : base(target, messages)
     {
     }

--- a/src/Umbraco.Core/Notifications/CopiedNotification.cs
+++ b/src/Umbraco.Core/Notifications/CopiedNotification.cs
@@ -27,6 +27,7 @@ public abstract class CopiedNotification<T> : ObjectNotification<T>
 
     public T Copy { get; }
 
+    [Obsolete("Please use parent key instead, scheduled for removal in V15")]
     public int ParentId { get; }
 
     public Guid? ParentKey { get; }

--- a/src/Umbraco.Core/Notifications/CopiedNotification.cs
+++ b/src/Umbraco.Core/Notifications/CopiedNotification.cs
@@ -8,12 +8,19 @@ namespace Umbraco.Cms.Core.Notifications;
 public abstract class CopiedNotification<T> : ObjectNotification<T>
     where T : class
 {
-    protected CopiedNotification(T original, T copy, int parentId, bool relateToOriginal, EventMessages messages)
+    protected CopiedNotification(T original, T copy, int parentId, Guid? parentKey, bool relateToOriginal, EventMessages messages)
         : base(original, messages)
     {
         Copy = copy;
         ParentId = parentId;
+        ParentKey = parentKey;
         RelateToOriginal = relateToOriginal;
+    }
+
+    [Obsolete("Please use constructor that takes a parent key, scheduled for removal in V15")]
+    protected CopiedNotification(T original, T copy, int parentId, bool relateToOriginal, EventMessages messages)
+        : this(original, copy, parentId, null, relateToOriginal, messages)
+    {
     }
 
     public T Original => Target;
@@ -21,6 +28,8 @@ public abstract class CopiedNotification<T> : ObjectNotification<T>
     public T Copy { get; }
 
     public int ParentId { get; }
+
+    public Guid? ParentKey { get; }
 
     public bool RelateToOriginal { get; }
 }

--- a/src/Umbraco.Core/Notifications/CopyingNotification.cs
+++ b/src/Umbraco.Core/Notifications/CopyingNotification.cs
@@ -16,6 +16,7 @@ public abstract class CopyingNotification<T> : CancelableObjectNotification<T>
         ParentKey = parentKey;
     }
 
+    [Obsolete("Please use constructor that takes a parent key, scheduled for removal in V15")]
     protected CopyingNotification(T original, T copy, int parentId, EventMessages messages)
         : this(original, copy, parentId, null, messages)
     {

--- a/src/Umbraco.Core/Notifications/CopyingNotification.cs
+++ b/src/Umbraco.Core/Notifications/CopyingNotification.cs
@@ -26,6 +26,7 @@ public abstract class CopyingNotification<T> : CancelableObjectNotification<T>
 
     public T Copy { get; }
 
+    [Obsolete("Please use parent key instead, scheduled for removal in V15")]
     public int ParentId { get; }
 
     public Guid? ParentKey { get; }

--- a/src/Umbraco.Core/Notifications/CopyingNotification.cs
+++ b/src/Umbraco.Core/Notifications/CopyingNotification.cs
@@ -8,11 +8,17 @@ namespace Umbraco.Cms.Core.Notifications;
 public abstract class CopyingNotification<T> : CancelableObjectNotification<T>
     where T : class
 {
-    protected CopyingNotification(T original, T copy, int parentId, EventMessages messages)
+    protected CopyingNotification(T original, T copy, int parentId, Guid? parentKey, EventMessages messages)
         : base(original, messages)
     {
         Copy = copy;
         ParentId = parentId;
+        ParentKey = parentKey;
+    }
+
+    protected CopyingNotification(T original, T copy, int parentId, EventMessages messages)
+        : this(original, copy, parentId, null, messages)
+    {
     }
 
     public T Original => Target;
@@ -20,4 +26,6 @@ public abstract class CopyingNotification<T> : CancelableObjectNotification<T>
     public T Copy { get; }
 
     public int ParentId { get; }
+
+    public Guid? ParentKey { get; }
 }

--- a/src/Umbraco.Core/Notifications/MediaMovedToRecycleBinNotification.cs
+++ b/src/Umbraco.Core/Notifications/MediaMovedToRecycleBinNotification.cs
@@ -8,12 +8,12 @@ namespace Umbraco.Cms.Core.Notifications;
 
 public sealed class MediaMovedToRecycleBinNotification : MovedToRecycleBinNotification<IMedia>
 {
-    public MediaMovedToRecycleBinNotification(MoveEventInfo<IMedia> target, EventMessages messages)
+    public MediaMovedToRecycleBinNotification(MoveToRecycleBinEventInfo<IMedia> target, EventMessages messages)
         : base(target, messages)
     {
     }
 
-    public MediaMovedToRecycleBinNotification(IEnumerable<MoveEventInfo<IMedia>> target, EventMessages messages)
+    public MediaMovedToRecycleBinNotification(IEnumerable<MoveToRecycleBinEventInfo<IMedia>> target, EventMessages messages)
         : base(target, messages)
     {
     }

--- a/src/Umbraco.Core/Notifications/MediaMovingToRecycleBinNotification.cs
+++ b/src/Umbraco.Core/Notifications/MediaMovingToRecycleBinNotification.cs
@@ -8,12 +8,12 @@ namespace Umbraco.Cms.Core.Notifications;
 
 public sealed class MediaMovingToRecycleBinNotification : MovingToRecycleBinNotification<IMedia>
 {
-    public MediaMovingToRecycleBinNotification(MoveEventInfo<IMedia> target, EventMessages messages)
+    public MediaMovingToRecycleBinNotification(MoveToRecycleBinEventInfo<IMedia> target, EventMessages messages)
         : base(target, messages)
     {
     }
 
-    public MediaMovingToRecycleBinNotification(IEnumerable<MoveEventInfo<IMedia>> target, EventMessages messages)
+    public MediaMovingToRecycleBinNotification(IEnumerable<MoveToRecycleBinEventInfo<IMedia>> target, EventMessages messages)
         : base(target, messages)
     {
     }

--- a/src/Umbraco.Core/Notifications/MovedToRecycleBinNotification.cs
+++ b/src/Umbraco.Core/Notifications/MovedToRecycleBinNotification.cs
@@ -5,17 +5,17 @@ using Umbraco.Cms.Core.Events;
 
 namespace Umbraco.Cms.Core.Notifications;
 
-public abstract class MovedToRecycleBinNotification<T> : ObjectNotification<IEnumerable<MoveEventInfo<T>>>
+public abstract class MovedToRecycleBinNotification<T> : ObjectNotification<IEnumerable<MoveToRecycleBinEventInfo<T>>>
 {
-    protected MovedToRecycleBinNotification(MoveEventInfo<T> target, EventMessages messages)
+    protected MovedToRecycleBinNotification(MoveToRecycleBinEventInfo<T> target, EventMessages messages)
         : base(new[] { target }, messages)
     {
     }
 
-    protected MovedToRecycleBinNotification(IEnumerable<MoveEventInfo<T>> target, EventMessages messages)
+    protected MovedToRecycleBinNotification(IEnumerable<MoveToRecycleBinEventInfo<T>> target, EventMessages messages)
         : base(target, messages)
     {
     }
 
-    public IEnumerable<MoveEventInfo<T>> MoveInfoCollection => Target;
+    public IEnumerable<MoveToRecycleBinEventInfo<T>> MoveInfoCollection => Target;
 }

--- a/src/Umbraco.Core/Notifications/MovingToRecycleBinNotification.cs
+++ b/src/Umbraco.Core/Notifications/MovingToRecycleBinNotification.cs
@@ -5,17 +5,17 @@ using Umbraco.Cms.Core.Events;
 
 namespace Umbraco.Cms.Core.Notifications;
 
-public abstract class MovingToRecycleBinNotification<T> : CancelableObjectNotification<IEnumerable<MoveEventInfo<T>>>
+public abstract class MovingToRecycleBinNotification<T> : CancelableObjectNotification<IEnumerable<MoveToRecycleBinEventInfo<T>>>
 {
-    protected MovingToRecycleBinNotification(MoveEventInfo<T> target, EventMessages messages)
+    protected MovingToRecycleBinNotification(MoveToRecycleBinEventInfo<T> target, EventMessages messages)
         : base(new[] { target }, messages)
     {
     }
 
-    protected MovingToRecycleBinNotification(IEnumerable<MoveEventInfo<T>> target, EventMessages messages)
+    protected MovingToRecycleBinNotification(IEnumerable<MoveToRecycleBinEventInfo<T>> target, EventMessages messages)
         : base(target, messages)
     {
     }
 
-    public IEnumerable<MoveEventInfo<T>> MoveInfoCollection => Target;
+    public IEnumerable<MoveToRecycleBinEventInfo<T>> MoveInfoCollection => Target;
 }

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -2770,8 +2770,8 @@ public class ContentService : RepositoryService, IContentService
         IEntityService entityService = StaticServiceProvider.Instance.GetRequiredService<IEntityService>();
         Attempt<Guid> result = entityService.GetKey(parentId, UmbracoObjectTypes.Document);
         return result.Success
-            ? Copy(content, parentId, result.Result, relateToOriginal, true, userId)
-            : Copy(content, parentId, null, relateToOriginal, true, userId);
+            ? Copy(content, parentId, result.Result, relateToOriginal, recursive, userId)
+            : Copy(content, parentId, null, relateToOriginal, recursive, userId);
     }
 
     /// <summary>

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -2404,8 +2404,8 @@ public class ContentService : RepositoryService, IContentService
             scope.Notifications.Publish(
                 new ContentTreeChangeNotification(content, TreeChangeTypes.RefreshBranch, eventMessages));
 
-            MoveEventInfo<IContent>[] moveInfo = moves
-                .Select(x => new MoveEventInfo<IContent>(x.Item1, x.Item2, x.Item1.ParentId))
+            MoveToRecycleBinEventInfo<IContent>[] moveInfo = moves
+                .Select(x => new MoveToRecycleBinEventInfo<IContent>(x.Item1, x.Item2))
                 .ToArray();
 
             scope.Notifications.Publish(
@@ -3445,8 +3445,8 @@ public class ContentService : RepositoryService, IContentService
                 changes.Add(new TreeChange<IContent>(content, TreeChangeTypes.Remove));
             }
 
-            MoveEventInfo<IContent>[] moveInfos = moves
-                .Select(x => new MoveEventInfo<IContent>(x.Item1, x.Item2, x.Item1.ParentId))
+            MoveToRecycleBinEventInfo<IContent>[] moveInfos = moves
+                .Select(x => new MoveToRecycleBinEventInfo<IContent>(x.Item1, x.Item2))
                 .ToArray();
             if (moveInfos.Length > 0)
             {

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -2752,7 +2752,7 @@ public class ContentService : RepositoryService, IContentService
                 new ContentTreeChangeNotification(copy, TreeChangeTypes.RefreshBranch, eventMessages));
             foreach (Tuple<IContent, IContent> x in copies)
             {
-                scope.Notifications.Publish(new ContentCopiedNotification(x.Item1, x.Item2, parentId, relateToOriginal, eventMessages));
+                scope.Notifications.Publish(new ContentCopiedNotification(x.Item1, x.Item2, parentId, parentKey, relateToOriginal, eventMessages));
             }
 
             Audit(AuditType.Copy, userId, content.Id);

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -2458,6 +2458,7 @@ public class ContentService : RepositoryService, IContentService
                 throw new InvalidOperationException("Parent does not exist or is trashed."); // causes rollback
             }
 
+            // FIXME: Use MoveEventInfo that also takes a parent key when implementing move with parentKey.
             var moveEventInfo = new MoveEventInfo<IContent>(content, content.Path, parentId);
 
             var movingNotification = new ContentMovingNotification(moveEventInfo, eventMessages);
@@ -2488,13 +2489,10 @@ public class ContentService : RepositoryService, IContentService
                 new ContentTreeChangeNotification(content, TreeChangeTypes.RefreshBranch, eventMessages));
 
             // changes
-            List<MoveEventInfo<IContent>> moveInfo = new ();
-
-            foreach ((IContent, string) move in moves)
-            {
-                IEntitySlim? parentEntity = _entityRepository.Get(move.Item1.ParentId);
-                moveInfo.Add(new MoveEventInfo<IContent>(move.Item1, move.Item2, move.Item1.ParentId, parentEntity?.Key));
-            }
+            // FIXME: Use MoveEventInfo that also takes a parent key when implementing move with parentKey.
+            MoveEventInfo<IContent>[] moveInfo = moves
+                .Select(x => new MoveEventInfo<IContent>(x.Item1, x.Item2, x.Item1.ParentId))
+                .ToArray();
 
             scope.Notifications.Publish(
                 new ContentMovedNotification(moveInfo, eventMessages).WithStateFrom(movingNotification));

--- a/src/Umbraco.Core/Services/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
+++ b/src/Umbraco.Core/Services/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
@@ -850,12 +850,10 @@ public abstract class ContentTypeServiceBase<TRepository, TItem> : ContentTypeSe
             return OperationResult.Attempt.Fail(MoveOperationStatusType.FailedNotAllowedByPath, eventMessages);
         }
 
-
         var moveInfo = new List<MoveEventInfo<TItem>>();
         using (ICoreScope scope = ScopeProvider.CreateCoreScope())
         {
-            Guid? containerKey = _containerRepository.Get(containerId)?.Key;
-            var moveEventInfo = new MoveEventInfo<TItem>(moving, moving.Path, containerId, containerKey);
+            var moveEventInfo = new MoveEventInfo<TItem>(moving, moving.Path, containerId);
             MovingNotification<TItem> movingNotification = GetMovingNotification(moveEventInfo, eventMessages);
             if (scope.Notifications.PublishCancelable(movingNotification))
             {

--- a/src/Umbraco.Core/Services/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
+++ b/src/Umbraco.Core/Services/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
@@ -850,10 +850,12 @@ public abstract class ContentTypeServiceBase<TRepository, TItem> : ContentTypeSe
             return OperationResult.Attempt.Fail(MoveOperationStatusType.FailedNotAllowedByPath, eventMessages);
         }
 
+
         var moveInfo = new List<MoveEventInfo<TItem>>();
         using (ICoreScope scope = ScopeProvider.CreateCoreScope())
         {
-            var moveEventInfo = new MoveEventInfo<TItem>(moving, moving.Path, containerId);
+            Guid? containerKey = _containerRepository.Get(containerId)?.Key;
+            var moveEventInfo = new MoveEventInfo<TItem>(moving, moving.Path, containerId, containerKey);
             MovingNotification<TItem> movingNotification = GetMovingNotification(moveEventInfo, eventMessages);
             if (scope.Notifications.PublishCancelable(movingNotification))
             {

--- a/src/Umbraco.Core/Services/DataTypeService.cs
+++ b/src/Umbraco.Core/Services/DataTypeService.cs
@@ -405,7 +405,7 @@ namespace Umbraco.Cms.Core.Services.Implement
                     return Attempt.SucceedWithStatus(DataTypeOperationStatus.Success, toMove);
                 }
 
-                var moveEventInfo = new MoveEventInfo<IDataType>(toMove, toMove.Path, parentId);
+                var moveEventInfo = new MoveEventInfo<IDataType>(toMove, toMove.Path, parentId, containerKey);
                 var movingDataTypeNotification = new DataTypeMovingNotification(moveEventInfo, eventMessages);
                 if (scope.Notifications.PublishCancelable(movingDataTypeNotification))
                 {

--- a/src/Umbraco.Core/Services/DictionaryItemService.cs
+++ b/src/Umbraco.Core/Services/DictionaryItemService.cs
@@ -212,7 +212,7 @@ internal sealed class DictionaryItemService : RepositoryService, IDictionaryItem
             dictionaryItem.ParentId = parentId;
 
             EventMessages eventMessages = EventMessagesFactory.Get();
-            var moveEventInfo = new MoveEventInfo<IDictionaryItem>(dictionaryItem, string.Empty, parent?.Id ?? Constants.System.Root);
+            var moveEventInfo = new MoveEventInfo<IDictionaryItem>(dictionaryItem, string.Empty, parent?.Id ?? Constants.System.Root, parentId);
             var movingNotification = new DictionaryItemMovingNotification(moveEventInfo, eventMessages);
             if (await scope.Notifications.PublishCancelableAsync(movingNotification))
             {

--- a/src/Umbraco.Core/Services/MediaService.cs
+++ b/src/Umbraco.Core/Services/MediaService.cs
@@ -947,7 +947,7 @@ namespace Umbraco.Cms.Core.Services
 
                 var originalPath = media.Path;
 
-                var moveEventInfo = new MoveEventInfo<IMedia>(media, originalPath, Constants.System.RecycleBinMedia);
+                var moveEventInfo = new MoveToRecycleBinEventInfo<IMedia>(media, originalPath);
 
                 var movingToRecycleBinNotification = new MediaMovingToRecycleBinNotification(moveEventInfo, messages);
                 if (scope.Notifications.PublishCancelable(movingToRecycleBinNotification))

--- a/src/Umbraco.Core/Services/MediaService.cs
+++ b/src/Umbraco.Core/Services/MediaService.cs
@@ -998,6 +998,7 @@ namespace Umbraco.Cms.Core.Services
                     throw new InvalidOperationException("Parent does not exist or is trashed."); // causes rollback
                 }
 
+                // FIXME: Use MoveEventInfo that also takes a parent key when implementing move with parentKey.
                 var moveEventInfo = new MoveEventInfo<IMedia>(media, media.Path, parentId);
                 var movingNotification = new MediaMovingNotification(moveEventInfo, messages);
                 if (scope.Notifications.PublishCancelable(movingNotification))
@@ -1015,6 +1016,7 @@ namespace Umbraco.Cms.Core.Services
                 scope.Notifications.Publish(new MediaTreeChangeNotification(media, TreeChangeTypes.RefreshBranch, messages));
 
                 MoveEventInfo<IMedia>[] moveInfo = moves //changes
+                    // FIXME: Use MoveEventInfo that also takes a parent key when implementing move with parentKey.
                     .Select(x => new MoveEventInfo<IMedia>(x.Item1, x.Item2, x.Item1.ParentId))
                     .ToArray();
                 scope.Notifications.Publish(new MediaMovedNotification(moveInfo, messages).WithStateFrom(movingNotification));

--- a/src/Umbraco.Core/Services/MediaService.cs
+++ b/src/Umbraco.Core/Services/MediaService.cs
@@ -959,7 +959,7 @@ namespace Umbraco.Cms.Core.Services
                 PerformMoveLocked(media, Constants.System.RecycleBinMedia, null, userId, moves, true);
 
                 scope.Notifications.Publish(new MediaTreeChangeNotification(media, TreeChangeTypes.RefreshBranch, messages));
-                MoveEventInfo<IMedia>[] moveInfo = moves.Select(x => new MoveEventInfo<IMedia>(x.Item1, x.Item2, x.Item1.ParentId)).ToArray();
+                MoveToRecycleBinEventInfo<IMedia>[] moveInfo = moves.Select(x => new MoveToRecycleBinEventInfo<IMedia>(x.Item1, x.Item2)).ToArray();
                 scope.Notifications.Publish(new MediaMovedToRecycleBinNotification(moveInfo, messages).WithStateFrom(movingToRecycleBinNotification));
                 Audit(AuditType.Move, userId, media.Id, "Move Media to recycle bin");
 
@@ -1322,7 +1322,7 @@ namespace Umbraco.Cms.Core.Services
                     changes.Add(new TreeChange<IMedia>(media, TreeChangeTypes.Remove));
                 }
 
-                MoveEventInfo<IMedia>[] moveInfos = moves.Select(x => new MoveEventInfo<IMedia>(x.Item1, x.Item2, x.Item1.ParentId))
+                MoveToRecycleBinEventInfo<IMedia>[] moveInfos = moves.Select(x => new MoveToRecycleBinEventInfo<IMedia>(x.Item1, x.Item2))
                     .ToArray();
                 if (moveInfos.Length > 0)
                 {

--- a/src/Umbraco.Infrastructure/Events/RelateOnTrashNotificationHandler.cs
+++ b/src/Umbraco.Infrastructure/Events/RelateOnTrashNotificationHandler.cs
@@ -71,7 +71,7 @@ public sealed class RelateOnTrashNotificationHandler :
                 _relationService.Save(relationType);
             }
 
-            foreach (MoveEventInfo<IContent> item in notification.MoveInfoCollection)
+            foreach (MoveToRecycleBinEventInfo<IContent> item in notification.MoveInfoCollection)
             {
                 IList<string> originalPath = item.OriginalPath.ToDelimitedList();
                 var originalParentId = originalPath.Count > 2
@@ -132,7 +132,7 @@ public sealed class RelateOnTrashNotificationHandler :
                 _relationService.Save(relationType);
             }
 
-            foreach (MoveEventInfo<IMedia> item in notification.MoveInfoCollection)
+            foreach (MoveToRecycleBinEventInfo<IMedia> item in notification.MoveInfoCollection)
             {
                 IList<string> originalPath = item.OriginalPath.ToDelimitedList();
                 var originalParentId = originalPath.Count > 2

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
@@ -120,6 +120,7 @@ internal abstract class ContentTypeRepositoryBase<TEntity> : EntityRepositoryBas
 
         foreach (TEntity descendant in descendants.OrderBy(x => x.Level))
         {
+            //FIXME: Use MoveEventInfo constructor that takes a parentKey when this method is refactored
             moveInfo.Add(new MoveEventInfo<TEntity>(descendant, descendant.Path, descendant.ParentId));
 
             descendant.Path = paths[descendant.Id] = paths[descendant.ParentId] + "," + descendant.Id;

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
@@ -80,6 +80,7 @@ internal abstract class ContentTypeRepositoryBase<TEntity> : EntityRepositoryBas
     public IEnumerable<MoveEventInfo<TEntity>> Move(TEntity moving, EntityContainer? container)
     {
         var parentId = Constants.System.Root;
+        Guid? parentKey = Constants.System.RootKey;
         if (container != null)
         {
             // check path
@@ -92,10 +93,11 @@ internal abstract class ContentTypeRepositoryBase<TEntity> : EntityRepositoryBas
             }
 
             parentId = container.Id;
+            parentKey = container.Key;
         }
 
         // track moved entities
-        var moveInfo = new List<MoveEventInfo<TEntity>> { new(moving, moving.Path, parentId) };
+        var moveInfo = new List<MoveEventInfo<TEntity>> { new(moving, moving.Path, parentId, parentKey) };
 
         // get the level delta (old pos to new pos)
         var levelDelta = container == null

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DataTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DataTypeRepository.cs
@@ -48,7 +48,8 @@ internal class DataTypeRepository : EntityRepositoryBase<int, IDataType>, IDataT
 
     public IEnumerable<MoveEventInfo<IDataType>> Move(IDataType toMove, EntityContainer? container)
     {
-        var parentId = -1;
+        var parentId = Constants.System.Root;
+        Guid? parentKey = Constants.System.RootKey;
         if (container != null)
         {
             // Check on paths
@@ -60,10 +61,11 @@ internal class DataTypeRepository : EntityRepositoryBase<int, IDataType>, IDataT
             }
 
             parentId = container.Id;
+            parentKey = container.Key;
         }
 
         // used to track all the moved entities to be given to the event
-        var moveInfo = new List<MoveEventInfo<IDataType>> { new(toMove, toMove.Path, parentId) };
+        var moveInfo = new List<MoveEventInfo<IDataType>> { new(toMove, toMove.Path, parentId, parentKey) };
 
         var origPath = toMove.Path;
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Events/MoveEventInfoTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Events/MoveEventInfoTests.cs
@@ -1,0 +1,29 @@
+﻿using NUnit.Framework;
+using Umbraco.Cms.Core.Events;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Events;
+
+public class MoveEventInfoTests
+{
+    [Test]
+    public void Can_Equate_Move_To_Recyclebin_Move_Event_Infos()
+    {
+        string testString = "Test";
+        var recycleBinMoveEvent = new MoveToRecycleBinEventInfo<string>(testString, string.Empty);
+        var recycleBinMoveEventTwo = new MoveToRecycleBinEventInfo<string>(testString, string.Empty);
+
+        Assert.IsTrue(recycleBinMoveEvent.Equals(recycleBinMoveEventTwo));
+    }
+
+    [Test]
+    [TestCase(0, "00000000-0000-0000-0000-000000000000")]
+    [TestCase(8, "979344F9-E0A4-495E-8A68-88F05F64EBAB")]
+    public void Can_Equate_Move_Event_Infos(int parentId, Guid parentKey)
+    {
+        string testString = "Test";
+        var recycleBinMoveEvent = new MoveEventInfo<string>(testString, string.Empty, parentId, parentKey);
+        var recycleBinMoveEventTwo = new MoveEventInfo<string>(testString, string.Empty, parentId, parentKey);
+
+        Assert.IsTrue(recycleBinMoveEvent.Equals(recycleBinMoveEventTwo));
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Events/MoveEventInfoTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Events/MoveEventInfoTests.cs
@@ -5,25 +5,51 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Events;
 
 public class MoveEventInfoTests
 {
-    [Test]
-    public void Can_Equate_Move_To_Recyclebin_Move_Event_Infos()
+    [TestCase("", "path", false)]
+    [TestCase("entity", "", false)]
+    [TestCase("entity", "path", true)]
+    public void Can_Equate_Move_To_Recyclebin_Move_Event_Infos(string entity, string originalPath, bool expectedResult)
     {
-        string testString = "Test";
-        var recycleBinMoveEvent = new MoveToRecycleBinEventInfo<string>(testString, string.Empty);
-        var recycleBinMoveEventTwo = new MoveToRecycleBinEventInfo<string>(testString, string.Empty);
+        var recycleBinMoveEvent = new MoveToRecycleBinEventInfo<string>(entity, originalPath);
+        var recycleBinMoveEventTwo = new MoveToRecycleBinEventInfo<string>("entity", "path");
+
+        Assert.AreEqual(expectedResult, recycleBinMoveEvent.Equals(recycleBinMoveEventTwo));
+    }
+
+    [Test]
+    public void Can_Equate_Move_To_Recyclebin_Move_Event_Infos_All_Params_Null_Or_Empty()
+    {
+        var recycleBinMoveEvent = new MoveToRecycleBinEventInfo<string>(string.Empty, string.Empty);
+        var recycleBinMoveEventTwo = new MoveToRecycleBinEventInfo<string>(string.Empty, string.Empty);
 
         Assert.IsTrue(recycleBinMoveEvent.Equals(recycleBinMoveEventTwo));
     }
 
     [Test]
-    [TestCase(0, "00000000-0000-0000-0000-000000000000")]
-    [TestCase(8, "979344F9-E0A4-495E-8A68-88F05F64EBAB")]
-    public void Can_Equate_Move_Event_Infos(int parentId, Guid parentKey)
+    public void Can_Equate_Move_Event_Infos_Parent_Key_Null()
     {
-        string testString = "Test";
-        var recycleBinMoveEvent = new MoveEventInfo<string>(testString, string.Empty, parentId, parentKey);
-        var recycleBinMoveEventTwo = new MoveEventInfo<string>(testString, string.Empty, parentId, parentKey);
+        var moveEvent = new MoveEventInfo<string>("entity", "path", 123, null);
+        var moveEventTwo = new MoveEventInfo<string>("entity", "path", 123, null);
+        Assert.IsTrue(moveEvent.Equals(moveEventTwo));
+    }
 
-        Assert.IsTrue(recycleBinMoveEvent.Equals(recycleBinMoveEventTwo));
+    [Test]
+    public void Can_Equate_Move_Event_Infos_All_Params_Null_Or_Empty()
+    {
+        var moveEvent = new MoveEventInfo<string>(string.Empty, string.Empty, 0, null);
+        var moveEventTwo = new MoveEventInfo<string>(string.Empty, string.Empty, 0, null);
+        Assert.IsTrue(moveEvent.Equals(moveEventTwo));
+    }
+
+    [TestCase(123, "entity", "", "063897F1-194A-4C42-B406-CA80DBC12968", false)]
+    [TestCase(123, "", "path", "063897F1-194A-4C42-B406-CA80DBC12968", false)]
+    [TestCase(12, "entity", "path", "063897F1-194A-4C42-B406-CA80DBC12968", false)]
+    [TestCase(123, "entity", "path", "C6D6EA3E-C2B0-483F-B772-2F4D8BBF5027", false)]
+    [TestCase(123, "entity", "path", "063897F1-194A-4C42-B406-CA80DBC12968", true)]
+    public void Can_Equate_Move_Event_Infos(int parentId, string entity, string originalPath, Guid parentKey, bool expectedResult)
+    {
+        var moveEvent = new MoveEventInfo<string>(entity, originalPath, parentId, parentKey);
+        var moveEventTwo = new MoveEventInfo<string>("entity", "path", 123, new Guid("063897F1-194A-4C42-B406-CA80DBC12968"));
+        Assert.AreEqual(expectedResult, moveEvent.Equals(moveEventTwo));
     }
 }


### PR DESCRIPTION
# Notes
- Added MoveEventInfoBase
- Added MovedToRecycleBinInfo instead, as we don't need to know the parent id/key of the recycle bin, we already know by the notification that it is moving there.
- Added parent key to move info so its passed out in notifications.
- Added FIXME's where it doesn't make sense to use the new ctor of MoveEventInfo, as those methods will be refactored anyways.

# How to test
- Test the different Notifications and ensure they have parentkeys (Copy notifications and MoveToRecycleBin)
- Lets do an example of ContentTypeMovedNotification:
- Create a document type and an empty folder in the doctype tree
- Stop Umbraco and implement the respective NotificationHandler
```
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Notifications;

namespace Umbraco.Cms.Web.UI;

public class MyNotificationHandler : INotificationHandler<ContentTypeMovedNotification>
{
    public void Handle(ContentTypeMovedNotification notification)
    {
        foreach (var movedEntity in notification.MoveInfoCollection)
        {
            if (movedEntity.NewParentKey is not null)
            {
                Console.WriteLine("I HAVE A PARENT KEY: " + movedEntity.NewParentKey);
            }
        }
    }
}

public class MyComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder) => builder.AddNotificationHandler<ContentTypeMovedNotification, MyNotificationHandler>();
}

```
- Set a debug pointing the foreach loop
- Try to move the doctype in the empty folder and assert the movedEntity has a parent key that is not null