### PR TITLE
Removed path so we can generate templates

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -110,7 +110,7 @@ stages:
                   }
                 }
 
-                foreach($csproj in Get-ChildItem –Path "src/" -Recurse -Filter *.csproj)
+                foreach($csproj in Get-ChildItem -Recurse -Filter *.csproj)
                 {
                   dotnet pack $csproj --configuration $(buildConfiguration) --no-build --output $(Build.ArtifactStagingDirectory)/nupkg
                 }


### PR DESCRIPTION
Removed path so we can find the correct template 