### PR TITLE
Set TwoFactorEnabled property on MemberIdentityUser

### DIFF
--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberManagerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberManagerTests.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
@@ -46,7 +42,8 @@ public class MemberManagerTests
                 Mock.Of<ILocalizedTextService>(),
                 Mock.Of<IEntityService>(),
                 new TestOptionsSnapshot<GlobalSettings>(new GlobalSettings()),
-                AppCaches.Disabled),
+                AppCaches.Disabled,
+                Mock.Of<ITwoFactorLoginService>())
         };
 
         _fakeMemberStore = new MemberUserStore(


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/13837

## Details
- When a member was returned from `IMemberManager.GetCurrentMemberAsync()`, its `TwoFactorEnabled` property wasn't set.

## Test
- Set up 2FA for members (_PR https://github.com/umbraco/Umbraco-CMS/pull/13369 describes in details in the Test section how to_);
- Make sure a member has 2FA enabled;
- Use the following code to verify that `TwoFactorEnabled` property is set correctly (_try enabling and disabling 2FA from the backoffice_):
```c#
        var member = await _memberManager.GetCurrentMemberAsync();
        bool twoFactorEnabled = member.TwoFactorEnabled;
```