### PR TITLE
Ensure cropperHelper.pixelsToCoordinates returns valid coordinates - Fix #13783

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/cropperhelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/cropperhelper.service.js
@@ -98,9 +98,8 @@ function cropperHelper(umbRequestHelper, $http) {
 		},
 
 		pixelsToCoordinates : function(image, width, height, offset){
-
-			var x1_px = Math.abs(image.left-offset);
-			var y1_px = Math.abs(image.top-offset);
+			var x1_px = Math.abs((image.left || 0)-offset);
+			var y1_px = Math.abs((image.top || 0)-offset);
 
 			var x2_px = image.width - (x1_px + width);
 			var y2_px = image.height - (y1_px + height);


### PR DESCRIPTION
### Prerequisites

This fixes #13783

### Description

Repeatedly creating a crop and resetting it for an image corrupts the image, as described in the issue.

This is due to function `umbraco.services.cropperHelper.pixelsToCoordinates(image, width, height, offset)` assuming that `image.top` and `image.left` exist. They don't if there is no existing crop for the image (such as when resetting the crop). In this case `pixelsToCoordinates` returns coordinates that are `NaN` rather than valid coordinates.

The fix ensures that `pixelsToCoordinates` returns valid coordinates even if `image.top` and `image.left` don't exist by using 0 as a default value for both `image.top` and `image.left`. This should be in line with `pixelsToCoordinates` already using 0 as default coordinate if the calculated coordinates are negative.
