### PR TITLE
Use keys for tracked references

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/ByIdTrackedReferenceController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/ByIdTrackedReferenceController.cs
@@ -27,16 +27,16 @@ public class ByIdTrackedReferenceController : TrackedReferenceControllerBase
     ///     Used by info tabs on content, media etc. and for the delete and unpublish of single items.
     ///     This is basically finding parents of relations.
     /// </remarks>
-    [HttpGet("{id:int}")]
+    [HttpGet("{key:guid}")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<RelationItemViewModel>), StatusCodes.Status200OK)]
     public async Task<ActionResult<PagedViewModel<RelationItemViewModel>>> Get(
-        int id,
-        long skip,
-        long take,
-        bool? filterMustBeIsDependency)
+        Guid key,
+        long skip = 0,
+        long take = 20,
+        bool filterMustBeIsDependency = false)
     {
-        PagedModel<RelationItemModel> relationItems = _trackedReferencesService.GetPagedRelationsForItem(id, skip, take, filterMustBeIsDependency ?? false);
+        PagedModel<RelationItemModel> relationItems = await _trackedReferencesService.GetPagedRelationsForItemAsync(key, skip, take, filterMustBeIsDependency);
 
         var pagedViewModel = new PagedViewModel<RelationItemViewModel>
         {

--- a/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/DescendantsTrackedReferenceController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/DescendantsTrackedReferenceController.cs
@@ -28,12 +28,12 @@ public class DescendantsTrackedReferenceController : TrackedReferenceControllerB
     ///     kind of relation.
     ///     This is basically finding the descending items which are children in relations.
     /// </remarks>
-    [HttpGet("descendants/{parentId:int}")]
+    [HttpGet("descendants/{parentKey:guid}")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<RelationItemViewModel>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<PagedViewModel<RelationItemViewModel>>> Descendants(int parentId, long skip, long take, bool? filterMustBeIsDependency)
+    public async Task<ActionResult<PagedViewModel<RelationItemViewModel>>> Descendants(Guid parentKey, long skip, long take, bool? filterMustBeIsDependency)
     {
-        PagedModel<RelationItemModel> relationItems = _trackedReferencesSkipTakeService.GetPagedDescendantsInReferences(parentId, skip, take, filterMustBeIsDependency ?? true);
+        PagedModel<RelationItemModel> relationItems = await _trackedReferencesSkipTakeService.GetPagedDescendantsInReferencesAsync(parentKey, skip, take, filterMustBeIsDependency ?? true);
         var pagedViewModel = new PagedViewModel<RelationItemViewModel>
         {
             Total = relationItems.Total,

--- a/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/DescendantsTrackedReferenceController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/DescendantsTrackedReferenceController.cs
@@ -31,9 +31,9 @@ public class DescendantsTrackedReferenceController : TrackedReferenceControllerB
     [HttpGet("descendants/{parentKey:guid}")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<RelationItemViewModel>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<PagedViewModel<RelationItemViewModel>>> Descendants(Guid parentKey, long skip, long take, bool? filterMustBeIsDependency)
+    public async Task<ActionResult<PagedViewModel<RelationItemViewModel>>> Descendants(Guid parentKey, long skip, long take, bool filterMustBeIsDependency = true)
     {
-        PagedModel<RelationItemModel> relationItems = await _trackedReferencesSkipTakeService.GetPagedDescendantsInReferencesAsync(parentKey, skip, take, filterMustBeIsDependency ?? true);
+        PagedModel<RelationItemModel> relationItems = await _trackedReferencesSkipTakeService.GetPagedDescendantsInReferencesAsync(parentKey, skip, take, filterMustBeIsDependency);
         var pagedViewModel = new PagedViewModel<RelationItemViewModel>
         {
             Total = relationItems.Total,

--- a/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/ItemsTrackedReferenceController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/ItemsTrackedReferenceController.cs
@@ -21,7 +21,7 @@ public class ItemsTrackedReferenceController : TrackedReferenceControllerBase
     }
 
     /// <summary>
-    ///     Gets a page list of the items used in any kind of relation from selected integer ids.
+    ///     Gets a page list of the items used in any kind of relation from selected keys.
     /// </summary>
     /// <remarks>
     ///     Used when bulk deleting content/media and bulk unpublishing content (delete and unpublish on List view).
@@ -30,9 +30,9 @@ public class ItemsTrackedReferenceController : TrackedReferenceControllerBase
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<RelationItemViewModel>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<PagedViewModel<RelationItemViewModel>>> GetPagedReferencedItems([FromQuery]int[] ids, long skip, long take, bool? filterMustBeIsDependency)
+    public async Task<ActionResult<PagedViewModel<RelationItemViewModel>>> GetPagedReferencedItems([FromQuery(Name="key")]SortedSet<Guid> keys, long skip = 0, long take = 20, bool filterMustBeIsDependency = true)
     {
-        PagedModel<RelationItemModel> relationItems = _trackedReferencesSkipTakeService.GetPagedItemsWithRelations(ids, skip, take, filterMustBeIsDependency ?? true);
+        PagedModel<RelationItemModel> relationItems = await _trackedReferencesSkipTakeService.GetPagedItemsWithRelationsAsync(keys, skip, take, filterMustBeIsDependency);
         var pagedViewModel = new PagedViewModel<RelationItemViewModel>
         {
             Total = relationItems.Total,

--- a/src/Umbraco.Cms.Api.Management/Mapping/TrackedReferences/TrackedReferenceViewModelsMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/TrackedReferences/TrackedReferenceViewModelsMapDefinition.cs
@@ -23,6 +23,7 @@ public class TrackedReferenceViewModelsMapDefinition : IMapDefinition
         target.RelationTypeIsBidirectional = source.RelationTypeIsBidirectional;
         target.RelationTypeIsDependency = source.RelationTypeIsDependency;
         target.RelationTypeName = source.RelationTypeName;
+        target.NodePublished = source.NodePublished;
     }
 
 }

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -702,6 +702,9 @@
               }
             }
           },
+          "404": {
+            "description": "Not Found"
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -711,9 +714,6 @@
                 }
               }
             }
-          },
-          "404": {
-            "description": "Not Found"
           },
           "409": {
             "description": "Conflict",
@@ -998,9 +998,7 @@
         ],
         "operationId": "PostDictionaryUpload",
         "requestBody": {
-          "content": {
-
-          }
+          "content": { }
         },
         "responses": {
           "200": {
@@ -1420,6 +1418,9 @@
           }
         ],
         "responses": {
+          "401": {
+            "description": "Unauthorized"
+          },
           "200": {
             "description": "Success",
             "content": {
@@ -1429,9 +1430,6 @@
                 }
               }
             }
-          },
-          "401": {
-            "description": "Unauthorized"
           }
         }
       }
@@ -1463,6 +1461,9 @@
           }
         ],
         "responses": {
+          "401": {
+            "description": "Unauthorized"
+          },
           "200": {
             "description": "Success",
             "content": {
@@ -1472,9 +1473,6 @@
                 }
               }
             }
-          },
-          "401": {
-            "description": "Unauthorized"
           }
         }
       }
@@ -1709,6 +1707,9 @@
           }
         ],
         "responses": {
+          "404": {
+            "description": "Not Found"
+          },
           "200": {
             "description": "Success",
             "content": {
@@ -1722,9 +1723,6 @@
                 }
               }
             }
-          },
-          "404": {
-            "description": "Not Found"
           }
         }
       }
@@ -1746,6 +1744,9 @@
           }
         ],
         "responses": {
+          "404": {
+            "description": "Not Found"
+          },
           "200": {
             "description": "Success",
             "content": {
@@ -1759,9 +1760,6 @@
                 }
               }
             }
-          },
-          "404": {
-            "description": "Not Found"
           }
         }
       }
@@ -1786,6 +1784,16 @@
           }
         },
         "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
+                }
+              }
+            }
+          },
           "200": {
             "description": "Success",
             "content": {
@@ -1796,16 +1804,6 @@
                       "$ref": "#/components/schemas/HealthCheckResultModel"
                     }
                   ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -1860,22 +1858,22 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PagedHelpPageModel"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetailsModel"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedHelpPageModel"
                 }
               }
             }
@@ -1938,6 +1936,16 @@
           }
         ],
         "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
+                }
+              }
+            }
+          },
           "200": {
             "description": "Success",
             "content": {
@@ -1948,16 +1956,6 @@
                       "$ref": "#/components/schemas/IndexModel"
                     }
                   ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -1982,22 +1980,22 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OkResultModel"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetailsModel"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OkResultModel"
                 }
               }
             }
@@ -2012,20 +2010,6 @@
         ],
         "operationId": "GetInstallSettings",
         "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/InstallSettingsModel"
-                    }
-                  ]
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2042,6 +2026,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetailsModel"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/InstallSettingsModel"
+                    }
+                  ]
                 }
               }
             }
@@ -2069,9 +2067,6 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "Success"
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2091,6 +2086,9 @@
                 }
               }
             }
+          },
+          "200": {
+            "description": "Success"
           }
         }
       }
@@ -2115,9 +2113,6 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "Success"
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2127,6 +2122,9 @@
                 }
               }
             }
+          },
+          "200": {
+            "description": "Success"
           }
         }
       }
@@ -2189,6 +2187,19 @@
           }
         },
         "responses": {
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
+                }
+              }
+            }
+          },
           "201": {
             "description": "Created",
             "headers": {
@@ -2201,19 +2212,6 @@
                 }
               }
             }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetailsModel"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found"
           }
         }
       }
@@ -2235,6 +2233,9 @@
           }
         ],
         "responses": {
+          "404": {
+            "description": "Not Found"
+          },
           "200": {
             "description": "Success",
             "content": {
@@ -2248,9 +2249,6 @@
                 }
               }
             }
-          },
-          "404": {
-            "description": "Not Found"
           }
         }
       },
@@ -2270,9 +2268,6 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Success"
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2292,6 +2287,9 @@
                 }
               }
             }
+          },
+          "200": {
+            "description": "Success"
           }
         }
       },
@@ -2324,8 +2322,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "Success"
+          "404": {
+            "description": "Not Found"
           },
           "400": {
             "description": "Bad Request",
@@ -2337,8 +2335,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found"
+          "200": {
+            "description": "Success"
           }
         }
       }
@@ -2408,9 +2406,6 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Success"
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2420,6 +2415,9 @@
                 }
               }
             }
+          },
+          "200": {
+            "description": "Success"
           }
         }
       }
@@ -2547,22 +2545,22 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PagedLogTemplateModel"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetailsModel"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedLogTemplateModel"
                 }
               }
             }
@@ -2628,6 +2626,16 @@
           }
         },
         "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
+                }
+              }
+            }
+          },
           "201": {
             "description": "Created",
             "headers": {
@@ -2637,16 +2645,6 @@
                   "type": "string",
                   "description": "Location of the newly created resource",
                   "format": "uri"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -2671,6 +2669,9 @@
           }
         ],
         "responses": {
+          "404": {
+            "description": "Not Found"
+          },
           "200": {
             "description": "Success",
             "content": {
@@ -2684,9 +2685,6 @@
                 }
               }
             }
-          },
-          "404": {
-            "description": "Not Found"
           }
         }
       },
@@ -2706,11 +2704,11 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Success"
-          },
           "404": {
             "description": "Not Found"
+          },
+          "200": {
+            "description": "Success"
           }
         }
       }
@@ -2740,9 +2738,6 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Success"
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -2752,6 +2747,9 @@
                 }
               }
             }
+          },
+          "200": {
+            "description": "Success"
           }
         }
       }
@@ -2938,6 +2936,9 @@
           }
         ],
         "responses": {
+          "401": {
+            "description": "Unauthorized"
+          },
           "200": {
             "description": "Success",
             "content": {
@@ -2947,9 +2948,6 @@
                 }
               }
             }
-          },
-          "401": {
-            "description": "Unauthorized"
           }
         }
       }
@@ -2981,6 +2979,9 @@
           }
         ],
         "responses": {
+          "401": {
+            "description": "Unauthorized"
+          },
           "200": {
             "description": "Success",
             "content": {
@@ -2990,9 +2991,6 @@
                 }
               }
             }
-          },
-          "401": {
-            "description": "Unauthorized"
           }
         }
       }
@@ -3654,22 +3652,22 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PagedRedirectUrlModel"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetailsModel"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedRedirectUrlModel"
                 }
               }
             }
@@ -4224,6 +4222,16 @@
         ],
         "operationId": "GetServerStatus",
         "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
+                }
+              }
+            }
+          },
           "200": {
             "description": "Success",
             "content": {
@@ -4234,16 +4242,6 @@
                       "$ref": "#/components/schemas/ServerStatusModel"
                     }
                   ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -4258,6 +4256,16 @@
         ],
         "operationId": "GetServerVersion",
         "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
+                }
+              }
+            }
+          },
           "200": {
             "description": "Success",
             "content": {
@@ -4268,16 +4276,6 @@
                       "$ref": "#/components/schemas/VersionModel"
                     }
                   ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -4617,9 +4615,6 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "Success"
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -4629,6 +4624,9 @@
                 }
               }
             }
+          },
+          "200": {
+            "description": "Success"
           }
         }
       }
@@ -5034,20 +5032,20 @@
         }
       }
     },
-    "/umbraco/management/api/v1/tracked-reference/{id}": {
+    "/umbraco/management/api/v1/tracked-reference/{key}": {
       "get": {
         "tags": [
           "Tracked Reference"
         ],
-        "operationId": "GetTrackedReferenceById",
+        "operationId": "GetTrackedReferenceByKey",
         "parameters": [
           {
-            "name": "id",
+            "name": "key",
             "in": "path",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -5055,7 +5053,8 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int64"
+              "format": "int64",
+              "default": 0
             }
           },
           {
@@ -5063,14 +5062,16 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int64"
+              "format": "int64",
+              "default": 20
             }
           },
           {
             "name": "filterMustBeIsDependency",
             "in": "query",
             "schema": {
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             }
           }
         ],
@@ -5088,20 +5089,20 @@
         }
       }
     },
-    "/umbraco/management/api/v1/tracked-reference/descendants/{parentId}": {
+    "/umbraco/management/api/v1/tracked-reference/descendants/{parentKey}": {
       "get": {
         "tags": [
           "Tracked Reference"
         ],
-        "operationId": "GetTrackedReferenceDescendantsByParentId",
+        "operationId": "GetTrackedReferenceDescendantsByParentKey",
         "parameters": [
           {
-            "name": "parentId",
+            "name": "parentKey",
             "in": "path",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -5150,13 +5151,14 @@
         "operationId": "GetTrackedReferenceItem",
         "parameters": [
           {
-            "name": "ids",
+            "name": "key",
             "in": "query",
             "schema": {
+              "uniqueItems": true,
               "type": "array",
               "items": {
-                "type": "integer",
-                "format": "int32"
+                "type": "string",
+                "format": "uuid"
               }
             }
           },
@@ -5165,7 +5167,8 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int64"
+              "format": "int64",
+              "default": 0
             }
           },
           {
@@ -5173,14 +5176,16 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int64"
+              "format": "int64",
+              "default": 20
             }
           },
           {
             "name": "filterMustBeIsDependency",
             "in": "query",
             "schema": {
-              "type": "boolean"
+              "type": "boolean",
+              "default": true
             }
           }
         ],
@@ -5285,6 +5290,16 @@
           }
         },
         "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
+                }
+              }
+            }
+          },
           "201": {
             "description": "Created",
             "headers": {
@@ -5294,16 +5309,6 @@
                   "type": "string",
                   "description": "Location of the newly created resource",
                   "format": "uri"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetailsModel"
                 }
               }
             }
@@ -6401,9 +6406,7 @@
           },
           "providerProperties": {
             "type": "object",
-            "additionalProperties": {
-
-            },
+            "additionalProperties": { },
             "nullable": true
           }
         },
@@ -7332,9 +7335,7 @@
             "nullable": true
           }
         },
-        "additionalProperties": {
-
-        }
+        "additionalProperties": { }
       },
       "ProfilingStatusModel": {
         "type": "object",
@@ -7448,6 +7449,10 @@
           },
           "nodeType": {
             "type": "string",
+            "nullable": true
+          },
+          "nodePublished": {
+            "type": "boolean",
             "nullable": true
           },
           "contentTypeIcon": {
@@ -8047,9 +8052,7 @@
           "authorizationCode": {
             "authorizationUrl": "/umbraco/management/api/v1.0/security/back-office/authorize",
             "tokenUrl": "/umbraco/management/api/v1.0/security/back-office/token",
-            "scopes": {
-
-            }
+            "scopes": { }
           }
         }
       }
@@ -8057,9 +8060,7 @@
   },
   "security": [
     {
-      "OAuth": [
-
-      ]
+      "OAuth": [ ]
     }
   ]
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/TrackedReferences/RelationItemViewModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/TrackedReferences/RelationItemViewModel.cs
@@ -8,6 +8,8 @@ public class RelationItemViewModel
 
     public string? NodeType { get; set; }
 
+    public bool? NodePublished { get; set; }
+
     public string? ContentTypeIcon { get; set; }
 
     public string? ContentTypeAlias { get; set; }
@@ -19,4 +21,5 @@ public class RelationItemViewModel
     public bool RelationTypeIsBidirectional { get; set; }
 
     public bool RelationTypeIsDependency { get; set; }
+
 }

--- a/src/Umbraco.Core/Models/RelationItemModel.cs
+++ b/src/Umbraco.Core/Models/RelationItemModel.cs
@@ -8,6 +8,8 @@ public class RelationItemModel
 
     public string? NodeType { get; set; }
 
+    public bool? NodePublished { get; set; }
+
     public string? ContentTypeIcon { get; set; }
 
     public string? ContentTypeAlias { get; set; }

--- a/src/Umbraco.Core/Persistence/Repositories/ITrackedReferencesRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/ITrackedReferencesRepository.cs
@@ -17,6 +17,7 @@ public interface ITrackedReferencesRepository
     /// </param>
     /// <param name="totalRecords">The total count of the items with reference to the current item.</param>
     /// <returns>An enumerable list of <see cref="RelationItem" /> objects.</returns>
+    [Obsolete("Use overload that takes key instead of id. This will be removed in Umbraco 15.")]
     IEnumerable<RelationItem> GetPagedRelationsForItem(int id, long pageIndex, int pageSize, bool filterMustBeIsDependency, out long totalRecords);
 
     /// <summary>
@@ -31,6 +32,7 @@ public interface ITrackedReferencesRepository
     /// </param>
     /// <param name="totalRecords">The total count of the items in any kind of relation.</param>
     /// <returns>An enumerable list of <see cref="RelationItem" /> objects.</returns>
+    [Obsolete("Use overload that takes key instead of id. This will be removed in Umbraco 15.")]
     IEnumerable<RelationItem> GetPagedItemsWithRelations(int[] ids, long pageIndex, int pageSize, bool filterMustBeIsDependency, out long totalRecords);
 
     /// <summary>
@@ -45,6 +47,7 @@ public interface ITrackedReferencesRepository
     /// </param>
     /// <param name="totalRecords">The total count of descending items.</param>
     /// <returns>An enumerable list of <see cref="RelationItem" /> objects.</returns>
+    [Obsolete("Use overload that takes key instead of id. This will be removed in Umbraco 15.")]
     IEnumerable<RelationItem> GetPagedDescendantsInReferences(int parentId, long pageIndex, int pageSize, bool filterMustBeIsDependency, out long totalRecords);
 
     /// <summary>
@@ -60,6 +63,15 @@ public interface ITrackedReferencesRepository
     /// </param>
     /// <param name="totalRecords">The total count of the items with reference to the current item.</param>
     /// <returns>An enumerable list of <see cref="RelationItem" /> objects.</returns>
+    IEnumerable<RelationItemModel> GetPagedRelationsForItem(
+        Guid key,
+        long skip,
+        long take,
+        bool filterMustBeIsDependency,
+        out long totalRecords) =>
+        throw new NotImplementedException();
+
+    [Obsolete("Use overload that takes key instead of id. This will be removed in Umbraco 15.")]
     IEnumerable<RelationItemModel> GetPagedRelationsForItem(
         int id,
         long skip,
@@ -81,17 +93,24 @@ public interface ITrackedReferencesRepository
     /// <param name="totalRecords">The total count of the items in any kind of relation.</param>
     /// <returns>An enumerable list of <see cref="RelationItem" /> objects.</returns>
     IEnumerable<RelationItemModel> GetPagedItemsWithRelations(
+        ISet<Guid> keys,
+        long skip,
+        long take,
+        bool filterMustBeIsDependency,
+        out long totalRecords);
+
+    [Obsolete("Use overload that takes key instead of id. This will be removed in Umbraco 15.")]
+    IEnumerable<RelationItemModel> GetPagedItemsWithRelations(
         int[] ids,
         long skip,
         long take,
         bool filterMustBeIsDependency,
-        out long totalRecords) =>
-        throw new NotImplementedException();
+        out long totalRecords);
 
     /// <summary>
     ///     Gets a page of the descending items that have any references, given a parent id.
     /// </summary>
-    /// <param name="parentId">The unique identifier of the parent to retrieve descendants for.</param>
+    /// <param name="parentKey">The unique identifier of the parent to retrieve descendants for.</param>
     /// <param name="skip">The amount of items to skip.</param>
     /// <param name="take">The amount of items to take.</param>
     /// <param name="filterMustBeIsDependency">
@@ -101,10 +120,17 @@ public interface ITrackedReferencesRepository
     /// <param name="totalRecords">The total count of descending items.</param>
     /// <returns>An enumerable list of <see cref="RelationItem" /> objects.</returns>
     IEnumerable<RelationItemModel> GetPagedDescendantsInReferences(
+        Guid parentKey,
+        long skip,
+        long take,
+        bool filterMustBeIsDependency,
+        out long totalRecords);
+
+    [Obsolete("Use overload that takes key instead of id. This will be removed in Umbraco 15.")]
+    IEnumerable<RelationItemModel> GetPagedDescendantsInReferences(
         int parentId,
         long skip,
         long take,
         bool filterMustBeIsDependency,
-        out long totalRecords) =>
-        throw new NotImplementedException();
+        out long totalRecords);
 }

--- a/src/Umbraco.Core/Services/ITrackedReferencesService.cs
+++ b/src/Umbraco.Core/Services/ITrackedReferencesService.cs
@@ -17,6 +17,7 @@ public interface ITrackedReferencesService
     ///     dependencies (isDependency field is set to true).
     /// </param>
     /// <returns>A paged result of <see cref="RelationItem" /> objects.</returns>
+    [Obsolete("Use overload that takes key instead of id. This will be removed in Umbraco 15.")]
     PagedResult<RelationItem> GetPagedRelationsForItem(int id, long pageIndex, int pageSize, bool filterMustBeIsDependency);
 
     /// <summary>
@@ -30,6 +31,7 @@ public interface ITrackedReferencesService
     ///     dependencies (isDependency field is set to true).
     /// </param>
     /// <returns>A paged result of <see cref="RelationItem" /> objects.</returns>
+    [Obsolete("Use overload that takes key instead of id. This will be removed in Umbraco 15.")]
     PagedResult<RelationItem> GetPagedDescendantsInReferences(int parentId, long pageIndex, int pageSize, bool filterMustBeIsDependency);
 
     /// <summary>
@@ -43,9 +45,13 @@ public interface ITrackedReferencesService
     ///     dependencies (isDependency field is set to true).
     /// </param>
     /// <returns>A paged result of <see cref="RelationItem" /> objects.</returns>
+    [Obsolete("Use method that takes key (Guid) instead of id (int). This will be removed in Umbraco 15.")]
     PagedResult<RelationItem> GetPagedItemsWithRelations(int[] ids, long pageIndex, int pageSize, bool filterMustBeIsDependency);
 
-        /// <summary>
+    [Obsolete("Use method that takes key (Guid) instead of id (int). This will be removed in Umbraco 15.")]
+    PagedModel<RelationItemModel> GetPagedRelationsForItem(int id, long skip, long take, bool filterMustBeIsDependency);
+
+    /// <summary>
     ///     Gets a paged result of items which are in relation with the current item.
     ///     Basically, shows the items which depend on the current item.
     /// </summary>
@@ -58,26 +64,32 @@ public interface ITrackedReferencesService
     /// </param>
     /// <param name="totalItems">The total amount of items.</param>
     /// <returns>A paged result of <see cref="RelationItemModel" /> objects.</returns>
-    PagedModel<RelationItemModel> GetPagedRelationsForItem(int id, long skip, long take, bool filterMustBeIsDependency) => throw new NotImplementedException();
+    Task<PagedModel<RelationItemModel>> GetPagedRelationsForItemAsync(Guid key, long skip, long take, bool filterMustBeIsDependency);
+
+    [Obsolete("Use method that takes key (Guid) instead of id (int). This will be removed in Umbraco 15.")]
+    PagedModel<RelationItemModel> GetPagedDescendantsInReferences(int parentId, long skip, long take, bool filterMustBeIsDependency);
 
     /// <summary>
     ///     Gets a paged result of the descending items that have any references, given a parent id.
     /// </summary>
-    /// <param name="parentId">The unique identifier of the parent to retrieve descendants for.</param>
+    /// <param name="parentKey">The unique identifier of the parent to retrieve descendants for.</param>
     /// <param name="skip">The amount of items to skip</param>
     /// <param name="take">The amount of items to take.</param>
     /// <param name="filterMustBeIsDependency">
     ///     A boolean indicating whether to filter only the RelationTypes which are
     ///     dependencies (isDependency field is set to true).
     /// </param>
-    /// <param name="totalItems">The total amount of items.</param>
     /// <returns>A paged result of <see cref="RelationItemModel" /> objects.</returns>
-    PagedModel<RelationItemModel> GetPagedDescendantsInReferences(int parentId, long skip, long take, bool filterMustBeIsDependency) => throw new NotImplementedException();
+    Task<PagedModel<RelationItemModel>> GetPagedDescendantsInReferencesAsync(Guid parentKey, long skip, long take, bool filterMustBeIsDependency);
+
+    [Obsolete("Use method that takes keys (Guid) instead of ids (int). This will be removed in Umbraco 15.")]
+    PagedModel<RelationItemModel> GetPagedItemsWithRelations(int[] ids, long skip, long take,
+        bool filterMustBeIsDependency);
 
     /// <summary>
     ///     Gets a paged result of items used in any kind of relation from selected integer ids.
     /// </summary>
-    /// <param name="ids">The identifiers of the entities to check for relations.</param>
+    /// <param name="keys">The identifiers of the entities to check for relations.</param>
     /// <param name="skip">The amount of items to skip</param>
     /// <param name="take">The amount of items to take.</param>
     /// <param name="filterMustBeIsDependency">
@@ -86,5 +98,6 @@ public interface ITrackedReferencesService
     /// </param>
     /// <param name="totalItems">The total amount of items.</param>
     /// <returns>A paged result of <see cref="RelationItemModel" /> objects.</returns>
-    PagedModel<RelationItemModel> GetPagedItemsWithRelations(int[] ids, long skip, long take, bool filterMustBeIsDependency) => throw new NotImplementedException();
+    Task<PagedModel<RelationItemModel>> GetPagedItemsWithRelationsAsync(ISet<Guid> keys, long skip, long take,
+        bool filterMustBeIsDependency);
 }

--- a/src/Umbraco.Core/Services/TrackedReferencesService.cs
+++ b/src/Umbraco.Core/Services/TrackedReferencesService.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Scoping;
@@ -8,28 +10,33 @@ namespace Umbraco.Cms.Core.Services;
 public class TrackedReferencesService : ITrackedReferencesService
 {
     private readonly ICoreScopeProvider _scopeProvider;
+    private readonly IEntityService _entityService;
     private readonly ITrackedReferencesRepository _trackedReferencesRepository;
 
-    [Obsolete("Please use ctor that does not take an IEntityService, scheduled for removal in V12")]
+
     public TrackedReferencesService(
         ITrackedReferencesRepository trackedReferencesRepository,
         ICoreScopeProvider scopeProvider,
-        IEntityService entityService) : this(trackedReferencesRepository, scopeProvider)
-    {
-    }
-
-    public TrackedReferencesService(
-        ITrackedReferencesRepository trackedReferencesRepository,
-        ICoreScopeProvider scopeProvider)
+        IEntityService entityService)
     {
         _trackedReferencesRepository = trackedReferencesRepository;
         _scopeProvider = scopeProvider;
+        _entityService = entityService;
+    }
+
+    [Obsolete("Please use ctor that does not take an IEntityService, scheduled for removal in V15")]
+    public TrackedReferencesService(
+        ITrackedReferencesRepository trackedReferencesRepository,
+        ICoreScopeProvider scopeProvider): this(trackedReferencesRepository, scopeProvider, StaticServiceProvider.Instance.GetRequiredService<IEntityService>())
+    {
+
     }
 
     /// <summary>
     ///     Gets a paged result of items which are in relation with the current item.
     ///     Basically, shows the items which depend on the current item.
     /// </summary>
+    [Obsolete("Use overload that takes key instead of id. This will be removed in Umbraco 15.")]
     public PagedResult<RelationItem> GetPagedRelationsForItem(int id, long pageIndex, int pageSize, bool filterMustBeIsDependency)
     {
         using ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true);
@@ -41,6 +48,7 @@ public class TrackedReferencesService : ITrackedReferencesService
     /// <summary>
     ///     Gets a paged result of items used in any kind of relation from selected integer ids.
     /// </summary>
+    [Obsolete("Use overload that takes key instead of id. This will be removed in Umbraco 15.")]
     public PagedResult<RelationItem> GetPagedItemsWithRelations(int[] ids, long pageIndex, int pageSize, bool filterMustBeIsDependency)
     {
         using ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true);
@@ -52,6 +60,7 @@ public class TrackedReferencesService : ITrackedReferencesService
     /// <summary>
     ///     Gets a paged result of the descending items that have any references, given a parent id.
     /// </summary>
+    [Obsolete("Use overload that takes key instead of id. This will be removed in Umbraco 15.")]
     public PagedResult<RelationItem> GetPagedDescendantsInReferences(int parentId, long pageIndex, int pageSize, bool filterMustBeIsDependency)
     {
         using ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true);
@@ -65,6 +74,7 @@ public class TrackedReferencesService : ITrackedReferencesService
         return new PagedResult<RelationItem>(totalItems, pageIndex + 1, pageSize) { Items = items };
     }
 
+    [Obsolete("Use overload that takes key instead of id. This will be removed in Umbraco 15.")]
     public PagedModel<RelationItemModel> GetPagedRelationsForItem(int id, long skip, long take, bool filterMustBeIsDependency)
     {
         using ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true);
@@ -74,6 +84,16 @@ public class TrackedReferencesService : ITrackedReferencesService
         return pagedModel;
     }
 
+    public async Task<PagedModel<RelationItemModel>> GetPagedRelationsForItemAsync(Guid key, long skip, long take, bool filterMustBeIsDependency)
+    {
+        using ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true);
+        IEnumerable<RelationItemModel> items = _trackedReferencesRepository.GetPagedRelationsForItem(key, skip, take, filterMustBeIsDependency, out var totalItems);
+        var pagedModel = new PagedModel<RelationItemModel>(totalItems, items);
+
+        return await Task.FromResult(pagedModel);
+    }
+
+    [Obsolete("Use overload that takes key instead of id. This will be removed in Umbraco 15.")]
     public PagedModel<RelationItemModel> GetPagedDescendantsInReferences(int parentId, long skip, long take, bool filterMustBeIsDependency)
     {
         using ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true);
@@ -89,6 +109,22 @@ public class TrackedReferencesService : ITrackedReferencesService
         return pagedModel;
     }
 
+    public async Task<PagedModel<RelationItemModel>> GetPagedDescendantsInReferencesAsync(Guid parentKey, long skip, long take, bool filterMustBeIsDependency)
+    {
+        using ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true);
+
+        IEnumerable<RelationItemModel> items = _trackedReferencesRepository.GetPagedDescendantsInReferences(
+            parentKey,
+            skip,
+            take,
+            filterMustBeIsDependency,
+            out var totalItems);
+        var pagedModel = new PagedModel<RelationItemModel>(totalItems, items);
+
+        return await Task.FromResult(pagedModel);
+    }
+
+    [Obsolete("Use overload that takes key instead of id. This will be removed in Umbraco 15.")]
     public PagedModel<RelationItemModel> GetPagedItemsWithRelations(int[] ids, long skip, long take, bool filterMustBeIsDependency)
     {
         using ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true);
@@ -96,5 +132,14 @@ public class TrackedReferencesService : ITrackedReferencesService
         var pagedModel = new PagedModel<RelationItemModel>(totalItems, items);
 
         return pagedModel;
+    }
+
+    public async Task<PagedModel<RelationItemModel>> GetPagedItemsWithRelationsAsync(ISet<Guid> keys, long skip, long take, bool filterMustBeIsDependency)
+    {
+        using ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true);
+        IEnumerable<RelationItemModel> items = _trackedReferencesRepository.GetPagedItemsWithRelations(keys, skip, take, filterMustBeIsDependency, out var totalItems);
+        var pagedModel = new PagedModel<RelationItemModel>(totalItems, items);
+
+        return await Task.FromResult(pagedModel);
     }
 }

--- a/src/Umbraco.Infrastructure/Persistence/UmbracoDatabaseExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/UmbracoDatabaseExtensions.cs
@@ -73,4 +73,11 @@ internal static class UmbracoDatabaseExtensions
     /// <returns></returns>
     public static bool IsDatabaseEmpty(this IUmbracoDatabase database)
         => database.SqlContext.SqlSyntax.GetTablesInSchema(database).Any() == false;
+
+    public static long Count(this IUmbracoDatabase database, Sql sql)
+    {
+        var query = new Sql().Select("COUNT(*)").From().Append("(").Append(sql).Append(")");
+
+        return database.ExecuteScalar<long>(query);
+    }
 }

--- a/src/Umbraco.New.Cms.Infrastructure/Persistence/Mappers/RelationModelMapDefinition.cs
+++ b/src/Umbraco.New.Cms.Infrastructure/Persistence/Mappers/RelationModelMapDefinition.cs
@@ -22,5 +22,7 @@ public class RelationModelMapDefinition : IMapDefinition
         target.ContentTypeAlias = source.ChildContentTypeAlias;
         target.ContentTypeIcon = source.ChildContentTypeIcon;
         target.ContentTypeName = source.ChildContentTypeName;
+
+        target.NodePublished = source.ChildNodePublished;
     }
 }


### PR DESCRIPTION
Updates the management api endpoints to use keys instead of IDs

### Tests
- /umbraco/management/api/v1/tracked-reference/{key}
  - This is what is used on the content-info tab. This should shown all using this item
-/umbraco/management/api/v1/tracked-reference/descendants/{parentKey}
  - This is used when deleting/unpublishing an item.. Should find descendants that have references.
-/umbraco/management/api/v1/tracked-reference/item
  - This is used when deleting/unpublishing many items. Should return those of them that have references. (Always a subset of the inputted)