### PR TITLE
Changed modifier for ContentPickerValueConverter

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/ContentPickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/ContentPickerValueConverter.cs
@@ -5,7 +5,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 
-internal class ContentPickerValueConverter : PropertyValueConverterBase
+public class ContentPickerValueConverter : PropertyValueConverterBase
 {
     private static readonly List<string> PropertiesToExclude = new()
     {


### PR DESCRIPTION
Changed access modifier of `ContentPickerValueConverter` from `internal` to `public`.
This Value Converter was the only one defined as internal while all others are public.
It was confirmed as bug
Fixes issue #13863 3858