### PR TITLE
Reset selected index/searcher

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.controller.js
@@ -85,9 +85,11 @@ function ExamineManagementController($http, $q, $timeout, umbRequestHelper, loca
     function nextSearchResultPage(pageNumber) {
         search(vm.selectedIndex ? vm.selectedIndex : vm.selectedSearcher, null, pageNumber);
     }
+    
     function prevSearchResultPage(pageNumber) {
         search(vm.selectedIndex ? vm.selectedIndex : vm.selectedSearcher, null, pageNumber);
     }
+    
     function goToPageSearchResultPage(pageNumber) {
         search(vm.selectedIndex ? vm.selectedIndex : vm.selectedSearcher, null, pageNumber);
     }
@@ -137,11 +139,13 @@ function ExamineManagementController($http, $q, $timeout, umbRequestHelper, loca
     }
 
     function showIndexInfo(index) {
+        vm.selectedSearcher = null;
         vm.selectedIndex = index;
         setViewState("index-details");
     }
 
     function showSearcherInfo(searcher) {
+        vm.selectedIndex = null;
         vm.selectedSearcher = searcher;
         setViewState("searcher-details");
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/13749

### Description
When selecting an index and then navigating to registered searchers, it was using the previous selected index as searcher name, instead of the actually searcher.