### PR TITLE
Fix TinyMCE Link Picker - empty link throws JS error #13860

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -1144,7 +1144,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
 
       // the href might be an external url, so check the value for an anchor/qs
       // href has the anchor re-appended later, hence the reset here to avoid duplicating the anchor
-      if (!target.anchor) {
+      if (!target.anchor && href) {
         var urlParts = href.split(/(#|\?)/);
         if (urlParts.length === 3) {
           href = urlParts[0];


### PR DESCRIPTION
Undefined error when inserting an empty link in the RTE editor
This fixes: #13860 
