### PR TITLE
Change GetMinNonAlphaNumericChars() to return 1

### DIFF
--- a/src/Umbraco.Core/Extensions/PasswordConfigurationExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PasswordConfigurationExtensions.cs
@@ -30,5 +30,5 @@ public static class PasswordConfigurationExtensions
         };
 
     public static int GetMinNonAlphaNumericChars(this IPasswordConfiguration passwordConfiguration) =>
-        passwordConfiguration.RequireNonLetterOrDigit ? 2 : 0;
+        passwordConfiguration.RequireNonLetterOrDigit ? 1 : 0;
 }


### PR DESCRIPTION
Change the return value of this extension method to return either 0 or 1. Returning 2 forces all passwords to contain at least 2 special characters when using this extension in code to check if a password meets requirements


Image of  Microsoft.AspNetCore.Identity.PasswordOptions, does not default to 2 special characters (it's not configurable)
![image](https://user-images.githubusercontent.com/28493458/220841180-93564f36-9bcb-4cc0-ba93-c2b3b59c3032.png)
