### PR TITLE
Make additionalRouteVals nullable in HtmlHelperRenderExtensions.BeginUmbracoForm() - Fixes #13662

### DIFF
--- a/src/Umbraco.Web.Website/Extensions/HtmlHelperRenderExtensions.cs
+++ b/src/Umbraco.Web.Website/Extensions/HtmlHelperRenderExtensions.cs
@@ -337,7 +337,7 @@ public static class HtmlHelperRenderExtensions
         this IHtmlHelper html,
         string action,
         string controllerName,
-        object additionalRouteVals,
+        object? additionalRouteVals,
         FormMethod method)
         => html.BeginUmbracoForm(action, controllerName, additionalRouteVals, new Dictionary<string, object?>(), method);
 
@@ -348,7 +348,7 @@ public static class HtmlHelperRenderExtensions
         this IHtmlHelper html,
         string action,
         string controllerName,
-        object additionalRouteVals)
+        object? additionalRouteVals = null)
         => html.BeginUmbracoForm(action, controllerName, additionalRouteVals, new Dictionary<string, object?>());
 
     /// <summary>
@@ -358,7 +358,7 @@ public static class HtmlHelperRenderExtensions
         this IHtmlHelper html,
         string action,
         string controllerName,
-        object additionalRouteVals,
+        object? additionalRouteVals,
         object htmlAttributes,
         FormMethod method) =>
         html.BeginUmbracoForm(
@@ -375,7 +375,7 @@ public static class HtmlHelperRenderExtensions
         this IHtmlHelper html,
         string action,
         string controllerName,
-        object additionalRouteVals,
+        object? additionalRouteVals,
         object htmlAttributes) =>
         html.BeginUmbracoForm(
             action,
@@ -483,7 +483,7 @@ public static class HtmlHelperRenderExtensions
         this IHtmlHelper html,
         string action,
         Type surfaceType,
-        object additionalRouteVals,
+        object? additionalRouteVals,
         FormMethod method) =>
         html.BeginUmbracoForm(
             action,
@@ -499,21 +499,21 @@ public static class HtmlHelperRenderExtensions
         this IHtmlHelper html,
         string action,
         Type surfaceType,
-        object additionalRouteVals) =>
+        object? additionalRouteVals = null) =>
         html.BeginUmbracoForm(action, surfaceType, additionalRouteVals, new Dictionary<string, object?>());
 
     /// <summary>
     ///     Helper method to create a new form to execute in the Umbraco request pipeline to a surface controller plugin
     /// </summary>
     /// <typeparam name="T">The <see cref="SurfaceController" /> type</typeparam>
-    public static MvcForm BeginUmbracoForm<T>(this IHtmlHelper html, string action, object additionalRouteVals, FormMethod method)
+    public static MvcForm BeginUmbracoForm<T>(this IHtmlHelper html, string action, object? additionalRouteVals, FormMethod method)
         where T : SurfaceController => html.BeginUmbracoForm(action, typeof(T), additionalRouteVals, method);
 
     /// <summary>
     ///     Helper method to create a new form to execute in the Umbraco request pipeline to a surface controller plugin
     /// </summary>
     /// <typeparam name="T">The <see cref="SurfaceController" /> type</typeparam>
-    public static MvcForm BeginUmbracoForm<T>(this IHtmlHelper html, string action, object additionalRouteVals)
+    public static MvcForm BeginUmbracoForm<T>(this IHtmlHelper html, string action, object? additionalRouteVals = null)
         where T : SurfaceController => html.BeginUmbracoForm(action, typeof(T), additionalRouteVals);
 
     /// <summary>
@@ -523,7 +523,7 @@ public static class HtmlHelperRenderExtensions
         this IHtmlHelper html,
         string action,
         Type surfaceType,
-        object additionalRouteVals,
+        object? additionalRouteVals,
         object htmlAttributes) =>
         html.BeginUmbracoForm(
             action,
@@ -538,7 +538,7 @@ public static class HtmlHelperRenderExtensions
         this IHtmlHelper html,
         string action,
         Type surfaceType,
-        object additionalRouteVals,
+        object? additionalRouteVals,
         object htmlAttributes,
         FormMethod method) =>
         html.BeginUmbracoForm(
@@ -555,7 +555,7 @@ public static class HtmlHelperRenderExtensions
         this IHtmlHelper html,
         string action,
         Type surfaceType,
-        object additionalRouteVals,
+        object? additionalRouteVals,
         object htmlAttributes,
         FormMethod method,
         bool? antiforgery) =>
@@ -574,7 +574,7 @@ public static class HtmlHelperRenderExtensions
     public static MvcForm BeginUmbracoForm<T>(
         this IHtmlHelper html,
         string action,
-        object additionalRouteVals,
+        object? additionalRouteVals,
         object htmlAttributes,
         FormMethod method)
         where T : SurfaceController =>
@@ -587,7 +587,7 @@ public static class HtmlHelperRenderExtensions
     public static MvcForm BeginUmbracoForm<T>(
         this IHtmlHelper html,
         string action,
-        object additionalRouteVals,
+        object? additionalRouteVals,
         object htmlAttributes,
         FormMethod method,
         bool? antiforgery)
@@ -600,7 +600,7 @@ public static class HtmlHelperRenderExtensions
     public static MvcForm BeginUmbracoForm<T>(
         this IHtmlHelper html,
         string action,
-        object additionalRouteVals,
+        object? additionalRouteVals,
         object htmlAttributes)
         where T : SurfaceController => html.BeginUmbracoForm(action, typeof(T), additionalRouteVals, htmlAttributes);
 
@@ -690,7 +690,7 @@ public static class HtmlHelperRenderExtensions
     public static MvcForm BeginUmbracoForm<T>(
         this IHtmlHelper html,
         string action,
-        object additionalRouteVals,
+        object? additionalRouteVals,
         IDictionary<string, object?> htmlAttributes,
         FormMethod method)
         where T : SurfaceController =>
@@ -703,7 +703,7 @@ public static class HtmlHelperRenderExtensions
     public static MvcForm BeginUmbracoForm<T>(
         this IHtmlHelper html,
         string action,
-        object additionalRouteVals,
+        object? additionalRouteVals,
         IDictionary<string, object?> htmlAttributes)
         where T : SurfaceController => html.BeginUmbracoForm(action, typeof(T), additionalRouteVals, htmlAttributes);
 


### PR DESCRIPTION
### Prerequisites

Fixes #13662

### Description

In `Umbraco.Extensions.HtmlHelperRenderExtensions.BeginUmbracoForm()`, parameter `additionalRouteVals` was not consistently nullable. Here it is made nullable across the various BeginUmbracoForm() versions.