### PR TITLE
Fixing issue #13865 (i.e. Rich text link picker not resolving correct variant when using .ValueFor()).

### DIFF
--- a/src/Umbraco.Core/Extensions/PublishedElementExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedElementExtensions.cs
@@ -134,6 +134,27 @@ public static class PublishedElementExtensions
 
     #endregion
 
+    #region CheckVariation
+    /// <summary>
+    /// Method to check if VariationContext culture differs from culture parameter, if so it will update the VariationContext for the PublishedValueFallback.
+    /// </summary>
+    /// <param name="publishedValueFallback">The requested PublishedValueFallback.</param>
+    /// <param name="culture">The requested culture.</param>
+    /// <param name="segment">The requested segment.</param>
+    /// <returns></returns>
+    private static void EventuallyUpdateVariationContext(IPublishedValueFallback publishedValueFallback, string? culture, string? segment)
+    {
+        IVariationContextAccessor? variationContextAccessor = publishedValueFallback.VariationContextAccessor;
+
+        //If there is a difference in requested culture and the culture that is set in the VariationContext, it will pick wrong localized content.
+        //This happens for example using links to localized content in a RichText Editor.
+        if (!string.IsNullOrEmpty(culture) && variationContextAccessor?.VariationContext?.Culture != culture)
+        {
+            variationContextAccessor!.VariationContext = new VariationContext(culture, segment);
+        }
+    }
+    #endregion
+
     #region Value<T>
 
     /// <summary>
@@ -173,6 +194,8 @@ public static class PublishedElementExtensions
         T? defaultValue = default)
     {
         IPublishedProperty? property = content.GetProperty(alias);
+
+        EventuallyUpdateVariationContext(publishedValueFallback, culture, segment);
 
         // if we have a property, and it has a value, return that value
         if (property != null && property.HasValue(culture, segment))

--- a/src/Umbraco.Core/Models/PublishedContent/IPublishedValueFallback.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/IPublishedValueFallback.cs
@@ -6,6 +6,11 @@ namespace Umbraco.Cms.Core.Models.PublishedContent;
 public interface IPublishedValueFallback
 {
     /// <summary>
+    /// VariationContextAccessor that is not required to be implemented, therefore throws NotImplementedException as default.
+    /// </summary>
+    IVariationContextAccessor VariationContextAccessor { get { throw new NotImplementedException(); } set { throw new NotImplementedException(); } }
+
+    /// <summary>
     ///     Tries to get a fallback value for a property.
     /// </summary>
     /// <param name="property">The property.</param>

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedValueFallback.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedValueFallback.cs
@@ -20,6 +20,8 @@ public class PublishedValueFallback : IPublishedValueFallback
         _variationContextAccessor = variationContextAccessor;
     }
 
+    public IVariationContextAccessor VariationContextAccessor { get { return _variationContextAccessor; } }
+
     /// <inheritdoc />
     public bool TryGetValue(IPublishedProperty property, string? culture, string? segment, Fallback fallback, object? defaultValue, out object? value) =>
         TryGetValue<object>(property, culture, segment, fallback, defaultValue, out value);

--- a/src/Umbraco.Infrastructure/ModelsBuilder/PublishedElementExtensions.cs
+++ b/src/Umbraco.Infrastructure/ModelsBuilder/PublishedElementExtensions.cs
@@ -26,28 +26,7 @@ public static class PublishedElementExtensions
         where TModel : IPublishedElement
     {
         var alias = GetAlias(model, property);
-        return model.Value(CheckVariationContext(publishedValueFallback,culture,segment), alias, culture, segment, fallback, defaultValue);
-    }
-
-    /// <summary>
-    /// Method to check if VariationContext culture differs from culture parameter, if so it will update the VariationContext for the PublishedValueFallback.
-    /// </summary>
-    /// <param name="publishedValueFallback">The requested PublishedValueFallback.</param>
-    /// <param name="culture">The requested culture.</param>
-    /// <param name="segment">The requested segment.</param>
-    /// <returns></returns>
-    private static IPublishedValueFallback CheckVariationContext(IPublishedValueFallback publishedValueFallback, string? culture, string? segment)
-    {
-        IVariationContextAccessor? variationContextAccessor = publishedValueFallback.VariationContextAccessor;
-
-        //If there is a difference in requested culture and the culture that is set in the VariationContext, it will pick wrong localized content.
-        //This happens for example using links to localized content in a RichText Editor.
-        if (!string.IsNullOrEmpty(culture) && variationContextAccessor?.VariationContext?.Culture != culture)
-        {
-            variationContextAccessor!.VariationContext = new VariationContext(culture, segment);
-        }
-
-        return publishedValueFallback!;
+        return model.Value(publishedValueFallback, alias, culture, segment, fallback, defaultValue);
     }
 
     // fixme that one should be public so ppl can use it

--- a/src/Umbraco.Infrastructure/ModelsBuilder/PublishedElementExtensions.cs
+++ b/src/Umbraco.Infrastructure/ModelsBuilder/PublishedElementExtensions.cs
@@ -29,14 +29,22 @@ public static class PublishedElementExtensions
         return model.Value(CheckVariationContext(publishedValueFallback,culture,segment), alias, culture, segment, fallback, defaultValue);
     }
 
+    /// <summary>
+    /// Method to check if VariationContext culture differs from culture parameter, if so it will update the VariationContext for the PublishedValueFallback.
+    /// </summary>
+    /// <param name="publishedValueFallback">The requested PublishedValueFallback.</param>
+    /// <param name="culture">The requested culture.</param>
+    /// <param name="segment">The requested segment.</param>
+    /// <returns></returns>
     private static IPublishedValueFallback CheckVariationContext(IPublishedValueFallback publishedValueFallback, string? culture, string? segment)
     {
-        var variationContextAccessor = (IVariationContextAccessor?)publishedValueFallback?.GetType()?.GetField("_variationContextAccessor", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(publishedValueFallback);
-        PropertyInfo? variationContext = variationContextAccessor?.GetType()?.GetProperty("Value", BindingFlags.Instance | BindingFlags.NonPublic);
+        IVariationContextAccessor? variationContextAccessor = publishedValueFallback.VariationContextAccessor;
 
+        //If there is a difference in requested culture and the culture that is set in the VariationContext, it will pick wrong localized content.
+        //This happens for example using links to localized content in a RichText Editor.
         if (!string.IsNullOrEmpty(culture) && variationContextAccessor?.VariationContext?.Culture != culture)
         {
-            variationContext?.SetValue(variationContextAccessor, new VariationContext(culture, segment));
+            variationContextAccessor!.VariationContext = new VariationContext(culture, segment);
         }
 
         return publishedValueFallback!;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This PR fixes this issue: https://github.com/umbraco/Umbraco-CMS/issues/13865.

### Description
Added a change in ```Value<T>``` so potential discrepancys between the culture of VariationContext and culture parameter passed to the ```Value<T>``` method, is corrected. This fixes problem when i.e. picking correct localized href for link in Rich text link Editor.

Unit test is not provided, but I have been running all existing tests and they passed. But if you want me to provide som kind of test I could update this PR.

This might not be the best way to fix this issue. I'm gladly replying to any questions on why I did it like this. But please provide feedback 😊
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
