### PR TITLE
Use latest c# language version instead of csharp 8 in runtime views

### DIFF
--- a/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/CompilationOptionsProvider.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/CompilationOptionsProvider.cs
@@ -195,8 +195,7 @@ internal class CompilationOptionsProvider
 
         if (string.IsNullOrEmpty(dependencyContextOptions.LanguageVersion))
         {
-            // If the user does not specify a LanguageVersion, assume CSharp 8.0. This matches the language version Razor 3.0 targets by default.
-            parseOptions = parseOptions.WithLanguageVersion(LanguageVersion.CSharp8);
+            parseOptions = parseOptions.WithLanguageVersion(LanguageVersion.Latest);
         }
         else if (LanguageVersionFacts.TryParse(dependencyContextOptions.LanguageVersion, out var languageVersion))
         {


### PR DESCRIPTION
Updated to use latest C# version when building runtime views. Seems to be required when using dotnet 8 preview 1