### PR TITLE
Fix issue with searching internal index with hypen

### DIFF
--- a/src/Umbraco.Examine.Lucene/BackOfficeExamineSearcher.cs
+++ b/src/Umbraco.Examine.Lucene/BackOfficeExamineSearcher.cs
@@ -169,7 +169,10 @@ public class BackOfficeExamineSearcher : IBackOfficeExamineSearcher
         var allLangs = _languageService.GetAllLanguages().Select(x => x.IsoCode.ToLowerInvariant()).ToList();
 
         // the chars [*-_] in the query will mess everything up so let's remove those
-        query = Regex.Replace(query, "[\\*\\-_]", string.Empty);
+        // However we cannot just remove - and _  since these signify a space, so we instead replace them with that.
+        query = Regex.Replace(query, "[\\*]", string.Empty);
+        query = Regex.Replace(query, "[\\-_]", " ");
+
 
         //check if text is surrounded by single or double quotes, if so, then exact match
         var surroundedByQuotes = Regex.IsMatch(query, "^\".*?\"$")


### PR DESCRIPTION
This fixes #13890.

The issue was that in our searcher we replaced hyphens and underscores with an empty string, this mean that when you searched `some-name` this got turned into `somename` but it's actually indexed as `some` and `name`, so this remedies that, your query will not be `some name` which works. 

## Testing

Upload an image to the section with a hyphen in the name I.E. `my-image`
Try and search for the image, including the hyphen: `my-image`, before its PR it wouldn't show up, but now it will.

