### PR TITLE
V13: fix logviewer total

### DIFF
--- a/src/Umbraco.Infrastructure/Logging/Viewer/SerilogLogViewerSourceBase.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/SerilogLogViewerSourceBase.cs
@@ -111,8 +111,6 @@ public abstract class SerilogLogViewerSourceBase : ILogViewer
         // Order By, Skip, Take & Select
         IEnumerable<LogMessage> logMessages = filteredLogs
             .OrderBy(l => l.Timestamp, orderDirection)
-            .Skip(skip)
-            .Take(take)
             .Select(x => new LogMessage
             {
                 Timestamp = x.Timestamp,
@@ -123,7 +121,7 @@ public abstract class SerilogLogViewerSourceBase : ILogViewer
                 RenderedMessage = x.RenderMessage(),
             });
 
-        return new PagedModel<LogMessage>(logMessages.Count(), logMessages);
+        return new PagedModel<LogMessage>(logMessages.Count(), logMessages.Skip(skip).Take(take));
     }
 
     /// <summary>


### PR DESCRIPTION
# Notes
- There was a bug where when you requested x amount of logs, the total would always be the same as x
- Scenario:
- Total 1000 logs
- I request 100
- The total would also be 100

# How to test
- Test the {{baseUrl}}/umbraco/management/api/v1/log-viewer/log?skip=0&take=1 endpoint with a GET request
- Assert that the total > take