### PR TITLE
Fallback to use ActivatorUtilities to create controller from type, if…

### DIFF
--- a/src/Umbraco.Web.Common/Routing/UmbracoVirtualPageRoute.cs
+++ b/src/Umbraco.Web.Common/Routing/UmbracoVirtualPageRoute.cs
@@ -61,8 +61,9 @@ public class UmbracoVirtualPageRoute : IUmbracoVirtualPageRoute
 
                 if (controllerType != null)
                 {
-                    // Get the controller for the endpoint
-                    var controller = httpContext.RequestServices.GetRequiredService(controllerType);
+                    // Get the controller for the endpoint. We need to fallback to ActivatorUtilities if the controller is not registered in DI.
+                    var controller = httpContext.RequestServices.GetService(controllerType)
+                                     ?? ActivatorUtilities.CreateInstance(httpContext.RequestServices, controllerType);
 
                     // Try and find the content if this is a virtual page
                     IPublishedContent? publishedContent = FindContent(


### PR DESCRIPTION
Fixes #13836 

### Summary
Controllers cannot be resolved from DI if they are not registred. Therefore we have to fall back to use `ActivatorUtilities`


### Tests
- Follow setup guide in https://github.com/umbraco/Umbraco-CMS/issues/13017
- Also comment out the `Umbraco.Cms.Web.UI.Composers.ControllersAsServicesComposer`. Otherwise this would already have worked.