### PR TITLE
V10: Fix missing 404 status

### DIFF
--- a/src/Umbraco.Web.Common/Controllers/PublishedRequestFilterAttribute.cs
+++ b/src/Umbraco.Web.Common/Controllers/PublishedRequestFilterAttribute.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Web.Common.ActionsResults;
 using Umbraco.Cms.Web.Common.Routing;
 
 namespace Umbraco.Cms.Web.Common.Controllers;
@@ -15,9 +16,11 @@ internal class PublishedRequestFilterAttribute : ResultFilterAttribute
     /// </summary>
     public override void OnResultExecuting(ResultExecutingContext context)
     {
-        if (context.Result is not null)
+        if (context.Result is MaintenanceResult)
         {
-            // If the result is already set, we just skip the execution
+            // If the result is already set to a maintenance result we can't do anything
+            // Since the umbraco pipeline has not run.
+            // Fortunately we don't need to either.
             return;
         }
 


### PR DESCRIPTION
This fixes #13907.

The problem was that when using the `Error404Collection ` in `appsettings` the correct not found page would be shown. but the request status would be 200. 

Looking at it, it's because the status is set by our `PublishedRequestFilterAttribute` using the route values, however since the result has been set by the `ContentFinderByConfigured404` meaning the route values are never fetched, and therefore the status is never set. 

This was added as a part of #13767 since the maintenance page no longer returns umbraco content (so there's no route values).
 
I've fixed this by explicitly checking if the result is a `MaintenanceResult` and only then do we skip fetching the route values.

## Testing

Set up a custom 404:

```json
"Error404Collection": [
  {
    "Culture": "default",
    "ContentKey": "abd58ca0-c700-47f3-b7ab-6672583572ce"
  }
]
```

Try and request it and see that it returns 200 before this PR and 404 after this pr. 

Next try and create a noop migration to enter upgrade mode and ensure that the maintenance page still works 😄 