### PR TITLE
Fix ViewContext.FormContext not being set during BeginUmbracoForm

### DIFF
--- a/src/Umbraco.Web.Website/Extensions/HtmlHelperRenderExtensions.cs
+++ b/src/Umbraco.Web.Website/Extensions/HtmlHelperRenderExtensions.cs
@@ -767,6 +767,12 @@ public static class HtmlHelperRenderExtensions
                 nameof(controllerName));
         }
 
+        // Push the new FormContext; MvcForm.GenerateEndForm() does the corresponding pop.
+        html.ViewContext.FormContext = new FormContext
+        {
+            CanRenderAtEndOfForm = true
+        };
+
         IUmbracoContextAccessor umbracoContextAccessor = GetRequiredService<IUmbracoContextAccessor>(html);
         IUmbracoContext umbracoContext = umbracoContextAccessor.GetRequiredUmbracoContext();
         var formAction = umbracoContext.OriginalRequestUrl.PathAndQuery;

--- a/src/Umbraco.Web.Website/Extensions/HtmlHelperRenderExtensions.cs
+++ b/src/Umbraco.Web.Website/Extensions/HtmlHelperRenderExtensions.cs
@@ -767,7 +767,7 @@ public static class HtmlHelperRenderExtensions
                 nameof(controllerName));
         }
 
-        // Push the new FormContext; MvcForm.GenerateEndForm() does the corresponding pop.
+        // Create a new form context in order to ensure client validation is set properly when adding multiple forms in a page. More context in PR #13914.
         html.ViewContext.FormContext = new FormContext
         {
             CanRenderAtEndOfForm = true


### PR DESCRIPTION
Client validation is broken without this if there are multiple forms with the same field names on a page.

### Prerequisites

Fixes #13913

### Description

Fixes ViewContext.FormContext not being set by Html.BeginUmbracoForm which is normally set in Html.BeginForm
