### PR TITLE
Delivery API: Fix API routes

### DIFF
--- a/src/Umbraco.Cms.Api.Content/Controllers/ByIdContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Content/Controllers/ByIdContentApiController.cs
@@ -19,7 +19,7 @@ public class ByIdContentApiController : ContentApiControllerBase
     /// </summary>
     /// <param name="id">The unique identifier of the content item.</param>
     /// <returns>The content item or not found result.</returns>
-    [HttpGet("{id:guid}")]
+    [HttpGet("item/{id:guid}")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IApiContent), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]

--- a/src/Umbraco.Cms.Api.Content/Controllers/ByRouteContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Content/Controllers/ByRouteContentApiController.cs
@@ -28,7 +28,7 @@ public class ByRouteContentApiController : ContentApiControllerBase
     ///     can be added through a "start-node" header.
     /// </remarks>
     /// <returns>The content item or not found result.</returns>
-    [HttpGet("{*path}")]
+    [HttpGet("item/{*path}")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IApiContent), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]

--- a/src/Umbraco.Cms.Api.Content/Routing/VersionedContentApiRouteAttribute.cs
+++ b/src/Umbraco.Cms.Api.Content/Routing/VersionedContentApiRouteAttribute.cs
@@ -1,11 +1,11 @@
-﻿using Umbraco.Cms.Api.Common.Routing;
+using Umbraco.Cms.Api.Common.Routing;
 
 namespace Umbraco.Cms.Api.Content.Routing;
 
 public class VersionedContentApiRouteAttribute : BackOfficeRouteAttribute
 {
     public VersionedContentApiRouteAttribute(string template)
-        : base($"content/api/v{{version:apiVersion}}/{template.TrimStart('/')}")
+        : base($"delivery/api/v{{version:apiVersion}}/{template.TrimStart('/')}")
     {
     }
 }


### PR DESCRIPTION
## Details
- renamed the ContentApiRoute to `/delivery/api/`;
- added `/item` for the item-based enpoints.