### PR TITLE
Set detailed telemetry as default in installer

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/installer/steps/user.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/user.controller.js
@@ -3,7 +3,7 @@ angular.module("umbraco.install").controller("Umbraco.Install.UserController", f
   $scope.majorVersion = Umbraco.Sys.ServerVariables.application.version;
   $scope.passwordPattern = /.*/;
   $scope.installer.current.model.subscribeToNewsLetter = $scope.installer.current.model.subscribeToNewsLetter || false;
-  setTelemetryLevelAndDescription($scope.installer.current.model.telemetryIndex ?? 1);
+  setTelemetryLevelAndDescription($scope.installer.current.model.telemetryIndex ?? 2);
 
   if ($scope.installer.current.model.minNonAlphaNumericLength > 0) {
     var exp = "";


### PR DESCRIPTION
# Notes
- This PR enables "Detailed" telemetry by default in the installer, instead of Basic.
![image](https://user-images.githubusercontent.com/70372949/223410336-2b40c1d9-03a6-4451-ac22-f772186a8b6b.png)

# How to test
- Run the installer
- Assert that the chosen telemetry level is "Detailed" by default