### PR TITLE
Prioritise surface controller requests highest

### DIFF
--- a/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -64,6 +64,7 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddSingleton<IUmbracoVirtualPageRoute, UmbracoVirtualPageRoute>();
         builder.Services.AddSingleton<IUmbracoRouteValuesFactory, UmbracoRouteValuesFactory>();
         builder.Services.AddSingleton<IRoutableDocumentFilter, RoutableDocumentFilter>();
+        builder.Services.AddSingleton<MatcherPolicy, SurfaceControllerMatcherPolicy>();
 
         builder.Services.AddSingleton<FrontEndRoutes>();
 

--- a/src/Umbraco.Web.Website/Routing/SurfaceControllerMatcherPolicy.cs
+++ b/src/Umbraco.Web.Website/Routing/SurfaceControllerMatcherPolicy.cs
@@ -40,10 +40,10 @@ internal class SurfaceControllerMatcherPolicy : MatcherPolicy, IEndpointSelector
             return Task.CompletedTask;
         }
 
-        int surfaceControllerIndex = GetSurfaceControllerCandidateIndex(candidates);
-        if (surfaceControllerIndex >= 0)
+        int? surfaceControllerIndex = GetSurfaceControllerCandidateIndex(candidates);
+        if (surfaceControllerIndex.HasValue)
         {
-            HashSet<string> allowedHttpMethods = GetAllowedHttpMethods(candidates[surfaceControllerIndex]);
+            HashSet<string> allowedHttpMethods = GetAllowedHttpMethods(candidates[surfaceControllerIndex.Value]);
 
             if (allowedHttpMethods.Any()
                 && allowedHttpMethods.Contains(httpContext.Request.Method) is false)
@@ -55,7 +55,7 @@ internal class SurfaceControllerMatcherPolicy : MatcherPolicy, IEndpointSelector
             else
             {
                 // Otherwise we invalidate all other endpoints than the surface controller that matched.
-                InvalidateAllCandidatesExceptIndex(candidates, surfaceControllerIndex);
+                InvalidateAllCandidatesExceptIndex(candidates, surfaceControllerIndex.Value);
             }
         }
 
@@ -79,7 +79,7 @@ internal class SurfaceControllerMatcherPolicy : MatcherPolicy, IEndpointSelector
         return surfaceControllerAllowedHttpMethods;
     }
 
-    private static int GetSurfaceControllerCandidateIndex(CandidateSet candidates)
+    private static int? GetSurfaceControllerCandidateIndex(CandidateSet candidates)
     {
         for (var i = 0; i < candidates.Count; i++)
         {
@@ -94,7 +94,7 @@ internal class SurfaceControllerMatcherPolicy : MatcherPolicy, IEndpointSelector
             }
         }
 
-        return -1;
+        return null;
     }
 
     private static void InvalidateAllCandidatesExceptIndex(CandidateSet candidates, int index)

--- a/src/Umbraco.Web.Website/Routing/SurfaceControllerMatcherPolicy.cs
+++ b/src/Umbraco.Web.Website/Routing/SurfaceControllerMatcherPolicy.cs
@@ -1,0 +1,105 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Matching;
+using Umbraco.Cms.Web.Website.Controllers;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Web.Website.Routing;
+
+/// <summary>
+/// Ensures the surface controller requests takes priority over other things like virtual routes.
+/// Also ensures that requests to a surface controller on a virtual route will return 405, like HttpMethodMatcherPolicy ensures for non-virtual route requests.
+/// </summary>
+internal class SurfaceControllerMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy
+{
+    private const string Http405EndpointDisplayName = "405 HTTP Method Not Supported";
+
+    public override int Order { get; } // default order should be okay. Count be everything positive to not conflict with MS policies
+
+    public bool AppliesToEndpoints(IReadOnlyList<Endpoint> endpoints)
+    {
+        // In theory all endpoints can have the query string data for a surface controller
+        return true;
+    }
+
+    public Task ApplyAsync(HttpContext httpContext, CandidateSet candidates)
+    {
+        if (httpContext == null)
+        {
+            throw new ArgumentNullException(nameof(httpContext));
+        }
+
+        if (candidates == null)
+        {
+            throw new ArgumentNullException(nameof(candidates));
+        }
+
+        if (candidates.Count < 2)
+        {
+            return Task.CompletedTask;
+        }
+
+        var surfaceControllerIndex = -1;
+        ISet<string> surfaceControllerAllowedHttpMethods = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < candidates.Count; i++)
+        {
+            CandidateState candidate = candidates[i];
+
+            ControllerActionDescriptor? controllerActionDescriptor =
+                candidate.Endpoint?.Metadata.GetMetadata<ControllerActionDescriptor>();
+
+            if (controllerActionDescriptor?.ControllerTypeInfo.IsType<SurfaceController>() == true)
+            {
+                surfaceControllerIndex = i;
+
+                IHttpMethodMetadata? httpMethodMetadata = candidate.Endpoint?.Metadata.GetMetadata<IHttpMethodMetadata>();
+                if (httpMethodMetadata is not null)
+                {
+                    foreach (var httpMethod in httpMethodMetadata.HttpMethods)
+                    {
+                        surfaceControllerAllowedHttpMethods.Add(httpMethod);
+                    }
+                }
+                break;
+            }
+        }
+
+        if (surfaceControllerIndex >= 0)
+        {
+            if (surfaceControllerAllowedHttpMethods.Any()
+                && surfaceControllerAllowedHttpMethods.Contains(httpContext.Request.Method) is false)
+            {
+                // We need to handle this as a 405 like the HttpMethodMatcherPolicy would do.
+                httpContext.SetEndpoint(CreateRejectEndpoint(surfaceControllerAllowedHttpMethods));
+                httpContext.Request.RouteValues = null!;
+            }
+            else
+            {
+                // Otherwise we invalidate all other endpoints than the surface controller that matched.
+                for (var i = 0; i < candidates.Count; i++)
+                {
+                    if (i != surfaceControllerIndex)
+                    {
+                        candidates.SetValidity(i, false);
+                    }
+                }
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static Endpoint CreateRejectEndpoint(ISet<string> allowedHttpMethods) =>
+        new Endpoint(
+            (context) =>
+            {
+                context.Response.StatusCode = 405;
+
+                context.Response.Headers.Allow = string.Join(", ", allowedHttpMethods);
+
+                return Task.CompletedTask;
+            },
+            EndpointMetadataCollection.Empty,
+            Http405EndpointDisplayName);
+}

--- a/src/Umbraco.Web.Website/Routing/SurfaceControllerMatcherPolicy.cs
+++ b/src/Umbraco.Web.Website/Routing/SurfaceControllerMatcherPolicy.cs
@@ -25,15 +25,8 @@ internal class SurfaceControllerMatcherPolicy : MatcherPolicy, IEndpointSelector
 
     public Task ApplyAsync(HttpContext httpContext, CandidateSet candidates)
     {
-        if (httpContext == null)
-        {
-            throw new ArgumentNullException(nameof(httpContext));
-        }
-
-        if (candidates == null)
-        {
-            throw new ArgumentNullException(nameof(candidates));
-        }
+        ArgumentNullException.ThrowIfNull(nameof(httpContext));
+        ArgumentNullException.ThrowIfNull(nameof(candidates));
 
         if (candidates.Count < 2)
         {
@@ -83,14 +76,16 @@ internal class SurfaceControllerMatcherPolicy : MatcherPolicy, IEndpointSelector
     {
         for (var i = 0; i < candidates.Count; i++)
         {
-            CandidateState candidate = candidates[i];
-
-            ControllerActionDescriptor? controllerActionDescriptor =
-                candidate.Endpoint?.Metadata.GetMetadata<ControllerActionDescriptor>();
-
-            if (controllerActionDescriptor?.ControllerTypeInfo.IsType<SurfaceController>() == true)
+            if (candidates.IsValidCandidate(i))
             {
-                return i;
+                CandidateState candidate = candidates[i];
+                ControllerActionDescriptor? controllerActionDescriptor =
+                    candidate.Endpoint?.Metadata.GetMetadata<ControllerActionDescriptor>();
+
+                if (controllerActionDescriptor?.ControllerTypeInfo.IsType<SurfaceController>() == true)
+                {
+                    return i;
+                }
             }
         }
 


### PR DESCRIPTION
Fixed issue mentioned in #13836 

Now surface controller requests always has higher priority than other. So if this is both a surface controller request and a virtual page request, it will execute the surface controller.

This is done using a `SurfaceControllerMatcherPolicy` that will invalidate all other endpoints than the surface controller, if a surface controller matched the request (This should only ever happen, if the magic query string is added)

### Test steps
There are a couple of usecases to test out. Please follow guide here: https://github.com/umbraco/Umbraco-CMS/pull/13919.

We have to test the combinations:

| - | Regular page ('/') | Hijacked page ('/hijacked') | Virtual page ('/demo') with no http verbs | Virtual page ('/demo') with HttpGet |  Virtual page ('/demo') with HttpPost |  Virtual page ('/demo') with HttpGet and HttpPost | 
| ------------- | ------------- | ------------- |------------- |------------ | ------------- |------------- |
| **No http verbs on surface actions** | We expect it to work on both httpGet and httpPost  | We expect it to work on both httpGet and httpPost  | We expect it to work on both httpGet and httpPost | We expect it to work on both httpGet and httpPost  | We expect it to work on both httpGet and httpPost  | We expect it to work on both httpGet and httpPost |
| **HttpGet and HttpPost on surface actions** | We expect it to work on both httpGet and httpPost  | We expect it to work on both httpGet and httpPost  | We expect it to work on both httpGet and httpPost | We expect it to work on both httpGet and httpPost  | We expect it to work on both httpGet and httpPost  | We expect it to work on both httpGet and httpPost |
| **HttpGet on surface actions** | only get should work. post should give 405  | only get should work. post should give 405   | only get should work. post should give 405  | only get should work. post should give 405   | only get should work. post should give 405   | only get should work. post should give 405  |
| **HttpPost on surface actions** | only post should work. get should give 405  | only post should work. get should give 405   | only post should work. get should give 405  | only post should work. get should give 405   | only post should work. get should give 405   | only post should work. get should give 405  |


