### PR TITLE
V12/segment support in published request builder

### DIFF
--- a/src/Umbraco.Core/Routing/IPublishedRequest.cs
+++ b/src/Umbraco.Core/Routing/IPublishedRequest.cs
@@ -61,6 +61,11 @@ public interface IPublishedRequest
     string? Culture { get; }
 
     /// <summary>
+    ///     Gets the content request's segment.
+    /// </summary>
+    string? Segment { get; }
+
+    /// <summary>
     ///     Gets the url to redirect to, when the content request triggers a redirect.
     /// </summary>
     string? RedirectUrl { get; }

--- a/src/Umbraco.Core/Routing/IPublishedRequestBuilder.cs
+++ b/src/Umbraco.Core/Routing/IPublishedRequestBuilder.cs
@@ -32,6 +32,11 @@ public interface IPublishedRequestBuilder
     string? Culture { get; }
 
     /// <summary>
+    ///     Gets the segment (if any)
+    /// </summary>
+    string? Segment { get; }
+
+    /// <summary>
     ///     Gets a value indicating whether the current published content has been obtained
     ///     from the initial published content following internal redirections exclusively.
     /// </summary>
@@ -70,6 +75,11 @@ public interface IPublishedRequestBuilder
     ///     Sets the culture for the request
     /// </summary>
     IPublishedRequestBuilder SetCulture(string? culture);
+
+    /// <summary>
+    ///     Sets the segment for the request
+    /// </summary>
+    IPublishedRequestBuilder SetSegment(string? segment);
 
     /// <summary>
     ///     Sets the found <see cref="IPublishedContent" /> for the request

--- a/src/Umbraco.Core/Routing/PublishedRequest.cs
+++ b/src/Umbraco.Core/Routing/PublishedRequest.cs
@@ -8,6 +8,7 @@ public class PublishedRequest : IPublishedRequest
     /// <summary>
     ///     Initializes a new instance of the <see cref="PublishedRequest" /> class.
     /// </summary>
+    [Obsolete("Use the constructor that includes a segment parameter")]
     public PublishedRequest(
         Uri uri,
         string absolutePathDecoded,
@@ -22,6 +23,40 @@ public class PublishedRequest : IPublishedRequest
         IReadOnlyDictionary<string, string>? headers,
         bool setNoCacheHeader,
         bool ignorePublishedContentCollisions)
+        : this(
+            uri,
+            absolutePathDecoded,
+            publishedContent,
+            isInternalRedirect,
+            template,
+            domain,
+            culture,
+            null,
+            redirectUrl,
+            responseStatusCode,
+            cacheExtensions,
+            headers,
+            setNoCacheHeader,
+            ignorePublishedContentCollisions) { }
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="PublishedRequest" /> class.
+    /// </summary>
+    public PublishedRequest(
+        Uri uri,
+        string absolutePathDecoded,
+        IPublishedContent? publishedContent,
+        bool isInternalRedirect,
+        ITemplate? template,
+        DomainAndUri? domain,
+        string? culture,
+        string? segment,
+        string? redirectUrl,
+        int? responseStatusCode,
+        IReadOnlyList<string>? cacheExtensions,
+        IReadOnlyDictionary<string, string>? headers,
+        bool setNoCacheHeader,
+        bool ignorePublishedContentCollisions)
     {
         Uri = uri ?? throw new ArgumentNullException(nameof(uri));
         AbsolutePathDecoded = absolutePathDecoded ?? throw new ArgumentNullException(nameof(absolutePathDecoded));
@@ -30,6 +65,7 @@ public class PublishedRequest : IPublishedRequest
         Template = template;
         Domain = domain;
         Culture = culture;
+        Segment = segment;
         RedirectUrl = redirectUrl;
         ResponseStatusCode = responseStatusCode;
         CacheExtensions = cacheExtensions;
@@ -61,6 +97,9 @@ public class PublishedRequest : IPublishedRequest
 
     /// <inheritdoc />
     public string? Culture { get; }
+
+    /// <inheritdoc />
+    public string? Segment { get; }
 
     /// <inheritdoc />
     public string? RedirectUrl { get; }

--- a/src/Umbraco.Core/Routing/PublishedRequestBuilder.cs
+++ b/src/Umbraco.Core/Routing/PublishedRequestBuilder.cs
@@ -40,6 +40,9 @@ public class PublishedRequestBuilder : IPublishedRequestBuilder
     public string? Culture { get; private set; }
 
     /// <inheritdoc />
+    public string? Segment { get; private set; }
+
+    /// <inheritdoc />
     public ITemplate? Template { get; private set; }
 
     /// <inheritdoc />
@@ -69,6 +72,7 @@ public class PublishedRequestBuilder : IPublishedRequestBuilder
         Template,
         Domain,
         Culture,
+        Segment,
         _redirectUrl,
         _responseStatus.HasValue ? (int?)_responseStatus : null,
         _cacheExtensions,
@@ -94,6 +98,13 @@ public class PublishedRequestBuilder : IPublishedRequestBuilder
     public IPublishedRequestBuilder SetCulture(string? culture)
     {
         Culture = culture;
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IPublishedRequestBuilder SetSegment(string? segment)
+    {
+        Segment = segment;
         return this;
     }
 

--- a/src/Umbraco.Core/Routing/PublishedRouter.cs
+++ b/src/Umbraco.Core/Routing/PublishedRouter.cs
@@ -177,8 +177,8 @@ public class PublishedRouter : IPublishedRouter
             return result;
         }
 
-        // set the culture -- again, 'cos it might have changed in the event handler
-        SetVariationContext(result.Culture);
+        // set the culture and segment -- again, 'cos it might have changed in the event handler
+        SetVariationContext(result.Culture, result.Segment);
 
         return result;
     }
@@ -202,15 +202,15 @@ public class PublishedRouter : IPublishedRouter
         return request.Build();
     }
 
-    private void SetVariationContext(string? culture)
+    private void SetVariationContext(string? culture, string? segment)
     {
         VariationContext? variationContext = _variationContextAccessor.VariationContext;
-        if (variationContext != null && variationContext.Culture == culture)
+        if (variationContext != null && variationContext.Culture == culture && variationContext.Segment == segment)
         {
             return;
         }
 
-        _variationContextAccessor.VariationContext = new VariationContext(culture);
+        _variationContextAccessor.VariationContext = new VariationContext(culture, segment);
     }
 
     private async Task RouteRequestInternalAsync(IPublishedRequestBuilder builder, bool skipContentFinders = false)
@@ -223,7 +223,7 @@ public class PublishedRouter : IPublishedRouter
         }
 
         // set the culture
-        SetVariationContext(builder.Culture);
+        SetVariationContext(builder.Culture, builder.Segment);
 
         var foundContentByFinders = false;
 
@@ -257,8 +257,8 @@ public class PublishedRouter : IPublishedRouter
             // handle wildcard domains
             HandleWildcardDomains(builder);
 
-            // set the culture  -- again, 'cos it might have changed due to a finder or wildcard domain
-            SetVariationContext(builder.Culture);
+            // set the culture and segment  -- again, 'cos it might have changed due to a finder or wildcard domain
+            SetVariationContext(builder.Culture, builder.Segment);
         }
 
         // trigger the routing request (used to be called Prepared) event - at that point it is still possible to change about anything

--- a/src/Umbraco.Core/Routing/PublishedRouter.cs
+++ b/src/Umbraco.Core/Routing/PublishedRouter.cs
@@ -204,8 +204,15 @@ public class PublishedRouter : IPublishedRouter
 
     private void SetVariationContext(string? culture, string? segment)
     {
+        // Null and Empty should be considered equal (see VariationContext ctor),
+        //   so change the nullability of the parameters
+        culture ??= string.Empty;
+        segment ??= string.Empty;
+
         VariationContext? variationContext = _variationContextAccessor.VariationContext;
-        if (variationContext != null && variationContext.Culture == culture && variationContext.Segment == segment)
+        if (variationContext != null &&
+            variationContext.Culture == culture &&
+            variationContext.Segment == segment)
         {
             return;
         }


### PR DESCRIPTION
### Prerequisites

From (discussion 13594](https://github.com/umbraco/Umbraco-CMS/discussions/13594)

### Description
IPublishedRequestBuilder allows you to set the culture based on the content finders. However the segment cannot be set. If the segment is set, it will get overwritten.

This PR allows the segment to be set just as the culture is.
