### PR TITLE
Extract redirect URL from route values for member logout

### DIFF
--- a/src/Umbraco.Web.Website/Controllers/UmbLoginStatusController.cs
+++ b/src/Umbraco.Web.Website/Controllers/UmbLoginStatusController.cs
@@ -65,7 +65,7 @@ public class UmbLoginStatusController : SurfaceController
     /// <param name="model"></param>
     private void MergeRouteValuesToModel(PostRedirectModel model)
     {
-        if (RouteData.Values.TryGetValue(nameof(PostRedirectModel.RedirectUrl), out var redirectUrl) && redirectUrl != null)
+        if (RouteData.Values.TryGetValue(nameof(PostRedirectModel.RedirectUrl), out var redirectUrl) && redirectUrl is not null)
         {
             model.RedirectUrl = redirectUrl.ToString();
         }

--- a/src/Umbraco.Web.Website/Controllers/UmbLoginStatusController.cs
+++ b/src/Umbraco.Web.Website/Controllers/UmbLoginStatusController.cs
@@ -38,6 +38,8 @@ public class UmbLoginStatusController : SurfaceController
             return CurrentUmbracoPage();
         }
 
+        MergeRouteValuesToModel(model);
+
         var isLoggedIn = HttpContext.User.Identity?.IsAuthenticated ?? false;
 
         if (isLoggedIn)
@@ -55,5 +57,17 @@ public class UmbLoginStatusController : SurfaceController
 
         // Redirect to current page by default.
         return RedirectToCurrentUmbracoPage();
+    }
+
+    /// <summary>
+    ///     We pass in values via encrypted route values so they cannot be tampered with and merge them into the model for use
+    /// </summary>
+    /// <param name="model"></param>
+    private void MergeRouteValuesToModel(PostRedirectModel model)
+    {
+        if (RouteData.Values.TryGetValue(nameof(PostRedirectModel.RedirectUrl), out var redirectUrl) && redirectUrl != null)
+        {
+            model.RedirectUrl = redirectUrl.ToString();
+        }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/13925

### Description

It seems we're not extracting the redirect URL from the route values when handling member logout in the default controllers.

### Testing this PR

1. Create a member.
2. Create a "Login" and a "Login Status" macro, and add them to an RTE on any page.
3. Modify the "Login Status" macro template to have a different redirect URL than the page it resides on.
![image](https://user-images.githubusercontent.com/7405322/223974031-f9c4f506-36a7-4875-8920-ab2acf007a54.png)
4. Perform login and subsequent logout with the created member (logout is handled by the "Login Status" macro).
5. Verify that you're redirected to the assigned redirect URL upon successful logout.
