### PR TITLE
update block label not assigning fixes: #13833

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -641,7 +641,7 @@
                 };
 
                 // first time instant update of label.
-                blockObject.label = blockObject.content?.contentTypeName || "";
+                blockObject.label = (blockObject.config.label || blockObject.content?.contentTypeName) ?? "" ;
                 blockObject.index = 0;
 
                 if (blockObject.config.label && blockObject.config.label !== "" && blockObject.config.unsupported !== true) {


### PR DESCRIPTION
Fixes #13833 

Assigns the config label as the first instance, if this is not set (left empty) then uses the contenttype name of the block. If that fails, which is unlikely, will default to an empty string to prevent failure elsewhere.
