### PR TITLE
Add skip links to header

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -878,6 +878,8 @@
     <key alias="header">Header</key>
     <key alias="systemField">system field</key>
     <key alias="lastUpdated">Last Updated</key>
+    <key alias="skipToMenu">Skip to menu</key>
+    <key alias="skipToContent">Skip to content</key>
   </area>
   <area alias="colors">
     <key alias="blue">Blue</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -908,6 +908,8 @@
     <key alias="header">Header</key>
     <key alias="systemField">system field</key>
     <key alias="lastUpdated">Last Updated</key>
+    <key alias="skipToMenu">Skip to menu</key>
+    <key alias="skipToContent">Skip to content</key>
   </area>
   <area alias="colors">
     <key alias="blue">Blue</key>

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbappheader.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbappheader.directive.js
@@ -127,6 +127,20 @@
                 }
             };
 
+            scope.skipToMenu = function() {
+                document.querySelector('#applications a').focus();
+            };
+
+            scope.skipToContent = function() {
+                var focusableElements = document.querySelectorAll('.umb-app-content a, .umb-app-content button');
+                for(var i=0; i < focusableElements.length; i++){
+                    if(focusableElements[i].offsetParent !== null) {
+                        focusableElements[i].focus();
+                        break;
+                    }
+                }
+            };
+
         }
 
         var directive = {

--- a/src/Umbraco.Web.UI.Client/src/less/components/application/umb-app-header.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/application/umb-app-header.less
@@ -123,7 +123,7 @@
     overflow: hidden;
     clip: rect(1px,1px,1px,1px);
     border-radius: 3px;
-    z-index: 100;
+    z-index: 1;
 }
 
 .umb-app-header__skip-button:focus {

--- a/src/Umbraco.Web.UI.Client/src/less/components/application/umb-app-header.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/application/umb-app-header.less
@@ -110,3 +110,27 @@
 .umb-app-header__button:focus .umb-app-header__action-icon {
     opacity: 1;
 }
+
+.umb-app-header__skip-button {
+    position: absolute;
+    top: 7.5px;
+    left: 5px;
+    background-color: #FFF;
+    border: 1px solid #000;
+    display: block;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    clip: rect(1px,1px,1px,1px);
+    border-radius: 3px;
+    z-index: 100;
+}
+
+.umb-app-header__skip-button:focus {
+    height: auto;
+    width: auto;
+    clip: auto;
+    padding: 10px;
+    line-height: normal;
+    text-decoration: none;
+}

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-app-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-app-header.html
@@ -1,5 +1,9 @@
 <div>
     <div class="umb-app-header">
+
+        <button type="button" class="umb-app-header__skip-button" ng-click="skipToMenu()"><localize key="general_skipToMenu">Go to menu</localize></button>
+        <button type="button" class="umb-app-header__skip-button" ng-click="skipToContent()"><localize key="general_skipToContent">Go to content</localize></button>
+
         <div class="umb-app-header__logo" ng-if="hideBackofficeLogo !== true">
             <button type="button"
                     id="umbraco-logo-mark"


### PR DESCRIPTION
### Prerequisites

This issue resolves https://github.com/umbraco/Umbraco-CMS.Accessibility.Issues/issues/15

### Description

This PR adds skip links to the header to allow users to skip to the menu and main content.

![umbraco-skip-links](https://user-images.githubusercontent.com/1424517/224045784-ab08ba5f-6954-4297-9093-91f73e36f23b.gif)

To test the change tab through the website and select each skip link. "Skip to menu" will skip the user to the first navigation link and "Skip to content" the user to the first visible focusable element in the main content.  On pages where there is a left column, this will focus on the first element in the left column. On pages where there is no left column (like Packages), it will focus on the first focusable element in the main column.

I had to use buttons instead of links (you would normally use links for skip links that anchor to ids), because the angular routing in Umbraco uses hashes and these were being intercepted.

I debated about the placement of these links. I tried pushing the navigation right when they are focused, however this meant the navigation was partly pushed off screen on certain viewports sizes. I also considered pushing the content down (I've seen this on some websites), however the main content in Umbraco is absolutely positioned.

W3 reference:
https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html