### PR TITLE
Solves tooltip issue for block column editor on remove block column e…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/umb-block-grid-column-editor-option.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/umb-block-grid-column-editor-option.html
@@ -5,7 +5,7 @@
             {{vm.columnSpanOption.columnSpan}}
         </span>
         <div class="__border"></div>
-        <button type="button" class="btn-reset" ng-click="vm.onClickRemove()">
+        <button type="button" ng-attr-title="{{vm.removeLabel}}" class="btn-reset" ng-click="vm.onClickRemove()">
             <span class="sr-only">
                 <localize key="general_remove">Remove</localize>
             </span>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/umbBlockGridColumnEditorOption.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/umbBlockGridColumnEditorOption.component.js
@@ -23,9 +23,13 @@
             }
         });
 
-    function BlockGridColumnOptionController() {
+    function BlockGridColumnOptionController(localizationService) {
 
-        var vm = this;
+      var vm = this;
+
+      localizationService.localize("general_remove").then(function (value) {
+        vm.removeLabel = value;
+      })
 
         vm.$onInit = function() {
 


### PR DESCRIPTION
…ditor option



If there's an existing issue for this PR then this fixes <!-- link to the issue here! --> Fixes issue #13187

Injected the localisation service into the block column edit option and added an ng-attr-title which renders a tooltip for the element in the localised language to the element. Issued solved with @Bakersbakebread 