### PR TITLE
New Sections Notification

### DIFF
--- a/src/Umbraco.Core/Notifications/SendingSectionsNotification.cs
+++ b/src/Umbraco.Core/Notifications/SendingSectionsNotification.cs
@@ -1,0 +1,17 @@
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Web;
+
+namespace Umbraco.Cms.Core.Notifications;
+
+public class SendingSectionsNotification : INotification
+{
+    public SendingSectionsNotification(IEnumerable<Section> sections, IUmbracoContext umbracoContext)
+    {
+        Sections = sections;
+        UmbracoContext = umbracoContext;
+    }
+
+    public IUmbracoContext UmbracoContext { get; }
+
+    public IEnumerable<Section> Sections { get; set; }
+}

--- a/src/Umbraco.Web.BackOffice/Controllers/SectionController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/SectionController.cs
@@ -13,6 +13,7 @@ using Umbraco.Cms.Core.Sections;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Trees;
+using Umbraco.Cms.Web.BackOffice.Filters;
 using Umbraco.Cms.Web.BackOffice.Trees;
 using Umbraco.Cms.Web.Common.Attributes;
 using Umbraco.Extensions;
@@ -54,6 +55,8 @@ public class SectionController : UmbracoAuthorizedJsonController
         _actionDescriptorCollectionProvider = actionDescriptorCollectionProvider;
     }
 
+    [ValidateAngularAntiForgeryToken]
+    [OutgoingEditorModelEvent]
     public async Task<ActionResult<IEnumerable<Section>>> GetSections()
     {
         IEnumerable<ISection> sections =

--- a/src/Umbraco.Web.BackOffice/Filters/OutgoingEditorModelEventAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/OutgoingEditorModelEventAttribute.cs
@@ -124,11 +124,16 @@ internal sealed class OutgoingEditorModelEventAttribute : TypeFilterAttribute
                             case IEnumerable<Tab<IDashboardSlim>> dashboards:
                                 _eventAggregator.Publish(new SendingDashboardsNotification(dashboards, umbracoContext));
                                 break;
+                            case IEnumerable<Section> sections:
+                                var sectionsNotification = new SendingSectionsNotification(sections, umbracoContext);
+                                _eventAggregator.Publish(sectionsNotification);
+                                context.Result = new ObjectResult(sectionsNotification.Sections);
+                                break;
                             case IEnumerable<ContentTypeBasic> allowedChildren:
                                 // Changing the Enumerable will generate a new instance, so we need to update the context result with the new content
-                                var notification = new SendingAllowedChildrenNotification(allowedChildren, umbracoContext);
-                                _eventAggregator.Publish(notification);
-                                context.Result = new ObjectResult(notification.Children);
+                                var allowedChildrenNotification = new SendingAllowedChildrenNotification(allowedChildren, umbracoContext);
+                                _eventAggregator.Publish(allowedChildrenNotification);
+                                context.Result = new ObjectResult(allowedChildrenNotification.Children);
                                 break;
                         }
                     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below


### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

Created a notification handler to backoffice Sections, the notification occurs on the GetSections from Sections controller, and is processed by the OutgoingEditorModelEventAttribute script.

My motivation was to create a way to remove some sections from the backoffice dashboard by a custom arbirtary rule, independently of the user permissions.

To test this create a new public class the inherits from `INotificationHandler<SendingSectionsNotification>` and manipulate the `notification.Sections` property, example:

```
public class SendingSectionHandler : INotificationHandler<SendingSectionsNotification>
{
    public void Handle(SendingSectionsNotification notification)
    {
        notification.Sections = notification.Sections.Where(a => a.Alias != "forms");
    }
}
```
The code above removes the Form section from the backoffice dashboard.

Then add this new class to the builder notification handler in the Startup.cs or in a custom composer using `builder.AddNotificationHandler<SendingSectionsNotification, SendingSectionHandler>();`.

For simple test, you can do this on the `src\Umbraco.Web.UI.Client` project, using the existent `Composers/ControllersAsServicesComposer.cs` file as this:

```
using Microsoft.AspNetCore.Mvc.Controllers;
using Microsoft.Extensions.DependencyInjection.Extensions;
using Microsoft.Extensions.Options;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Configuration.Models;
using Umbraco.Cms.Core.DependencyInjection;
using Umbraco.Cms.Core.Notifications;
using Umbraco.Cms.Core.Web;
using Umbraco.Cms.Web.Website.Controllers;
using Umbraco.Cms.Core.Events;

using Umbraco.Extensions;
using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;

namespace Umbraco.Cms.Web.UI.Composers
{
    // New class to test the Sending Section Notification
    public class SendingSectionHandler : INotificationHandler<SendingSectionsNotification>
    {
        public void Handle(SendingSectionsNotification notification)
        {
            notification.Sections = notification.Sections.Where(a => a.Alias != "forms");
        }
    }

    public class ControllersAsServicesComposer : IComposer
    {
        public void Compose(IUmbracoBuilder builder){

        // Add the new notification class above into the builder notifications list
        builder.AddNotificationHandler<SendingSectionsNotification, SendingSectionHandler>();

        builder.Services
            .AddMvc()
            .AddControllersAsServicesWithoutChangingActivator();
        }
    }

    internal static class MvcBuilderExtensions
    {
        public static IMvcBuilder AddControllersAsServicesWithoutChangingActivator(this IMvcBuilder builder)
        {
            var feature = new ControllerFeature();
            builder.PartManager.PopulateFeature(feature);

            foreach (Type controller in feature.Controllers.Select(c => c.AsType()))
            {
                builder.Services.TryAddTransient(controller, controller);
            }

            builder.Services.AddUnique<RenderNoContentController>(x => new RenderNoContentController(x.GetService<IUmbracoContextAccessor>()!, x.GetService<IOptionsSnapshot<GlobalSettings>>()!, x.GetService<IHostingEnvironment>()!));
            return builder;
        }
    }
}
```

The dashboard should change from this:
![image](https://user-images.githubusercontent.com/14986428/224459654-c53742bc-76a2-43c1-a2c5-60b5d40afd8f.png)

To this one without the forms:
![image](https://user-images.githubusercontent.com/14986428/224459939-bbe2246d-e71d-4eb5-ad1a-922f47d9d40e.png)

Cheers! :)

<!-- Thanks for contributing to Umbraco CMS! -->

#