### PR TITLE
Add setting to disable domain warnings

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/ContentSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ContentSettings.cs
@@ -158,6 +158,7 @@ public class ContentSettings
     internal const bool StaticDisableDeleteWhenReferenced = false;
     internal const bool StaticDisableUnpublishWhenReferenced = false;
     internal const bool StaticAllowEditInvariantFromNonDefault = false;
+    internal const bool StaticShowDomainWarnings = true;
 
     /// <summary>
     ///     Gets or sets a value for the content notification settings.
@@ -267,4 +268,9 @@ public class ContentSettings
     /// Gets or sets the allowed external host for media. If empty only relative paths are allowed.
     /// </summary>
     public string[] AllowedMediaHosts { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show domain warnings.
+    /// </summary>
+    public bool ShowDomainWarnings { get; set; } = StaticShowDomainWarnings;
 }

--- a/src/Umbraco.Core/Configuration/Models/ContentSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ContentSettings.cs
@@ -272,5 +272,6 @@ public class ContentSettings
     /// <summary>
     /// Gets or sets a value indicating whether to show domain warnings.
     /// </summary>
+    [DefaultValue(StaticShowDomainWarnings)]
     public bool ShowDomainWarnings { get; set; } = StaticShowDomainWarnings;
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.BackOffice/Controllers/ContentControllerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.BackOffice/Controllers/ContentControllerTests.cs
@@ -4,9 +4,11 @@ using System.Globalization;
 using System.Linq;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Dictionary;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Mapping;
@@ -266,7 +268,8 @@ public class ContentControllerTests
             Mock.Of<ICoreScopeProvider>(),
             Mock.Of<IAuthorizationService>(),
             Mock.Of<IContentVersionService>(),
-            Mock.Of<ICultureImpactFactory>());
+            Mock.Of<ICultureImpactFactory>(),
+            new OptionsWrapper<ContentSettings>(new ContentSettings()));
 
         return controller;
     }


### PR DESCRIPTION
Adds a setting to disable the domain warnings. 


# Testing 
1. Add a couple of languages
2. Create a document type that varies by language
3. Try publishing a couple of languages without having set domains up 
4. Ensure that the warnings are shown if the setting is enabled, and that they aren't when it's disabled.