### PR TITLE
V13: Add default superuser key

### DIFF
--- a/src/Umbraco.Core/Constants-Security.cs
+++ b/src/Umbraco.Core/Constants-Security.cs
@@ -9,6 +9,9 @@ public static partial class Constants
         /// </summary>
         public const int SuperUserId = -1;
 
+        /// <summary>
+        /// Gets the unique key of the 'super' user.
+        /// </summary>
         public static readonly Guid SuperUserKey = new("1E70F841-C261-413B-ABB2-2D68CDB96094");
 
         public const string SuperUserIdAsString = "-1";

--- a/src/Umbraco.Core/Constants-Security.cs
+++ b/src/Umbraco.Core/Constants-Security.cs
@@ -7,6 +7,7 @@ public static partial class Constants
         /// <summary>
         ///     Gets the identifier of the 'super' user.
         /// </summary>
+        [Obsolete("Use SuperUserKey instead. Scheduled for removal in V15.")]
         public const int SuperUserId = -1;
 
         /// <summary>
@@ -14,6 +15,7 @@ public static partial class Constants
         /// </summary>
         public static readonly Guid SuperUserKey = new("1E70F841-C261-413B-ABB2-2D68CDB96094");
 
+        [Obsolete("Use SuperUserKey instead. Scheduled for removal in V15.")]
         public const string SuperUserIdAsString = "-1";
 
         /// <summary>

--- a/src/Umbraco.Core/Constants-Security.cs
+++ b/src/Umbraco.Core/Constants-Security.cs
@@ -9,6 +9,8 @@ public static partial class Constants
         /// </summary>
         public const int SuperUserId = -1;
 
+        public static readonly Guid SuperUserKey = new("1E70F841-C261-413B-ABB2-2D68CDB96094");
+
         public const string SuperUserIdAsString = "-1";
 
         /// <summary>

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
@@ -1152,7 +1152,7 @@ internal class DatabaseDataCreator
         new UserDto
         {
             Id = Constants.Security.SuperUserId,
-            Key = new Guid("1E70F841-C261-413B-ABB2-2D68CDB96094"),
+            Key = Constants.Security.SuperUserKey,
             Disabled = false,
             NoConsole = false,
             UserName = "Administrator",

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_0_0/AddGuidsToUsers.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_0_0/AddGuidsToUsers.cs
@@ -44,21 +44,21 @@ public class AddGuidsToUsers : UnscopedMigrationBase
     {
         var columns = SqlSyntax.GetColumnsInSchema(Context.Database).ToList();
         AddColumnIfNotExists<UserDto>(columns, NewColumnName);
-        List<UserDto>? dtos = Database.Fetch<UserDto>();
-        if (dtos is null)
+        List<UserDto>? userDtos = Database.Fetch<UserDto>();
+        if (userDtos is null)
         {
             return;
         }
 
-        UserDto? superUser = dtos.Where(x => x.Id == -1).FirstOrDefault();
+        UserDto? superUser = userDtos.FirstOrDefault(x => x.Id == -1);
         if (superUser is not null)
         {
             superUser.Key = Constants.Security.SuperUserKey;
             Database.Update(superUser);
         }
 
-        MigrateExternalLogins(dtos);
-        MigrateTwoFactorLogins(dtos);
+        MigrateExternalLogins(userDtos);
+        MigrateTwoFactorLogins(userDtos);
     }
 
     private void MigrateSqlite()

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_0_0/AddGuidsToUsers.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_0_0/AddGuidsToUsers.cs
@@ -50,6 +50,13 @@ public class AddGuidsToUsers : UnscopedMigrationBase
             return;
         }
 
+        UserDto? superUser = dtos.Where(x => x.Id == -1).FirstOrDefault();
+        if (superUser is not null)
+        {
+            superUser.Key = Constants.Security.SuperUserKey;
+            Database.Update(superUser);
+        }
+
         MigrateExternalLogins(dtos);
         MigrateTwoFactorLogins(dtos);
     }
@@ -78,7 +85,7 @@ public class AddGuidsToUsers : UnscopedMigrationBase
         List<UserDto> users = Database.Fetch<OldUserDto>().Select(x => new UserDto
         {
             Id = x.Id,
-            Key = Guid.NewGuid(),
+            Key = x.Id is -1 ? Constants.Security.SuperUserKey : Guid.NewGuid(),
             Disabled = x.Disabled,
             NoConsole = x.NoConsole,
             UserName = x.UserName,


### PR DESCRIPTION
# Notes
- Added new Super user key constant
- Update existing super usey key with constant

# How to test
- Install umbraco 11/12
- Checkout this branch
- Run the migration
- Assert the user now has key `1E70F841-C261-413B-ABB2-2D68CDB96094` in the umbracoUser table