### PR TITLE
Add allow list for absolute urls

### DIFF
--- a/src/Umbraco.Core/Configuration/UmbracoSettings/ContentElement.cs
+++ b/src/Umbraco.Core/Configuration/UmbracoSettings/ContentElement.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Configuration;
 using Umbraco.Core.Macros;
 
@@ -34,6 +35,9 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
         [ConfigurationProperty("disallowedUploadFiles")]
         internal CommaDelimitedConfigurationElement DisallowedUploadFiles => GetOptionalDelimitedElement("disallowedUploadFiles", new[] {"ashx", "aspx", "ascx", "config", "cshtml", "vbhtml", "asmx", "air", "axd", "xamlx"});
 
+        [ConfigurationProperty("allowedMediaHosts")]
+        internal CommaDelimitedConfigurationElement AllowedMediaHosts => GetOptionalDelimitedElement("allowedMediaHosts", new string[0]);
+
         [ConfigurationProperty("allowedUploadFiles")]
         internal CommaDelimitedConfigurationElement AllowedUploadFiles => GetOptionalDelimitedElement("allowedUploadFiles", new string[0]);
 
@@ -48,6 +52,7 @@ namespace Umbraco.Core.Configuration.UmbracoSettings
 
         [ConfigurationProperty("hideBackofficeLogo")]
         internal InnerTextConfigurationElement<bool> HideBackOfficeLogo => GetOptionalTextElement("hideBackofficeLogo", false);
+
 
         string IContentSection.NotificationEmailAddress => Notifications.NotificationEmailAddress;
 

--- a/src/Umbraco.Web/Editors/ImagesController.cs
+++ b/src/Umbraco.Web/Editors/ImagesController.cs
@@ -114,8 +114,6 @@ namespace Umbraco.Web.Editors
                 }
             }
 
-
-
             return false;
         }
     }


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/12200 by adding an list of allowed media hosts in content settings.