### PR TITLE
Fixed issue where Block Grid elements in areas cannot be properly filtered

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbBlockGridPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbBlockGridPropertyEditor.component.js
@@ -708,7 +708,7 @@
                         } else 
                         if(allowance.elementTypeKey) {
                             const blockType = vm.availableBlockTypes.find(x => x.blockConfigModel.contentElementTypeKey === allowance.elementTypeKey);
-                            if(allowedElementTypes.indexOf(blockType) === -1) {
+                            if(blockType && allowedElementTypes.indexOf(blockType) === -1) {
                                 allowedElementTypes.push(blockType);
                             }
                         }


### PR DESCRIPTION
We ran into this issue while playing with a NotificationHandler to filter allowed element types.

When `vm.availableBlockTypes` doesn't contain an element type that an area specifically references, the old code would just add an `undefined` to the `allowedElementTypes`. This causes the "add content" overlay to not open anymore.