### PR TITLE
Use correct listenAddress for Karma on node 18+

### DIFF
--- a/src/Umbraco.Web.UI.Client/test/config/karma.conf.js
+++ b/src/Umbraco.Web.UI.Client/test/config/karma.conf.js
@@ -79,6 +79,9 @@ module.exports = function (config) {
     // CLI --runner-port 9100
     runnerPort: 9100,
 
+    // Add support for new DNS resolution in Node 17+
+    listenAddress: '::',
+
     // enable / disable colors in the output (reporters and logs)
     // CLI --colors --no-colors
     colors: true,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

From Node.js 17 DNS resolution is different, causing the Karma server to listen to the wrong address by default. This breaks Umbraco's gulp test tasks and default gulp build.

Telling the karma server to listen on `::` fixes the problem - as per [the issue on the Karma repo](https://github.com/karma-runner/karma/issues/3730). This change is backwards compatible down to (at least) Node.js v14 so doesn't change version requirements for Umbraco 🎉

To test: run `gulp build` from `/src/Umbraco.Web.UI.Client` on any version from Node.js from 14+

I've tested on 14, 16, 18 and 19

Once this is merged, it would be worth checking if HQ can bump the Node.js version in the pipelines to latest LTS.