### PR TITLE
Added sort audit to nodes actually being sorted

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -2932,6 +2932,7 @@ public class ContentService : RepositoryService, IContentService
             // save
             saved.Add(content);
             _documentRepository.Save(content);
+            Audit(AuditType.Sort, userId, content.Id, "Sorting content performed by user");
         }
 
         // first saved, then sorted
@@ -2947,8 +2948,7 @@ public class ContentService : RepositoryService, IContentService
         {
             scope.Notifications.Publish(new ContentPublishedNotification(published, eventMessages));
         }
-
-        Audit(AuditType.Sort, userId, 0, "Sorting content performed by user");
+        
         return OperationResult.Succeed(eventMessages);
     }
 


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

Fix to the following issue: https://github.com/umbraco/Umbraco-CMS/issues/13977

### Description
With the PR the sort audit is being tracked on the nodes actually being sorted instead of just id 0 as before.

This means that you can now see the sort audit on the history of the nodes.

![image](https://user-images.githubusercontent.com/2575817/226359698-d647923b-19b8-4005-9639-1ec1ea574122.png)

