### PR TITLE
Add a constant for each property with ModelsBuilder

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/ModelsBuilderSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ModelsBuilderSettings.cs
@@ -15,6 +15,7 @@ public class ModelsBuilderSettings
     internal const string StaticModelsMode = "InMemoryAuto";
     internal const string StaticModelsDirectory = "~/umbraco/models";
     internal const bool StaticAcceptUnsafeModelsDirectory = false;
+    internal const bool StaticGeneratePropertyAliasConstants = false;
     internal const int StaticDebugLevel = 0;
     private bool _flagOutOfDateModels = true;
 
@@ -72,6 +73,15 @@ public class ModelsBuilderSettings
     /// </remarks>
     [DefaultValue(StaticAcceptUnsafeModelsDirectory)]
     public bool AcceptUnsafeModelsDirectory { get; set; } = StaticAcceptUnsafeModelsDirectory;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to generate constants for property aliases.
+    /// </summary>
+    /// <remarks>
+    /// When turned on, certain combinations of property aliases can cause compile errors on the generated models.
+    /// </remarks>
+    [DefaultValue(StaticGeneratePropertyAliasConstants)]
+    public bool GeneratePropertyAliasConstants { get; set; } = StaticGeneratePropertyAliasConstants;
 
     /// <summary>
     ///     Gets or sets a value indicating the debug log level.

--- a/src/Umbraco.Infrastructure/ModelsBuilder/Building/TextBuilder.cs
+++ b/src/Umbraco.Infrastructure/ModelsBuilder/Building/TextBuilder.cs
@@ -346,6 +346,15 @@ public class TextBuilder : Builder
     {
         sb.Append("\n");
 
+        if (Config.GeneratePropertyAliasConstants)
+        {
+            WriteGeneratedCodeAttribute(sb, "\t\t");
+            sb.AppendFormat(
+                "\t\tpublic const string {0} = \"{1}\";\n\n",
+                property.ClrName + "Alias",
+                property.Alias);
+        }
+
         // Adds xml summary to each property containing
         // property name and property description
         if (!string.IsNullOrWhiteSpace(property.Name) || !string.IsNullOrWhiteSpace(property.Description))
@@ -419,6 +428,15 @@ public class TextBuilder : Builder
 
             sb.Append("\t\t *\n");
             sb.Append("\n");
+        }
+
+        if (Config.GeneratePropertyAliasConstants)
+        {
+            WriteGeneratedCodeAttribute(sb, "\t\t");
+            sb.AppendFormat(
+                "\t\tpublic const string {0} = \"{1}\";\n\n",
+                property.ClrName + "Alias",
+                property.Alias);
         }
 
         // Adds xml summary to each property containing


### PR DESCRIPTION
In response to #13994. With very few changes, generated models will now contain a constant for each property:

![image](https://user-images.githubusercontent.com/869973/226675847-77e7d5e1-d160-4638-b04e-418478d29588.png)

EDIT: After the force-push this image is outdated, it will now **just** add constants. Not replace the strings in the getter/attribute. It's also on opt-in basis through a setting as something interesting was pointed out by @leekelleher.

This will prevent developers from having to create generators (additional work) and/or add their own constants (hard to maintain) and/or extension methods (performance).