### PR TITLE
Issue-13948: Added unpublish call for published content moving to recycle bin

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.DependencyInjection;
@@ -2398,8 +2399,16 @@ public class ContentService : RepositoryService, IContentService
             // if it's published we may want to force-unpublish it - that would be backward-compatible... but...
             // making a radical decision here: trashing is equivalent to moving under an unpublished node so
             // it's NOT unpublishing, only the content is now masked - allowing us to restore it if wanted
-            // if (content.HasPublishedVersion)
-            // { }
+            if (content.PublishedState == PublishedState.Published)
+            {
+                var result = Unpublish(content, userId: userId);
+
+                if (result.Result != PublishResultType.SuccessUnpublish)
+                {
+                    _logger.LogError($"Failed to unpublish content with id {content.Id} while moving to recycle bin.");
+                }
+            }
+
             PerformMoveLocked(content, Constants.System.RecycleBinContent, null, userId, moves, true);
             scope.Notifications.Publish(
                 new ContentTreeChangeNotification(content, TreeChangeTypes.RefreshBranch, eventMessages));


### PR DESCRIPTION
### Prerequisites

This pr fixes: https://github.com/umbraco/Umbraco-CMS/issues/13948

### Description
In the MoveToRecycleBin method a check has been added to see if content is published. If content is published it a new call to the Unpublish method is made. This makes sure that any content moving to the recycle bin is no longer published. This should fix the issue where content has that status `published` while sitting in the recycle bin. This is also more consistent because currently any content that is restored is unpublished. 

Result
![UnpublishWhenRecycling](https://user-images.githubusercontent.com/77411834/226942226-caad8e8c-ad74-4855-b783-5e9aec14f128.gif)

I've left in the comment above my added code for the purpose of discussion. I'm not sure if unpublishing while moving it to the recycle bin is necessary or desired. It wasn't very clear to me what "masked" means in the context of moving a node under an unpublished node. I assume that it means that the recycle bin acts like an unpublished node that hides it's descendants.   