### PR TITLE
New Backoffice: Fix total number of items (health checks, log viewer, packages)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,7 +38,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" IsImplicitlyDefined="true" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.113" PrivateAssets="all" IsImplicitlyDefined="true" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.119" PrivateAssets="all" IsImplicitlyDefined="true" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406" PrivateAssets="all" IsImplicitlyDefined="true" />
     <PackageReference Include="Umbraco.Code" Version="2.0.0" PrivateAssets="all" IsImplicitlyDefined="true" />
     <PackageReference Include="Umbraco.GitVersioning.Extensions" Version="0.2.0" PrivateAssets="all" IsImplicitlyDefined="true" />

--- a/src/Umbraco.Cms.Api.Management/Controllers/HealthCheck/Group/AllHealthCheckGroupController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/HealthCheck/Group/AllHealthCheckGroupController.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.Factories;
-using Umbraco.Cms.Api.Management.Mapping.HealthCheck;
 using Umbraco.Cms.Api.Management.ViewModels.HealthCheck;
 using Umbraco.Cms.Core.Mapping;
 
@@ -32,11 +31,16 @@ public class AllHealthCheckGroupController : HealthCheckGroupControllerBase
     [ProducesResponseType(typeof(PagedViewModel<HealthCheckGroupResponseModel>), StatusCodes.Status200OK)]
     public async Task<ActionResult<PagedViewModel<HealthCheckGroupResponseModel>>> All(int skip = 0, int take = 100)
     {
-        IEnumerable<IGrouping<string?, Core.HealthChecks.HealthCheck>> groups = _healthCheckGroupPresentationFactory
+        IGrouping<string?, Core.HealthChecks.HealthCheck>[] groups = _healthCheckGroupPresentationFactory
             .CreateGroupingFromHealthCheckCollection()
-            .Skip(skip)
-            .Take(take);
+            .ToArray();
 
-        return await Task.FromResult(Ok(_umbracoMapper.Map<PagedViewModel<HealthCheckGroupResponseModel>>(groups)));
+        var viewModel = new PagedViewModel<HealthCheckGroupResponseModel>
+        {
+            Total = groups.Length,
+            Items = _umbracoMapper.MapEnumerable<IGrouping<string?, Core.HealthChecks.HealthCheck>, HealthCheckGroupResponseModel>(groups.Skip(skip).Take(take))
+        };
+
+        return await Task.FromResult(Ok(viewModel));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/AllLogViewerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/AllLogViewerController.cs
@@ -55,7 +55,13 @@ public class AllLogViewerController : LogViewerControllerBase
 
         if (logsAttempt.Success)
         {
-            return Ok(_umbracoMapper.Map<PagedViewModel<LogMessageResponseModel>>(logsAttempt.Result));
+            var viewModel = new PagedViewModel<LogMessageResponseModel>
+            {
+                Total = logsAttempt.Result!.Total,
+                Items = _umbracoMapper.MapEnumerable<ILogEntry, LogMessageResponseModel>(logsAttempt.Result.Items)
+            };
+
+            return Ok(viewModel);
         }
 
         return LogViewerOperationStatusResult(logsAttempt.Status);

--- a/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/AllSinkLevelLogViewerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/AllSinkLevelLogViewerController.cs
@@ -30,11 +30,16 @@ public class AllSinkLevelLogViewerController : LogViewerControllerBase
     [ProducesResponseType(typeof(PagedViewModel<LoggerResponseModel>), StatusCodes.Status200OK)]
     public async Task<ActionResult<PagedViewModel<LoggerResponseModel>>> AllLogLevels(int skip = 0, int take = 100)
     {
-        IEnumerable<KeyValuePair<string, LogLevel>> logLevels = _logViewerService
+        KeyValuePair<string, LogLevel>[] logLevels = _logViewerService
             .GetLogLevelsFromSinks()
-            .Skip(skip)
-            .Take(take);
+            .ToArray();
 
-        return await Task.FromResult(Ok(_umbracoMapper.Map<PagedViewModel<LoggerResponseModel>>(logLevels)));
+        var viewModel = new PagedViewModel<LoggerResponseModel>
+        {
+            Total = logLevels.Length,
+            Items = _umbracoMapper.MapEnumerable<KeyValuePair<string, LogLevel>, LoggerResponseModel>(logLevels.Skip(skip).Take(take))
+        };
+
+        return await Task.FromResult(Ok(viewModel));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/SavedSearch/AllSavedSearchLogViewerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/SavedSearch/AllSavedSearchLogViewerController.cs
@@ -5,6 +5,7 @@ using Umbraco.Cms.Api.Management.ViewModels.LogViewer;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
+using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Management.Controllers.LogViewer.SavedSearch;
 
@@ -30,8 +31,14 @@ public class AllSavedSearchLogViewerController : SavedSearchLogViewerControllerB
     [ProducesResponseType(typeof(PagedViewModel<SavedLogSearchResponseModel>), StatusCodes.Status200OK)]
     public async Task<ActionResult<PagedViewModel<SavedLogSearchResponseModel>>> AllSavedSearches(int skip = 0, int take = 100)
     {
-        IEnumerable<ILogViewerQuery> savedLogQueries = (await _logViewerService.GetSavedLogQueriesAsync()).Skip(skip).Take(take);
+        PagedModel<ILogViewerQuery> savedLogQueries = await _logViewerService.GetSavedLogQueriesAsync(skip, take);
 
-        return Ok(_umbracoMapper.Map<PagedViewModel<SavedLogSearchResponseModel>>(savedLogQueries));
+        var viewModel = new PagedViewModel<SavedLogSearchResponseModel>
+        {
+            Total = savedLogQueries.Total,
+            Items = _umbracoMapper.MapEnumerable<ILogViewerQuery, SavedLogSearchResponseModel>(savedLogQueries.Items)
+        };
+
+        return Ok(viewModel);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Package/AllMigrationStatusPackageController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Package/AllMigrationStatusPackageController.cs
@@ -33,12 +33,12 @@ public class AllMigrationStatusPackageController : PackageControllerBase
     {
         PagedModel<InstalledPackage> migrationPlans = await _packagingService.GetInstalledPackagesFromMigrationPlansAsync(skip, take);
 
-        IEnumerable<PackageMigrationStatusResponseModel> viewModels = _umbracoMapper.MapEnumerable<InstalledPackage, PackageMigrationStatusResponseModel>(migrationPlans.Items);
-
-        return Ok(new PagedViewModel<PackageMigrationStatusResponseModel>()
+        var viewModel = new PagedViewModel<PackageMigrationStatusResponseModel>
         {
             Total = migrationPlans.Total,
-            Items = viewModels,
-        });
+            Items = _umbracoMapper.MapEnumerable<InstalledPackage, PackageMigrationStatusResponseModel>(migrationPlans.Items)
+        };
+
+        return Ok(viewModel);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Package/Created/AllCreatedPackageController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Package/Created/AllCreatedPackageController.cs
@@ -5,7 +5,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Package;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Packaging;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Extensions;
+using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Package.Created;
 
@@ -31,12 +31,14 @@ public class AllCreatedPackageController : CreatedPackageControllerBase
     [ProducesResponseType(typeof(PagedViewModel<PackageDefinitionResponseModel>), StatusCodes.Status200OK)]
     public async Task<ActionResult<PagedViewModel<PackageDefinitionResponseModel>>> All(int skip = 0, int take = 100)
     {
-        IEnumerable<PackageDefinition> createdPackages = _packagingService
-            .GetAllCreatedPackages()
-            .WhereNotNull()
-            .Skip(skip)
-            .Take(take);
+        PagedModel<PackageDefinition> createdPackages = await _packagingService.GetCreatedPackagesAsync(skip, take);
 
-        return await Task.FromResult(Ok(_umbracoMapper.Map<PagedViewModel<PackageDefinitionResponseModel>>(createdPackages)));
+        var viewModel = new PagedViewModel<PackageDefinitionResponseModel>
+        {
+            Total = createdPackages.Total,
+            Items = _umbracoMapper.MapEnumerable<PackageDefinition, PackageDefinitionResponseModel>(createdPackages.Items)
+        };
+
+        return await Task.FromResult(Ok(viewModel));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Mapping/HealthCheck/HealthCheckViewModelsMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/HealthCheck/HealthCheckViewModelsMapDefinition.cs
@@ -1,6 +1,3 @@
-using NPoco.FluentMappings;
-using Umbraco.Cms.Api.Common.ViewModels.Pagination;
-using Umbraco.Cms.Api.Management.Controllers.HealthCheck.Group;
 using Umbraco.Cms.Api.Management.ViewModels.HealthCheck;
 using Umbraco.Cms.Core.HealthChecks;
 using Umbraco.Cms.Core.Mapping;
@@ -11,19 +8,18 @@ public class HealthCheckViewModelsMapDefinition : IMapDefinition
 {
     public void DefineMaps(IUmbracoMapper mapper)
     {
-        mapper.Define<HealthCheckActionRequestModel, HealthCheckAction>((source, context) => new HealthCheckAction(), Map);
-        mapper.Define<HealthCheckAction, HealthCheckActionRequestModel>((source, context) => new HealthCheckActionRequestModel() { ValueRequired = false }, Map);
-        mapper.Define<HealthCheckStatus, HealthCheckResultResponseModel>((source, context) => new HealthCheckResultResponseModel() { Message = string.Empty }, Map);
-        mapper.Define<Core.HealthChecks.HealthCheck, HealthCheckViewModel>((source, context) => new HealthCheckViewModel() { Name = string.Empty }, Map);
+        mapper.Define<HealthCheckActionRequestModel, HealthCheckAction>((_, _) => new HealthCheckAction(), Map);
+        mapper.Define<HealthCheckAction, HealthCheckActionRequestModel>((_, _) => new HealthCheckActionRequestModel { ValueRequired = false }, Map);
+        mapper.Define<HealthCheckStatus, HealthCheckResultResponseModel>((_, _) => new HealthCheckResultResponseModel { Message = string.Empty }, Map);
+        mapper.Define<Core.HealthChecks.HealthCheck, HealthCheckViewModel>((_, _) => new HealthCheckViewModel { Name = string.Empty }, Map);
         mapper.Define<IGrouping<string?, Core.HealthChecks.HealthCheck>, HealthCheckGroupPresentationModel>(
-            (source, context) => new HealthCheckGroupPresentationModel()
+            (_, _) => new HealthCheckGroupPresentationModel
             {
                 Name = string.Empty,
                 Checks = new List<HealthCheckViewModel>()
             },
             Map);
-        mapper.Define<IGrouping<string?, Core.HealthChecks.HealthCheck>, HealthCheckGroupResponseModel>((source, context) => new HealthCheckGroupResponseModel() { Name = string.Empty }, Map);
-        mapper.Define<IEnumerable<IGrouping<string?, Core.HealthChecks.HealthCheck>>, PagedViewModel<HealthCheckGroupResponseModel>>((source, context) => new PagedViewModel<HealthCheckGroupResponseModel>(), Map);
+        mapper.Define<IGrouping<string?, Core.HealthChecks.HealthCheck>, HealthCheckGroupResponseModel>((_, _) => new HealthCheckGroupResponseModel { Name = string.Empty }, Map);
     }
 
     // Umbraco.Code.MapAll -ActionParameters
@@ -91,12 +87,5 @@ public class HealthCheckViewModelsMapDefinition : IMapDefinition
         {
             target.Name = source.Key;
         }
-    }
-
-    // Umbraco.Code.MapAll
-    private static void Map(IEnumerable<IGrouping<string?, Core.HealthChecks.HealthCheck>> source, PagedViewModel<HealthCheckGroupResponseModel> target, MapperContext context)
-    {
-        target.Items = context.MapEnumerable<IGrouping<string?, Core.HealthChecks.HealthCheck>, HealthCheckGroupResponseModel>(source);
-        target.Total = source.Count();
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Mapping/LogViewer/LogViewerViewModelMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/LogViewer/LogViewerViewModelMapDefinition.cs
@@ -1,10 +1,8 @@
-using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.ViewModels.LogViewer;
 using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Logging.Viewer;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
-using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Management.Mapping.LogViewer;
 
@@ -12,23 +10,19 @@ public class LogViewerViewModelMapDefinition : IMapDefinition
 {
     public void DefineMaps(IUmbracoMapper mapper)
     {
-        mapper.Define<LogLevelCounts, LogLevelCountsReponseModel>((source, context) => new LogLevelCountsReponseModel(), Map);
+        mapper.Define<LogLevelCounts, LogLevelCountsReponseModel>((_, _) => new LogLevelCountsReponseModel(), Map);
         mapper.Define<KeyValuePair<string, string?>, LogMessagePropertyPresentationModel>(
-            (source, context) => new LogMessagePropertyPresentationModel() { Name = string.Empty }, Map);
-        mapper.Define<KeyValuePair<string, LogLevel>, LoggerResponseModel>((source, context) => new LoggerResponseModel() { Name = string.Empty }, Map);
+            (_, _) => new LogMessagePropertyPresentationModel { Name = string.Empty }, Map);
+        mapper.Define<KeyValuePair<string, LogLevel>, LoggerResponseModel>((_, _) => new LoggerResponseModel { Name = string.Empty }, Map);
         mapper.Define<ILogViewerQuery, SavedLogSearchResponseModel>(
-            (source, context) => new SavedLogSearchResponseModel()
+            (_, _) => new SavedLogSearchResponseModel
             {
                 Name = string.Empty,
                 Query = string.Empty
             },
             Map);
-        mapper.Define<LogTemplate, LogTemplateResponseModel>((source, context) => new LogTemplateResponseModel(), Map);
-        mapper.Define<ILogEntry, LogMessageResponseModel>((source, context) => new LogMessageResponseModel(), Map);
-        mapper.Define<IEnumerable<KeyValuePair<string, LogLevel>>, PagedViewModel<LoggerResponseModel>>((source, context) => new PagedViewModel<LoggerResponseModel>(), Map);
-        mapper.Define<IEnumerable<ILogViewerQuery>, PagedViewModel<SavedLogSearchResponseModel>>((source, context) => new PagedViewModel<SavedLogSearchResponseModel>(), Map);
-        mapper.Define<IEnumerable<LogTemplate>, PagedViewModel<LogTemplateResponseModel>>((source, context) => new PagedViewModel<LogTemplateResponseModel>(), Map);
-        mapper.Define<PagedModel<ILogEntry>, PagedViewModel<LogMessageResponseModel>>((source, context) => new PagedViewModel<LogMessageResponseModel>(), Map);
+        mapper.Define<LogTemplate, LogTemplateResponseModel>((_, _) => new LogTemplateResponseModel(), Map);
+        mapper.Define<ILogEntry, LogMessageResponseModel>((_, _) => new LogMessageResponseModel(), Map);
     }
 
     // Umbraco.Code.MapAll
@@ -79,33 +73,5 @@ public class LogViewerViewModelMapDefinition : IMapDefinition
         target.RenderedMessage = source.RenderedMessage;
         target.Properties = context.MapEnumerable<KeyValuePair<string, string?>, LogMessagePropertyPresentationModel>(source.Properties);
         target.Exception = source.Exception;
-    }
-
-    // Umbraco.Code.MapAll
-    private static void Map(IEnumerable<KeyValuePair<string, LogLevel>> source, PagedViewModel<LoggerResponseModel> target, MapperContext context)
-    {
-        target.Items = context.MapEnumerable<KeyValuePair<string, LogLevel>, LoggerResponseModel>(source);
-        target.Total = source.Count();
-    }
-
-    // Umbraco.Code.MapAll
-    private static void Map(IEnumerable<ILogViewerQuery> source, PagedViewModel<SavedLogSearchResponseModel> target, MapperContext context)
-    {
-        target.Items = context.MapEnumerable<ILogViewerQuery, SavedLogSearchResponseModel>(source);
-        target.Total = source.Count();
-    }
-
-    // Umbraco.Code.MapAll
-    private static void Map(IEnumerable<LogTemplate> source, PagedViewModel<LogTemplateResponseModel> target, MapperContext context)
-    {
-        target.Items = context.MapEnumerable<LogTemplate, LogTemplateResponseModel>(source);
-        target.Total = source.Count();
-    }
-
-    // Umbraco.Code.MapAll
-    private static void Map(PagedModel<ILogEntry> source, PagedViewModel<LogMessageResponseModel> target, MapperContext context)
-    {
-        target.Items = context.MapEnumerable<ILogEntry, LogMessageResponseModel>(source.Items);
-        target.Total = source.Total;
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Mapping/Package/PackageViewModelMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Package/PackageViewModelMapDefinition.cs
@@ -1,4 +1,3 @@
-using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.ViewModels.Package;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Mapping;
@@ -12,14 +11,10 @@ public class PackageViewModelMapDefinition : IMapDefinition
     {
         mapper.Define<PackageModelBase, PackageDefinition>((_, _) => new PackageDefinition(), Map);
         mapper.Define<PackageDefinition, PackageDefinitionResponseModel>(
-            (_, _) => new PackageDefinitionResponseModel
-            {
-                Name = string.Empty,
-                PackagePath = string.Empty
-            },
+            (_, _) => new PackageDefinitionResponseModel { Name = string.Empty, PackagePath = string.Empty },
             Map);
-        mapper.Define<InstalledPackage, PackageMigrationStatusResponseModel>((_, _) => new PackageMigrationStatusResponseModel { PackageName = string.Empty }, Map);
-        mapper.Define<IEnumerable<PackageDefinition>, PagedViewModel<PackageDefinitionResponseModel>>((_, _) => new PagedViewModel<PackageDefinitionResponseModel>(), Map);
+        mapper.Define<InstalledPackage, PackageMigrationStatusResponseModel>(
+            (_, _) => new PackageMigrationStatusResponseModel { PackageName = string.Empty }, Map);
     }
 
     // Umbraco.Code.MapAll -Id -PackageId -PackagePath -Macros
@@ -71,13 +66,5 @@ public class PackageViewModelMapDefinition : IMapDefinition
         }
 
         target.HasPendingMigrations = source.HasPendingMigrations;
-    }
-
-    // Umbraco.Code.MapAll
-    private static void Map(IEnumerable<PackageDefinition> source, PagedViewModel<PackageDefinitionResponseModel> target, MapperContext context)
-    {
-        PackageDefinition[] definitions = source.ToArray();
-        target.Items = context.MapEnumerable<PackageDefinition, PackageDefinitionResponseModel>(definitions);
-        target.Total = definitions.Length;
     }
 }

--- a/src/Umbraco.Core/Services/ILogViewerService.cs
+++ b/src/Umbraco.Core/Services/ILogViewerService.cs
@@ -32,9 +32,11 @@ public interface ILogViewerService : IService
         string[]? logLevels = null);
 
     /// <summary>
-    ///     Get all saved log queries from your chosen data source.
+    ///     Get all saved log queries from your chosen data source as a paged model.
     /// </summary>
-    Task<IReadOnlyList<ILogViewerQuery>> GetSavedLogQueriesAsync();
+    /// <param name="skip">The amount of items to skip.</param>
+    /// <param name="take">The amount of items to take.</param>
+    Task<PagedModel<ILogViewerQuery>> GetSavedLogQueriesAsync(int skip, int take);
 
     /// <summary>
     ///     Gets a saved log query by name from your chosen data source.
@@ -74,13 +76,15 @@ public interface ILogViewerService : IService
     Task<Attempt<LogLevelCounts?, LogViewerOperationStatus>> GetLogLevelCountsAsync(DateTime? startDate, DateTime? endDate);
 
     /// <summary>
-    ///     Returns a list of all unique message templates and their counts.
+    ///     Returns a paged model of all unique message templates and their counts.
     ///     The attempt will fail if the log files for the given
     ///     time period are too large (more than 1GB).
     /// </summary>
     /// <param name="startDate">The start date for the date range.</param>
     /// <param name="endDate">The end date for the date range.</param>
-    Task<Attempt<IEnumerable<LogTemplate>, LogViewerOperationStatus>> GetMessageTemplatesAsync(DateTime? startDate, DateTime? endDate);
+    /// <param name="skip">The amount of items to skip.</param>
+    /// <param name="take">The amount of items to take.</param>
+    Task<Attempt<PagedModel<LogTemplate>, LogViewerOperationStatus>> GetMessageTemplatesAsync(DateTime? startDate, DateTime? endDate, int skip, int take);
 
     /// <summary>
     ///     Get the log level values of the global minimum and the UmbracoFile one from the config file.

--- a/src/Umbraco.Core/Services/IPackagingService.cs
+++ b/src/Umbraco.Core/Services/IPackagingService.cs
@@ -2,6 +2,7 @@ using System.Xml.Linq;
 using Umbraco.Cms.Core.Models.Packaging;
 using Umbraco.Cms.Core.Packaging;
 using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Extensions;
 using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Core.Services;
@@ -45,7 +46,12 @@ public interface IPackagingService : IService
     /// </summary>
     /// <param name="skip">The amount of items to skip.</param>
     /// <param name="take">The amount of items to take.</param>
-    Task<PagedModel<PackageDefinition>> GetCreatedPackagesAsync(int skip, int take);
+    Task<PagedModel<PackageDefinition>> GetCreatedPackagesAsync(int skip, int take)
+    {
+        PackageDefinition[] packages = GetAllCreatedPackages().WhereNotNull().ToArray();
+        var pagedModel = new PagedModel<PackageDefinition>(packages.Length, packages.Skip(skip).Take(take));
+        return Task.FromResult(pagedModel);
+    }
 
     /// <summary>
     ///     Returns a created package by id

--- a/src/Umbraco.Core/Services/IPackagingService.cs
+++ b/src/Umbraco.Core/Services/IPackagingService.cs
@@ -37,11 +37,15 @@ public interface IPackagingService : IService
 
     InstalledPackage? GetInstalledPackageByName(string packageName);
 
-    /// <summary>
-    ///     Returns the created packages
-    /// </summary>
-    /// <returns></returns>
+    [Obsolete("Use GetCreatedPackagesAsync instead. Scheduled for removal in Umbraco 15.")]
     IEnumerable<PackageDefinition?> GetAllCreatedPackages();
+
+    /// <summary>
+    ///     Returns the created packages as a paged model.
+    /// </summary>
+    /// <param name="skip">The amount of items to skip.</param>
+    /// <param name="take">The amount of items to take.</param>
+    Task<PagedModel<PackageDefinition>> GetCreatedPackagesAsync(int skip, int take);
 
     /// <summary>
     ///     Returns a created package by id

--- a/src/Umbraco.Infrastructure/Services/Implement/PackagingService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/PackagingService.cs
@@ -151,7 +151,16 @@ public class PackagingService : IPackagingService
         return Attempt.SucceedWithStatus<PackageDefinition?, PackageOperationStatus>(PackageOperationStatus.Success, package);
     }
 
+    [Obsolete("Use GetCreatedPackagesAsync instead. Scheduled for removal in Umbraco 15.")]
     public IEnumerable<PackageDefinition?> GetAllCreatedPackages() => _createdPackages.GetAll();
+
+    /// <inheritdoc/>
+    public async Task<PagedModel<PackageDefinition>> GetCreatedPackagesAsync(int skip, int take)
+    {
+        PackageDefinition[] packages = _createdPackages.GetAll().WhereNotNull().ToArray();
+        var pagedModel = new PagedModel<PackageDefinition>(packages.Length, packages.Skip(skip).Take(take));
+        return await Task.FromResult(pagedModel);
+    }
 
     public PackageDefinition? GetCreatedPackageById(int id) => _createdPackages.GetById(id);
 


### PR DESCRIPTION
## Details

- The total number of items were wrong in controllers related to _health checks_, _log viewer_ and _packages_, due to doing the skip and take operations before constructing a `PagedViewModel`;
- This PR fixes those cases.

## Test
- Check that modifying the `skip` and `take` values in the following endpoints still returns the right amount of results based on the values provided & now the total number of items is correct:
  - **Health Check**
    - `/umbraco/management/api/v1/health-check-group`
  - **Log Viewer**
    - `/umbraco/management/api/v1/log-viewer/level`
    - `/umbraco/management/api/v1/log-viewer/log`
    - `/umbraco/management/api/v1/log-viewer/message-template`
    - `/umbraco/management/api/v1/log-viewer/saved-search`
  - **Package**
    - `/umbraco/management/api/v1/package/created`
    - `/umbraco/management/api/v1/package/migration-status`