### PR TITLE
Do not run package validation in benchmark tests

### DIFF
--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -5,8 +5,9 @@
   <PropertyGroup>
     <!-- TODO: Update test projects to use nullable reference types and remove this to enable nullable warnings as errors (the solution default) -->
     <Nullable>annotations</Nullable>
+    <EnablePackageValidation>false</EnablePackageValidation>
   </PropertyGroup>
-  
+
   <!-- Specify rule set for all test projects -->
   <PropertyGroup>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)codeanalysis.ruleset</CodeAnalysisRuleSet>

--- a/tests/Umbraco.Tests.Common/Umbraco.Tests.Common.csproj
+++ b/tests/Umbraco.Tests.Common/Umbraco.Tests.Common.csproj
@@ -4,6 +4,7 @@
     <Title>Umbraco CMS - Test tools</Title>
     <Description>Contains commonly used tools to write tests for Umbraco CMS, such as various builders for content etc.</Description>
     <RootNamespace>Umbraco.Cms.Tests.Common</RootNamespace>
+    <EnablePackageValidation>true</EnablePackageValidation>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
@@ -6,6 +6,7 @@
     <IsPackable>true</IsPackable>
     <IsTestProject>true</IsTestProject>
     <RootNamespace>Umbraco.Cms.Tests.Integration</RootNamespace>
+    <EnablePackageValidation>true</EnablePackageValidation>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
Reverse the EnablePackageValidation in tests, so it is explicity opt-in. Otherwise the generated csproj file in Benchmarks will always fail with an error like
```
BenchmarkDotNet.Autogenerated.csproj : error NU1101: Unable to find package {GUID}. No packages exist with this id in source(s): ...
```
## Test
- You should be able to run benchmark tests without having to uncomment package validation.