### PR TITLE
V13: build new backoffice on Azure

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -71,6 +71,12 @@ stages:
               gulpFile: src/Umbraco.Web.UI.Client/gulpfile.js
               targets: coreBuild
               workingDirectory: src/Umbraco.Web.UI.Client
+          - script: npm ci --no-fund --no-audit --prefer-offline
+            workingDirectory:  src/Umbraco.Web.UI.New.Client
+            displayName: Run npm ci
+          - script: npm run build:for:cms
+            displayName: Run New Backoffice Build
+            workingDirectory: src/Umbraco.Web.UI.New.Client
           - task: UseDotNet@2
             displayName: Use .NET $(dotnetVersion)
             inputs:

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -42,6 +42,7 @@ stages:
 
     variables:
       npm_config_cache: $(Pipeline.Workspace)/.npm_client
+      NODE_OPTIONS: --max_old_space_size=16384
     jobs:
       - job: A
         displayName: Build Umbraco CMS


### PR DESCRIPTION
This fixes the current build error for v13 backoffice by pulling out the jobs from msbuild (just like the current backoffice is being built) and increases the max allowed heap size for NodeJS.