### PR TITLE
Fixing two urls for the same page (preview mode)

### DIFF
--- a/src/Umbraco.Core/Routing/ContentFinderByUrl.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByUrl.cs
@@ -36,7 +36,12 @@ public class ContentFinderByUrl : IContentFinder
     /// <returns>A value indicating whether an Umbraco document was found and assigned.</returns>
     public virtual Task<bool> TryFindContent(IPublishedRequestBuilder frequest)
     {
-        if (!UmbracoContextAccessor.TryGetUmbracoContext(out IUmbracoContext? _))
+        if (!UmbracoContextAccessor.TryGetUmbracoContext(out IUmbracoContext? umbracoContext))
+        {
+            return Task.FromResult(false);
+        }
+
+        if (umbracoContext.InPreviewMode)
         {
             return Task.FromResult(false);
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #13824 

### Description
Fixing the edge case described in the bug ticket by adding a check on the found content if it is a root node and its name is a valid integer

### How to test
- Create a node. It is not important if the node is created at the root or as a subpage.
- Save and publish the page. Write down the node ID for the page.
- Open preview to see if the page is displayed.
- Create a new node in the root (important) and give it the name of the ID of the node created in step 1.
- Create some text on the page
- Save and publish
- Go to the first created node and open preview
- Make sure the correct content is displayed
- Go to the root node with the id as name and open in preview
- Make sure the correct content is displayed
- Also open another root node in preview to make sure the content is displayed correctly
