### PR TITLE
Case-insensitive tag names with SQLite provider

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TagRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TagRepository.cs
@@ -131,7 +131,7 @@ internal class TagRepository : EntityRepositoryBase<int, ITag>, ITagRepository
         var sql1 = $@"INSERT INTO cmsTags (tag, {group}, languageId)
 SELECT tagSet.tag, tagSet.{group}, tagSet.languageId
 FROM {tagSetSql}
-LEFT OUTER JOIN cmsTags ON (tagSet.tag = cmsTags.tag AND tagSet.{group} = cmsTags.{group} AND COALESCE(tagSet.languageId, -1) = COALESCE(cmsTags.languageId, -1))
+LEFT OUTER JOIN cmsTags ON (tagSet.tag LIKE cmsTags.tag AND tagSet.{group} = cmsTags.{group} AND COALESCE(tagSet.languageId, -1) = COALESCE(cmsTags.languageId, -1))
 WHERE cmsTags.id IS NULL";
 
         Database.Execute(sql1);
@@ -321,7 +321,7 @@ WHERE r.tagId IS NULL";
         Sql<ISqlContext> sql = GetTaggedEntitiesSql(objectType, culture);
 
         sql = sql
-            .Where<TagDto>(dto => dto.Text == tag);
+            .WhereLike<TagDto>(dto => dto.Text, tag);
 
         if (group.IsNullOrWhiteSpace() == false)
         {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TagRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TagRepositoryTest.cs
@@ -13,6 +13,7 @@ using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
+using static Umbraco.Cms.Core.Constants.Conventions;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence.Repositories;
 
@@ -95,6 +96,45 @@ public class TagRepositoryTest : UmbracoIntegrationTest
                 false);
 
             Assert.AreEqual(2, repository.GetTagsForEntity(content.Id).Count());
+        }
+    }
+
+    [Test]
+    public void Can_Create_Tag_Relations_With_Mixed_Casing()
+    {
+        var provider = ScopeProvider;
+        using (ScopeProvider.CreateScope())
+        {
+            var template = TemplateBuilder.CreateTextPageTemplate();
+            FileService.SaveTemplate(template);
+
+            var contentType =
+                ContentTypeBuilder.CreateSimpleContentType("test", "Test", defaultTemplateId: template.Id);
+            ContentTypeRepository.Save(contentType);
+
+            var content1 = ContentBuilder.CreateSimpleContent(contentType);
+            var content2 = ContentBuilder.CreateSimpleContent(contentType);
+            DocumentRepository.Save(content1);
+            DocumentRepository.Save(content2);
+
+            var repository = CreateRepository(provider);
+            Tag[] tags1 = { new Tag { Text = "tag1", Group = "test" } };
+            repository.Assign(
+                content1.Id,
+                contentType.PropertyTypes.First().Id,
+                tags1,
+                false);
+
+            // Note the casing is different from tags1, but both should be considered equivalent
+            Tag[] tags2 = { new Tag { Text = "TAG1", Group = "test" } };
+            repository.Assign(
+                content2.Id,
+                contentType.PropertyTypes.First().Id,
+                tags2,
+                false);
+
+            // The template should have only one tag, despite case differences
+            Assert.AreEqual(1, repository.GetTaggedEntitiesByTag(TaggableObjectTypes.Content, "tag1").Count());
         }
     }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #13981 

### Description

I've fixed the case-sensitivity issues with tags in SQLite by using LIKE instead of = when querying and joining tags.

This could be fixed through collations but would require either database-specific SQL or database-specific schema changes. I liked this way because it works everywhere and doesn't need large changes in the database setup.

To test:
- Create an Umbraco site and add a content template with variants enabled and a tag property editor.
- Create one page with tag "Umbraco" and another with tag "umbraco" instead.
- Both pages should save and publish.
- Test SQLite and SQL Server to be sure.

I have also added an integration test, though this only tests the in-memory SQLite database.