### PR TITLE
Fix RebuildOnStartupHandler to use the IIndexRebuilder instead of the concrete type.

### DIFF
--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Events.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Events.cs
@@ -28,6 +28,16 @@ public static partial class UmbracoBuilderExtensions
         return builder;
     }
 
+    public static IUmbracoBuilder AddNotificationHandler<TNotification, TNotificationHandler>(
+        this IUmbracoBuilder builder,
+        Func<IServiceProvider, INotificationHandler<TNotification>> factory)
+        where TNotificationHandler : INotificationHandler<TNotification>
+        where TNotification : INotification
+    {
+        builder.Services.AddNotificationHandler<TNotification, TNotificationHandler>(factory);
+        return builder;
+    }
+
     /// <summary>
     ///     Registers a notification async handler against the Umbraco service collection.
     /// </summary>
@@ -45,15 +55,21 @@ public static partial class UmbracoBuilderExtensions
     }
 
     internal static IServiceCollection AddNotificationHandler<TNotification, TNotificationHandler>(
-        this IServiceCollection services)
+        this IServiceCollection services,
+        Func<IServiceProvider, object>? factory = null)
         where TNotificationHandler : INotificationHandler<TNotification>
         where TNotification : INotification
     {
         // Register the handler as transient. This ensures that anything can be injected into it.
-        var descriptor = new UniqueServiceDescriptor(
-            typeof(INotificationHandler<TNotification>),
-            typeof(TNotificationHandler),
-            ServiceLifetime.Transient);
+        UniqueServiceDescriptor descriptor = factory == null
+            ? new UniqueServiceDescriptor(
+                typeof(INotificationHandler<TNotification>),
+                typeof(TNotificationHandler),
+                ServiceLifetime.Transient)
+            : new UniqueServiceDescriptor(
+                typeof(INotificationHandler<TNotification>),
+                factory,
+                ServiceLifetime.Transient);
 
         if (!services.Contains(descriptor))
         {

--- a/src/Umbraco.Core/DependencyInjection/UniqueServiceDescriptor.cs
+++ b/src/Umbraco.Core/DependencyInjection/UniqueServiceDescriptor.cs
@@ -22,6 +22,16 @@ public sealed class UniqueServiceDescriptor : ServiceDescriptor, IEquatable<Uniq
     {
     }
 
+    public UniqueServiceDescriptor(Type serviceType, Func<IServiceProvider, object> factory, ServiceLifetime lifetime)
+        : base(serviceType, factory, lifetime)
+    {
+    }
+
+    public UniqueServiceDescriptor(Type serviceType, object instance)
+        : base(serviceType, instance)
+    {
+    }
+
     /// <inheritdoc />
     public bool Equals(UniqueServiceDescriptor? other) => other != null && Lifetime == other.Lifetime &&
                                                           EqualityComparer<Type>.Default.Equals(

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Examine.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Examine.cs
@@ -1,11 +1,13 @@
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
+using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Infrastructure.Examine;
 using Umbraco.Cms.Infrastructure.Search;
 using Umbraco.Extensions;
@@ -56,7 +58,12 @@ public static partial class UmbracoBuilderExtensions
         builder.AddNotificationHandler<MemberCacheRefresherNotification, MemberIndexingNotificationHandler>();
         builder.AddNotificationHandler<LanguageCacheRefresherNotification, LanguageIndexingNotificationHandler>();
 
-        builder.AddNotificationHandler<UmbracoRequestBeginNotification, RebuildOnStartupHandler>();
+        // Add notification handler with factory to ensure that the non-obsolete constructor is used.
+        builder.AddNotificationHandler<UmbracoRequestBeginNotification, RebuildOnStartupHandler>(
+            factory => new RebuildOnStartupHandler(
+                factory.GetRequiredService<ISyncBootStateAccessor>(),
+                factory.GetRequiredService<IIndexRebuilder>(),
+                factory.GetRequiredService<IRuntimeState>()));
 
         return builder;
     }

--- a/src/Umbraco.Infrastructure/Examine/RebuildOnStartupHandler.cs
+++ b/src/Umbraco.Infrastructure/Examine/RebuildOnStartupHandler.cs
@@ -24,13 +24,13 @@ public sealed class RebuildOnStartupHandler : INotificationHandler<UmbracoReques
     private static bool _isReady;
     private static bool _isReadSet;
     private static object? _isReadyLock;
-    private readonly ExamineIndexRebuilder _backgroundIndexRebuilder;
+    private readonly IExamineIndexRebuilder _backgroundIndexRebuilder;
     private readonly IRuntimeState _runtimeState;
     private readonly ISyncBootStateAccessor _syncBootStateAccessor;
 
     public RebuildOnStartupHandler(
         ISyncBootStateAccessor syncBootStateAccessor,
-        ExamineIndexRebuilder backgroundIndexRebuilder,
+        IExamineIndexRebuilder backgroundIndexRebuilder,
         IRuntimeState runtimeState)
     {
         _syncBootStateAccessor = syncBootStateAccessor;

--- a/src/Umbraco.Infrastructure/Examine/RebuildOnStartupHandler.cs
+++ b/src/Umbraco.Infrastructure/Examine/RebuildOnStartupHandler.cs
@@ -24,13 +24,13 @@ public sealed class RebuildOnStartupHandler : INotificationHandler<UmbracoReques
     private static bool _isReady;
     private static bool _isReadSet;
     private static object? _isReadyLock;
-    private readonly IExamineIndexRebuilder _backgroundIndexRebuilder;
+    private readonly IIndexRebuilder _backgroundIndexRebuilder;
     private readonly IRuntimeState _runtimeState;
     private readonly ISyncBootStateAccessor _syncBootStateAccessor;
 
     public RebuildOnStartupHandler(
         ISyncBootStateAccessor syncBootStateAccessor,
-        IExamineIndexRebuilder backgroundIndexRebuilder,
+        IIndexRebuilder backgroundIndexRebuilder,
         IRuntimeState runtimeState)
     {
         _syncBootStateAccessor = syncBootStateAccessor;

--- a/src/Umbraco.Infrastructure/Examine/RebuildOnStartupHandler.cs
+++ b/src/Umbraco.Infrastructure/Examine/RebuildOnStartupHandler.cs
@@ -38,6 +38,17 @@ public sealed class RebuildOnStartupHandler : INotificationHandler<UmbracoReques
         _runtimeState = runtimeState;
     }
 
+    [Obsolete("Use the constructor specifying the IIndexRebuilder instead")]
+    public RebuildOnStartupHandler(
+        ISyncBootStateAccessor syncBootStateAccessor,
+        ExamineIndexRebuilder backgroundIndexRebuilder,
+        IRuntimeState runtimeState)
+    {
+        _syncBootStateAccessor = syncBootStateAccessor;
+        _backgroundIndexRebuilder = backgroundIndexRebuilder;
+        _runtimeState = runtimeState;
+    }
+
     /// <summary>
     ///     On first http request schedule an index rebuild for any empty indexes (or all if it's a cold boot)
     /// </summary>


### PR DESCRIPTION
The interface should be injected here not the concrete implementation. This breaks ExamineX functionality for cold boot startups since it shouldn't rebuild non-empty indexes on cold boot. The workaround is to replace both the IIndexRebuilder and ExamineIndexRebuilder (concrete type) in ExamineX. `ExamineIndexRebuilder` should actually not be registered directly in the container at all.