### PR TITLE
Fix bug, in multiurlpicker where you cannot deselect a selected entity.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.controller.js
@@ -128,6 +128,13 @@ angular.module("umbraco").controller("Umbraco.Editors.LinkPickerController",
             eventsService.emit("dialogs.linkPicker.select", args);
 
             if ($scope.currentNode) {
+                if ($scope.currentNode.id == args.node.id && $scope.currentNode.selected) {
+                    $scope.model.target = {};
+                    $scope.currentNode.selected = false;
+
+                    return;
+                }
+
                 //un-select if there's a current one selected
                 $scope.currentNode.selected = false;
             }


### PR DESCRIPTION
Prerequisites
This pr fixes: #14006

### Description
If you select a node in the MultiUrlPicker editor. But if you regrets or simple by mistake picked a node, but want to use the external linking. You need to cancel the dialog and start over. You cannot just click on the node once again to deselect it. 

This PR fix, this bug, and make it posiable to deselected the picket entity.