### PR TITLE
Dedicated property cache level for Content API

### DIFF
--- a/src/Umbraco.Core/Models/PublishedContent/IPublishedPropertyType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/IPublishedPropertyType.cs
@@ -52,6 +52,11 @@ public interface IPublishedPropertyType
     PropertyCacheLevel CacheLevel { get; }
 
     /// <summary>
+    ///     Gets the property cache level for content API representation.
+    /// </summary>
+    PropertyCacheLevel ContentApiCacheLevel { get; }
+
+    /// <summary>
     ///     Gets the property model CLR type.
     /// </summary>
     /// <remarks>

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedPropertyBase.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedPropertyBase.cs
@@ -20,6 +20,7 @@ public abstract class PublishedPropertyBase : IPublishedProperty
 
         ValidateCacheLevel(ReferenceCacheLevel, true);
         ValidateCacheLevel(PropertyType.CacheLevel, false);
+        ValidateCacheLevel(PropertyType.ContentApiCacheLevel, false);
     }
 
     /// <summary>

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedPropertyType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedPropertyType.cs
@@ -20,6 +20,7 @@ namespace Umbraco.Cms.Core.Models.PublishedContent
         private volatile bool _initialized;
         private IPropertyValueConverter? _converter;
         private PropertyCacheLevel _cacheLevel;
+        private PropertyCacheLevel _contentApiCacheLevel;
 
         private Type? _modelClrType;
         private Type? _clrType;
@@ -191,6 +192,9 @@ namespace Umbraco.Cms.Core.Models.PublishedContent
             }
 
             _cacheLevel = _converter?.GetPropertyCacheLevel(this) ?? PropertyCacheLevel.Snapshot;
+            _contentApiCacheLevel = _converter is IContentApiPropertyValueConverter contentApiConverter
+                ? contentApiConverter.GetPropertyContentApiCacheLevel(this)
+                : _cacheLevel;
             _modelClrType = _converter == null ? typeof (object) : _converter.GetPropertyValueType(this);
         }
 
@@ -223,6 +227,20 @@ namespace Umbraco.Cms.Core.Models.PublishedContent
                 }
 
                 return _cacheLevel;
+            }
+        }
+
+        /// <inheritdoc />
+        public PropertyCacheLevel ContentApiCacheLevel
+        {
+            get
+            {
+                if (!_initialized)
+                {
+                    Initialize();
+                }
+
+                return _contentApiCacheLevel;
             }
         }
 

--- a/src/Umbraco.Core/PropertyEditors/ContentApi/IContentApiPropertyValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ContentApi/IContentApiPropertyValueConverter.cs
@@ -5,6 +5,13 @@ namespace Umbraco.Cms.Core.PropertyEditors.ContentApi;
 public interface IContentApiPropertyValueConverter : IPropertyValueConverter
 {
     /// <summary>
+    ///     Gets the property cache level for content API representation.
+    /// </summary>
+    /// <param name="propertyType">The property type.</param>
+    /// <returns>The property cache level.</returns>
+    PropertyCacheLevel GetPropertyContentApiCacheLevel(IPublishedPropertyType propertyType);
+
+    /// <summary>
     ///     Gets the type of values returned by the converter for content API representation.
     /// </summary>
     /// <param name="propertyType">The property type.</param>

--- a/src/Umbraco.Core/PropertyEditors/TextStringValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/TextStringValueConverter.cs
@@ -1,10 +1,11 @@
 using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PropertyEditors.ContentApi;
 using Umbraco.Cms.Core.Templates;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
 [DefaultPropertyValueConverter]
-public class TextStringValueConverter : PropertyValueConverterBase
+public class TextStringValueConverter : PropertyValueConverterBase, IContentApiPropertyValueConverter
 {
     private static readonly string[] PropertyTypeAliases =
     {
@@ -54,4 +55,13 @@ public class TextStringValueConverter : PropertyValueConverterBase
 
         // source should come from ConvertSource and be a string (or null) already
         inter;
+
+    public PropertyCacheLevel GetPropertyContentApiCacheLevel(IPublishedPropertyType propertyType)
+        => PropertyCacheLevel.Element;
+
+    public Type GetContentApiPropertyValueType(IPublishedPropertyType propertyType)
+        => GetPropertyValueType(propertyType);
+
+    public object ConvertIntermediateToContentApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
+        => ConvertIntermediateToObject(owner, propertyType, referenceCacheLevel, inter, preview);
 }

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/ContentPickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/ContentPickerValueConverter.cs
@@ -96,6 +96,8 @@ internal class ContentPickerValueConverter : PropertyValueConverterBase, IConten
         return inter.ToString();
     }
 
+    public PropertyCacheLevel GetPropertyContentApiCacheLevel(IPublishedPropertyType propertyType) => GetPropertyCacheLevel(propertyType);
+
     public Type GetContentApiPropertyValueType(IPublishedPropertyType propertyType) => typeof(IApiContent);
 
     public object? ConvertIntermediateToContentApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MediaPickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MediaPickerValueConverter.cs
@@ -121,6 +121,8 @@ public class MediaPickerValueConverter : PropertyValueConverterBase, IContentApi
         return source;
     }
 
+    public PropertyCacheLevel GetPropertyContentApiCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Element;
+
     public Type GetContentApiPropertyValueType(IPublishedPropertyType propertyType) => typeof(IEnumerable<IApiMedia>);
 
     public object? ConvertIntermediateToContentApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MemberGroupPickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MemberGroupPickerValueConverter.cs
@@ -31,6 +31,8 @@ public class MemberGroupPickerValueConverter : PropertyValueConverterBase, ICont
 
     public override object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object? source, bool preview) => source?.ToString() ?? string.Empty;
 
+    public PropertyCacheLevel GetPropertyContentApiCacheLevel(IPublishedPropertyType propertyType) => GetPropertyCacheLevel(propertyType);
+
     public Type GetContentApiPropertyValueType(IPublishedPropertyType propertyType) => typeof(string[]);
 
     public object? ConvertIntermediateToContentApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MemberPickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MemberPickerValueConverter.cs
@@ -103,6 +103,8 @@ public class MemberPickerValueConverter : PropertyValueConverterBase, IContentAp
         return source;
     }
 
+    public PropertyCacheLevel GetPropertyContentApiCacheLevel(IPublishedPropertyType propertyType) => GetPropertyCacheLevel(propertyType);
+
     public Type GetContentApiPropertyValueType(IPublishedPropertyType propertyType) => typeof(string);
 
     // member picker is unsupported for content API output to avoid leaking member data by accident.

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MultiNodeTreePickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MultiNodeTreePickerValueConverter.cs
@@ -181,6 +181,8 @@ public class MultiNodeTreePickerValueConverter : PropertyValueConverterBase, ICo
         return source;
     }
 
+    public PropertyCacheLevel GetPropertyContentApiCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Elements;
+
     public Type GetContentApiPropertyValueType(IPublishedPropertyType propertyType)
         => GetEntityType(propertyType) switch
         {

--- a/src/Umbraco.Core/PublishedCache/PublishedElementPropertyBase.cs
+++ b/src/Umbraco.Core/PublishedCache/PublishedElementPropertyBase.cs
@@ -84,6 +84,12 @@ internal class PublishedElementPropertyBase : PublishedPropertyBase
     public override object? GetSourceValue(string? culture = null, string? segment = null) => _sourceValue;
 
     private void GetCacheLevels(out PropertyCacheLevel cacheLevel, out PropertyCacheLevel referenceCacheLevel)
+        => GetCacheLevels(PropertyType.CacheLevel, out cacheLevel, out referenceCacheLevel);
+
+    private void GetContentApiCacheLevels(out PropertyCacheLevel cacheLevel, out PropertyCacheLevel referenceCacheLevel)
+        => GetCacheLevels(PropertyType.ContentApiCacheLevel, out cacheLevel, out referenceCacheLevel);
+
+    private void GetCacheLevels(PropertyCacheLevel propertyTypeCacheLevel, out PropertyCacheLevel cacheLevel, out PropertyCacheLevel referenceCacheLevel)
     {
         // based upon the current reference cache level (ReferenceCacheLevel) and this property
         // cache level (PropertyType.CacheLevel), determines both the actual cache level for the
@@ -97,9 +103,9 @@ internal class PublishedElementPropertyBase : PublishedPropertyBase
         // currently (reference) caching at published snapshot, property specifies
         // elements, ok to use element. OTOH, currently caching at elements,
         // property specifies snapshot, need to use snapshot.
-        if (PropertyType.CacheLevel > ReferenceCacheLevel || PropertyType.CacheLevel == PropertyCacheLevel.None)
+        if (propertyTypeCacheLevel > ReferenceCacheLevel || propertyTypeCacheLevel == PropertyCacheLevel.None)
         {
-            cacheLevel = PropertyType.CacheLevel;
+            cacheLevel = propertyTypeCacheLevel;
             referenceCacheLevel = cacheLevel;
         }
         else
@@ -216,7 +222,7 @@ internal class PublishedElementPropertyBase : PublishedPropertyBase
 
     public override object? GetContentApiValue(bool expanding, string? culture = null, string? segment = null)
     {
-        GetCacheLevels(out PropertyCacheLevel cacheLevel, out PropertyCacheLevel referenceCacheLevel);
+        GetContentApiCacheLevels(out PropertyCacheLevel cacheLevel, out PropertyCacheLevel referenceCacheLevel);
 
         lock (_locko)
         {

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueConverter.cs
@@ -39,6 +39,8 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
         public override object? ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
             => ConvertIntermediateToBlockGridModel(propertyType, referenceCacheLevel, inter, preview);
 
+        public PropertyCacheLevel GetPropertyContentApiCacheLevel(IPublishedPropertyType propertyType) => GetPropertyCacheLevel(propertyType);
+
         public Type GetContentApiPropertyValueType(IPublishedPropertyType propertyType)
             => typeof(ApiBlockGridModel);
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockListPropertyValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockListPropertyValueConverter.cs
@@ -109,6 +109,9 @@ public class BlockListPropertyValueConverter : BlockPropertyValueConverterBase<B
     }
 
     /// <inheritdoc />
+    public PropertyCacheLevel GetPropertyContentApiCacheLevel(IPublishedPropertyType propertyType) => GetPropertyCacheLevel(propertyType);
+
+    /// <inheritdoc />
     public Type GetContentApiPropertyValueType(IPublishedPropertyType propertyType)
         => typeof(IEnumerable<ApiBlockListModel>);
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/ImageCropperValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/ImageCropperValueConverter.cs
@@ -68,6 +68,8 @@ public class ImageCropperValueConverter : PropertyValueConverterBase, IContentAp
         return value;
     }
 
+    public PropertyCacheLevel GetPropertyContentApiCacheLevel(IPublishedPropertyType propertyType) => GetPropertyCacheLevel(propertyType);
+
     public Type GetContentApiPropertyValueType(IPublishedPropertyType propertyType) => typeof(ApiImageCropperValue);
 
     public object? ConvertIntermediateToContentApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MarkdownEditorValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MarkdownEditorValueConverter.cs
@@ -61,6 +61,8 @@ public class MarkdownEditorValueConverter : PropertyValueConverterBase, IContent
         // source should come from ConvertSource and be a string (or null) already
         inter?.ToString() ?? string.Empty;
 
+    public PropertyCacheLevel GetPropertyContentApiCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Element;
+
     public Type GetContentApiPropertyValueType(IPublishedPropertyType propertyType) => typeof(string);
 
     public object ConvertIntermediateToContentApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MediaPickerWithCropsValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MediaPickerWithCropsValueConverter.cs
@@ -120,6 +120,8 @@ public class MediaPickerWithCropsValueConverter : PropertyValueConverterBase, IC
         return isMultiple ? mediaItems : mediaItems.FirstOrDefault();
     }
 
+    public PropertyCacheLevel GetPropertyContentApiCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Element;
+
     public Type GetContentApiPropertyValueType(IPublishedPropertyType propertyType) => typeof(IEnumerable<ApiMediaWithCrops>);
 
     public object? ConvertIntermediateToContentApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
@@ -150,6 +150,8 @@ public class MultiUrlPickerValueConverter : PropertyValueConverterBase, IContent
         }
     }
 
+    public PropertyCacheLevel GetPropertyContentApiCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Elements;
+
     public Type GetContentApiPropertyValueType(IPublishedPropertyType propertyType) => typeof(IEnumerable<ApiLink>);
 
     public object? ConvertIntermediateToContentApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/NestedContentManyValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/NestedContentManyValueConverter.cs
@@ -114,6 +114,8 @@ public class NestedContentManyValueConverter : NestedContentValueConverterBase, 
         }
     }
 
+    public PropertyCacheLevel GetPropertyContentApiCacheLevel(IPublishedPropertyType propertyType) => GetPropertyCacheLevel(propertyType);
+
     public Type GetContentApiPropertyValueType(IPublishedPropertyType propertyType) => typeof(IEnumerable<IApiElement>);
 
     public object? ConvertIntermediateToContentApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/NestedContentSingleValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/NestedContentSingleValueConverter.cs
@@ -98,6 +98,8 @@ public class NestedContentSingleValueConverter : NestedContentValueConverterBase
         }
     }
 
+    public PropertyCacheLevel GetPropertyContentApiCacheLevel(IPublishedPropertyType propertyType) => GetPropertyCacheLevel(propertyType);
+
     public Type GetContentApiPropertyValueType(IPublishedPropertyType propertyType) => typeof(IEnumerable<IApiElement>);
 
     public object? ConvertIntermediateToContentApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RteMacroRenderingValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RteMacroRenderingValueConverter.cs
@@ -52,6 +52,8 @@ public class RteMacroRenderingValueConverter : SimpleTinyMceValueConverter, ICon
         return new HtmlEncodedString(converted ?? string.Empty);
     }
 
+    public PropertyCacheLevel GetPropertyContentApiCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Elements;
+
     public Type GetContentApiPropertyValueType(IPublishedPropertyType propertyType) => typeof(string);
 
     public object? ConvertIntermediateToContentApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)

--- a/src/Umbraco.PublishedCache.NuCache/Property.cs
+++ b/src/Umbraco.PublishedCache.NuCache/Property.cs
@@ -317,7 +317,7 @@ internal class Property : PublishedPropertyBase
         object? value;
         lock (_locko)
         {
-            CacheValue cacheValues = GetCacheValues(PropertyType.CacheLevel).For(culture, segment);
+            CacheValue cacheValues = GetCacheValues(PropertyType.ContentApiCacheLevel).For(culture, segment);
 
             // initial reference cache level always is .Content
             const PropertyCacheLevel initialCacheLevel = PropertyCacheLevel.Element;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/ContentApi/CacheTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/ContentApi/CacheTests.cs
@@ -49,6 +49,7 @@ public class CacheTests
         var propertyType = new Mock<IPublishedPropertyType>();
         var invocationCount = 0;
         propertyType.SetupGet(p => p.CacheLevel).Returns(cacheLevel);
+        propertyType.SetupGet(p => p.ContentApiCacheLevel).Returns(cacheLevel);
         propertyType
             .Setup(p => p.ConvertInterToContentApiObject(It.IsAny<IPublishedElement>(), It.IsAny<PropertyCacheLevel>(), It.IsAny<object?>(), It.IsAny<bool>()))
             .Returns(() => $"Content API value: {++invocationCount}");

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ContentApi/CacheTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ContentApi/CacheTests.cs
@@ -31,6 +31,7 @@ public class CacheTests : ContentApiTests
         ).Returns(() => $"Content API value: {++invocationCount}");
         propertyValueConverter.Setup(p => p.IsConverter(It.IsAny<IPublishedPropertyType>())).Returns(true);
         propertyValueConverter.Setup(p => p.GetPropertyCacheLevel(It.IsAny<IPublishedPropertyType>())).Returns(cacheLevel);
+        propertyValueConverter.Setup(p => p.GetPropertyContentApiCacheLevel(It.IsAny<IPublishedPropertyType>())).Returns(cacheLevel);
 
         var propertyType = SetupPublishedPropertyType(propertyValueConverter.Object, "something", "Some.Thing");
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ContentApi/ContentApiTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ContentApi/ContentApiTests.cs
@@ -37,6 +37,7 @@ public class ContentApiTests
         ).Returns("Default value");
         contentApiPropertyValueConverter.Setup(p => p.IsConverter(It.IsAny<IPublishedPropertyType>())).Returns(true);
         contentApiPropertyValueConverter.Setup(p => p.GetPropertyCacheLevel(It.IsAny<IPublishedPropertyType>())).Returns(PropertyCacheLevel.None);
+        contentApiPropertyValueConverter.Setup(p => p.GetPropertyContentApiCacheLevel(It.IsAny<IPublishedPropertyType>())).Returns(PropertyCacheLevel.None);
 
         ContentApiPropertyType = SetupPublishedPropertyType(contentApiPropertyValueConverter.Object, "contentApi", "Content.Api.Editor");
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ContentApi/NestedContentValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ContentApi/NestedContentValueConverterTests.cs
@@ -40,6 +40,7 @@ public class NestedContentValueConverterTests : PropertyValueConverterTests
         publishedPropertyType.SetupGet(p => p.DataType).Returns(publishedDataType);
         publishedPropertyType.SetupGet(p => p.Alias).Returns("prop1");
         publishedPropertyType.SetupGet(p => p.CacheLevel).Returns(PropertyCacheLevel.Element);
+        publishedPropertyType.SetupGet(p => p.ContentApiCacheLevel).Returns(PropertyCacheLevel.Element);
         publishedPropertyType
             .Setup(p => p.ConvertSourceToInter(It.IsAny<IPublishedElement>(), It.IsAny<object>(), It.IsAny<bool>()))
             .Returns((IPublishedElement owner, object? source, bool preview) => source);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ContentApi/OutputExpansionStrategyTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ContentApi/OutputExpansionStrategyTests.cs
@@ -436,6 +436,7 @@ public class OutputExpansionStrategyTests : PropertyValueConverterTests
             .Returns(() => apiElementBuilder.Build(element.Object));
         elementValueConverter.Setup(p => p.IsConverter(It.IsAny<IPublishedPropertyType>())).Returns(true);
         elementValueConverter.Setup(p => p.GetPropertyCacheLevel(It.IsAny<IPublishedPropertyType>())).Returns(PropertyCacheLevel.None);
+        elementValueConverter.Setup(p => p.GetPropertyContentApiCacheLevel(It.IsAny<IPublishedPropertyType>())).Returns(PropertyCacheLevel.None);
 
         var elementPropertyType = SetupPublishedPropertyType(elementValueConverter.Object, elementPropertyAlias, "My.Element.Property");
         return new PublishedElementPropertyBase(elementPropertyType, parent, false, PropertyCacheLevel.None);


### PR DESCRIPTION
### Description

Adds dedicated property cache levels for content API value converters, so they can utilize the lesser need for context awareness when rendering property data.

Peer reviewed 👍 