### PR TITLE
Determine correct if we can create a database with current connectionstring

### DIFF
--- a/src/Umbraco.Cms.Persistence.SqlServer/Constants.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Constants.cs
@@ -1,12 +1,12 @@
 namespace Umbraco.Cms.Persistence.SqlServer;
 
 /// <summary>
-///     Constants related to SQLite.
+///     Constants related to SQL Server.
 /// </summary>
 public static class Constants
 {
     /// <summary>
-    ///     SQLite provider name.
+    ///     SQL Server provider name.
     /// </summary>
     public const string ProviderName = "Microsoft.Data.SqlClient";
 }

--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlAzureDatabaseProviderMetadata.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlAzureDatabaseProviderMetadata.cs
@@ -1,4 +1,5 @@
 using System.Runtime.Serialization;
+using Microsoft.Data.SqlClient;
 using Umbraco.Cms.Core.Install.Models;
 using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Extensions;
@@ -50,6 +51,25 @@ public class SqlAzureDatabaseProviderMetadata : IDatabaseProviderMetadata
     /// <inheritdoc />
     public bool ForceCreateDatabase => false;
 
+    /// <inheritdoc />
+    public bool CanRecognizeConnectionString(string? connectionString)
+    {
+        if (connectionString is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            var builder = new SqlConnectionStringBuilder(connectionString);
+
+            return string.IsNullOrEmpty(builder.AttachDBFilename) && builder.DataSource.Contains("database.windows.net");
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
     /// <inheritdoc />
     public string GenerateConnectionString(DatabaseModel databaseModel)
     {

--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlLocalDbDatabaseProviderMetadata.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlLocalDbDatabaseProviderMetadata.cs
@@ -52,6 +52,27 @@ public class SqlLocalDbDatabaseProviderMetadata : IDatabaseProviderMetadata
     public bool ForceCreateDatabase => true;
 
     /// <inheritdoc />
+    public bool CanRecognizeConnectionString(string? connectionString)
+    {
+        if (connectionString is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            var builder = new SqlConnectionStringBuilder(connectionString);
+
+            return !string.IsNullOrEmpty(builder.AttachDBFilename);
+
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
     public string GenerateConnectionString(DatabaseModel databaseModel)
     {
         var builder = new SqlConnectionStringBuilder

--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDatabaseProviderMetadata.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDatabaseProviderMetadata.cs
@@ -1,6 +1,9 @@
+using System.Data.Common;
 using System.Runtime.Serialization;
+using Microsoft.Data.SqlClient;
 using Umbraco.Cms.Core.Install.Models;
 using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Persistence.SqlServer.Services;
 
@@ -48,6 +51,26 @@ public class SqlServerDatabaseProviderMetadata : IDatabaseProviderMetadata
 
     /// <inheritdoc />
     public bool ForceCreateDatabase => false;
+
+    /// <inheritdoc />
+    public bool CanRecognizeConnectionString(string? connectionString)
+    {
+        if (connectionString is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            var builder = new SqlConnectionStringBuilder(connectionString);
+
+            return string.IsNullOrEmpty(builder.AttachDBFilename);
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
 
     /// <inheritdoc />
     public string GenerateConnectionString(DatabaseModel databaseModel) =>

--- a/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteDatabaseProviderMetadata.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteDatabaseProviderMetadata.cs
@@ -57,6 +57,26 @@ public class SqliteDatabaseProviderMetadata : IDatabaseProviderMetadata
     public bool ForceCreateDatabase => true;
 
     /// <inheritdoc />
+    public bool CanRecognizeConnectionString(string? connectionString)
+    {
+        if (connectionString is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            var builder = new SqliteConnectionStringBuilder(connectionString);
+
+            return !string.IsNullOrEmpty(builder.DataSource);
+
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+    /// <inheritdoc />
     public string GenerateConnectionString(DatabaseModel databaseModel)
     {
         var builder = new SqliteConnectionStringBuilder

--- a/src/Umbraco.Infrastructure/Install/InstallHelper.cs
+++ b/src/Umbraco.Infrastructure/Install/InstallHelper.cs
@@ -164,7 +164,7 @@ namespace Umbraco.Cms.Infrastructure.Install
         private bool IsBrandNewInstall =>
             _connectionStrings.CurrentValue.IsConnectionStringConfigured() == false ||
             _databaseBuilder.IsDatabaseConfigured == false ||
-            (_databaseBuilder.CanConnectToDatabase == false && _databaseProviderMetadata.CanForceCreateDatabase(_umbracoDatabaseFactory.SqlContext.SqlSyntax.DbProvider)) ||
+            (_databaseBuilder.CanConnectToDatabase == false && _databaseProviderMetadata.CanForceCreateDatabase(_umbracoDatabaseFactory)) ||
             _databaseBuilder.IsUmbracoInstalled() == false;
     }
 }

--- a/src/Umbraco.Infrastructure/Persistence/DatabaseProviderMetadataExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/DatabaseProviderMetadataExtensions.cs
@@ -27,7 +27,7 @@ public static class DatabaseProviderMetadataExtensions
     /// <returns>
     ///   <c>true</c> if a database can be created for the specified provider name; otherwise, <c>false</c>.
     /// </returns>
-    [Obsolete("Use CanForceCreateDatabase that takes an IUmbracoDatabaseFactory. Scheduled for removable in Umbraco 13.")]
+    [Obsolete("Use CanForceCreateDatabase that takes an IUmbracoDatabaseFactory. Scheduled for removal in Umbraco 13.")]
     public static bool CanForceCreateDatabase(this IEnumerable<IDatabaseProviderMetadata> databaseProviderMetadata, string? providerName)
     {
         return databaseProviderMetadata
@@ -40,14 +40,14 @@ public static class DatabaseProviderMetadataExtensions
     /// Determines whether a database can be created for the specified provider name while ignoring the value of <see cref="GlobalSettings.InstallMissingDatabase" />.
     /// </summary>
     /// <param name="databaseProviderMetadata">The database provider metadata.</param>
-    /// <param name="IUmbracoDatabaseFactory">The database factory.</param>
+    /// <param name="umbracoDatabaseFactory">The database factory.</param>
     /// <returns>
     ///   <c>true</c> if a database can be created for the specified database; otherwise, <c>false</c>.
     /// </returns>
     public static bool CanForceCreateDatabase(this IEnumerable<IDatabaseProviderMetadata> databaseProviderMetadata, IUmbracoDatabaseFactory umbracoDatabaseFactory)
     {
         // In case more metadata providers can recognize the connection string, we need to check if any can force create.
-        // E.g. Both SqlServer and SqlAzure will recognize an azure connection string, but luckily non can force create.
+        // E.g. Both SqlServer and SqlAzure will recognize an azure connection string, but luckily none of those can force create.
         return databaseProviderMetadata
             .Where(x =>
                 string.Equals(x.ProviderName, umbracoDatabaseFactory.SqlContext.SqlSyntax.ProviderName, StringComparison.InvariantCultureIgnoreCase)

--- a/src/Umbraco.Infrastructure/Persistence/DatabaseProviderMetadataExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/DatabaseProviderMetadataExtensions.cs
@@ -1,4 +1,5 @@
 using Umbraco.Cms.Core.Install.Models;
+using Umbraco.Cms.Infrastructure.Persistence.SqlSyntax;
 
 namespace Umbraco.Cms.Infrastructure.Persistence;
 
@@ -26,8 +27,32 @@ public static class DatabaseProviderMetadataExtensions
     /// <returns>
     ///   <c>true</c> if a database can be created for the specified provider name; otherwise, <c>false</c>.
     /// </returns>
+    [Obsolete("Use CanForceCreateDatabase that takes an IUmbracoDatabaseFactory. Scheduled for removable in Umbraco 13.")]
     public static bool CanForceCreateDatabase(this IEnumerable<IDatabaseProviderMetadata> databaseProviderMetadata, string? providerName)
-        => databaseProviderMetadata.FirstOrDefault(x => string.Equals(x.ProviderName, providerName, StringComparison.InvariantCultureIgnoreCase))?.ForceCreateDatabase == true;
+    {
+        return databaseProviderMetadata
+            .FirstOrDefault(x =>
+                string.Equals(x.ProviderName, providerName, StringComparison.InvariantCultureIgnoreCase))
+            ?.ForceCreateDatabase == true;
+    }
+
+    /// <summary>
+    /// Determines whether a database can be created for the specified provider name while ignoring the value of <see cref="GlobalSettings.InstallMissingDatabase" />.
+    /// </summary>
+    /// <param name="databaseProviderMetadata">The database provider metadata.</param>
+    /// <param name="IUmbracoDatabaseFactory">The database factory.</param>
+    /// <returns>
+    ///   <c>true</c> if a database can be created for the specified database; otherwise, <c>false</c>.
+    /// </returns>
+    public static bool CanForceCreateDatabase(this IEnumerable<IDatabaseProviderMetadata> databaseProviderMetadata, IUmbracoDatabaseFactory umbracoDatabaseFactory)
+    {
+        // In case more metadata providers can recognize the connection string, we need to check if any can force create.
+        // E.g. Both SqlServer and SqlAzure will recognize an azure connection string, but luckily non can force create.
+        return databaseProviderMetadata
+            .Where(x =>
+                string.Equals(x.ProviderName, umbracoDatabaseFactory.SqlContext.SqlSyntax.ProviderName, StringComparison.InvariantCultureIgnoreCase)
+                && x.CanRecognizeConnectionString(umbracoDatabaseFactory.ConnectionString) && x.IsAvailable).Any(x => x.ForceCreateDatabase == true);
+    }
 
     /// <summary>
     /// Generates the connection string.

--- a/src/Umbraco.Infrastructure/Persistence/IDatabaseProviderMetadata.cs
+++ b/src/Umbraco.Infrastructure/Persistence/IDatabaseProviderMetadata.cs
@@ -82,6 +82,12 @@ public interface IDatabaseProviderMetadata
     /// </summary>
     public bool ForceCreateDatabase { get; }
 
+
+    /// <summary>
+    /// Gets a value indicating whether this connections could have been build using <see cref="GenerateConnectionString"/>.
+    /// </summary>
+    public bool CanRecognizeConnectionString(string? connectionString) => false;
+
     /// <summary>
     ///     Creates a connection string for this provider.
     /// </summary>

--- a/src/Umbraco.Infrastructure/Runtime/RuntimeState.cs
+++ b/src/Umbraco.Infrastructure/Runtime/RuntimeState.cs
@@ -209,7 +209,7 @@ public class RuntimeState : IRuntimeState
                     // cannot connect to configured database, this is bad, fail
                     _logger.LogDebug("Could not connect to database.");
 
-                    if (_globalSettings.Value.InstallMissingDatabase || _databaseProviderMetadata.CanForceCreateDatabase(_databaseFactory.ProviderName))
+                    if (_globalSettings.Value.InstallMissingDatabase || _databaseProviderMetadata.CanForceCreateDatabase(_databaseFactory))
                     {
                         // ok to install on a configured but missing database
                         Level = RuntimeLevel.Install;

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/SqAzureDatabaseProviderMetadataTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/SqAzureDatabaseProviderMetadataTests.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Identity;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Install.Models;
+using Umbraco.Cms.Persistence.SqlServer.Services;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Persistence.SqlServer;
+
+[TestFixture]
+public class SqlAzureDatabaseProviderMetadataTests
+{
+    
+    
+    [Test]
+    [TestCase("myServer", "myDatabase", "myLogin", "myPassword", true /*ignored*/, ExpectedResult = "Server=tcp:myServer.database.windows.net,1433;Database=myDatabase;User ID=myLogin@myServer;Password=myPassword")]
+    [TestCase("myServer", "myDatabase", "myLogin", "myPassword", false, ExpectedResult = "Server=tcp:myServer.database.windows.net,1433;Database=myDatabase;User ID=myLogin@myServer;Password=myPassword")]
+    public string GenerateConnectionString(string server, string databaseName, string login, string password, bool integratedAuth)
+    {
+        var sut = new SqlAzureDatabaseProviderMetadata();
+        return sut.GenerateConnectionString(new DatabaseModel()
+        {
+            DatabaseName = databaseName,
+            Login = login,
+            Password = password,
+            Server = server,
+            IntegratedAuth = integratedAuth
+        });
+    }
+    
+    [Test]
+    [TestCase("Server=myServer;Database=myDatabase;Integrated Security=true", ExpectedResult = false)] // SqlServer
+    [TestCase("Server=myServer;Database=myDatabase;User Id=myLogin;Password=myPassword", ExpectedResult = false)] // SqlServer
+    [TestCase("Server=tcp:cmstest27032000.database.windows.net,1433;Database=test_27032000;User ID=asdasdas@cmstest27032000;Password=123456879", ExpectedResult = true)] // Azure
+    [TestCase("Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True", ExpectedResult = false)] // Sqlite
+    [TestCase("Data Source=(LocalDb)\\MSSQLLocalDB;Initial Catalog=aspnet-MvcMovie;Integrated Security=SSPI;AttachDBFilename=|DataDirectory|\\umbraco.mdf", ExpectedResult = false)] // localDB
+    public bool CanRecognizeConnectionString(string connectionString)
+    {
+        var sut = new SqlAzureDatabaseProviderMetadata();
+        return sut.CanRecognizeConnectionString(connectionString);
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/SqAzureDatabaseProviderMetadataTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/SqAzureDatabaseProviderMetadataTests.cs
@@ -1,16 +1,12 @@
-using Microsoft.AspNetCore.Identity;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Install.Models;
 using Umbraco.Cms.Persistence.SqlServer.Services;
-using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Persistence.SqlServer;
 
 [TestFixture]
 public class SqlAzureDatabaseProviderMetadataTests
 {
-    
-    
     [Test]
     [TestCase("myServer", "myDatabase", "myLogin", "myPassword", true /*ignored*/, ExpectedResult = "Server=tcp:myServer.database.windows.net,1433;Database=myDatabase;User ID=myLogin@myServer;Password=myPassword")]
     [TestCase("myServer", "myDatabase", "myLogin", "myPassword", false, ExpectedResult = "Server=tcp:myServer.database.windows.net,1433;Database=myDatabase;User ID=myLogin@myServer;Password=myPassword")]
@@ -26,7 +22,7 @@ public class SqlAzureDatabaseProviderMetadataTests
             IntegratedAuth = integratedAuth
         });
     }
-    
+
     [Test]
     [TestCase("Server=myServer;Database=myDatabase;Integrated Security=true", ExpectedResult = false)] // SqlServer
     [TestCase("Server=myServer;Database=myDatabase;User Id=myLogin;Password=myPassword", ExpectedResult = false)] // SqlServer

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/SqlLocalDbDatabaseProviderMetadataTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/SqlLocalDbDatabaseProviderMetadataTests.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.Identity;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Install.Models;
+using Umbraco.Cms.Persistence.SqlServer.Services;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Persistence.SqlServer;
+
+[TestFixture]
+public class SqlLocalDbDatabaseProviderMetadataTests
+{
+    
+    
+    [Test]
+    [TestCase("ignored", "myDatabase", "ignored", "ignored", true, ExpectedResult = "Data Source=(localdb)\\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\\myDatabase.mdf;Integrated Security=True")]
+    [TestCase("ignored", "myDatabase2", "ignored", "ignored", false /*ignored*/, ExpectedResult = "Data Source=(localdb)\\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\\myDatabase2.mdf;Integrated Security=True")]
+    public string GenerateConnectionString(string server, string databaseName, string login, string password, bool integratedAuth)
+    {
+        var sut = new SqlLocalDbDatabaseProviderMetadata();
+        return sut.GenerateConnectionString(new DatabaseModel()
+        {
+            DatabaseName = databaseName,
+            Login = login,
+            Password = password,
+            Server = server,
+            IntegratedAuth = integratedAuth,
+            
+        });
+    }
+    
+    [Test]
+    [TestCase("Server=myServer;Database=myDatabase;Integrated Security=true", ExpectedResult = false)] // SqlServer
+    [TestCase("Server=myServer;Database=myDatabase;User Id=myLogin;Password=myPassword", ExpectedResult = false)] // SqlServer
+    [TestCase("Server=tcp:cmstest27032000.database.windows.net,1433;Database=test_27032000;User ID=asdasdas@cmstest27032000;Password=123456879", ExpectedResult = false)] // Azure
+    [TestCase("Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True", ExpectedResult = false)] // Sqlite
+    [TestCase("Data Source=(LocalDb)\\MSSQLLocalDB;Initial Catalog=aspnet-MvcMovie;Integrated Security=SSPI;AttachDBFilename=|DataDirectory|\\umbraco.mdf", ExpectedResult = true)] // localDB
+    public bool CanRecognizeConnectionString(string connectionString)
+    {
+        var sut = new SqlLocalDbDatabaseProviderMetadata();
+        return sut.CanRecognizeConnectionString(connectionString);
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/SqlLocalDbDatabaseProviderMetadataTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/SqlLocalDbDatabaseProviderMetadataTests.cs
@@ -1,16 +1,12 @@
-using Microsoft.AspNetCore.Identity;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Install.Models;
 using Umbraco.Cms.Persistence.SqlServer.Services;
-using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Persistence.SqlServer;
 
 [TestFixture]
 public class SqlLocalDbDatabaseProviderMetadataTests
 {
-    
-    
     [Test]
     [TestCase("ignored", "myDatabase", "ignored", "ignored", true, ExpectedResult = "Data Source=(localdb)\\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\\myDatabase.mdf;Integrated Security=True")]
     [TestCase("ignored", "myDatabase2", "ignored", "ignored", false /*ignored*/, ExpectedResult = "Data Source=(localdb)\\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\\myDatabase2.mdf;Integrated Security=True")]
@@ -24,10 +20,9 @@ public class SqlLocalDbDatabaseProviderMetadataTests
             Password = password,
             Server = server,
             IntegratedAuth = integratedAuth,
-            
         });
     }
-    
+
     [Test]
     [TestCase("Server=myServer;Database=myDatabase;Integrated Security=true", ExpectedResult = false)] // SqlServer
     [TestCase("Server=myServer;Database=myDatabase;User Id=myLogin;Password=myPassword", ExpectedResult = false)] // SqlServer

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/SqlServerDatabaseProviderMetadataTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/SqlServerDatabaseProviderMetadataTests.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Identity;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Install.Models;
+using Umbraco.Cms.Persistence.SqlServer.Services;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Persistence.SqlServer;
+
+[TestFixture]
+public class SqlServerDatabaseProviderMetadataTests
+{
+    
+    
+    [Test]
+    [TestCase("myServer", "myDatabase", "myLogin", "myPassword", true, ExpectedResult = "Server=myServer;Database=myDatabase;Integrated Security=true")]
+    [TestCase("myServer", "myDatabase", "myLogin", "myPassword", false, ExpectedResult = "Server=myServer;Database=myDatabase;User Id=myLogin;Password=myPassword")]
+    public string GenerateConnectionString(string server, string databaseName, string login, string password, bool integratedAuth)
+    {
+        var sut = new SqlServerDatabaseProviderMetadata();
+        return sut.GenerateConnectionString(new DatabaseModel()
+        {
+            DatabaseName = databaseName,
+            Login = login,
+            Password = password,
+            Server = server,
+            IntegratedAuth = integratedAuth
+        });
+    }
+    
+    [Test]
+    [TestCase("Server=myServer;Database=myDatabase;Integrated Security=true", ExpectedResult = true)] // SqlServer
+    [TestCase("Server=myServer;Database=myDatabase;User Id=myLogin;Password=myPassword", ExpectedResult = true)] // SqlServer
+    [TestCase("Server=tcp:cmstest27032000.database.windows.net,1433;Database=test_27032000;User ID=asdasdas@cmstest27032000;Password=123456879", ExpectedResult = true)] // Azure
+    [TestCase("Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True", ExpectedResult = false)] // Sqlite
+    [TestCase("Data Source=(LocalDb)\\MSSQLLocalDB;Initial Catalog=aspnet-MvcMovie;Integrated Security=SSPI;AttachDBFilename=|DataDirectory|\\umbraco.mdf", ExpectedResult = false)] // localDB
+    public bool CanRecognizeConnectionString(string connectionString)
+    {
+        var sut = new SqlServerDatabaseProviderMetadata();
+        return sut.CanRecognizeConnectionString(connectionString);
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/SqlServerDatabaseProviderMetadataTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/SqlServerDatabaseProviderMetadataTests.cs
@@ -1,16 +1,12 @@
-using Microsoft.AspNetCore.Identity;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Install.Models;
 using Umbraco.Cms.Persistence.SqlServer.Services;
-using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Persistence.SqlServer;
 
 [TestFixture]
 public class SqlServerDatabaseProviderMetadataTests
 {
-    
-    
     [Test]
     [TestCase("myServer", "myDatabase", "myLogin", "myPassword", true, ExpectedResult = "Server=myServer;Database=myDatabase;Integrated Security=true")]
     [TestCase("myServer", "myDatabase", "myLogin", "myPassword", false, ExpectedResult = "Server=myServer;Database=myDatabase;User Id=myLogin;Password=myPassword")]
@@ -26,7 +22,7 @@ public class SqlServerDatabaseProviderMetadataTests
             IntegratedAuth = integratedAuth
         });
     }
-    
+
     [Test]
     [TestCase("Server=myServer;Database=myDatabase;Integrated Security=true", ExpectedResult = true)] // SqlServer
     [TestCase("Server=myServer;Database=myDatabase;User Id=myLogin;Password=myPassword", ExpectedResult = true)] // SqlServer

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.Sqlite/SqliteDatabaseProviderMetadataTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.Sqlite/SqliteDatabaseProviderMetadataTests.cs
@@ -1,17 +1,12 @@
-using Microsoft.AspNetCore.Identity;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Install.Models;
 using Umbraco.Cms.Persistence.Sqlite.Services;
-using Umbraco.Cms.Persistence.SqlServer.Services;
-using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Persistence.Sqlite;
 
 [TestFixture]
 public class SqliteDatabaseProviderMetadataTests
 {
-    
-    
     [Test]
     [TestCase("ignored", "myDatabase", "ignored", "ignored", true /*ignored*/, ExpectedResult = "Data Source=|DataDirectory|/myDatabase.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True")]
     [TestCase("ignored", "myDatabase2", "ignored", "ignored", false /*ignored*/, ExpectedResult = "Data Source=|DataDirectory|/myDatabase2.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True")]
@@ -27,7 +22,7 @@ public class SqliteDatabaseProviderMetadataTests
             IntegratedAuth = integratedAuth
         });
     }
-    
+
     [Test]
     [TestCase("Server=myServer;Database=myDatabase;Integrated Security=true", ExpectedResult = false)] // SqlServer
     [TestCase("Server=myServer;Database=myDatabase;User Id=myLogin;Password=myPassword", ExpectedResult = false)] // SqlServer

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.Sqlite/SqliteDatabaseProviderMetadataTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.Sqlite/SqliteDatabaseProviderMetadataTests.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.Identity;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Install.Models;
+using Umbraco.Cms.Persistence.Sqlite.Services;
+using Umbraco.Cms.Persistence.SqlServer.Services;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Persistence.Sqlite;
+
+[TestFixture]
+public class SqliteDatabaseProviderMetadataTests
+{
+    
+    
+    [Test]
+    [TestCase("ignored", "myDatabase", "ignored", "ignored", true /*ignored*/, ExpectedResult = "Data Source=|DataDirectory|/myDatabase.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True")]
+    [TestCase("ignored", "myDatabase2", "ignored", "ignored", false /*ignored*/, ExpectedResult = "Data Source=|DataDirectory|/myDatabase2.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True")]
+    public string GenerateConnectionString(string server, string databaseName, string login, string password, bool integratedAuth)
+    {
+        var sut = new SqliteDatabaseProviderMetadata();
+        return sut.GenerateConnectionString(new DatabaseModel()
+        {
+            DatabaseName = databaseName,
+            Login = login,
+            Password = password,
+            Server = server,
+            IntegratedAuth = integratedAuth
+        });
+    }
+    
+    [Test]
+    [TestCase("Server=myServer;Database=myDatabase;Integrated Security=true", ExpectedResult = false)] // SqlServer
+    [TestCase("Server=myServer;Database=myDatabase;User Id=myLogin;Password=myPassword", ExpectedResult = false)] // SqlServer
+    [TestCase("Server=tcp:cmstest27032000.database.windows.net,1433;Database=test_27032000;User ID=asdasdas@cmstest27032000;Password=123456879", ExpectedResult = false)] // Azure
+    [TestCase("Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True", ExpectedResult = true)] // Sqlite
+    [TestCase("Data Source=(LocalDb)\\MSSQLLocalDB;Initial Catalog=aspnet-MvcMovie;Integrated Security=SSPI;AttachDBFilename=|DataDirectory|\\umbraco.mdf", ExpectedResult = false)] // localDB
+    public bool CanRecognizeConnectionString(string connectionString)
+    {
+        var sut = new SqliteDatabaseProviderMetadata();
+        return sut.CanRecognizeConnectionString(connectionString);
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.New.Cms.Infrastructure/Factories/DatabaseSettingsFactoryTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.New.Cms.Infrastructure/Factories/DatabaseSettingsFactoryTests.cs
@@ -177,6 +177,8 @@ public class DatabaseSettingsFactoryTests
         public Func<DatabaseModel, string> GenerateConnectionStringDelegate { get; set; } =
             _ => "ConnectionString";
 
+        public bool CanRecognizeConnectionString(string? connectionString) => false;
+
         public string? GenerateConnectionString(DatabaseModel databaseModel) => GenerateConnectionStringDelegate(databaseModel);
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Tests.UnitTests.csproj
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Tests.UnitTests.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
   
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Umbraco.Cms.Persistence.Sqlite\Umbraco.Cms.Persistence.Sqlite.csproj" />
     <ProjectReference Include="..\Umbraco.Tests.Common\Umbraco.Tests.Common.csproj" />
     <ProjectReference Include="..\..\src\Umbraco.Cms.ManagementApi\Umbraco.Cms.ManagementApi.csproj" />
     <ProjectReference Include="..\..\src\Umbraco.Cms.Imaging.ImageSharp\Umbraco.Cms.Imaging.ImageSharp.csproj" />


### PR DESCRIPTION
## Summary
Fixes issue where some connections strings was determined as  we could create the database while we cannot. 

This can happen if you have LocalDB available but uses a sql-server (or azure)connection string, due to the fact we just used the providername - which is the same for all three databases.

The reason this failed before was because LocalDB was set first in DI.


## Test:
- Specify a non-existing sqlserver or azure connectionstring, and ensure this ends in a boot failed state
- Specify a non-existing localDb connecitonstring, and ensure this ends in install state