### PR TITLE
V13/bugfix/fix key names to id and allow sending id on create for datatypes

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/ByKeyDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/ByKeyDataTypeController.cs
@@ -18,13 +18,13 @@ public class ByKeyDataTypeController : DataTypeControllerBase
         _umbracoMapper = umbracoMapper;
     }
 
-    [HttpGet("{key:guid}")]
+    [HttpGet("{id:guid}")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(DataTypeResponseModel), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<DataTypeResponseModel>> ByKey(Guid key)
+    public async Task<ActionResult<DataTypeResponseModel>> ByKey(Guid id)
     {
-        IDataType? dataType = await _dataTypeService.GetAsync(key);
+        IDataType? dataType = await _dataTypeService.GetAsync(id);
         if (dataType == null)
         {
             return NotFound();

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/CopyDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/CopyDataTypeController.cs
@@ -20,13 +20,13 @@ public class CopyDataTypeController : DataTypeControllerBase
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
-    [HttpPost("{key:guid}/copy")]
+    [HttpPost("{id:guid}/copy")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> Copy(Guid key, CopyDataTypeRequestModel copyDataTypeRequestModel)
+    public async Task<IActionResult> Copy(Guid id, CopyDataTypeRequestModel copyDataTypeRequestModel)
     {
-        IDataType? source = await _dataTypeService.GetAsync(key);
+        IDataType? source = await _dataTypeService.GetAsync(id);
         if (source is null)
         {
             return NotFound();

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/DataTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/DataTypeControllerBase.cs
@@ -20,16 +20,23 @@ public abstract class DataTypeControllerBase : ManagementApiControllerBase
                 .WithTitle("Invalid data type configuration")
                 .WithDetail("The supplied data type configuration was not valid. Please see the log for more details.")
                 .Build()),
-            DataTypeOperationStatus.NotFound => NotFound("The data type could not be found"),
+            DataTypeOperationStatus.NotFound => DataTypeNotFound(),
             DataTypeOperationStatus.InvalidName => BadRequest(new ProblemDetailsBuilder()
                 .WithTitle("Invalid data type name")
                 .WithDetail("The data type name must be non-empty and no longer than 255 characters.")
+                .Build()),
+            DataTypeOperationStatus.DuplicateKey => BadRequest(new ProblemDetailsBuilder()
+                .WithTitle("The id is already used")
+                .WithDetail("The data type id must be unique.")
                 .Build()),
             DataTypeOperationStatus.CancelledByNotification => BadRequest(new ProblemDetailsBuilder()
                 .WithTitle("Cancelled by notification")
                 .WithDetail("A notification handler prevented the data type operation.")
                 .Build()),
+            DataTypeOperationStatus.PropertyEditorNotFound => NotFound("The targeted property editor was not found."),
             DataTypeOperationStatus.ParentNotFound => NotFound("The targeted parent for the data type operation was not found."),
             _ => StatusCode(StatusCodes.Status500InternalServerError, "Unknown data type operation status")
         };
+
+    protected IActionResult DataTypeNotFound() => NotFound("The data type could not be found");
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/DeleteDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/DeleteDataTypeController.cs
@@ -19,14 +19,14 @@ public class DeleteDataTypeController : DataTypeControllerBase
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
-    [HttpDelete("{key:guid}")]
+    [HttpDelete("{id:guid}")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> Delete(Guid key)
+    public async Task<IActionResult> Delete(Guid id)
     {
-        Attempt<IDataType?, DataTypeOperationStatus> result = await _dataTypeService.DeleteAsync(key, CurrentUserKey(_backOfficeSecurityAccessor));
+        Attempt<IDataType?, DataTypeOperationStatus> result = await _dataTypeService.DeleteAsync(id, CurrentUserKey(_backOfficeSecurityAccessor));
 
         return result.Success
             ? Ok()

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/ByKeyDataTypeFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/ByKeyDataTypeFolderController.cs
@@ -13,9 +13,9 @@ public class ByKeyDataTypeFolderController : DataTypeFolderControllerBase
     {
     }
 
-    [HttpGet("{key:guid}")]
+    [HttpGet("{id:guid}")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(FolderReponseModel), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> ByKey(Guid key) => await GetFolderAsync(key);
+    public async Task<IActionResult> ByKey(Guid id) => await GetFolderAsync(id);
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/CreateDataTypeFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/CreateDataTypeFolderController.cs
@@ -17,5 +17,8 @@ public class CreateDataTypeFolderController : DataTypeFolderControllerBase
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status201Created)]
     public async Task<IActionResult> Create(CreateFolderRequestModel createFolderRequestModel)
-        => await CreateFolderAsync<ByKeyDataTypeFolderController>(createFolderRequestModel, controller => nameof(controller.ByKey));
+    {
+        return await CreateFolderAsync<ByKeyDataTypeFolderController>(createFolderRequestModel,
+            controller => nameof(controller.ByKey));
+    }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DataTypeFolderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DataTypeFolderControllerBase.cs
@@ -48,7 +48,7 @@ public abstract class DataTypeFolderControllerBase : FolderManagementControllerB
                 .WithTitle("The name is already used")
                 .WithDetail("The data type folder name must be unique on this parent.")
                 .Build()),
-            DataTypeContainerOperationStatus.InvalidKey => BadRequest(new ProblemDetailsBuilder()
+            DataTypeContainerOperationStatus.DuplicateKey => BadRequest(new ProblemDetailsBuilder()
                 .WithTitle("The id is already used")
                 .WithDetail("The data type folder id must be unique.")
                 .Build()),

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DataTypeFolderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DataTypeFolderControllerBase.cs
@@ -44,6 +44,14 @@ public abstract class DataTypeFolderControllerBase : FolderManagementControllerB
         {
             DataTypeContainerOperationStatus.NotFound => NotFound("The data type folder could not be found"),
             DataTypeContainerOperationStatus.ParentNotFound => NotFound("The data type parent folder could not be found"),
+            DataTypeContainerOperationStatus.DuplicateName => BadRequest(new ProblemDetailsBuilder()
+                .WithTitle("The name is already used")
+                .WithDetail("The data type folder name must be unique on this parent.")
+                .Build()),
+            DataTypeContainerOperationStatus.InvalidKey => BadRequest(new ProblemDetailsBuilder()
+                .WithTitle("The id is already used")
+                .WithDetail("The data type folder id must be unique.")
+                .Build()),
             DataTypeContainerOperationStatus.NotEmpty => BadRequest(new ProblemDetailsBuilder()
                 .WithTitle("The folder is not empty")
                 .WithDetail("The data type folder must be empty to perform this action.")

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DeleteDataTypeFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DeleteDataTypeFolderController.cs
@@ -13,9 +13,9 @@ public class DeleteDataTypeFolderController : DataTypeFolderControllerBase
     {
     }
 
-    [HttpDelete("{key:guid}")]
+    [HttpDelete("{id:guid}")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> Delete(Guid key) => await DeleteFolderAsync(key);
+    public async Task<IActionResult> Delete(Guid id) => await DeleteFolderAsync(id);
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/UpdateDataTypeFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/UpdateDataTypeFolderController.cs
@@ -13,9 +13,9 @@ public class UpdateDataTypeFolderController : DataTypeFolderControllerBase
     {
     }
 
-    [HttpPut("{key:guid}")]
+    [HttpPut("{id:guid}")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> Update(Guid key, UpdateFolderReponseModel updateFolderReponseModel) => await UpdateFolderAsync(key, updateFolderReponseModel);
+    public async Task<IActionResult> Update(Guid id, UpdateFolderReponseModel updateFolderReponseModel) => await UpdateFolderAsync(id, updateFolderReponseModel);
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/MoveDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/MoveDataTypeController.cs
@@ -20,13 +20,13 @@ public class MoveDataTypeController : DataTypeControllerBase
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
-    [HttpPost("{key:guid}/move")]
+    [HttpPost("{id:guid}/move")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> Move(Guid key, MoveDataTypeRequestModel moveDataTypeRequestModel)
+    public async Task<IActionResult> Move(Guid id, MoveDataTypeRequestModel moveDataTypeRequestModel)
     {
-        IDataType? source = await _dataTypeService.GetAsync(key);
+        IDataType? source = await _dataTypeService.GetAsync(id);
         if (source is null)
         {
             return NotFound();

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/ReferencesDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/ReferencesDataTypeController.cs
@@ -19,13 +19,13 @@ public class ReferencesDataTypeController : DataTypeControllerBase
         _dataTypeReferencePresentationFactory = dataTypeReferencePresentationFactory;
     }
 
-    [HttpGet("{key:guid}/references")]
+    [HttpGet("{id:guid}/references")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(DataTypeReferenceResponseModel[]), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> References(Guid key)
+    public async Task<IActionResult> References(Guid id)
     {
-        Attempt<IReadOnlyDictionary<Udi, IEnumerable<string>>, DataTypeOperationStatus> result = await _dataTypeService.GetReferencesAsync(key);
+        Attempt<IReadOnlyDictionary<Udi, IEnumerable<string>>, DataTypeOperationStatus> result = await _dataTypeService.GetReferencesAsync(id);
         if (result.Success == false)
         {
             return DataTypeOperationStatusResult(result.Status);

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/UpdateDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/UpdateDataTypeController.cs
@@ -23,14 +23,14 @@ public class UpdateDataTypeController : DataTypeControllerBase
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
-    [HttpPut("{key:guid}")]
+    [HttpPut("{id:guid}")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> Update(Guid key, UpdateDataTypeRequestModel updateDataTypeViewModel)
+    public async Task<IActionResult> Update(Guid id, UpdateDataTypeRequestModel updateDataTypeViewModel)
     {
-        IDataType? current = await _dataTypeService.GetAsync(key);
+        IDataType? current = await _dataTypeService.GetAsync(id);
         if (current == null)
         {
             return NotFound();

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/UpdateDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/UpdateDataTypeController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.DataType;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Mapping;
@@ -13,14 +14,14 @@ namespace Umbraco.Cms.Api.Management.Controllers.DataType;
 public class UpdateDataTypeController : DataTypeControllerBase
 {
     private readonly IDataTypeService _dataTypeService;
-    private readonly IUmbracoMapper _umbracoMapper;
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+    private IDataTypePresentationFactory _dataTypePresentationFactory;
 
-    public UpdateDataTypeController(IDataTypeService dataTypeService, IUmbracoMapper umbracoMapper, IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+    public UpdateDataTypeController(IDataTypeService dataTypeService, IBackOfficeSecurityAccessor backOfficeSecurityAccessor, IDataTypePresentationFactory dataTypePresentationFactory)
     {
         _dataTypeService = dataTypeService;
-        _umbracoMapper = umbracoMapper;
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+        _dataTypePresentationFactory = dataTypePresentationFactory;
     }
 
     [HttpPut("{id:guid}")]
@@ -33,12 +34,16 @@ public class UpdateDataTypeController : DataTypeControllerBase
         IDataType? current = await _dataTypeService.GetAsync(id);
         if (current == null)
         {
-            return NotFound();
+            return DataTypeNotFound();
         }
 
-        IDataType updated = _umbracoMapper.Map(updateDataTypeViewModel, current);
-        Attempt<IDataType, DataTypeOperationStatus> result = await _dataTypeService.UpdateAsync(updated, CurrentUserKey(_backOfficeSecurityAccessor));
+        Attempt<IDataType, DataTypeOperationStatus> attempt = await _dataTypePresentationFactory.CreateAsync(updateDataTypeViewModel, current);
+        if (!attempt.Success)
+        {
+            return DataTypeOperationStatusResult(attempt.Status);
+        }
 
+        Attempt<IDataType, DataTypeOperationStatus> result = await _dataTypeService.UpdateAsync(attempt.Result, CurrentUserKey(_backOfficeSecurityAccessor));
         return result.Success
             ? Ok()
             : DataTypeOperationStatusResult(result.Status);

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/DictionaryTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/DictionaryTreeControllerBase.cs
@@ -34,7 +34,7 @@ public class DictionaryTreeControllerBase : EntityTreeControllerBase<EntityTreeI
             {
                 Icon = Constants.Icons.Dictionary,
                 Name = dictionaryItem.ItemKey,
-                Key = dictionaryItem.Key,
+                Id = dictionaryItem.Key,
                 Type = Constants.UdiEntityType.DictionaryItem,
                 HasChildren = hasChildren,
                 IsContainer = false,

--- a/src/Umbraco.Cms.Api.Management/Controllers/FolderManagementControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/FolderManagementControllerBase.cs
@@ -29,8 +29,8 @@ public abstract class FolderManagementControllerBase<TStatus> : ManagementApiCon
         return Ok(new FolderReponseModel
         {
             Name = container.Name!,
-            Key = container.Key,
-            ParentKey = parentContainer?.Key
+            Id = container.Key,
+            ParentId = parentContainer?.Key
         });
     }
 
@@ -40,9 +40,14 @@ public abstract class FolderManagementControllerBase<TStatus> : ManagementApiCon
     {
         var container = new EntityContainer(ContainerObjectType) { Name = createFolderRequestModel.Name };
 
+        if (createFolderRequestModel.Id.HasValue)
+        {
+            container.Key = createFolderRequestModel.Id.Value;
+        }
+
         Attempt<EntityContainer, TStatus> result = await CreateContainerAsync(
             container,
-            createFolderRequestModel.ParentKey,
+            createFolderRequestModel.ParentId,
             CurrentUserKey(_backOfficeSecurityAccessor));
 
         return result.Success

--- a/src/Umbraco.Cms.Api.Management/Controllers/ManagementApiControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/ManagementApiControllerBase.cs
@@ -9,8 +9,8 @@ namespace Umbraco.Cms.Api.Management.Controllers;
 [JsonOptionsName(Constants.JsonOptionsNames.BackOffice)]
 public class ManagementApiControllerBase : Controller
 {
-    protected CreatedAtActionResult CreatedAtAction<T>(Expression<Func<T, string>> action, Guid key)
-        => CreatedAtAction(action, new { key = key });
+    protected CreatedAtActionResult CreatedAtAction<T>(Expression<Func<T, string>> action, Guid id)
+        => CreatedAtAction(action, new { id = id });
 
     protected CreatedAtActionResult CreatedAtAction<T>(Expression<Func<T, string>> action, object routeValues)
     {

--- a/src/Umbraco.Cms.Api.Management/Controllers/RecycleBin/RecycleBinControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RecycleBin/RecycleBinControllerBase.cs
@@ -67,7 +67,7 @@ public abstract class RecycleBinControllerBase<TItem> : Controller
         {
             Icon = _itemUdiType,
             Name = entity.Name!,
-            Key = entity.Key,
+            Id = entity.Key,
             Type = _itemUdiType,
             HasChildren = entity.HasChildren,
             IsContainer = entity.IsContainer,

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Tree/RelationTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Tree/RelationTypeTreeControllerBase.cs
@@ -28,7 +28,7 @@ public class RelationTypeTreeControllerBase : EntityTreeControllerBase<EntityTre
         {
             Icon = Constants.Icons.RelationType,
             Name = relationType.Name!,
-            Key = relationType.Key,
+            Id = relationType.Key,
             Type = Constants.UdiEntityType.RelationType,
             HasChildren = false,
             IsContainer = false,

--- a/src/Umbraco.Cms.Api.Management/Controllers/Tree/EntityTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tree/EntityTreeControllerBase.cs
@@ -117,7 +117,7 @@ public abstract class EntityTreeControllerBase<TItem> : ManagementApiControllerB
         {
             Icon = _itemUdiType,
             Name = entity.Name!,
-            Key = entity.Key,
+            Id = entity.Key,
             Type = _itemUdiType,
             HasChildren = entity.HasChildren,
             IsContainer = entity.IsContainer,

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/DataTypeBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/DataTypeBuilderExtensions.cs
@@ -11,6 +11,7 @@ internal static class DataTypeBuilderExtensions
     internal static IUmbracoBuilder AddDataTypes(this IUmbracoBuilder builder)
     {
         builder.Services.AddTransient<IDataTypeReferencePresentationFactory, DataTypeReferencePresentationFactory>();
+        builder.Services.AddTransient<IDataTypePresentationFactory, DataTypePresentationFactory>();
 
         builder.WithCollectionBuilder<MapDefinitionCollectionBuilder>().Add<DataTypeViewModelMapDefinition>();
 

--- a/src/Umbraco.Cms.Api.Management/Factories/DataTypePresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DataTypePresentationFactory.cs
@@ -1,0 +1,105 @@
+﻿
+using Umbraco.Cms.Api.Management.ViewModels.DataType;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Api.Management.Factories;
+
+/// <inheritdoc />
+public class DataTypePresentationFactory : IDataTypePresentationFactory
+{
+    private readonly IDataTypeService _dataTypeService;
+    private readonly PropertyEditorCollection _propertyEditorCollection;
+    private readonly IDataValueEditorFactory _dataValueEditorFactory;
+    private readonly IConfigurationEditorJsonSerializer _configurationEditorJsonSerializer;
+
+    public DataTypePresentationFactory(
+        IDataTypeService dataTypeService,
+        PropertyEditorCollection propertyEditorCollection,
+        IDataValueEditorFactory dataValueEditorFactory,
+        IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
+    {
+        _dataTypeService = dataTypeService;
+        _propertyEditorCollection = propertyEditorCollection;
+        _dataValueEditorFactory = dataValueEditorFactory;
+        _configurationEditorJsonSerializer = configurationEditorJsonSerializer;
+    }
+
+    /// <inheritdoc />
+    public Task<Attempt<IDataType, DataTypeOperationStatus>> CreateAsync(CreateDataTypeRequestModel requestModel)
+    {
+        if (!_propertyEditorCollection.TryGet(requestModel.PropertyEditorAlias, out IDataEditor? editor))
+        {
+            return Task.FromResult(Attempt.FailWithStatus<IDataType, DataTypeOperationStatus>(DataTypeOperationStatus.PropertyEditorNotFound, new DataType(new VoidEditor(_dataValueEditorFactory), _configurationEditorJsonSerializer) ));
+        }
+
+        var dataType = new DataType(editor, _configurationEditorJsonSerializer)
+        {
+            Name = requestModel.Name,
+            EditorUiAlias = requestModel.PropertyEditorUiAlias,
+            DatabaseType = GetEditorValueStorageType(editor),
+            ConfigurationData = MapConfigurationData(requestModel, editor),
+            ParentId = MapParentId(requestModel.ParentId),
+            CreateDate = DateTime.Now,
+        };
+
+        if (requestModel.Id.HasValue)
+        {
+            dataType.Key = requestModel.Id.Value;
+        }
+
+
+        return Task.FromResult(Attempt.SucceedWithStatus<IDataType, DataTypeOperationStatus>(DataTypeOperationStatus.Success, dataType));
+    }
+
+    public Task<Attempt<IDataType, DataTypeOperationStatus>> CreateAsync(UpdateDataTypeRequestModel requestModel, IDataType current)
+    {
+        if (!_propertyEditorCollection.TryGet(requestModel.PropertyEditorAlias, out IDataEditor? editor))
+        {
+            return Task.FromResult(Attempt.FailWithStatus<IDataType, DataTypeOperationStatus>(DataTypeOperationStatus.PropertyEditorNotFound, new DataType(new VoidEditor(_dataValueEditorFactory), _configurationEditorJsonSerializer) ));
+        }
+
+        IDataType dataType = (IDataType)current.DeepClone();
+
+        dataType.Name = requestModel.Name;
+        dataType.Editor = editor;
+        dataType.EditorUiAlias = requestModel.PropertyEditorUiAlias;
+        dataType.DatabaseType = GetEditorValueStorageType(editor);
+        dataType.ConfigurationData = MapConfigurationData(requestModel, editor);
+
+        return Task.FromResult(Attempt.SucceedWithStatus<IDataType, DataTypeOperationStatus>(DataTypeOperationStatus.Success, dataType));
+    }
+
+    private int MapParentId(Guid? parentKey)
+    {
+        if (parentKey == null)
+        {
+            return Constants.System.Root;
+        }
+
+        EntityContainer? container = _dataTypeService.GetContainer(parentKey.Value);
+        return container?.Id ?? throw new InvalidOperationException($"Could not find a parent container with key \"{parentKey}\".");
+    }
+
+    private ValueStorageType GetEditorValueStorageType(IDataEditor editor)
+    {
+        var valueType = editor.GetValueEditor().ValueType;
+        return ValueTypes.ToStorageType(valueType);
+    }
+
+    private IDictionary<string, object> MapConfigurationData<T>(T source, IDataEditor editor) where T : DataTypeModelBase
+    {
+        var configuration = source
+            .Values
+            .Where(p => p.Value is not null)
+            .ToDictionary(p => p.Alias, p => p.Value!);
+        IConfigurationEditor? configurationEditor = editor?.GetConfigurationEditor();
+        return configurationEditor?.FromConfigurationEditor(configuration)
+               ?? new Dictionary<string, object>();
+    }
+
+}

--- a/src/Umbraco.Cms.Api.Management/Factories/IDataTypePresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IDataTypePresentationFactory.cs
@@ -1,0 +1,13 @@
+using Umbraco.Cms.Api.Management.ViewModels.DataType;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Api.Management.Factories;
+
+public interface IDataTypePresentationFactory
+{
+
+    Task<Attempt<IDataType, DataTypeOperationStatus>> CreateAsync(CreateDataTypeRequestModel requestModel);
+    Task<Attempt<IDataType, DataTypeOperationStatus>> CreateAsync(UpdateDataTypeRequestModel requestModel, IDataType current);
+}

--- a/src/Umbraco.Cms.Api.Management/Factories/UserGroupPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/UserGroupPresentationFactory.cs
@@ -43,7 +43,7 @@ public class UserGroupPresentationFactory : IUserGroupPresentationFactory
         return new UserGroupPresentationModel
         {
             Name = userGroup.Name ?? string.Empty,
-            Key = userGroup.Key,
+            Id = userGroup.Key,
             DocumentStartNodeKey = contentStartNodeKey,
             MediaStartNodeKey = mediaStartNodeKey,
             Icon = userGroup.Icon,

--- a/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
@@ -34,7 +34,7 @@ public class UserPresentationFactory : IUserPresentationFactory
     {
         var responseModel = new UserResponseModel
         {
-            Key = user.Key,
+            Id = user.Key,
             Email = user.Email,
             Name = user.Name ?? string.Empty,
             AvatarUrls = user.GetUserAvatarUrls(_appCaches.RuntimeCache, _mediaFileManager, _imageUrlGenerator),

--- a/src/Umbraco.Cms.Api.Management/Mapping/DataType/DataTypeViewModelMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/DataType/DataTypeViewModelMapDefinition.cs
@@ -42,7 +42,7 @@ public class DataTypeViewModelMapDefinition : IMapDefinition
     // Umbraco.Code.MapAll
     private void Map(IDataType source, DataTypeResponseModel target, MapperContext context)
     {
-        target.Key = source.Key;
+        target.Id = source.Key;
         target.ParentKey = _dataTypeService.GetContainer(source.ParentId)?.Key;
         target.Name = source.Name ?? string.Empty;
         target.PropertyEditorAlias = source.EditorAlias;

--- a/src/Umbraco.Cms.Api.Management/Mapping/DataType/DataTypeViewModelMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/DataType/DataTypeViewModelMapDefinition.cs
@@ -1,9 +1,7 @@
 ﻿using Umbraco.Cms.Api.Management.ViewModels.DataType;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
-using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Mapping.DataType;
@@ -11,32 +9,19 @@ namespace Umbraco.Cms.Api.Management.Mapping.DataType;
 public class DataTypeViewModelMapDefinition : IMapDefinition
 {
     private readonly PropertyEditorCollection _propertyEditors;
-    private readonly IConfigurationEditorJsonSerializer _serializer;
     private readonly IDataTypeService _dataTypeService;
 
     public DataTypeViewModelMapDefinition(
         PropertyEditorCollection propertyEditors,
-        IConfigurationEditorJsonSerializer serializer,
         IDataTypeService dataTypeService)
     {
         _propertyEditors = propertyEditors;
-        _serializer = serializer;
         _dataTypeService = dataTypeService;
     }
 
     public void DefineMaps(IUmbracoMapper mapper)
     {
         mapper.Define<IDataType, DataTypeResponseModel>((_, _) => new DataTypeResponseModel(), Map);
-
-        mapper.Define<UpdateDataTypeRequestModel, IDataType>(InitializeDataType, Map);
-
-        mapper.Define<CreateDataTypeRequestModel, IDataType>(InitializeDataType, Map);
-
-        IDataType InitializeDataType<T>(T source, MapperContext _) where T : DataTypeModelBase =>
-            new Core.Models.DataType(_propertyEditors[source.PropertyEditorAlias], _serializer)
-            {
-                CreateDate = DateTime.Now
-            };
     }
 
     // Umbraco.Code.MapAll
@@ -58,70 +43,5 @@ public class DataTypeViewModelMapDefinition : IMapDefinition
                 Alias = c.Key,
                 Value = c.Value
             }).ToArray();
-    }
-
-    // Umbraco.Code.MapAll -CreateDate -DeleteDate -UpdateDate -ParentId
-    // Umbraco.Code.MapAll -Id -Key -Path -CreatorId -Level -SortOrder
-    private void Map(UpdateDataTypeRequestModel source, IDataType target, MapperContext context)
-    {
-        IDataEditor editor = GetRequiredDataEditor(source);
-
-        target.Name = source.Name;
-        target.Editor = editor;
-        target.EditorUiAlias = source.PropertyEditorUiAlias;
-        target.DatabaseType = GetEditorValueStorageType(editor);
-        target.ConfigurationData = MapConfigurationData(source, editor);
-    }
-
-    // Umbraco.Code.MapAll -CreateDate -DeleteDate -UpdateDate
-    // Umbraco.Code.MapAll -Id -Key -Path -CreatorId -Level -SortOrder
-    private void Map(CreateDataTypeRequestModel source, IDataType target, MapperContext context)
-    {
-        IDataEditor editor = GetRequiredDataEditor(source);
-
-        target.Name = source.Name;
-        target.ParentId = MapParentId(source.ParentKey);
-        target.Editor = editor;
-        target.EditorUiAlias = source.PropertyEditorUiAlias;
-        target.DatabaseType = GetEditorValueStorageType(editor);
-        target.ConfigurationData = MapConfigurationData(source, editor);
-    }
-
-    private IDataEditor GetRequiredDataEditor<T>(T source) where T : DataTypeModelBase
-    {
-        if (_propertyEditors.TryGet(source.PropertyEditorAlias, out IDataEditor? editor) == false)
-        {
-            throw new InvalidOperationException($"Could not find a property editor with alias \"{source.PropertyEditorAlias}\".");
-        }
-
-        return editor;
-    }
-
-    private ValueStorageType GetEditorValueStorageType(IDataEditor editor)
-    {
-        var valueType = editor.GetValueEditor().ValueType;
-        return ValueTypes.ToStorageType(valueType);
-    }
-
-    private IDictionary<string, object> MapConfigurationData<T>(T source, IDataEditor editor) where T : DataTypeModelBase
-    {
-        var configuration = source
-            .Values
-            .Where(p => p.Value is not null)
-            .ToDictionary(p => p.Alias, p => p.Value!);
-        IConfigurationEditor? configurationEditor = editor?.GetConfigurationEditor();
-        return configurationEditor?.FromConfigurationEditor(configuration)
-                                   ?? new Dictionary<string, object>();
-    }
-
-    private int MapParentId(Guid? parentKey)
-    {
-        if (parentKey == null)
-        {
-            return Constants.System.Root;
-        }
-
-        EntityContainer? container = _dataTypeService.GetContainer(parentKey.Value);
-        return container?.Id ?? throw new InvalidOperationException($"Could not find a parent container with key \"{parentKey}\".");
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Mapping/Dictionary/DictionaryMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Dictionary/DictionaryMapDefinition.cs
@@ -19,7 +19,7 @@ public class DictionaryMapDefinition : IMapDefinition
     // Umbraco.Code.MapAll -Translations
     private void Map(IDictionaryItem source, DictionaryItemResponseModel target, MapperContext context)
     {
-        target.Key = source.Key;
+        target.Id = source.Key;
         target.Name = source.ItemKey;
     }
 

--- a/src/Umbraco.Cms.Api.Management/Mapping/Template/TemplateViewModelMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Template/TemplateViewModelMapDefinition.cs
@@ -21,7 +21,7 @@ public class TemplateViewModelMapDefinition : IMapDefinition
     // Umbraco.Code.MapAll
     private void Map(ITemplate source, TemplateResponseModel target, MapperContext context)
     {
-        target.Key = source.Key;
+        target.Id = source.Key;
         target.Name = source.Name ?? string.Empty;
         target.Alias = source.Alias;
         target.Content = source.Content;

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -270,15 +270,15 @@
         }
       }
     },
-    "/umbraco/management/api/v1/data-type/{key}": {
+    "/umbraco/management/api/v1/data-type/{id}": {
       "get": {
         "tags": [
           "Data Type"
         ],
-        "operationId": "GetDataTypeByKey",
+        "operationId": "GetDataTypeById",
         "parameters": [
           {
-            "name": "key",
+            "name": "id",
             "in": "path",
             "required": true,
             "schema": {
@@ -311,10 +311,10 @@
         "tags": [
           "Data Type"
         ],
-        "operationId": "DeleteDataTypeByKey",
+        "operationId": "DeleteDataTypeById",
         "parameters": [
           {
-            "name": "key",
+            "name": "id",
             "in": "path",
             "required": true,
             "schema": {
@@ -346,10 +346,10 @@
         "tags": [
           "Data Type"
         ],
-        "operationId": "PutDataTypeByKey",
+        "operationId": "PutDataTypeById",
         "parameters": [
           {
-            "name": "key",
+            "name": "id",
             "in": "path",
             "required": true,
             "schema": {
@@ -391,15 +391,15 @@
         }
       }
     },
-    "/umbraco/management/api/v1/data-type/{key}/copy": {
+    "/umbraco/management/api/v1/data-type/{id}/copy": {
       "post": {
         "tags": [
           "Data Type"
         ],
-        "operationId": "PostDataTypeByKeyCopy",
+        "operationId": "PostDataTypeByIdCopy",
         "parameters": [
           {
-            "name": "key",
+            "name": "id",
             "in": "path",
             "required": true,
             "schema": {
@@ -441,15 +441,15 @@
         }
       }
     },
-    "/umbraco/management/api/v1/data-type/{key}/move": {
+    "/umbraco/management/api/v1/data-type/{id}/move": {
       "post": {
         "tags": [
           "Data Type"
         ],
-        "operationId": "PostDataTypeByKeyMove",
+        "operationId": "PostDataTypeByIdMove",
         "parameters": [
           {
-            "name": "key",
+            "name": "id",
             "in": "path",
             "required": true,
             "schema": {
@@ -481,15 +481,15 @@
         }
       }
     },
-    "/umbraco/management/api/v1/data-type/{key}/references": {
+    "/umbraco/management/api/v1/data-type/{id}/references": {
       "get": {
         "tags": [
           "Data Type"
         ],
-        "operationId": "GetDataTypeByKeyReferences",
+        "operationId": "GetDataTypeByIdReferences",
         "parameters": [
           {
-            "name": "key",
+            "name": "id",
             "in": "path",
             "required": true,
             "schema": {
@@ -558,15 +558,15 @@
         }
       }
     },
-    "/umbraco/management/api/v1/data-type/folder/{key}": {
+    "/umbraco/management/api/v1/data-type/folder/{id}": {
       "get": {
         "tags": [
           "Data Type"
         ],
-        "operationId": "GetDataTypeFolderByKey",
+        "operationId": "GetDataTypeFolderById",
         "parameters": [
           {
-            "name": "key",
+            "name": "id",
             "in": "path",
             "required": true,
             "schema": {
@@ -599,10 +599,10 @@
         "tags": [
           "Data Type"
         ],
-        "operationId": "DeleteDataTypeFolderByKey",
+        "operationId": "DeleteDataTypeFolderById",
         "parameters": [
           {
-            "name": "key",
+            "name": "id",
             "in": "path",
             "required": true,
             "schema": {
@@ -624,10 +624,10 @@
         "tags": [
           "Data Type"
         ],
-        "operationId": "PutDataTypeFolderByKey",
+        "operationId": "PutDataTypeFolderById",
         "parameters": [
           {
-            "name": "key",
+            "name": "id",
             "in": "path",
             "required": true,
             "schema": {
@@ -6894,6 +6894,533 @@
           }
         }
       }
+    },
+    "/umbraco/management/api/v1/users": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "operationId": "PostUsers",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateUserRequestModel"
+                  },
+                  {
+                    "$ref": "#/components/schemas/InviteUserRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/CreateUserResponseModel"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "operationId": "GetUsers",
+        "parameters": [
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedUserResponseModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/umbraco/management/api/v1/users/{id}": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "operationId": "GetUsersById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/UserResponseModel"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Users"
+        ],
+        "operationId": "DeleteUsersById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Users"
+        ],
+        "operationId": "PutUsersById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateUserRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/umbraco/management/api/v1/users/avatar/{id}": {
+      "delete": {
+        "tags": [
+          "Users"
+        ],
+        "operationId": "DeleteUsersAvatarById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "operationId": "PostUsersAvatarById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SetAvatarRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/umbraco/management/api/v1/users/change-password/{id}": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "operationId": "PostUsersChangePasswordById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/umbraco/management/api/v1/users/disable": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "operationId": "PostUsersDisable",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/DisableUserRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/umbraco/management/api/v1/users/enable": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "operationId": "PostUsersEnable",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/EnableUserRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/umbraco/management/api/v1/users/filter": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "operationId": "GetUsersFilter",
+        "parameters": [
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/UserOrderModel"
+            }
+          },
+          {
+            "name": "orderDirection",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/DirectionModel"
+            }
+          },
+          {
+            "name": "userGroupIds",
+            "in": "query",
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          },
+          {
+            "name": "userStates",
+            "in": "query",
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/UserStateModel"
+              }
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/umbraco/management/api/v1/users/invite": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "operationId": "PostUsersInvite",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/InviteUserRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/umbraco/management/api/v1/users/set-user-groups": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "operationId": "PostUsersSetUserGroups",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateUserGroupsOnUserRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/umbraco/management/api/v1/users/unlock": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "operationId": "PostUsersUnlock",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UnlockUsersRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsModel"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -6992,6 +7519,19 @@
         ],
         "type": "integer",
         "format": "int32"
+      },
+      "ChangePasswordUserRequestModel": {
+        "type": "object",
+        "properties": {
+          "newPassword": {
+            "type": "string"
+          },
+          "oldPassword": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
       },
       "ConsentLevelPresentationModel": {
         "type": "object",
@@ -7429,7 +7969,12 @@
           }
         ],
         "properties": {
-          "parentKey": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "parentId": {
             "type": "string",
             "format": "uuid",
             "nullable": true
@@ -7498,6 +8043,29 @@
             "$ref": "#/components/schemas/TemplateModelBaseModel"
           }
         ],
+        "additionalProperties": false
+      },
+      "CreateUserRequestModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/UserPresentationBaseModel"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "CreateUserResponseModel": {
+        "type": "object",
+        "properties": {
+          "userKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "initialPassword": {
+            "type": "string",
+            "nullable": true
+          }
+        },
         "additionalProperties": false
       },
       "CultureReponseModel": {
@@ -7599,7 +8167,7 @@
           "$type": {
             "type": "string"
           },
-          "key": {
+          "id": {
             "type": "string",
             "format": "uuid"
           },
@@ -7732,7 +8300,7 @@
           "$type": {
             "type": "string"
           },
-          "key": {
+          "id": {
             "type": "string",
             "format": "uuid"
           }
@@ -7789,6 +8357,20 @@
         ],
         "type": "integer",
         "format": "int32"
+      },
+      "DisableUserRequestModel": {
+        "type": "object",
+        "properties": {
+          "userIds": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        },
+        "additionalProperties": false
       },
       "DocumentBlueprintTreeItemResponseModel": {
         "required": [
@@ -8086,6 +8668,20 @@
         ],
         "additionalProperties": false
       },
+      "EnableUserRequestModel": {
+        "type": "object",
+        "properties": {
+          "userIds": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
       "EntityTreeItemResponseModel": {
         "required": [
           "$type"
@@ -8100,7 +8696,7 @@
           "$type": {
             "type": "string"
           },
-          "key": {
+          "id": {
             "type": "string",
             "format": "uuid"
           },
@@ -8181,11 +8777,11 @@
           "$type": {
             "type": "string"
           },
-          "key": {
+          "id": {
             "type": "string",
             "format": "uuid"
           },
-          "parentKey": {
+          "parentId": {
             "type": "string",
             "format": "uuid",
             "nullable": true
@@ -8525,6 +9121,21 @@
           },
           "telemetryLevel": {
             "$ref": "#/components/schemas/TelemetryLevelModel"
+          }
+        },
+        "additionalProperties": false
+      },
+      "InviteUserRequestModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CreateUserRequestModel"
+          }
+        ],
+        "properties": {
+          "message": {
+            "type": "string",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -9756,6 +10367,30 @@
         },
         "additionalProperties": false
       },
+      "PagedUserResponseModel": {
+        "required": [
+          "items",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/UserResponseModel"
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
+      },
       "ProblemDetailsModel": {
         "type": "object",
         "properties": {
@@ -9915,7 +10550,7 @@
           "$type": {
             "type": "string"
           },
-          "key": {
+          "id": {
             "type": "string",
             "format": "uuid"
           },
@@ -10225,6 +10860,16 @@
         },
         "additionalProperties": false
       },
+      "SetAvatarRequestModel": {
+        "type": "object",
+        "properties": {
+          "fileKey": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
       "StatusResultTypeModel": {
         "enum": [
           "Success",
@@ -10474,7 +11119,7 @@
           "$type": {
             "type": "string"
           },
-          "key": {
+          "id": {
             "type": "string",
             "format": "uuid"
           }
@@ -10528,6 +11173,20 @@
           },
           "hasChildren": {
             "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UnlockUsersRequestModel": {
+        "type": "object",
+        "properties": {
+          "userIds": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         },
         "additionalProperties": false
@@ -10707,6 +11366,58 @@
         ],
         "additionalProperties": false
       },
+      "UpdateUserGroupsOnUserRequestModel": {
+        "type": "object",
+        "properties": {
+          "userIds": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "userGroupIds": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateUserRequestModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/UserPresentationBaseModel"
+          }
+        ],
+        "properties": {
+          "languageIsoCode": {
+            "type": "string"
+          },
+          "contentStartNodeIds": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "mediaStartNodeIds": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
       "UpgradeSettingsResponseModel": {
         "type": "object",
         "properties": {
@@ -10788,7 +11499,7 @@
           "$type": {
             "type": "string"
           },
-          "key": {
+          "id": {
             "type": "string",
             "format": "uuid"
           }
@@ -10830,6 +11541,128 @@
         },
         "additionalProperties": false
       },
+      "UserOrderModel": {
+        "enum": [
+          "UserName",
+          "Language",
+          "Name",
+          "Email",
+          "Id",
+          "CreateDate",
+          "UpdateDate",
+          "IsApproved",
+          "IsLockedOut",
+          "LastLoginDate"
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "UserPresentationBaseModel": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "userName": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "userGroupIds": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "UserResponseModel": {
+        "required": [
+          "$type"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/UserPresentationBaseModel"
+          }
+        ],
+        "properties": {
+          "$type": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "languageIsoCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "contentStartNodeKeys": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "mediaStartNodeKeys": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "avatarUrls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "state": {
+            "$ref": "#/components/schemas/UserStateModel"
+          },
+          "failedLoginAttempts": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "createDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updateDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "lastLoginDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "lastlockoutDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "lastPasswordChangeDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "discriminator": {
+          "propertyName": "$type",
+          "mapping": {
+            "UserResponseModel": "#/components/schemas/UserResponseModel"
+          }
+        }
+      },
       "UserSettingsModel": {
         "type": "object",
         "properties": {
@@ -10853,6 +11686,18 @@
           }
         },
         "additionalProperties": false
+      },
+      "UserStateModel": {
+        "enum": [
+          "Active",
+          "Disabled",
+          "LockedOut",
+          "Invited",
+          "Inactive",
+          "All"
+        ],
+        "type": "integer",
+        "format": "int32"
       },
       "ValueModelBaseModel": {
         "required": [

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -7917,7 +7917,12 @@
           }
         ],
         "properties": {
-          "parentKey": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "parentId": {
             "type": "string",
             "format": "uuid",
             "nullable": true

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DataType/CreateDataTypeRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DataType/CreateDataTypeRequestModel.cs
@@ -2,5 +2,6 @@
 
 public class CreateDataTypeRequestModel : DataTypeModelBase
 {
-    public Guid? ParentKey { get; set; }
+    public Guid? Id { get; set; }
+    public Guid? ParentId { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DataTypeResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DataTypeResponseModel.cs
@@ -2,7 +2,7 @@
 
 public class DataTypeResponseModel : DataTypeModelBase, INamedEntityPresentationModel
 {
-    public Guid Key { get; set; }
+    public Guid Id { get; set; }
 
     public Guid? ParentKey { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Dictionary/DictionaryItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Dictionary/DictionaryItemResponseModel.cs
@@ -2,5 +2,5 @@
 
 public class DictionaryItemResponseModel : DictionaryItemModelBase, INamedEntityPresentationModel
 {
-    public Guid Key { get; set; }
+    public Guid Id { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Folder/FolderCreateModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Folder/FolderCreateModel.cs
@@ -2,5 +2,6 @@
 
 public class CreateFolderRequestModel : FolderModelBase
 {
-    public Guid? ParentKey { get; set; }
+    public Guid? Id { get; set; }
+    public Guid? ParentId { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Folder/FolderViewModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Folder/FolderViewModel.cs
@@ -2,7 +2,7 @@
 
 public class FolderReponseModel : FolderModelBase, INamedEntityPresentationModel
 {
-    public Guid Key { get; set; }
+    public Guid Id { get; set; }
 
-    public Guid? ParentKey { get; set; }
+    public Guid? ParentId { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/INamedEntityPresentationModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/INamedEntityPresentationModel.cs
@@ -2,7 +2,7 @@ namespace Umbraco.Cms.Api.Management.ViewModels;
 
 public interface INamedEntityPresentationModel
 {
-    Guid Key { get; }
+    Guid Id { get; }
 
     string Name { get;}
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/RecycleBin/RecycleBinItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/RecycleBin/RecycleBinItemResponseModel.cs
@@ -2,7 +2,7 @@
 
 public class RecycleBinItemResponseModel : INamedEntityPresentationModel
 {
-    public Guid Key { get; set; }
+    public Guid Id { get; set; }
 
     public string Name { get; set; } = string.Empty;
 

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Template/TemplateResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Template/TemplateResponseModel.cs
@@ -2,5 +2,5 @@
 
 public class TemplateResponseModel : TemplateModelBase, INamedEntityPresentationModel
 {
-    public Guid Key { get; set; }
+    public Guid Id { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Tree/EntityTreeItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Tree/EntityTreeItemResponseModel.cs
@@ -2,7 +2,7 @@
 
 public class EntityTreeItemResponseModel : TreeItemPresentationModel, INamedEntityPresentationModel
 {
-    public Guid Key { get; set; }
+    public Guid Id { get; set; }
 
     public bool IsContainer { get; set; }
 

--- a/src/Umbraco.Cms.Api.Management/ViewModels/UserGroups/UserGroupPresentationModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/UserGroups/UserGroupPresentationModel.cs
@@ -5,6 +5,6 @@ public class UserGroupPresentationModel : UserGroupBase, INamedEntityPresentatio
     /// <summary>
     /// The key identifier for the user group.
     /// </summary>
-    public required Guid Key { get; init; }
+    public required Guid Id { get; init; }
 
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Users/UserResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Users/UserResponseModel.cs
@@ -4,7 +4,7 @@ namespace Umbraco.Cms.Api.Management.ViewModels.Users;
 
 public class UserResponseModel : UserPresentationBase, INamedEntityPresentationModel
 {
-    public Guid Key { get; set; }
+    public Guid Id { get; set; }
 
     public string? LanguageIsoCode { get; set; }
 

--- a/src/Umbraco.Core/Persistence/Repositories/IDataTypeRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IDataTypeRepository.cs
@@ -5,6 +5,9 @@ namespace Umbraco.Cms.Core.Persistence.Repositories;
 
 public interface IDataTypeRepository : IReadWriteQueryRepository<int, IDataType>
 {
+    
+    IDataType? Get(Guid key);
+
     IEnumerable<MoveEventInfo<IDataType>> Move(IDataType toMove, EntityContainer? container);
 
     /// <summary>

--- a/src/Umbraco.Core/Services/DataTypeContainerService.cs
+++ b/src/Umbraco.Core/Services/DataTypeContainerService.cs
@@ -59,6 +59,11 @@ internal sealed class DataTypeContainerService : RepositoryService, IDataTypeCon
                     return DataTypeContainerOperationStatus.InvalidId;
                 }
 
+                if (_dataTypeContainerRepository.Get(container.Key) is not null)
+                {
+                    return DataTypeContainerOperationStatus.InvalidKey;
+                }
+
                 EntityContainer? parentContainer = parentKey.HasValue
                     ? _dataTypeContainerRepository.Get(parentKey.Value)
                     : null;
@@ -66,6 +71,12 @@ internal sealed class DataTypeContainerService : RepositoryService, IDataTypeCon
                 if (parentKey.HasValue && parentContainer == null)
                 {
                     return DataTypeContainerOperationStatus.ParentNotFound;
+                }
+
+
+                if (_dataTypeContainerRepository.Get(container.Name!, (parentContainer?.Level ?? 0) + 1).Any())
+                {
+                    return DataTypeContainerOperationStatus.DuplicateName;
                 }
 
                 container.ParentId = parentContainer?.Id ?? Constants.System.Root;

--- a/src/Umbraco.Core/Services/DataTypeContainerService.cs
+++ b/src/Umbraco.Core/Services/DataTypeContainerService.cs
@@ -61,7 +61,7 @@ internal sealed class DataTypeContainerService : RepositoryService, IDataTypeCon
 
                 if (_dataTypeContainerRepository.Get(container.Key) is not null)
                 {
-                    return DataTypeContainerOperationStatus.InvalidKey;
+                    return DataTypeContainerOperationStatus.DuplicateKey;
                 }
 
                 EntityContainer? parentContainer = parentKey.HasValue

--- a/src/Umbraco.Core/Services/DataTypeService.cs
+++ b/src/Umbraco.Core/Services/DataTypeService.cs
@@ -522,7 +522,18 @@ namespace Umbraco.Cms.Core.Services.Implement
                 return Attempt.FailWithStatus(DataTypeOperationStatus.InvalidId, dataType);
             }
 
-            return await SaveAsync(dataType, () => DataTypeOperationStatus.Success, userKey, AuditType.New);
+            using ICoreScope scope = ScopeProvider.CreateCoreScope();
+
+            if (_dataTypeRepository.Get(dataType.Key) is not null)
+            {
+                return Attempt.FailWithStatus(DataTypeOperationStatus.DuplicateKey, dataType);
+            }
+
+            var result = await SaveAsync(dataType, () => DataTypeOperationStatus.Success, userKey, AuditType.New);
+
+            scope.Complete();
+
+            return result;
         }
 
         /// <inheritdoc />

--- a/src/Umbraco.Core/Services/OperationStatus/DataTypeContainerOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/DataTypeContainerOperationStatus.cs
@@ -6,7 +6,7 @@ public enum DataTypeContainerOperationStatus
     CancelledByNotification,
     InvalidObjectType,
     InvalidId,
-    InvalidKey,
+    DuplicateKey,
     NotFound,
     ParentNotFound,
     NotEmpty,

--- a/src/Umbraco.Core/Services/OperationStatus/DataTypeContainerOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/DataTypeContainerOperationStatus.cs
@@ -6,7 +6,9 @@ public enum DataTypeContainerOperationStatus
     CancelledByNotification,
     InvalidObjectType,
     InvalidId,
+    InvalidKey,
     NotFound,
     ParentNotFound,
-    NotEmpty
+    NotEmpty,
+    DuplicateName
 }

--- a/src/Umbraco.Core/Services/OperationStatus/DataTypeOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/DataTypeOperationStatus.cs
@@ -7,6 +7,8 @@ public enum DataTypeOperationStatus
     InvalidConfiguration,
     InvalidName,
     InvalidId,
+    DuplicateKey,
     NotFound,
-    ParentNotFound
+    ParentNotFound,
+    PropertyEditorNotFound
 }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DataTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DataTypeRepository.cs
@@ -46,6 +46,8 @@ internal class DataTypeRepository : EntityRepositoryBase<int, IDataType>, IDataT
 
     protected Guid NodeObjectTypeId => Constants.ObjectTypes.DataType;
 
+    public IDataType? Get(Guid key) => GetMany().FirstOrDefault(x=>x.Key == key);
+
     public IEnumerable<MoveEventInfo<IDataType>> Move(IDataType toMove, EntityContainer? container)
     {
         var parentId = -1;


### PR DESCRIPTION
Fixed issues with datatype endpoints.

- Allow creating with keys (ids)
- Renamed keys to ids
- Fixed issues when creating with unknown propertyeditoralias