### PR TITLE
Prevent false redirect to "Page Not Found" from UmbracoMemberAuthorize attribute handling

### DIFF
--- a/src/Umbraco.Web.Common/Filters/UmbracoMemberAuthorizeFilter.cs
+++ b/src/Umbraco.Web.Common/Filters/UmbracoMemberAuthorizeFilter.cs
@@ -54,11 +54,20 @@ public class UmbracoMemberAuthorizeFilter : IAsyncAuthorizationFilter
 
         IMemberManager memberManager = context.HttpContext.RequestServices.GetRequiredService<IMemberManager>();
 
-        if (!await IsAuthorizedAsync(memberManager))
+        if (memberManager.IsLoggedIn())
+        {
+            if (!await IsAuthorizedAsync(memberManager))
+            {
+                context.HttpContext.SetReasonPhrase(
+                    "Resource restricted: the member is not of a permitted type or group.");
+                context.Result = new ForbidResult();
+            }
+        }
+        else
         {
             context.HttpContext.SetReasonPhrase(
-                "Resource restricted: either member is not logged on or is not of a permitted type or group.");
-            context.Result = new ForbidResult();
+                "Resource restricted: the member is not logged in.");
+            context.Result = new UnauthorizedResult();
         }
     }
 

--- a/src/Umbraco.Web.Common/Security/ConfigureMemberCookieOptions.cs
+++ b/src/Umbraco.Web.Common/Security/ConfigureMemberCookieOptions.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Routing;
@@ -43,6 +44,12 @@ public sealed class ConfigureMemberCookieOptions : IConfigureNamedOptions<Cookie
 
                 // When we are signed in with the cookie, assign the principal to the current HttpContext
                 ctx.HttpContext.SetPrincipalForRequest(ctx.Principal);
+
+                return Task.CompletedTask;
+            },
+            OnRedirectToAccessDenied = ctx =>
+            {
+                ctx.Response.StatusCode = StatusCodes.Status403Forbidden;
 
                 return Task.CompletedTask;
             },


### PR DESCRIPTION
Fixes #13946

## Details
`[UmbracoMemberAuthorize]` attribute checks if the current member is authorized for a given request. When the member wasn't authorized we set the result to Forbidden and then we were redirected to a 404 page which wasn't the intention. This PR fixes the behaviour to return 401 Unauthorized when the member is not logged in and 403 Forbidden when the member is not of a permitted type or group.

## Test
- You can follow the issue's "_Steps to reproduce_" or you can use the code below:
```c#
using Microsoft.AspNetCore.Mvc;
using Umbraco.Cms.Web.Common.Controllers;
using Umbraco.Cms.Web.Common.Filters;

namespace Umbraco.Cms.Web.UI;

public class TestController : UmbracoApiController
{
    [UmbracoMemberAuthorize("", "All", "")]
    // /umbraco/api/test/test
    public IActionResult Test()
    {
        return Ok("Working");
    }
}
```
- In the BO, create a member group called "_All_", as well as a few members and assign some of them to that group;
- Create 2 Partial View Macro Files from snippet - **LoginStatus.cshtml** and **Login.cshtml**;
- In the Macros folder in the Settings section, enable the 2 macros to be used in rich text editor and the grid;
- Create a doc type with a Richtext editor and create a content page where you insert the 2 macros;
- Remember to display the value of the RTE property in the template of your doc type - add `@Model.Value("RTEaliasHERE")`;
- Open the Network dev tools and verify: 
  - Login with a member of the "_All_" group and verify you get _"Working"_  as a response when visiting https://localhost:44331/umbraco/api/test/test;
  - Login with a member **not** part of the "_All_" group and verify you get a Forbidden resource response for the same link ⬆️ ;
  - And finally, visiting the same link when no member is logged in returns an Unauthorized response, like:

![Screenshot](https://user-images.githubusercontent.com/21998037/228815831-f49015b5-e969-4aa6-89bd-1b39c9c3ad48.png)

- Set the other values of `[UmbracoMemberAuthorize("", "", "")]` attribute and verify that the said behaviour is still correct - there are some examples in https://docs.umbraco.com/umbraco-cms/v/10.latest-lts/reference/routing/umbraco-api-controllers/authorization#using-memberauthorizeattribute

 