### PR TITLE
New backoffice: Tag controller

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Tag/ByQueryTagController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tag/ByQueryTagController.cs
@@ -22,9 +22,9 @@ public class ByQueryTagController : TagControllerBase
     [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<TagResponseModel>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<PagedViewModel<TagResponseModel>>> ByQuery(string query, string? tagGroup, string? culture, int skip = 0, int take = 100)
+    public async Task<ActionResult<PagedViewModel<TagResponseModel>>> ByQuery(string? query, string? tagGroup, string? culture, int skip = 0, int take = 100)
     {
-        IEnumerable<ITag> result = await _tagService.GetByQueryAsync(query, tagGroup, culture);
+        IEnumerable<ITag> result = await _tagService.GetByQueryAsync(query ?? string.Empty, tagGroup, culture);
 
         List<TagResponseModel> responseModels = _mapper.MapEnumerable<ITag, TagResponseModel>(result);
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Tag/ByQueryTagController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tag/ByQueryTagController.cs
@@ -5,7 +5,6 @@ using Umbraco.Cms.Api.Management.ViewModels.Tag;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Tag;
 
@@ -23,18 +22,17 @@ public class ByQueryTagController : TagControllerBase
     [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<TagResponseModel>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<PagedViewModel<TagResponseModel>>> ByQuery(string tagGroup, string? culture, string? query = null, int skip = 0, int take = 100)
+    public async Task<ActionResult<PagedViewModel<TagResponseModel>>> ByQuery(string? tagGroup, string? culture, string? query = null, int skip = 0, int take = 100)
     {
-        if (culture == string.Empty)
+        IEnumerable<ITag> result;
+
+        if (query is not null)
         {
-            culture = null;
+            result = await _tagService.GetByQueryAsync(query, tagGroup, culture);
         }
-
-        IEnumerable<ITag> result = _tagService.GetAllTags(tagGroup, culture);
-
-        if (query.IsNullOrWhiteSpace() is false)
+        else
         {
-            result = result.Where(x => x.Text.InvariantContains(query));
+            result = await _tagService.GetAllAsync(tagGroup, culture);
         }
 
         List<TagResponseModel> responseModels = _mapper.MapEnumerable<ITag, TagResponseModel>(result);

--- a/src/Umbraco.Cms.Api.Management/Controllers/Tag/ByQueryTagController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tag/ByQueryTagController.cs
@@ -22,7 +22,7 @@ public class ByQueryTagController : TagControllerBase
     [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<TagResponseModel>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<PagedViewModel<TagResponseModel>>> ByQuery(string? tagGroup, string? culture, string query, int skip = 0, int take = 100)
+    public async Task<ActionResult<PagedViewModel<TagResponseModel>>> ByQuery(string query, string? tagGroup, string? culture, int skip = 0, int take = 100)
     {
         IEnumerable<ITag> result = await _tagService.GetByQueryAsync(query, tagGroup, culture);
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Tag/ByQueryTagController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tag/ByQueryTagController.cs
@@ -22,18 +22,9 @@ public class ByQueryTagController : TagControllerBase
     [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<TagResponseModel>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<PagedViewModel<TagResponseModel>>> ByQuery(string? tagGroup, string? culture, string? query = null, int skip = 0, int take = 100)
+    public async Task<ActionResult<PagedViewModel<TagResponseModel>>> ByQuery(string? tagGroup, string? culture, string query, int skip = 0, int take = 100)
     {
-        IEnumerable<ITag> result;
-
-        if (query is not null)
-        {
-            result = await _tagService.GetByQueryAsync(query, tagGroup, culture);
-        }
-        else
-        {
-            result = await _tagService.GetAllAsync(tagGroup, culture);
-        }
+        IEnumerable<ITag> result = await _tagService.GetByQueryAsync(query, tagGroup, culture);
 
         List<TagResponseModel> responseModels = _mapper.MapEnumerable<ITag, TagResponseModel>(result);
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Tag/ByQueryTagController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tag/ByQueryTagController.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Common.ViewModels.Pagination;
+using Umbraco.Cms.Api.Management.ViewModels.Tag;
+using Umbraco.Cms.Core.Mapping;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Tag;
+
+public class ByQueryTagController : TagControllerBase
+{
+    private readonly ITagService _tagService;
+    private readonly IUmbracoMapper _mapper;
+
+    public ByQueryTagController(ITagService tagService, IUmbracoMapper mapper)
+    {
+        _tagService = tagService;
+        _mapper = mapper;
+    }
+
+    [HttpGet]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(PagedViewModel<TagResponseModel>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<PagedViewModel<TagResponseModel>>> ByQuery(string tagGroup, string? culture, string? query = null, int skip = 0, int take = 100)
+    {
+        if (culture == string.Empty)
+        {
+            culture = null;
+        }
+
+        IEnumerable<ITag> result = _tagService.GetAllTags(tagGroup, culture);
+
+        if (query.IsNullOrWhiteSpace() is false)
+        {
+            result = result.Where(x => x.Text.InvariantContains(query));
+        }
+
+        List<TagResponseModel> responseModels = _mapper.MapEnumerable<ITag, TagResponseModel>(result);
+
+        var pagedViewModel = new PagedViewModel<TagResponseModel>
+        {
+            Items = responseModels.Skip(skip).Take(take),
+            Total = responseModels.Count,
+        };
+
+        return await Task.FromResult(Ok(pagedViewModel));
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Tag/TagControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tag/TagControllerBase.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Routing;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Tag;
+
+[ApiController]
+[VersionedApiBackOfficeRoute("tag")]
+[ApiExplorerSettings(GroupName = "Tag")]
+[ApiVersion("1.0")]
+public class TagControllerBase : ManagementApiControllerBase
+{
+}

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/TagBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/TagBuilderExtensions.cs
@@ -1,0 +1,16 @@
+﻿using Umbraco.Cms.Api.Management.Mapping.Tag;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Mapping;
+
+namespace Umbraco.Cms.Api.Management.DependencyInjection;
+
+public static class TagBuilderExtensions
+{
+    internal static IUmbracoBuilder AddTags(this IUmbracoBuilder builder)
+    {
+        builder.WithCollectionBuilder<MapDefinitionCollectionBuilder>()
+            .Add<TagResponseModelMapDefinition>();
+
+        return builder;
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/ManagementApiComposer.cs
+++ b/src/Umbraco.Cms.Api.Management/ManagementApiComposer.cs
@@ -35,6 +35,7 @@ public class ManagementApiComposer : IComposer
             .AddHealthChecks()
             .AddModelsBuilder()
             .AddRedirectUrl()
+            .AddTags()
             .AddTrackedReferences()
             .AddTemporaryFiles()
             .AddDataTypes()

--- a/src/Umbraco.Cms.Api.Management/Mapping/Tag/TagResponseModelMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Tag/TagResponseModelMapDefinition.cs
@@ -1,0 +1,20 @@
+﻿using Umbraco.Cms.Api.Management.ViewModels.Tag;
+using Umbraco.Cms.Core.Mapping;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Api.Management.Mapping.Tag;
+
+public class TagResponseModelMapDefinition : IMapDefinition
+{
+    public void DefineMaps(IUmbracoMapper mapper) =>
+        mapper.Define<ITag, TagResponseModel>((_, _) => new TagResponseModel(), Map);
+
+    // Umbraco.Code.MapAll
+    private void Map(ITag source, TagResponseModel target, MapperContext context)
+    {
+        target.Group = source.Group;
+        target.Id = source.Key;
+        target.NodeCount = source.NodeCount;
+        target.Text = source.Text;
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Tag/TagResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Tag/TagResponseModel.cs
@@ -1,0 +1,12 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Tag;
+
+public class TagResponseModel
+{
+    public Guid Id { get; set; }
+
+    public string? Text { get; set; }
+
+    public string? Group { get; set; }
+
+    public int NodeCount { get; set; }
+}

--- a/src/Umbraco.Core/Services/ITagService.cs
+++ b/src/Umbraco.Core/Services/ITagService.cs
@@ -1,4 +1,5 @@
 ﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Services;
 
@@ -58,9 +59,18 @@ public interface ITagService : IService
     /// </summary>
     IEnumerable<ITag> GetAllTags(string? group = null, string? culture = null);
 
-    Task<IEnumerable<ITag>> GetAllAsync(string? group = null, string? culture = null);
+    Task<IEnumerable<ITag>> GetAllAsync(string? group = null, string? culture = null)
+    {
+        if (culture == string.Empty)
+        {
+            culture = null;
+        }
 
-    Task<IEnumerable<ITag>> GetByQueryAsync(string query, string? group = null, string? culture = null);
+        return Task.FromResult(GetAllTags(group, culture));
+    }
+
+    Task<IEnumerable<ITag>> GetByQueryAsync(string query, string? group = null, string? culture = null)
+        => Task.FromResult(GetAllAsync(group, culture).GetAwaiter().GetResult().Where(x => x.Text.InvariantContains(query)));
 
     /// <summary>
     ///     Gets all document tags.

--- a/src/Umbraco.Core/Services/ITagService.cs
+++ b/src/Umbraco.Core/Services/ITagService.cs
@@ -58,6 +58,10 @@ public interface ITagService : IService
     /// </summary>
     IEnumerable<ITag> GetAllTags(string? group = null, string? culture = null);
 
+    Task<IEnumerable<ITag>> GetAllAsync(string? group = null, string? culture = null);
+
+    Task<IEnumerable<ITag>> GetByQueryAsync(string query, string? group = null, string? culture = null);
+
     /// <summary>
     ///     Gets all document tags.
     /// </summary>

--- a/src/Umbraco.Core/Services/TagService.cs
+++ b/src/Umbraco.Core/Services/TagService.cs
@@ -3,6 +3,7 @@ using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Scoping;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Services;
 
@@ -101,6 +102,18 @@ public class TagService : RepositoryService, ITagService
             return _tagRepository.GetTagsForEntityType(TaggableObjectTypes.All, group, culture);
         }
     }
+
+    public Task<IEnumerable<ITag>> GetAllAsync(string? group = null, string? culture = null)
+    {
+        if (culture == string.Empty)
+        {
+            culture = null;
+        }
+
+        return Task.FromResult(GetAllTags(group, culture));
+    }
+
+    public async Task<IEnumerable<ITag>> GetByQueryAsync(string query, string? group = null, string? culture = null) => (await GetAllAsync(group, culture)).Where(x => x.Text.InvariantContains(query));
 
     /// <inheritdoc />
     public IEnumerable<ITag> GetAllContentTags(string? group = null, string? culture = null)


### PR DESCRIPTION
# Notes
- Added TagController
- Added ByQuery endpoint

# How to test 
You cannot create tags in the old backoffice anymore due to model changes.

- Create a document type with allow as root
- Create an empty content
- Stop umbraco
- Implement the sample code
- Run umbraco
- Now you should be able to call the new endpoint via swagger, and get some data back 👍 
```
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Notifications;
using Umbraco.Cms.Core.Persistence.Repositories;
using Umbraco.Cms.Infrastructure.Scoping;

namespace Umbraco.Cms.Web.UI;

public class MyComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder) => builder.AddNotificationHandler<UmbracoApplicationStartedNotification, MyNotiHandler>();
}

public class MyNotiHandler : INotificationHandler<UmbracoApplicationStartedNotification>
{
    private readonly ITagRepository _tagRepository;
    private readonly IScopeProvider _scopeProvider;

    public MyNotiHandler(ITagRepository tagRepository, IScopeProvider scopeProvider)
    {
        _tagRepository = tagRepository;
        _scopeProvider = scopeProvider;
    }
    public void Handle(UmbracoApplicationStartedNotification notification)
    {
        var tag = new Tag(0, "default", "cccc");
        var tag2 = new Tag(0, "default", "ddddd");

        using (var scope = _scopeProvider.CreateScope())
        {

            _tagRepository.Save(tag);
            _tagRepository.Save(tag2);
            _tagRepository.Assign(1057, 52, new []{ tag, tag2});
            scope.Complete();
        }
    }
}

```