### PR TITLE
Adds padding to the icon in btn-social

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/pages/login.less
+++ b/src/Umbraco.Web.UI.Client/src/less/pages/login.less
@@ -116,6 +116,8 @@
 
 .login-overlay .btn-social>:first-child {
     line-height: 36px;
+    padding: 2px;
+    box-sizing: border-box;
 }
 
 .login-overlay .text-error,

--- a/src/Umbraco.Web.UI.Client/src/less/pages/login.less
+++ b/src/Umbraco.Web.UI.Client/src/less/pages/login.less
@@ -116,6 +116,9 @@
 
 .login-overlay .btn-social>:first-child {
     line-height: 36px;
+}
+
+.login-overlay .btn-social > .umb-icon
     padding: 2px;
     box-sizing: border-box;
 }

--- a/src/Umbraco.Web.UI.Client/src/less/pages/login.less
+++ b/src/Umbraco.Web.UI.Client/src/less/pages/login.less
@@ -118,7 +118,7 @@
     line-height: 36px;
 }
 
-.login-overlay .btn-social > .umb-icon
+.login-overlay .btn-social > .umb-icon {
     padding: 2px;
     box-sizing: border-box;
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Bootstrap Social doesn't work that well with the embedded svg icons in Umbraco, so I've added a little padding to make it look nicer.

To test, add an external login provider and verify that there is padding around the icon. Should look like this:

before:
![image](https://user-images.githubusercontent.com/3726467/231436578-d4c31e19-dff8-4368-afe7-b5454ba5b2e6.png)

after:
![image](https://user-images.githubusercontent.com/3726467/231436654-2aec9754-7be5-4266-9129-9189d943888e.png)
