### PR TITLE
Delivery API: Adding pagination to query endpoint

### DIFF
--- a/src/Umbraco.Cms.Api.Content/Controllers/QueryContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Content/Controllers/QueryContentApiController.cs
@@ -4,6 +4,7 @@ using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Core.ContentApi;
 using Umbraco.Cms.Core.Models.ContentApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Content.Controllers;
 
@@ -38,14 +39,14 @@ public class QueryContentApiController : ContentApiControllerBase
         int skip = 0,
         int take = 10)
     {
-        IEnumerable<Guid> ids = _apiQueryService.ExecuteQuery(fetch, filter, sort);
-        IEnumerable<IPublishedContent> contentItems = ApiPublishedContentCache.GetByIds(ids);
-        IApiContentResponse[] results = contentItems.Select(ApiContentResponseBuilder.Build).ToArray();
+        PagedModel<Guid> pagedResult = _apiQueryService.ExecuteQuery(fetch, filter, sort, skip, take);
+        IEnumerable<IPublishedContent> contentItems = ApiPublishedContentCache.GetByIds(pagedResult.Items);
+        IApiContentResponse[] apiContentItems = contentItems.Select(ApiContentResponseBuilder.Build).ToArray();
 
         var model = new PagedViewModel<IApiContentResponse>
         {
-            Total = results.Length,
-            Items = results.Skip(skip).Take(take)
+            Total = pagedResult.Total,
+            Items = apiContentItems
         };
 
         return await Task.FromResult(Ok(model));

--- a/src/Umbraco.Cms.Api.Content/Services/ApiQueryService.cs
+++ b/src/Umbraco.Cms.Api.Content/Services/ApiQueryService.cs
@@ -57,9 +57,7 @@ internal sealed class ApiQueryService : IApiQueryService // Examine-specific imp
         // Handle Sorting
         IOrdering? sortQuery = HandleSorting(sorts, queryOperation);
 
-        ISearchResults? results = sortQuery is not null
-            ? sortQuery.Execute(QueryOptions.SkipTake(skip, take))
-            : DefaultSort(queryOperation)?.Execute(QueryOptions.SkipTake(skip, take));
+        ISearchResults? results = (sortQuery ?? DefaultSort(queryOperation))?.Execute(QueryOptions.SkipTake(skip, take));
 
         if (results is null)
         {

--- a/src/Umbraco.Core/Configuration/Models/ContentApiSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ContentApiSettings.cs
@@ -37,6 +37,6 @@ public class ContentApiSettings
     ///     Gets or sets the aliases of the content types that may never be exposed through the Content API. Content of these
     ///     types will never be returned from any Content API endpoint, nor added to the query index.
     /// </summary>
-    /// <value>A <c>string</c> representing the API key.</value>
+    /// <value>The content type aliases that are not to be exposed.</value>
     public string[] DisallowedContentTypeAliases { get; set; } = Array.Empty<string>();
 }

--- a/src/Umbraco.Core/ContentApi/IApiQueryService.cs
+++ b/src/Umbraco.Core/ContentApi/IApiQueryService.cs
@@ -1,3 +1,5 @@
+using Umbraco.New.Cms.Core.Models;
+
 namespace Umbraco.Cms.Core.ContentApi;
 
 /// <summary>
@@ -6,11 +8,13 @@ namespace Umbraco.Cms.Core.ContentApi;
 public interface IApiQueryService
 {
     /// <summary>
-    ///     Returns a collection of item ids that passed the search criteria.
+    ///     Returns a collection of item ids that passed the search criteria as a paged model.
     /// </summary>
     /// <param name="fetch">Optional fetch query parameter value.</param>
     /// <param name="filters">Optional filter query parameters values.</param>
     /// <param name="sorts">Optional sort query parameters values.</param>
-    /// <returns>A collection of item ids that are returned after applying the search queries.</returns>
-    IEnumerable<Guid> ExecuteQuery(string? fetch, IEnumerable<string> filters, IEnumerable<string> sorts);
+    /// <param name="skip">The amount of items to skip.</param>
+    /// <param name="take">The amount of items to take.</param>
+    /// <returns>A paged model of item ids that are returned after applying the search queries.</returns>
+    PagedModel<Guid> ExecuteQuery(string? fetch, IEnumerable<string> filters, IEnumerable<string> sorts, int skip, int take);
 }

--- a/src/Umbraco.Core/ContentApi/NoopApiQueryService.cs
+++ b/src/Umbraco.Core/ContentApi/NoopApiQueryService.cs
@@ -1,8 +1,10 @@
+using Umbraco.New.Cms.Core.Models;
+
 namespace Umbraco.Cms.Core.ContentApi;
 
 public sealed class NoopApiQueryService : IApiQueryService
 {
     /// <inheritdoc />
-    public IEnumerable<Guid> ExecuteQuery(string? fetch, IEnumerable<string> filters, IEnumerable<string> sorts)
-        => Enumerable.Empty<Guid>();
+    public PagedModel<Guid> ExecuteQuery(string? fetch, IEnumerable<string> filters, IEnumerable<string> sorts, int skip, int take)
+        => new();
 }


### PR DESCRIPTION
## Details
- Paginating the output from the query endpoint.

## Test
- Apply different `skip` and `take` values to `https://localhost:44331/umbraco/delivery/api/v1/content` endpoint and verify the number of items changes in the output;
  - Use different combinations of query parameters - _ex: use `skip` and `take` with `sort`_ - and check that the response is correct.