### PR TITLE
Alter the datatype of the UmbracoKeyValue value column

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -67,5 +67,8 @@ public class UmbracoPlan : MigrationPlan
 
         // To 11.3.0
         To<V_11_3_0.AddDomainSortOrder>("{BB3889ED-E2DE-49F2-8F71-5FD8616A2661}");
+
+        // To 11.4.0
+        To<V_11_4_0.AlterKeyValueDataType>("{FFB6B9B0-F1A8-45E9-9CD7-25700577D1CA}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_11_4_0/AlterKeyValueDataType.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_11_4_0/AlterKeyValueDataType.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+using NPoco;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_11_4_0;
+
+public class AlterKeyValueDataType : MigrationBase
+{
+    public AlterKeyValueDataType(IMigrationContext context)
+        : base(context)
+    { }
+
+    protected override void Migrate()
+    {
+        string tableName = KeyValueDto.TableName;
+        string colName = "value";
+
+        // Determine the current datatype of the column within the database
+        string colDataType = Database.ExecuteScalar<string>($"SELECT TOP(1) CHARACTER_MAXIMUM_LENGTH FROM INFORMATION_SCHEMA.COLUMNS" +
+            $" WHERE TABLE_NAME = '{tableName}' AND COLUMN_NAME = '{colName}'");
+
+        // 255 is the old length, -1 indicate MAX length
+        if (colDataType == "255")
+        {
+            // Upgrade to MAX length
+            Database.Execute($"ALTER TABLE {tableName} ALTER COLUMN {colName} nvarchar(MAX)");
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/KeyValueDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/KeyValueDto.cs
@@ -11,6 +11,8 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [ExplicitColumns]
 internal class KeyValueDto
 {
+    public const string TableName = Constants.DatabaseSchema.Tables.KeyValue;
+
     [Column("key")]
     [Length(256)]
     [PrimaryKeyColumn(AutoIncrement = false, Clustered = true)]


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes, this addresses a [discussion](https://github.com/umbraco/Umbraco-CMS/discussions/14007)

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

This update alters the data type in the database of the `umbracoKeyValue.value` column from `nvarchar(255)` to `nvarchar(MAX)`. My only real thought would be around permissions for the `INFORMATION_SCHEMA` check in the migration, but looking at the permissions in the [docs](https://learn.microsoft.com/en-us/sql/relational-databases/system-information-schema-views/system-information-schema-views-transact-sql?view=sql-server-2017#permissions) this should be allowed in the vast majority of cases. Thought I'd flag incase this should be documented somewhere!

Sample code that I used to spin up a quick test (just via a test surface controller):
```
// Declared in cstr
IKeyValueService _kvs; 

...

public void Test() {
  string a255String = "";
  string a500String = "";
  for (int i = 0; i < 255; i++) { a255String += "0"; }
  for (int i = 0; i < 500; i++) { a500String += "0"; }

  _kvs.SetValue("test+test255", a255String);
  _kvs.SetValue("test+test500", a500String);
}
```

<!-- Thanks for contributing to Umbraco CMS! -->
