### PR TITLE
Using GetValue(culture) in same context when called a property on content (default culture) breaks fetching content with passed culture. Fixing #14071

### DIFF
--- a/src/Umbraco.PublishedCache.NuCache/Property.cs
+++ b/src/Umbraco.PublishedCache.NuCache/Property.cs
@@ -263,9 +263,29 @@ internal class Property : PublishedPropertyBase
         return vvalue.InterValue;
     }
 
+    /// <summary>
+    /// Method to check if VariationContext culture differs from culture parameter, if so it will update the VariationContext for the PublishedValueFallback.
+    /// </summary>
+    /// <param name="publishedContent">The requested PublishedValueFallback.</param>
+    /// <param name="culture">The requested culture.</param>
+    /// <param name="segment">The requested segment.</param>
+    /// <returns></returns>
+    private static void EventuallyUpdateVariationContext(PublishedContent publishedContent, string? culture, string? segment)
+    {
+        IVariationContextAccessor? variationContextAccessor = publishedContent.VariationContextAccessor;
+
+        //If there is a difference in requested culture and the culture that is set in the VariationContext, it will pick wrong localized content.
+        //This happens for example using links to localized content in a RichText Editor.
+        if (!string.IsNullOrEmpty(culture) && variationContextAccessor?.VariationContext?.Culture != culture)
+        {
+            variationContextAccessor!.VariationContext = new VariationContext(culture, segment);
+        }
+    }
+
     public override object? GetValue(string? culture = null, string? segment = null)
     {
         _content.VariationContextAccessor.ContextualizeVariation(_variations, _content.Id, ref culture, ref segment);
+        EventuallyUpdateVariationContext(_content, culture, segment);
 
         object? value;
         lock (_locko)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes issue https://github.com/umbraco/Umbraco-CMS/issues/14071

### Description
* Added a method that checks if current VariationContext culture is according to the culture passed to the GetValue()-method. If it is a discrepancy it will update the VariationContext.


<!-- Thanks for contributing to Umbraco CMS! -->