### PR TITLE
Save and Preview blank on second use #14052

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -941,15 +941,13 @@
             const openPreviewWindow = () => {
                 // Chromes popup blocker will kick in if a window is opened
                 // without the initial scoped request. This trick will fix that.
-                //
-                const previewWindow = $window.open('preview/?init=true', 'umbpreview');
+              
+              const previewWindow = window.open(`preview/?id=${content.id}${$scope.culture ? `&culture=${$scope.culture}` : ''}`, 'umbpreview');
 
-                // Build the correct path so both /#/ and #/ work.
-                let query = 'id=' + content.id;
-                if ($scope.culture) {
-                   query += "#?culture=" + $scope.culture;
-                }
-                previewWindow.location.href = Umbraco.Sys.ServerVariables.umbracoSettings.umbracoPath + '/preview/?' + query;
+              previewWindow.addEventListener('load', () => {
+                previewWindow.location.href = previewWindow.document.URL;
+              });
+
             }
 
             //The user cannot save if they don't have access to do that, in which case we just want to preview

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -942,7 +942,7 @@
                 // Chromes popup blocker will kick in if a window is opened
                 // without the initial scoped request. This trick will fix that.
               
-              const previewWindow = window.open(`preview/?id=${content.id}${$scope.culture ? `&culture=${$scope.culture}` : ''}`, 'umbpreview');
+              const previewWindow = $window.open(`preview/?id=${content.id}${$scope.culture ? `&culture=${$scope.culture}` : ''}`, 'umbpreview');
 
               previewWindow.addEventListener('load', () => {
                 previewWindow.location.href = previewWindow.document.URL;


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [Issue mentioned](https://github.com/umbraco/Umbraco-CMS/issues/14052) #14052 

### Description

-  I have been trying to replicate an issue, but it seems to occur inconsistently. I have attempted multiple times, and while the issue sometimes does not happen, at other times it does. I suspect that it could be a timing issue, perhaps related to opening the preview window and the URL simultaneously.

-  To address this, I have made a few changes to the code. Firstly, I have replaced the use of $window with window.

> $window with window.
changed back to $window .

 -  Secondly, I have added an EventListener for the load event to the preview window, which should ensure that the window has fully loaded before any further actions are taken. Hopefully, these changes will help to resolve the issue.

-  After making these changes, I thoroughly tested the code, and I think that the issue appears to have been resolved. The code is now functioning as expected, without any errors or unexpected behaviours

<!-- Thanks for contributing to Umbraco CMS! -->
