### PR TITLE
fix for the char limit(512) for textbox datatype

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/textstringlimited.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/textstringlimited.html
@@ -5,7 +5,7 @@
                ng-model="model.value"
                val-server="value"
                min="0"
-               max="500"
+               max="512"
                fix-number />
 
         <span ng-messages="prevalueTextLimitedForm.textLimitedField.$error" show-validation-on-submit >
@@ -13,5 +13,5 @@
         </span>
 
     </ng-form>
-    
+     
 </div>


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

[Reported Issue](https://github.com/umbraco/Umbraco-CMS/issues/14063) #14063 

### Description

- Resolved by changing the `Max` to 512

<!-- Thanks for contributing to Umbraco CMS! -->
