### PR TITLE
Addresses Issue #12388: When a Block List Editor is the last property on a tab, it's components properties have little to no spacing.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -165,7 +165,7 @@ h6.-black {
     }
 }
 
-umb-property:last-of-type .umb-control-group {
+umb-property:last-of-type > .umb-property > ng-form > .umb-control-group {
     &::after {
         margin-top: 0px;
         height: 0;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklistentryeditors/inlineblock/inlineblock.editor.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/blocklistentryeditors/inlineblock/inlineblock.editor.less
@@ -6,6 +6,10 @@
     border-radius: @baseBorderRadius;
     transition: border-color 120ms, background-color 120ms;
 
+	.umb-box {
+		margin-bottom: 0;
+	}
+
     .umb-block-list__block:not(.--active) &:hover {
         border-color: @gray-8;
     }


### PR DESCRIPTION
[When a Block List Editor is the last property on a tab, it's components properties have little to no spacing.](https://github.com/umbraco/Umbraco-CMS/issues/12388)

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #12388. 

### Description

- When the Block List is the last property editor on a tab, and using inline editing, the margin between the properties disappears. There's also a smidge of additional margin at the bottom that could be removed.
- Minimal changes to LESS were made to address this issue.
- Please review the backoffice editing experience thoroughly. 

### Before PR:

<img width="430" alt="image" src="https://user-images.githubusercontent.com/713355/231944345-8b60c924-3500-4a0e-9aa2-36514c6beaf7.png">

### After PR:

<img width="431" alt="image" src="https://user-images.githubusercontent.com/713355/231944145-bd1c6e2c-4437-4db2-a345-529a2cc41b46.png">

