### PR TITLE
Edge Cases for Issue #13838: Hotkey Actions Triggered from Web Components

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/keyboard.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/keyboard.service.js
@@ -206,7 +206,9 @@ function keyboardService($window, $timeout) {
                 // Disable event handler when focus input and textarea
                 if (opt['inputDisabled']) {
                     var elt;
-                    if (e.target) {
+					if (e.composedPath()) {
+						elt = e.composedPath()[0];
+					} else if (e.target) {
                         elt = e.target;
                     } else if (e.srcElement) {
                         elt = e.srcElement;

--- a/src/Umbraco.Web.UI.Client/src/common/services/keyboard.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/keyboard.service.js
@@ -2,326 +2,329 @@
 // http://www.openjs.com/scripts/events/keyboard_shortcuts/index.php
 
 function keyboardService($window, $timeout) {
-    
-    var keyboardManagerService = {};
-    
-    var defaultOpt = {
-        'type':             'keydown',
-        'propagate':        false,
-        'inputDisabled':    false,
-        'target':           $window.document,
-        'keyCode':          false
-    };
 
-    // Work around for stupid Shift key bug created by using lowercase - as a result the shift+num combination was broken
-    var shift_nums = {
-        "`": "~",
-        "1": "!",
-        "2": "@",
-        "3": "#",
-        "4": "$",
-        "5": "%",
-        "6": "^",
-        "7": "&",
-        "8": "*",
-        "9": "(",
-        "0": ")",
-        "-": "_",
-        "=": "+",
-        ";": ":",
-        "'": "\"",
-        ",": "<",
-        ".": ">",
-        "/": "?",
-        "\\": "|"
-    };
+  var keyboardManagerService = {};
 
-    // Special Keys - and their codes
-    var special_keys = {
-        'esc': 27,
-        'escape': 27,
-        'tab': 9,
-        'space': 32,
-        'return': 13,
-        'enter': 13,
-        'backspace': 8,
+  var defaultOpt = {
+    'type': 'keydown',
+    'propagate': false,
+    'inputDisabled': false,
+    'target': $window.document,
+    'keyCode': false
+  };
 
-        'scrolllock': 145,
-        'scroll_lock': 145,
-        'scroll': 145,
-        'capslock': 20,
-        'caps_lock': 20,
-        'caps': 20,
-        'numlock': 144,
-        'num_lock': 144,
-        'num': 144,
+  // Work around for stupid Shift key bug created by using lowercase - as a result the shift+num combination was broken
+  var shift_nums = {
+    "`": "~",
+    "1": "!",
+    "2": "@",
+    "3": "#",
+    "4": "$",
+    "5": "%",
+    "6": "^",
+    "7": "&",
+    "8": "*",
+    "9": "(",
+    "0": ")",
+    "-": "_",
+    "=": "+",
+    ";": ":",
+    "'": "\"",
+    ",": "<",
+    ".": ">",
+    "/": "?",
+    "\\": "|"
+  };
 
-        'pause': 19,
-        'break': 19,
+  // Special Keys - and their codes
+  var special_keys = {
+    'esc': 27,
+    'escape': 27,
+    'tab': 9,
+    'space': 32,
+    'return': 13,
+    'enter': 13,
+    'backspace': 8,
 
-        'insert': 45,
-        'home': 36,
-        'delete': 46,
-        'end': 35,
+    'scrolllock': 145,
+    'scroll_lock': 145,
+    'scroll': 145,
+    'capslock': 20,
+    'caps_lock': 20,
+    'caps': 20,
+    'numlock': 144,
+    'num_lock': 144,
+    'num': 144,
 
-        'pageup': 33,
-        'page_up': 33,
-        'pu': 33,
+    'pause': 19,
+    'break': 19,
 
-        'pagedown': 34,
-        'page_down': 34,
-        'pd': 34,
+    'insert': 45,
+    'home': 36,
+    'delete': 46,
+    'end': 35,
 
-        'left': 37,
-        'up': 38,
-        'right': 39,
-        'down': 40,
+    'pageup': 33,
+    'page_up': 33,
+    'pu': 33,
 
-        'f1': 112,
-        'f2': 113,
-        'f3': 114,
-        'f4': 115,
-        'f5': 116,
-        'f6': 117,
-        'f7': 118,
-        'f8': 119,
-        'f9': 120,
-        'f10': 121,
-        'f11': 122,
-        'f12': 123
-    };
+    'pagedown': 34,
+    'page_down': 34,
+    'pd': 34,
 
-    var isMac = navigator.platform.toUpperCase().indexOf('MAC')>=0;
+    'left': 37,
+    'up': 38,
+    'right': 39,
+    'down': 40,
 
-    // The event handler for bound element events
-    function eventHandler(e) {
-        e = e || $window.event;
+    'f1': 112,
+    'f2': 113,
+    'f3': 114,
+    'f4': 115,
+    'f5': 116,
+    'f6': 117,
+    'f7': 118,
+    'f8': 119,
+    'f9': 120,
+    'f10': 121,
+    'f11': 122,
+    'f12': 123
+  };
 
-        var code, k;
+  var isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
 
-        // Find out which key is pressed
-        if (e.keyCode)
-        {
-            code = e.keyCode;
-        }
-        else if (e.which) {
-            code = e.which;
-        }
+  // The event handler for bound element events
+  function eventHandler(e) {
+    e = e || $window.event;
 
-        var character = String.fromCharCode(code).toLowerCase();
+    var code, k;
 
-        if (code === 188){character = ",";} // If the user presses , when the type is onkeydown
-        if (code === 190){character = ".";} // If the user presses , when the type is onkeydown
-
-        var propagate = true;
-
-        //Now we need to determine which shortcut this event is for, we'll do this by iterating over each 
-        //registered shortcut to find the match. We use Find here so that the loop exits as soon
-        //as we've found the one we're looking for
-        _.find(_.keys(keyboardManagerService.keyboardEvent), function(key) {
-
-            var shortcutLabel = key;
-            var shortcutVal = keyboardManagerService.keyboardEvent[key];
-
-            // Key Pressed - counts the number of valid keypresses - if it is same as the number of keys, the shortcut function is invoked
-            var kp = 0;
-
-            // Some modifiers key
-            var modifiers = {
-                shift: {
-                    wanted: false,
-                    pressed: e.shiftKey ? true : false
-                },
-                ctrl: {
-                    wanted: false,
-                    pressed: e.ctrlKey ? true : false
-                },
-                alt: {
-                    wanted: false,
-                    pressed: e.altKey ? true : false
-                },
-                meta: { //Meta is Mac specific
-                    wanted: false,
-                    pressed: e.metaKey ? true : false
-                }
-            };
-
-            var keys = shortcutLabel.split("+");
-            var opt = shortcutVal.opt;
-            var callback = shortcutVal.callback;
-
-            // Foreach keys in label (split on +)
-            var l = keys.length;
-            for (var i = 0; i < l; i++) {
-
-                var k = keys[i];
-                switch (k) {
-                    case 'ctrl':
-                    case 'control':
-                        kp++;
-                        modifiers.ctrl.wanted = true;
-                        break;
-                    case 'shift':
-                    case 'alt':
-                    case 'meta':
-                        kp++;
-                        modifiers[k].wanted = true;
-                        break;
-                }
-
-                if (k.length > 1) { // If it is a special key
-                    if (special_keys[k] === code) {
-                        kp++;
-                    }
-                }
-                else if (opt['keyCode']) { // If a specific key is set into the config
-                    if (opt['keyCode'] === code) {
-                        kp++;
-                    }
-                }
-                else { // The special keys did not match
-                    if (character === k) {
-                        kp++;
-                    }
-                    else {
-                        if (shift_nums[character] && e.shiftKey) { // Stupid Shift key bug created by using lowercase
-                            character = shift_nums[character];
-                            if (character === k) {
-                                kp++;
-                            }
-                        }
-                    }
-                }
-
-            } //for end
-
-            if (kp === keys.length &&
-                modifiers.ctrl.pressed === modifiers.ctrl.wanted &&
-                modifiers.shift.pressed === modifiers.shift.wanted &&
-                modifiers.alt.pressed === modifiers.alt.wanted &&
-                modifiers.meta.pressed === modifiers.meta.wanted) {
-
-                //found the right callback!
-
-                // Disable event handler when focus input and textarea
-                if (opt['inputDisabled']) {
-                    var elt;
-					if (e.composedPath()) {
-						elt = e.composedPath()[0];
-					} else if (e.target) {
-                        elt = e.target;
-                    } else if (e.srcElement) {
-                        elt = e.srcElement;
-                    }
-
-                    if (elt.nodeType === 3) { elt = elt.parentNode; }
-                    if (elt.tagName === 'INPUT' || elt.tagName === 'TEXTAREA' || elt.hasAttribute('disable-hotkeys')) {
-                        //This exits the Find loop
-                        return true;
-                    }
-                }
-
-                $timeout(function () {
-                    callback(e);
-                }, 1);
-
-                if (!opt['propagate']) { // Stop the event
-                    propagate = false;
-                }
-
-                //This exits the Find loop
-                return true;
-            }
-
-            //we haven't found one so continue looking
-            return false;
-
-        });
-
-        // Stop the event if required
-        if (!propagate) {
-            // e.cancelBubble is supported by IE - this will kill the bubbling process.
-            e.cancelBubble = true;
-            e.returnValue = false;
-
-            // e.stopPropagation works in Firefox.
-            if (e.stopPropagation) {
-                e.stopPropagation();
-                e.preventDefault();
-            }
-            return false;
-        }
+    // Find out which key is pressed
+    if (e.keyCode) {
+      code = e.keyCode;
+    } else if (e.which) {
+      code = e.which;
     }
 
-    // Store all keyboard combination shortcuts
-    keyboardManagerService.keyboardEvent = {};
+    var character = String.fromCharCode(code).toLowerCase();
 
-    // Add a new keyboard combination shortcut
-    keyboardManagerService.bind = function (label, callback, opt) {
+    if (code === 188) {
+      character = ",";
+    } // If the user presses , when the type is onkeydown
+    if (code === 190) {
+      character = ".";
+    } // If the user presses , when the type is onkeydown
 
-        //replace ctrl key with meta key
-        if(isMac && label !== "ctrl+space"){
-            label = label.replace("ctrl","meta");
+    var propagate = true;
+
+    //Now we need to determine which shortcut this event is for, we'll do this by iterating over each
+    //registered shortcut to find the match. We use Find here so that the loop exits as soon
+    //as we've found the one we're looking for
+    _.find(_.keys(keyboardManagerService.keyboardEvent), function (key) {
+
+      var shortcutLabel = key;
+      var shortcutVal = keyboardManagerService.keyboardEvent[key];
+
+      // Key Pressed - counts the number of valid keypresses - if it is same as the number of keys, the shortcut function is invoked
+      var kp = 0;
+
+      // Some modifiers key
+      var modifiers = {
+        shift: {
+          wanted: false,
+          pressed: e.shiftKey ? true : false
+        },
+        ctrl: {
+          wanted: false,
+          pressed: e.ctrlKey ? true : false
+        },
+        alt: {
+          wanted: false,
+          pressed: e.altKey ? true : false
+        },
+        meta: { //Meta is Mac specific
+          wanted: false,
+          pressed: e.metaKey ? true : false
+        }
+      };
+
+      var keys = shortcutLabel.split("+");
+      var opt = shortcutVal.opt;
+      var callback = shortcutVal.callback;
+
+      // Foreach keys in label (split on +)
+      var l = keys.length;
+      for (var i = 0; i < l; i++) {
+
+        var k = keys[i];
+        switch (k) {
+          case 'ctrl':
+          case 'control':
+            kp++;
+            modifiers.ctrl.wanted = true;
+            break;
+          case 'shift':
+          case 'alt':
+          case 'meta':
+            kp++;
+            modifiers[k].wanted = true;
+            break;
         }
 
-        var elt;
-        // Initialize opt object
-        opt   = Utilities.extend({}, defaultOpt, opt);
-        label = label.toLowerCase();
-        elt   = opt.target;
-        if(typeof opt.target === 'string'){
-            elt = document.getElementById(opt.target);
-        }
-        
-        //Ensure we aren't double binding to the same element + type otherwise we'll end up multi-binding
-        // and raising events for now reason. So here we'll check if the event is already registered for the element
-        var boundValues = _.values(keyboardManagerService.keyboardEvent);
-        var found = _.find(boundValues, function (i) {
-            return i.target === elt && i.event === opt['type'];
-        });
-
-        // Store shortcut
-        keyboardManagerService.keyboardEvent[label] = {
-            'callback': callback,
-            'target':   elt,
-            'opt':      opt
-        };
-
-        if (!found) {
-            //Attach the function with the event
-            if (elt.addEventListener) {
-                elt.addEventListener(opt['type'], eventHandler, false);
-            } else if (elt.attachEvent) {
-                elt.attachEvent('on' + opt['type'], eventHandler);
-            } else {
-                elt['on' + opt['type']] = eventHandler;
+        if (k.length > 1) { // If it is a special key
+          if (special_keys[k] === code) {
+            kp++;
+          }
+        } else if (opt['keyCode']) { // If a specific key is set into the config
+          if (opt['keyCode'] === code) {
+            kp++;
+          }
+        } else { // The special keys did not match
+          if (character === k) {
+            kp++;
+          } else {
+            if (shift_nums[character] && e.shiftKey) { // Stupid Shift key bug created by using lowercase
+              character = shift_nums[character];
+              if (character === k) {
+                kp++;
+              }
             }
+          }
         }
-        
-    };
-    // Remove the shortcut - just specify the shortcut and I will remove the binding
-    keyboardManagerService.unbind = function (label) {
-        label = label.toLowerCase();
-        var binding = keyboardManagerService.keyboardEvent[label];
-        delete(keyboardManagerService.keyboardEvent[label]);
 
-        if(!binding){return;}
+      } //for end
 
-        var type	= binding['event'],
-		elt			= binding['target'],
-		callback	= binding['callback'];
+      if (kp === keys.length &&
+        modifiers.ctrl.pressed === modifiers.ctrl.wanted &&
+        modifiers.shift.pressed === modifiers.shift.wanted &&
+        modifiers.alt.pressed === modifiers.alt.wanted &&
+        modifiers.meta.pressed === modifiers.meta.wanted) {
 
-        if(elt.detachEvent){
-            elt.detachEvent('on' + type, callback);
-        }else if(elt.removeEventListener){
-            elt.removeEventListener(type, callback, false);
-        }else{
-            elt['on'+type] = false;
+        //found the right callback!
+
+        // Disable event handler when focus input and textarea
+        if (opt['inputDisabled']) {
+          var elt;
+          if (e.composedPath()) {
+            elt = e.composedPath()[0];
+          } else if (e.target) {
+            elt = e.target;
+          } else if (e.srcElement) {
+            elt = e.srcElement;
+          }
+
+          if (elt.nodeType === 3) {
+            elt = elt.parentNode;
+          }
+          if (elt.tagName === 'INPUT' || elt.tagName === 'TEXTAREA' || elt.hasAttribute('disable-hotkeys')) {
+            //This exits the Find loop
+            return true;
+          }
         }
-    };
-    //
 
-    return keyboardManagerService;
+        $timeout(function () {
+          callback(e);
+        }, 1);
+
+        if (!opt['propagate']) { // Stop the event
+          propagate = false;
+        }
+
+        //This exits the Find loop
+        return true;
+      }
+
+      //we haven't found one so continue looking
+      return false;
+
+    });
+
+    // Stop the event if required
+    if (!propagate) {
+      // e.cancelBubble is supported by IE - this will kill the bubbling process.
+      e.cancelBubble = true;
+      e.returnValue = false;
+
+      // e.stopPropagation works in Firefox.
+      if (e.stopPropagation) {
+        e.stopPropagation();
+        e.preventDefault();
+      }
+      return false;
+    }
+  }
+
+  // Store all keyboard combination shortcuts
+  keyboardManagerService.keyboardEvent = {};
+
+  // Add a new keyboard combination shortcut
+  keyboardManagerService.bind = function (label, callback, opt) {
+
+    //replace ctrl key with meta key
+    if (isMac && label !== "ctrl+space") {
+      label = label.replace("ctrl", "meta");
+    }
+
+    var elt;
+    // Initialize opt object
+    opt = Utilities.extend({}, defaultOpt, opt);
+    label = label.toLowerCase();
+    elt = opt.target;
+    if (typeof opt.target === 'string') {
+      elt = document.getElementById(opt.target);
+    }
+
+    //Ensure we aren't double binding to the same element + type otherwise we'll end up multi-binding
+    // and raising events for now reason. So here we'll check if the event is already registered for the element
+    var boundValues = _.values(keyboardManagerService.keyboardEvent);
+    var found = _.find(boundValues, function (i) {
+      return i.target === elt && i.event === opt['type'];
+    });
+
+    // Store shortcut
+    keyboardManagerService.keyboardEvent[label] = {
+      'callback': callback,
+      'target': elt,
+      'opt': opt
+    };
+
+    if (!found) {
+      //Attach the function with the event
+      if (elt.addEventListener) {
+        elt.addEventListener(opt['type'], eventHandler, false);
+      } else if (elt.attachEvent) {
+        elt.attachEvent('on' + opt['type'], eventHandler);
+      } else {
+        elt['on' + opt['type']] = eventHandler;
+      }
+    }
+
+  };
+  // Remove the shortcut - just specify the shortcut and I will remove the binding
+  keyboardManagerService.unbind = function (label) {
+    label = label.toLowerCase();
+    var binding = keyboardManagerService.keyboardEvent[label];
+    delete (keyboardManagerService.keyboardEvent[label]);
+
+    if (!binding) {
+      return;
+    }
+
+    var type = binding['event'],
+      elt = binding['target'],
+      callback = binding['callback'];
+
+    if (elt.detachEvent) {
+      elt.detachEvent('on' + type, callback);
+    } else if (elt.removeEventListener) {
+      elt.removeEventListener(type, callback, false);
+    } else {
+      elt['on' + type] = false;
+    }
+  };
+  //
+
+  return keyboardManagerService;
 }
 
 angular.module('umbraco.services').factory('keyboardService', ['$window', '$timeout', keyboardService]);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

#13838 Typing '1' or '2' into an input inside a web component toggles the content/info content apps instead of writing '1' or '2' 

### Reproduce:

1. Create the necessary folder structure: `/App_Plugins/WebComponent/`
2. Create a `package.manifest` (below)
3. Create a `template.html` (below)
4. Restart your Umbraco web application as necessary.
5. Update a `content type` with a new `property` and choose the `Web Component` editor.
6. Type "**1**" or "**2**" into the property editor field to see the hotkey actions toggle between apps.

> **package.manifest**

```
{
    "propertyEditors": [
        {
            "alias": "Web Component #13838",
            "name": "WebComponent13838",
            "icon": "icon-block",
            "group": "Common",
            "editor": {
                "view": "~/App_Plugins/WebComponent/template.html",
            }
        }
    ]
}
```

> **template.html**

```
<uui-input
	label="Username"
	type="text"
	placeholder="Enter your username...">
</uui-input>
```

### After this PR:

The code for hotkey actions already has some basic checks in place. With this PR, the element we run these checks against will first come from `composedPath`. [Read more about **composedPath** from MDN.](https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath) 

For web components with a _open_ Shadow DOM, we have a better look at the true source of the event.

For web components with a _closed_ Shadow DOM, nothing should change. 

7. Switch to this branch and rebuild the UI.
8. Restart your Umbraco web application as necessary.
9. Type `**1**` or `**2**` into the property editor field. The hotkey actions will be cancelled.

### Opportunities:

Web Component authors should be informed about the hotkey system and potential issues from allowing keydown events to propagate too far. I am not confident I know the best place in our documentation to put such warning/notice. Nor am I confident I know what the current status of the UUI library is, and the architecture of the upcoming replacement for AngularJS.
