### PR TITLE
Fix DataValueEditor configuration handling + update naming to be more explicit

### DIFF
--- a/src/Umbraco.Core/CompatibilitySuppressions.xml
+++ b/src/Umbraco.Core/CompatibilitySuppressions.xml
@@ -535,6 +535,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Umbraco.Cms.Core.Models.PublishedContent.PublishedDataType.get_Configuration</Target>
+    <Left>lib/net7.0/Umbraco.Core.dll</Left>
+    <Right>lib/net7.0/Umbraco.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Umbraco.Cms.Core.Models.RelationType.#ctor(System.String,System.String,System.Boolean,System.Nullable{System.Guid},System.Nullable{System.Guid},System.Boolean)</Target>
     <Left>lib/net7.0/Umbraco.Core.dll</Left>
     <Right>lib/net7.0/Umbraco.Core.dll</Right>
@@ -676,6 +683,20 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Umbraco.Cms.Core.PropertyEditors.ConfigurationEditor`1.ToConfigurationEditor(`0)</Target>
+    <Left>lib/net7.0/Umbraco.Core.dll</Left>
+    <Right>lib/net7.0/Umbraco.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Umbraco.Cms.Core.PropertyEditors.DataValueEditor.get_Configuration</Target>
+    <Left>lib/net7.0/Umbraco.Core.dll</Left>
+    <Right>lib/net7.0/Umbraco.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Umbraco.Cms.Core.PropertyEditors.DataValueEditor.set_Configuration(System.Object)</Target>
     <Left>lib/net7.0/Umbraco.Core.dll</Left>
     <Right>lib/net7.0/Umbraco.Core.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Umbraco.Core/Models/Mapping/ContentPropertyDisplayMapper.cs
+++ b/src/Umbraco.Core/Models/Mapping/ContentPropertyDisplayMapper.cs
@@ -36,9 +36,7 @@ internal class ContentPropertyDisplayMapper : ContentPropertyBasicMapper<Content
     {
         base.Map(originalProp, dest, context);
 
-        var config = originalProp.PropertyType is null
-            ? null
-            : DataTypeService.GetDataType(originalProp.PropertyType.DataTypeId)?.ConfigurationData;
+        IDataType? dataType = DataTypeService.GetDataType(originalProp.PropertyType.DataTypeId);
 
         // TODO: IDataValueEditor configuration - general issue
         // GetValueEditor() returns a non-configured IDataValueEditor
@@ -47,7 +45,7 @@ internal class ContentPropertyDisplayMapper : ContentPropertyBasicMapper<Content
         // - does it make any sense to use a IDataValueEditor without configuring it?
 
         // configure the editor for display with configuration
-        IDataValueEditor? valEditor = dest.PropertyEditor?.GetValueEditor(config);
+        IDataValueEditor? valEditor = dest.PropertyEditor?.GetValueEditor(dataType?.ConfigurationObject);
 
         // set the display properties after mapping
         dest.Alias = originalProp.Alias;
@@ -75,9 +73,9 @@ internal class ContentPropertyDisplayMapper : ContentPropertyBasicMapper<Content
         else
         {
             // let the property editor format the pre-values
-            if (config != null)
+            if (dataType != null)
             {
-                dest.Config = dest.PropertyEditor.GetConfigurationEditor().ToValueEditor(config);
+                dest.Config = dest.PropertyEditor.GetConfigurationEditor().ToValueEditor(dataType.ConfigurationData);
             }
             dest.View = valEditor?.View;
         }

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedDataType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedDataType.cs
@@ -39,9 +39,10 @@ public class PublishedDataType
     public string EditorAlias { get; }
 
     /// <summary>
-    ///     Gets the data type configuration.
+    ///     Gets the data type configuration object.
     /// </summary>
-    public object? Configuration => _lazyConfiguration?.Value;
+    /// <seealso cref="IDataType.ConfigurationObject"/>
+    public object? ConfigurationObject => _lazyConfiguration?.Value;
 
     /// <summary>
     ///     Gets the configuration object.
@@ -51,7 +52,7 @@ public class PublishedDataType
     public T? ConfigurationAs<T>()
         where T : class
     {
-        switch (Configuration)
+        switch (ConfigurationObject)
         {
             case null:
                 return null;
@@ -60,6 +61,6 @@ public class PublishedDataType
         }
 
         throw new InvalidCastException(
-            $"Cannot cast dataType configuration, of type {Configuration.GetType().Name}, to {typeof(T).Name}.");
+            $"Cannot cast dataType configuration, of type {ConfigurationObject.GetType().Name}, to {typeof(T).Name}.");
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/DataEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataEditor.cs
@@ -149,7 +149,7 @@ public class DataEditor : IDataEditor
     ///         simple enough for now.
     ///     </para>
     /// </remarks>
-    public virtual IDataValueEditor GetValueEditor(object? configuration)
+    public virtual IDataValueEditor GetValueEditor(object? configurationObject)
     {
         // if an explicit value editor has been set (by the manifest parser)
         // then return it, and ignore the configuration, which is going to be
@@ -160,9 +160,9 @@ public class DataEditor : IDataEditor
         }
 
         IDataValueEditor editor = CreateValueEditor();
-        if (configuration is not null)
+        if (configurationObject is not null)
         {
-            ((DataValueEditor)editor).Configuration = configuration; // TODO: casting is bad
+            ((DataValueEditor)editor).ConfigurationObject = configurationObject; // TODO: casting is bad
         }
 
         return editor;

--- a/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
@@ -77,7 +77,8 @@ public class DataValueEditor : IDataValueEditor
     /// <summary>
     ///     Gets or sets the value editor configuration.
     /// </summary>
-    public virtual object? Configuration { get; set; }
+    /// <seealso cref="IDataType.ConfigurationObject"/>
+    public virtual object? ConfigurationObject { get; set; }
 
     public bool SupportsReadOnly { get; set; }
 
@@ -120,7 +121,7 @@ public class DataValueEditor : IDataValueEditor
     public IEnumerable<ValidationResult> Validate(object? value, bool required, string? format)
     {
         List<ValidationResult>? results = null;
-        var r = Validators.SelectMany(v => v.Validate(value, ValueType, Configuration)).ToList();
+        var r = Validators.SelectMany(v => v.Validate(value, ValueType, ConfigurationObject)).ToList();
         if (r.Any())
         {
             results = r;

--- a/src/Umbraco.Core/PropertyEditors/IDataEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/IDataEditor.cs
@@ -63,7 +63,7 @@ public interface IDataEditor : IDiscoverable
     /// <summary>
     ///     Gets a configured value editor.
     /// </summary>
-    IDataValueEditor GetValueEditor(object? configuration);
+    IDataValueEditor GetValueEditor(object? configurationObject);
 
     /// <summary>
     ///     Gets an editor to edit the value editor configuration.

--- a/src/Umbraco.Core/PropertyEditors/MissingPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/MissingPropertyEditor.cs
@@ -28,5 +28,5 @@ public class MissingPropertyEditor : IDataEditor
 
     public IDataValueEditor GetValueEditor() => throw new NotImplementedException();
 
-    public IDataValueEditor GetValueEditor(object? configuration) => throw new NotImplementedException();
+    public IDataValueEditor GetValueEditor(object? configurationObject) => throw new NotImplementedException();
 }

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/LabelValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/LabelValueConverter.cs
@@ -21,7 +21,7 @@ public class LabelValueConverter : PropertyValueConverterBase
     public override Type GetPropertyValueType(IPublishedPropertyType propertyType)
     {
         LabelConfiguration? valueType =
-            ConfigurationEditor.ConfigurationAs<LabelConfiguration>(propertyType.DataType.Configuration);
+            ConfigurationEditor.ConfigurationAs<LabelConfiguration>(propertyType.DataType.ConfigurationObject);
         switch (valueType?.ValueType)
         {
             case ValueTypes.DateTime:
@@ -46,7 +46,7 @@ public class LabelValueConverter : PropertyValueConverterBase
     public override object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object? source, bool preview)
     {
         LabelConfiguration? valueType =
-            ConfigurationEditor.ConfigurationAs<LabelConfiguration>(propertyType.DataType.Configuration);
+            ConfigurationEditor.ConfigurationAs<LabelConfiguration>(propertyType.DataType.ConfigurationObject);
         switch (valueType?.ValueType)
         {
             case ValueTypes.DateTime:

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MediaPickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MediaPickerValueConverter.cs
@@ -58,7 +58,7 @@ public class MediaPickerValueConverter : PropertyValueConverterBase
     private bool IsMultipleDataType(PublishedDataType dataType)
     {
         MediaPickerConfiguration? config =
-            ConfigurationEditor.ConfigurationAs<MediaPickerConfiguration>(dataType.Configuration);
+            ConfigurationEditor.ConfigurationAs<MediaPickerConfiguration>(dataType.ConfigurationObject);
         return config?.Multiple ?? false;
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -311,7 +311,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
                     continue; // not implementing IDataValueTags, continue
                 }
 
-                object? configuration = DataTypeService.GetDataType(property.PropertyType.DataTypeId)?.ConfigurationObject;
+                object? configurationObject = DataTypeService.GetDataType(property.PropertyType.DataTypeId)?.ConfigurationObject;
 
                 if (property.PropertyType.VariesByCulture())
                 {
@@ -319,14 +319,14 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
                     foreach (IPropertyValue pvalue in property.Values)
                     {
                         var languageId = LanguageRepository.GetIdByIsoCode(pvalue.Culture);
-                        tags.AddRange(tagsProvider.GetTags(pvalue.EditedValue, configuration, languageId));
+                        tags.AddRange(tagsProvider.GetTags(pvalue.EditedValue, configurationObject, languageId));
                     }
 
                     tagRepo.Assign(entity.Id, property.PropertyTypeId, tags);
                 }
                 else
                 {
-                    IEnumerable<ITag> tags = tagsProvider.GetTags(property.GetValue(), configuration, null);
+                    IEnumerable<ITag> tags = tagsProvider.GetTags(property.GetValue(), configurationObject, null);
                     tagRepo.Assign(entity.Id, property.PropertyTypeId, tags);
                 }
             }

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyValueEditor.cs
@@ -102,9 +102,9 @@ internal abstract class BlockEditorPropertyValueEditor : DataValueEditor, IDataV
                     continue;
                 }
 
-                object? configuration = _dataTypeService.GetDataType(prop.Value.PropertyType.DataTypeKey)?.ConfigurationObject;
+                object? configurationObject = _dataTypeService.GetDataType(prop.Value.PropertyType.DataTypeKey)?.ConfigurationObject;
 
-                result.AddRange(tagsProvider.GetTags(prop.Value.Value, configuration, languageId));
+                result.AddRange(tagsProvider.GetTags(prop.Value.Value, configurationObject, languageId));
             }
         }
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/NestedContentPropertyEditor.cs
@@ -116,9 +116,9 @@ public class NestedContentPropertyEditor : DataEditor
         }
 
         /// <inheritdoc />
-        public override object? Configuration
+        public override object? ConfigurationObject
         {
-            get => base.Configuration;
+            get => base.ConfigurationObject;
             set
             {
                 if (value == null)
@@ -133,7 +133,7 @@ public class NestedContentPropertyEditor : DataEditor
                         nameof(value));
                 }
 
-                base.Configuration = value;
+                base.ConfigurationObject = value;
 
                 HideLabel = configuration.HideLabel.TryConvertTo<bool>().Result;
             }
@@ -190,9 +190,9 @@ public class NestedContentPropertyEditor : DataEditor
                         continue;
                     }
 
-                    object? configuration = _dataTypeService.GetDataType(prop.Value.PropertyType.DataTypeKey)?.ConfigurationObject;
+                    object? configurationObject = _dataTypeService.GetDataType(prop.Value.PropertyType.DataTypeKey)?.ConfigurationObject;
 
-                    result.AddRange(tagsProvider.GetTags(prop.Value.Value, configuration, languageId));
+                    result.AddRange(tagsProvider.GetTags(prop.Value.Value, configurationObject, languageId));
                 }
             }
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
@@ -193,9 +193,9 @@ public class RichTextPropertyEditor : DataEditor
         }
 
         /// <inheritdoc />
-        public override object? Configuration
+        public override object? ConfigurationObject
         {
-            get => base.Configuration;
+            get => base.ConfigurationObject;
             set
             {
                 if (value == null)
@@ -210,7 +210,7 @@ public class RichTextPropertyEditor : DataEditor
                         nameof(value));
                 }
 
-                base.Configuration = value;
+                base.ConfigurationObject = value;
 
                 HideLabel = configuration.HideLabel;
             }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockListPropertyValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockListPropertyValueConverter.cs
@@ -45,7 +45,7 @@ public class BlockListPropertyValueConverter : BlockPropertyValueConverterBase<B
         if (isSingleBlockMode)
         {
             BlockListConfiguration.BlockConfiguration? block =
-                ConfigurationEditor.ConfigurationAs<BlockListConfiguration>(propertyType.DataType.Configuration)?.Blocks.FirstOrDefault();
+                ConfigurationEditor.ConfigurationAs<BlockListConfiguration>(propertyType.DataType.ConfigurationObject)?.Blocks.FirstOrDefault();
 
             ModelType? contentElementType = block?.ContentElementTypeKey is Guid contentElementTypeKey && _contentTypeService.Get(contentElementTypeKey) is IContentType contentType ? ModelType.For(contentType.Alias) : null;
             ModelType? settingsElementType = block?.SettingsElementTypeKey is Guid settingsElementTypeKey && _contentTypeService.Get(settingsElementTypeKey) is IContentType settingsType ? ModelType.For(settingsType.Alias) : null;
@@ -69,7 +69,7 @@ public class BlockListPropertyValueConverter : BlockPropertyValueConverterBase<B
     private bool IsSingleBlockMode(PublishedDataType dataType)
     {
         BlockListConfiguration? config =
-            ConfigurationEditor.ConfigurationAs<BlockListConfiguration>(dataType.Configuration);
+            ConfigurationEditor.ConfigurationAs<BlockListConfiguration>(dataType.ConfigurationObject);
         return (config?.UseSingleBlockMode ?? false) && config?.Blocks.Length == 1 && config?.ValidationLimit?.Min == 1 && config?.ValidationLimit?.Max == 1;
     }
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/ColorPickerValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/ColorPickerValueConverter.cs
@@ -57,7 +57,7 @@ public class ColorPickerValueConverter : PropertyValueConverterBase
     }
 
     private bool UseLabel(IPublishedPropertyType propertyType) => ConfigurationEditor
-        .ConfigurationAs<ColorPickerConfiguration>(propertyType.DataType.Configuration)?.UseLabel ?? false;
+        .ConfigurationAs<ColorPickerConfiguration>(propertyType.DataType.ConfigurationObject)?.UseLabel ?? false;
 
     public class PickedColor
     {

--- a/tests/Umbraco.Tests.Common/Builders/DataValueEditorBuilder.cs
+++ b/tests/Umbraco.Tests.Common/Builders/DataValueEditorBuilder.cs
@@ -59,7 +59,7 @@ public class DataValueEditorBuilder<TParent> : ChildBuilderBase<TParent, IDataVa
             Mock.Of<IShortStringHelper>(),
             Mock.Of<IJsonSerializer>())
         {
-            Configuration = configuration,
+            ConfigurationObject = configuration,
             View = view,
             HideLabel = hideLabel,
             ValueType = valueType

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/ValueEditorCacheTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/ValueEditorCacheTests.cs
@@ -124,7 +124,7 @@ public class ValueEditorCacheTests
             return Mock.Of<IDataValueEditor>();
         }
 
-        public IDataValueEditor GetValueEditor(object configuration) => GetValueEditor();
+        public IDataValueEditor GetValueEditor(object configurationObject) => GetValueEditor();
 
         public IDictionary<string, object> DefaultConfiguration { get; }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueEditorReuseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueEditorReuseTests.cs
@@ -78,10 +78,10 @@ public class DataValueEditorReuseTests
         // no matter what, a property editor should never reuse its data value editor when created *with* configuration
         var dataValueEditor1 = textboxPropertyEditor.GetValueEditor("config");
         Assert.NotNull(dataValueEditor1);
-        Assert.AreEqual("config", ((DataValueEditor)dataValueEditor1).Configuration);
+        Assert.AreEqual("config", ((DataValueEditor)dataValueEditor1).ConfigurationObject);
         var dataValueEditor2 = textboxPropertyEditor.GetValueEditor("config");
         Assert.NotNull(dataValueEditor2);
-        Assert.AreEqual("config", ((DataValueEditor)dataValueEditor2).Configuration);
+        Assert.AreEqual("config", ((DataValueEditor)dataValueEditor2).ConfigurationObject);
         Assert.AreNotSame(dataValueEditor1, dataValueEditor2);
         _dataValueEditorFactoryMock.Verify(
             m => m.Create<TextOnlyValueEditor>(It.IsAny<DataEditorAttribute>()),
@@ -122,10 +122,10 @@ public class DataValueEditorReuseTests
         // no matter what, a property editor should never reuse its data value editor when created *with* configuration
         var dataValueEditor1 = blockListPropertyEditor.GetValueEditor("config");
         Assert.NotNull(dataValueEditor1);
-        Assert.AreEqual("config", ((DataValueEditor)dataValueEditor1).Configuration);
+        Assert.AreEqual("config", ((DataValueEditor)dataValueEditor1).ConfigurationObject);
         var dataValueEditor2 = blockListPropertyEditor.GetValueEditor("config");
         Assert.NotNull(dataValueEditor2);
-        Assert.AreEqual("config", ((DataValueEditor)dataValueEditor2).Configuration);
+        Assert.AreEqual("config", ((DataValueEditor)dataValueEditor2).ConfigurationObject);
         Assert.AreNotSame(dataValueEditor1, dataValueEditor2);
         _dataValueEditorFactoryMock.Verify(
             m => m.Create<BlockListPropertyEditorBase.BlockListEditorPropertyValueEditor>(It.IsAny<DataEditorAttribute>()),

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/MultiValuePropertyEditorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/MultiValuePropertyEditorTests.cs
@@ -77,7 +77,7 @@ public class MultiValuePropertyEditorTests
         prop.SetValue("Value 1,Value 2,Value 3");
 
         var valueEditor = dataType.Editor.GetValueEditor();
-        ((DataValueEditor)valueEditor).Configuration = dataType.ConfigurationObject;
+        ((DataValueEditor)valueEditor).ConfigurationObject = dataType.ConfigurationObject;
         var result = valueEditor.ConvertDbToString(prop.PropertyType, prop.GetValue());
 
         Assert.AreEqual("Value 1,Value 2,Value 3", result);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The previous datatype configuration refactoring left the mapping in `ContentPropertyDisplayMapper` broken. This is noticeable when one attempts to edit content with an RTE or a Block List property in the old backoffice on the V13 branch (an exception is thrown).

While `ContentPropertyDisplayMapper` is not supposed to remain in V13, the problem highlights the need for a more explicit naming of the `IDataValueEditor` configuration, so it becomes clearer that the configuration originates from `IDataType.ConfigurationObject`. Thus the configuration has been renamed from `IDataValueEditor.Configuration` to `IDataValueEditor.ConfigurationObject`. Additionally, the property docs now also reference `IDataType.ConfigurationObject`.
