### PR TITLE
Ambertvu/obsoletemessage

### DIFF
--- a/src/Umbraco.Core/Models/ContentEditing/Language.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/Language.cs
@@ -22,7 +22,7 @@ public class Language
     [DataMember(Name = "isMandatory")]
     public bool IsMandatory { get; set; }
 
-    [Obsolete("This will be replaced by fallback language ISO code in V13.")]
+    [Obsolete("This will be replaced by fallback language ISO code in V15.")]
     [DataMember(Name = "fallbackLanguageId")]
     public int? FallbackLanguageId { get; set; }
 }

--- a/src/Umbraco.Core/Models/DictionaryItem.cs
+++ b/src/Umbraco.Core/Models/DictionaryItem.cs
@@ -34,7 +34,7 @@ public class DictionaryItem : EntityBase, IDictionaryItem
         _translations = new List<IDictionaryTranslation>();
     }
 
-    [Obsolete("This will be removed in V13.")]
+    [Obsolete("This will be removed in V15.")]
     public Func<int, ILanguage?>? GetLanguage { get; set; }
 
     /// <summary>

--- a/src/Umbraco.Core/Models/DictionaryItemExtensions.cs
+++ b/src/Umbraco.Core/Models/DictionaryItemExtensions.cs
@@ -22,7 +22,7 @@ public static class DictionaryItemExtensions
     /// </summary>
     /// <param name="d"></param>
     /// <returns></returns>
-    [Obsolete("Warning: This method ONLY works in very specific scenarios. It will be removed in V13.")]
+    [Obsolete("Warning: This method ONLY works in very specific scenarios. It will be removed in V15.")]
     public static string? GetDefaultValue(this IDictionaryItem d)
     {
         IDictionaryTranslation? defaultTranslation = d.Translations.FirstOrDefault(x => x.Language?.Id == 1);

--- a/src/Umbraco.Core/Models/DictionaryItemExtensions.cs
+++ b/src/Umbraco.Core/Models/DictionaryItemExtensions.cs
@@ -10,7 +10,7 @@ public static class DictionaryItemExtensions
     /// <param name="d"></param>
     /// <param name="languageId"></param>
     /// <returns></returns>
-    [Obsolete("This will be replaced in V13 by a corresponding method accepting language ISO code instead of language ID.")]
+    [Obsolete("This will be replaced in V15 by a corresponding method accepting language ISO code instead of language ID.")]
     public static string? GetTranslatedValue(this IDictionaryItem d, int languageId)
     {
         IDictionaryTranslation? trans = d.Translations.FirstOrDefault(x => x.LanguageId == languageId);

--- a/src/Umbraco.Core/Models/DictionaryTranslation.cs
+++ b/src/Umbraco.Core/Models/DictionaryTranslation.cs
@@ -30,14 +30,14 @@ public class DictionaryTranslation : EntityBase, IDictionaryTranslation
         Key = uniqueId;
     }
 
-    [Obsolete("Please use constructor that accepts ILanguage. This will be removed in V13.")]
+    [Obsolete("Please use constructor that accepts ILanguage. This will be removed in V15.")]
     public DictionaryTranslation(int languageId, string value)
     {
         LanguageId = languageId;
         _value = value;
     }
 
-    [Obsolete("Please use constructor that accepts ILanguage. This will be removed in V13.")]
+    [Obsolete("Please use constructor that accepts ILanguage. This will be removed in V15.")]
     public DictionaryTranslation(int languageId, string value, Guid uniqueId)
     {
         LanguageId = languageId;
@@ -58,7 +58,7 @@ public class DictionaryTranslation : EntityBase, IDictionaryTranslation
     ///     returned
     ///     on a callback.
     /// </remarks>
-    [Obsolete("This will be removed in V13. From V13 onwards you should get languages by ISO code from ILanguageService.")]
+    [Obsolete("This will be removed in V15. From V15 onwards you should get languages by ISO code from ILanguageService.")]
     [DataMember]
     [DoNotClone]
     public ILanguage? Language
@@ -86,7 +86,7 @@ public class DictionaryTranslation : EntityBase, IDictionaryTranslation
         }
     }
 
-    [Obsolete("This will be replaced by language ISO code in V13.")]
+    [Obsolete("This will be replaced by language ISO code in V15.")]
     public int LanguageId { get; private set; }
 
     /// <summary>

--- a/src/Umbraco.Core/Models/IDictionaryTranslation.cs
+++ b/src/Umbraco.Core/Models/IDictionaryTranslation.cs
@@ -8,11 +8,11 @@ public interface IDictionaryTranslation : IEntity, IRememberBeingDirty
     /// <summary>
     ///     Gets or sets the <see cref="Language" /> for the translation
     /// </summary>
-    [Obsolete("This will be removed in V13. From V13 onwards you should get languages by ISO code from ILanguageService.")]
+    [Obsolete("This will be removed in V13. From V15 onwards you should get languages by ISO code from ILanguageService.")]
     [DataMember]
     ILanguage? Language { get; set; }
 
-    [Obsolete("This will be replaced by language ISO code in V13.")]
+    [Obsolete("This will be replaced by language ISO code in V15.")]
     int LanguageId { get; }
 
     /// <summary>

--- a/src/Umbraco.Core/Models/IDictionaryTranslation.cs
+++ b/src/Umbraco.Core/Models/IDictionaryTranslation.cs
@@ -8,7 +8,7 @@ public interface IDictionaryTranslation : IEntity, IRememberBeingDirty
     /// <summary>
     ///     Gets or sets the <see cref="Language" /> for the translation
     /// </summary>
-    [Obsolete("This will be removed in V13. From V15 onwards you should get languages by ISO code from ILanguageService.")]
+    [Obsolete("This will be removed in V15. From V13 onwards you should get languages by ISO code from ILanguageService.")]
     [DataMember]
     ILanguage? Language { get; set; }
 

--- a/src/Umbraco.Core/Models/ILanguage.cs
+++ b/src/Umbraco.Core/Models/ILanguage.cs
@@ -55,7 +55,7 @@ public interface ILanguage : IEntity, IRememberBeingDirty
     ///         define fallback strategies when a value does not exist for a requested language.
     ///     </para>
     /// </remarks>
-    [Obsolete("This will be replaced by fallback language ISO code in V13.")]
+    [Obsolete("This will be replaced by fallback language ISO code in V15.")]
     [DataMember]
     int? FallbackLanguageId { get; set; }
 }

--- a/src/Umbraco.Core/Models/Language.cs
+++ b/src/Umbraco.Core/Models/Language.cs
@@ -74,7 +74,7 @@ public class Language : EntityBase, ILanguage
     }
 
     /// <inheritdoc />
-    [Obsolete("This will be replaced by fallback language ISO code in V13.")]
+    [Obsolete("This will be replaced by fallback language ISO code in V15.")]
     public int? FallbackLanguageId
     {
         get => _fallbackLanguageId;

--- a/tests/Umbraco.Tests.Common/Builders/LanguageBuilder.cs
+++ b/tests/Umbraco.Tests.Common/Builders/LanguageBuilder.cs
@@ -95,7 +95,7 @@ public class LanguageBuilder<TParent>
         return this;
     }
 
-    [Obsolete("This will be replaced in V13 by a corresponding method accepting language ISO code instead of language ID.")]
+    [Obsolete("This will be replaced in V15 by a corresponding method accepting language ISO code instead of language ID.")]
     public LanguageBuilder<TParent> WithFallbackLanguageId(int fallbackLanguageId)
     {
         _fallbackLanguageId = fallbackLanguageId;


### PR DESCRIPTION
[ILanguageService ](https://github.com/umbraco/Umbraco-CMS/pull/13751) is scheduled for V13, however the obsolete notifications for some methods (see PR) say these are getting removed in V13. 

### Description
I've changed the notices in the obsolete messages to refer V15, as ILanguageService is the actual replacement for those methods and should be there till two versions after V13

This is the original PR: https://github.com/umbraco/Umbraco-CMS/pull/13753