### PR TITLE
Set PublishedState of content to Publishing before handling ContentSavingNotification

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1146,6 +1146,8 @@ public class ContentService : RepositoryService, IContentService
 
             var allLangs = _languageRepository.GetMany().ToList();
 
+            // Change state to publishing
+            content.PublishedState = PublishedState.Publishing;
             var savingNotification = new ContentSavingNotification(content, evtMsgs);
             if (scope.Notifications.PublishCancelable(savingNotification))
             {


### PR DESCRIPTION
## Details

- #14112 points out a problem when trying to update a value in a notification while attempting to "Save and publish" a content item. The issue demonstrates how to do this by using `ContentPublishingNotification`, however using <code>Content<b>Saving</b>Notification</code> is the proper course of action, because:
  - When using the `ContentPublishingNotification`, it will be already too late to change the value as the content item will be already saved in a draft version that is going to be published afterwards.
  - With the `ContentSavingNotification`approach, we make sure to change the value before we save the content item, and then we will only need to publish it once and all the changes will be gathered together.
- To make use of the <code>Content<b>Saving</b>Notification</code>, however, we had to set the `.PublishedState` of the content item to `Publishing` so we can perform a check in any custom Notification whether the item is going to be published to then apply the intended changes before finalizing the publishing. That is what this PR is ensuring.

## Testing
- Create a simple document type with a text string property called "Example Property", and display the published property value in your view;
- Create a `ContentSavingNotification` similar to this:
```c#
public class ExamplePublishedNotification : INotificationHandler<ContentSavingNotification>
{
    public void Handle(ContentSavingNotification notification)
    {
        const string alias = "exampleProperty";

        foreach (var item in notification.SavedEntities)
        {
            try
            {
                if (item.PublishedState == PublishedState.Publishing)
                {

                    var dateValue = DateTime.Now;
                    item.SetValue(alias, dateValue.ToString());

                    notification.Messages.Add(new EventMessage(
                        "The \"Example Property\" value has automatically been set to",
                        dateValue.ToString("yyyy-MM-dd"),
                        EventMessageType.Success));
                }
            }
            catch (Exception ex)
            {
                notification.Messages.Add(new EventMessage(
                    "There was a problem when trying to set the \"Example Property\" value automatically.", ex.Message,
                    EventMessageType.Error));
            }
        }
    }
}
```
- Register the notification handler in the startup class, like:

```c#
        public void ConfigureServices(IServiceCollection services)
        {
            services.AddUmbraco(_env, _config)
                .AddBackOffice()
                .AddWebsite()
                .AddComposers()
                .AddNotificationHandler<ContentSavingNotification, ExamplePublishedNotification>()
                .Build();
        }
```
- Test save and publishing the value and verify that the value is published.