### PR TITLE
Fixes #14102 - NestedPropertyIndexValueFactoryBase ignores compositions

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/NestedPropertyIndexValueFactoryBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/NestedPropertyIndexValueFactoryBase.cs
@@ -38,7 +38,7 @@ internal abstract class NestedPropertyIndexValueFactoryBase<TSerialized, TItem> 
 
             var propertyTypeDictionary =
                 contentType
-                    .PropertyGroups
+                    .CompositionPropertyGroups
                     .SelectMany(x => x.PropertyTypes!)
                     .ToDictionary(x => x.Alias);
 


### PR DESCRIPTION
### Description
Fixes #14102

Now:
![image](https://user-images.githubusercontent.com/23340481/232781573-f5b8780b-c95f-47a5-a0c3-60a56e5f5a5c.png)

<!-- Thanks for contributing to Umbraco CMS! -->
