### PR TITLE
Dedicated cookie setup for new backoffice login

### DIFF
--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeAuthBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeAuthBuilderExtensions.cs
@@ -19,7 +19,8 @@ public static class BackOfficeAuthBuilderExtensions
     {
         builder
             .AddDbContext()
-            .AddOpenIddict();
+            .AddOpenIddict()
+            .AddBackOfficeLogin();
 
         return builder;
     }
@@ -124,6 +125,19 @@ public static class BackOfficeAuthBuilderExtensions
         return builder;
     }
 
+    private static IUmbracoBuilder AddBackOfficeLogin(this IUmbracoBuilder builder)
+    {
+        builder.Services
+            .AddAuthentication()
+            .AddCookie(Constants.Security.NewBackOfficeAuthenticationType, options =>
+            {
+                options.LoginPath = "/umbraco/login";
+                options.Cookie.Name = Constants.Security.NewBackOfficeAuthenticationType;
+            });
+
+        return builder;
+    }
+
     // TODO: remove this once EF is implemented
     public class DatabaseManager : IHostedService
     {
@@ -140,7 +154,7 @@ public static class BackOfficeAuthBuilderExtensions
 
             // TODO: add BackOfficeAuthorizationInitializationMiddleware before UseAuthorization (to make it run for unauthorized API requests) and remove this
             IBackOfficeApplicationManager backOfficeApplicationManager = scope.ServiceProvider.GetRequiredService<IBackOfficeApplicationManager>();
-            await backOfficeApplicationManager.EnsureBackOfficeApplicationAsync(new Uri("https://localhost:44331/"), cancellationToken);
+            await backOfficeApplicationManager.EnsureBackOfficeApplicationAsync(new Uri("https://localhost:44339/"), cancellationToken);
         }
 
         public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -5762,12 +5762,27 @@
             "description": "Success"
           }
         }
-      },
+      }
+    },
+    "/umbraco/management/api/v1/security/back-office/login": {
       "post": {
         "tags": [
           "Security"
         ],
-        "operationId": "PostSecurityBackOfficeAuthorize",
+        "operationId": "PostSecurityBackOfficeLogin",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/LoginRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Success"
@@ -9736,6 +9751,18 @@
           },
           "level": {
             "$ref": "#/components/schemas/LogLevelModel"
+          }
+        },
+        "additionalProperties": false
+      },
+      "LoginRequestModel": {
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
           }
         },
         "additionalProperties": false

--- a/src/Umbraco.Cms.Api.Management/Security/BackOfficeApplicationManager.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/BackOfficeApplicationManager.cs
@@ -13,15 +13,17 @@ public class BackOfficeApplicationManager : IBackOfficeApplicationManager
     private readonly IOpenIddictApplicationManager _applicationManager;
     private readonly IWebHostEnvironment _webHostEnvironment;
     private readonly Uri? _backOfficeHost;
+    private readonly string? _authorizeCallbackPathName;
 
     public BackOfficeApplicationManager(
         IOpenIddictApplicationManager applicationManager,
         IWebHostEnvironment webHostEnvironment,
-        IOptionsMonitor<NewBackOfficeSettings> securitySettingsMonitor)
+        IOptions<NewBackOfficeSettings> securitySettings)
     {
         _applicationManager = applicationManager;
         _webHostEnvironment = webHostEnvironment;
-        _backOfficeHost = securitySettingsMonitor.CurrentValue.BackOfficeHost;
+        _backOfficeHost = securitySettings.Value.BackOfficeHost;
+        _authorizeCallbackPathName = securitySettings.Value.AuthorizeCallbackPathName;
     }
 
     public async Task EnsureBackOfficeApplicationAsync(Uri backOfficeUrl, CancellationToken cancellationToken = default)
@@ -38,7 +40,7 @@ public class BackOfficeApplicationManager : IBackOfficeApplicationManager
                 ClientId = Constants.OauthClientIds.BackOffice,
                 RedirectUris =
                 {
-                    CallbackUrlFor(_backOfficeHost ?? backOfficeUrl, "/umbraco")
+                    CallbackUrlFor(_backOfficeHost ?? backOfficeUrl, _authorizeCallbackPathName ?? "/umbraco")
                 },
                 Type = OpenIddictConstants.ClientTypes.Public,
                 Permissions =

--- a/src/Umbraco.Core/Constants-Security.cs
+++ b/src/Umbraco.Core/Constants-Security.cs
@@ -78,6 +78,8 @@ public static partial class Constants
         public const string BackOfficeTokenAuthenticationType = "UmbracoBackOfficeToken";
         public const string BackOfficeTwoFactorAuthenticationType = "UmbracoTwoFactorCookie";
         public const string BackOfficeTwoFactorRememberMeAuthenticationType = "UmbracoTwoFactorRememberMeCookie";
+        // FIXME: remove this in favor of BackOfficeAuthenticationType when the old backoffice auth is no longer necessary
+        public const string NewBackOfficeAuthenticationType = "NewUmbracoBackOffice";
 
         public const string EmptyPasswordPrefix = "___UIDEMPTYPWORD__";
 

--- a/src/Umbraco.New.Cms.Core/Models/Configuration/NewBackOfficeSettings.cs
+++ b/src/Umbraco.New.Cms.Core/Models/Configuration/NewBackOfficeSettings.cs
@@ -7,4 +7,6 @@ namespace Umbraco.New.Cms.Core.Models.Configuration;
 public class NewBackOfficeSettings
 {
     public Uri? BackOfficeHost { get; set; } = null;
+
+    public string? AuthorizeCallbackPathName { get; set; } = null;
 }

--- a/src/Umbraco.Web.UI.New/BackOfficeLoginController.cs
+++ b/src/Umbraco.Web.UI.New/BackOfficeLoginController.cs
@@ -27,10 +27,7 @@ public class BackOfficeLoginController : Controller
     // GET
     public IActionResult Index(BackOfficeLoginModel model)
     {
-        var authUrl = _linkGenerator.GetUmbracoApiServiceBaseUrl<AuthenticationController>(
-            controller => controller.PostLogin(new LoginModel()));
-
-        model.AuthUrl = authUrl ?? string.Empty;
+        model.AuthUrl = "/umbraco/management/api/v1.0/security/back-office";
 
         return View("/umbraco/UmbracoLogin/Index.cshtml", model);
     }

--- a/src/Umbraco.Web.UI.New/umbraco/UmbracoLogin/Index.cshtml
+++ b/src/Umbraco.Web.UI.New/umbraco/UmbracoLogin/Index.cshtml
@@ -1,7 +1,4 @@
 @model Umbraco.Cms.Web.UI.BackOfficeLoginModel
-@{
-    var authUrlLogin = Model.AuthUrl + "PostLogin";
-}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -43,7 +40,7 @@
 
 <script>
     !(function () {
-        const authUrlLogin = "@authUrlLogin"
+        const authUrlLogin = "@Model.AuthUrl/login"
         const returnUrl = "@Model.ReturnUrl".replaceAll("&amp;", "&")
 
         console.log('urls', {authUrlLogin, returnUrl})
@@ -72,22 +69,10 @@
                 })
 
                 const content = await res.text()
-                console.log('raw content', content)
+                console.log('login success', content)
 
-                if (!content) throw new Error('No content from server')
-
-                // Special AngularJS scraping
-                const splitContent = content.split("\n")
-
-                if (splitContent.length < 2) throw new Error('Invalid content from server')
-
-                const response = JSON.parse(splitContent[1])
-
-                if (response) {
-                    console.log('login success', response)
-                    if (returnUrl) {
-                        location.href = returnUrl
-                    }
+                if (returnUrl) {
+                    location.href = returnUrl
                 }
             } catch (err) {
                 alert('Could not login: ' + err.message)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This introduces a dedicated cookie setup for the new backoffice, which is necessary for the old and new backoffice to be able to co-exist.

This is a temporary solution. Once the old backoffice is no longer necessary for testing the new one and the new management APIs, the old backoffice login must be merged with this setup (including 2FA handling and external login handling).

### Testing this PR

The management APIs aren't protected yet, nor does the client handle auth perfectly well yet, so we have to fake the test a bit.

1. Start the new backoffice client.
2. In the browser, go to `/umbraco/management/api/v1.0/security/back-office/authorize?client_id=umbraco-back-office&response_type=code&scope=offline_access&code_challenge=WZRHGrsBESr8wYFZ9sx0tPURuZgG2lmzyvWpwXPKz8U&code_challenge_method=S256`.
3. Verify that you are redirected to the login page for the new backoffice (`/umbraco/login/`).
4. Login using your backoffice credentials.
5. Verify that you are redirected to the backoffice.
6. In an incognito browser, go to `/umbraco/swagger/index.html`.
7. Verify that you can complete an authorization flow in the Swagger client using the new backoffice login.

Also verify that you can still login to the old backoffice.