### PR TITLE
Updated so it now shows the parentId instead of null

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/ChildrenDictionaryTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/ChildrenDictionaryTreeController.cs
@@ -31,7 +31,7 @@ public class ChildrenDictionaryTreeController : DictionaryTreeControllerBase
             await DictionaryItemService.GetChildrenAsync(parentId),
             out var totalItems);
 
-        EntityTreeItemResponseModel[] viewModels = await MapTreeItemViewModels(null, dictionaryItems);
+        EntityTreeItemResponseModel[] viewModels = await MapTreeItemViewModels(parentId, dictionaryItems);
 
         PagedViewModel<EntityTreeItemResponseModel> result = PagedViewModel(viewModels, totalItems);
         return await Task.FromResult(Ok(result));


### PR DESCRIPTION
The childDictionary was missing the ParentId since its value was set to null. It has now been updated to actually show the parentId of the childDictionary 