### PR TITLE
Make Block Grid and Block List use System.Text.Json instead of Json.NET

### DIFF
--- a/src/Umbraco.Infrastructure/Models/Blocks/BlockEditorData.cs
+++ b/src/Umbraco.Infrastructure/Models/Blocks/BlockEditorData.cs
@@ -1,21 +1,21 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using Newtonsoft.Json.Linq;
-
 namespace Umbraco.Cms.Core.Models.Blocks;
 
 /// <summary>
 ///     Convertable block data from json
 /// </summary>
-public class BlockEditorData
+public class BlockEditorData<TValue, TLayout>
+    where TValue : BlockValue<TLayout>, new()
+    where TLayout : class, IBlockLayoutItem, new()
 {
     private readonly string _propertyEditorAlias;
 
     public BlockEditorData(
         string propertyEditorAlias,
         IEnumerable<ContentAndSettingsReference> references,
-        BlockValue blockValue)
+        BlockValue<TLayout> blockValue)
     {
         if (string.IsNullOrWhiteSpace(propertyEditorAlias))
         {
@@ -32,20 +32,20 @@ public class BlockEditorData
     private BlockEditorData()
     {
         _propertyEditorAlias = string.Empty;
-        BlockValue = new BlockValue();
+        BlockValue = new TValue();
     }
 
-    public static BlockEditorData Empty { get; } = new();
+    public static BlockEditorData<TValue, TLayout> Empty { get; } = new();
 
     /// <summary>
     ///     Returns the layout for this specific property editor
     /// </summary>
-    public JToken? Layout => BlockValue.Layout.TryGetValue(_propertyEditorAlias, out JToken? layout) ? layout : null;
+    public IEnumerable<TLayout>? Layout => BlockValue.Layout.TryGetValue(_propertyEditorAlias, out IEnumerable<TLayout>? layout) ? layout : null;
 
     /// <summary>
     ///     Returns the reference to the original BlockValue
     /// </summary>
-    public BlockValue BlockValue { get; }
+    public BlockValue<TLayout> BlockValue { get; }
 
     public List<ContentAndSettingsReference> References { get; } = new();
 }

--- a/src/Umbraco.Infrastructure/Models/Blocks/BlockGridLayoutAreaItem.cs
+++ b/src/Umbraco.Infrastructure/Models/Blocks/BlockGridLayoutAreaItem.cs
@@ -1,12 +1,8 @@
-﻿using Newtonsoft.Json;
-
-namespace Umbraco.Cms.Core.Models.Blocks;
+﻿namespace Umbraco.Cms.Core.Models.Blocks;
 
 public class BlockGridLayoutAreaItem
 {
-    [JsonProperty("key", NullValueHandling = NullValueHandling.Ignore)]
     public Guid Key { get; set; } = Guid.Empty;
 
-    [JsonProperty("items", NullValueHandling = NullValueHandling.Ignore)]
     public BlockGridLayoutItem[] Items { get; set; } = Array.Empty<BlockGridLayoutItem>();
 }

--- a/src/Umbraco.Infrastructure/Models/Blocks/BlockGridLayoutItem.cs
+++ b/src/Umbraco.Infrastructure/Models/Blocks/BlockGridLayoutItem.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using Newtonsoft.Json;
 using Umbraco.Cms.Infrastructure.Serialization;
 
 namespace Umbraco.Cms.Core.Models.Blocks;
@@ -11,20 +10,13 @@ namespace Umbraco.Cms.Core.Models.Blocks;
 /// </summary>
 public class BlockGridLayoutItem : IBlockLayoutItem
 {
-    [JsonProperty("contentUdi", Required = Required.Always)]
-    [JsonConverter(typeof(UdiJsonConverter))]
     public Udi? ContentUdi { get; set; }
 
-    [JsonProperty("settingsUdi", NullValueHandling = NullValueHandling.Ignore)]
-    [JsonConverter(typeof(UdiJsonConverter))]
     public Udi? SettingsUdi { get; set; }
 
-    [JsonProperty("columnSpan", NullValueHandling = NullValueHandling.Ignore)]
     public int? ColumnSpan { get; set; }
 
-    [JsonProperty("rowSpan", NullValueHandling = NullValueHandling.Ignore)]
     public int? RowSpan { get; set; }
 
-    [JsonProperty("areas", NullValueHandling = NullValueHandling.Ignore)]
     public BlockGridLayoutAreaItem[] Areas { get; set; } = Array.Empty<BlockGridLayoutAreaItem>();
 }

--- a/src/Umbraco.Infrastructure/Models/Blocks/BlockGridValue.cs
+++ b/src/Umbraco.Infrastructure/Models/Blocks/BlockGridValue.cs
@@ -1,0 +1,5 @@
+﻿namespace Umbraco.Cms.Core.Models.Blocks;
+
+public class BlockGridValue : BlockValue<BlockGridLayoutItem>
+{
+}

--- a/src/Umbraco.Infrastructure/Models/Blocks/BlockItemData.cs
+++ b/src/Umbraco.Infrastructure/Models/Blocks/BlockItemData.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using Newtonsoft.Json;
-using Umbraco.Cms.Infrastructure.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Umbraco.Cms.Core.Models.Blocks;
 
@@ -11,7 +10,6 @@ namespace Umbraco.Cms.Core.Models.Blocks;
 /// </summary>
 public class BlockItemData
 {
-    [JsonProperty("contentTypeKey")]
     public Guid ContentTypeKey { get; set; }
 
     /// <summary>
@@ -20,8 +18,6 @@ public class BlockItemData
     [JsonIgnore]
     public string ContentTypeAlias { get; set; } = string.Empty;
 
-    [JsonProperty("udi")]
-    [JsonConverter(typeof(UdiJsonConverter))]
     public Udi? Udi { get; set; }
 
     [JsonIgnore]
@@ -32,7 +28,7 @@ public class BlockItemData
     /// </summary>
     /// <remarks>
     ///     The JsonExtensionDataAttribute is used to put the non-typed properties into a bucket
-    ///     http://www.newtonsoft.com/json/help/html/DeserializeExtensionData.htm
+    ///     https://docs.microsoft.com/en-us/dotnet/api/system.text.json.serialization.jsonextensiondataattribute
     ///     NestedContent serializes to string, int, whatever eg
     ///     "stringValue":"Some String","numericValue":125,"otherNumeric":null
     /// </remarks>

--- a/src/Umbraco.Infrastructure/Models/Blocks/BlockListEditorDataConverter.cs
+++ b/src/Umbraco.Infrastructure/Models/Blocks/BlockListEditorDataConverter.cs
@@ -1,23 +1,28 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using Newtonsoft.Json.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Serialization;
 
 namespace Umbraco.Cms.Core.Models.Blocks;
 
 /// <summary>
 ///     Data converter for the block list property editor
 /// </summary>
-public class BlockListEditorDataConverter : BlockEditorDataConverter
+public class BlockListEditorDataConverter : BlockEditorDataConverter<BlockListValue, BlockListLayoutItem>
 {
+    [Obsolete("Use the constructor that takes IJsonSerializer. Will be removed in V15.")]
     public BlockListEditorDataConverter()
-        : base(Constants.PropertyEditors.Aliases.BlockList)
+        : this(StaticServiceProvider.Instance.GetRequiredService<IJsonSerializer>())
     {
     }
 
-    protected override IEnumerable<ContentAndSettingsReference>? GetBlockReferences(JToken jsonLayout)
+    public BlockListEditorDataConverter(IJsonSerializer jsonSerializer)
+        : base(Constants.PropertyEditors.Aliases.BlockList, jsonSerializer)
     {
-        IEnumerable<BlockListLayoutItem>? blockListLayout = jsonLayout.ToObject<IEnumerable<BlockListLayoutItem>>();
-        return blockListLayout?.Select(x => new ContentAndSettingsReference(x.ContentUdi, x.SettingsUdi)).ToList();
     }
+
+    protected override IEnumerable<ContentAndSettingsReference> GetBlockReferences(IEnumerable<BlockListLayoutItem> layout)
+        => layout.Select(x => new ContentAndSettingsReference(x.ContentUdi, x.SettingsUdi)).ToList();
 }

--- a/src/Umbraco.Infrastructure/Models/Blocks/BlockListLayoutItem.cs
+++ b/src/Umbraco.Infrastructure/Models/Blocks/BlockListLayoutItem.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using Newtonsoft.Json;
 using Umbraco.Cms.Infrastructure.Serialization;
 
 namespace Umbraco.Cms.Core.Models.Blocks;
@@ -11,11 +10,7 @@ namespace Umbraco.Cms.Core.Models.Blocks;
 /// </summary>
 public class BlockListLayoutItem : IBlockLayoutItem
 {
-    [JsonProperty("contentUdi", Required = Required.Always)]
-    [JsonConverter(typeof(UdiJsonConverter))]
     public Udi? ContentUdi { get; set; }
 
-    [JsonProperty("settingsUdi", NullValueHandling = NullValueHandling.Ignore)]
-    [JsonConverter(typeof(UdiJsonConverter))]
     public Udi? SettingsUdi { get; set; }
 }

--- a/src/Umbraco.Infrastructure/Models/Blocks/BlockListValue.cs
+++ b/src/Umbraco.Infrastructure/Models/Blocks/BlockListValue.cs
@@ -1,0 +1,5 @@
+﻿namespace Umbraco.Cms.Core.Models.Blocks;
+
+public class BlockListValue : BlockValue<BlockListLayoutItem>
+{
+}

--- a/src/Umbraco.Infrastructure/Models/Blocks/BlockValue.cs
+++ b/src/Umbraco.Infrastructure/Models/Blocks/BlockValue.cs
@@ -1,19 +1,13 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-
 namespace Umbraco.Cms.Core.Models.Blocks;
 
-public class BlockValue
+public abstract class BlockValue<TLayout> where TLayout : IBlockLayoutItem
 {
-    [JsonProperty("layout")]
-    public IDictionary<string, JToken> Layout { get; set; } = null!;
+    public IDictionary<string, IEnumerable<TLayout>> Layout { get; set; } = null!;
 
-    [JsonProperty("contentData")]
     public List<BlockItemData> ContentData { get; set; } = new();
 
-    [JsonProperty("settingsData")]
     public List<BlockItemData> SettingsData { get; set; } = new();
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorMinMaxValidatorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorMinMaxValidatorBase.cs
@@ -11,7 +11,9 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 /// <summary>
 /// Validates the min/max number of items of a block based editor
 /// </summary>
-internal abstract class BlockEditorMinMaxValidatorBase : IValueValidator
+internal abstract class BlockEditorMinMaxValidatorBase<TValue, TLayout> : IValueValidator
+    where TValue : BlockValue<TLayout>, new()
+    where TLayout : class, IBlockLayoutItem, new()
 {
     protected BlockEditorMinMaxValidatorBase(ILocalizedTextService textService) => TextService = textService;
 
@@ -19,7 +21,7 @@ internal abstract class BlockEditorMinMaxValidatorBase : IValueValidator
 
     public abstract IEnumerable<ValidationResult> Validate(object? value, string? valueType, object? dataTypeConfiguration);
 
-    protected IEnumerable<ValidationResult> ValidateNumberOfBlocks(BlockEditorData? blockEditorData, int? min, int? max)
+    protected IEnumerable<ValidationResult> ValidateNumberOfBlocks(BlockEditorData<TValue, TLayout>? blockEditorData, int? min, int? max)
     {
         var numberOfBlocks = blockEditorData?.Layout?.Count() ?? 0;
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyValueEditor.cs
@@ -2,7 +2,6 @@
 // See LICENSE for more details.
 
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Blocks;
@@ -13,19 +12,22 @@ using Umbraco.Cms.Core.Strings;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
-internal abstract class BlockEditorPropertyValueEditor : DataValueEditor, IDataValueReference, IDataValueTags
+internal abstract class BlockEditorPropertyValueEditor<TValue, TLayout> : DataValueEditor, IDataValueReference, IDataValueTags
+    where TValue : BlockValue<TLayout>, new()
+    where TLayout : class, IBlockLayoutItem, new()
 {
-    private BlockEditorValues? _blockEditorValues;
+    private BlockEditorValues<TValue, TLayout>? _blockEditorValues;
     private readonly IDataTypeService _dataTypeService;
-    private readonly ILogger<BlockEditorPropertyValueEditor> _logger;
+    private readonly ILogger<BlockEditorPropertyValueEditor<TValue, TLayout>> _logger;
     private readonly PropertyEditorCollection _propertyEditors;
+    private readonly IJsonSerializer _jsonSerializer;
 
     protected BlockEditorPropertyValueEditor(
         DataEditorAttribute attribute,
         PropertyEditorCollection propertyEditors,
         IDataTypeService dataTypeService,
         ILocalizedTextService textService,
-        ILogger<BlockEditorPropertyValueEditor> logger,
+        ILogger<BlockEditorPropertyValueEditor<TValue, TLayout>> logger,
         IShortStringHelper shortStringHelper,
         IJsonSerializer jsonSerializer,
         IIOHelper ioHelper)
@@ -34,9 +36,10 @@ internal abstract class BlockEditorPropertyValueEditor : DataValueEditor, IDataV
         _propertyEditors = propertyEditors;
         _dataTypeService = dataTypeService;
         _logger = logger;
+        _jsonSerializer = jsonSerializer;
     }
 
-    protected BlockEditorValues BlockEditorValues
+    protected BlockEditorValues<TValue, TLayout> BlockEditorValues
     {
         get => _blockEditorValues ?? throw new NullReferenceException($"The property {nameof(BlockEditorValues)} must be initialized at value editor construction");
         set => _blockEditorValues = value;
@@ -47,7 +50,7 @@ internal abstract class BlockEditorPropertyValueEditor : DataValueEditor, IDataV
         var rawJson = value == null ? string.Empty : value is string str ? str : value.ToString();
 
         var result = new List<UmbracoEntityReference>();
-        BlockEditorData? blockEditorData = BlockEditorValues.DeserializeAndClean(rawJson);
+        BlockEditorData<TValue, TLayout>? blockEditorData = BlockEditorValues.DeserializeAndClean(rawJson);
         if (blockEditorData == null)
         {
             return Enumerable.Empty<UmbracoEntityReference>();
@@ -82,7 +85,7 @@ internal abstract class BlockEditorPropertyValueEditor : DataValueEditor, IDataV
     {
         var rawJson = value == null ? string.Empty : value is string str ? str : value.ToString();
 
-        BlockEditorData? blockEditorData = BlockEditorValues.DeserializeAndClean(rawJson);
+        BlockEditorData<TValue, TLayout>? blockEditorData = BlockEditorValues.DeserializeAndClean(rawJson);
         if (blockEditorData == null)
         {
             return Enumerable.Empty<ITag>();
@@ -127,12 +130,12 @@ internal abstract class BlockEditorPropertyValueEditor : DataValueEditor, IDataV
     {
         var val = property.GetValue(culture, segment);
 
-        BlockEditorData? blockEditorData;
+        BlockEditorData<TValue, TLayout>? blockEditorData;
         try
         {
             blockEditorData = BlockEditorValues.DeserializeAndClean(val);
         }
-        catch (JsonSerializationException)
+        catch
         {
             // if this occurs it means the data is invalid, shouldn't happen but has happened if we change the data format.
             return string.Empty;
@@ -163,12 +166,12 @@ internal abstract class BlockEditorPropertyValueEditor : DataValueEditor, IDataV
             return null;
         }
 
-        BlockEditorData? blockEditorData;
+        BlockEditorData<TValue, TLayout>? blockEditorData;
         try
         {
             blockEditorData = BlockEditorValues.DeserializeAndClean(editorValue.Value);
         }
-        catch (JsonSerializationException)
+        catch
         {
             // if this occurs it means the data is invalid, shouldn't happen but has happened if we change the data format.
             return string.Empty;
@@ -183,7 +186,7 @@ internal abstract class BlockEditorPropertyValueEditor : DataValueEditor, IDataV
         MapBlockItemDataFromEditor(blockEditorData.BlockValue.SettingsData);
 
         // return json
-        return JsonConvert.SerializeObject(blockEditorData.BlockValue, Formatting.None);
+        return _jsonSerializer.Serialize(blockEditorData.BlockValue);
     }
 
     private void MapBlockItemDataToEditor(IProperty property, List<BlockItemData> items)

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorValidator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorValidator.cs
@@ -7,14 +7,16 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
-internal class BlockEditorValidator : ComplexEditorValidator
+internal class BlockEditorValidator<TValue, TLayout> : ComplexEditorValidator
+    where TValue : BlockValue<TLayout>, new()
+    where TLayout : class, IBlockLayoutItem, new()
 {
-    private readonly BlockEditorValues _blockEditorValues;
+    private readonly BlockEditorValues<TValue, TLayout> _blockEditorValues;
     private readonly IContentTypeService _contentTypeService;
 
     public BlockEditorValidator(
         IPropertyValidationService propertyValidationService,
-        BlockEditorValues blockEditorValues,
+        BlockEditorValues<TValue, TLayout> blockEditorValues,
         IContentTypeService contentTypeService)
         : base(propertyValidationService)
     {
@@ -24,7 +26,7 @@ internal class BlockEditorValidator : ComplexEditorValidator
 
     protected override IEnumerable<ElementTypeValidationModel> GetElementTypeValidation(object? value)
     {
-        BlockEditorData? blockEditorData = _blockEditorValues.DeserializeAndClean(value);
+        BlockEditorData<TValue, TLayout>? blockEditorData = _blockEditorValues.DeserializeAndClean(value);
         if (blockEditorData != null)
         {
             // There is no guarantee that the client will post data for every property defined in the Element Type but we still

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorValues.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorValues.cs
@@ -12,20 +12,22 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 /// <summary>
 /// Used to deserialize json values and clean up any values based on the existence of element types and layout structure
 /// </summary>
-internal class BlockEditorValues
+internal class BlockEditorValues<TValue, TLayout>
+    where TValue : BlockValue<TLayout>, new()
+    where TLayout : class, IBlockLayoutItem, new()
 {
     private readonly Lazy<Dictionary<Guid, IContentType>> _contentTypes;
-    private readonly BlockEditorDataConverter _dataConverter;
+    private readonly BlockEditorDataConverter<TValue, TLayout> _dataConverter;
     private readonly ILogger _logger;
 
-    public BlockEditorValues(BlockEditorDataConverter dataConverter, IContentTypeService contentTypeService, ILogger logger)
+    public BlockEditorValues(BlockEditorDataConverter<TValue, TLayout> dataConverter, IContentTypeService contentTypeService, ILogger logger)
     {
         _contentTypes = new Lazy<Dictionary<Guid, IContentType>>(() => contentTypeService.GetAll().ToDictionary(c => c.Key));
         _dataConverter = dataConverter;
         _logger = logger;
     }
 
-    public BlockEditorData? DeserializeAndClean(object? propertyValue)
+    public BlockEditorData<TValue, TLayout>? DeserializeAndClean(object? propertyValue)
     {
         var propertyValueAsString = propertyValue?.ToString();
         if (string.IsNullOrWhiteSpace(propertyValueAsString))
@@ -33,7 +35,7 @@ internal class BlockEditorValues
             return null;
         }
 
-        BlockEditorData blockEditorData = _dataConverter.Deserialize(propertyValueAsString);
+        BlockEditorData<TValue, TLayout> blockEditorData = _dataConverter.Deserialize(propertyValueAsString);
 
         if (blockEditorData.BlockValue.ContentData.Count == 0)
         {

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditorBase.cs
@@ -41,7 +41,7 @@ public abstract class BlockListPropertyEditorBase : DataEditor
     protected override IDataValueEditor CreateValueEditor() =>
         DataValueEditorFactory.Create<BlockListEditorPropertyValueEditor>(Attribute!);
 
-    internal class BlockListEditorPropertyValueEditor : BlockEditorPropertyValueEditor
+    internal class BlockListEditorPropertyValueEditor : BlockEditorPropertyValueEditor<BlockListValue, BlockListLayoutItem>
     {
         public BlockListEditorPropertyValueEditor(
             DataEditorAttribute attribute,
@@ -49,23 +49,23 @@ public abstract class BlockListPropertyEditorBase : DataEditor
             IDataTypeService dataTypeService,
             IContentTypeService contentTypeService,
             ILocalizedTextService textService,
-            ILogger<BlockEditorPropertyValueEditor> logger,
+            ILogger<BlockListEditorPropertyValueEditor> logger,
             IShortStringHelper shortStringHelper,
             IJsonSerializer jsonSerializer,
             IIOHelper ioHelper,
             IPropertyValidationService propertyValidationService) :
             base(attribute, propertyEditors, dataTypeService, textService, logger, shortStringHelper, jsonSerializer, ioHelper)
         {
-            BlockEditorValues = new BlockEditorValues(new BlockListEditorDataConverter(), contentTypeService, logger);
-            Validators.Add(new BlockEditorValidator(propertyValidationService, BlockEditorValues, contentTypeService));
+            BlockEditorValues = new BlockEditorValues<BlockListValue, BlockListLayoutItem>(new BlockListEditorDataConverter(jsonSerializer), contentTypeService, logger);
+            Validators.Add(new BlockEditorValidator<BlockListValue, BlockListLayoutItem>(propertyValidationService, BlockEditorValues, contentTypeService));
             Validators.Add(new MinMaxValidator(BlockEditorValues, textService));
         }
 
-        private class MinMaxValidator : BlockEditorMinMaxValidatorBase
+        private class MinMaxValidator : BlockEditorMinMaxValidatorBase<BlockListValue, BlockListLayoutItem>
         {
-            private readonly BlockEditorValues _blockEditorValues;
+            private readonly BlockEditorValues<BlockListValue, BlockListLayoutItem> _blockEditorValues;
 
-            public MinMaxValidator(BlockEditorValues blockEditorValues, ILocalizedTextService textService)
+            public MinMaxValidator(BlockEditorValues<BlockListValue, BlockListLayoutItem> blockEditorValues, ILocalizedTextService textService)
                 : base(textService) =>
                 _blockEditorValues = blockEditorValues;
 
@@ -79,7 +79,7 @@ public abstract class BlockListPropertyEditorBase : DataEditor
                     return Array.Empty<ValidationResult>();
                 }
 
-                BlockEditorData? blockEditorData = _blockEditorValues.DeserializeAndClean(value);
+                BlockEditorData<BlockListValue, BlockListLayoutItem>? blockEditorData = _blockEditorValues.DeserializeAndClean(value);
 
                 return ValidateNumberOfBlocks(blockEditorData, validationLimit.Min, validationLimit.Max);
             }

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyIndexValueFactory.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyIndexValueFactory.cs
@@ -9,7 +9,7 @@ using Umbraco.Cms.Core.Services;
 namespace Umbraco.Cms.Core.PropertyEditors;
 
 internal sealed class BlockValuePropertyIndexValueFactory :
-    NestedPropertyIndexValueFactoryBase<BlockValue, BlockItemData>,
+    NestedPropertyIndexValueFactoryBase<BlockValuePropertyIndexValueFactory.IndexValueFactoryBlockValue, BlockItemData>,
     IBlockValuePropertyIndexValueFactory
 {
     private readonly IContentTypeService _contentTypeService;
@@ -31,5 +31,16 @@ internal sealed class BlockValuePropertyIndexValueFactory :
     protected override IDictionary<string, object?> GetRawProperty(BlockItemData blockItemData) =>
         blockItemData.RawPropertyValues;
 
-    protected override IEnumerable<BlockItemData> GetDataItems(BlockValue input) => input.ContentData;
+    protected override IEnumerable<BlockItemData> GetDataItems(IndexValueFactoryBlockValue input) => input.ContentData;
+
+    internal class IndexValueFactoryBlockValue : BlockValue<IndexValueFactoryBlockLayoutItem>
+    {
+    }
+
+    internal class IndexValueFactoryBlockLayoutItem : IBlockLayoutItem
+    {
+        public Udi? ContentUdi { get; set; }
+
+        public Udi? SettingsUdi { get; set; }
+    }
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockEditorConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockEditorConverter.cs
@@ -45,6 +45,11 @@ public sealed class BlockEditorConverter
             Guid.TryParse(keyo!.ToString(), out key);
         }
 
+        if (key == Guid.Empty)
+        {
+            return null;
+        }
+
         IPublishedElement element = new PublishedElement(publishedContentType, key, propertyValues, preview, referenceCacheLevel, _publishedSnapshotAccessor);
         element = _publishedModelFactory.CreateModel(element);
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueConverter.cs
@@ -14,7 +14,7 @@ using static Umbraco.Cms.Core.PropertyEditors.BlockGridConfiguration;
 namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
 {
     [DefaultPropertyValueConverter(typeof(JsonValueConverter))]
-    public class BlockGridPropertyValueConverter : BlockPropertyValueConverterBase<BlockGridModel, BlockGridItem, BlockGridLayoutItem, BlockGridBlockConfiguration>, IDeliveryApiPropertyValueConverter
+    public class BlockGridPropertyValueConverter : BlockPropertyValueConverterBase<BlockGridModel, BlockGridItem, BlockGridLayoutItem, BlockGridBlockConfiguration, BlockGridValue>, IDeliveryApiPropertyValueConverter
     {
         private readonly IProfilingLogger _proflog;
         private readonly IJsonSerializer _jsonSerializer;
@@ -84,7 +84,7 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
             using (_proflog.DebugDuration<BlockGridPropertyValueConverter>($"ConvertPropertyToBlockGrid ({propertyType.DataType.Id})"))
             {
                 // Get configuration
-                var configuration = propertyType.DataType.ConfigurationAs<BlockGridConfiguration>();
+                BlockGridConfiguration? configuration = propertyType.DataType.ConfigurationAs<BlockGridConfiguration>();
                 if (configuration is null)
                 {
                     return null;
@@ -131,7 +131,7 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
             }
         }
 
-        protected override BlockEditorDataConverter CreateBlockEditorDataConverter() => new BlockGridEditorDataConverter(_jsonSerializer);
+        protected override BlockGridEditorDataConverter CreateBlockEditorDataConverter() => new(_jsonSerializer);
 
         protected override BlockItemActivator<BlockGridItem> CreateBlockItemActivator() => new BlockGridItemActivator(BlockEditorConverter);
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/BlockListPropertyValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/BlockListPropertyValueConverterTests.cs
@@ -5,7 +5,6 @@ using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DeliveryApi;
-using Umbraco.Cms.Core.Models.DeliveryApi;
 using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Core.Models.PublishedContent;
@@ -13,6 +12,7 @@ using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Serialization;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.PropertyEditors;
 
@@ -68,7 +68,8 @@ public class BlockListPropertyValueConverterTests
             Mock.Of<IProfilingLogger>(),
             new BlockEditorConverter(publishedSnapshotAccessor, publishedModelFactory),
             Mock.Of<IContentTypeService>(),
-            new ApiElementBuilder(Mock.Of<IOutputExpansionStrategyAccessor>()));
+            new ApiElementBuilder(Mock.Of<IOutputExpansionStrategyAccessor>()),
+            new SystemTextJsonSerializer());
         return editor;
     }
 
@@ -204,8 +205,8 @@ public class BlockListPropertyValueConverterTests
         Assert.AreEqual(0, converted.Count);
 
         json = @"{
-layout: {},
-data: []}";
+""layout"": {},
+""data"": []}";
         converted = editor.ConvertIntermediateToObject(publishedElement, propertyType, PropertyCacheLevel.None, json, false) as BlockListModel;
 
         Assert.IsNotNull(converted);
@@ -214,14 +215,14 @@ data: []}";
         // Even though there is a layout, there is no data, so the conversion will result in zero elements in total
         json = @"
 {
-    layout: {
-        '" + Constants.PropertyEditors.Aliases.BlockList + @"': [
+    ""layout"": {
+        """ + Constants.PropertyEditors.Aliases.BlockList + @""": [
             {
-                'contentUdi': 'umb://element/e7dba547615b4e9ab4ab2a7674845bc9'
+                ""contentUdi"": ""umb://element/e7dba547615b4e9ab4ab2a7674845bc9""
             }
         ]
     },
-    contentData: []
+    ""contentData"": []
 }";
 
         converted = editor.ConvertIntermediateToObject(publishedElement, propertyType, PropertyCacheLevel.None, json, false) as BlockListModel;
@@ -232,16 +233,16 @@ data: []}";
         // Even though there is a layout and data, the data is invalid (missing required keys) so the conversion will result in zero elements in total
         json = @"
 {
-    layout: {
-        '" + Constants.PropertyEditors.Aliases.BlockList + @"': [
+    ""layout"": {
+        """ + Constants.PropertyEditors.Aliases.BlockList + @""": [
             {
-                'contentUdi': 'umb://element/e7dba547615b4e9ab4ab2a7674845bc9'
+                ""contentUdi"": ""umb://element/e7dba547615b4e9ab4ab2a7674845bc9""
             }
         ]
     },
-        contentData: [
+    ""contentData"": [
         {
-            'udi': 'umb://element/e7dba547615b4e9ab4ab2a7674845bc9'
+            ""udi"": ""umb://element/e7dba547615b4e9ab4ab2a7674845bc9""
         }
     ]
 }";
@@ -254,17 +255,17 @@ data: []}";
         // Everthing is ok except the udi reference in the layout doesn't match the data so it will be empty
         json = @"
 {
-    layout: {
-        '" + Constants.PropertyEditors.Aliases.BlockList + @"': [
+    ""layout"": {
+        """ + Constants.PropertyEditors.Aliases.BlockList + @""": [
             {
-                'contentUdi': 'umb://element/1304E1DDAC87439684FE8A399231CB3D'
+                ""contentUdi"": ""umb://element/1304E1DDAC87439684FE8A399231CB3D""
             }
         ]
     },
-        contentData: [
+    ""contentData"": [
         {
-            'contentTypeKey': '" + _contentKey1 + @"',
-            'key': '1304E1DD-0000-4396-84FE-8A399231CB3D'
+            ""contentTypeKey"": """ + _contentKey1 + @""",
+            ""key"": ""1304E1DD-0000-4396-84FE-8A399231CB3D""
         }
     ]
 }";
@@ -285,17 +286,17 @@ data: []}";
 
         var json = @"
 {
-    layout: {
-        '" + Constants.PropertyEditors.Aliases.BlockList + @"': [
+    ""layout"": {
+        """ + Constants.PropertyEditors.Aliases.BlockList + @""": [
             {
-                'contentUdi': 'umb://element/1304E1DDAC87439684FE8A399231CB3D'
+                ""contentUdi"": ""umb://element/1304E1DDAC87439684FE8A399231CB3D""
             }
         ]
     },
-        contentData: [
+    ""contentData"": [
         {
-            'contentTypeKey': '" + _contentKey1 + @"',
-            'udi': 'umb://element/1304E1DDAC87439684FE8A399231CB3D'
+            ""contentTypeKey"": """ + _contentKey1 + @""",
+            ""udi"": ""umb://element/1304E1DDAC87439684FE8A399231CB3D""
         }
     ]
 }";
@@ -322,46 +323,46 @@ data: []}";
 
         var json = @"
 {
-    layout: {
-        '" + Constants.PropertyEditors.Aliases.BlockList + @"': [
+    ""layout"": {
+        """ + Constants.PropertyEditors.Aliases.BlockList + @""": [
             {
-                'contentUdi': 'umb://element/1304E1DDAC87439684FE8A399231CB3D',
-                'settingsUdi': 'umb://element/1F613E26CE274898908A561437AF5100'
+                ""contentUdi"": ""umb://element/1304E1DDAC87439684FE8A399231CB3D"",
+                ""settingsUdi"": ""umb://element/1F613E26CE274898908A561437AF5100""
             },
             {
-                'contentUdi': 'umb://element/0A4A416E547D464FABCC6F345C17809A',
-                'settingsUdi': 'umb://element/63027539B0DB45E7B70459762D4E83DD'
+                ""contentUdi"": ""umb://element/0A4A416E547D464FABCC6F345C17809A"",
+                ""settingsUdi"": ""umb://element/63027539B0DB45E7B70459762D4E83DD""
             }
         ]
     },
-    contentData: [
+    ""contentData"": [
         {
-            'contentTypeKey': '" + _contentKey1 + @"',
-            'udi': 'umb://element/1304E1DDAC87439684FE8A399231CB3D'
+            ""contentTypeKey"": """ + _contentKey1 + @""",
+            ""udi"": ""umb://element/1304E1DDAC87439684FE8A399231CB3D""
         },
         {
-            'contentTypeKey': '" + _contentKey2 + @"',
-            'udi': 'umb://element/E05A034704424AB3A520E048E6197E79'
+            ""contentTypeKey"": """ + _contentKey2 + @""",
+            ""udi"": ""umb://element/E05A034704424AB3A520E048E6197E79""
         },
         {
-            'contentTypeKey': '" + _contentKey2 + @"',
-            'udi': 'umb://element/0A4A416E547D464FABCC6F345C17809A'
+            ""contentTypeKey"": """ + _contentKey2 + @""",
+            ""udi"": ""umb://element/0A4A416E547D464FABCC6F345C17809A""
         }
     ],
-    settingsData: [
+    ""settingsData"": [
         {
-            'contentTypeKey': '" + _settingKey1 + @"',
-            'udi': 'umb://element/63027539B0DB45E7B70459762D4E83DD'
+            ""contentTypeKey"": """ + _settingKey1 + @""",
+            ""udi"": ""umb://element/63027539B0DB45E7B70459762D4E83DD""
         },
         {
-            'contentTypeKey': '" + _settingKey2 + @"',
-            'udi': 'umb://element/1F613E26CE274898908A561437AF5100'
+            ""contentTypeKey"": """ + _settingKey2 + @""",
+            ""udi"": ""umb://element/1F613E26CE274898908A561437AF5100""
         },
         {
-            'contentTypeKey': '" + _settingKey2 + @"',
-            'udi': 'umb://element/BCF4BA3DA40C496C93EC58FAC85F18B9'
+            ""contentTypeKey"": """ + _settingKey2 + @""",
+            ""udi"": ""umb://element/BCF4BA3DA40C496C93EC58FAC85F18B9""
         }
-    ],
+    ]
 }";
 
         var converted =
@@ -408,46 +409,46 @@ data: []}";
 
         var json = @"
 {
-    layout: {
-        '" + Constants.PropertyEditors.Aliases.BlockList + @"': [
+    ""layout"": {
+        """ + Constants.PropertyEditors.Aliases.BlockList + @""": [
             {
-                'contentUdi': 'umb://element/1304E1DDAC87439684FE8A399231CB3D',
-                'settingsUdi': 'umb://element/1F613E26CE274898908A561437AF5100'
+                ""contentUdi"": ""umb://element/1304E1DDAC87439684FE8A399231CB3D"",
+                ""settingsUdi"": ""umb://element/1F613E26CE274898908A561437AF5100""
             },
             {
-                'contentUdi': 'umb://element/0A4A416E547D464FABCC6F345C17809A',
-                'settingsUdi': 'umb://element/63027539B0DB45E7B70459762D4E83DD'
+                ""contentUdi"": ""umb://element/0A4A416E547D464FABCC6F345C17809A"",
+                ""settingsUdi"": ""umb://element/63027539B0DB45E7B70459762D4E83DD""
             }
         ]
     },
-    contentData: [
+    ""contentData"": [
         {
-            'contentTypeKey': '" + _contentKey1 + @"',
-            'udi': 'umb://element/1304E1DDAC87439684FE8A399231CB3D'
+            ""contentTypeKey"": """ + _contentKey1 + @""",
+            ""udi"": ""umb://element/1304E1DDAC87439684FE8A399231CB3D""
         },
         {
-            'contentTypeKey': '" + _contentKey2 + @"',
-            'udi': 'umb://element/E05A034704424AB3A520E048E6197E79'
+            ""contentTypeKey"": """ + _contentKey2 + @""",
+            ""udi"": ""umb://element/E05A034704424AB3A520E048E6197E79""
         },
         {
-            'contentTypeKey': '" + _contentKey2 + @"',
-            'udi': 'umb://element/0A4A416E547D464FABCC6F345C17809A'
+            ""contentTypeKey"": """ + _contentKey2 + @""",
+            ""udi"": ""umb://element/0A4A416E547D464FABCC6F345C17809A""
         }
     ],
-    settingsData: [
+    ""settingsData"": [
         {
-            'contentTypeKey': '" + _settingKey1 + @"',
-            'udi': 'umb://element/63027539B0DB45E7B70459762D4E83DD'
+            ""contentTypeKey"": """ + _settingKey1 + @""",
+            ""udi"": ""umb://element/63027539B0DB45E7B70459762D4E83DD""
         },
         {
-            'contentTypeKey': '" + _settingKey2 + @"',
-            'udi': 'umb://element/1F613E26CE274898908A561437AF5100'
+            ""contentTypeKey"": """ + _settingKey2 + @""",
+            ""udi"": ""umb://element/1F613E26CE274898908A561437AF5100""
         },
         {
-            'contentTypeKey': '" + _settingKey2 + @"',
-            'udi': 'umb://element/BCF4BA3DA40C496C93EC58FAC85F18B9'
+            ""contentTypeKey"": """ + _settingKey2 + @""",
+            ""udi"": ""umb://element/BCF4BA3DA40C496C93EC58FAC85F18B9""
         }
-    ],
+    ]
 }";
 
         var converted =


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR ensures that Block Grid and Block List work with `System.Text.Json`.

`BlockEditorData` currently has a direct dependency on Json.NET by using `JToken` as `Layout` type. This might have been convenient at the time of implementation, but it won't work moving forward.

The simplest way to go about this would be to replace `JToken` with the `System.Text.Json` equivalent, but that's hardly any kind of great solution. So I've gone the long way here to make `Layout` strongly typed, which means a lot of generics happening all of the sudden.

Also this is breaking, but it would be no matter which direction we went, given the explicit dependency on Json.NET.

### Testing this PR

It's rather hard to test this, since both Block Grid and Block List are now completely broken in the old backoffice with these changes. In reality they have been slightly broken for a while due to config deserialization, but these changes make it so much worse.

Thus, the only way to test this is to create a Block Grid and Block List setup in V11 or V12 and upgrade the DB to V13. With this upgraded DB, the document CRUD endpoints should be able to manipulate Block Grid and Block List properties.

....or get in touch with @kjac to get a working DB 😆 