### PR TITLE
XPath can unambiguously use $site/$parent

### DIFF
--- a/src/Umbraco.Core/Xml/UmbracoXPathPathSyntaxParser.cs
+++ b/src/Umbraco.Core/Xml/UmbracoXPathPathSyntaxParser.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Core.Xml;
 /// </summary>
 public class UmbracoXPathPathSyntaxParser
 {
-    [Obsolete("This will be removed in Umbraco 13. Use ParseXpath which accepts a parentId instead")]
+    [Obsolete("This will be removed in Umbraco 13. Use ParseXPathQuery which accepts a parentId instead")]
     public static string ParseXPathQuery(
         string xpathExpression,
         int? nodeContextId,

--- a/src/Umbraco.Core/Xml/UmbracoXPathPathSyntaxParser.cs
+++ b/src/Umbraco.Core/Xml/UmbracoXPathPathSyntaxParser.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Core.Xml;
 /// </summary>
 public class UmbracoXPathPathSyntaxParser
 {
-    [Obsolete("This will be removed in Umbraco 13. Use constructor with parentId instead")]
+    [Obsolete("This will be removed in Umbraco 13. Use ParseXpath which accepts a parentId instead")]
     public static string ParseXPathQuery(
         string xpathExpression,
         int? nodeContextId,

--- a/src/Umbraco.Core/Xml/UmbracoXPathPathSyntaxParser.cs
+++ b/src/Umbraco.Core/Xml/UmbracoXPathPathSyntaxParser.cs
@@ -112,6 +112,28 @@ public class UmbracoXPathPathSyntaxParser
                     string.Format(rootXpath, closestPublishedAncestorId) + "/ancestor-or-self::*[@level = 1]");
             });
         }
+        else if (nodeContextId.HasValue)
+        {
+            vars.Add("$parent", q =>
+            {
+                var path = getPath(nodeContextId.Value)?.ToArray();
+                if (path?[0] == nodeContextId.ToString())
+                {
+                    path = path?.Skip(1).ToArray();
+                }
+
+                var closestPublishedAncestorId = getClosestPublishedAncestor(path);
+                return q.Replace("$parent", string.Format(rootXpath, closestPublishedAncestorId));
+            });
+
+            vars.Add("$site", q =>
+            {
+                var closestPublishedAncestorId = getClosestPublishedAncestor(getPath(nodeContextId.Value));
+                return q.Replace(
+                    "$site",
+                    string.Format(rootXpath, closestPublishedAncestorId) + "/ancestor-or-self::*[@level = 1]");
+            });
+        }
 
         // These parameters must have a node id context
         if (nodeContextId.HasValue)

--- a/src/Umbraco.Core/Xml/UmbracoXPathPathSyntaxParser.cs
+++ b/src/Umbraco.Core/Xml/UmbracoXPathPathSyntaxParser.cs
@@ -8,6 +8,13 @@ namespace Umbraco.Cms.Core.Xml;
 /// </summary>
 public class UmbracoXPathPathSyntaxParser
 {
+    [Obsolete("This will be removed in Umbraco 13. Use constructor with parentId instead")]
+    public static string ParseXPathQuery(
+        string xpathExpression,
+        int? nodeContextId,
+        Func<int, IEnumerable<string>?> getPath,
+        Func<int, bool> publishedContentExists) => ParseXPathQuery(xpathExpression, nodeContextId, null, getPath, publishedContentExists);
+
     /// <summary>
     ///     Parses custom umbraco xpath expression
     /// </summary>

--- a/src/Umbraco.Infrastructure/Routing/NotFoundHandlerHelper.cs
+++ b/src/Umbraco.Infrastructure/Routing/NotFoundHandlerHelper.cs
@@ -79,6 +79,7 @@ internal class NotFoundHandlerHelper
                 var xpathResult = UmbracoXPathPathSyntaxParser.ParseXPathQuery(
                     errorPage.ContentXPath!,
                     domainContentId,
+                    null,
                     nodeid =>
                     {
                         IEntitySlim? ent = entityService.Get(nodeid);

--- a/src/Umbraco.Web.BackOffice/Controllers/EntityController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/EntityController.cs
@@ -522,8 +522,9 @@ public class EntityController : UmbracoAuthorizedJsonController
     /// <param name="query"></param>
     /// <param name="nodeContextId"></param>
     /// <param name="type"></param>
+    /// <param name="parentId"></param>
     /// <returns></returns>
-    public ActionResult<EntityBasic?>? GetByQuery(string query, int nodeContextId, UmbracoEntityTypes type)
+    public ActionResult<EntityBasic?>? GetByXPath(string query, int nodeContextId, int parentId, UmbracoEntityTypes type)
     {
         // TODO: Rename this!!! It's misleading, it should be GetByXPath
 
@@ -534,7 +535,7 @@ public class EntityController : UmbracoAuthorizedJsonController
         }
 
 
-        var q = ParseXPathQuery(query, nodeContextId);
+        var q = ParseXPathQuery(query, nodeContextId, parentId);
         IPublishedContent? node = _publishedContentQuery.ContentSingleAtXPath(q);
 
         if (node == null)
@@ -546,10 +547,11 @@ public class EntityController : UmbracoAuthorizedJsonController
     }
 
     // PP: Work in progress on the query parser
-    private string ParseXPathQuery(string query, int id) =>
+    private string ParseXPathQuery(string query, int id, int parentId) =>
         UmbracoXPathPathSyntaxParser.ParseXPathQuery(
             query,
             id,
+            parentId,
             nodeid =>
             {
                 IEntitySlim? ent = _entityService.Get(nodeid);

--- a/src/Umbraco.Web.BackOffice/Controllers/EntityController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/EntityController.cs
@@ -515,6 +515,15 @@ public class EntityController : UmbracoAuthorizedJsonController
         return Ok(returnUrl);
     }
 
+    /// <summary>
+    ///     Gets an entity by a xpath query - OBSOLETE
+    /// </summary>
+    /// <param name="query"></param>
+    /// <param name="nodeContextId"></param>
+    /// <param name="type"></param>
+    /// <returns></returns>
+    [Obsolete("This will be removed in Umbraco 13. Use GetByXPath instead")]
+    public ActionResult<EntityBasic?>? GetByQuery(string query, int nodeContextId, UmbracoEntityTypes type) => GetByXPath(query, nodeContextId, null, type);
 
     /// <summary>
     ///     Gets an entity by a xpath query
@@ -524,16 +533,12 @@ public class EntityController : UmbracoAuthorizedJsonController
     /// <param name="type"></param>
     /// <param name="parentId"></param>
     /// <returns></returns>
-    public ActionResult<EntityBasic?>? GetByXPath(string query, int nodeContextId, int parentId, UmbracoEntityTypes type)
+    public ActionResult<EntityBasic?>? GetByXPath(string query, int nodeContextId, int? parentId, UmbracoEntityTypes type)
     {
-        // TODO: Rename this!!! It's misleading, it should be GetByXPath
-
-
         if (type != UmbracoEntityTypes.Document)
         {
             throw new ArgumentException("Get by query is only compatible with entities of type Document");
         }
-
 
         var q = ParseXPathQuery(query, nodeContextId, parentId);
         IPublishedContent? node = _publishedContentQuery.ContentSingleAtXPath(q);
@@ -547,7 +552,7 @@ public class EntityController : UmbracoAuthorizedJsonController
     }
 
     // PP: Work in progress on the query parser
-    private string ParseXPathQuery(string query, int id, int parentId) =>
+    private string ParseXPathQuery(string query, int id, int? parentId) =>
         UmbracoXPathPathSyntaxParser.ParseXPathQuery(
             query,
             id,

--- a/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
@@ -319,6 +319,19 @@ function entityResource($q, $http, umbRequestHelper) {
         },
 
         /**
+         * @deprecated use getByXPath instead.
+         */
+        getByQuery: function (query, nodeContextId, type) {
+            return umbRequestHelper.resourcePromise(
+            $http.get(
+                umbRequestHelper.getApiUrl(
+                    "entityApiBaseUrl",
+                    "GetByQuery",
+                    [{ query: query }, { nodeContextId: nodeContextId }, { type: type }])),
+            'Failed to retrieve entity data for query ' + query);
+        },
+
+        /**
          * @ngdoc method
          * @name umbraco.resources.entityResource#getByXPath
          * @methodOf umbraco.resources.entityResource

--- a/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
@@ -320,7 +320,7 @@ function entityResource($q, $http, umbRequestHelper) {
 
         /**
          * @ngdoc method
-         * @name umbraco.resources.entityResource#getByQuery
+         * @name umbraco.resources.entityResource#getByXPath
          * @methodOf umbraco.resources.entityResource
          *
          * @description
@@ -329,7 +329,7 @@ function entityResource($q, $http, umbRequestHelper) {
          * ##usage
          * <pre>
          * //get content by xpath
-         * entityResource.getByQuery("$current", -1, "Document")
+         * entityResource.getByXPath("$current", -1, -1, "Document")
          *    .then(function(ent) {
          *        var myDoc = ent;
          *        alert('its here!');
@@ -338,17 +338,18 @@ function entityResource($q, $http, umbRequestHelper) {
          *
          * @param {string} query xpath to use in query
          * @param {Int} nodeContextId id id to start from
+         * @param {Int} parentId id id of the parent to the starting point
          * @param {string} type Object type name
          * @returns {Promise} resourcePromise object containing the entity.
          *
          */
-        getByQuery: function (query, nodeContextId, type) {
+        getByXPath: function (query, nodeContextId, parentId, type) {
             return umbRequestHelper.resourcePromise(
                $http.get(
                    umbRequestHelper.getApiUrl(
                        "entityApiBaseUrl",
-                       "GetByQuery",
-                       [{ query: query }, { nodeContextId: nodeContextId }, { type: type }])),
+                       "GetByXPath",
+                       [{ query: query }, { nodeContextId: nodeContextId }, { parentId: parentId }, { type: type }])),
                'Failed to retrieve entity data for query ' + query);
         },
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.controller.js
@@ -245,9 +245,12 @@ function contentPickerController($scope, $q, $routeParams, $location, entityReso
         dialogOptions.startNodeId = -1;
     }
     else if ($scope.model.config.startNode.query) {
-        //if we have a query for the startnode, we will use that.
-        var rootId = editorState.current.id;
-        entityResource.getByQuery($scope.model.config.startNode.query, rootId, "Document").then(function (ent) {
+        entityResource.getByXPath(
+            $scope.model.config.startNode.query,
+            editorState.current.id,
+            editorState.current.parentId,
+            "Document"
+        ).then(function (ent) {
             dialogOptions.startNodeId = ($scope.model.config.idType === "udi" ? ent.udi : ent.id).toString();
         });
     }


### PR DESCRIPTION
This fixes https://github.com/umbraco/Umbraco-CMS/issues/13958

### Description

After this commit here https://github.com/umbraco/Umbraco-CMS/commit/8d2ee3a6d4bfbe650750e6980649ee57706248ef we lost the functionality to evaluate `$site` and `$parent` as XPath variables inside a Multinode Treepicker during the creation of a new node where said picker is a property.
Before the commit, the meaning of `$current` and `$parent` was also ambiguous, changing depending on whether or not you are creating a new node or not.

There is a blog entry explaining how you previously could work around the issue:
https://www.dot-see.com/blog/getting-the-right-starting-node-for-multinode-treepicker-with-xpath/
However with today's code one can't use the Multinode Treepicker with XPath correctly during node creation at all, if they depend on these variables.

This has lead to issue #13958 being raised.

The changes proposed in the code makes sure that the parent node id is always available so the node from `$parent` is always the same regardless of creating a new node or not.

The code does not change how `$current` resolves, as it there is an argument for keeping it as is for the state of creating a new node. The use cases that has raised issue #13958 does also not depend on `$current`. Most likely you would set up a treepicker for this scenario to pick from nodes that are children to your `$current`, at which point you already have it published.

My knowledge in XPath is limited to what has been discussed in the linked blog article and the linked issue, and our own company's use case. There is very little documentation I have found helpful to understand the syntax in the context of Umbraco.

So while I am confident the proposed code will suffice and not introduce any regression, it would be prudent to have someone somewhat experienced in XPath within Umbraco have a look at this.
