### PR TITLE
V12: Reset cache on migrating

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -1,9 +1,5 @@
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration;
-using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_10_0_0;
-using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_10_2_0;
-using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_10_5_0;
-using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_12_0_0;
 
 namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade;
 
@@ -76,6 +72,7 @@ public class UmbracoPlan : MigrationPlan
         To<V_11_3_0.AddDomainSortOrder>("{BB3889ED-E2DE-49F2-8F71-5FD8616A2661}");
 
         // To 12.0.0
-        To<UseNvarcharInsteadOfNText>("{888A0D5D-51E4-4C7E-AA0A-01306523C7FB}");
+        To<V_12_0_0.UseNvarcharInsteadOfNText>("{888A0D5D-51E4-4C7E-AA0A-01306523C7FB}");
+        To<V_12_0_0.ResetCache>("{539F2F83-FBA7-4C48-81A3-75081A56BB9D}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_12_0_0/ResetCache.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_12_0_0/ResetCache.cs
@@ -14,7 +14,19 @@ public class ResetCache : MigrationBase
     protected override void Migrate()
     {
         RebuildCache = true;
-        var distCacheFolderAbsolutePath = _hostEnvironment.MapPathContentRoot(Constants.SystemDirectories.TempFileUploads + "/DistCache");
-        File.Delete(distCacheFolderAbsolutePath);
+        var distCacheFolderAbsolutePath = _hostEnvironment.MapPathContentRoot(Constants.SystemDirectories.TempData + "/DistCache");
+        var nuCacheFolderAbsolutePath = _hostEnvironment.MapPathContentRoot(Constants.SystemDirectories.TempData + "/NuCache");
+        DeleteAllFilesInFolder(distCacheFolderAbsolutePath);
+        DeleteAllFilesInFolder(nuCacheFolderAbsolutePath);
+    }
+
+    private void DeleteAllFilesInFolder(string path)
+    {
+        var directoryInfo = new DirectoryInfo(path);
+
+        foreach (FileInfo file in directoryInfo.GetFiles())
+        {
+            file.Delete();
+        }
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_12_0_0/ResetCache.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_12_0_0/ResetCache.cs
@@ -1,10 +1,20 @@
-﻿namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_12_0_0;
+﻿using Microsoft.Extensions.Hosting;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Extensions;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_12_0_0;
 
 public class ResetCache : MigrationBase
 {
-    public ResetCache(IMigrationContext context) : base(context)
-    {
-    }
+    private readonly IHostEnvironment _hostEnvironment;
 
-    protected override void Migrate() => RebuildCache = true;
+    public ResetCache(IMigrationContext context, IHostEnvironment hostEnvironment)
+        : base(context) => _hostEnvironment = hostEnvironment;
+
+    protected override void Migrate()
+    {
+        RebuildCache = true;
+        var distCacheFolderAbsolutePath = _hostEnvironment.MapPathContentRoot(Constants.SystemDirectories.TempFileUploads + "/DistCache");
+        File.Delete(distCacheFolderAbsolutePath);
+    }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_12_0_0/ResetCache.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_12_0_0/ResetCache.cs
@@ -1,0 +1,10 @@
+﻿namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_12_0_0;
+
+public class ResetCache : MigrationBase
+{
+    public ResetCache(IMigrationContext context) : base(context)
+    {
+    }
+
+    protected override void Migrate() => RebuildCache = true;
+}


### PR DESCRIPTION
Fixes a V12 exclusive bug, where when migrating from 11 -> 12, you would get an exception, because we've updated the BPlusTree dependency, this PR remedies that by creating a migration that deletes the old cache files.
# Notes
- Added a V12 migration, which deletes all the files in the `DistCache` folder & the `NuCache` folder.

# How to test
- Run umbaco on V11 with the starter kit installed
- Install umbraco.
- Stop the site
- Upgrade to v12
- This should no longer throw exceptions 🙌 