### PR TITLE
V11: Fallback to detailed if not telemetry level not set

### DIFF
--- a/src/Umbraco.Cms.ManagementApi/ViewModels/Installer/InstallViewModel.cs
+++ b/src/Umbraco.Cms.ManagementApi/ViewModels/Installer/InstallViewModel.cs
@@ -13,5 +13,5 @@ public class InstallViewModel
     public DatabaseInstallViewModel Database { get; set; } = null!;
 
     [JsonConverter(typeof(JsonStringEnumConverter))]
-    public TelemetryLevel TelemetryLevel { get; set; } = TelemetryLevel.Basic;
+    public TelemetryLevel TelemetryLevel { get; set; } = TelemetryLevel.Detailed;
 }

--- a/src/Umbraco.Core/Services/MetricsConsentService.cs
+++ b/src/Umbraco.Core/Services/MetricsConsentService.cs
@@ -60,7 +60,7 @@ public class MetricsConsentService : IMetricsConsentService
         if (analyticsLevelString is null ||
             Enum.TryParse(analyticsLevelString, out TelemetryLevel analyticsLevel) is false)
         {
-            return TelemetryLevel.Basic;
+            return TelemetryLevel.Detailed;
         }
 
         return analyticsLevel;

--- a/src/Umbraco.New.Cms.Core/Models/Installer/InstallData.cs
+++ b/src/Umbraco.New.Cms.Core/Models/Installer/InstallData.cs
@@ -8,5 +8,5 @@ public class InstallData
 
     public DatabaseInstallData Database { get; set; } = null!;
 
-    public TelemetryLevel TelemetryLevel { get; set; } = TelemetryLevel.Basic;
+    public TelemetryLevel TelemetryLevel { get; set; } = TelemetryLevel.Detailed;
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
@@ -84,7 +84,7 @@ public class TelemetryServiceTests
         };
         var manifestParser = CreateManifestParser(manifests);
         var metricsConsentService = new Mock<IMetricsConsentService>();
-        metricsConsentService.Setup(x => x.GetConsentLevel()).Returns(TelemetryLevel.Basic);
+        metricsConsentService.Setup(x => x.GetConsentLevel()).Returns(TelemetryLevel.Detailed);
         var sut = new TelemetryService(
             manifestParser,
             version,
@@ -119,7 +119,7 @@ public class TelemetryServiceTests
         };
         var manifestParser = CreateManifestParser(manifests);
         var metricsConsentService = new Mock<IMetricsConsentService>();
-        metricsConsentService.Setup(x => x.GetConsentLevel()).Returns(TelemetryLevel.Basic);
+        metricsConsentService.Setup(x => x.GetConsentLevel()).Returns(TelemetryLevel.Detailed);
         var sut = new TelemetryService(
             manifestParser,
             version,


### PR DESCRIPTION
# Notes
- This is a follow up of this PR: https://github.com/umbraco/Umbraco-CMS/pull/13918
- We missed also defaulting to Detailed telemetry if its not set at all (this should only happen if you manually delete the entry in the table)

# How to test
- Install Umbraco
- Open up the `umbracoKeyValue` table
- Delete the telemetry level row
- Navigate to the Telemetry dashboard in the `Settings section`
- Assert that its set to detailed