### PR TITLE
[Fix] Block editor labels showing Angular JS on first load.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -639,7 +639,6 @@
                         mapToPropertyModel(this.settings, this.settingsData);
                     }
                 };
-              debugger;
                 // first time instant update of label.
               blockObject.label = blockObject.content?.contentTypeName || "";
                 blockObject.index = 0; 

--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -641,7 +641,7 @@
                 };
 
                 // first time instant update of label.
-                blockObject.label = (blockObject.config.label || blockObject.content?.contentTypeName) ?? "" ;
+              blockObject.label = (blockObject.labelInterpolator(blockObject.data) || blockObject.content?.contentTypeName) ?? "";
                 blockObject.index = 0;
 
                 if (blockObject.config.label && blockObject.config.label !== "" && blockObject.config.unsupported !== true) {

--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -639,10 +639,10 @@
                         mapToPropertyModel(this.settings, this.settingsData);
                     }
                 };
-
+              debugger;
                 // first time instant update of label.
-              blockObject.label = (blockObject.labelInterpolator(blockObject.data) || blockObject.content?.contentTypeName) ?? "";
-                blockObject.index = 0;
+              blockObject.label = blockObject.content?.contentTypeName || "";
+                blockObject.index = 0; 
 
                 if (blockObject.config.label && blockObject.config.label !== "" && blockObject.config.unsupported !== true) {
                     var labelElement = $('<div></div>', { text: blockObject.config.label});


### PR DESCRIPTION


### Prerequisites
>>The Block Label of Block Components is displaying Angular JS code rather than result on first load. If opened again the label displays correctly

Reported issue https://github.com/umbraco/Umbraco-CMS/issues/14105

### Description

old code
>>   blockObject.label = (blockObject.config.label || blockObject.content?.contentTypeName) ?? "" ;

new code
>> blockObject.label = (blockObject.labelInterpolator(blockObject.data) || blockObject.content?.contentTypeName) ?? "";

Replace `blockObject.config.label` with  `blockObject.labelInterpolator(blockObject.data)`, because of `blockObject.config.label` always has the property alias eg: {{propertyAlias}}

 

<!-- Thanks for contributing to Umbraco CMS! -->
