### PR TITLE
Fix the "disposed object" error when rendering RTE content as JSON

### DIFF
--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextParser.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextParser.cs
@@ -69,9 +69,9 @@ public partial class ApiRichTextParser : IApiRichTextParser
 
         SanitizeAttributes(attributes);
 
-        IEnumerable<RichTextElement> childElements = childNodes?.Any() is true
-            ? childNodes.Select(child => ParseRecursively(child, publishedSnapshot))
-            : Enumerable.Empty<RichTextElement>();
+        RichTextElement[] childElements = childNodes?.Any() is true
+            ? childNodes.Select(child => ParseRecursively(child, publishedSnapshot)).ToArray()
+            : Array.Empty<RichTextElement>();
 
         return new RichTextElement(tag, innerText, attributes, childElements);
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When configured to render JSON instead of HTML for Delivery API output, the RTE value converter is currently caching an expression to create the output rather than the actual output. Besides being bad for caching, this also yields issues with disposed objects when trying to access published content for rendering local links.

### Testing

1. Set `Umbraco::CMS::DeliveryApi::RichTextOutputAsJson` to `true` in app settings.
2. Create content with an RTE that contains links to other content.
3. Fetch the content through the Delivery API two times or more.
4. Ensure no errors are thrown.
