### PR TITLE
Block Grid: fix situation when config was not available (13834)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbBlockGridPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbBlockGridPropertyEditor.component.js
@@ -382,7 +382,7 @@
 
 
                 const contextColumns = getContextColumns(parentBlock, areaKey);
-                const relevantColumnSpanOptions = block.config.columnSpanOptions.filter(option => option.columnSpan <= contextColumns);
+                const relevantColumnSpanOptions = block.config.columnSpanOptions?.filter(option => option.columnSpan <= contextColumns) ?? [];
 
                 // if no columnSpan or no columnSpanOptions configured, then we set(or rewrite) one:
                 if (!layoutEntry.columnSpan || layoutEntry.columnSpan > contextColumns || relevantColumnSpanOptions.length === 0) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbblockgridentry.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbblockgridentry.component.js
@@ -147,7 +147,7 @@
 
             vm.layoutColumnsInt = parseInt(vm.layoutColumns, 10);
 
-            vm.relevantColumnSpanOptions = vm.layoutEntry.$block.config.columnSpanOptions.filter(x => x.columnSpan <= vm.layoutColumnsInt).sort((a,b) => (a.columnSpan > b.columnSpan) ? 1 : ((b.columnSpan > a.columnSpan) ? -1 : 0));
+            vm.relevantColumnSpanOptions = vm.layoutEntry.$block.config.columnSpanOptions ? vm.layoutEntry.$block.config.columnSpanOptions.filter(x => x.columnSpan <= vm.layoutColumnsInt).sort((a,b) => (a.columnSpan > b.columnSpan) ? 1 : ((b.columnSpan > a.columnSpan) ? -1 : 0)) : [];
             const hasRelevantColumnSpanOptions = vm.relevantColumnSpanOptions.length > 1;
             const hasRowSpanOptions = vm.layoutEntry.$block.config.rowMinSpan && vm.layoutEntry.$block.config.rowMaxSpan && vm.layoutEntry.$block.config.rowMaxSpan !== vm.layoutEntry.$block.config.rowMinSpan;
             vm.canScale = (hasRelevantColumnSpanOptions || hasRowSpanOptions);


### PR DESCRIPTION
Fixes the issue of https://github.com/umbraco/Umbraco-CMS/issues/13834

The ideal solution has been coded previously but changes to the code base had broken its ability to be shown. This PR fixes that.

By ensuring an empty array the code can continue as it is and the unsupported block view will be displayed on blocks that do not have a configuration anymore.

Here a screenshot from my test, proving it's working now:
![image](https://user-images.githubusercontent.com/6791648/233959902-337c760f-57e4-470c-b78d-47e0085de4e0.png)
