### PR TITLE
Fix: Form elements in thirdparty dashboard views get removed

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/dashboard.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dashboard.html
@@ -1,6 +1,6 @@
 <div ng-controller="Umbraco.DashboardController">
 
-    <form name="dashboardForm" val-form-manager>
+    <ng-form name="dashboardForm" val-form-manager>
 
         <umb-load-indicator ng-show="page.loading"></umb-load-indicator>
 
@@ -32,6 +32,6 @@
 
         </div>
 
-    </form>
+    </ng-form>
 
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/common/dashboard.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dashboard.html
@@ -1,37 +1,35 @@
 <div ng-controller="Umbraco.DashboardController">
 
-    <form name="dashboardForm" val-form-manager>
+    <umb-load-indicator ng-show="page.loading"></umb-load-indicator>
 
-        <umb-load-indicator ng-show="page.loading"></umb-load-indicator>
+    <div class="umb-dashboard" ng-if="!page.loading" data-element='dashboard'>
 
-        <div class="umb-dashboard" ng-if="!page.loading" data-element='dashboard'>
+        <div class="umb-dashboard__header" ng-show="dashboard.tabs.length > 1" ng-form="dashboardForm" val-form-manager>
 
-            <div class="umb-dashboard__header" ng-show="dashboard.tabs.length > 1">
-                <umb-tabs-nav
-                    ng-if="dashboard.tabs"
-                    tabs="dashboard.tabs"
-                    on-tab-change="changeTab(tab)">
-                </umb-tabs-nav>
-            </div>
-
-            <div class="umb-dashboard__content">
-
-                <umb-tab-content ng-repeat="tab in dashboard.tabs" ng-if="tab.active" tab="tab" class="row-fluid">
-
-                    <div ng-repeat="property in tab.properties">
-
-                        <div class="clearfix">
-                            <div ng-include="property.view"></div>
-                        </div>
-
-                    </div>
-
-                </umb-tab-content>
-
-            </div>
+            <umb-tabs-nav
+                ng-if="dashboard.tabs"
+                tabs="dashboard.tabs"
+                on-tab-change="changeTab(tab)">
+            </umb-tabs-nav>
 
         </div>
 
-    </form>
+        <div class="umb-dashboard__content">
+
+            <umb-tab-content ng-repeat="tab in dashboard.tabs" ng-if="tab.active" tab="tab" class="row-fluid">
+
+                <div ng-repeat="property in tab.properties">
+
+                    <div class="clearfix">
+                        <div ng-include="property.view"></div>
+                    </div>
+
+                </div>
+
+            </umb-tab-content>
+
+        </div>
+
+    </div>
 
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/common/dashboard.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dashboard.html
@@ -1,35 +1,37 @@
 <div ng-controller="Umbraco.DashboardController">
 
-    <umb-load-indicator ng-show="page.loading"></umb-load-indicator>
+    <form name="dashboardForm" val-form-manager>
 
-    <div class="umb-dashboard" ng-if="!page.loading" data-element='dashboard'>
+        <umb-load-indicator ng-show="page.loading"></umb-load-indicator>
 
-        <div class="umb-dashboard__header" ng-show="dashboard.tabs.length > 1" ng-form="dashboardForm" val-form-manager>
+        <div class="umb-dashboard" ng-if="!page.loading" data-element='dashboard'>
 
-            <umb-tabs-nav
-                ng-if="dashboard.tabs"
-                tabs="dashboard.tabs"
-                on-tab-change="changeTab(tab)">
-            </umb-tabs-nav>
+            <div class="umb-dashboard__header" ng-show="dashboard.tabs.length > 1">
+                <umb-tabs-nav
+                    ng-if="dashboard.tabs"
+                    tabs="dashboard.tabs"
+                    on-tab-change="changeTab(tab)">
+                </umb-tabs-nav>
+            </div>
 
-        </div>
+            <div class="umb-dashboard__content">
 
-        <div class="umb-dashboard__content">
+                <umb-tab-content ng-repeat="tab in dashboard.tabs" ng-if="tab.active" tab="tab" class="row-fluid">
 
-            <umb-tab-content ng-repeat="tab in dashboard.tabs" ng-if="tab.active" tab="tab" class="row-fluid">
+                    <div ng-repeat="property in tab.properties">
 
-                <div ng-repeat="property in tab.properties">
+                        <div class="clearfix">
+                            <div ng-include="property.view"></div>
+                        </div>
 
-                    <div class="clearfix">
-                        <div ng-include="property.view"></div>
                     </div>
 
-                </div>
+                </umb-tab-content>
 
-            </umb-tab-content>
+            </div>
 
         </div>
 
-    </div>
+    </form>
 
 </div>

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Tabs/tabs.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Tabs/tabs.spec.ts
@@ -46,6 +46,14 @@ test.describe('Tabs', () => {
     await openDocTypeFolder(umbracoUi, page);
   }
 
+  test.only('Click dashboard tabs', async ({umbracoUi, page}) => {
+    await umbracoUi.goToSection('content');
+    await page.locator('[data-element="tab-contentRedirectManager"] > button').click();
+    expect(page.locator('.redirecturlsearch')).not.toBeNull();
+    await page.locator('[data-element="tab-contentIntro"] > button').click();
+    await expect(page.locator('[data-element="tab-contentIntro"]')).toHaveClass('umb-tab ng-scope umb-tab--active');
+  });
+
   test('Create tab', async ({umbracoUi, umbracoApi, page}) => {
     await umbracoApi.documentTypes.ensureNameNotExists(tabsDocTypeName);
     await umbracoApi.content.deleteAllContent();
@@ -67,7 +75,7 @@ test.describe('Tabs', () => {
     await umbracoUi.waitForTreeLoad('settings');
 
     await umbracoUi.clickElement(umbracoUi.getTreeItem("settings", ["Document Types", tabsDocTypeName]))
-    // Create a tab 
+    // Create a tab
     await page.locator('.umb-group-builder__tabs__add-tab').click();
     await page.locator('ng-form.ng-invalid > .umb-group-builder__group-title-input').fill('Tab 1');
     // Create a 2nd tab manually
@@ -178,7 +186,7 @@ test.describe('Tabs', () => {
     await expect(await page.locator('[title=urlPicker]')).toHaveCount(0);
   });
 
-  test('Reorders tab', async ({umbracoUi, umbracoApi, page}) => { 
+  test('Reorders tab', async ({umbracoUi, umbracoApi, page}) => {
     await umbracoApi.documentTypes.ensureNameNotExists(tabsDocTypeName);
 
     const tabsDocType = new DocumentTypeBuilder()
@@ -485,7 +493,7 @@ test.describe('Tabs', () => {
     await openDocTypeFolder(umbracoUi, page);
     await page.locator('[alias="reorder"]').click();
     await page.locator('.umb-group-builder__tab').last().click();
-    
+
     // Drag and drop property from tab 2 into tab 1
     await page.locator('.umb-group-builder__property-meta > .flex > .icon >> nth=1').last().hover();
     await page.mouse.down();
@@ -493,16 +501,16 @@ test.describe('Tabs', () => {
     await page.waitForTimeout(500);
     await page.locator('[data-element="group-Tab group"]').hover({force:true});
     await page.mouse.up();
-    
+
     // Stop reordering and save
     await page.locator('[alias="reorder"]').click();
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.save));
-    
+
     // Assert
     await umbracoUi.isSuccessNotificationVisible();
     await expect(await page.locator('[title="urlPickerTabTwo"]')).toBeVisible();
   });
-  
+
   test('Drags and drops a group and converts to tab', async ({umbracoUi, umbracoApi, page}) => {
     await umbracoApi.documentTypes.ensureNameNotExists(tabsDocTypeName);
     const tabsDocType = new DocumentTypeBuilder()


### PR DESCRIPTION
Remove wrapping form for dashboards and wrap umb-tabs-nav with ngForm instead

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description

If you include a `<form>` tag in a dashboard, it gets removed because of a wrapping form element in `dashboard.html`. Changing the wrapping `<form>` to an `<ng-form>` fixes this. 

It looks like dashboards have a wrapping form because of `<umb-tabs-nav>` element, which has functionality for checking if a contained form is `$invalid`. This functionality still works even with this change. I have also tried installing a few packages that include custom dashboards and those dashboards seem to work.

### How to reproduce

1. Create a custom dashboard however you like
2. Add a normal HTML form to that dashboard such as
```html
<form>
  <input type="text" name="name">
</form>
```
3. See that the `<form>` element gets removed. 

### How to test

1. Perform the same tests as above
2. Check that the `<form>` element now no longer gets removed
