### PR TITLE
V10: Set culture variation when getting property types for indexing

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/NestedPropertyIndexValueFactoryBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/NestedPropertyIndexValueFactoryBase.cs
@@ -40,6 +40,23 @@ internal abstract class NestedPropertyIndexValueFactoryBase<TSerialized, TItem> 
                 contentType
                     .PropertyGroups
                     .SelectMany(x => x.PropertyTypes!)
+                    .Select(propertyType =>
+                    {
+                        // We want to ensure that the nested properties are set vary by culture if the parent is
+                        // This is because it's perfectly valid to have a nested property type that's set to invariant even if the parent varies.
+                        // For instance in a block list, the list it self can vary, but the elements can be invariant, at the same time.
+                        if (culture is not null)
+                        {
+                            propertyType.Variations |= ContentVariation.Culture;
+                        }
+
+                        if (segment is not null)
+                        {
+                            propertyType.Variations |= ContentVariation.Segment;
+                        }
+
+                        return propertyType;
+                    })
                     .ToDictionary(x => x.Alias);
 
             result.AddRange(GetNestedResults(


### PR DESCRIPTION
This PR implements the solution suggested by @PerplexDaniel to fix #14096 (Big H5YR! 🎉) 

As mentioned in his comment the issue was because the property was not set to vary by culture/segment, however, the property was resolved in a varying context, this is because it's perfectly possible to have a blocklist or block grid that varies by culture, but its blocks does not (since varying blocks is not a thing...Yet) 

This fixes the issue by specifying that the property varies, when it's parent does, which makes sense because it's essentially "inheriting" the varying.


# Testing

This is kinda tricky to test, but #14149 has a good repro description. 

Additionally, test that nothing blows up if you add segments into the mix. 


# Appendix

Enabling segments can be quite tricky, so here's a short guide (reach out if more assistance is needed)

1. First go into `BackOfficeServerVariables` and set `showAllowSegmentationForDocumentTypes` to true in the `GetServerVariablesAsync` method.
2. Add a dependency to `Umbraco.TestData.csproj` in the `Umbraco.Web.UI`
3. Now a button shows up to enable segments on a document type in the backoffice. 
4. Add a segment by setting some property value for a given segment, this is done with the `AddSegmentData` endpoint, for instance by sending a request to the endpoint, for instance `https://localhost:44331/umbraco/surface/SegmentTest/AddSegmentData?contentId=1060&propertyAlias=simple&value=SomeValue&culture=en-US&segment=SomeSegment`