### PR TITLE
Delivery API: Apply start-item in the base querying request

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Services/ApiContentQueryService.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/ApiContentQueryService.cs
@@ -100,7 +100,6 @@ internal sealed class ApiContentQueryService : IApiContentQueryService // Examin
         else
         {
             // If no params or no fetch value, get everything from the index - this is a way to do that with Examine
-            // TODO: Make a default selector to fetch everything from the index and register it by the end of the SelectorHandlerCollection collection
             fieldName = UmbracoExamineFieldNames.CategoryFieldName;
             fieldValue = "content";
 

--- a/src/Umbraco.Cms.Api.Delivery/Services/ApiContentQueryService.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/ApiContentQueryService.cs
@@ -9,8 +9,7 @@ using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Delivery.Services;
 
-internal sealed class
-    ApiContentQueryService : IApiContentQueryService // Examine-specific implementation - can be swapped out
+internal sealed class ApiContentQueryService : IApiContentQueryService // Examine-specific implementation - can be swapped out
 {
     private readonly IExamineManager _examineManager;
     private readonly IRequestStartItemProviderAccessor _requestStartItemProviderAccessor;


### PR DESCRIPTION
## Details
- If all the query parameters are left out on the querying endpoint (`/umbraco/delivery/api/v1/content`) or no `fetch` parameter is provided, we will retrieve all the items from the index and use that as the base query when querying our `DeliveryApiContentIndex`;
- This PR takes into account that if a `Start-Item` header is present and it denotes a valid root node `id` or `path`, we will query from that starting point.
  - The implementation is similar to having a descendants selector handling _"descendants:[start-item header value]"_ query.

## Test
- Have multiple root nodes with children;
- Set `Umbraco:CMS:Global:HideTopLevelNodeFromPath` to false;
- Query `umbraco/delivery/api/v1/content`:
  - with no params and no headers - things should still work as before (_all published content nodes should be retrieved_);
  - any combination of `fetch`, `filter` or `sort` params with or without `Start-Item` header - things should still work as before (_only the published content  nodes that meet the criteria will be retrieved_);
  - with invalid `fetch` param with or without `Start-Item` header - things should still work as before (_no items will be retrieved_);
  - with no params and valid `Start-Item` header  value for `id` or `path` of existing root node - _all published content nodes that are descendants of that root item will be retrieved_;
  - with no params and invalid `Start-Item` header value - _all published content nodes should be retrieved as if the `Start-Item` header is not present_.