### PR TITLE
New backoffice: Fix renaming user groups

### DIFF
--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserGroupServiceValidationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserGroupServiceValidationTests.cs
@@ -148,4 +148,24 @@ public class UserGroupServiceValidationTests : UmbracoIntegrationTest
         Assert.IsFalse(updateResult.Success);
         Assert.AreEqual(UserGroupOperationStatus.DuplicateAlias, updateResult.Status);
     }
+
+    [Test]
+    public async Task Can_Update_UserGroup_To_New_Name()
+    {
+        var userGroup = new UserGroup(ShortStringHelper)
+        {
+            Name = "Some Name",
+            Alias = "someAlias"
+        };
+        var setupResult = await UserGroupService.CreateAsync(userGroup, Constants.Security.SuperUserId);
+        Assert.IsTrue(setupResult.Success);
+
+
+        var updateName = "New Name";
+        userGroup.Name = updateName;
+        var updateResult = await UserGroupService.UpdateAsync(userGroup, Constants.Security.SuperUserId);
+        Assert.IsTrue(updateResult.Success);
+        var updatedGroup = updateResult.Result;
+        Assert.AreEqual(updateName, updatedGroup.Name);
+    }
 }


### PR DESCRIPTION
Fixes an issue where you could not rename a user group because it would conflict with the alias.

This is because the check didn't take into account the key of the user groups, so this fixes that. 


## Testing

I've added an integration test that tests this 👍 