### PR TITLE
Umbraco 8 - SQL Server 2022 NuCache Error Using JSON Serializer

### DIFF
--- a/src/Umbraco.Core/Persistence/IUmbracoDatabase.cs
+++ b/src/Umbraco.Core/Persistence/IUmbracoDatabase.cs
@@ -1,4 +1,5 @@
 ﻿using NPoco;
+using System.Data.Common;
 
 namespace Umbraco.Core.Persistence
 {
@@ -20,5 +21,7 @@ namespace Umbraco.Core.Persistence
         /// Gets a value indicating whether the database is currently in a transaction.
         /// </summary>
         bool InTransaction { get; }
+
+        void AddParameter(DbCommand cmd, PocoColumn column, object value);
     }
 }

--- a/src/Umbraco.Core/Persistence/NPocoDatabaseExtensions-Bulk.cs
+++ b/src/Umbraco.Core/Persistence/NPocoDatabaseExtensions-Bulk.cs
@@ -156,7 +156,9 @@ namespace Umbraco.Core.Persistence
                     var recordValues = new string[columns.Length];
                     for (var columnIndex = 0; columnIndex < columns.Length; columnIndex++)
                     {
-                        database.AddParameter(command, columns[columnIndex].Value.GetValue(record));
+                        var column = columns[columnIndex].Value;
+                        database.AddParameter(command, column, column.GetValue(record));
+                        //database.AddParameter(command, columns[columnIndex].Value.GetValue(record));
                         recordValues[columnIndex] = prefix + parameterIndex++;
                     }
                     recordsValues[commandRecordIndex] = "(" + string.Join(",", recordValues) + ")";

--- a/src/Umbraco.Core/Persistence/NPocoDatabaseExtensions-Bulk.cs
+++ b/src/Umbraco.Core/Persistence/NPocoDatabaseExtensions-Bulk.cs
@@ -158,7 +158,6 @@ namespace Umbraco.Core.Persistence
                     {
                         var column = columns[columnIndex].Value;
                         database.AddParameter(command, column, column.GetValue(record));
-                        //database.AddParameter(command, columns[columnIndex].Value.GetValue(record));
                         recordValues[columnIndex] = prefix + parameterIndex++;
                     }
                     recordsValues[commandRecordIndex] = "(" + string.Join(",", recordValues) + ")";

--- a/src/Umbraco.Core/Persistence/UmbracoDatabase.cs
+++ b/src/Umbraco.Core/Persistence/UmbracoDatabase.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Data;
 using System.Data.Common;
+using System.Data.SqlClient;
 using System.Linq;
 using System.Text;
 using NPoco;
 using StackExchange.Profiling;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Persistence.FaultHandling;
+using Umbraco.Core.Persistence.Mappers;
 
 namespace Umbraco.Core.Persistence
 {
@@ -86,6 +88,22 @@ namespace Umbraco.Core.Persistence
                     parameter.DbType = DbType.String;
 
             return command;
+        }
+
+        public void AddParameter(DbCommand cmd, PocoColumn column, object value)
+        {
+            if (DatabaseType.IsSqlServer())
+            {
+                if (column.ColumnType == typeof(byte[]) && value == null)
+                {
+                    value = new SqlParameter("_bytes", SqlDbType.VarBinary, -1)
+                    {
+                        Value = DBNull.Value
+                    };
+                }
+            }
+
+            base.AddParameter(cmd, value);
         }
 
         #endregion

--- a/src/Umbraco.Tests/Testing/TestDatabase.cs
+++ b/src/Umbraco.Tests/Testing/TestDatabase.cs
@@ -116,6 +116,11 @@ namespace Umbraco.Tests.Testing
             throw new NotImplementedException();
         }
 
+        public void AddParameter(DbCommand cmd, PocoColumn column, object value)
+        {
+            throw new NotImplementedException();
+        }
+
         public DbCommand CreateCommand(DbConnection connection, CommandType commandType, string sql, params object[] args)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description

When using the latest version of Umbraco 8 on SQL Server 2022, there is an error when rebuilding the NuCache database cache when the serializer is set JSON and not MsgPack in the web.config (which older sites most likely will be).  This can happen from the Settings > Published Status screen in the back-office or when booting, making the site error completely and never load.  If you are able to login to Umbraco the same error can also happen when saving document types.

The following exception is thrown:

```
-> Umbraco.Core.Exceptions.BootFailedException: Boot failed.

-> System.Data.SqlClient.SqlException: Implicit conversion from data type nvarchar to varbinary(max) is not allowed. Use the CONVERT function to run this query.
  at System.Data.SqlClient.SqlConnection.OnError(SqlException exception, Boolean breakConnection, Action`1 wrapCloseInAction)
  at System.Data.SqlClient.TdsParser.ThrowExceptionAndWarning(TdsParserStateObject stateObj, Boolean callerHasConnectionLock, Boolean asyncClose)
  at System.Data.SqlClient.TdsParser.TryRun(RunBehavior runBehavior, SqlCommand cmdHandler, SqlDataReader dataStream, BulkCopySimpleResultSet bulkCopyHandler, TdsParserStateObject stateObj, Boolean& dataReady)
  at System.Data.SqlClient.SqlCommand.FinishExecuteReader(SqlDataReader ds, RunBehavior runBehavior, String resetOptionsString, Boolean isInternal, Boolean forDescribeParameterEncryption, Boolean shouldCacheForAlwaysEncrypted)
  at System.Data.SqlClient.SqlCommand.RunExecuteReaderTds(CommandBehavior cmdBehavior, RunBehavior runBehavior, Boolean returnStream, Boolean async, Int32 timeout, Task& task, Boolean asyncWrite, Boolean inRetry, SqlDataReader ds, Boolean describeParameterEncryptionRequest)
  at System.Data.SqlClient.SqlCommand.RunExecuteReader(CommandBehavior cmdBehavior, RunBehavior runBehavior, Boolean returnStream, String method, TaskCompletionSource`1 completion, Int32 timeout, Task& task, Boolean& usedCache, Boolean asyncWrite, Boolean inRetry)
  at System.Data.SqlClient.SqlCommand.InternalExecuteNonQuery(TaskCompletionSource`1 completion, String methodName, Boolean sendToPipe, Int32 timeout, Boolean& usedCache, Boolean asyncWrite, Boolean inRetry)
  at System.Data.SqlClient.SqlCommand.ExecuteNonQuery()
  at StackExchange.Profiling.Data.ProfiledDbCommand.ExecuteNonQuery() in C:\projects\dotnet\src\MiniProfiler.Shared\Data\ProfiledDbCommand.cs:line 284
  at Umbraco.Core.Persistence.FaultHandling.FaultHandlingDbCommand.<ExecuteNonQuery>b__31_0() in D:\My Documents\Projects\Open Source\Umbraco-CMS\src\Umbraco.Core\Persistence\FaultHandling\RetryDbConnection.cs:line 209
  at Umbraco.Core.Persistence.FaultHandling.FaultHandlingDbCommand.<>c__DisplayClass33_0`1.<Execute>b__0() in D:\My Documents\Projects\Open Source\Umbraco-CMS\src\Umbraco.Core\Persistence\FaultHandling\RetryDbConnection.cs:line 222
  at Umbraco.Core.Persistence.FaultHandling.RetryPolicy.ExecuteAction[TResult](Func`1 func) in D:\My Documents\Projects\Open Source\Umbraco-CMS\src\Umbraco.Core\Persistence\FaultHandling\RetryPolicy.cs:line 174
  at Umbraco.Core.Persistence.FaultHandling.FaultHandlingDbCommand.Execute[T](Func`1 f) in D:\My Documents\Projects\Open Source\Umbraco-CMS\src\Umbraco.Core\Persistence\FaultHandling\RetryDbConnection.cs:line 219
  at Umbraco.Core.Persistence.FaultHandling.FaultHandlingDbCommand.ExecuteNonQuery() in D:\My Documents\Projects\Open Source\Umbraco-CMS\src\Umbraco.Core\Persistence\FaultHandling\RetryDbConnection.cs:line 209
  at Umbraco.Core.Persistence.NPocoDatabaseExtensions.BulkInsertRecordsWithCommands[T](IUmbracoDatabase database, T[] records) in D:\My Documents\Projects\Open Source\Umbraco-CMS\src\Umbraco.Core\Persistence\NPocoDatabaseExtensions-Bulk.cs:line 107
  at Umbraco.Core.Persistence.NPocoDatabaseExtensions.BulkInsertRecords[T](IUmbracoDatabase database, IEnumerable`1 records, Boolean useNativeBulkInsert) in D:\My Documents\Projects\Open Source\Umbraco-CMS\src\Umbraco.Core\Persistence\NPocoDatabaseExtensions-Bulk.cs:line 89
  at Umbraco.Web.PublishedCache.NuCache.PublishedSnapshotService.RebuildContentDbCacheLocked(IContentCacheDataSerializer serializer, IScope scope, Int32 groupSize, IEnumerable`1 contentTypeIds) in D:\My Documents\Projects\Open Source\Umbraco-CMS\src\Umbraco.Web\PublishedCache\NuCache\PublishedSnapshotService.cs:line 1549
  at Umbraco.Web.PublishedCache.NuCache.PublishedSnapshotService.Rebuild() in D:\My Documents\Projects\Open Source\Umbraco-CMS\src\Umbraco.Web\PublishedCache\NuCache\PublishedSnapshotService.cs:line 1474
  at Umbraco.Web.PublishedCache.NuCache.NuCacheSerializerComponent.RebuildDatabaseCacheIfSerializerChanged() in D:\My Documents\Projects\Open Source\Umbraco-CMS\src\Umbraco.Web\PublishedCache\NuCache\NuCacheSerializerComponent.cs:line 60
  at Umbraco.Web.PublishedCache.NuCache.NuCacheSerializerComponent.Initialize() in D:\My Documents\Projects\Open Source\Umbraco-CMS\src\Umbraco.Web\PublishedCache\NuCache\NuCacheSerializerComponent.cs:line 37
  at Umbraco.Core.Composing.ComponentCollection.Initialize() in D:\My Documents\Projects\Open Source\Umbraco-CMS\src\Umbraco.Core\Composing\ComponentCollection.cs:line 32
  at Umbraco.Core.Runtime.CoreRuntime.Boot(IRegister register, DisposableTimer timer) in D:\My Documents\Projects\Open Source\Umbraco-CMS\src\Umbraco.Core\Runtime\CoreRuntime.cs:line 219
```

This works perfectly fine on SQL Server 2019 but not SQL Server 2022.

1. Make sure you are using SQL Server 2022
2. Comment out the following line in the web.config:
`<add key="Umbraco.Web.PublishedCache.NuCache.Serializer" value="MsgPack"/>`
4. Run Umbraco and try and rebuild the database cache from settings.  If it won't let you get that far it will fail at boot with the error described above.

SQL Server 2019 Express (15.0.4312) - The error does not occur.
SQL Server 2022 Express (16.0.4025) - The error occurs as described above.

I have tested the fix on both SQL Server 2019 and SQL Server 2022 and they both work fine.

There are 3 failing tests but none of them are due to these changes.

This is quite a fundamental issue so I think it really needs merging.