### PR TITLE
Update the delivery API content index at un/publish

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Indexing/Selectors/AncestorsSelectorIndexer.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Indexing/Selectors/AncestorsSelectorIndexer.cs
@@ -3,7 +3,7 @@ using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Delivery.Indexing.Selectors;
 
-public class AncestorsSelectorIndexer : IContentIndexHandler
+public sealed class AncestorsSelectorIndexer : IContentIndexHandler
 {
     // NOTE: "id" is a reserved field name
     internal const string FieldName = "itemId";

--- a/src/Umbraco.Cms.Api.Delivery/Indexing/Selectors/AncestorsSelectorIndexer.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Indexing/Selectors/AncestorsSelectorIndexer.cs
@@ -1,0 +1,17 @@
+﻿using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Api.Delivery.Indexing.Selectors;
+
+public class AncestorsSelectorIndexer : IContentIndexHandler
+{
+    // NOTE: "id" is a reserved field name
+    internal const string FieldName = "itemId";
+
+    public IEnumerable<IndexFieldValue> GetFieldValues(IContent content)
+        => new[] { new IndexFieldValue { FieldName = FieldName, Value = content.Key } };
+
+    public IEnumerable<IndexField> GetFields()
+        => new[] { new IndexField { FieldName = FieldName, FieldType = FieldType.String } };
+}
+

--- a/src/Umbraco.Cms.Api.Delivery/Querying/Selectors/AncestorsSelector.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Querying/Selectors/AncestorsSelector.cs
@@ -1,3 +1,4 @@
+using Umbraco.Cms.Api.Delivery.Indexing.Selectors;
 using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
@@ -33,7 +34,7 @@ public sealed class AncestorsSelector : QueryOptionBase, ISelectorHandler
             // it means that CanHandle() returned true, meaning that this Selector should be able to handle the selector value
             return new SelectorOption
             {
-                FieldName = "id",
+                FieldName = AncestorsSelectorIndexer.FieldName,
                 Value = string.Empty
             };
         }
@@ -44,7 +45,7 @@ public sealed class AncestorsSelector : QueryOptionBase, ISelectorHandler
 
         return new SelectorOption
         {
-            FieldName = "id",
+            FieldName = AncestorsSelectorIndexer.FieldName,
             Value = string.Join(" ", ancestorKeys)
         };
     }

--- a/src/Umbraco.Cms.Api.Delivery/Services/ApiContentQueryService.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/ApiContentQueryService.cs
@@ -63,10 +63,11 @@ internal sealed class ApiContentQueryService : IApiContentQueryService // Examin
         HandleFiltering(filters, queryOperation);
 
         // Handle Sorting
-        IOrdering sortQuery = HandleSorting(sorts, queryOperation);
-        IOrdering? selectedFields = sortQuery.SelectFields(_itemIdOnlyFieldSet);
+        IOrdering sortQuery = HandleSorting(sorts, queryOperation).SelectFields(_itemIdOnlyFieldSet);
 
-        ISearchResults? results = selectedFields.Execute(QueryOptions.SkipTake(skip, take));
+        ISearchResults? results = sortQuery
+            .SelectFields(_itemIdOnlyFieldSet)
+            .Execute(QueryOptions.SkipTake(skip, take));
 
         if (results is null)
         {

--- a/src/Umbraco.Examine.Lucene/DeliveryApiContentIndex.cs
+++ b/src/Umbraco.Examine.Lucene/DeliveryApiContentIndex.cs
@@ -1,3 +1,4 @@
+using Examine;
 using Examine.Lucene;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -6,7 +7,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Infrastructure.Examine;
 
-public class DeliveryApiContentIndex : UmbracoExamineIndex
+public class DeliveryApiContentIndex : UmbracoContentIndexBase
 {
     public DeliveryApiContentIndex(
         ILoggerFactory loggerFactory,
@@ -16,5 +17,13 @@ public class DeliveryApiContentIndex : UmbracoExamineIndex
         IRuntimeState runtimeState)
         : base(loggerFactory, name, indexOptions, hostingEnvironment, runtimeState)
     {
+        PublishedValuesOnly = true;
+        EnableDefaultEventHandler = true;
+    }
+
+    protected override void OnTransformingIndexValues(IndexingItemEventArgs e)
+    {
+        // UmbracoExamineIndex (base class down the hierarchy) performs some magic transformations here for paths and icons;
+        // we don't want that for the Delivery API, so we'll have to override this method and simply do nothing.
     }
 }

--- a/src/Umbraco.Examine.Lucene/UmbracoContentIndex.cs
+++ b/src/Umbraco.Examine.Lucene/UmbracoContentIndex.cs
@@ -3,7 +3,6 @@
 
 using Examine;
 using Examine.Lucene;
-using Examine.Search;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Hosting;
@@ -14,11 +13,8 @@ namespace Umbraco.Cms.Infrastructure.Examine;
 /// <summary>
 ///     An indexer for Umbraco content and media
 /// </summary>
-public class UmbracoContentIndex : UmbracoExamineIndex, IUmbracoContentIndex
+public class UmbracoContentIndex : UmbracoContentIndexBase, IUmbracoContentIndex
 {
-    private readonly ISet<string> _idOnlyFieldSet = new HashSet<string> { "id" };
-    private readonly ILogger<UmbracoContentIndex> _logger;
-
     public UmbracoContentIndex(
         ILoggerFactory loggerFactory,
         string name,
@@ -29,7 +25,6 @@ public class UmbracoContentIndex : UmbracoExamineIndex, IUmbracoContentIndex
         : base(loggerFactory, name, indexOptions, hostingEnvironment, runtimeState)
     {
         LanguageService = languageService;
-        _logger = loggerFactory.CreateLogger<UmbracoContentIndex>();
 
         LuceneDirectoryIndexOptions namedOptions = indexOptions.Get(name);
         if (namedOptions == null)
@@ -108,44 +103,5 @@ public class UmbracoContentIndex : UmbracoExamineIndex, IUmbracoContentIndex
             //we need to manually call the completed method
             onComplete(new IndexOperationEventArgs(this, 0));
         }
-    }
-
-    /// <inheritdoc />
-    /// <summary>
-    ///     Deletes a node from the index.
-    /// </summary>
-    /// <remarks>
-    ///     When a content node is deleted, we also need to delete it's children from the index so we need to perform a
-    ///     custom Lucene search to find all decendents and create Delete item queues for them too.
-    /// </remarks>
-    /// <param name="itemIds">ID of the node to delete</param>
-    /// <param name="onComplete"></param>
-    protected override void PerformDeleteFromIndex(IEnumerable<string> itemIds, Action<IndexOperationEventArgs>? onComplete)
-    {
-        var idsAsList = itemIds.ToList();
-
-        for (var i = 0; i < idsAsList.Count; i++)
-        {
-            var nodeId = idsAsList[i];
-
-            //find all descendants based on path
-            var descendantPath = $@"\-1\,*{nodeId}\,*";
-            var rawQuery = $"{UmbracoExamineFieldNames.IndexPathFieldName}:{descendantPath}";
-            IQuery? c = Searcher.CreateQuery();
-            IBooleanOperation? filtered = c.NativeQuery(rawQuery);
-            IOrdering? selectedFields = filtered.SelectFields(_idOnlyFieldSet);
-            ISearchResults? results = selectedFields.Execute();
-
-            _logger.LogDebug("DeleteFromIndex with query: {Query} (found {TotalItems} results)", rawQuery, results.TotalItemCount);
-
-            var toRemove = results.Select(x => x.Id).ToList();
-            // delete those descendants (ensure base. is used here so we aren't calling ourselves!)
-            base.PerformDeleteFromIndex(toRemove, null);
-
-            // remove any ids from our list that were part of the descendants
-            idsAsList.RemoveAll(x => toRemove.Contains(x));
-        }
-
-        base.PerformDeleteFromIndex(idsAsList, onComplete);
     }
 }

--- a/src/Umbraco.Examine.Lucene/UmbracoContentIndexBase.cs
+++ b/src/Umbraco.Examine.Lucene/UmbracoContentIndexBase.cs
@@ -1,0 +1,63 @@
+﻿using Examine;
+using Examine.Lucene;
+using Examine.Search;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Infrastructure.Examine;
+
+public abstract class UmbracoContentIndexBase : UmbracoExamineIndex
+{
+    private readonly ISet<string> _idOnlyFieldSet = new HashSet<string> { "id" };
+    private readonly ILogger<UmbracoContentIndex> _logger;
+
+    protected UmbracoContentIndexBase(
+        ILoggerFactory loggerFactory,
+        string name,
+        IOptionsMonitor<LuceneDirectoryIndexOptions> indexOptions,
+        IHostingEnvironment hostingEnvironment,
+        IRuntimeState runtimeState)
+        : base(loggerFactory, name, indexOptions, hostingEnvironment, runtimeState) =>
+        _logger = loggerFactory.CreateLogger<UmbracoContentIndex>();
+
+    /// <inheritdoc />
+    /// <summary>
+    ///     Deletes a node from the index.
+    /// </summary>
+    /// <remarks>
+    ///     When a content node is deleted, we also need to delete it's children from the index so we need to perform a
+    ///     custom Lucene search to find all decendents and create Delete item queues for them too.
+    /// </remarks>
+    /// <param name="itemIds">ID of the node to delete</param>
+    /// <param name="onComplete"></param>
+    protected override void PerformDeleteFromIndex(IEnumerable<string> itemIds, Action<IndexOperationEventArgs>? onComplete)
+    {
+        var idsAsList = itemIds.ToList();
+
+        for (var i = 0; i < idsAsList.Count; i++)
+        {
+            var nodeId = idsAsList[i];
+
+            //find all descendants based on path
+            var descendantPath = $@"\-1\,*{nodeId}\,*";
+            var rawQuery = $"{UmbracoExamineFieldNames.IndexPathFieldName}:{descendantPath}";
+            IQuery? c = Searcher.CreateQuery();
+            IBooleanOperation? filtered = c.NativeQuery(rawQuery);
+            IOrdering? selectedFields = filtered.SelectFields(_idOnlyFieldSet);
+            ISearchResults? results = selectedFields.Execute();
+
+            _logger.LogDebug("DeleteFromIndex with query: {Query} (found {TotalItems} results)", rawQuery, results.TotalItemCount);
+
+            var toRemove = results.Select(x => x.Id).ToList();
+            // delete those descendants (ensure base. is used here so we aren't calling ourselves!)
+            base.PerformDeleteFromIndex(toRemove, null);
+
+            // remove any ids from our list that were part of the descendants
+            idsAsList.RemoveAll(x => toRemove.Contains(x));
+        }
+
+        base.PerformDeleteFromIndex(idsAsList, onComplete);
+    }
+}

--- a/src/Umbraco.Infrastructure/Examine/DeliveryApiContentIndexFieldDefinitionBuilder.cs
+++ b/src/Umbraco.Infrastructure/Examine/DeliveryApiContentIndexFieldDefinitionBuilder.cs
@@ -14,9 +14,12 @@ public class DeliveryApiContentIndexFieldDefinitionBuilder : IDeliveryApiContent
     public FieldDefinitionCollection Build()
     {
         // mandatory field definitions go here
+        // see also the field definitions in the Delivery API content index value set builder
         var fieldDefinitions = new List<FieldDefinition>
         {
-            new("id", FieldDefinitionTypes.FullText)
+            new("id", FieldDefinitionTypes.Integer),
+            new(UmbracoExamineFieldNames.IndexPathFieldName, FieldDefinitionTypes.Raw),
+            new(UmbracoExamineFieldNames.NodeNameFieldName, FieldDefinitionTypes.Raw)
         };
 
         // add custom fields from index handlers (selectors, filters, sorts)

--- a/src/Umbraco.Infrastructure/Examine/DeliveryApiContentIndexValueSetBuilder.cs
+++ b/src/Umbraco.Infrastructure/Examine/DeliveryApiContentIndexValueSetBuilder.cs
@@ -37,8 +37,9 @@ public class DeliveryApiContentIndexValueSetBuilder : IDeliveryApiContentIndexVa
             // mandatory index values go here
             var indexValues = new Dictionary<string, object>
             {
-                ["id"] = content.Key,
-                [UmbracoExamineFieldNames.NodeNameFieldName] = content.PublishName ?? string.Empty
+                ["id"] = content.Id, // required for unpublishing/deletion handling
+                [UmbracoExamineFieldNames.IndexPathFieldName] = content.Path, // required for unpublishing/deletion handling
+                [UmbracoExamineFieldNames.NodeNameFieldName] = content.PublishName ?? string.Empty, // primarily needed for backoffice index browsing
             };
 
             // add custom field values from index handlers (selectors, filters, sorts)
@@ -52,7 +53,8 @@ public class DeliveryApiContentIndexValueSetBuilder : IDeliveryApiContentIndexVa
                 indexValues[fieldValue.FieldName] = fieldValue.Value;
             }
 
-            yield return new ValueSet(content.Key.ToString(), IndexTypes.Content, content.ContentType.Alias, indexValues);
+            // NOTE: must use content.Id here, not content.Key - otherwise automatic clean-up i.e. on deletion or unpublishing will not work
+            yield return new ValueSet(content.Id.ToString(), IndexTypes.Content, content.ContentType.Alias, indexValues);
         }
     }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The delivery API content index must be updated whenever content is published or unpublished. To this end, a few changes has to be made to the index population and value set creation, in order to reuse the functionality from the existing content indexes (ExternalIndex, InternalIndex).

As it happens, the unpublish handling is primarily implemented in `UmbracoContentIndex`. Unfortunately, the remaining implementation of `UmbracoContentIndex` and the general usage of `UmbracoContentIndex` throughout the codebase is too biased towards the desired functionality for the existing content indexes. Thus I have abstracted the unpublish handling into a new `UmbracoContentIndexBase` base class for both the `UmbracoContentIndex` and `DeliveryApiContentIndex` index implementations to use.

The `id` index field is given special meaning in these implementations, and it _must_ contain the content integer ID to function correctly. This means we need to add the content keys to another field (`itemId`) for the ancestors filter to use. On the upside, this forces us to implement a `AncestorsSelectorIndexer` to provide data for the `AncestorsSelector` to query, which entirely aligns with the rest of the query handlers having their own accompanying index handler.

### Testing this PR

Test that:
- Content appears (or is updated) in the index on publish and disappears on unpublish.
- Children of unpublished content is removed from the index as well.
- Published children of newly published content is added to the index.

Even though this PR does not touch directly upon the following, for good measure also test that disallowed content and protected content is never added to the index when publishing.
