### PR TITLE
Update ContentValueSetValidator to allow include/exclude of fields

### DIFF
--- a/src/Umbraco.Infrastructure/Examine/ContentValueSetValidator.cs
+++ b/src/Umbraco.Infrastructure/Examine/ContentValueSetValidator.cs
@@ -30,8 +30,10 @@ public class ContentValueSetValidator : ValueSetValidator, IContentValueSetValid
         IScopeProvider? scopeProvider,
         int? parentId = null,
         IEnumerable<string>? includeItemTypes = null,
-        IEnumerable<string>? excludeItemTypes = null)
-        : base(includeItemTypes, excludeItemTypes, null, null)
+        IEnumerable<string>? excludeItemTypes = null,
+        IEnumerable<string>? includeFields = null,
+        IEnumerable<string>? excludeFields = null)
+        : base(includeItemTypes, excludeItemTypes, includeFields, excludeFields)
     {
         PublishedValuesOnly = publishedValuesOnly;
         SupportProtectedContent = supportProtectedContent;


### PR DESCRIPTION
Examine supports the inclusion and exclusion of fields in the index based on two IEnumerables of include and exclude fields.

Just trying to update the samples and documentation around Examine Custom Index Searching...

and found the existing samples do not work, but also seem convoluted...

... and if the ContentValueSetValidator supported these two fields it would make it less work to create a custom index. eg you wouldn't have to create your own validator (not that I necessarily think people should be creating custom indexes you understand... was just more puzzled why they option wasn't there)...

Also they could avoid creating their own populator, by making the index implement IUmbracoContentIndex, that would populate all the fields, and that's when you would need the include, exclude field list to tweak things.

Anyway I reckoned creating a PR was the quickest way to find out, if there were a reason why it was not possible to pass these through.

To Test this, follow the Custom Index example in the documentation with the starter kit
Update ProductIndex to be like this
public class ProductIndex : UmbracoExamineIndex, IUmbracoContentIndex

Update your field definitions to be
options.FieldDefinitions = new UmbracoFieldDefinitionCollection();

and then set your validator to be:
options.Validator = new ContentValueSetValidator(true,false, _publicAccessService, _scopeProvider, includeItemTypes: new[] { "product" },includeFields: new[] {"nodeName","id","__Published","path", "__NodeTypeAlias"});

build and rebuild your ProductIndex, it should include 8 products, and only contain the filtered include fields... (needs path and __Published for the validator logic to work... was wondering why it uses 'path' and not '__Path' but that's for another day.

Thanks for receiving this contribution to Umbraco CMS!