### PR TITLE
Add sort handlers for create and update date

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Indexing/Sorts/CreateDateSortIndexer.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Indexing/Sorts/CreateDateSortIndexer.cs
@@ -5,7 +5,7 @@ namespace Umbraco.Cms.Api.Delivery.Indexing.Sorts;
 
 public sealed class CreateDateSortIndexer : IContentIndexHandler
 {
-    internal const string FieldName = "created";
+    internal const string FieldName = "createDate";
 
     public IEnumerable<IndexFieldValue> GetFieldValues(IContent content)
         => new[] { new IndexFieldValue { FieldName = FieldName, Value = content.CreateDate } };

--- a/src/Umbraco.Cms.Api.Delivery/Indexing/Sorts/CreateDateSortIndexer.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Indexing/Sorts/CreateDateSortIndexer.cs
@@ -1,0 +1,15 @@
+﻿using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Api.Delivery.Indexing.Sorts;
+
+public class CreateDateSortIndexer : IContentIndexHandler
+{
+    internal const string FieldName = "created";
+
+    public IEnumerable<IndexFieldValue> GetFieldValues(IContent content)
+        => new[] { new IndexFieldValue { FieldName = FieldName, Value = content.CreateDate } };
+
+    public IEnumerable<IndexField> GetFields()
+        => new[] { new IndexField { FieldName = FieldName, FieldType = FieldType.Date } };
+}

--- a/src/Umbraco.Cms.Api.Delivery/Indexing/Sorts/CreateDateSortIndexer.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Indexing/Sorts/CreateDateSortIndexer.cs
@@ -3,7 +3,7 @@ using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Delivery.Indexing.Sorts;
 
-public class CreateDateSortIndexer : IContentIndexHandler
+public sealed class CreateDateSortIndexer : IContentIndexHandler
 {
     internal const string FieldName = "created";
 

--- a/src/Umbraco.Cms.Api.Delivery/Indexing/Sorts/UpdateDateSortIndexer.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Indexing/Sorts/UpdateDateSortIndexer.cs
@@ -1,0 +1,15 @@
+﻿using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Api.Delivery.Indexing.Sorts;
+
+public class UpdateDateSortIndexer : IContentIndexHandler
+{
+    internal const string FieldName = "updated";
+
+    public IEnumerable<IndexFieldValue> GetFieldValues(IContent content)
+        => new[] { new IndexFieldValue { FieldName = FieldName, Value = content.UpdateDate } };
+
+    public IEnumerable<IndexField> GetFields()
+        => new[] { new IndexField { FieldName = FieldName, FieldType = FieldType.Date } };
+}

--- a/src/Umbraco.Cms.Api.Delivery/Indexing/Sorts/UpdateDateSortIndexer.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Indexing/Sorts/UpdateDateSortIndexer.cs
@@ -5,7 +5,7 @@ namespace Umbraco.Cms.Api.Delivery.Indexing.Sorts;
 
 public sealed class UpdateDateSortIndexer : IContentIndexHandler
 {
-    internal const string FieldName = "updated";
+    internal const string FieldName = "updateDate";
 
     public IEnumerable<IndexFieldValue> GetFieldValues(IContent content)
         => new[] { new IndexFieldValue { FieldName = FieldName, Value = content.UpdateDate } };

--- a/src/Umbraco.Cms.Api.Delivery/Indexing/Sorts/UpdateDateSortIndexer.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Indexing/Sorts/UpdateDateSortIndexer.cs
@@ -3,7 +3,7 @@ using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Delivery.Indexing.Sorts;
 
-public class UpdateDateSortIndexer : IContentIndexHandler
+public sealed class UpdateDateSortIndexer : IContentIndexHandler
 {
     internal const string FieldName = "updated";
 

--- a/src/Umbraco.Cms.Api.Delivery/Querying/Filters/NameFilter.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Querying/Filters/NameFilter.cs
@@ -1,3 +1,4 @@
+using Umbraco.Cms.Api.Delivery.Indexing.Sorts;
 using Umbraco.Cms.Core.DeliveryApi;
 
 namespace Umbraco.Cms.Api.Delivery.Querying.Filters;
@@ -17,7 +18,7 @@ public sealed class NameFilter : IFilterHandler
 
         var filterOption = new FilterOption
         {
-            FieldName = "name",
+            FieldName = NameSortIndexer.FieldName,
             Value = string.Empty
         };
 

--- a/src/Umbraco.Cms.Api.Delivery/Querying/Sorts/CreateDateSort.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Querying/Sorts/CreateDateSort.cs
@@ -4,7 +4,7 @@ using Umbraco.Cms.Core.DeliveryApi;
 
 namespace Umbraco.Cms.Api.Delivery.Querying.Sorts;
 
-public class CreateDateSort : ISortHandler
+public sealed class CreateDateSort : ISortHandler
 {
     private const string SortOptionSpecifier = "createDate:";
 

--- a/src/Umbraco.Cms.Api.Delivery/Querying/Sorts/CreateDateSort.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Querying/Sorts/CreateDateSort.cs
@@ -1,0 +1,27 @@
+﻿using Umbraco.Cms.Api.Delivery.Indexing.Sorts;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.DeliveryApi;
+
+namespace Umbraco.Cms.Api.Delivery.Querying.Sorts;
+
+public class CreateDateSort : ISortHandler
+{
+    private const string SortOptionSpecifier = "createDate:";
+
+    /// <inheritdoc />
+    public bool CanHandle(string query)
+        => query.StartsWith(SortOptionSpecifier, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc/>
+    public SortOption BuildSortOption(string sort)
+    {
+        var sortDirection = sort.Substring(SortOptionSpecifier.Length);
+
+        return new SortOption
+        {
+            FieldName = CreateDateSortIndexer.FieldName,
+            Direction = sortDirection.StartsWith("asc") ? Direction.Ascending : Direction.Descending,
+            FieldType = FieldType.Date
+        };
+    }
+}

--- a/src/Umbraco.Cms.Api.Delivery/Querying/Sorts/UpdateDateSort.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Querying/Sorts/UpdateDateSort.cs
@@ -4,7 +4,7 @@ using Umbraco.Cms.Core.DeliveryApi;
 
 namespace Umbraco.Cms.Api.Delivery.Querying.Sorts;
 
-public class UpdateDateSort : ISortHandler
+public sealed class UpdateDateSort : ISortHandler
 {
     private const string SortOptionSpecifier = "updateDate:";
 

--- a/src/Umbraco.Cms.Api.Delivery/Querying/Sorts/UpdateDateSort.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Querying/Sorts/UpdateDateSort.cs
@@ -1,0 +1,27 @@
+﻿using Umbraco.Cms.Api.Delivery.Indexing.Sorts;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.DeliveryApi;
+
+namespace Umbraco.Cms.Api.Delivery.Querying.Sorts;
+
+public class UpdateDateSort : ISortHandler
+{
+    private const string SortOptionSpecifier = "updateDate:";
+
+    /// <inheritdoc />
+    public bool CanHandle(string query)
+        => query.StartsWith(SortOptionSpecifier, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc/>
+    public SortOption BuildSortOption(string sort)
+    {
+        var sortDirection = sort.Substring(SortOptionSpecifier.Length);
+
+        return new SortOption
+        {
+            FieldName = UpdateDateSortIndexer.FieldName,
+            Direction = sortDirection.StartsWith("asc") ? Direction.Ascending : Direction.Descending,
+            FieldType = FieldType.Date
+        };
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR adds sort handlers (and accompanying content indexers) for create and update date. 

I also removed a hardcoded field name in `NameFilter` while I was at it.

### Testing this PR

1. Rebuild the delivery API content index.
2. Verify that content queries can be sorted by content create and update date - i.e.  `createDate:asc` or  `updateDate:desc`.
3. Verify that both sort handlers support `asc` and `desc` sort order.
4. Verify that the sort handlers apply both date and time to the sorting - i.e. when publishing two content items, the last updated content item should be returned first when sorting by `updateDate:desc`. Subsequently publishing the first of the two items, the first one should now be returned by the same sorting due to the time component of the update date.
   - Remember you must manually rebuild the index to see changes reflected.