### PR TITLE
v12: Update to ImageSharp v3

### DIFF
--- a/src/Umbraco.Cms.Imaging.ImageSharp/ConfigureImageSharpMiddlewareOptions.cs
+++ b/src/Umbraco.Cms.Imaging.ImageSharp/ConfigureImageSharpMiddlewareOptions.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Headers;
 using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
-using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Web.Commands;
 using SixLabors.ImageSharp.Web.Middleware;
 using SixLabors.ImageSharp.Web.Processors;

--- a/src/Umbraco.Cms.Imaging.ImageSharp/ImageProcessors/CropWebProcessor.cs
+++ b/src/Umbraco.Cms.Imaging.ImageSharp/ImageProcessors/CropWebProcessor.cs
@@ -1,10 +1,7 @@
 using System.Globalization;
 using System.Numerics;
 using Microsoft.Extensions.Logging;
-using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
-using SixLabors.ImageSharp.Processing;
-using SixLabors.ImageSharp.Web;
 using SixLabors.ImageSharp.Web.Commands;
 using SixLabors.ImageSharp.Web.Processors;
 
@@ -48,7 +45,8 @@ public class CropWebProcessor : IImageWebProcessor
     private static Rectangle? GetCropRectangle(FormattedImage image, CommandCollection commands, CommandParser parser, CultureInfo culture)
     {
         var coordinates = parser.ParseValue<float[]>(commands.GetValueOrDefault(Coordinates), culture);
-        if (coordinates.Length != 4 ||
+        if (coordinates is null ||
+            coordinates.Length != 4 ||
             (coordinates[0] == 0 && coordinates[1] == 0 && coordinates[2] == 0 && coordinates[3] == 0))
         {
             return null;
@@ -64,7 +62,7 @@ public class CropWebProcessor : IImageWebProcessor
         Vector2 xy2 = ExifOrientationUtilities.Transform(new Vector2(right, bottom), Vector2.Zero, Vector2.One, orientation);
 
         // Scale points to a pixel based rectangle
-        Size size = image.Image.Size();
+        Size size = image.Image.Size;
 
         return Rectangle.Round(RectangleF.FromLTRB(
             MathF.Min(xy1.X, xy2.X) * size.Width,

--- a/src/Umbraco.Cms.Imaging.ImageSharp/ImageSharpComposer.cs
+++ b/src/Umbraco.Cms.Imaging.ImageSharp/ImageSharpComposer.cs
@@ -1,6 +1,5 @@
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
-using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Imaging.ImageSharp;
 

--- a/src/Umbraco.Cms.Imaging.ImageSharp/Media/ImageSharpDimensionExtractor.cs
+++ b/src/Umbraco.Cms.Imaging.ImageSharp/Media/ImageSharpDimensionExtractor.cs
@@ -1,4 +1,4 @@
-using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using Umbraco.Cms.Core.Media;
 using Size = System.Drawing.Size;
@@ -28,31 +28,35 @@ public sealed class ImageSharpDimensionExtractor : IImageDimensionExtractor
     {
         Size? size = null;
 
-        IImageInfo imageInfo = Image.Identify(_configuration, stream);
-        if (imageInfo != null)
+        if (stream is not null)
         {
-            size = IsExifOrientationRotated(imageInfo)
-                ? new Size(imageInfo.Height, imageInfo.Width)
-                : new Size(imageInfo.Width, imageInfo.Height);
+            DecoderOptions options = new()
+            {
+                Configuration = _configuration,
+            };
+
+            ImageInfo imageInfo = Image.Identify(options, stream);
+            if (imageInfo != null)
+            {
+                size = IsExifOrientationRotated(imageInfo)
+                    ? new Size(imageInfo.Height, imageInfo.Width)
+                    : new Size(imageInfo.Width, imageInfo.Height);
+            }
         }
 
         return size;
     }
 
-    private static bool IsExifOrientationRotated(IImageInfo imageInfo)
+    private static bool IsExifOrientationRotated(ImageInfo imageInfo)
         => GetExifOrientation(imageInfo) switch
         {
-            ExifOrientationMode.LeftTop
-                or ExifOrientationMode.RightTop
-                or ExifOrientationMode.RightBottom
-                or ExifOrientationMode.LeftBottom => true,
+            ExifOrientationMode.LeftTop or ExifOrientationMode.RightTop or ExifOrientationMode.RightBottom or ExifOrientationMode.LeftBottom => true,
             _ => false,
         };
 
-    private static ushort GetExifOrientation(IImageInfo imageInfo)
+    private static ushort GetExifOrientation(ImageInfo imageInfo)
     {
-        IExifValue<ushort>? orientation = imageInfo.Metadata.ExifProfile?.GetValue(ExifTag.Orientation);
-        if (orientation is not null)
+        if (imageInfo.Metadata.ExifProfile?.TryGetValue(ExifTag.Orientation, out IExifValue<ushort>? orientation) == true)
         {
             if (orientation.DataType == ExifDataType.Short)
             {

--- a/src/Umbraco.Cms.Imaging.ImageSharp/Media/ImageSharpImageUrlGenerator.cs
+++ b/src/Umbraco.Cms.Imaging.ImageSharp/Media/ImageSharpImageUrlGenerator.cs
@@ -1,7 +1,6 @@
 using System.Globalization;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Primitives;
-using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Web.Processors;
 using Umbraco.Cms.Core.Media;
 using Umbraco.Cms.Core.Models;

--- a/src/Umbraco.Cms.Imaging.ImageSharp/Umbraco.Cms.Imaging.ImageSharp.csproj
+++ b/src/Umbraco.Cms.Imaging.ImageSharp/Umbraco.Cms.Imaging.ImageSharp.csproj
@@ -2,13 +2,12 @@
   <PropertyGroup>
     <Title>Umbraco CMS - Imaging - ImageSharp</Title>
     <Description>Adds imaging support using ImageSharp/ImageSharp.Web to Umbraco CMS.</Description>
-    <!-- TODO: Enable when final version is shipped (because there's currently no previous version) -->
-    <EnablePackageValidation>false</EnablePackageValidation>
+    <EnablePackageValidation>true</EnablePackageValidation>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
-    <PackageReference Include="SixLabors.ImageSharp.Web" Version="2.0.2" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
+    <PackageReference Include="SixLabors.ImageSharp.Web" Version="3.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Umbraco.Cms.Imaging.ImageSharp/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Imaging.ImageSharp/UmbracoBuilderExtensions.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Web.Caching;
 using SixLabors.ImageSharp.Web.DependencyInjection;
 using SixLabors.ImageSharp.Web.Middleware;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
With [ImageSharp 3.0.0](https://sixlabors.com/posts/announcing-imagesharp-300/) and [ImageSharp.Web 3.0.0](https://sixlabors.com/posts/announcing-imagesharp-web-300/) being released in the last months, we can now bump our dependency versions for the next CMS v12 major, ensuring we use the latest versions on release.

Because the ImageSharp dependency has been decoupled in v11 (see PR https://github.com/umbraco/Umbraco-CMS/pull/12907) and there's no binary breaking changes in `Umbraco.Cms.Imaging.ImageSharp`, you _should_ still be able to use the v11 version (with a dependency on ImageSharp v2) on v12. I don't see a great reason for requiring this, because even with the new [Six Labors Split License](https://sixlabors.com/posts/license-changes/), as a transitive package dependency it will be licensed under the open source Apache License. And if you do have a direct dependency in your own code (e.g. because you're doing custom processing) and meet the other conditions, I'd recommend supporting the awesome work and purchase the [Six Labors Commercial Use License](https://sixlabors.com/pricing/) instead.

Testing this is quite straight forward: all the tests should pass and requesting an image with ImageSharp commands (e.g. media thumbnails within the back-office that add a `?width=500`) should still work.