### PR TITLE
V11: prevent currentuser resetting password without old password

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/CurrentUserController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/CurrentUserController.cs
@@ -278,7 +278,7 @@ public class CurrentUserController : UmbracoAuthorizedJsonController
         // all current users have access to reset/manually change their password
 
         Attempt<PasswordChangedModel?> passwordChangeResult =
-            await _passwordChanger.ChangePasswordWithIdentityAsync(changingPasswordModel, _backOfficeUserManager);
+            await _passwordChanger.ChangePasswordWithIdentityAsync(changingPasswordModel, _backOfficeUserManager, currentUser);
 
         if (passwordChangeResult.Success)
         {

--- a/src/Umbraco.Web.BackOffice/Controllers/MemberController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MemberController.cs
@@ -623,7 +623,7 @@ public class MemberController : ContentControllerBase
 
             // Change and persist the password
             Attempt<PasswordChangedModel?> passwordChangeResult =
-                await _passwordChanger.ChangePasswordWithIdentityAsync(changingPasswordModel, _memberManager);
+                await _passwordChanger.ChangePasswordWithIdentityAsync(changingPasswordModel, _memberManager, _backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser);
 
             if (!passwordChangeResult.Success)
             {

--- a/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
@@ -759,7 +759,7 @@ public class UsersController : BackOfficeNotificationsController
         }
 
         Attempt<PasswordChangedModel?> passwordChangeResult =
-            await _passwordChanger.ChangePasswordWithIdentityAsync(changingPasswordModel, _userManager);
+            await _passwordChanger.ChangePasswordWithIdentityAsync(changingPasswordModel, _userManager, currentUser);
 
         if (passwordChangeResult.Success)
         {

--- a/src/Umbraco.Web.BackOffice/Security/IPasswordChanger.cs
+++ b/src/Umbraco.Web.BackOffice/Security/IPasswordChanger.cs
@@ -15,5 +15,5 @@ public interface IPasswordChanger<TUser> where TUser : UmbracoIdentityUser
     public Task<Attempt<PasswordChangedModel?>> ChangePasswordWithIdentityAsync(
         ChangingPasswordModel passwordModel,
         IUmbracoUserManager<TUser> userMgr,
-        IUser? currentUser);
+        IUser? currentUser) => ChangePasswordWithIdentityAsync(passwordModel, userMgr);
 }

--- a/src/Umbraco.Web.BackOffice/Security/IPasswordChanger.cs
+++ b/src/Umbraco.Web.BackOffice/Security/IPasswordChanger.cs
@@ -1,12 +1,19 @@
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Security;
 
 namespace Umbraco.Cms.Web.Common.Security;
 
 public interface IPasswordChanger<TUser> where TUser : UmbracoIdentityUser
 {
+    [Obsolete("Please use method that also takes a nullable IUser, scheduled for removal in v13")]
     public Task<Attempt<PasswordChangedModel?>> ChangePasswordWithIdentityAsync(
         ChangingPasswordModel passwordModel,
         IUmbracoUserManager<TUser> userMgr);
+
+    public Task<Attempt<PasswordChangedModel?>> ChangePasswordWithIdentityAsync(
+        ChangingPasswordModel passwordModel,
+        IUmbracoUserManager<TUser> userMgr,
+        IUser? currentUser);
 }

--- a/src/Umbraco.Web.BackOffice/Security/PasswordChanger.cs
+++ b/src/Umbraco.Web.BackOffice/Security/PasswordChanger.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Extensions;
 
@@ -22,16 +23,20 @@ internal class PasswordChanger<TUser> : IPasswordChanger<TUser> where TUser : Um
     /// <param name="logger">Logger for this class</param>
     public PasswordChanger(ILogger<PasswordChanger<TUser>> logger) => _logger = logger;
 
+    public Task<Attempt<PasswordChangedModel?>> ChangePasswordWithIdentityAsync(ChangingPasswordModel passwordModel, IUmbracoUserManager<TUser> userMgr) => ChangePasswordWithIdentityAsync(passwordModel, userMgr, null);
+
     /// <summary>
     ///     Changes the password for a user based on the many different rules and config options
     /// </summary>
-    /// <param name="changingPasswordModel">The changing password model</param>
-    /// <param name="userMgr">The identity manager to use to update the password</param>
+    /// <param name="changingPasswordModel">The changing password model.</param>
+    /// <param name="userMgr">The identity manager to use to update the password.</param>
+    /// <param name="currentUser">The user performing the operation.</param>
     /// Create an adapter to pass through everything - adapting the member into a user for this functionality
     /// <returns>The outcome of the password changed model</returns>
     public async Task<Attempt<PasswordChangedModel?>> ChangePasswordWithIdentityAsync(
         ChangingPasswordModel changingPasswordModel,
-        IUmbracoUserManager<TUser> userMgr)
+        IUmbracoUserManager<TUser> userMgr,
+        IUser? currentUser)
     {
         if (changingPasswordModel == null)
         {
@@ -65,6 +70,14 @@ internal class PasswordChanger<TUser> : IPasswordChanger<TUser> where TUser : Um
         // Are we just changing another user/member's password?
         if (changingPasswordModel.OldPassword.IsNullOrWhiteSpace())
         {
+            if (changingPasswordModel.Id == currentUser?.Id)
+            {
+                return Attempt.Fail(new PasswordChangedModel
+                {
+                    ChangeError = new ValidationResult("Cannot change the password of current user without the old password", new[] { "value" }),
+                });
+            }
+
             // ok, we should be able to reset it
             var resetToken = await userMgr.GeneratePasswordResetTokenAsync(identityUser);
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.BackOffice/Controllers/MemberControllerUnitTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.BackOffice/Controllers/MemberControllerUnitTests.cs
@@ -359,7 +359,8 @@ public class MemberControllerUnitTests
             Mock.Get(passwordChanger)
                 .Setup(x => x.ChangePasswordWithIdentityAsync(
                     It.IsAny<ChangingPasswordModel>(),
-                    umbracoMembersUserManager))
+                    umbracoMembersUserManager,
+                    null))
                 .ReturnsAsync(() => attempt);
         }
         else
@@ -368,7 +369,8 @@ public class MemberControllerUnitTests
             Mock.Get(passwordChanger)
                 .Setup(x => x.ChangePasswordWithIdentityAsync(
                     It.IsAny<ChangingPasswordModel>(),
-                    umbracoMembersUserManager))
+                    umbracoMembersUserManager,
+                    null))
                 .ReturnsAsync(() => attempt);
         }
     }


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/13942

# Notes
- Checks when we have no `OldPassword` if we're changing the current users password
This will prevent people hijacking backoffice users sessions, and then changing their password

# How to test
- Follow steps in issue 🙌 