### PR TITLE
V8: Encode imagepath to handle special characters

### DIFF
--- a/src/Umbraco.Web/Editors/ImagesController.cs
+++ b/src/Umbraco.Web/Editors/ImagesController.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Web;
 using Umbraco.Core.Composing;
 using Umbraco.Core.Configuration.UmbracoSettings;
 using Umbraco.Core.IO;
@@ -58,10 +59,14 @@ namespace Umbraco.Web.Editors
         /// </remarks>
         public HttpResponseMessage GetResized(string imagePath, int width)
         {
+            // We have to use HttpUtility to encode the path here, for non-ASCII characters
+            // We cannot use the WebUtility, as we only want to encode the path, and not the entire string
+            var encodedImagePath = HttpUtility.UrlPathEncode(imagePath);
+
             var ext = Path.GetExtension(imagePath);
 
             // check if imagePath is local to prevent open redirect
-            if (!IsAllowed(imagePath))
+            if (!IsAllowed(encodedImagePath))
             {
                 return Request.CreateResponse(HttpStatusCode.Unauthorized);
             }
@@ -87,24 +92,24 @@ namespace Umbraco.Web.Editors
             }
 
             var rnd = imageLastModified.HasValue ? $"&rnd={imageLastModified:yyyyMMddHHmmss}" : null;
-            var imageUrl = _imageUrlGenerator.GetImageUrl(new ImageUrlGenerationOptions(imagePath) { UpScale = false, Width = width, AnimationProcessMode = "first", ImageCropMode = "max", CacheBusterValue = rnd });
+            var imageUrl = _imageUrlGenerator.GetImageUrl(new ImageUrlGenerationOptions(encodedImagePath) { UpScale = false, Width = width, AnimationProcessMode = "first", ImageCropMode = "max", CacheBusterValue = rnd });
 
             var response = Request.CreateResponse(HttpStatusCode.Found);
             response.Headers.Location = new Uri(imageUrl, UriKind.RelativeOrAbsolute);
             return response;
         }
 
-        private bool IsAllowed(string imagePath)
+        private bool IsAllowed(string encodedImagePath)
         {
 
-            if(Uri.IsWellFormedUriString(WebUtility.UrlEncode(imagePath), UriKind.Relative))
+            if(Uri.IsWellFormedUriString(encodedImagePath, UriKind.Relative))
             {
                 return true;
             }
 
             if (_contentSection is ContentElement contentElement)
             {
-                var builder = new UriBuilder(imagePath);
+                var builder = new UriBuilder(encodedImagePath);
 
                 foreach (var allowedMediaHost in contentElement.AllowedMediaHosts)
                 {

--- a/src/Umbraco.Web/Editors/ImagesController.cs
+++ b/src/Umbraco.Web/Editors/ImagesController.cs
@@ -96,7 +96,8 @@ namespace Umbraco.Web.Editors
 
         private bool IsAllowed(string imagePath)
         {
-            if(Uri.IsWellFormedUriString(imagePath, UriKind.Relative))
+
+            if(Uri.IsWellFormedUriString(WebUtility.UrlEncode(imagePath), UriKind.Relative))
             {
                 return true;
             }


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/14056
 
# Notes
- The image path was missing encoding, as we had in other versions
- Added the missing encoding of image path

# How to test
- Upload a media file with a special character in the filename like `è`
- Try to pick it with a media picker, this should now display the thumbnail 👍 