### PR TITLE
Cherry-Pick #14148 Fixing BlockGrid Editor With Deleted Element Type

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbBlockGridPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbBlockGridPropertyEditor.component.js
@@ -382,7 +382,7 @@
 
 
                 const contextColumns = getContextColumns(parentBlock, areaKey);
-                const relevantColumnSpanOptions = block.config.columnSpanOptions.filter(option => option.columnSpan <= contextColumns);
+                const relevantColumnSpanOptions = block.config.columnSpanOptions?.filter(option => option.columnSpan <= contextColumns) ?? [];
 
                 // if no columnSpan or no columnSpanOptions configured, then we set(or rewrite) one:
                 if (!layoutEntry.columnSpan || layoutEntry.columnSpan > contextColumns || relevantColumnSpanOptions.length === 0) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbblockgridentry.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbblockgridentry.component.js
@@ -147,7 +147,7 @@
 
             vm.layoutColumnsInt = parseInt(vm.layoutColumns, 10);
 
-            vm.relevantColumnSpanOptions = vm.layoutEntry.$block.config.columnSpanOptions.filter(x => x.columnSpan <= vm.layoutColumnsInt).sort((a,b) => (a.columnSpan > b.columnSpan) ? 1 : ((b.columnSpan > a.columnSpan) ? -1 : 0));
+            vm.relevantColumnSpanOptions = vm.layoutEntry.$block.config.columnSpanOptions ? vm.layoutEntry.$block.config.columnSpanOptions.filter(x => x.columnSpan <= vm.layoutColumnsInt).sort((a,b) => (a.columnSpan > b.columnSpan) ? 1 : ((b.columnSpan > a.columnSpan) ? -1 : 0)) : [];
             const hasRelevantColumnSpanOptions = vm.relevantColumnSpanOptions.length > 1;
             const hasRowSpanOptions = vm.layoutEntry.$block.config.rowMinSpan && vm.layoutEntry.$block.config.rowMaxSpan && vm.layoutEntry.$block.config.rowMaxSpan !== vm.layoutEntry.$block.config.rowMinSpan;
             vm.canScale = (hasRelevantColumnSpanOptions || hasRowSpanOptions);


### PR DESCRIPTION
This PR fixes #14161 

If a block is removed from the block grid configuration the back office view would break, interesting this was already fixed in #14148, however for some reason the changes seem to be missing from V10, so this PR cherry picks that PR into v10/dev


## Testing

Follow the steps in the issue, check out this branch, rebuild, issue no longer occurs 
