### PR TITLE
Changed so we are checking if the FolderExits

### DIFF
--- a/src/Umbraco.Core/Services/StylesheetService.cs
+++ b/src/Umbraco.Core/Services/StylesheetService.cs
@@ -103,7 +103,7 @@ public class StylesheetService : FileServiceBase<IStylesheetRepository, IStylesh
         }
 
         if (string.IsNullOrWhiteSpace(createModel.ParentPath) is false
-           && Repository.Exists(createModel.ParentPath) is false)
+            && Repository.FolderExists(createModel.ParentPath) is false)
         {
             return StylesheetOperationStatus.ParentNotFound;
         }


### PR DESCRIPTION
Before we werent able to add a Stylesheet to a folder because it didnt check if the folder existed. We are now checking if the Folder actually exists. 

