### PR TITLE
Updated API version package and moved attribute to each controller

### DIFF
--- a/src/Umbraco.Cms.Api.Common/Configuration/ConfigureApiExplorerOptions.cs
+++ b/src/Umbraco.Cms.Api.Common/Configuration/ConfigureApiExplorerOptions.cs
@@ -1,6 +1,5 @@
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ApiExplorer;
-using Microsoft.AspNetCore.Mvc.Versioning;
+using Asp.Versioning;
+using Asp.Versioning.ApiExplorer;
 using Microsoft.Extensions.Options;
 
 namespace Umbraco.Cms.Api.Common.Configuration;

--- a/src/Umbraco.Cms.Api.Common/Configuration/ConfigureApiVersioningOptions.cs
+++ b/src/Umbraco.Cms.Api.Common/Configuration/ConfigureApiVersioningOptions.cs
@@ -1,5 +1,5 @@
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Versioning;
+
+using Asp.Versioning;
 using Microsoft.Extensions.Options;
 
 namespace Umbraco.Cms.Api.Common.Configuration;
@@ -13,6 +13,5 @@ public class ConfigureApiVersioningOptions : IConfigureOptions<ApiVersioningOpti
         options.ApiVersionReader = new UrlSegmentApiVersionReader();
         options.ApiVersionSelector = new CurrentImplementationApiVersionSelector(options);
         options.AssumeDefaultVersionWhenUnspecified = true; // This is required for the old backoffice to work
-        options.UseApiBehavior = false;
     }
 }

--- a/src/Umbraco.Cms.Api.Common/Configuration/ConfigureUmbracoSwaggerGenOptions.cs
+++ b/src/Umbraco.Cms.Api.Common/Configuration/ConfigureUmbracoSwaggerGenOptions.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Umbraco.Cms.Api.Common.OpenApi;
+using Umbraco.Cms.Core.Models.DeliveryApi;
 using Umbraco.Extensions;
 using OperationIdRegexes = Umbraco.Cms.Api.Common.OpenApi.OperationIdRegexes;
 
@@ -55,8 +56,15 @@ public class ConfigureUmbracoSwaggerGenOptions : IConfigureOptions<SwaggerGenOpt
         swaggerGenOptions.SupportNonNullableReferenceTypes();
         swaggerGenOptions.UseOneOfForPolymorphism();
         swaggerGenOptions.UseAllOfForInheritance();
+        var cachedApiElementNamespace = typeof(ApiElement).Namespace ?? string.Empty;
         swaggerGenOptions.SelectDiscriminatorNameUsing(type =>
         {
+            if (type.Namespace != null && type.Namespace.StartsWith(cachedApiElementNamespace))
+            {
+                // We do not show type on delivery, as it is read only.
+                return null;
+            }
+
             if (type.GetInterfaces().Any())
             {
                 return "$type";

--- a/src/Umbraco.Cms.Api.Common/Configuration/ConfigureUmbracoSwaggerGenOptions.cs
+++ b/src/Umbraco.Cms.Api.Common/Configuration/ConfigureUmbracoSwaggerGenOptions.cs
@@ -1,7 +1,6 @@
-using Microsoft.AspNetCore.Mvc;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Controllers;
-using Microsoft.AspNetCore.Mvc.Versioning;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;

--- a/src/Umbraco.Cms.Api.Common/DependencyInjection/UmbracoBuilderApiExtensions.cs
+++ b/src/Umbraco.Cms.Api.Common/DependencyInjection/UmbracoBuilderApiExtensions.cs
@@ -23,9 +23,8 @@ public static class UmbracoBuilderApiExtensions
     public static IUmbracoBuilder AddUmbracoApiOpenApiUI(this IUmbracoBuilder builder)
     {
         builder.Services.ConfigureOptions<ConfigureApiVersioningOptions>();
-        builder.Services.AddApiVersioning();
         builder.Services.ConfigureOptions<ConfigureApiExplorerOptions>();
-        builder.Services.AddVersionedApiExplorer();
+        builder.Services.AddApiVersioning().AddApiExplorer();
 
         builder.Services.AddSwaggerGen();
         builder.Services.ConfigureOptions<ConfigureUmbracoSwaggerGenOptions>();

--- a/src/Umbraco.Cms.Api.Common/Extensions/MethodInfoApiCommonExtensions.cs
+++ b/src/Umbraco.Cms.Api.Common/Extensions/MethodInfoApiCommonExtensions.cs
@@ -1,5 +1,5 @@
 using System.Reflection;
-using Microsoft.AspNetCore.Mvc;
+using Asp.Versioning;
 using Umbraco.Cms.Api.Common.Attributes;
 using Umbraco.Cms.Api.Common.Configuration;
 

--- a/src/Umbraco.Cms.Api.Common/Umbraco.Cms.Api.Common.csproj
+++ b/src/Umbraco.Cms.Api.Common/Umbraco.Cms.Api.Common.csproj
@@ -9,13 +9,13 @@
   </PropertyGroup>
   <ItemGroup>
 <!--    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.8" />-->
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
+    <PackageReference Include="Asp.Versioning.Mvc" Version="7.0.0" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Umbraco.Core\Umbraco.Core.csproj" />
     <ProjectReference Include="..\Umbraco.Web.Common\Umbraco.Web.Common.csproj" />
-    
+
   </ItemGroup>
 </Project>

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/ByIdContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/ByIdContentApiController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.DeliveryApi;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Delivery.Controllers;
 
+[ApiVersion("1.0")]
 public class ByIdContentApiController : ContentApiItemControllerBase
 {
     public ByIdContentApiController(

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/ByRouteContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/ByRouteContentApiController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.DeliveryApi;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Delivery.Controllers;
 
+[ApiVersion("1.0")]
 public class ByRouteContentApiController : ContentApiItemControllerBase
 {
     private readonly IRequestRoutingService _requestRoutingService;

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/DeliveryApiControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/DeliveryApiControllerBase.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Attributes;
 using Umbraco.Cms.Api.Common.Filters;
@@ -8,7 +9,6 @@ using Umbraco.Cms.Core;
 namespace Umbraco.Cms.Api.Delivery.Controllers;
 
 [ApiController]
-[ApiVersion("1.0")]
 [DeliveryApiAccess]
 [JsonOptionsName(Constants.JsonOptionsNames.DeliveryApi)]
 [LocalizeFromAcceptLanguageHeader]

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/QueryContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/QueryContentApiController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -8,6 +9,7 @@ using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Delivery.Controllers;
 
+[ApiVersion("1.0")]
 public class QueryContentApiController : ContentApiControllerBase
 {
     private readonly IApiContentQueryService _apiContentQueryService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/AuditLog/AuditLogControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/AuditLog/AuditLogControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.AuditLog;
@@ -6,7 +7,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.AuditLog;
 [ApiController]
 [VersionedApiBackOfficeRoute("audit-log")]
 [ApiExplorerSettings(GroupName = "Audit Log")]
-[ApiVersion("1.0")]
 public class AuditLogControllerBase : ManagementApiControllerBase
 {
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/AuditLog/ByKeyAuditLogController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/AuditLog/ByKeyAuditLogController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.Factories;
@@ -10,6 +11,7 @@ using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Management.Controllers.AuditLog;
 
+[ApiVersion("1.0")]
 public class ByKeyAuditLogController : AuditLogControllerBase
 {
     private readonly IAuditService _auditService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/AuditLog/ByTypeAuditLogController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/AuditLog/ByTypeAuditLogController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.Factories;
@@ -8,6 +9,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.AuditLog;
 
+[ApiVersion("1.0")]
 public class ByTypeAuditLogController : AuditLogControllerBase
 {
     private readonly IAuditService _auditService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/AuditLog/CurrentUserAuditLogController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/AuditLog/CurrentUserAuditLogController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.Factories;
@@ -9,11 +10,11 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Management.Controllers.AuditLog;
 
+[ApiVersion("1.0")]
 public class CurrentUserAuditLogController : AuditLogControllerBase
 {
     private readonly IAuditService _auditService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Culture/AllCultureController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Culture/AllCultureController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Mapping;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Culture;
 
+[ApiVersion("1.0")]
 public class AllCultureController : CultureControllerBase
 {
     private readonly IUmbracoMapper _umbracoMapper;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Culture/CultureControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Culture/CultureControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Culture;
@@ -6,7 +7,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.Culture;
 [ApiController]
 [VersionedApiBackOfficeRoute("culture")]
 [ApiExplorerSettings(GroupName = "Culture")]
-[ApiVersion("1.0")]
 public abstract class CultureControllerBase : ManagementApiControllerBase
 {
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/ByKeyDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/ByKeyDataTypeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.DataType;
 using Umbraco.Cms.Core.Mapping;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType;
 
+[ApiVersion("1.0")]
 public class ByKeyDataTypeController : DataTypeControllerBase
 {
     private readonly IDataTypeService _dataTypeService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/CopyDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/CopyDataTypeController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.DataType;
@@ -9,6 +10,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType;
 
+[ApiVersion("1.0")]
 public class CopyDataTypeController : DataTypeControllerBase
 {
     private readonly IDataTypeService _dataTypeService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/CreateDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/CreateDataTypeController.cs
@@ -1,9 +1,9 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.DataType;
 using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
@@ -11,6 +11,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType;
 
+[ApiVersion("1.0")]
 public class CreateDataTypeController : DataTypeControllerBase
 {
     private readonly IDataTypeService _dataTypeService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/DataTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/DataTypeControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
@@ -10,7 +11,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.DataType;
 [ApiController]
 [VersionedApiBackOfficeRoute(Constants.UdiEntityType.DataType)]
 [ApiExplorerSettings(GroupName = "Data Type")]
-[ApiVersion("1.0")]
 public abstract class DataTypeControllerBase : ManagementApiControllerBase
 {
     protected IActionResult DataTypeOperationStatusResult(DataTypeOperationStatus status) =>

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/DeleteDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/DeleteDataTypeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
@@ -8,6 +9,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType;
 
+[ApiVersion("1.0")]
 public class DeleteDataTypeController : DataTypeControllerBase
 {
     private readonly IDataTypeService _dataTypeService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/ByKeyDataTypeFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/ByKeyDataTypeFolderController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Folder;
 using Umbraco.Cms.Core.Security;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType.Folder;
 
+[ApiVersion("1.0")]
 public class ByKeyDataTypeFolderController : DataTypeFolderControllerBase
 {
     public ByKeyDataTypeFolderController(IBackOfficeSecurityAccessor backOfficeSecurityAccessor, IDataTypeContainerService dataTypeContainerService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/CreateDataTypeFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/CreateDataTypeFolderController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Folder;
 using Umbraco.Cms.Core.Security;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType.Folder;
 
+[ApiVersion("1.0")]
 public class CreateDataTypeFolderController : DataTypeFolderControllerBase
 {
     public CreateDataTypeFolderController(IBackOfficeSecurityAccessor backOfficeSecurityAccessor, IDataTypeContainerService dataTypeContainerService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DataTypeFolderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DataTypeFolderControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
@@ -10,7 +11,6 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType.Folder;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.DataType}/folder")]
 [ApiExplorerSettings(GroupName = "Data Type")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DeleteDataTypeFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DeleteDataTypeFolderController.cs
@@ -1,11 +1,12 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Management.ViewModels.Folder;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType.Folder;
 
+[ApiVersion("1.0")]
 public class DeleteDataTypeFolderController : DataTypeFolderControllerBase
 {
     public DeleteDataTypeFolderController(IBackOfficeSecurityAccessor backOfficeSecurityAccessor, IDataTypeContainerService dataTypeContainerService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/UpdateDataTypeFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/UpdateDataTypeFolderController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Folder;
 using Umbraco.Cms.Core.Security;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType.Folder;
 
+[ApiVersion("1.0")]
 public class UpdateDataTypeFolderController : DataTypeFolderControllerBase
 {
     public UpdateDataTypeFolderController(IBackOfficeSecurityAccessor backOfficeSecurityAccessor, IDataTypeContainerService dataTypeContainerService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/IsUsedDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/IsUsedDataTypeController.cs
@@ -1,14 +1,13 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Management.ViewModels.DataType;
 using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Mapping;
-using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType;
 
+[ApiVersion("1.0")]
 public class IsUsedDataTypeController : DataTypeControllerBase
 {
     private readonly IDataTypeUsageService _dataTypeUsageService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Items/ItemDatatypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Items/ItemDatatypeItemController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.DataType.Item;
 using Umbraco.Cms.Core.Mapping;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType.Items;
 
+[ApiVersion("1.0")]
 public class ItemDatatypeItemController : DatatypeItemControllerBase
 {
     private readonly IDataTypeService _dataTypeService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/MoveDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/MoveDataTypeController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.DataType;
@@ -9,6 +10,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType;
 
+[ApiVersion("1.0")]
 public class MoveDataTypeController : DataTypeControllerBase
 {
     private readonly IDataTypeService _dataTypeService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/ReferencesDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/ReferencesDataTypeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.DataType;
@@ -8,6 +9,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType;
 
+[ApiVersion("1.0")]
 public class ReferencesDataTypeController : DataTypeControllerBase
 {
     private readonly IDataTypeService _dataTypeService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Tree/ChildrenDataTypeTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Tree/ChildrenDataTypeTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType.Tree;
 
+[ApiVersion("1.0")]
 public class ChildrenDataTypeTreeController : DataTypeTreeControllerBase
 {
     public ChildrenDataTypeTreeController(IEntityService entityService, IDataTypeService dataTypeService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Tree/DataTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Tree/DataTypeTreeControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
@@ -9,7 +10,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType.Tree;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.DataType}")]
 [ApiExplorerSettings(GroupName = "Data Type")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Tree/RootDataTypeTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Tree/RootDataTypeTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType.Tree;
 
+[ApiVersion("1.0")]
 public class RootDataTypeTreeController : DataTypeTreeControllerBase
 {
     public RootDataTypeTreeController(IEntityService entityService, IDataTypeService dataTypeService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/UpdateDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/UpdateDataTypeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.DataType;
@@ -10,6 +11,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType;
 
+[ApiVersion("1.0")]
 public class UpdateDataTypeController : DataTypeControllerBase
 {
     private readonly IDataTypeService _dataTypeService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/AllDictionaryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/AllDictionaryController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
@@ -9,6 +10,7 @@ using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Dictionary;
 
+[ApiVersion("1.0")]
 public class AllDictionaryController : DictionaryControllerBase
 {
     private readonly IDictionaryItemService _dictionaryItemService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/ByKeyDictionaryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/ByKeyDictionaryController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Core.Models;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Dictionary;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Dictionary;
 
+[ApiVersion("1.0")]
 public class ByKeyDictionaryController : DictionaryControllerBase
 {
     private readonly IDictionaryItemService _dictionaryItemService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/CreateDictionaryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/CreateDictionaryController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Core.Models;
@@ -10,6 +11,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Dictionary;
 
+[ApiVersion("1.0")]
 public class CreateDictionaryController : DictionaryControllerBase
 {
     private readonly IDictionaryItemService _dictionaryItemService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/DeleteDictionaryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/DeleteDictionaryController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
@@ -8,6 +9,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Dictionary;
 
+[ApiVersion("1.0")]
 public class DeleteDictionaryController : DictionaryControllerBase
 {
     private readonly IDictionaryItemService _dictionaryItemService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/DictionaryControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/DictionaryControllerBase.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
@@ -9,7 +10,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.Dictionary;
 [ApiController]
 [VersionedApiBackOfficeRoute("dictionary")]
 [ApiExplorerSettings(GroupName = "Dictionary")]
-[ApiVersion("1.0")]
 // TODO: Add authentication
 public abstract class DictionaryControllerBase : ManagementApiControllerBase
 {

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/ExportDictionaryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/ExportDictionaryController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.Mime;
 using System.Text;
 using System.Xml.Linq;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Models;
@@ -9,6 +10,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Dictionary;
 
+[ApiVersion("1.0")]
 public class ExportDictionaryController : DictionaryControllerBase
 {
     private readonly IDictionaryItemService _dictionaryItemService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/ImportDictionaryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/ImportDictionaryController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Core.Models;
@@ -10,6 +11,7 @@ using Umbraco.Cms.Core.Security;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Dictionary;
 
+[ApiVersion("1.0")]
 public class ImportDictionaryController : DictionaryControllerBase
 {
     private readonly IDictionaryItemImportService _dictionaryItemImportService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Item/ItemDictionaryItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Item/ItemDictionaryItemController.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Management.ViewModels.DataType.Item;
 using Umbraco.Cms.Api.Management.ViewModels.Dictionary.Item;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
@@ -8,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Dictionary.Item;
 
+[ApiVersion("1.0")]
 public class ItemDictionaryItemController : DictionaryItemControllerBase
 {
     private readonly IDictionaryItemService _dictionaryItemService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/MoveDictionaryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/MoveDictionaryController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Dictionary;
 using Umbraco.Cms.Core;
@@ -9,6 +10,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Dictionary;
 
+[ApiVersion("1.0")]
 public class MoveDictionaryController : DictionaryControllerBase
 {
     private readonly IDictionaryItemService _dictionaryItemService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/ChildrenDictionaryTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/ChildrenDictionaryTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
@@ -8,6 +9,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Dictionary.Tree;
 
+[ApiVersion("1.0")]
 public class ChildrenDictionaryTreeController : DictionaryTreeControllerBase
 {
     public ChildrenDictionaryTreeController(IEntityService entityService, IDictionaryItemService dictionaryItemService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/DictionaryTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/DictionaryTreeControllerBase.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
@@ -8,7 +9,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Dictionary.Tree;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/dictionary")]
 [ApiExplorerSettings(GroupName = "Dictionary")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/RootDictionaryTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/RootDictionaryTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
@@ -8,6 +9,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Dictionary.Tree;
 
+[ApiVersion("1.0")]
 public class RootDictionaryTreeController : DictionaryTreeControllerBase
 {
     public RootDictionaryTreeController(IEntityService entityService, IDictionaryItemService dictionaryItemService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/UpdateDictionaryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/UpdateDictionaryController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Core.Models;
@@ -10,6 +11,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Dictionary;
 
+[ApiVersion("1.0")]
 public class UpdateDictionaryController : DictionaryControllerBase
 {
     private readonly IDictionaryItemService _dictionaryItemService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/ByKeyDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/ByKeyDocumentController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.Document;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document;
 
+[ApiVersion("1.0")]
 public class ByKeyDocumentController : DocumentControllerBase
 {
     private readonly IContentEditingService _contentEditingService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/CopyDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/CopyDocumentController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Document;
 using Umbraco.Cms.Core;
@@ -9,6 +10,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document;
 
+[ApiVersion("1.0")]
 public class CopyDocumentController : DocumentControllerBase
 {
     private readonly IContentEditingService _contentEditingService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/CreateDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/CreateDocumentController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.Document;
@@ -11,6 +12,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document;
 
+[ApiVersion("1.0")]
 public class CreateDocumentController : DocumentControllerBase
 {
     private readonly IContentEditingService _contentEditingService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/DocumentControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/DocumentControllerBase.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Content;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute(Constants.UdiEntityType.Document)]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Document))]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/DomainsController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/DomainsController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Document;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document;
 
+[ApiVersion("1.0")]
 public class DomainsController : DocumentControllerBase
 {
     private readonly IDomainService _domainService;
@@ -17,6 +19,7 @@ public class DomainsController : DocumentControllerBase
         _umbracoMapper = umbracoMapper;
     }
 
+    [MapToApiVersion("1.0")]
     [HttpGet("{id:guid}/domains")]
     public async Task<IActionResult> DomainsAsync(Guid id)
     {

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/DocumentItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/DocumentItemControllerBase.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document.Item;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute(Constants.UdiEntityType.Document)]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Document))]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/ItemDocumentItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/ItemDocumentItemController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.Services.Entities;
@@ -10,6 +11,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document.Item;
 
+[ApiVersion("1.0")]
 public class ItemDocumentItemController : DocumentItemControllerBase
 {
     private readonly IEntityService _entityService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/MoveDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/MoveDocumentController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Document;
 using Umbraco.Cms.Core;
@@ -9,6 +10,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document;
 
+[ApiVersion("1.0")]
 public class MoveDocumentController : DocumentControllerBase
 {
     private readonly IContentEditingService _contentEditingService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/MoveToRecycleBinDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/MoveToRecycleBinDocumentController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
@@ -8,6 +9,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document;
 
+[ApiVersion("1.0")]
 public class MoveToRecycleBinDocumentController : DocumentControllerBase
 {
     private readonly IContentEditingService _contentEditingService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/NotificationsController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/NotificationsController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.Document;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document;
 
+[ApiVersion("1.0")]
 public class NotificationsController : DocumentControllerBase
 {
     private readonly IContentEditingService _contentEditingService;
@@ -18,6 +20,7 @@ public class NotificationsController : DocumentControllerBase
         _documentNotificationPresentationFactory = documentNotificationPresentationFactory;
     }
 
+    [MapToApiVersion("1.0")]
     [HttpGet("{id:guid}/notifications")]
     [ProducesResponseType(typeof(IEnumerable<DocumentNotificationResponseModel>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/RecycleBin/ChildrenDocumentRecycleBinController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/RecycleBin/ChildrenDocumentRecycleBinController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.RecycleBin;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document.RecycleBin;
 
+[ApiVersion("1.0")]
 public class ChildrenDocumentRecycleBinController : DocumentRecycleBinControllerBase
 {
     public ChildrenDocumentRecycleBinController(IEntityService entityService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/RecycleBin/DocumentRecycleBinControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/RecycleBin/DocumentRecycleBinControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
@@ -11,7 +12,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document.RecycleBin;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.RecycleBin}/{Constants.UdiEntityType.Document}")]
 [RequireDocumentTreeRootAccess]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/RecycleBin/RootDocumentRecycleBinController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/RecycleBin/RootDocumentRecycleBinController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.RecycleBin;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document.RecycleBin;
 
+[ApiVersion("1.0")]
 public class RootDocumentRecycleBinController : DocumentRecycleBinControllerBase
 {
     public RootDocumentRecycleBinController(IEntityService entityService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/ChildrenDocumentTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/ChildrenDocumentTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Security;
@@ -9,6 +10,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document.Tree;
 
+[ApiVersion("1.0")]
 public class ChildrenDocumentTreeController : DocumentTreeControllerBase
 {
     public ChildrenDocumentTreeController(

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/DocumentTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/DocumentTreeControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
@@ -13,7 +14,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document.Tree;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.Document}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Document))]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/RootDocumentTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/RootDocumentTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Security;
@@ -9,6 +10,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document.Tree;
 
+[ApiVersion("1.0")]
 public class RootDocumentTreeController : DocumentTreeControllerBase
 {
     public RootDocumentTreeController(

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/UpdateDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/UpdateDocumentController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.Document;
@@ -11,6 +12,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document;
 
+[ApiVersion("1.0")]
 public class UpdateDocumentController : DocumentControllerBase
 {
     private readonly IContentEditingService _contentEditingService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/UpdateDomainsController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/UpdateDomainsController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.ViewModels.Document;
@@ -11,6 +12,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document;
 
+[ApiVersion("1.0")]
 public class UpdateDomainsController : DocumentControllerBase
 {
     private readonly IDomainService _domainService;
@@ -22,6 +24,7 @@ public class UpdateDomainsController : DocumentControllerBase
         _umbracoMapper = umbracoMapper;
     }
 
+    [MapToApiVersion("1.0")]
     [HttpPut("{id:guid}/domains")]
     public async Task<IActionResult> UpdateDomainsAsync(Guid id, UpdateDomainsRequestModel updateModel)
     {

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/UpdateNotificationsController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/UpdateNotificationsController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Document;
 using Umbraco.Cms.Core.Models;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document;
 
+[ApiVersion("1.0")]
 public class UpdateNotificationsController : DocumentControllerBase
 {
     private readonly IContentEditingService _contentEditingService;
@@ -20,6 +22,7 @@ public class UpdateNotificationsController : DocumentControllerBase
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
+    [MapToApiVersion("1.0")]
     [HttpPut("{id:guid}/notifications")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/Item/DocumentBlueprintItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/Item/DocumentBlueprintItemControllerBase.cs
@@ -4,7 +4,6 @@ using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint.Item;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.DocumentBlueprint}")]
 [ApiExplorerSettings(GroupName = "Document Blueprint")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/Item/ItemDocumentBlueprintController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/Item/ItemDocumentBlueprintController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.DocumentBlueprint.Item;
@@ -9,6 +10,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint.Item;
 
+[ApiVersion("1.0")]
 public class ItemDocumentBlueprintController : DocumentBlueprintItemControllerBase
 {
     private readonly IEntityService _entityService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/Tree/DocumentBlueprintTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/Tree/DocumentBlueprintTreeControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
@@ -9,7 +10,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint.Tree;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.DocumentBlueprint}")]
 [ApiExplorerSettings(GroupName = "Document Blueprint")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/Tree/RootDocumentBlueprintTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/Tree/RootDocumentBlueprintTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint.Tree;
 
+[ApiVersion("1.0")]
 public class RootDocumentBlueprintTreeController : DocumentBlueprintTreeControllerBase
 {
     public RootDocumentBlueprintTreeController(IEntityService entityService, IContentTypeService contentTypeService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/ByKeyDocumentTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/ByKeyDocumentTypeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.DocumentType;
 using Umbraco.Cms.Core.Mapping;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DocumentType;
 
+[ApiVersion("1.0")]
 public class ByKeyDocumentTypeController : DocumentTypeControllerBase
 {
     private readonly IContentTypeService _contentTypeService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/DocumentTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/DocumentTypeControllerBase.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DocumentType;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute(Constants.UdiEntityType.DocumentType)]
 [ApiExplorerSettings(GroupName = "Document Type")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Item/DocumentTypeItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Item/DocumentTypeItemControllerBase.cs
@@ -4,7 +4,6 @@ using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DocumentType.Item;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute(Constants.UdiEntityType.DocumentType)]
 [ApiExplorerSettings(GroupName = "Document Type")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Item/ItemDocumentTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Item/ItemDocumentTypeItemController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.DocumentType.Item;
 using Umbraco.Cms.Core.Mapping;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DocumentType.Item;
 
+[ApiVersion("1.0")]
 public class ItemDocumentTypeItemController : DocumentTypeItemControllerBase
 {
     private readonly IContentTypeService _contentTypeService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Tree/ChildrenDocumentTypeTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Tree/ChildrenDocumentTypeTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DocumentType.Tree;
 
+[ApiVersion("1.0")]
 public class ChildrenDocumentTypeTreeController : DocumentTypeTreeControllerBase
 {
     public ChildrenDocumentTypeTreeController(IEntityService entityService, IContentTypeService contentTypeService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Tree/DocumentTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Tree/DocumentTypeTreeControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
@@ -9,7 +10,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DocumentType.Tree;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.DocumentType}")]
 [ApiExplorerSettings(GroupName = "Document Type")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Tree/RootDocumentTypeTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Tree/RootDocumentTypeTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DocumentType.Tree;
 
+[ApiVersion("1.0")]
 public class RootDocumentTypeTreeController : DocumentTypeTreeControllerBase
 {
     public RootDocumentTypeTreeController(IEntityService entityService, IContentTypeService contentTypeService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/HealthCheck/ExecuteActionHealthCheckController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/HealthCheck/ExecuteActionHealthCheckController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -8,6 +9,7 @@ using Umbraco.Cms.Core.Mapping;
 
 namespace Umbraco.Cms.Api.Management.Controllers.HealthCheck;
 
+[ApiVersion("1.0")]
 public class ExecuteActionHealthCheckController : HealthCheckControllerBase
 {
     private readonly HealthCheckCollection _healthChecks;

--- a/src/Umbraco.Cms.Api.Management/Controllers/HealthCheck/Group/AllHealthCheckGroupController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/HealthCheck/Group/AllHealthCheckGroupController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Mapping;
 
 namespace Umbraco.Cms.Api.Management.Controllers.HealthCheck.Group;
 
+[ApiVersion("1.0")]
 public class AllHealthCheckGroupController : HealthCheckGroupControllerBase
 {
     private readonly IHealthCheckGroupPresentationFactory _healthCheckGroupPresentationFactory;

--- a/src/Umbraco.Cms.Api.Management/Controllers/HealthCheck/Group/ByNameHealthCheckGroupController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/HealthCheck/Group/ByNameHealthCheckGroupController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
@@ -7,6 +8,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.HealthCheck.Group;
 
+[ApiVersion("1.0")]
 public class ByNameHealthCheckGroupController : HealthCheckGroupControllerBase
 {
     private readonly IHealthCheckGroupPresentationFactory _healthCheckGroupPresentationFactory;

--- a/src/Umbraco.Cms.Api.Management/Controllers/HealthCheck/Group/CheckHealthCheckGroupController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/HealthCheck/Group/CheckHealthCheckGroupController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
@@ -6,6 +7,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.HealthCheck.Group;
 
+[ApiVersion("1.0")]
 public class CheckHealthCheckGroupController : HealthCheckGroupControllerBase
 {
     private readonly IHealthCheckGroupPresentationFactory _healthCheckGroupPresentationFactory;

--- a/src/Umbraco.Cms.Api.Management/Controllers/HealthCheck/Group/HealthCheckGroupControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/HealthCheck/Group/HealthCheckGroupControllerBase.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Constants = Umbraco.Cms.Core.Constants;
@@ -7,7 +8,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.HealthCheck.Group;
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.HealthChecks.RoutePath.HealthCheck}-group")]
 [ApiExplorerSettings(GroupName = "Health Check")]
-[ApiVersion("1.0")]
 public abstract class HealthCheckGroupControllerBase : ManagementApiControllerBase
 {
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/HealthCheck/HealthCheckControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/HealthCheck/HealthCheckControllerBase.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Constants = Umbraco.Cms.Core.Constants;
@@ -7,7 +8,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.HealthCheck;
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.HealthChecks.RoutePath.HealthCheck}")]
 [ApiExplorerSettings(GroupName = "Health Check")]
-[ApiVersion("1.0")]
 public abstract class HealthCheckControllerBase : ManagementApiControllerBase
 {
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Help/GetHelpController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Help/GetHelpController.cs
@@ -1,16 +1,17 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Api.Common.Builders;
-using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.Help;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Help;
 
+[ApiVersion("1.0")]
 public class GetHelpController : HelpControllerBase
 {
     private readonly ILogger<GetHelpController> _logger;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Help/HelpControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Help/HelpControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Help;
@@ -6,7 +7,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.Help;
 [ApiController]
 [VersionedApiBackOfficeRoute("help")]
 [ApiExplorerSettings(GroupName = "Help")]
-[ApiVersion("1.0")]
 public abstract class HelpControllerBase : ManagementApiControllerBase
 {
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Indexer/AllIndexerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Indexer/AllIndexerController.cs
@@ -1,4 +1,5 @@
-﻿using Examine;
+﻿using Asp.Versioning;
+using Examine;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Indexer/DetailsIndexerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Indexer/DetailsIndexerController.cs
@@ -1,4 +1,5 @@
-﻿using Examine;
+﻿using Asp.Versioning;
+using Examine;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Indexer/RebuildIndexerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Indexer/RebuildIndexerController.cs
@@ -1,4 +1,5 @@
-﻿using Examine;
+﻿using Asp.Versioning;
+using Examine;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Install/SettingsInstallController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Install/SettingsInstallController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Infrastructure.Install;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Install/SetupInstallController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Install/SetupInstallController.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Api.Management.ViewModels.Installer;
-using Umbraco.Extensions;
 using Umbraco.New.Cms.Core.Models.Installer;
 using Umbraco.New.Cms.Core.Services.Installer;
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Install/ValidateDatabaseInstallController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Install/ValidateDatabaseInstallController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Install.Models;
 using Umbraco.Cms.Core.Mapping;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Language/AllLanguageController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Language/AllLanguageController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.ViewModels.Language;
@@ -8,6 +9,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Language;
 
+[ApiVersion("1.0")]
 public class AllLanguageController : LanguageControllerBase
 {
     private readonly ILanguageService _languageService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Language/ByIsoCodeLanguageController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Language/ByIsoCodeLanguageController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Language;
 using Umbraco.Cms.Core.Mapping;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Language;
 
+[ApiVersion("1.0")]
 public class ByIsoCodeLanguageController : LanguageControllerBase
 {
     private readonly ILanguageService _languageService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Language/CreateLanguageController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Language/CreateLanguageController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Language;
 using Umbraco.Cms.Core;
@@ -10,6 +11,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Language;
 
+[ApiVersion("1.0")]
 public class CreateLanguageController : LanguageControllerBase
 {
     private readonly ILanguageService _languageService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Language/DeleteLanguageController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Language/DeleteLanguageController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
@@ -8,6 +9,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Language;
 
+[ApiVersion("1.0")]
 public class DeleteLanguageController : LanguageControllerBase
 {
     private readonly ILanguageService _languageService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Language/Item/ItemsLanguageEntityController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Language/Item/ItemsLanguageEntityController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Language.Item;
 using Umbraco.Cms.Core.Mapping;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Language.Item;
 
+[ApiVersion("1.0")]
 public class ItemsLanguageEntityController : LanguageEntityControllerBase
 {
     private readonly ILanguageService _languageService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Language/LanguageControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Language/LanguageControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
@@ -9,7 +10,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.Language;
 [ApiController]
 [VersionedApiBackOfficeRoute("language")]
 [ApiExplorerSettings(GroupName = "Language")]
-[ApiVersion("1.0")]
 public abstract class LanguageControllerBase : ManagementApiControllerBase
 {
     protected IActionResult LanguageOperationStatusResult(LanguageOperationStatus status) =>

--- a/src/Umbraco.Cms.Api.Management/Controllers/Language/UpdateLanguageController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Language/UpdateLanguageController.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.Language;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Mapping;
@@ -11,6 +11,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Language;
 
+[ApiVersion("1.0")]
 public class UpdateLanguageController : LanguageControllerBase
 {
     private readonly ILanguageService _languageService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/AllLogViewerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/AllLogViewerController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -12,6 +13,7 @@ using LogLevel = Umbraco.Cms.Core.Logging.LogLevel;
 
 namespace Umbraco.Cms.Api.Management.Controllers.LogViewer;
 
+[ApiVersion("1.0")]
 public class AllLogViewerController : LogViewerControllerBase
 {
     private readonly ILogViewerService _logViewerService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/AllMessageTemplateLogViewerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/AllMessageTemplateLogViewerController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -11,6 +12,7 @@ using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Management.Controllers.LogViewer;
 
+[ApiVersion("1.0")]
 public class AllMessageTemplateLogViewerController : LogViewerControllerBase
 {
     private readonly ILogViewerService _logViewerService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/AllSinkLevelLogViewerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/AllSinkLevelLogViewerController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -8,6 +9,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.LogViewer;
 
+[ApiVersion("1.0")]
 public class AllSinkLevelLogViewerController : LogViewerControllerBase
 {
     private readonly ILogViewerService _logViewerService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/LogLevelCountLogViewerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/LogLevelCountLogViewerController.cs
@@ -1,6 +1,6 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.ViewModels.LogViewer;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Logging.Viewer;
@@ -10,6 +10,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.LogViewer;
 
+[ApiVersion("1.0")]
 public class LogLevelCountLogViewerController : LogViewerControllerBase
 {
     private readonly ILogViewerService _logViewerService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/LogViewerControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/LogViewerControllerBase.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
@@ -9,7 +10,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.LogViewer;
 [ApiController]
 [VersionedApiBackOfficeRoute("log-viewer")]
 [ApiExplorerSettings(GroupName = "Log Viewer")]
-[ApiVersion("1.0")]
 public abstract class LogViewerControllerBase : ManagementApiControllerBase
 {
     protected IActionResult LogViewerOperationStatusResult(LogViewerOperationStatus status) =>

--- a/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/SavedSearch/AllSavedSearchLogViewerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/SavedSearch/AllSavedSearchLogViewerController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -9,6 +10,7 @@ using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Management.Controllers.LogViewer.SavedSearch;
 
+[ApiVersion("1.0")]
 public class AllSavedSearchLogViewerController : SavedSearchLogViewerControllerBase
 {
     private readonly ILogViewerService _logViewerService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/SavedSearch/ByNameSavedSearchLogViewerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/SavedSearch/ByNameSavedSearchLogViewerController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.LogViewer;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.LogViewer.SavedSearch;
 
+[ApiVersion("1.0")]
 public class ByNameSavedSearchLogViewerController : SavedSearchLogViewerControllerBase
 {
     private readonly ILogViewerService _logViewerService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/SavedSearch/CreateSavedSearchLogViewerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/SavedSearch/CreateSavedSearchLogViewerController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.LogViewer;
@@ -8,6 +9,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.LogViewer.SavedSearch;
 
+[ApiVersion("1.0")]
 public class CreateSavedSearchLogViewerController : SavedSearchLogViewerControllerBase
 {
     private readonly ILogViewerService _logViewerService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/SavedSearch/DeleteSavedSearchLogViewerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/SavedSearch/DeleteSavedSearchLogViewerController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.LogViewer.SavedSearch;
 
+[ApiVersion("1.0")]
 public class DeleteSavedSearchLogViewerController : SavedSearchLogViewerControllerBase
 {
     private readonly ILogViewerService _logViewerService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/SavedSearch/SavedSearchLogViewerControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/SavedSearch/SavedSearchLogViewerControllerBase.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 
@@ -6,7 +7,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.LogViewer.SavedSearch;
 [ApiController]
 [VersionedApiBackOfficeRoute("log-viewer/saved-search")]
 [ApiExplorerSettings(GroupName = "Log Viewer")]
-[ApiVersion("1.0")]
 public class SavedSearchLogViewerControllerBase : LogViewerControllerBase
 {
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/ValidateLogFileSizeLogViewerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/ValidateLogFileSizeLogViewerController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.LogViewer;
 
+[ApiVersion("1.0")]
 public class ValidateLogFileSizeLogViewerController : LogViewerControllerBase
 {
     private readonly ILogViewerService _logViewerService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/ByKeyMediaController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/ByKeyMediaController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.Document;
@@ -8,6 +9,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Media;
 
+[ApiVersion("1.0")]
 public class ByKeyMediaController : MediaControllerBase
 {
     private readonly IMediaEditingService _mediaEditingService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/CreateMediaController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/CreateMediaController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.Media;
@@ -11,6 +12,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Media;
 
+[ApiVersion("1.0")]
 public class CreateMediaController : MediaControllerBase
 {
     private readonly IMediaEditingService _mediaEditingService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/ItemMediaItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/ItemMediaItemController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Services.Entities;
 using Umbraco.Cms.Api.Management.ViewModels.Media.Item;
@@ -10,7 +11,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Media.Item;
 
-
+[ApiVersion("1.0")]
 public class ItemMediaItemController : MediaItemControllerBase
 {
     private readonly IEntityService _entityService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/MediaItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/MediaItemControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/MediaControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/MediaControllerBase.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Content;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Media;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute(Constants.UdiEntityType.Media)]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Media))]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/MoveMediaController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/MoveMediaController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Media;
 using Umbraco.Cms.Core;
@@ -9,6 +10,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Media;
 
+[ApiVersion("1.0")]
 public class MoveMediaController : MediaControllerBase
 {
     private readonly IMediaEditingService _mediaEditingService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/MoveToRecycleBinMediaController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/MoveToRecycleBinMediaController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
@@ -8,6 +9,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Media;
 
+[ApiVersion("1.0")]
 public class MoveToRecycleBinMediaController : MediaControllerBase
 {
     private readonly IMediaEditingService _mediaEditingService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/RecycleBin/ChildrenMediaRecycleBinController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/RecycleBin/ChildrenMediaRecycleBinController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.RecycleBin;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Media.RecycleBin;
 
+[ApiVersion("1.0")]
 public class ChildrenMediaRecycleBinController : MediaRecycleBinControllerBase
 {
     public ChildrenMediaRecycleBinController(IEntityService entityService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/RecycleBin/MediaRecycleBinControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/RecycleBin/MediaRecycleBinControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
@@ -11,7 +12,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Media.RecycleBin;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.RecycleBin}/{Constants.UdiEntityType.Media}")]
 [RequireMediaTreeRootAccess]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/RecycleBin/RootMediaRecycleBinController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/RecycleBin/RootMediaRecycleBinController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.RecycleBin;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Media.RecycleBin;
 
+[ApiVersion("1.0")]
 public class RootMediaRecycleBinController : MediaRecycleBinControllerBase
 {
     public RootMediaRecycleBinController(IEntityService entityService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Tree/ChildrenMediaTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Tree/ChildrenMediaTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Security;
@@ -9,6 +10,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Media.Tree;
 
+[ApiVersion("1.0")]
 public class ChildrenMediaTreeController : MediaTreeControllerBase
 {
     public ChildrenMediaTreeController(

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Tree/ItemsMediaTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Tree/ItemsMediaTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Security;
@@ -8,6 +9,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Media.Tree;
 
+[ApiVersion("1.0")]
 public class ItemsMediaTreeController : MediaTreeControllerBase
 {
     public ItemsMediaTreeController(

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Tree/MediaTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Tree/MediaTreeControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
@@ -13,7 +14,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Media.Tree;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.Media}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Media))]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Tree/RootMediaTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Tree/RootMediaTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Security;
@@ -9,6 +10,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Media.Tree;
 
+[ApiVersion("1.0")]
 public class RootMediaTreeController : MediaTreeControllerBase
 {
     public RootMediaTreeController(

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/UpdateMediaController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/UpdateMediaController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.Media;
@@ -11,6 +12,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Media;
 
+[ApiVersion("1.0")]
 public class UpdateMediaController : MediaControllerBase
 {
     private readonly IMediaEditingService _mediaEditingService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/ByKeyMediaTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/ByKeyMediaTypeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.MediaType;
 using Umbraco.Cms.Core.Mapping;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MediaType;
 
+[ApiVersion("1.0")]
 public class ByKeyMediaTypeController : MediaTypeControllerBase
 {
     private readonly IMediaTypeService _mediaTypeService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/ItemMediaTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/ItemMediaTypeItemController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.MediaType.Item;
 using Umbraco.Cms.Core.Mapping;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MediaType.Item;
 
+[ApiVersion("1.0")]
 public class ItemMediaTypeItemController : MediaTypeItemControllerBase
 {
     private readonly IMediaTypeService _mediaTypeService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/MediaTypeItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/MediaTypeItemControllerBase.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MediaType.Item;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute(Constants.UdiEntityType.MediaType)]
 [ApiExplorerSettings(GroupName = "Media Type")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/MediaTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/MediaTypeControllerBase.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MediaType;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute(Constants.UdiEntityType.MediaType)]
 [ApiExplorerSettings(GroupName = "Media Type")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Tree/ChildrenMediaTypeTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Tree/ChildrenMediaTypeTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MediaType.Tree;
 
+[ApiVersion("1.0")]
 public class ChildrenMediaTypeTreeController : MediaTypeTreeControllerBase
 {
     public ChildrenMediaTypeTreeController(IEntityService entityService, IMediaTypeService mediaTypeService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Tree/MediaTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Tree/MediaTypeTreeControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
@@ -9,7 +10,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MediaType.Tree;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.MediaType}")]
 [ApiExplorerSettings(GroupName = "Media Type")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Tree/RootMediaTypeTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Tree/RootMediaTypeTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MediaType.Tree;
 
+[ApiVersion("1.0")]
 public class RootMediaTypeTreeController : MediaTypeTreeControllerBase
 {
     public RootMediaTypeTreeController(IEntityService entityService, IMediaTypeService mediaTypeService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/Item/ItemMemberItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/Item/ItemMemberItemController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Member.Item;
 using Umbraco.Cms.Core.Mapping;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Member.Item;
 
+[ApiVersion("1.0")]
 public class ItemMemberItemController : MemberItemControllerBase
 {
     private readonly IMemberService _memberService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/Item/MemberItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/Item/MemberItemControllerBase.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Member.Item;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.Member}")]
 [ApiExplorerSettings(GroupName = "Member")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberGroup/Item/ItemMemberGroupItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberGroup/Item/ItemMemberGroupItemController.cs
@@ -1,4 +1,5 @@
-﻿using J2N.Collections.Generic.Extensions;
+﻿using Asp.Versioning;
+using J2N.Collections.Generic.Extensions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.MemberGroup.Item;
@@ -9,6 +10,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MemberGroup.Item;
 
+[ApiVersion("1.0")]
 public class ItemMemberGroupItemController : MemberGroupItemControllerBase
 {
     private readonly IEntityService _entityService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberGroup/Item/MemberGroupItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberGroup/Item/MemberGroupItemControllerBase.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MemberGroup.Item;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.MemberGroup}")]
 [ApiExplorerSettings(GroupName = "Member Group")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberGroup/Tree/MemberGroupTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberGroup/Tree/MemberGroupTreeControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
@@ -9,7 +10,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MemberGroup.Tree;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.MemberGroup}")]
 [ApiExplorerSettings(GroupName = "Member Group")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberGroup/Tree/RootMemberGroupTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberGroup/Tree/RootMemberGroupTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MemberGroup.Tree;
 
+[ApiVersion("1.0")]
 public class RootMemberGroupTreeController : MemberGroupTreeControllerBase
 {
     public RootMemberGroupTreeController(IEntityService entityService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Items/ItemMemberTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Items/ItemMemberTypeItemController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.MemberType.Items;
 using Umbraco.Cms.Core.Mapping;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MemberType.Items;
 
+[ApiVersion("1.0")]
 public class ItemMemberTypeItemController : MemberTypeItemControllerBase
 {
     private readonly IUmbracoMapper _mapper;

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Items/MemberTypeItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Items/MemberTypeItemControllerBase.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MemberType.Items;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.MemberType}")]
 [ApiExplorerSettings(GroupName = "Member Type")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Tree/MemberTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Tree/MemberTypeTreeControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
@@ -9,7 +10,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MemberType.Tree;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.MemberType}")]
 [ApiExplorerSettings(GroupName = "Member Type")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Tree/RootMemberTypeTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Tree/RootMemberTypeTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MemberType.Tree;
 
+[ApiVersion("1.0")]
 public class RootMemberTypeTreeController : MemberTypeTreeControllerBase
 {
     public RootMemberTypeTreeController(IEntityService entityService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/ModelsBuilder/BuildModelsBuilderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/ModelsBuilder/BuildModelsBuilderController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -10,6 +11,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.ModelsBuilder;
 
+[ApiVersion("1.0")]
 public class BuildModelsBuilderController : ModelsBuilderControllerBase
 {
     private ModelsBuilderSettings _modelsBuilderSettings;

--- a/src/Umbraco.Cms.Api.Management/Controllers/ModelsBuilder/GetModelsBuilderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/ModelsBuilder/GetModelsBuilderController.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.ModelsBuilderDashboard;
 
 namespace Umbraco.Cms.Api.Management.Controllers.ModelsBuilder;
 
+[ApiVersion("1.0")]
 public class GetModelsBuilderController : ModelsBuilderControllerBase
 {
     private readonly IModelsBuilderPresentationFactory _modelsBuilderPresentationFactory;

--- a/src/Umbraco.Cms.Api.Management/Controllers/ModelsBuilder/ModelsBuilderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/ModelsBuilder/ModelsBuilderControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.ModelsBuilder;
@@ -6,8 +7,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.ModelsBuilder;
 [ApiController]
 [VersionedApiBackOfficeRoute("models-builder")]
 [ApiExplorerSettings(GroupName = "Models Builder")]
-[ApiVersion("1.0")]
-
 public class ModelsBuilderControllerBase : ManagementApiControllerBase
 {
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/ModelsBuilder/StatusModelsBuilderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/ModelsBuilder/StatusModelsBuilderController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Infrastructure.ModelsBuilder;
@@ -7,6 +8,7 @@ using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Management.Controllers.ModelsBuilder;
 
+[ApiVersion("1.0")]
 public class StatusModelsBuilderController : ModelsBuilderControllerBase
 {
     private readonly OutOfDateModelsStatus _outOfDateModelsStatus;

--- a/src/Umbraco.Cms.Api.Management/Controllers/ObjectTypes/AllowedObjectTypesController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/ObjectTypes/AllowedObjectTypesController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.Factories;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.RelationType;
 
 namespace Umbraco.Cms.Api.Management.Controllers.ObjectTypes;
 
+[ApiVersion("1.0")]
 public class AllowedObjectTypesController : ObjectTypesControllerBase
 {
     private readonly IObjectTypePresentationFactory _objectTypePresentationFactory;

--- a/src/Umbraco.Cms.Api.Management/Controllers/ObjectTypes/ObjectTypesControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/ObjectTypes/ObjectTypesControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.ObjectTypes;
@@ -6,7 +7,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.ObjectTypes;
 [ApiController]
 [VersionedApiBackOfficeRoute("object-types")]
 [ApiExplorerSettings(GroupName = "Object Types")]
-[ApiVersion("1.0")]
 public class ObjectTypesControllerBase : ManagementApiControllerBase
 {
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Package/AllMigrationStatusPackageController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Package/AllMigrationStatusPackageController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -9,6 +10,7 @@ using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Package;
 
+[ApiVersion("1.0")]
 public class AllMigrationStatusPackageController : PackageControllerBase
 {
     private readonly IPackagingService _packagingService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Package/AllPackageManifestController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Package/AllPackageManifestController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Package;
 using Umbraco.Cms.Core.Manifest;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Core.Mapping;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Package;
 
+[ApiVersion("1.0")]
 public class AllPackageManifestController : PackageControllerBase
 {
     private readonly IPackageManifestService _packageManifestService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Package/Created/AllCreatedPackageController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Package/Created/AllCreatedPackageController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -9,6 +10,7 @@ using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Package.Created;
 
+[ApiVersion("1.0")]
 public class AllCreatedPackageController : CreatedPackageControllerBase
 {
     private readonly IPackagingService _packagingService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Package/Created/ByKeyCreatedPackageController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Package/Created/ByKeyCreatedPackageController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Package;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Package.Created;
 
+[ApiVersion("1.0")]
 public class ByKeyCreatedPackageController : CreatedPackageControllerBase
 {
     private readonly IPackagingService _packagingService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Package/Created/CreateCreatedPackageController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Package/Created/CreateCreatedPackageController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
@@ -10,6 +11,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Package.Created;
 
+[ApiVersion("1.0")]
 public class CreateCreatedPackageController : CreatedPackageControllerBase
 {
     private readonly IPackagingService _packagingService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Package/Created/CreatedPackageControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Package/Created/CreatedPackageControllerBase.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 
@@ -6,7 +7,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.Package.Created;
 [ApiController]
 [VersionedApiBackOfficeRoute("package/created")]
 [ApiExplorerSettings(GroupName = "Package")]
-[ApiVersion("1.0")]
 public class CreatedPackageControllerBase : PackageControllerBase
 {
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Package/Created/DeleteCreatedPackageController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Package/Created/DeleteCreatedPackageController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
@@ -8,6 +9,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Package.Created;
 
+[ApiVersion("1.0")]
 public class DeleteCreatedPackageController : CreatedPackageControllerBase
 {
     private readonly IPackagingService _packagingService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Package/Created/DownloadCreatedPackageController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Package/Created/DownloadCreatedPackageController.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Mime;
 using System.Text;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Net.Http.Headers;
@@ -9,6 +10,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Package.Created;
 
+[ApiVersion("1.0")]
 public class DownloadCreatedPackageController : CreatedPackageControllerBase
 {
     private readonly IPackagingService _packagingService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Package/Created/UpdateCreatedPackageController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Package/Created/UpdateCreatedPackageController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Package;
@@ -10,6 +11,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Package.Created;
 
+[ApiVersion("1.0")]
 public class UpdateCreatedPackageController : CreatedPackageControllerBase
 {
     private readonly IPackagingService _packagingService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Package/PackageControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Package/PackageControllerBase.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
@@ -9,7 +10,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.Package;
 [ApiController]
 [VersionedApiBackOfficeRoute("package")]
 [ApiExplorerSettings(GroupName = "Package")]
-[ApiVersion("1.0")]
 public abstract class PackageControllerBase : ManagementApiControllerBase
 {
     protected IActionResult PackageOperationStatusResult(PackageOperationStatus status) =>

--- a/src/Umbraco.Cms.Api.Management/Controllers/Package/RunMigrationPackageController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Package/RunMigrationPackageController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Infrastructure.Install;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Package;
 
+[ApiVersion("1.0")]
 public class RunMigrationPackageController : PackageControllerBase
 {
     private readonly PackageMigrationRunner _packageMigrationRunner;

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/ByPathPartialViewController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/ByPathPartialViewController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.PartialView;
 using Umbraco.Cms.Core.Mapping;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PartialView;
 
+[ApiVersion("1.0")]
 public class ByPathPartialViewController : PartialViewControllerBase
 {
     private readonly IPartialViewService _partialViewService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/CreatePartialViewController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/CreatePartialViewController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.PartialView;
 using Umbraco.Cms.Core;
@@ -10,6 +11,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PartialView;
 
+[ApiVersion("1.0")]
 public class CreatePartialViewController : PartialViewControllerBase
 {
     private readonly IUmbracoMapper _umbracoMapper;

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/DeletePartialViewController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/DeletePartialViewController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PartialView;
 
+[ApiVersion("1.0")]
 public class DeletePartialViewController : PartialViewControllerBase
 {
     private readonly IPartialViewService _partialViewService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Folder/ByPathPartialViewFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Folder/ByPathPartialViewFolderController.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PartialView.Folder;
 
+[ApiVersion("1.0")]
 public class ByPathPartialViewFolderController : PartialViewFolderControllerBase
 {
     public ByPathPartialViewFolderController(IUmbracoMapper mapper, IPartialViewFolderService partialViewFolderService) : base(mapper, partialViewFolderService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Folder/CreatePartialViewFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Folder/CreatePartialViewFolderController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Folder;
 using Umbraco.Cms.Core.Mapping;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PartialView.Folder;
 
+[ApiVersion("1.0")]
 public class CreatePartialViewFolderController : PartialViewFolderControllerBase
 {
     public CreatePartialViewFolderController(

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Folder/DeletePartialViewFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Folder/DeletePartialViewFolderController.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PartialView.Folder;
 
+[ApiVersion("1.0")]
 public class DeletePartialViewFolderController : PartialViewFolderControllerBase
 {
     public DeletePartialViewFolderController(

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Folder/PartialViewFolderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Folder/PartialViewFolderControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
@@ -10,7 +11,6 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PartialView.Folder;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.PartialView}/folder")]
 [ApiExplorerSettings(GroupName = "Partial View")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Items/ItemPartialViewItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Items/ItemPartialViewItemController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.PartialView.Item;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Core.IO;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PartialView.Items;
 
+[ApiVersion("1.0")]
 public class ItemPartialViewItemController : PartialViewItemControllerBase
 {
     private readonly IFileItemPresentationModelFactory _fileItemPresentationModelFactory;

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Items/PartialViewItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Items/PartialViewItemControllerBase.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PartialView.Items;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.PartialView}")]
 [ApiExplorerSettings(GroupName = "Partial View")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/PartialViewControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/PartialViewControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
@@ -7,7 +8,6 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PartialView;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.PartialView}")]
 [ApiExplorerSettings(GroupName = "Partial View")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Snippet/ByNameController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Snippet/ByNameController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.PartialView.Snippets;
 using Umbraco.Cms.Core.Mapping;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Snippets;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PartialView.Snippet;
 
+[ApiVersion("1.0")]
 public class ByNameController : PartialViewControllerBase
 {
     private readonly IPartialViewService _partialViewService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Snippet/GetAllController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Snippet/GetAllController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.ViewModels.PartialView.Snippets;
@@ -7,6 +8,7 @@ using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PartialView.Snippet;
 
+[ApiVersion("1.0")]
 public class GetAllController : PartialViewControllerBase
 {
     private readonly IPartialViewService _partialViewService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Tree/ChildrenPartialViewTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Tree/ChildrenPartialViewTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PartialView.Tree;
 
+[ApiVersion("1.0")]
 public class ChildrenPartialViewTreeController : PartialViewTreeControllerBase
 {
     public ChildrenPartialViewTreeController(FileSystems fileSystems)

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Tree/PartialViewTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Tree/PartialViewTreeControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Api.Management.Controllers.Tree;
@@ -6,7 +7,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PartialView.Tree;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.PartialView}")]
 [ApiExplorerSettings(GroupName = "Partial View")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Tree/RootPartialViewTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Tree/RootPartialViewTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PartialView.Tree;
 
+[ApiVersion("1.0")]
 public class RootPartialViewTreeController : PartialViewTreeControllerBase
 {
     public RootPartialViewTreeController(FileSystems fileSystems)

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/UpdatePartialViewController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/UpdatePartialViewController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.PartialView;
 using Umbraco.Cms.Core;
@@ -10,6 +11,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PartialView;
 
+[ApiVersion("1.0")]
 public class UpdatePartialViewController : PartialViewControllerBase
 {
     private readonly IPartialViewService _partialViewService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Profiling/GetStatusProfilingController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Profiling/GetStatusProfilingController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Profiling;
 using Umbraco.Cms.Core;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Profiling;
 
+[ApiVersion("1.0")]
 public class GetStatusProfilingController : ProfilingControllerBase
 {
     private readonly IWebProfilerService _webProfilerService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Profiling/ProfilingControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Profiling/ProfilingControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
@@ -6,7 +7,6 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Profiling;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute("profiling")]
 [ApiExplorerSettings(GroupName = "Profiling")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Profiling/UpdateStatusProfilingController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Profiling/UpdateStatusProfilingController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Profiling;
 using Umbraco.Cms.Core;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Profiling;
 
+[ApiVersion("1.0")]
 public class UpdateStatusProfilingController : ProfilingControllerBase
 {
     private readonly IWebProfilerService _webProfilerService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/PropertyType/IsUsedPropertyTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PropertyType/IsUsedPropertyTypeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Core;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PropertyType;
 
+[ApiVersion("1.0")]
 public class IsUsedPropertyTypeController : PropertyTypeControllerBase
 {
     private readonly IPropertyTypeUsageService _propertyTypeUsageService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/PropertyType/PropertyTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PropertyType/PropertyTypeControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core.Services.OperationStatus;
@@ -8,7 +9,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.PropertyType;
 [ApiController]
 [VersionedApiBackOfficeRoute("property-type")]
 [ApiExplorerSettings(GroupName = "Property Type")]
-[ApiVersion("1.0")]
 public abstract class PropertyTypeControllerBase : ManagementApiControllerBase
 {
     protected IActionResult PropertyTypeOperationStatusResult(PropertyTypeOperationStatus status) =>

--- a/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/CollectPublishedCacheController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/CollectPublishedCacheController.cs
@@ -1,9 +1,11 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.PublishedCache;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PublishedCache;
 
+[ApiVersion("1.0")]
 public class CollectPublishedCacheController : PublishedCacheControllerBase
 {
     private readonly IPublishedSnapshotService _publishedSnapshotService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/PublishedCacheControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/PublishedCacheControllerBase.cs
@@ -1,9 +1,9 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PublishedCache;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute("published-cache")]
 [ApiExplorerSettings(GroupName = "Published Cache")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/RebuildPublishedCacheController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/RebuildPublishedCacheController.cs
@@ -1,9 +1,11 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.PublishedCache;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PublishedCache;
 
+[ApiVersion("1.0")]
 public class RebuildPublishedCacheController : PublishedCacheControllerBase
 {
     private readonly IPublishedSnapshotService _publishedSnapshotService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/ReloadPublishedCacheController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/ReloadPublishedCacheController.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PublishedCache;
 
+[ApiVersion("1.0")]
 public class ReloadPublishedCacheController : PublishedCacheControllerBase
 {
     private readonly DistributedCache _distributedCache;

--- a/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/StatusPublishedCacheController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/StatusPublishedCacheController.cs
@@ -1,9 +1,11 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.PublishedCache;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PublishedCache;
 
+[ApiVersion("1.0")]
 public class StatusPublishedCacheController : PublishedCacheControllerBase
 {
     private readonly IPublishedSnapshotStatus _publishedSnapshotStatus;

--- a/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/ByKeyRedirectUrlManagementController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/ByKeyRedirectUrlManagementController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.Factories;
@@ -8,7 +9,8 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.RedirectUrlManagement;
 
-public class ByKeyRedirectUrlManagementController : RedirectUrlManagementBaseController
+[ApiVersion("1.0")]
+public class ByKeyRedirectUrlManagementController : RedirectUrlManagementControllerBase
 {
     private readonly IRedirectUrlService _redirectUrlService;
     private readonly IRedirectUrlPresentationFactory _redirectUrlPresentationFactory;
@@ -21,6 +23,7 @@ public class ByKeyRedirectUrlManagementController : RedirectUrlManagementBaseCon
         _redirectUrlPresentationFactory = redirectUrlPresentationFactory;
     }
 
+    [MapToApiVersion("1.0")]
     [HttpGet("{id:guid}")]
     [ProducesResponseType(typeof(PagedViewModel<RedirectUrlResponseModel>), StatusCodes.Status200OK)]
     public Task<ActionResult<PagedViewModel<RedirectUrlResponseModel>>> ByKey(Guid id, int skip, int take)

--- a/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/DeleteByKeyRedirectUrlManagementController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/DeleteByKeyRedirectUrlManagementController.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.RedirectUrlManagement;
 
-public class DeleteByKeyRedirectUrlManagementController : RedirectUrlManagementBaseController
+[ApiVersion("1.0")]
+public class DeleteByKeyRedirectUrlManagementController : RedirectUrlManagementControllerBase
 {
     private readonly IRedirectUrlService _redirectUrlService;
 
@@ -13,6 +15,7 @@ public class DeleteByKeyRedirectUrlManagementController : RedirectUrlManagementB
         _redirectUrlService = redirectUrlService;
     }
 
+    [MapToApiVersion("1.0")]
     [HttpDelete("{id:guid}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<IActionResult> DeleteByKey(Guid id)

--- a/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/GetAllRedirectUrlManagementController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/GetAllRedirectUrlManagementController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.Factories;
@@ -9,7 +10,8 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.RedirectUrlManagement;
 
-public class GetAllRedirectUrlManagementController : RedirectUrlManagementBaseController
+[ApiVersion("1.0")]
+public class GetAllRedirectUrlManagementController : RedirectUrlManagementControllerBase
 {
     private readonly IRedirectUrlService _redirectUrlService;
     private readonly IRedirectUrlPresentationFactory _redirectUrlPresentationFactory;
@@ -22,6 +24,7 @@ public class GetAllRedirectUrlManagementController : RedirectUrlManagementBaseCo
         _redirectUrlPresentationFactory = redirectUrlPresentationFactory;
     }
 
+    [MapToApiVersion("1.0")]
     [HttpGet]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(PagedViewModel<RedirectUrlResponseModel>), StatusCodes.Status200OK)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/GetStatusRedirectUrlManagementController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/GetStatusRedirectUrlManagementController.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.RedirectUrlManagement;
 
 namespace Umbraco.Cms.Api.Management.Controllers.RedirectUrlManagement;
 
-public class GetStatusRedirectUrlManagementController : RedirectUrlManagementBaseController
+[ApiVersion("1.0")]
+public class GetStatusRedirectUrlManagementController : RedirectUrlManagementControllerBase
 {
     private readonly IRedirectUrlStatusPresentationFactory _redirectUrlStatusPresentationFactory;
 
@@ -12,6 +14,7 @@ public class GetStatusRedirectUrlManagementController : RedirectUrlManagementBas
         IRedirectUrlStatusPresentationFactory redirectUrlStatusPresentationFactory) =>
         _redirectUrlStatusPresentationFactory = redirectUrlStatusPresentationFactory;
 
+    [MapToApiVersion("1.0")]
     [HttpGet("status")]
     [ProducesResponseType(typeof(RedirectUrlStatusResponseModel), 200)]
     public Task<ActionResult<RedirectUrlStatusResponseModel>> GetStatus() =>

--- a/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/RedirectUrlManagementControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/RedirectUrlManagementControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.RedirectUrlManagement;
@@ -6,8 +7,7 @@ namespace Umbraco.Cms.Api.Management.Controllers.RedirectUrlManagement;
 [ApiController]
 [VersionedApiBackOfficeRoute("redirect-management")]
 [ApiExplorerSettings(GroupName = "Redirect Management")]
-[ApiVersion("1.0")]
-public class RedirectUrlManagementBaseController : ManagementApiControllerBase
+public class RedirectUrlManagementControllerBase : ManagementApiControllerBase
 {
 
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/SetStatusRedirectUrlManagementController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/SetStatusRedirectUrlManagementController.cs
@@ -1,11 +1,13 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Security;
 using Umbraco.New.Cms.Core.Models.RedirectUrlManagement;
 
 namespace Umbraco.Cms.Api.Management.Controllers.RedirectUrlManagement;
 
-public class SetStatusRedirectUrlManagementController : RedirectUrlManagementBaseController
+[ApiVersion("1.0")]
+public class SetStatusRedirectUrlManagementController : RedirectUrlManagementControllerBase
 {
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
     private readonly IConfigManipulator _configManipulator;
@@ -22,6 +24,7 @@ public class SetStatusRedirectUrlManagementController : RedirectUrlManagementBas
     // We generally don't want to edit the appsettings from our code.
     // But maybe there is a valid use case for doing it on the fly.
     [HttpPost("status")]
+    [MapToApiVersion("1.0")]
     public async Task<IActionResult> SetStatus([FromQuery] RedirectStatus status)
     {
         // TODO: uncomment this when auth is implemented.

--- a/src/Umbraco.Cms.Api.Management/Controllers/Relation/ByChildRelationController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Relation/ByChildRelationController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
@@ -9,6 +10,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Relation;
 
+[ApiVersion("1.0")]
 public class ByChildRelationController : RelationControllerBase
 {
     private readonly IRelationService _relationService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Relation/ByIdRelationController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Relation/ByIdRelationController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Relation;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Relation;
 
+[ApiVersion("1.0")]
 public class ByIdRelationController : RelationControllerBase
 {
     private readonly IRelationService _relationService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Relation/ByRelationTypeKeyRelationController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Relation/ByRelationTypeKeyRelationController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.Factories;
@@ -11,6 +12,7 @@ using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Relation;
 
+[ApiVersion("1.0")]
 public class ByRelationTypeKeyRelationController : RelationControllerBase
 {
     private readonly IRelationService _relationService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Relation/RelationControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Relation/RelationControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core.Services.OperationStatus;
@@ -8,7 +9,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.Relation;
 [ApiController]
 [VersionedApiBackOfficeRoute("relation")]
 [ApiExplorerSettings(GroupName = "Relation")]
-[ApiVersion("1.0")]
 // TODO: Implement Authentication
 public abstract class RelationControllerBase : ManagementApiControllerBase
 {

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Item/ItemRelationTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Item/ItemRelationTypeItemController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.RelationType.Item;
 using Umbraco.Cms.Core.Mapping;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.RelationType.Item;
 
+[ApiVersion("1.0")]
 public class ItemRelationTypeItemController : RelationTypeItemControllerBase
 {
     private readonly IRelationService _relationService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Item/RelationTypeItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Item/RelationTypeItemControllerBase.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Api.Management.Controllers.RelationType.Item;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.RelationType}")]
 [ApiExplorerSettings(GroupName = "Relation Type")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Query/ByKeyRelationTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Query/ByKeyRelationTypeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.RelationType;
 using Umbraco.Cms.Core.Mapping;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.RelationType.Query;
 
+[ApiVersion("1.0")]
 public class ByKeyRelationTypeController : RelationTypeControllerBase
 {
     private readonly IRelationService _relationService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Query/CreateRelationTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Query/CreateRelationTypeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.RelationType;
@@ -8,9 +9,9 @@ using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 
-
 namespace Umbraco.Cms.Api.Management.Controllers.RelationType.Query;
 
+[ApiVersion("1.0")]
 public class CreateRelationTypeController : RelationTypeControllerBase
 {
     private readonly IRelationService _relationService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Query/DeleteRelationTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Query/DeleteRelationTypeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
@@ -8,6 +9,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.RelationType.Query;
 
+[ApiVersion("1.0")]
 public class DeleteRelationTypeController : RelationTypeControllerBase
 {
     private readonly IRelationService _relationService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Query/RelationTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Query/RelationTypeControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
@@ -9,7 +10,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.RelationType.Query;
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.RelationType}")]
 [ApiExplorerSettings(GroupName = "Relation Type")]
-[ApiVersion("1.0")]
 public class RelationTypeControllerBase : ManagementApiControllerBase
 {
         protected IActionResult RelationTypeOperationStatusResult(RelationTypeOperationStatus status) =>

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Query/UpdateRelationTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Query/UpdateRelationTypeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Factories;
@@ -11,6 +12,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.RelationType.Query;
 
+[ApiVersion("1.0")]
 public class UpdateRelationTypeController : RelationTypeControllerBase
 {
     private readonly IRelationService _relationService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Tree/RelationTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Tree/RelationTypeTreeControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
@@ -8,7 +9,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.RelationType.Tree;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.RelationType}")]
 [ApiExplorerSettings(GroupName = "Relation Type")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Tree/RootRelationTypeTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Tree/RootRelationTypeTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
@@ -8,6 +9,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.RelationType.Tree;
 
+[ApiVersion("1.0")]
 public class RootRelationTypeTreeController : RelationTypeTreeControllerBase
 {
     private readonly IRelationService _relationService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/ByPathScriptController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/ByPathScriptController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Script;
 using Umbraco.Cms.Core.Mapping;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Script;
 
+[ApiVersion("1.0")]
 public class ByPathScriptController : ScriptControllerBase
 {
     private readonly IScriptService _scriptService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/CreateScriptController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/CreateScriptController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Script;
 using Umbraco.Cms.Core;
@@ -10,6 +11,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Script;
 
+[ApiVersion("1.0")]
 public class CreateScriptController : ScriptControllerBase
 {
     private readonly IScriptService _scriptService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/DeleteScriptController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/DeleteScriptController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Script;
 
+[ApiVersion("1.0")]
 public class DeleteScriptController : ScriptControllerBase
 {
     private readonly IScriptService _scriptService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/Folder/ByPathScriptFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/Folder/ByPathScriptFolderController.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Script.Folder;
 
+[ApiVersion("1.0")]
 public class ByPathScriptFolderController : ScriptFolderControllerBase
 {
     public ByPathScriptFolderController(

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/Folder/CreateScriptFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/Folder/CreateScriptFolderController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Folder;
 using Umbraco.Cms.Core.Mapping;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Script.Folder;
 
+[ApiVersion("1.0")]
 public class CreateScriptFolderController : ScriptFolderControllerBase
 {
     public CreateScriptFolderController(

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/Folder/DeleteScriptFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/Folder/DeleteScriptFolderController.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Script.Folder;
 
+[ApiVersion("1.0")]
 public class DeleteScriptFolderController : ScriptFolderControllerBase
 {
     public DeleteScriptFolderController(IUmbracoMapper mapper, IScriptFolderService scriptFolderService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/Folder/ScriptFolderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/Folder/ScriptFolderControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
@@ -10,7 +11,6 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Script.Folder;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.Script}/folder")]
 [ApiExplorerSettings(GroupName = "Script")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/Item/ItemScriptItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/Item/ItemScriptItemController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.Script.Item;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Core.IO;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Script.Item;
 
+[ApiVersion("1.0")]
 public class ItemScriptItemController : ScriptItemControllerBase
 {
     private readonly IFileSystem _fileSystem;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/Item/ScriptItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/Item/ScriptItemControllerBase.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Script.Item;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.Script}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Script))]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/ScriptControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/ScriptControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
@@ -7,7 +8,6 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Script;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.Script}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Script))]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/Tree/ChildrenScriptTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/Tree/ChildrenScriptTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Script.Tree;
 
+[ApiVersion("1.0")]
 public class ChildrenScriptTreeController : ScriptTreeControllerBase
 {
     public ChildrenScriptTreeController(FileSystems fileSystems)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/Tree/RootScriptTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/Tree/RootScriptTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Script.Tree;
 
+[ApiVersion("1.0")]
 public class RootScriptTreeController : ScriptTreeControllerBase
 {
     public RootScriptTreeController(FileSystems fileSystems)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/Tree/ScriptTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/Tree/ScriptTreeControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Api.Management.Controllers.Tree;
@@ -6,7 +7,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Script.Tree;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.Script}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Script))]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/UpdateScriptController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/UpdateScriptController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Script;
 using Umbraco.Cms.Core;
@@ -10,6 +11,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Script;
 
+[ApiVersion("1.0")]
 public class UpdateScriptController : ScriptControllerBase
 {
     private readonly IScriptService _scriptService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Searcher/AllSearcherController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Searcher/AllSearcherController.cs
@@ -1,4 +1,5 @@
-﻿using Examine;
+﻿using Asp.Versioning;
+using Examine;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Searcher/QuerySearcherController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Searcher/QuerySearcherController.cs
@@ -1,4 +1,5 @@
-﻿using Examine;
+﻿using Asp.Versioning;
+using Examine;
 using Examine.Search;
 using Lucene.Net.QueryParsers.Classic;
 using Microsoft.AspNetCore.Http;
@@ -17,7 +18,7 @@ public class QuerySearcherController : SearcherControllerBase
 
     public QuerySearcherController(IExamineManagerService examineManagerService) => _examineManagerService = examineManagerService;
 
-    [HttpGet("{searcherName}/query")]
+    [Microsoft.AspNetCore.Mvc.HttpGet("{searcherName}/query")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<SearchResultResponseModel>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Security.Claims;
+using Asp.Versioning;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
@@ -18,6 +19,7 @@ using IdentitySignInResult = Microsoft.AspNetCore.Identity.SignInResult;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Security;
 
+[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute(Paths.BackOfficeApiEndpointTemplate)]
 [ApiExplorerSettings(GroupName = "Security")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Server/StatusServerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Server/StatusServerController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Api.Management.ViewModels.Server;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Server/VersionServerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Server/VersionServerController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Api.Management.ViewModels.Server;

--- a/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Item/ItemStaticFileItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Item/ItemStaticFileItemController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.StaticFile.Item;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Core.IO;
 
 namespace Umbraco.Cms.Api.Management.Controllers.StaticFile.Item;
 
+[ApiVersion("1.0")]
 public class ItemStaticFileItemController : StaticFileItemControllerBase
 {
     private readonly IFileItemPresentationModelFactory _presentationModelFactory;

--- a/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Item/StaticFileItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Item/StaticFileItemControllerBase.cs
@@ -1,9 +1,9 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.StaticFile.Item;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute("static-file")]
 [ApiExplorerSettings(GroupName = "Static File")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Tree/ChildrenStaticFileTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Tree/ChildrenStaticFileTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.StaticFile.Tree;
 
+[ApiVersion("1.0")]
 public class ChildrenStaticFileTreeController : StaticFileTreeControllerBase
 {
     public ChildrenStaticFileTreeController(IPhysicalFileSystem physicalFileSystem)

--- a/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Tree/RootStaticFileTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Tree/RootStaticFileTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.StaticFile.Tree;
 
+[ApiVersion("1.0")]
 public class RootStaticFileTreeController : StaticFileTreeControllerBase
 {
     public RootStaticFileTreeController(IPhysicalFileSystem physicalFileSystem)

--- a/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Tree/StaticFileTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Tree/StaticFileTreeControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Api.Management.Controllers.Tree;
@@ -6,7 +7,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.StaticFile.Tree;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/static-file")]
 [ApiExplorerSettings(GroupName = "Static File")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/AllStylesheetController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/AllStylesheetController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.ViewModels.Stylesheet;
@@ -8,6 +9,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet;
 
+[ApiVersion("1.0")]
 public class AllStylesheetController : StylesheetControllerBase
 {
     private readonly IStylesheetService _stylesheetService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/ByPathStylesheetController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/ByPathStylesheetController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Stylesheet;
 using Umbraco.Cms.Core.Mapping;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet;
 
+[ApiVersion("1.0")]
 public class ByPathStylesheetController : StylesheetControllerBase
 {
     private readonly IStylesheetService _stylesheetService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/CreateStylesheetController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/CreateStylesheetController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Stylesheet;
 using Umbraco.Cms.Core;
@@ -10,6 +11,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet;
 
+[ApiVersion("1.0")]
 public class CreateStylesheetController : StylesheetControllerBase
 {
     private readonly IStylesheetService _stylesheetService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/DeleteStylesheetController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/DeleteStylesheetController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet;
 
+[ApiVersion("1.0")]
 public class DeleteStylesheetController : StylesheetControllerBase
 {
     private readonly IStylesheetService _stylesheetService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/ExtractRichTextRulesController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/ExtractRichTextRulesController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.RichTextStylesheet;
 using Umbraco.Cms.Core.Mapping;
@@ -8,6 +9,7 @@ using Umbraco.Cms.Core.Strings.Css;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet;
 
+[ApiVersion("1.0")]
 public class ExtractRichTextRulesController : StylesheetControllerBase
 {
     private readonly IRichTextStylesheetService _richTextStylesheetService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Folder/ByPathStylesheetFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Folder/ByPathStylesheetFolderController.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet.Folder;
 
+[ApiVersion("1.0")]
 public class ByPathStylesheetFolderController : StylesheetFolderControllerBase
 {
     public ByPathStylesheetFolderController(IUmbracoMapper mapper, IStylesheetFolderService stylesheetFolderService) : base(mapper, stylesheetFolderService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Folder/CreateStylesheetFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Folder/CreateStylesheetFolderController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Folder;
 using Umbraco.Cms.Core.Mapping;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet.Folder;
 
+[ApiVersion("1.0")]
 public class CreateStylesheetFolderController : StylesheetFolderControllerBase
 {
     public CreateStylesheetFolderController(IUmbracoMapper mapper, IStylesheetFolderService stylesheetFolderService) : base(mapper, stylesheetFolderService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Folder/DeleteStylesheetFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Folder/DeleteStylesheetFolderController.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet.Folder;
 
+[ApiVersion("1.0")]
 public class DeleteStylesheetFolderController : StylesheetFolderControllerBase
 {
     public DeleteStylesheetFolderController(IUmbracoMapper mapper, IStylesheetFolderService stylesheetFolderService) : base(mapper, stylesheetFolderService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Folder/StylesheetFolderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Folder/StylesheetFolderControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
@@ -10,7 +11,6 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet.Folder;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.Stylesheet}/folder")]
 [ApiExplorerSettings(GroupName = "Stylesheet")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/GetRichTextRulesByPath.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/GetRichTextRulesByPath.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.RichTextStylesheet;
 using Umbraco.Cms.Core;
@@ -9,6 +10,7 @@ using StylesheetRule = Umbraco.Cms.Core.Strings.Css.StylesheetRule;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet;
 
+[ApiVersion("1.0")]
 public class GetRichTextRulesByPath : StylesheetControllerBase
 {
     private readonly IRichTextStylesheetService _richTextStylesheetService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/InterpolateRichTextRulesController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/InterpolateRichTextRulesController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.RichTextStylesheet;
 using Umbraco.Cms.Core.Mapping;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet;
 
+[ApiVersion("1.0")]
 public class InterpolateRichTextRulesController : StylesheetControllerBase
 {
     private readonly IRichTextStylesheetService _richTextStylesheetService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Item/ItemStylesheetItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Item/ItemStylesheetItemController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.Script.Item;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.IO;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet.Item;
 
+[ApiVersion("1.0")]
 public class ItemStylesheetItemController : StylesheetItemControllerBase
 {
     private readonly IFileItemPresentationModelFactory _fileItemPresentationModelFactory;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Item/StylesheetItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Item/StylesheetItemControllerBase.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet.Item;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.Stylesheet}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Stylesheet))]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/StylesheetControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/StylesheetControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
@@ -7,7 +8,6 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.Stylesheet}")]
 [ApiExplorerSettings(GroupName = "Stylesheet")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Tree/ChildrenStylesheetTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Tree/ChildrenStylesheetTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet.Tree;
 
+[ApiVersion("1.0")]
 public class ChildrenStylesheetTreeController : StylesheetTreeControllerBase
 {
     public ChildrenStylesheetTreeController(FileSystems fileSystems)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Tree/RootStylesheetTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Tree/RootStylesheetTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet.Tree;
 
+[ApiVersion("1.0")]
 public class RootStylesheetTreeController : StylesheetTreeControllerBase
 {
     public RootStylesheetTreeController(FileSystems fileSystems)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Tree/StylesheetTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Tree/StylesheetTreeControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Api.Management.Controllers.Tree;
@@ -6,7 +7,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet.Tree;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.Stylesheet}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Stylesheet))]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/UpdateStylesheetController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/UpdateStylesheetController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Stylesheet;
 using Umbraco.Cms.Core;
@@ -10,6 +11,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet;
 
+[ApiVersion("1.0")]
 public class UpdateStylesheetController : StylesheetControllerBase
 {
     private readonly IStylesheetService _stylesheetService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Tag/ByQueryTagController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tag/ByQueryTagController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.ViewModels.Tag;
@@ -8,6 +9,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Tag;
 
+[ApiVersion("1.0")]
 public class ByQueryTagController : TagControllerBase
 {
     private readonly ITagService _tagService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Tag/TagControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tag/TagControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Tag;
@@ -6,7 +7,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.Tag;
 [ApiController]
 [VersionedApiBackOfficeRoute("tag")]
 [ApiExplorerSettings(GroupName = "Tag")]
-[ApiVersion("1.0")]
 public class TagControllerBase : ManagementApiControllerBase
 {
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Telemetry/AllTelemetryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Telemetry/AllTelemetryController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Models;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Telemetry;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Telemetry;
 
+[ApiVersion("1.0")]
 public class AllTelemetryController : TelemetryControllerBase
 {
     [HttpGet]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Telemetry/GetTelemetryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Telemetry/GetTelemetryController.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Api.Management.ViewModels.Telemetry;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Telemetry;
 
+[ApiVersion("1.0")]
 public class GetTelemetryController : TelemetryControllerBase
 {
     private readonly IMetricsConsentService _metricsConsentService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Telemetry/SetTelemetryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Telemetry/SetTelemetryController.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Api.Management.ViewModels.Telemetry;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Telemetry;
 
+[ApiVersion("1.0")]
 public class SetTelemetryController : TelemetryControllerBase
 {
     private readonly IMetricsConsentService _metricsConsentService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Telemetry/TelemetryControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Telemetry/TelemetryControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Telemetry;
@@ -6,7 +7,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.Telemetry;
 [ApiController]
 [VersionedApiBackOfficeRoute("telemetry")]
 [ApiExplorerSettings(GroupName = "Telemetry")]
-[ApiVersion("1.0")]
 public abstract class TelemetryControllerBase : ManagementApiControllerBase
 {
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/ByKeyTemplateController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/ByKeyTemplateController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Template;
 using Umbraco.Cms.Core.Mapping;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Template;
 
+[ApiVersion("1.0")]
 public class ByKeyTemplateController : TemplateControllerBase
 {
     private readonly ITemplateService _templateService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/CreateTemplateController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/CreateTemplateController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Template;
 using Umbraco.Cms.Core;
@@ -9,6 +10,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Template;
 
+[ApiVersion("1.0")]
 public class CreateTemplateController : TemplateControllerBase
 {
     private readonly ITemplateService _templateService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/DeleteTemplateController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/DeleteTemplateController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
@@ -8,6 +9,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Template;
 
+[ApiVersion("1.0")]
 public class DeleteTemplateController : TemplateControllerBase
 {
     private readonly ITemplateService _templateService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Item/ItemTemplateItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Item/ItemTemplateItemController.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Management.ViewModels.MediaType.Item;
 using Umbraco.Cms.Api.Management.ViewModels.Template.Item;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
@@ -9,6 +9,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Template.Item;
 
+[ApiVersion("1.0")]
 public class ItemTemplateItemController : TemplateItemControllerBase
 {
     private readonly IEntityService _entityService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Item/TemplateItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Item/TemplateItemControllerBase.cs
@@ -4,7 +4,6 @@ using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Template.Item;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.Template}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Template))]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/ExecuteTemplateQueryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/ExecuteTemplateQueryController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Text;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Template.Query;
@@ -12,6 +13,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Template.Query;
 
+[ApiVersion("1.0")]
 public class ExecuteTemplateQueryController : TemplateQueryControllerBase
 {
     private readonly IPublishedContentQuery _publishedContentQuery;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/SettingsTemplateQueryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/SettingsTemplateQueryController.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Template.Query;
 using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Template.Query;
 
+[ApiVersion("1.0")]
 public class SettingsTemplateQueryController : TemplateQueryControllerBase
 {
     private readonly IContentTypeService _contentTypeService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/ScaffoldTemplateController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/ScaffoldTemplateController.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Template;
 using Umbraco.Cms.Core.IO;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Template;
 
+[ApiVersion("1.0")]
 public class ScaffoldTemplateController : TemplateControllerBase
 {
     private readonly IDefaultViewContentProvider _defaultViewContentProvider;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/TemplateControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/TemplateControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
@@ -10,7 +11,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.Template;
 [ApiController]
 [VersionedApiBackOfficeRoute(Constants.UdiEntityType.Template)]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Template))]
-[ApiVersion("1.0")]
 public class TemplateControllerBase : ManagementApiControllerBase
 {
     protected IActionResult TemplateOperationStatusResult(TemplateOperationStatus status) =>

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Tree/ChildrenTemplateTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Tree/ChildrenTemplateTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Template.Tree;
 
+[ApiVersion("1.0")]
 public class ChildrenTemplateTreeController : TemplateTreeControllerBase
 {
     public ChildrenTemplateTreeController(IEntityService entityService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Tree/RootTemplateTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Tree/RootTemplateTreeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Template.Tree;
 
+[ApiVersion("1.0")]
 public class RootTemplateTreeController : TemplateTreeControllerBase
 {
     public RootTemplateTreeController(IEntityService entityService)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Tree/TemplateTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Tree/TemplateTreeControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
@@ -9,7 +10,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Template.Tree;
 
-[ApiVersion("1.0")]
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.Template}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Template))]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/UpdateTemplateController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/UpdateTemplateController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Template;
 using Umbraco.Cms.Core;
@@ -10,6 +11,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Template;
 
+[ApiVersion("1.0")]
 public class UpdateTemplateController : TemplateControllerBase
 {
     private readonly ITemplateService _templateService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/TemporaryFile/ByKeyTemporaryFileController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/TemporaryFile/ByKeyTemporaryFileController.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Management.ViewModels.Language;
 using Umbraco.Cms.Api.Management.ViewModels.TemporaryFile;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models.TemporaryFile;
@@ -8,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.TemporaryFile;
 
+[ApiVersion("1.0")]
 public class ByKeyTemporaryFileController : TemporaryFileControllerBase
 {
     private readonly ITemporaryFileService _temporaryFileService;
@@ -20,6 +21,8 @@ public class ByKeyTemporaryFileController : TemporaryFileControllerBase
     }
 
     [HttpGet($"{{{nameof(id)}}}")]
+
+
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/TemporaryFile/CreateTemporaryFileController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/TemporaryFile/CreateTemporaryFileController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.TemporaryFile;
 using Umbraco.Cms.Core;
@@ -9,6 +10,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.TemporaryFile;
 
+[ApiVersion("1.0")]
 public class CreateTemporaryFileController : TemporaryFileControllerBase
 {
     private readonly ITemporaryFileService _temporaryFileService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/TemporaryFile/DeleteTemporaryFileController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/TemporaryFile/DeleteTemporaryFileController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.TemporaryFile;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.TemporaryFile;
 
+[ApiVersion("1.0")]
 public class DeleteTemporaryFileController : TemporaryFileControllerBase
 {
     private readonly ITemporaryFileService _temporaryFileService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/TemporaryFile/TemporaryFileControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/TemporaryFile/TemporaryFileControllerBase.cs
@@ -2,7 +2,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
-using Umbraco.Cms.Core.Models.TemporaryFile;
 using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.TemporaryFile;
@@ -10,7 +9,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.TemporaryFile;
 [ApiController]
 [VersionedApiBackOfficeRoute("temporaryfile")]
 [ApiExplorerSettings(GroupName = "Temporary File")]
-[ApiVersion("1.0")]
 public abstract class TemporaryFileControllerBase : ManagementApiControllerBase
 {
     protected IActionResult TemporaryFileStatusResult(TemporaryFileOperationStatus operationStatus) =>

--- a/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/ByIdTrackedReferenceController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/ByIdTrackedReferenceController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
@@ -9,6 +10,7 @@ using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Management.Controllers.TrackedReference;
 
+[ApiVersion("1.0")]
 public class ByIdTrackedReferenceController : TrackedReferenceControllerBase
 {
     private readonly ITrackedReferencesService _trackedReferencesService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/DescendantsTrackedReferenceController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/DescendantsTrackedReferenceController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
@@ -9,6 +10,7 @@ using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Management.Controllers.TrackedReference;
 
+[ApiVersion("1.0")]
 public class DescendantsTrackedReferenceController : TrackedReferenceControllerBase
 {
     private readonly ITrackedReferencesService _trackedReferencesSkipTakeService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/ItemsTrackedReferenceController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/ItemsTrackedReferenceController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
@@ -9,6 +10,7 @@ using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Management.Controllers.TrackedReference;
 
+[ApiVersion("1.0")]
 public class ItemsTrackedReferenceController : TrackedReferenceControllerBase
 {
     private readonly ITrackedReferencesService _trackedReferencesSkipTakeService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/TrackedReferencesControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/TrackedReferencesControllerBase.cs
@@ -6,7 +6,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.TrackedReference;
 [ApiController]
 [VersionedApiBackOfficeRoute("tracked-reference")]
 [ApiExplorerSettings(GroupName = "Tracked Reference")]
-[ApiVersion("1.0")]
 public abstract class TrackedReferenceControllerBase : ManagementApiControllerBase
 {
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Upgrade/AuthorizeUpgradeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Upgrade/AuthorizeUpgradeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.New.Cms.Core.Services.Installer;
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Upgrade/SettingsUpgradeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Upgrade/SettingsUpgradeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Api.Management.ViewModels.Installer;

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/ByKeyUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/ByKeyUsersController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.User;
@@ -8,6 +9,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User;
 
+[ApiVersion("1.0")]
 public class ByKeyUserController : UserControllerBase
 {
     private readonly IUserService _userService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/ChangePasswordUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/ChangePasswordUsersController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.User;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Mapping;
@@ -10,6 +11,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User;
 
+[ApiVersion("1.0")]
 public class ChangePasswordUserController : UserControllerBase
 {
     private readonly IUserService _userService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/ClearAvatarUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/ClearAvatarUsersController.cs
@@ -1,15 +1,18 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User;
 
+[ApiVersion("1.0")]
 public class ClearAvatarUserController : UserControllerBase
 {
     private readonly IUserService _userService;
 
     public ClearAvatarUserController(IUserService userService) => _userService = userService;
 
+    [MapToApiVersion("1.0")]
     [HttpDelete("avatar/{id:guid}")]
     public async Task<IActionResult> ClearAvatar(Guid id)
     {

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/CreateUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/CreateUsersController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.User;
@@ -12,6 +13,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User;
 
+[ApiVersion("1.0")]
 public class CreateUserController : UserControllerBase
 {
     private readonly IUserService _userService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/DeleteUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/DeleteUsersController.cs
@@ -1,15 +1,18 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User;
 
+[ApiVersion("1.0")]
 public class DeleteUserController : UserControllerBase
 {
     public DeleteUserController(IUserService userService) => _userService = userService;
 
     private readonly IUserService _userService;
 
+    [MapToApiVersion("1.0")]
     [HttpDelete("{id:guid}")]
     public async Task<IActionResult> DeleteUser(Guid id)
     {

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/DisableUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/DisableUsersController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.User;
 using Umbraco.Cms.Core.Security;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User;
 
+[ApiVersion("1.0")]
 public class DisableUserController : UserControllerBase
 {
     private readonly IUserService _userService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/EnableUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/EnableUsersController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.User;
 using Umbraco.Cms.Core.Security;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User;
 
+[ApiVersion("1.0")]
 public class EnableUserController : UserControllerBase
 {
     private readonly IUserService _userService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/FilterUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/FilterUsersController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.User;
@@ -11,6 +12,7 @@ using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User;
 
+[ApiVersion("1.0")]
 public class FilterUserController : UserControllerBase
 {
     private readonly IUserService _userService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/GetAllUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/GetAllUsersController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.Factories;
@@ -13,6 +14,7 @@ using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User;
 
+[ApiVersion("1.0")]
 public class GetAllUserController : UserControllerBase
 {
     private readonly IUserService _userService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/InviteUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/InviteUsersController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.User;
@@ -11,6 +12,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User;
 
+[ApiVersion("1.0")]
 public class InviteUserController : UserControllerBase
 {
     private readonly IUserService _userService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/Item/ItemUserItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/Item/ItemUserItemController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.User.Item;
 using Umbraco.Cms.Core.Mapping;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User.Item;
 
+[ApiVersion("1.0")]
 public class ItemUserItemController : UserItemControllerBase
 {
     private readonly IUserService _userService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/Item/UserItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/Item/UserItemControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User.Item;
@@ -6,7 +7,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.User.Item;
 [ApiController]
 [VersionedApiBackOfficeRoute("user")]
 [ApiExplorerSettings(GroupName = "User")]
-[ApiVersion("1.0")]
 public class UserItemControllerBase : ManagementApiControllerBase
 {
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/SetAvatarUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/SetAvatarUsersController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.User;
 using Umbraco.Cms.Core.Services;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User;
 
+[ApiVersion("1.0")]
 public class SetAvatarUserController : UserControllerBase
 {
     private readonly IUserService _userService;
@@ -15,6 +17,7 @@ public class SetAvatarUserController : UserControllerBase
         _userService = userService;
     }
 
+    [MapToApiVersion("1.0")]
     [HttpPost("avatar/{id:guid}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/UnlockUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/UnlockUsersController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.User;
 using Umbraco.Cms.Core;
@@ -9,6 +10,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User;
 
+[ApiVersion("1.0")]
 public class UnlockUserController : UserControllerBase
 {
     private readonly IUserService _userService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/UpdateUserGroupsUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/UpdateUserGroupsUsersController.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.User;
 using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User;
 
+[ApiVersion("1.0")]
 public class UpdateUserGroupsUserController : UserControllerBase
 {
     private readonly IUserGroupService _userGroupService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/UpdateUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/UpdateUsersController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.User;
 using Umbraco.Cms.Core;
@@ -10,6 +11,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User;
 
+[ApiVersion("1.0")]
 public class UpdateUserController : UserControllerBase
 {
     private readonly IUserService _userService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/UsersControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/UsersControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
@@ -10,7 +11,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.User;
 [ApiController]
 [VersionedApiBackOfficeRoute("user")]
 [ApiExplorerSettings(GroupName = "User")]
-[ApiVersion("1.0")]
 public abstract class UserControllerBase : ManagementApiControllerBase
 {
     protected IActionResult UserOperationStatusResult(UserOperationStatus status, ErrorMessageResult? errorMessageResult = null) =>

--- a/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/ByKeyUserGroupController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/ByKeyUserGroupController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.UserGroup;
@@ -7,7 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.UserGroup;
 
-
+[ApiVersion("1.0")]
 public class ByKeyUserGroupController : UserGroupControllerBase
 {
     private readonly IUserGroupService _userGroupService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/CreateUserGroupController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/CreateUserGroupController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.UserGroup;
@@ -10,6 +11,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.UserGroup;
 
+[ApiVersion("1.0")]
 public class CreateUserGroupController : UserGroupControllerBase
 {
     private readonly IUserGroupService _userGroupService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/DeleteUserGroupController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/DeleteUserGroupController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Services;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.UserGroup;
 
+[ApiVersion("1.0")]
 public class DeleteUserGroupController : UserGroupControllerBase
 {
     private readonly IUserGroupService _userGroupService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/GetAllUserGroupController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/GetAllUserGroupController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.Factories;
@@ -9,6 +10,7 @@ using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Management.Controllers.UserGroup;
 
+[ApiVersion("1.0")]
 public class GetAllUserGroupController : UserGroupControllerBase
 {
     private readonly IUserGroupService _userGroupService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/Item/ItemUserGroupItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/Item/ItemUserGroupItemController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.UserGroup.Item;
 using Umbraco.Cms.Core.Mapping;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.UserGroup.Item;
 
+[ApiVersion("1.0")]
 public class ItemUserGroupItemController : UserGroupItemControllerBase
 {
     private readonly IUserGroupService _userGroupService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/Item/UserGroupItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/Item/UserGroupItemControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.UserGroup.Item;
@@ -6,7 +7,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.UserGroup.Item;
 [ApiController]
 [VersionedApiBackOfficeRoute("user-group")]
 [ApiExplorerSettings(GroupName = "User Group")]
-[ApiVersion("1.0")]
 public class UserGroupItemControllerBase : ManagementApiControllerBase
 {
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/UpdateUserGroupController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/UpdateUserGroupController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.UserGroup;
@@ -9,6 +10,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.UserGroup;
 
+[ApiVersion("1.0")]
 public class UpdateUserGroupController : UserGroupControllerBase
 {
     private readonly IUserGroupService _userGroupService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/UserGroupsControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/UserGroupsControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
@@ -11,7 +12,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.UserGroup;
 [ApiController]
 [VersionedApiBackOfficeRoute("user-group")]
 [ApiExplorerSettings(GroupName = "User Group")]
-[ApiVersion("1.0")]
 public class UserGroupControllerBase : ManagementApiControllerBase
 {
     protected IActionResult UserGroupOperationStatusResult(UserGroupOperationStatus status) =>


### PR DESCRIPTION
### Summary
Changed to use [Asp.Versioning.Http](https://www.nuget.org/packages/Asp.Versioning.Http).

At the same time updated all controllers to have the ApiVersionAttribute on the controller it selves, as this cannot be inherited. (It couldn't before either).

### Test
- Ensure all Apis have same versioning.
- Try to create a v2 endpoint
   - Add `[ApiVersion("2.0")]` to a controller
   - Add `[MapToApiVersion("2.0")]` on a new action.
   - Ensure only this version have v2 and not any other endpoints