### PR TITLE
Delivery API: Not Found response when the start-item in "Start-Item" header is invalid

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Controllers/ByRouteContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/ByRouteContentApiController.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Delivery.Filters;
 using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Models.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
@@ -8,7 +7,6 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Delivery.Controllers;
 
-[ValidateStartItem]
 public class ByRouteContentApiController : ContentApiItemControllerBase
 {
     private readonly IRequestRoutingService _requestRoutingService;

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/ByRouteContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/ByRouteContentApiController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Delivery.Filters;
 using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Models.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Delivery.Controllers;
 
+[ValidateStartItem]
 public class ByRouteContentApiController : ContentApiItemControllerBase
 {
     private readonly IRequestRoutingService _requestRoutingService;

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/ContentApiControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/ContentApiControllerBase.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
+using Umbraco.Cms.Api.Delivery.Filters;
 using Umbraco.Cms.Api.Delivery.Routing;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DeliveryApi;
@@ -9,6 +10,8 @@ namespace Umbraco.Cms.Api.Delivery.Controllers;
 
 [VersionedDeliveryApiRoute("content")]
 [ApiExplorerSettings(GroupName = "Content")]
+[LocalizeFromAcceptLanguageHeader]
+[ValidateStartItem]
 public abstract class ContentApiControllerBase : DeliveryApiControllerBase
 {
     protected IApiPublishedContentCache ApiPublishedContentCache { get; }

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/DeliveryApiControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/DeliveryApiControllerBase.cs
@@ -9,7 +9,6 @@ namespace Umbraco.Cms.Api.Delivery.Controllers;
 [ApiVersion("1.0")]
 [DeliveryApiAccess]
 [JsonOptionsName(Constants.JsonOptionsNames.DeliveryApi)]
-[LocalizeFromAcceptLanguageHeader]
 public abstract class DeliveryApiControllerBase : Controller
 {
 }

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/QueryContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/QueryContentApiController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
+using Umbraco.Cms.Api.Delivery.Filters;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Models.DeliveryApi;
@@ -10,6 +11,7 @@ using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Delivery.Controllers;
 
+[ValidateStartItem]
 public class QueryContentApiController : ContentApiControllerBase
 {
     private readonly IApiContentQueryService _apiContentQueryService;
@@ -34,6 +36,7 @@ public class QueryContentApiController : ContentApiControllerBase
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<IApiContentResponse>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Query(
         string? fetch,
         [FromQuery] string[] filter,

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/QueryContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/QueryContentApiController.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
-using Umbraco.Cms.Api.Delivery.Filters;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Models.DeliveryApi;
@@ -11,7 +10,6 @@ using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Delivery.Controllers;
 
-[ValidateStartItem]
 public class QueryContentApiController : ContentApiControllerBase
 {
     private readonly IApiContentQueryService _apiContentQueryService;

--- a/src/Umbraco.Cms.Api.Delivery/Filters/ValidateStartItemAttribute.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Filters/ValidateStartItemAttribute.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace Umbraco.Cms.Api.Delivery.Filters;
+
+internal sealed class ValidateStartItemAttribute : TypeFilterAttribute
+{
+    public ValidateStartItemAttribute()
+        : base(typeof(ValidateStartItemFilter))
+    {
+    }
+
+    private class ValidateStartItemFilter : IActionFilter
+    {
+        private readonly IRequestStartItemProvider _requestStartItemProvider;
+
+        public ValidateStartItemFilter(IRequestStartItemProvider requestStartItemProvider)
+            => _requestStartItemProvider = requestStartItemProvider;
+
+        public void OnActionExecuting(ActionExecutingContext context)
+        {
+            if (_requestStartItemProvider.StartItemHeaderHasValue() == false)
+            {
+                return;
+            }
+
+            IPublishedContent? startItem = _requestStartItemProvider.GetStartItem();
+
+            if (startItem is null)
+            {
+                context.Result = new NotFoundObjectResult("The Start-Item could not be found");
+            }
+        }
+
+        public void OnActionExecuted(ActionExecutedContext context)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Cms.Api.Delivery/Filters/ValidateStartItemAttribute.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Filters/ValidateStartItemAttribute.cs
@@ -21,7 +21,7 @@ internal sealed class ValidateStartItemAttribute : TypeFilterAttribute
 
         public void OnActionExecuting(ActionExecutingContext context)
         {
-            if (_requestStartItemProvider.StartItemHeaderHasValue() == false)
+            if (_requestStartItemProvider.RequestedStartItem() is null)
             {
                 return;
             }

--- a/src/Umbraco.Cms.Api.Delivery/Querying/Filters/ContentTypeFilter.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Querying/Filters/ContentTypeFilter.cs
@@ -22,7 +22,7 @@ public sealed class ContentTypeFilter : IFilterHandler
             Value = string.Empty
         };
 
-        // TODO: do we support negation?
+        // Support negation
         if (alias.StartsWith('!'))
         {
             filterOption.Value = alias.Substring(1);

--- a/src/Umbraco.Cms.Api.Delivery/Querying/Filters/NameFilter.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Querying/Filters/NameFilter.cs
@@ -22,7 +22,7 @@ public sealed class NameFilter : IFilterHandler
             Value = string.Empty
         };
 
-        // TODO: do we support negation?
+        // Support negation
         if (value.StartsWith('!'))
         {
             filterOption.Value = value.Substring(1);

--- a/src/Umbraco.Cms.Api.Delivery/Services/RequestStartItemProvider.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/RequestStartItemProvider.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
@@ -32,7 +33,8 @@ internal sealed class RequestStartItemProvider : RequestHeaderHandler, IRequestS
             return null;
         }
 
-        var headerValue = GetHeaderValue("Start-Item");
+        // We make sure there is a value with the above check
+        var headerValue = GetHeaderValue("Start-Item")!.Trim(Constants.CharArrays.ForwardSlash);
 
         if (_publishedSnapshotAccessor.TryGetPublishedSnapshot(out IPublishedSnapshot? publishedSnapshot) == false || publishedSnapshot?.Content == null)
         {
@@ -43,7 +45,7 @@ internal sealed class RequestStartItemProvider : RequestHeaderHandler, IRequestS
 
         _requestedStartContent = Guid.TryParse(headerValue, out Guid key)
             ? rootContent.FirstOrDefault(c => c.Key == key)
-            : rootContent.FirstOrDefault(c => c.UrlSegment == headerValue);
+            : rootContent.FirstOrDefault(c => c.UrlSegment.InvariantEquals(headerValue));
 
         return _requestedStartContent;
     }

--- a/src/Umbraco.Cms.Api.Delivery/Services/RequestStartItemProvider.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/RequestStartItemProvider.cs
@@ -28,13 +28,11 @@ internal sealed class RequestStartItemProvider : RequestHeaderHandler, IRequestS
             return _requestedStartContent;
         }
 
-        if (StartItemHeaderHasValue() == false)
+        var headerValue = RequestedStartItem()?.Trim(Constants.CharArrays.ForwardSlash);
+        if (headerValue.IsNullOrWhiteSpace())
         {
             return null;
         }
-
-        // We make sure there is a value with the above check
-        var headerValue = GetHeaderValue("Start-Item")!.Trim(Constants.CharArrays.ForwardSlash);
 
         if (_publishedSnapshotAccessor.TryGetPublishedSnapshot(out IPublishedSnapshot? publishedSnapshot) == false || publishedSnapshot?.Content == null)
         {
@@ -51,5 +49,5 @@ internal sealed class RequestStartItemProvider : RequestHeaderHandler, IRequestS
     }
 
     /// <inheritdoc/>
-    public bool StartItemHeaderHasValue() => !GetHeaderValue("Start-Item").IsNullOrWhiteSpace();
+    public string? RequestedStartItem() => GetHeaderValue("Start-Item");
 }

--- a/src/Umbraco.Cms.Api.Delivery/Services/RequestStartItemProvider.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/RequestStartItemProvider.cs
@@ -27,11 +27,12 @@ internal sealed class RequestStartItemProvider : RequestHeaderHandler, IRequestS
             return _requestedStartContent;
         }
 
-        var headerValue = GetHeaderValue("Start-Item");
-        if (headerValue.IsNullOrWhiteSpace())
+        if (StartItemHeaderHasValue() == false)
         {
             return null;
         }
+
+        var headerValue = GetHeaderValue("Start-Item");
 
         if (_publishedSnapshotAccessor.TryGetPublishedSnapshot(out IPublishedSnapshot? publishedSnapshot) == false || publishedSnapshot?.Content == null)
         {
@@ -46,4 +47,7 @@ internal sealed class RequestStartItemProvider : RequestHeaderHandler, IRequestS
 
         return _requestedStartContent;
     }
+
+    /// <inheritdoc/>
+    public bool StartItemHeaderHasValue() => !GetHeaderValue("Start-Item").IsNullOrWhiteSpace();
 }

--- a/src/Umbraco.Core/DeliveryApi/IRequestStartItemProvider.cs
+++ b/src/Umbraco.Core/DeliveryApi/IRequestStartItemProvider.cs
@@ -5,12 +5,12 @@ namespace Umbraco.Cms.Core.DeliveryApi;
 public interface IRequestStartItemProvider
 {
     /// <summary>
-    ///     Gets the requested start item from the "Start-Item" header, if present.
+    ///     Gets the requested start item, if present.
     /// </summary>
     IPublishedContent? GetStartItem();
 
     /// <summary>
-    ///     Checks whether the "Start-Item" header has value.
+    ///     Gets the value of the requested start item, if present.
     /// </summary>
-    bool StartItemHeaderHasValue();
+    string? RequestedStartItem();
 }

--- a/src/Umbraco.Core/DeliveryApi/IRequestStartItemProvider.cs
+++ b/src/Umbraco.Core/DeliveryApi/IRequestStartItemProvider.cs
@@ -8,4 +8,9 @@ public interface IRequestStartItemProvider
     ///     Gets the requested start item from the "Start-Item" header, if present.
     /// </summary>
     IPublishedContent? GetStartItem();
+
+    /// <summary>
+    ///     Checks whether the "Start-Item" header has value.
+    /// </summary>
+    bool StartItemHeaderHasValue();
 }

--- a/src/Umbraco.Core/DeliveryApi/NoopRequestStartItemProvider.cs
+++ b/src/Umbraco.Core/DeliveryApi/NoopRequestStartItemProvider.cs
@@ -8,5 +8,5 @@ internal sealed class NoopRequestStartItemProvider : IRequestStartItemProvider
     public IPublishedContent? GetStartItem() => null;
 
     /// <inheritdoc />
-    public bool StartItemHeaderHasValue() => false;
+    public string? RequestedStartItem() => null;
 }

--- a/src/Umbraco.Core/DeliveryApi/NoopRequestStartItemProvider.cs
+++ b/src/Umbraco.Core/DeliveryApi/NoopRequestStartItemProvider.cs
@@ -6,4 +6,7 @@ internal sealed class NoopRequestStartItemProvider : IRequestStartItemProvider
 {
     /// <inheritdoc />
     public IPublishedContent? GetStartItem() => null;
+
+    /// <inheritdoc />
+    public bool StartItemHeaderHasValue() => false;
 }


### PR DESCRIPTION
## Details
- If the value of the "**Start-Item**" header is representing an invalid start node, `Not Found` response will be returned from all endpoints: <code>umbraco/delivery/api/v1/content/item/<b>{id}</b></code>, <code>umbraco/delivery/api/v1/content/item/<b>{path}</b></code> and `umbraco/delivery/api/v1/content/`.

## Test
- Test that without passing a "Start-Item" header, everything works as before;
- Pass invalid Guid or URL segment of a start item and verify that you get a 404 with a meaningful message;
- Test that passing a value with a **wrong** URL segment **casing** in a "Start-Item" header (of a valid item) returns the **found** item;
  - Ex: </br> GET https://localhost:44331/umbraco/delivery/api/v1/content/item/article </br> Start-Item: Blog
- Test that passing a URL segment with `/` in a "Start-Item" header (of a valid item) returns the **found** item;
  - Ex: </br> GET https://localhost:44331/umbraco/delivery/api/v1/content/item/article </br> Start-Item: Blog/
- Test with getting the **variant** item in the single-item endpoint with a "Start-Item" header with a valid GUID or URL segment of a start node and with Accept-Language header of the desired culture still works.
  - Ex: </br> GET https://localhost:44331/umbraco/delivery/api/v1/content/item/art-in-danish </br> Accept-Language: da-DK </br> Start-Item: 605a5fe0-d772-42a8-8ad3-d0683bf1bc08 OR my-blog-in-danish
   

