### PR TITLE
IAppCache implementations should not cache null values

### DIFF
--- a/src/Umbraco.Core/Cache/DictionaryAppCache.cs
+++ b/src/Umbraco.Core/Cache/DictionaryAppCache.cs
@@ -24,7 +24,19 @@ public class DictionaryAppCache : IRequestCache
     public virtual object? Get(string key) => _items.TryGetValue(key, out var value) ? value : null;
 
     /// <inheritdoc />
-    public virtual object? Get(string key, Func<object?> factory) => _items.GetOrAdd(key, _ => factory());
+    public virtual object? Get(string key, Func<object?> factory)
+    {
+        var value = _items.GetOrAdd(key, _ => factory());
+
+        if (value is not null)
+        {
+            return value;
+        }
+
+        // do not cache null values
+        _items.TryRemove(key, out _);
+        return null;
+    }
 
     public bool Set(string key, object? value) => _items.TryAdd(key, value);
 

--- a/src/Umbraco.Core/Cache/FastDictionaryAppCache.cs
+++ b/src/Umbraco.Core/Cache/FastDictionaryAppCache.cs
@@ -31,6 +31,14 @@ public class FastDictionaryAppCache : IAppCache
         Lazy<object?>? result = _items.GetOrAdd(cacheKey, k => SafeLazy.GetSafeLazy(getCacheItem));
 
         var value = result.Value; // will not throw (safe lazy)
+
+        if (value is null)
+        {
+            // do not cache null values
+            _items.TryRemove(cacheKey, out _);
+            return null;
+        }
+
         if (!(value is SafeLazy.ExceptionHolder eh))
         {
             return value;

--- a/src/Umbraco.Core/Cache/IAppCache.cs
+++ b/src/Umbraco.Core/Cache/IAppCache.cs
@@ -18,6 +18,7 @@ public interface IAppCache
     /// <param name="key">The key of the item.</param>
     /// <param name="factory">A factory function that can create the item.</param>
     /// <returns>The item.</returns>
+    /// <remarks>Null values returned from the factory function are never cached.</remarks>
     object? Get(string key, Func<object?> factory);
 
     /// <summary>

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/AppCacheTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/AppCacheTests.cs
@@ -82,6 +82,25 @@ public abstract class AppCacheTests
     }
 
     [Test]
+    public void Does_Not_Cache_Null_Values()
+    {
+        var counter = 0;
+
+        object? Factory()
+        {
+            counter++;
+            return counter == 3 ? "Not a null value" : null;
+        }
+
+        object? Get() => AppCache.Get("Blah", Factory);
+
+        Assert.IsNull(Get());
+        Assert.IsNull(Get());
+        Assert.AreEqual("Not a null value", Get());
+        Assert.AreEqual(3, counter);
+    }
+
+    [Test]
     public void Ensures_Delegate_Result_Is_Cached_Once()
     {
         var counter = 0;

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/FastDictionaryAppCacheTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/FastDictionaryAppCacheTests.cs
@@ -1,0 +1,20 @@
+﻿using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Cache;
+
+[TestFixture]
+public class FastDictionaryAppCacheTests : AppCacheTests
+{
+    public override void Setup()
+    {
+        base.Setup();
+        _appCache = new FastDictionaryAppCache();
+    }
+
+    private FastDictionaryAppCache _appCache;
+
+    internal override IAppCache AppCache => _appCache;
+
+    protected override int GetTotalItemCount => _appCache.Count;
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

There are currently a few different implementations of `IAppCache`:

- `DeepCloneAppCache`
- `DictionaryAppCache`
- `FastDictionaryAppCache`
- `HttpContextRequestAppCache`
- `NoAppCache`
- `ObjectCacheAppCache`

Of these, only the two concurrency dictionary based ones (`DictionaryAppCache` and `FastDictionaryAppCache`) allow caching of `null` values, while the other ones do not. This causes some unpredictable behaviour in certain edge cases related to routing.

This PR ensures that `null` values are never cached.

### Breaking change?

While this is not a binary breaking change, it is in principle a functionally breaking change. However, given the discrepancy between the `IAppCache` implementations, I do believe we're best off aligning their functionality across the board.

### Testing this PR

The routing behaviour is not the easiest thing to reproduce. You'll need a culture _variant_ content item below a culture _invariant_ root. The root should not have any hostname mappings, thus causing the non-default culture to be unroutable by the default routing mechanisms.

![route-unroutable](https://user-images.githubusercontent.com/7405322/236895046-86b57fe6-fd5c-41e1-8791-9913052722f5.png)

Now attempt to fetch the content in its non-default culture using the Delivery API *without* supplying the applicable `Accept-Language` header - i.e.:

<img width="644" alt="image" src="https://user-images.githubusercontent.com/7405322/236896949-3eb50804-d6ea-4cef-8f92-060d913d3131.png">

This will yield a `NotFound` result, which is acceptable. In principle it should yield the content item in the default culture, but routing limitations means we have to settle for `NotFound` here.

Now add the `Accept-Language` header. Without this PR applied, the request will continue to yield `NotFound`, because the `FastDictionaryAppCache` has cached a lazy null value for this route:

<img width="640" alt="image" src="https://user-images.githubusercontent.com/7405322/236897017-909c1c55-d7cf-4b50-a665-24aadd3beb7d.png">

With this PR applied, the request yields the non-default culture variant of the content item:

<img width="630" alt="image" src="https://user-images.githubusercontent.com/7405322/236897309-066cac6c-d252-4dae-9c91-4e16693fd4af.png">

...which is precisely what we're looking for - and also the same as is returned when querying by ID (with or without this PR applied):

<img width="708" alt="image" src="https://user-images.githubusercontent.com/7405322/236897543-d19c1da3-143c-4838-a19a-b05971fa2e0f.png">
