### PR TITLE
v12: Unbreak IMigrationPlanExecutor

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/ExecutedMigrationPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/ExecutedMigrationPlan.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Umbraco.Cms.Infrastructure.Migrations;
 
 public class ExecutedMigrationPlan
@@ -9,6 +11,7 @@ public class ExecutedMigrationPlan
         FinalState = finalState ?? throw new ArgumentNullException(nameof(finalState));
     }
 
+    [SetsRequiredMembers]
     public ExecutedMigrationPlan(
         MigrationPlan plan,
         string initialState,

--- a/src/Umbraco.Infrastructure/Migrations/IMigrationPlanExecutor.cs
+++ b/src/Umbraco.Infrastructure/Migrations/IMigrationPlanExecutor.cs
@@ -1,8 +1,18 @@
 using Umbraco.Cms.Infrastructure.Migrations;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Migrations;
 
 public interface IMigrationPlanExecutor
 {
-    ExecutedMigrationPlan ExecutePlan(MigrationPlan plan, string fromState);
+    [Obsolete("Use ExecutePlan instead.")]
+    string Execute(MigrationPlan plan, string fromState);
+
+    ExecutedMigrationPlan ExecutePlan(MigrationPlan plan, string fromState)
+    {
+        var state = Execute(plan, fromState);
+
+        // We have no real way of knowing whether it was successfull or not here, assume true.
+        return new ExecutedMigrationPlan(plan, fromState, state, true, plan.Transitions.Select(x => x.Value).WhereNotNull().ToList());
+    }
 }

--- a/src/Umbraco.Infrastructure/Migrations/MigrationPlanExecutor.cs
+++ b/src/Umbraco.Infrastructure/Migrations/MigrationPlanExecutor.cs
@@ -80,6 +80,8 @@ public class MigrationPlanExecutor : IMigrationPlanExecutor
     {
     }
 
+    public string Execute(MigrationPlan plan, string fromState) => ExecutePlan(plan, fromState).FinalState;
+
     /// <summary>
     ///     Executes the plan.
     /// </summary>


### PR DESCRIPTION
# Notes
- Reintroduce `Execute`
- Add default implementation for `ExecutePlan`

# How to test
- Assert you can run a migration, here's som test code:

```
using Umbraco.Cms.Core;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Migrations;
using Umbraco.Cms.Core.Notifications;
using Umbraco.Cms.Core.Scoping;
using Umbraco.Cms.Core.Services;
using Umbraco.Cms.Infrastructure.Migrations;
using Umbraco.Cms.Infrastructure.Migrations.Upgrade;

namespace Umbraco.Cms.Web.UI;

public class Composer : IComposer
{
    public void Compose(IUmbracoBuilder builder) =>
        _ = builder.AddNotificationHandler<UmbracoApplicationStartedNotification, ApplicationStartedHandler>();
}

public class ApplicationStartedHandler : INotificationHandler<UmbracoApplicationStartedNotification>
{
    private readonly IMigrationPlanExecutor _migrationPlanExecutor;
    private readonly IKeyValueService _keyValueService;

    public ApplicationStartedHandler(
        IMigrationPlanExecutor migrationPlanExecutor,
        IKeyValueService keyValueService)
    {
        _migrationPlanExecutor = migrationPlanExecutor;
        _keyValueService = keyValueService;
    }

    public void Handle(UmbracoApplicationStartedNotification notification)
    {
        var plan = new SimpleMigrationPlan();
        string? initialState = _keyValueService.GetValue(Constants.Conventions.Migrations.KeyValuePrefix + plan.Name);
        initialState ??= plan.InitialState;
        var state = _migrationPlanExecutor.Execute(plan, initialState!);
    }
}

public class SimpleMigrationPlan : MigrationPlan
{
    public SimpleMigrationPlan()
        : base("SimpleMigrationPlan") => DefinePlan();

    public override string InitialState => "SimpleMigrationPlan_InitialState";

    private void DefinePlan()
    {
        MigrationPlan plan = From(InitialState)
            .To<SimpleMigrationStep>(nameof(SimpleMigrationStep));
    }
}

public class SimpleMigrationStep : MigrationBase
{
    private readonly ILogger<SimpleMigrationStep> _logger;

    public SimpleMigrationStep(
        IMigrationContext context,
        ILogger<SimpleMigrationStep> logger)
        : base(context) => _logger = logger;

    protected override void Migrate() => _logger.LogDebug("Here be migration");
}

``` 