### PR TITLE
V10: Fix NoopPublishedValuefallback varation context member not implemented

### DIFF
--- a/src/Umbraco.Core/Models/PublishedContent/NoopPublishedValueFallback.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/NoopPublishedValueFallback.cs
@@ -17,40 +17,35 @@ public class NoopPublishedValueFallback : IPublishedValueFallback
     }
 
     /// <inheritdoc />
-    public bool TryGetValue(IPublishedProperty property, string? culture, string? segment, Fallback fallback,
-        object? defaultValue, out object? value)
+    public bool TryGetValue(IPublishedProperty property, string? culture, string? segment, Fallback fallback, object? defaultValue, out object? value)
     {
         value = default;
         return false;
     }
 
     /// <inheritdoc />
-    public bool TryGetValue<T>(IPublishedProperty property, string? culture, string? segment, Fallback fallback,
-        T? defaultValue, out T? value)
+    public bool TryGetValue<T>(IPublishedProperty property, string? culture, string? segment, Fallback fallback, T? defaultValue, out T? value)
     {
         value = default;
         return false;
     }
 
     /// <inheritdoc />
-    public bool TryGetValue(IPublishedElement content, string alias, string? culture, string? segment,
-        Fallback fallback, object? defaultValue, out object? value)
+    public bool TryGetValue(IPublishedElement content, string alias, string? culture, string? segment, Fallback fallback, object? defaultValue, out object? value)
     {
         value = default;
         return false;
     }
 
     /// <inheritdoc />
-    public bool TryGetValue<T>(IPublishedElement content, string alias, string? culture, string? segment,
-        Fallback fallback, T? defaultValue, out T? value)
+    public bool TryGetValue<T>(IPublishedElement content, string alias, string? culture, string? segment, Fallback fallback, T? defaultValue, out T? value)
     {
         value = default;
         return false;
     }
 
     /// <inheritdoc />
-    public bool TryGetValue(IPublishedContent content, string alias, string? culture, string? segment,
-        Fallback fallback, object? defaultValue, out object? value, out IPublishedProperty? noValueProperty)
+    public bool TryGetValue(IPublishedContent content, string alias, string? culture, string? segment, Fallback fallback, object? defaultValue, out object? value, out IPublishedProperty? noValueProperty)
     {
         value = default;
         noValueProperty = default;
@@ -58,8 +53,7 @@ public class NoopPublishedValueFallback : IPublishedValueFallback
     }
 
     /// <inheritdoc />
-    public bool TryGetValue<T>(IPublishedContent content, string alias, string? culture, string? segment,
-        Fallback fallback, T defaultValue, out T? value, out IPublishedProperty? noValueProperty)
+    public bool TryGetValue<T>(IPublishedContent content, string alias, string? culture, string? segment, Fallback fallback, T defaultValue, out T? value, out IPublishedProperty? noValueProperty)
     {
         value = default;
         noValueProperty = default;

--- a/src/Umbraco.Core/Models/PublishedContent/NoopPublishedValueFallback.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/NoopPublishedValueFallback.cs
@@ -7,37 +7,50 @@ namespace Umbraco.Cms.Core.Models.PublishedContent;
 ///     <para>This is for tests etc - does not implement fallback at all.</para>
 /// </remarks>
 public class NoopPublishedValueFallback : IPublishedValueFallback
+
 {
     /// <inheritdoc />
-    public bool TryGetValue(IPublishedProperty property, string? culture, string? segment, Fallback fallback, object? defaultValue, out object? value)
+    public IVariationContextAccessor VariationContextAccessor
+    {
+        get => new ThreadCultureVariationContextAccessor();
+        set { }
+    }
+
+    /// <inheritdoc />
+    public bool TryGetValue(IPublishedProperty property, string? culture, string? segment, Fallback fallback,
+        object? defaultValue, out object? value)
     {
         value = default;
         return false;
     }
 
     /// <inheritdoc />
-    public bool TryGetValue<T>(IPublishedProperty property, string? culture, string? segment, Fallback fallback, T? defaultValue, out T? value)
+    public bool TryGetValue<T>(IPublishedProperty property, string? culture, string? segment, Fallback fallback,
+        T? defaultValue, out T? value)
     {
         value = default;
         return false;
     }
 
     /// <inheritdoc />
-    public bool TryGetValue(IPublishedElement content, string alias, string? culture, string? segment, Fallback fallback, object? defaultValue, out object? value)
+    public bool TryGetValue(IPublishedElement content, string alias, string? culture, string? segment,
+        Fallback fallback, object? defaultValue, out object? value)
     {
         value = default;
         return false;
     }
 
     /// <inheritdoc />
-    public bool TryGetValue<T>(IPublishedElement content, string alias, string? culture, string? segment, Fallback fallback, T? defaultValue, out T? value)
+    public bool TryGetValue<T>(IPublishedElement content, string alias, string? culture, string? segment,
+        Fallback fallback, T? defaultValue, out T? value)
     {
         value = default;
         return false;
     }
 
     /// <inheritdoc />
-    public bool TryGetValue(IPublishedContent content, string alias, string? culture, string? segment, Fallback fallback, object? defaultValue, out object? value, out IPublishedProperty? noValueProperty)
+    public bool TryGetValue(IPublishedContent content, string alias, string? culture, string? segment,
+        Fallback fallback, object? defaultValue, out object? value, out IPublishedProperty? noValueProperty)
     {
         value = default;
         noValueProperty = default;
@@ -45,7 +58,8 @@ public class NoopPublishedValueFallback : IPublishedValueFallback
     }
 
     /// <inheritdoc />
-    public bool TryGetValue<T>(IPublishedContent content, string alias, string? culture, string? segment, Fallback fallback, T defaultValue, out T? value, out IPublishedProperty? noValueProperty)
+    public bool TryGetValue<T>(IPublishedContent content, string alias, string? culture, string? segment,
+        Fallback fallback, T defaultValue, out T? value, out IPublishedProperty? noValueProperty)
     {
         value = default;
         noValueProperty = default;


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/14202

Added missing interface member for the NoopPublishedValueFallback