### PR TITLE
V12: Remove test.only for acceptance tests

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Tabs/tabs.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Tabs/tabs.spec.ts
@@ -47,11 +47,14 @@ test.describe('Tabs', () => {
   }
 
   test('Click dashboard tabs', async ({umbracoUi, page}) => {
-    await umbracoUi.goToSection('content');
-    await page.locator('[data-element="tab-contentRedirectManager"] > button').click();
-    expect(page.locator('.redirecturlsearch')).not.toBeNull();
-    await page.locator('[data-element="tab-contentIntro"] > button').click();
-    await expect(page.locator('[data-element="tab-contentIntro"]')).toHaveClass('umb-tab umb-tab--active');
+    await umbracoUi.goToSection(ConstantHelper.sections.content);
+    await umbracoUi.clickDataElementByElementName('tab-contentRedirectManager');
+    await expect(page.locator('[data-element="tab-content-contentRedirectManager"]')).toBeVisible();
+    await umbracoUi.clickDataElementByElementName('tab-contentIntro');
+
+    // Assert
+    await expect(page.locator('[data-element="tab-contentIntro"]')).toHaveClass(/umb-tab--active/);
+    await expect(page.locator('[data-element="tab-content-contentIntro"]')).toBeVisible();
   });
 
   test('Create tab', async ({umbracoUi, umbracoApi, page}) => {

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Tabs/tabs.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Tabs/tabs.spec.ts
@@ -51,7 +51,7 @@ test.describe('Tabs', () => {
     await page.locator('[data-element="tab-contentRedirectManager"] > button').click();
     expect(page.locator('.redirecturlsearch')).not.toBeNull();
     await page.locator('[data-element="tab-contentIntro"] > button').click();
-    await expect(page.locator('[data-element="tab-contentIntro"]')).toHaveClass('umb-tab ng-scope umb-tab--active');
+    await expect(page.locator('[data-element="tab-contentIntro"]')).toHaveClass('umb-tab umb-tab--active');
   });
 
   test('Create tab', async ({umbracoUi, umbracoApi, page}) => {

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Tabs/tabs.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Tabs/tabs.spec.ts
@@ -46,7 +46,7 @@ test.describe('Tabs', () => {
     await openDocTypeFolder(umbracoUi, page);
   }
 
-  test.only('Click dashboard tabs', async ({umbracoUi, page}) => {
+  test('Click dashboard tabs', async ({umbracoUi, page}) => {
     await umbracoUi.goToSection('content');
     await page.locator('[data-element="tab-contentRedirectManager"] > button').click();
     expect(page.locator('.redirecturlsearch')).not.toBeNull();


### PR DESCRIPTION
Removed test.only, so our other test actually runs on the pipeline.

Updated the test itself so it asserts correctly.
