### PR TITLE
Enable ForceCreateDatabase for SqlServer

### DIFF
--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDatabaseProviderMetadata.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDatabaseProviderMetadata.cs
@@ -50,7 +50,7 @@ public class SqlServerDatabaseProviderMetadata : IDatabaseProviderMetadata
     public bool RequiresConnectionTest => true;
 
     /// <inheritdoc />
-    public bool ForceCreateDatabase => false;
+    public bool ForceCreateDatabase => true;
 
     /// <inheritdoc />
     public bool CanRecognizeConnectionString(string? connectionString)


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/14110
# Notes
- Enable `ForceCreateDatabase` for `SqlServerDatabaseProviderMetadata`

# How to test
- Set your connectionString in your `AppSettings.json`, I used my localDb like so:
(If you do not have a SQL server running, create one first)
Note here that although your server should be running, whatever database you set should not, so here my `test` database does not exist
```
  "ConnectionStrings": {
    "umbracoDbDSN": "Server=(localdb)\\MSSQLLocalDB;Database=test;Integrated Security=true",
    "umbracoDbDSN_ProviderName": "Microsoft.Data.SqlClient"
  },
```
- Enable UnattendedInstall by setting in your `AppSettings.Json`, in the `Umbraco/CMS` section
```
      "Unattended": {
        "InstallUnattended": true,
        "UnattendedUserName": "Nikolaj Geisle",
        "UnattendedUserEmail": "{YOUR EMAIL HERE}",
        "UnattendedUserPassword": "{YOUR PASSWORD HERE}"
      },
```
- Run Umbraco and assert that the database gets created, and thus umbraco gets installed and runs 👍 