### PR TITLE
Only index content for the Delivery API when it is enabled

### DIFF
--- a/src/Umbraco.Infrastructure/Examine/DeliveryApiContentIndexPopulator.cs
+++ b/src/Umbraco.Infrastructure/Examine/DeliveryApiContentIndexPopulator.cs
@@ -1,5 +1,8 @@
 using Examine;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
 
 namespace Umbraco.Cms.Infrastructure.Examine;
 
@@ -7,19 +10,31 @@ internal sealed class DeliveryApiContentIndexPopulator : IndexPopulator
 {
     private readonly IDeliveryApiContentIndexValueSetBuilder _deliveryContentIndexValueSetBuilder;
     private readonly IDeliveryApiContentIndexHelper _deliveryApiContentIndexHelper;
+    private readonly ILogger<DeliveryApiContentIndexPopulator> _logger;
+    private DeliveryApiSettings _deliveryApiSettings;
 
     public DeliveryApiContentIndexPopulator(
         IDeliveryApiContentIndexValueSetBuilder deliveryContentIndexValueSetBuilder,
-        IDeliveryApiContentIndexHelper deliveryApiContentIndexHelper)
+        IDeliveryApiContentIndexHelper deliveryApiContentIndexHelper,
+        ILogger<DeliveryApiContentIndexPopulator> logger,
+        IOptionsMonitor<DeliveryApiSettings> deliveryApiSettings)
     {
         _deliveryContentIndexValueSetBuilder = deliveryContentIndexValueSetBuilder;
         _deliveryApiContentIndexHelper = deliveryApiContentIndexHelper;
+        _logger = logger;
+        _deliveryApiSettings = deliveryApiSettings.CurrentValue;
+        deliveryApiSettings.OnChange(settings => _deliveryApiSettings = settings);
         RegisterIndex(Constants.UmbracoIndexes.DeliveryApiContentIndexName);
     }
 
     protected override void PopulateIndexes(IReadOnlyList<IIndex> indexes)
     {
         if (indexes.Any() is false)
+        {
+            return;
+        }
+
+        if (_deliveryApiSettings.Enabled is false)
         {
             return;
         }
@@ -34,5 +49,23 @@ internal sealed class DeliveryApiContentIndexPopulator : IndexPopulator
                     index.IndexItems(valueSets);
                 }
             });
+    }
+
+    public override bool IsRegistered(IIndex index)
+    {
+        if (_deliveryApiSettings.Enabled)
+        {
+            return base.IsRegistered(index);
+        }
+
+        // IsRegistered() is invoked for all indexes; only log a message when it's invoked for the Delivery API content index
+        if (index.Name is Constants.UmbracoIndexes.DeliveryApiContentIndexName)
+        {
+            // IsRegistered() is currently invoked only when Umbraco starts and when loading the Examine dashboard,
+            // so we won't be flooding the logs with info messages here
+            _logger.LogInformation("The Delivery API is not enabled, no indexing will performed for the Delivery API content index.");
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Updating content indexes can be an expensive operation for large sites. This PR ensures that we do not update the new content index for the Delivery API unless the Delivery API has been explicitly enabled by configuration.

### Testing

Prerequisites:

1. Stop the site if it is running.
2. Delete the Delivery API content index from disk. 
   - _Hint: Check the Examine dashboard to find the path on disk._

Steps:

1. Update the `Enabled` configuration to `false`:
![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/352b0973-cea3-4dd8-bacd-ae05a78da246)
2. Start the site and let it run undisturbed for a few minutes, until the "DeliveryApiContentIndex" folder is recreated on disk for the index. 
3. Now go to the Examine dashboard and verify that:
   - The document count for the index is 0.
![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/1a1ce8f6-1d7f-431d-b9af-8bcea94741ab)
   - The the "Rebuild index" button is disabled.
![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/5e0cfd0b-1f04-415a-8b4d-7ce44dc8795a)
4. Publish some content and verify that the document count on the Examine dashboard has not changed.
5. Stop the site and delete the Delivery API content index from disk again. 
6. Update the `Enabled` configuration to `true` and restart the site. Let it run undisturbed for a few minutes, until the "DeliveryApiContentIndex" folder is recreated once more.
7. Now go to the Examine dashboard and verify that the document count is more than 0 and that you can trigger index rebuilds manually.
8. Publish some content and verify that the documents are added or updated in the index
   - _Hint: Search for content key._
