### PR TITLE
Fix the args used in log endMessages in the profillingLogger

### DIFF
--- a/src/Umbraco.Core/Logging/DisposableTimer.cs
+++ b/src/Umbraco.Core/Logging/DisposableTimer.cs
@@ -59,7 +59,7 @@ public class DisposableTimer : DisposableObjectSlim
                     {
                         var args = new object[startMessageArgs.Length + 1];
                         startMessageArgs.CopyTo(args, 0);
-                        args[startMessageArgs.Length] = _timingId;
+                        args[^1] = _timingId;
                         logger.LogDebug(startMessage + " [Timing {TimingId}]", args);
                     }
 
@@ -73,7 +73,7 @@ public class DisposableTimer : DisposableObjectSlim
                     {
                         var args = new object[startMessageArgs.Length + 1];
                         startMessageArgs.CopyTo(args, 0);
-                        args[startMessageArgs.Length] = _timingId;
+                        args[^1] = _timingId;
                         logger.LogInformation(startMessage + " [Timing {TimingId}]", args);
                     }
 
@@ -127,8 +127,8 @@ public class DisposableTimer : DisposableObjectSlim
                 {
                     var args = new object[_failMessageArgs.Length + 2];
                     _failMessageArgs.CopyTo(args, 0);
-                    args[_failMessageArgs.Length - 1] = Stopwatch.ElapsedMilliseconds;
-                    args[_failMessageArgs.Length] = _timingId;
+                    args[^2] = Stopwatch.ElapsedMilliseconds;
+                    args[^1] = _timingId;
                     _logger.LogError(_failException, _failMessage + " ({Duration}ms) [Timing {TimingId}]", args);
                 }
             }
@@ -149,8 +149,8 @@ public class DisposableTimer : DisposableObjectSlim
                         {
                             var args = new object[_endMessageArgs.Length + 2];
                             _endMessageArgs.CopyTo(args, 0);
-                            args[^1] = Stopwatch.ElapsedMilliseconds;
-                            args[args.Length] = _timingId;
+                            args[^2] = Stopwatch.ElapsedMilliseconds;
+                            args[^1] = _timingId;
                             _logger.LogDebug(_endMessage + " ({Duration}ms) [Timing {TimingId}]", args);
                         }
 
@@ -168,8 +168,8 @@ public class DisposableTimer : DisposableObjectSlim
                         {
                             var args = new object[_endMessageArgs.Length + 2];
                             _endMessageArgs.CopyTo(args, 0);
-                            args[_endMessageArgs.Length - 1] = Stopwatch.ElapsedMilliseconds;
-                            args[_endMessageArgs.Length] = _timingId;
+                            args[^2] = Stopwatch.ElapsedMilliseconds;
+                            args[^1] = _timingId;
                             _logger.LogInformation(_endMessage + " ({Duration}ms) [Timing {TimingId}]", args);
                         }
 


### PR DESCRIPTION
When using the following code for the `profilingLogger` the endMessageArgs was not replaced correctly in the end log message with the duration and timing ID.

```csharp
var nodeKey = Guid.NewGuid();
using (_profilingLogger.TraceDuration<MyApiController>("Calculating complex code for node {nodeKey}", 
                   "Complex code completed for node {nodeKey}", 
                   startMessageArgs: new object[]{nodeKey}, 
                   endMessageArgs:new object[]{nodeKey}))
{
    Thread.Sleep(2000);
}
```

See attached screenshot of the values being replaced incorrectly.

![image](https://github.com/umbraco/Umbraco-CMS/assets/1389894/943312c1-2b56-48a2-9592-3646e60cd407)


### Test Notes
* Use the following code above in an `UmbracoApiController`
* Test this out before the PR is applied & verify the bug that the values are not correct.
* Apply the PR and verify the issue is fixed 😄 
