### PR TITLE
Fix delivery API cache level for media picker property editors

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MediaPickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MediaPickerValueConverter.cs
@@ -122,7 +122,7 @@ public class MediaPickerValueConverter : PropertyValueConverterBase, IDeliveryAp
         return source;
     }
 
-    public PropertyCacheLevel GetDeliveryApiPropertyCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Element;
+    public PropertyCacheLevel GetDeliveryApiPropertyCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Elements;
 
     public Type GetDeliveryApiPropertyValueType(IPublishedPropertyType propertyType) => typeof(IEnumerable<IApiMedia>);
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MediaPickerWithCropsValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MediaPickerWithCropsValueConverter.cs
@@ -120,7 +120,7 @@ public class MediaPickerWithCropsValueConverter : PropertyValueConverterBase, ID
         return isMultiple ? mediaItems : mediaItems.FirstOrDefault();
     }
 
-    public PropertyCacheLevel GetDeliveryApiPropertyCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Element;
+    public PropertyCacheLevel GetDeliveryApiPropertyCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Elements;
 
     public Type GetDeliveryApiPropertyValueType(IPublishedPropertyType propertyType) => typeof(IEnumerable<ApiMediaWithCrops>);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Media picker properties are being cached a bit too hard for the Delivery API, to the point where media changes are not reflected in the API output before a restart.

This PR adjusts these cache leves.

### Testing this PR

1. Create content with a picked media. It doesn't matter if it's MediaPicker or MediaPicker3.
2. Request the content using the Delivery API.
3. Change the picked media name.
4. Request the content again and verify that the media name is updated in the API repsonse.

If you want to get fancy, also test this with custom media properties (like an ALT text) using output expansion 😄 
