### PR TITLE
Delivery API: Add unauthorized to the produced response types 

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Controllers/ByIdContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/ByIdContentApiController.cs
@@ -27,6 +27,7 @@ public class ByIdContentApiController : ContentApiItemControllerBase
     [HttpGet("item/{id:guid}")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IApiContentResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> ById(Guid id)
     {

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/ByRouteContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/ByRouteContentApiController.cs
@@ -38,6 +38,7 @@ public class ByRouteContentApiController : ContentApiItemControllerBase
     [HttpGet("item/{*path}")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IApiContentResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> ByRoute(string path = "/")
     {


### PR DESCRIPTION
## Details
- Adding `Unauthorized` as a `ProducesResponseType` for the single-item endpoints.

## Test
- Verify that Unauthorized appears as a possible response for both `/umbraco/delivery/api/v1/content/item/{id}` and `/umbraco/delivery/api/v1/content/item/{path}` in Swagger.

![Responses](https://github.com/umbraco/Umbraco-CMS/assets/21998037/8533482e-9cc0-48e0-bc16-b3e584386f9c)
