### PR TITLE
Omit entirely un-routable content from Delivery API output

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Controllers/ByIdContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/ByIdContentApiController.cs
@@ -42,6 +42,12 @@ public class ByIdContentApiController : ContentApiItemControllerBase
             return Unauthorized();
         }
 
-        return await Task.FromResult(Ok(ApiContentResponseBuilder.Build(contentItem)));
+        IApiContentResponse? apiContentResponse = ApiContentResponseBuilder.Build(contentItem);
+        if (apiContentResponse is null)
+        {
+            return NotFound();
+        }
+
+        return await Task.FromResult(Ok(apiContentResponse));
     }
 }

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/QueryContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/QueryContentApiController.cs
@@ -7,6 +7,7 @@ using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Models.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Extensions;
 using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Delivery.Controllers;
@@ -53,7 +54,7 @@ public class QueryContentApiController : ContentApiControllerBase
 
         PagedModel<Guid> pagedResult = queryAttempt.Result;
         IEnumerable<IPublishedContent> contentItems = ApiPublishedContentCache.GetByIds(pagedResult.Items);
-        IApiContentResponse[] apiContentItems = contentItems.Select(ApiContentResponseBuilder.Build).ToArray();
+        IApiContentResponse[] apiContentItems = contentItems.Select(ApiContentResponseBuilder.Build).WhereNotNull().ToArray();
 
         var model = new PagedViewModel<IApiContentResponse>
         {

--- a/src/Umbraco.Core/DeliveryApi/ApiContentBuilderBase.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiContentBuilderBase.cs
@@ -19,8 +19,14 @@ public abstract class ApiContentBuilderBase<T>
 
     protected abstract T Create(IPublishedContent content, Guid id, string name, string contentType, IApiContentRoute route, IDictionary<string, object?> properties);
 
-    public virtual T Build(IPublishedContent content)
+    public virtual T? Build(IPublishedContent content)
     {
+        IApiContentRoute? route = _apiContentRouteBuilder.Build(content);
+        if (route is null)
+        {
+            return default;
+        }
+
         IDictionary<string, object?> properties =
             _outputExpansionStrategyAccessor.TryGetValue(out IOutputExpansionStrategy? outputExpansionStrategy)
                 ? outputExpansionStrategy.MapContentProperties(content)
@@ -31,7 +37,7 @@ public abstract class ApiContentBuilderBase<T>
             content.Key,
             _apiContentNameProvider.GetName(content),
             content.ContentType.Alias,
-            _apiContentRouteBuilder.Build(content),
+            route,
             properties);
     }
 }

--- a/src/Umbraco.Core/DeliveryApi/ApiContentResponseBuilder.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiContentResponseBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using Umbraco.Cms.Core.Models.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Routing;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.DeliveryApi;
@@ -14,12 +15,26 @@ public sealed class ApiContentResponseBuilder : ApiContentBuilderBase<IApiConten
 
     protected override IApiContentResponse Create(IPublishedContent content, Guid id, string name, string contentType, IApiContentRoute route, IDictionary<string, object?> properties)
     {
-        var cultures = content.Cultures.Values
-            .Where(publishedCultureInfo => publishedCultureInfo.Culture.IsNullOrWhiteSpace() == false) // filter out invariant cultures
-            .ToDictionary(
-                publishedCultureInfo => publishedCultureInfo.Culture,
-                publishedCultureInfo => _apiContentRouteBuilder.Build(content, publishedCultureInfo.Culture));
+        var routesByCulture = new Dictionary<string, IApiContentRoute>();
 
-        return new ApiContentResponse(id, name, contentType, route, properties, cultures);
+        foreach (PublishedCultureInfo publishedCultureInfo in content.Cultures.Values)
+        {
+            if (publishedCultureInfo.Culture.IsNullOrWhiteSpace())
+            {
+                // filter out invariant cultures
+                continue;
+            }
+
+            IApiContentRoute? cultureRoute = _apiContentRouteBuilder.Build(content, publishedCultureInfo.Culture);
+            if (cultureRoute == null)
+            {
+                // content is un-routable in this culture
+                continue;
+            }
+
+            routesByCulture[publishedCultureInfo.Culture] = cultureRoute;
+        }
+
+        return new ApiContentResponse(id, name, contentType, route, properties, routesByCulture);
     }
 }

--- a/src/Umbraco.Core/DeliveryApi/IApiContentBuilder.cs
+++ b/src/Umbraco.Core/DeliveryApi/IApiContentBuilder.cs
@@ -5,5 +5,5 @@ namespace Umbraco.Cms.Core.DeliveryApi;
 
 public interface IApiContentBuilder
 {
-    IApiContent Build(IPublishedContent content);
+    IApiContent? Build(IPublishedContent content);
 }

--- a/src/Umbraco.Core/DeliveryApi/IApiContentResponseBuilder.cs
+++ b/src/Umbraco.Core/DeliveryApi/IApiContentResponseBuilder.cs
@@ -5,5 +5,5 @@ namespace Umbraco.Cms.Core.DeliveryApi;
 
 public interface IApiContentResponseBuilder
 {
-    IApiContentResponse Build(IPublishedContent content);
+    IApiContentResponse? Build(IPublishedContent content);
 }

--- a/src/Umbraco.Core/DeliveryApi/IApiContentRouteBuilder.cs
+++ b/src/Umbraco.Core/DeliveryApi/IApiContentRouteBuilder.cs
@@ -5,5 +5,5 @@ namespace Umbraco.Cms.Core.DeliveryApi;
 
 public interface IApiContentRouteBuilder
 {
-    IApiContentRoute Build(IPublishedContent content, string? culture = null);
+    IApiContentRoute? Build(IPublishedContent content, string? culture = null);
 }

--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextParser.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextParser.cs
@@ -117,9 +117,12 @@ internal sealed partial class ApiRichTextParser : IApiRichTextParser
         {
             case Constants.UdiEntityType.Document:
                 IPublishedContent? content = publishedSnapshot.Content?.GetById(udi);
-                if (content != null)
+                IApiContentRoute? route = content != null
+                    ? _apiContentRouteBuilder.Build(content)
+                    : null;
+                if (route != null)
                 {
-                    attributes["route"] = _apiContentRouteBuilder.Build(content);
+                    attributes["route"] = route;
                 }
 
                 break;

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
@@ -177,14 +177,17 @@ public class MultiUrlPickerValueConverter : PropertyValueConverterBase, IDeliver
             {
                 case Constants.UdiEntityType.Document:
                     IPublishedContent? content = publishedSnapshot.Content?.GetById(item.Udi.Guid);
-                    return content == null
+                    IApiContentRoute? route = content != null
+                        ? _apiContentRouteBuilder.Build(content)
+                        : null;
+                    return content == null || route == null
                         ? null
                         : ApiLink.Content(
                             item.Name.IfNullOrWhiteSpace(_apiContentNameProvider.GetName(content)),
                             item.Target,
                             content.Key,
                             content.ContentType.Alias,
-                            _apiContentRouteBuilder.Build(content));
+                            route);
                 case Constants.UdiEntityType.Media:
                     IPublishedContent? media = publishedSnapshot.Media?.GetById(item.Udi.Guid);
                     return media == null

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ContentBuilderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ContentBuilderTests.cs
@@ -1,6 +1,7 @@
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Core.Models.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.PublishedCache;
@@ -61,10 +62,36 @@ public class ContentBuilderTests : DeliveryApiTests
         var customNameProvider = new Mock<IApiContentNameProvider>();
         customNameProvider.Setup(n => n.GetName(content.Object)).Returns($"Custom name for: {content.Object.Name}");
 
-        var builder = new ApiContentBuilder(customNameProvider.Object, Mock.Of<IApiContentRouteBuilder>(), CreateOutputExpansionStrategyAccessor());
+        var routeBuilder = new Mock<IApiContentRouteBuilder>();
+        routeBuilder
+            .Setup(r => r.Build(content.Object, It.IsAny<string?>()))
+            .Returns(new ApiContentRoute(content.Object.UrlSegment!, new ApiContentStartItem(Guid.NewGuid(), "/")));
+
+        var builder = new ApiContentBuilder(customNameProvider.Object, routeBuilder.Object, CreateOutputExpansionStrategyAccessor());
         var result = builder.Build(content.Object);
 
         Assert.NotNull(result);
         Assert.AreEqual("Custom name for: The page", result.Name);
+    }
+
+    [Test]
+    public void ContentBuilder_ReturnsNullForUnRoutableContent()
+    {
+        var content = new Mock<IPublishedContent>();
+
+        var contentType = new Mock<IPublishedContentType>();
+        contentType.SetupGet(c => c.Alias).Returns("thePageType");
+
+        ConfigurePublishedContentMock(content, Guid.NewGuid(), "The page", "the-page", contentType.Object, Array.Empty<PublishedElementPropertyBase>());
+
+        var routeBuilder = new Mock<IApiContentRouteBuilder>();
+        routeBuilder
+            .Setup(r => r.Build(content.Object, It.IsAny<string?>()))
+            .Returns((ApiContentRoute)null);
+
+        var builder = new ApiContentBuilder(new ApiContentNameProvider(), routeBuilder.Object, CreateOutputExpansionStrategyAccessor());
+        var result = builder.Build(content.Object);
+
+        Assert.Null(result);
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MultiNodeTreePickerValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MultiNodeTreePickerValueConverterTests.cs
@@ -15,13 +15,13 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.DeliveryApi;
 [TestFixture]
 public class MultiNodeTreePickerValueConverterTests : PropertyValueConverterTests
 {
-    private MultiNodeTreePickerValueConverter MultiNodeTreePickerValueConverter()
+    private MultiNodeTreePickerValueConverter MultiNodeTreePickerValueConverter(IApiContentRouteBuilder? routeBuilder = null)
     {
         var expansionStrategyAccessor = CreateOutputExpansionStrategyAccessor();
 
         var contentNameProvider = new ApiContentNameProvider();
         var apiUrProvider = new ApiMediaUrlProvider(PublishedUrlProvider);
-        var routeBuilder = new ApiContentRouteBuilder(PublishedUrlProvider, CreateGlobalSettings(), Mock.Of<IVariationContextAccessor>(), Mock.Of<IPublishedSnapshotAccessor>());
+        routeBuilder = routeBuilder ?? new ApiContentRouteBuilder(PublishedUrlProvider, CreateGlobalSettings(), Mock.Of<IVariationContextAccessor>(), Mock.Of<IPublishedSnapshotAccessor>());
         return new MultiNodeTreePickerValueConverter(
             PublishedSnapshotAccessor,
             Mock.Of<IUmbracoContextAccessor>(),
@@ -270,6 +270,23 @@ public class MultiNodeTreePickerValueConverterTests : PropertyValueConverterTest
 
         var valueConverter = MultiNodeTreePickerValueConverter();
 
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false) as IEnumerable<IApiContent>;
+        Assert.NotNull(result);
+        Assert.IsEmpty(result);
+    }
+
+    [Test]
+    public void MultiNodeTreePickerValueConverter_YieldsNothingForUnRoutableContent()
+    {
+        var publishedDataType = MultiNodePickerPublishedDataType(false, Constants.UdiEntityType.Document);
+        var publishedPropertyType = new Mock<IPublishedPropertyType>();
+        publishedPropertyType.SetupGet(p => p.DataType).Returns(publishedDataType);
+
+        // mocking the route builder will make it yield null values for all routes, so there is no need to setup anything on the mock
+        var routeBuilder = new Mock<IApiContentRouteBuilder>();
+        var valueConverter = MultiNodeTreePickerValueConverter(routeBuilder.Object);
+
+        var inter = new Udi[] { new GuidUdi(Constants.UdiEntityType.Document, PublishedContent.Key) };
         var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false) as IEnumerable<IApiContent>;
         Assert.NotNull(result);
         Assert.IsEmpty(result);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

In a culture variant setup with no hostname mappings assigned at root level, Umbraco is only able to route the default culture, unless `HideTopLevelNodeFromPath` is set to `false` (default is `true`).

With the introduction of the `Start-Item` header, the Delivery API is able to route all cultures in the same scenario. Unfortunately, this routing of otherwise un-routeable content is a little too lenient in certain scenarios, allowing for outputting descendants in a culture that is not published all the way up the content tree.

The result is content output with invalid `path` values:

<img width="357" alt="image" src="https://github.com/umbraco/Umbraco-CMS/assets/7405322/4cb04e4b-dc26-42af-90f9-b43f48435f21">
<img width="292" alt="image" src="https://github.com/umbraco/Umbraco-CMS/assets/7405322/bacaabbf-388f-4f51-b1a0-4038a5b11a28">

This PR ensures that the Delivery API only outputs content that has an "unbroken chain" of published content in any given culture - that is, all ancestors of the content is either published in that culture, or is culture invariant.

### Testing this PR

1. Create a structure of content using:
   - A culture _invariant_ root with no hostname mappings applied.
   - Culture _variant_ descendants in at least two levels.
2. Publish everything in all cultures.
3. Verify that content at level two (or below) can be fetched by path and ID in all cultures using the Delivery API.
4. Unpublish content at level one in the non-default culture.
5. Verify that content at level two (or below) can no longer be fetched in the non-defaullt culture using the Delivery API, neither by path or by ID.
6. Verify that the same content can be fetched in the default culture, and that the `cultures` collection of the output does not contain the non-default culture.
