### PR TITLE
Delivery API: Handle more unhappy paths when querying

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Querying/Filters/ContentTypeFilter.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Querying/Filters/ContentTypeFilter.cs
@@ -1,5 +1,6 @@
 using Umbraco.Cms.Api.Delivery.Indexing.Filters;
 using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Delivery.Querying.Filters;
 
@@ -19,7 +20,9 @@ public sealed class ContentTypeFilter : IFilterHandler
         return new FilterOption
         {
             FieldName = ContentTypeFilterIndexer.FieldName,
-            Values = new[] { alias.TrimStart('!') },
+            Values = alias.IsNullOrWhiteSpace() == false
+                ? new[] { alias.TrimStart('!') }
+                : Array.Empty<string>(),
             Operator = alias.StartsWith('!')
                 ? FilterOperation.IsNot
                 : FilterOperation.Is

--- a/src/Umbraco.Cms.Api.Delivery/Querying/Filters/NameFilter.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Querying/Filters/NameFilter.cs
@@ -1,5 +1,6 @@
 using Umbraco.Cms.Api.Delivery.Indexing.Sorts;
 using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Delivery.Querying.Filters;
 
@@ -19,7 +20,9 @@ public sealed class NameFilter : IFilterHandler
         return new FilterOption
         {
             FieldName = NameSortIndexer.FieldName,
-            Values = new[] { value.TrimStart('!') },
+            Values = value.IsNullOrWhiteSpace() == false
+                ? new[] { value.TrimStart('!') }
+                : Array.Empty<string>(),
             Operator = value.StartsWith('!')
                 ? FilterOperation.IsNot
                 : FilterOperation.Is

--- a/src/Umbraco.Cms.Api.Delivery/Querying/QueryOptionBase.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Querying/QueryOptionBase.cs
@@ -17,23 +17,23 @@ public abstract class QueryOptionBase
         _requestRoutingService = requestRoutingService;
     }
 
-    public Guid? GetGuidFromQuery(string queryStringValue)
+    protected Guid? GetGuidFromQuery(string queryStringValue)
     {
+        if (queryStringValue.IsNullOrWhiteSpace())
+        {
+            return null;
+        }
+
         if (Guid.TryParse(queryStringValue, out Guid id))
         {
             return id;
         }
 
-        if (queryStringValue.IsNullOrWhiteSpace() ||
-            !_publishedSnapshotAccessor.TryGetPublishedSnapshot(out IPublishedSnapshot? publishedSnapshot) ||
-            publishedSnapshot?.Content is null)
-        {
-            return null;
-        }
+        IPublishedSnapshot publishedSnapshot = _publishedSnapshotAccessor.GetRequiredPublishedSnapshot();
 
         // Check if the passed value is a path of a content item
         var contentRoute = _requestRoutingService.GetContentRoute(queryStringValue);
-        IPublishedContent? contentItem = publishedSnapshot.Content.GetByRoute(contentRoute);
+        IPublishedContent? contentItem = publishedSnapshot.Content?.GetByRoute(contentRoute);
 
         return contentItem?.Key;
     }

--- a/src/Umbraco.Cms.Api.Delivery/Querying/QueryOptionBase.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Querying/QueryOptionBase.cs
@@ -1,6 +1,7 @@
 using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Delivery.Querying;
 
@@ -23,7 +24,8 @@ public abstract class QueryOptionBase
             return id;
         }
 
-        if (!_publishedSnapshotAccessor.TryGetPublishedSnapshot(out IPublishedSnapshot? publishedSnapshot) ||
+        if (queryStringValue.IsNullOrWhiteSpace() ||
+            !_publishedSnapshotAccessor.TryGetPublishedSnapshot(out IPublishedSnapshot? publishedSnapshot) ||
             publishedSnapshot?.Content is null)
         {
             return null;

--- a/src/Umbraco.Cms.Api.Delivery/Services/RequestRoutingService.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/RequestRoutingService.cs
@@ -22,6 +22,11 @@ internal sealed class RequestRoutingService : RoutingServiceBase, IRequestRoutin
     /// <inheritdoc />
     public string GetContentRoute(string requestedPath)
     {
+        if (requestedPath.IsNullOrWhiteSpace())
+        {
+            return string.Empty;
+        }
+
         requestedPath = requestedPath.EnsureStartsWith("/");
 
         // do we have an explicit start item?


### PR DESCRIPTION
## Details
When passing an empty value to some of our built-in query options, we should have a safe fallback and get 0 items instead of Internal Server Errors.

## Test
- Try passing empty values to all built-in query options and verify that there are no Examine errors (_Internal Server_):
  - `?fetch=ancestors:`;
  - `?fetch=children:`;
  - `?fetch=descendants:`;
  - `?filter=contentType:`;
  - `?filter=name:`;
  - `?sort=createDate:`;
  - `?sort=level:`;
  - `?sort=name:`;
  - `?sort=sortOrder:`;
  - `?sort=updateDate:`.