### PR TITLE
Added IBackOfficeUserManager instead of BackOfficeUserManager

### DIFF
--- a/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs
+++ b/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs
@@ -27,7 +27,7 @@ public class BackOfficeSignInManager : UmbracoSignInManager<BackOfficeIdentityUs
     private readonly BackOfficeUserManager _userManager;
 
     public BackOfficeSignInManager(
-        BackOfficeUserManager userManager,
+        IBackOfficeUserManager userManager,
         IHttpContextAccessor contextAccessor,
         IBackOfficeExternalLoginProviders externalLogins,
         IUserClaimsPrincipalFactory<BackOfficeIdentityUser> claimsFactory,
@@ -37,9 +37,9 @@ public class BackOfficeSignInManager : UmbracoSignInManager<BackOfficeIdentityUs
         IAuthenticationSchemeProvider schemes,
         IUserConfirmation<BackOfficeIdentityUser> confirmation,
         IEventAggregator eventAggregator)
-        : base(userManager, contextAccessor, claimsFactory, optionsAccessor, logger, schemes, confirmation)
+        : base((BackOfficeUserManager)userManager, contextAccessor, claimsFactory, optionsAccessor, logger, schemes, confirmation)
     {
-        _userManager = userManager;
+        _userManager = (BackOfficeUserManager)userManager;
         _externalLogins = externalLogins;
         _eventAggregator = eventAggregator;
         _globalSettings = globalSettings.Value;
@@ -47,7 +47,7 @@ public class BackOfficeSignInManager : UmbracoSignInManager<BackOfficeIdentityUs
 
     [Obsolete("Use ctor with all params")]
     public BackOfficeSignInManager(
-        BackOfficeUserManager userManager,
+        IBackOfficeUserManager userManager,
         IHttpContextAccessor contextAccessor,
         IBackOfficeExternalLoginProviders externalLogins,
         IUserClaimsPrincipalFactory<BackOfficeIdentityUser> claimsFactory,

--- a/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs
+++ b/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs
@@ -45,9 +45,29 @@ public class BackOfficeSignInManager : UmbracoSignInManager<BackOfficeIdentityUs
         _globalSettings = globalSettings.Value;
     }
 
-    [Obsolete("Use ctor with all params")]
+    [Obsolete("Use ctor which takes IBackOfficeUserManager - this one will be removed in v14")]
     public BackOfficeSignInManager(
-        IBackOfficeUserManager userManager,
+        BackOfficeUserManager userManager,
+        IHttpContextAccessor contextAccessor,
+        IBackOfficeExternalLoginProviders externalLogins,
+        IUserClaimsPrincipalFactory<BackOfficeIdentityUser> claimsFactory,
+        IOptions<IdentityOptions> optionsAccessor,
+        IOptions<GlobalSettings> globalSettings,
+        ILogger<SignInManager<BackOfficeIdentityUser>> logger,
+        IAuthenticationSchemeProvider schemes,
+        IUserConfirmation<BackOfficeIdentityUser> confirmation,
+        IEventAggregator eventAggregator)
+        : base(userManager, contextAccessor, claimsFactory, optionsAccessor, logger, schemes, confirmation)
+    {
+        _userManager = userManager;
+        _externalLogins = externalLogins;
+        _eventAggregator = eventAggregator;
+        _globalSettings = globalSettings.Value;
+    }
+
+    [Obsolete("Use ctor with all params - this one will be removed in v14")]
+    public BackOfficeSignInManager(
+        BackOfficeUserManager userManager,
         IHttpContextAccessor contextAccessor,
         IBackOfficeExternalLoginProviders externalLogins,
         IUserClaimsPrincipalFactory<BackOfficeIdentityUser> claimsFactory,


### PR DESCRIPTION
This PR fixes an (I assume oversight) in the code of the BackOfficeSignInManager, that will make it possible to override the instance of the IBackOfficeUserManager.

Right now, the only workaround is to make your own BackOfficeSignInManager, to be able to inject an instance of IBackOfficeUserManager and then do this:
```
            builder.Services.Replace(new ServiceDescriptor(
                typeof(IBackOfficeSignInManager),
                typeof(MyBackOfficeSignInManager),
                ServiceLifetime.Scoped
            ));

            builder.Services.Replace(new ServiceDescriptor(
                typeof(IBackOfficeUserManager),
                typeof(MyBackOfficeUserManager),
                ServiceLifetime.Scoped
            ));
```

Do keep in mind that your custom IBackOfficeUserManager still has to extend the original BackOfficeUserManager, because it's tightly coupled in the code. But at least it's now possible to actually override virtuals.