### PR TITLE
Check if cache folders exist before trying to delete

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_12_0_0/ResetCache.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_12_0_0/ResetCache.cs
@@ -22,6 +22,11 @@ public class ResetCache : MigrationBase
 
     private void DeleteAllFilesInFolder(string path)
     {
+        if (Directory.Exists(path) == false)
+        {
+            return;
+        }
+
         var directoryInfo = new DirectoryInfo(path);
 
         foreach (FileInfo file in directoryInfo.GetFiles())


### PR DESCRIPTION
This was an issue if you had no `DistCache` or `NuCache` folder when upgrading

# How to test
- Go into `Umbraco/Data/Temp` and delete your NuCache & DistCache folders
- Add another line in `UmbracoPlan.cs`: `        To<V_12_0_0.ResetCache>("{539F2F83-FBA7-4C48-81A3-75081A56BB1D}");`
- Run the migration