### PR TITLE
Fix transparent background after upgrade of spectrum color picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-color-picker.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-color-picker.less
@@ -1,17 +1,13 @@
-﻿.umb-color-picker {
+.umb-color-picker {
 
     .sp-replacer {
         display: inline-flex;
         margin-right: 12px;
         height: 32px;
+        padding: 5px;
 
         &.sp-light {
             background-color: @white; 
-        }
-
-        .sp-preview {
-            margin: 5px;
-            height: auto;
         }
 
         .sp-dd {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
After upgrade of spectrum color picker, which had some accessibility enhancements and cleanup https://github.com/seballot/spectrum/pull/38 it affected that Umbraco set the `height: auto` so the checkered background wasn't visible.
https://github.com/umbraco/Umbraco-CMS/pull/14179

Furthermore it wasn't possible to see the current selected color.

**Before**

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/bb003df4-be5c-4e29-bc30-b19c123d6b9a)

**After**

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/f6858762-0b25-444c-b573-f775878705a3)
