### PR TITLE
Wrap RTE content in a dedicated model for future expansion

### DIFF
--- a/src/Umbraco.Core/Models/DeliveryApi/RichTextModel.cs
+++ b/src/Umbraco.Core/Models/DeliveryApi/RichTextModel.cs
@@ -1,0 +1,6 @@
+﻿namespace Umbraco.Cms.Core.Models.DeliveryApi;
+
+public class RichTextModel
+{
+    public required string Markup { get; set; }
+}

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RteMacroRenderingValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RteMacroRenderingValueConverter.cs
@@ -82,13 +82,16 @@ public class RteMacroRenderingValueConverter : SimpleTinyMceValueConverter, IDel
     public Type GetDeliveryApiPropertyValueType(IPublishedPropertyType propertyType)
         => _deliveryApiSettings.RichTextOutputAsJson
             ? typeof(IRichTextElement)
-            : typeof(string);
+            : typeof(RichTextModel);
 
     public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
     {
         if (_deliveryApiSettings.RichTextOutputAsJson is false)
         {
-            return Convert(inter, preview) ?? string.Empty;
+            return new RichTextModel
+            {
+                Markup = Convert(inter, preview) ?? string.Empty
+            };
         }
 
         var sourceString = inter?.ToString();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR wraps RTE markup in a dedicated output model for the Delivery API, so we can add to that model in the future - should the need arise.

### Testing this PR

Verify that the output now looks something like this:

<img width="299" alt="image" src="https://github.com/umbraco/Umbraco-CMS/assets/7405322/ad2be7f8-aa25-48c3-8c26-38b13ea159ff">

...where `content` is the alias of the RTE property.