### PR TITLE
Temp fix for MNTP with content for delivery api

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MultiNodeTreePickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MultiNodeTreePickerValueConverter.cs
@@ -204,6 +204,13 @@ public class MultiNodeTreePickerValueConverter : PropertyValueConverterBase, IDe
         IPublishedSnapshot publishedSnapshot = _publishedSnapshotAccessor.GetRequiredPublishedSnapshot();
 
         var entityType = GetEntityType(propertyType);
+
+        if (entityType == "content")
+        {
+            // TODO Why do MNTP config saves "content" and not "document"?
+            entityType = Constants.UdiEntityType.Document;
+        }
+
         GuidUdi[] entityTypeUdis = udis.Where(udi => udi.EntityType == entityType).OfType<GuidUdi>().ToArray();
         return entityType switch
         {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MultiNodeTreePickerValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MultiNodeTreePickerValueConverterTests.cs
@@ -93,7 +93,9 @@ public class MultiNodeTreePickerValueConverterTests : PropertyValueConverterTest
     }
 
     [Test]
-    public void MultiNodeTreePickerValueConverter_RendersContentProperties()
+    [TestCase(Constants.UdiEntityType.Document)]
+    [TestCase("content")]
+    public void MultiNodeTreePickerValueConverter_RendersContentProperties(string entityType)
     {
         var content = new Mock<IPublishedContent>();
 
@@ -112,7 +114,7 @@ public class MultiNodeTreePickerValueConverterTests : PropertyValueConverterTest
             .Setup(pcc => pcc.GetById(key))
             .Returns(content.Object);
 
-        var publishedDataType = MultiNodePickerPublishedDataType(false, Constants.UdiEntityType.Document);
+        var publishedDataType = MultiNodePickerPublishedDataType(false, entityType);
         var publishedPropertyType = new Mock<IPublishedPropertyType>();
         publishedPropertyType.SetupGet(p => p.DataType).Returns(publishedDataType);
 


### PR DESCRIPTION
This adds a temporary fix for Multi Node Tree Picker, when configured for "content" when requested using delivery api.

Before this fix it just return an empty list.

The reason this happens is because the datatype configuration saves "content" and not "document" when configured for content