### PR TITLE
Ignore macros completely in deliveryapi

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MultiNodeTreePickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MultiNodeTreePickerValueConverter.cs
@@ -204,6 +204,13 @@ public class MultiNodeTreePickerValueConverter : PropertyValueConverterBase, IDe
         IPublishedSnapshot publishedSnapshot = _publishedSnapshotAccessor.GetRequiredPublishedSnapshot();
 
         var entityType = GetEntityType(propertyType);
+
+        if (entityType == "content")
+        {
+            // TODO Why do MNTP config saves "content" and not "document"?
+            entityType = Constants.UdiEntityType.Document;
+        }
+
         GuidUdi[] entityTypeUdis = udis.Where(udi => udi.EntityType == entityType).OfType<GuidUdi>().ToArray();
         return entityType switch
         {

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RteMacroRenderingValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RteMacroRenderingValueConverter.cs
@@ -88,7 +88,7 @@ public class RteMacroRenderingValueConverter : SimpleTinyMceValueConverter, IDel
     {
         if (_deliveryApiSettings.RichTextOutputAsJson is false)
         {
-            return Convert(inter, preview) ?? string.Empty;
+            return Convert(inter, preview, false) ?? string.Empty;
         }
 
         var sourceString = inter?.ToString();
@@ -126,7 +126,7 @@ public class RteMacroRenderingValueConverter : SimpleTinyMceValueConverter, IDel
         }
     }
 
-    private string? Convert(object? source, bool preview)
+    private string? Convert(object? source, bool preview, bool handleMacros = true)
     {
         if (source == null)
         {
@@ -141,7 +141,10 @@ public class RteMacroRenderingValueConverter : SimpleTinyMceValueConverter, IDel
         sourceString = _imageSourceParser.EnsureImageSources(sourceString);
 
         // ensure string is parsed for macros and macros are executed correctly
-        sourceString = RenderRteMacros(sourceString, preview);
+        if (handleMacros)
+        {
+            sourceString = RenderRteMacros(sourceString, preview);
+        }
 
         // find and remove the rel attributes used in the Umbraco UI from img tags
         var doc = new HtmlDocument();

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MultiNodeTreePickerValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MultiNodeTreePickerValueConverterTests.cs
@@ -93,7 +93,9 @@ public class MultiNodeTreePickerValueConverterTests : PropertyValueConverterTest
     }
 
     [Test]
-    public void MultiNodeTreePickerValueConverter_RendersContentProperties()
+    [TestCase(Constants.UdiEntityType.Document)]
+    [TestCase("content")]
+    public void MultiNodeTreePickerValueConverter_RendersContentProperties(string entityType)
     {
         var content = new Mock<IPublishedContent>();
 
@@ -112,7 +114,7 @@ public class MultiNodeTreePickerValueConverterTests : PropertyValueConverterTest
             .Setup(pcc => pcc.GetById(key))
             .Returns(content.Object);
 
-        var publishedDataType = MultiNodePickerPublishedDataType(false, Constants.UdiEntityType.Document);
+        var publishedDataType = MultiNodePickerPublishedDataType(false, entityType);
         var publishedPropertyType = new Mock<IPublishedPropertyType>();
         publishedPropertyType.SetupGet(p => p.DataType).Returns(publishedDataType);
 


### PR DESCRIPTION
Builds on top of https://github.com/umbraco/Umbraco-CMS/pull/14261

Completely ignores macros instead of exploding in delivery api. Thereby output becomes something like

``
"<p>saasd</p>\n<p> </p>\n<?UMBRACO_MACRO macroAlias=\"asdasd\" />\n<p> </p>\n<p>asdasd</p>"
``