### PR TITLE
Updated the installer text about Codegarden

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/installer/installer.service.js
+++ b/src/Umbraco.Web.UI.Client/src/installer/installer.service.js
@@ -30,7 +30,7 @@ angular.module("umbraco.install").factory('installerService', function ($rootSco
 					"At least 4 people have the Umbraco logo tattooed on them",
 					"'Umbraco' is the Danish name for an allen key",
 					"Umbraco has been around since 2005, that's a looong time in IT",
-          "Every year around 1500 Umbraco enthusiasts from around the world join the biggest hybrid Umbraco conference <a target='_blank' rel='noopener' href='https://codegarden.umbraco.com/'>Codegarden</a>",					
+          "Every year around 1500 Umbraco enthusiasts from around the world join the biggest hybrid Umbraco conference <a target='_blank' rel='noopener' href='https://codegarden.umbraco.com/'>Codegarden</a>",
 					"While you are installing Umbraco someone else on the other side of the planet is probably doing it too",
 					"You can extend Umbraco without modifying the source code using either JavaScript or C#",
 					"Umbraco has been installed in more than 198 countries"

--- a/src/Umbraco.Web.UI.Client/src/installer/installer.service.js
+++ b/src/Umbraco.Web.UI.Client/src/installer/installer.service.js
@@ -30,7 +30,7 @@ angular.module("umbraco.install").factory('installerService', function ($rootSco
 					"At least 4 people have the Umbraco logo tattooed on them",
 					"'Umbraco' is the Danish name for an allen key",
 					"Umbraco has been around since 2005, that's a looong time in IT",
-					"More than 700 people from all over the world meet each year in Denmark in May for our annual conference <a target='_blank' rel='noopener' href='https://umbra.co/codegarden'>CodeGarden</a>",
+					"More than 700 people from all over the world meet each year in Denmark in June for our annual conference <a target='_blank' rel='noopener' href='https://codegarden.umbraco.com/'>Codegarden</a>",
 					"While you are installing Umbraco someone else on the other side of the planet is probably doing it too",
 					"You can extend Umbraco without modifying the source code using either JavaScript or C#",
 					"Umbraco has been installed in more than 198 countries"

--- a/src/Umbraco.Web.UI.Client/src/installer/installer.service.js
+++ b/src/Umbraco.Web.UI.Client/src/installer/installer.service.js
@@ -30,7 +30,7 @@ angular.module("umbraco.install").factory('installerService', function ($rootSco
 					"At least 4 people have the Umbraco logo tattooed on them",
 					"'Umbraco' is the Danish name for an allen key",
 					"Umbraco has been around since 2005, that's a looong time in IT",
-					"More than 700 people from all over the world meet each year in Denmark in June for our annual conference <a target='_blank' rel='noopener' href='https://codegarden.umbraco.com/'>Codegarden</a>",
+          "Every year around 1500 Umbraco enthusiasts from around the world join the biggest hybrid Umbraco conference <a target='_blank' rel='noopener' href='https://codegarden.umbraco.com/'>Codegarden</a>",					
 					"While you are installing Umbraco someone else on the other side of the planet is probably doing it too",
 					"You can extend Umbraco without modifying the source code using either JavaScript or C#",
 					"Umbraco has been installed in more than 198 countries"


### PR DESCRIPTION
Noticed on an install this morning that this was a bit out of date:

 - Links to Codegarden 2018
 - Says it's in May
 - Uses the wrong capitalization

So this updates it.