### PR TITLE
V12: Map |DataDirectory| to path in connectionString

### DIFF
--- a/src/Umbraco.Cms.Persistence.EFCore/Extensions/UmbracoEFCoreServiceCollectionExtensions.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/Extensions/UmbracoEFCoreServiceCollectionExtensions.cs
@@ -18,7 +18,7 @@ public static class UmbracoEFCoreServiceCollectionExtensions
 
         // Replace data directory
         string? dataDirectory = AppDomain.CurrentDomain.GetData(Constants.System.DataDirectoryName)?.ToString();
-        if (!string.IsNullOrEmpty(dataDirectory))
+        if (string.IsNullOrEmpty(dataDirectory) is false)
         {
             connectionString = connectionString.Replace(Constants.System.DataDirectoryPlaceholder, dataDirectory);
         }

--- a/src/Umbraco.Cms.Persistence.EFCore/Extensions/UmbracoEFCoreServiceCollectionExtensions.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/Extensions/UmbracoEFCoreServiceCollectionExtensions.cs
@@ -1,6 +1,6 @@
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DistributedLocking;
 using Umbraco.Cms.Persistence.EFCore.Locking;
 using Umbraco.Cms.Persistence.EFCore.Scoping;
@@ -15,6 +15,13 @@ public static class UmbracoEFCoreServiceCollectionExtensions
         where T : DbContext
     {
         defaultEFCoreOptionsAction ??= DefaultOptionsAction;
+
+        // Replace data directory
+        string? dataDirectory = AppDomain.CurrentDomain.GetData(Constants.System.DataDirectoryName)?.ToString();
+        if (!string.IsNullOrEmpty(dataDirectory))
+        {
+            connectionString = connectionString.Replace(Constants.System.DataDirectoryPlaceholder, dataDirectory);
+        }
 
         services.AddDbContext<T>(
             options =>

--- a/src/Umbraco.Core/Configuration/Models/ConnectionStrings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ConnectionStrings.cs
@@ -15,7 +15,7 @@ public class ConnectionStrings // TODO: Rename to [Umbraco]ConnectionString (sin
     /// <summary>
     ///     The DataDirectory placeholder.
     /// </summary>
-    public const string DataDirectoryPlaceholder = ConfigurationExtensions.DataDirectoryPlaceholder;
+    public const string DataDirectoryPlaceholder = Constants.System.DataDirectoryPlaceholder;
 
     /// <summary>
     ///     The postfix used to identify a connection strings provider setting.

--- a/src/Umbraco.Core/Constants-System.cs
+++ b/src/Umbraco.Core/Constants-System.cs
@@ -64,5 +64,15 @@ public static partial class Constants
 
         public const string UmbracoConnectionName = "umbracoDbDSN";
         public const string DefaultUmbracoPath = "~/umbraco";
+
+        /// <summary>
+        /// The DataDirectory name.
+        /// </summary>
+        public const string DataDirectoryName = "DataDirectory";
+
+        /// <summary>
+        /// The DataDirectory placeholder.
+        /// </summary>
+        public const string DataDirectoryPlaceholder = "|DataDirectory|";
     }
 }

--- a/src/Umbraco.Core/Extensions/ConfigurationExtensions.cs
+++ b/src/Umbraco.Core/Extensions/ConfigurationExtensions.cs
@@ -11,16 +11,6 @@ namespace Umbraco.Extensions;
 public static class ConfigurationExtensions
 {
     /// <summary>
-    /// The DataDirectory name.
-    /// </summary>
-    internal const string DataDirectoryName = "DataDirectory";
-
-    /// <summary>
-    /// The DataDirectory placeholder.
-    /// </summary>
-    internal const string DataDirectoryPlaceholder = "|DataDirectory|";
-
-    /// <summary>
     /// The postfix used to identify a connection string provider setting.
     /// </summary>
     internal const string ProviderNamePostfix = "_ProviderName";
@@ -76,10 +66,10 @@ public static class ConfigurationExtensions
         if (!string.IsNullOrEmpty(connectionString))
         {
             // Replace data directory
-            string? dataDirectory = AppDomain.CurrentDomain.GetData(DataDirectoryName)?.ToString();
+            string? dataDirectory = AppDomain.CurrentDomain.GetData(Constants.System.DataDirectoryName)?.ToString();
             if (!string.IsNullOrEmpty(dataDirectory))
             {
-                connectionString = connectionString.Replace(DataDirectoryPlaceholder, dataDirectory);
+                connectionString = connectionString.Replace(Constants.System.DataDirectoryPlaceholder, dataDirectory);
             }
 
             // Get provider name


### PR DESCRIPTION
# Notes
- Implements logic that will translate the `|DataDirectory|` part of you connection string, to an actual filepath, 
as this was tripping people up, when registering their DbContexts.
- Created Constants for `DataDirectoryName` & `DataDirectoryPlaceHolder` as they where now used multiple places

# How to test
- Follow the documentation for EFCore: https://docs.umbraco.com/umbraco-cms/v/12.latest/tutorials/getting-started-with-entity-framework-core
- Try to register your database with just copying your SQLite connection string from your appsettings.json, it should look like this: `Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True`
- You should be able to access your db context now 🙌 