### PR TITLE
V10: Add external login provider count to detailed telemetry

### DIFF
--- a/src/Umbraco.Core/Constants-Telemetry.cs
+++ b/src/Umbraco.Core/Constants-Telemetry.cs
@@ -28,5 +28,6 @@ public static partial class Constants
         public static string IsDebug = "IsDebug";
         public static string DatabaseProvider = "DatabaseProvider";
         public static string CurrentServerRole = "CurrentServerRole";
+        public static string BackofficeExternalLoginProviderCount = "BackofficeExternalLoginProviderCount";
     }
 }

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -3005,7 +3005,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
           We will send:
           <ul>
             <li>Anonymized site ID, Umbraco version, and packages installed.</li>
-            <li>Number of: Root nodes, Content nodes, Macros, Media, Document Types, Templates, Languages, Domains, User Group, Users, Members, and Property Editors in use.</li>
+            <li>Number of: Root nodes, Content nodes, Macros, Media, Document Types, Templates, Languages, Domains, User Group, Users, Members, Backoffice external login providers, and Property Editors in use.</li>
             <li>System information: Webserver, server OS, server framework, server OS language, and database provider.</li>
             <li>Configuration settings: Modelsbuilder mode, if custom Umbraco path exists, ASP environment, and if you are in debug mode.</li>
           </ul>

--- a/src/Umbraco.Infrastructure/Telemetry/Interfaces/IDetailedTelemetryProvider.cs
+++ b/src/Umbraco.Infrastructure/Telemetry/Interfaces/IDetailedTelemetryProvider.cs
@@ -2,7 +2,7 @@ using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Infrastructure.Telemetry.Interfaces;
 
-internal interface IDetailedTelemetryProvider
+public interface IDetailedTelemetryProvider
 {
     IEnumerable<UsageInformation> GetInformation();
 }

--- a/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilder.BackOfficeIdentity.cs
+++ b/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilder.BackOfficeIdentity.cs
@@ -11,7 +11,9 @@ using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Security;
+using Umbraco.Cms.Infrastructure.Telemetry.Interfaces;
 using Umbraco.Cms.Web.BackOffice.Security;
+using Umbraco.Cms.Web.BackOffice.Telemetry;
 using Umbraco.Cms.Web.Common.AspNetCore;
 using Umbraco.Cms.Web.Common.Security;
 
@@ -65,6 +67,7 @@ public static partial class UmbracoBuilderExtensions
         services.TryAddScoped<IIpResolver, AspNetCoreIpResolver>();
         services.TryAddSingleton<IBackOfficeExternalLoginProviders, BackOfficeExternalLoginProviders>();
         services.TryAddSingleton<IBackOfficeTwoFactorOptions, DefaultBackOfficeTwoFactorOptions>();
+        services.AddTransient<IDetailedTelemetryProvider, ExternalLoginTelemetryProvider>();
 
         return new BackOfficeIdentityBuilder(services);
     }

--- a/src/Umbraco.Web.BackOffice/Telemetry/ExternalLoginTelemetryProvider.cs
+++ b/src/Umbraco.Web.BackOffice/Telemetry/ExternalLoginTelemetryProvider.cs
@@ -1,0 +1,22 @@
+﻿using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Infrastructure.Telemetry.Interfaces;
+using Umbraco.Cms.Web.BackOffice.Security;
+
+namespace Umbraco.Cms.Web.BackOffice.Telemetry;
+
+public class ExternalLoginTelemetryProvider : IDetailedTelemetryProvider
+{
+    private readonly IBackOfficeExternalLoginProviders _externalLoginProviders;
+
+    public ExternalLoginTelemetryProvider(IBackOfficeExternalLoginProviders externalLoginProviders)
+    {
+        _externalLoginProviders = externalLoginProviders;
+    }
+
+    public IEnumerable<UsageInformation> GetInformation()
+    {
+        IEnumerable<BackOfficeExternaLoginProviderScheme> providers = _externalLoginProviders.GetBackOfficeProvidersAsync().GetAwaiter().GetResult();
+        yield return new UsageInformation(Constants.Telemetry.BackofficeExternalLoginProviderCount, providers.Count());
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
@@ -49,7 +49,8 @@ public class TelemetryServiceTests : UmbracoIntegrationTest
             Constants.Telemetry.AspEnvironment,
             Constants.Telemetry.IsDebug,
             Constants.Telemetry.DatabaseProvider,
-            Constants.Telemetry.CurrentServerRole
+            Constants.Telemetry.CurrentServerRole,
+            Constants.Telemetry.BackofficeExternalLoginProviderCount
         };
 
         MetricsConsentService.SetConsentLevel(TelemetryLevel.Detailed);


### PR DESCRIPTION
Adds the amount of backoffice external login providers to the detailed telemetry.

To test I:

* Added 1 external login provider to backoffice.
* Checked it showed in the telemetry
* Added 1 external login provider to **members**
* Checked it still only showed 1 providers in telemetry
* Added 1 more external login provider to backoffice.
* Checked it now showed 2 providers in telemetry.