### PR TITLE
V10: Implement varying blocklist indexing

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/DefaultPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Core/PropertyEditors/DefaultPropertyIndexValueFactory.cs
@@ -10,10 +10,14 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 public class DefaultPropertyIndexValueFactory : IPropertyIndexValueFactory
 {
     /// <inheritdoc />
-    public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published)
+    public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published, IEnumerable<string> availableCultures)
     {
         yield return new KeyValuePair<string, IEnumerable<object?>>(
             property.Alias,
             property.GetValue(culture, segment, published).Yield());
     }
+
+    [Obsolete("Use the overload with the availableCultures parameter instead, scheduled for removal in v14")]
+    public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published)
+        => GetIndexValues(property, culture, segment, published, Enumerable.Empty<string>());
 }

--- a/src/Umbraco.Core/PropertyEditors/IPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Core/PropertyEditors/IPropertyIndexValueFactory.cs
@@ -22,9 +22,9 @@ public interface IPropertyIndexValueFactory
     ///         more than one value for a given field.
     ///     </para>
     /// </remarks>
-    IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published, IEnumerable<string> availableCultures);
+    IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published, IEnumerable<string> availableCultures)
+        => GetIndexValues(property, culture, segment, published);
 
     [Obsolete("Use the overload with the availableCultures parameter instead, scheduled for removal in v14")]
-    IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published)
-        => GetIndexValues(property, culture, segment, published, Enumerable.Empty<string>());
+    IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published);
 }

--- a/src/Umbraco.Core/PropertyEditors/IPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Core/PropertyEditors/IPropertyIndexValueFactory.cs
@@ -22,5 +22,9 @@ public interface IPropertyIndexValueFactory
     ///         more than one value for a given field.
     ///     </para>
     /// </remarks>
-    IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published);
+    IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published, IEnumerable<string> availableCultures);
+
+    [Obsolete("Use the overload with the availableCultures parameter instead, scheduled for removal in v14")]
+    IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published)
+        => GetIndexValues(property, culture, segment, published, Enumerable.Empty<string>());
 }

--- a/src/Umbraco.Core/PropertyEditors/JsonPropertyIndexValueFactoryBase.cs
+++ b/src/Umbraco.Core/PropertyEditors/JsonPropertyIndexValueFactoryBase.cs
@@ -25,7 +25,8 @@ public abstract class JsonPropertyIndexValueFactoryBase<TSerialized> : IProperty
         IProperty property,
         string? culture,
         string? segment,
-        bool published)
+        bool published,
+        IEnumerable<string> availableCultures)
     {
         var result = new List<KeyValuePair<string, IEnumerable<object?>>>();
 
@@ -43,7 +44,7 @@ public abstract class JsonPropertyIndexValueFactoryBase<TSerialized> : IProperty
                     return result;
                 }
 
-                result.AddRange(Handle(deserializedPropertyValue, property, culture, segment, published));
+                result.AddRange(Handle(deserializedPropertyValue, property, culture, segment, published, availableCultures));
             }
             catch (InvalidCastException)
             {
@@ -75,10 +76,23 @@ public abstract class JsonPropertyIndexValueFactoryBase<TSerialized> : IProperty
     /// <summary>
     ///  Method that handle the deserialized object.
     /// </summary>
+    [Obsolete("Use the overload with the availableCultures parameter instead, scheduled for removal in v14")]
     protected abstract IEnumerable<KeyValuePair<string, IEnumerable<object?>>> Handle(
         TSerialized deserializedPropertyValue,
         IProperty property,
         string? culture,
         string? segment,
         bool published);
+
+    /// <summary>
+    ///  Method that handle the deserialized object.
+    /// </summary>
+    protected virtual IEnumerable<KeyValuePair<string, IEnumerable<object?>>> Handle(
+        TSerialized deserializedPropertyValue,
+        IProperty property,
+        string? culture,
+        string? segment,
+        bool published,
+        IEnumerable<string> availableCultures) =>
+        Handle(deserializedPropertyValue, property, culture, segment, published);
 }

--- a/src/Umbraco.Core/PropertyEditors/JsonPropertyIndexValueFactoryBase.cs
+++ b/src/Umbraco.Core/PropertyEditors/JsonPropertyIndexValueFactoryBase.cs
@@ -63,6 +63,10 @@ public abstract class JsonPropertyIndexValueFactoryBase<TSerialized> : IProperty
         return result;
     }
 
+    [Obsolete("Use method overload that has availableCultures, scheduled for removal in v14")]
+    public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published)
+        => GetIndexValues(property, culture, segment, published, Enumerable.Empty<string>());
+
     /// <summary>
     ///  Method to return a list of resume of the content. By default this returns an empty list
     /// </summary>

--- a/src/Umbraco.Core/PropertyEditors/NoopPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Core/PropertyEditors/NoopPropertyIndexValueFactory.cs
@@ -8,5 +8,9 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 public class NoopPropertyIndexValueFactory : IPropertyIndexValueFactory
 {
     /// <inheritdoc />
-    public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published) => Array.Empty<KeyValuePair<string, IEnumerable<object?>>>();
+    public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published, IEnumerable<string> availableCultures) => Array.Empty<KeyValuePair<string, IEnumerable<object?>>>();
+
+    [Obsolete("Use the overload with the availableCultures parameter instead, scheduled for removal in v14")]
+    public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published)
+        => GetIndexValues(property, culture, segment, published);
 }

--- a/src/Umbraco.Core/PropertyEditors/TagPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Core/PropertyEditors/TagPropertyIndexValueFactory.cs
@@ -14,6 +14,18 @@ public class TagPropertyIndexValueFactory : JsonPropertyIndexValueFactoryBase<st
         IProperty property,
         string? culture,
         string? segment,
+        bool published,
+        IEnumerable<string> availableCultures)
+    {
+        yield return new KeyValuePair<string, IEnumerable<object?>>(property.Alias, deserializedPropertyValue);
+    }
+
+    [Obsolete("Use the overload that specifies availableCultures, scheduled for removal in v14")]
+    protected override IEnumerable<KeyValuePair<string, IEnumerable<object?>>> Handle(
+        string[] deserializedPropertyValue,
+        IProperty property,
+        string? culture,
+        string? segment,
         bool published)
     {
         yield return new KeyValuePair<string, IEnumerable<object?>>(property.Alias, deserializedPropertyValue);

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Examine.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Examine.cs
@@ -37,7 +37,8 @@ public static partial class UmbracoBuilderExtensions
                 factory.GetRequiredService<IUserService>(),
                 factory.GetRequiredService<IShortStringHelper>(),
                 factory.GetRequiredService<IScopeProvider>(),
-                true));
+                true,
+                factory.GetRequiredService<ILocalizationService>()));
         builder.Services.AddUnique<IContentValueSetBuilder>(factory =>
             new ContentValueSetBuilder(
                 factory.GetRequiredService<PropertyEditorCollection>(),
@@ -45,7 +46,8 @@ public static partial class UmbracoBuilderExtensions
                 factory.GetRequiredService<IUserService>(),
                 factory.GetRequiredService<IShortStringHelper>(),
                 factory.GetRequiredService<IScopeProvider>(),
-                false));
+                false,
+                factory.GetRequiredService<ILocalizationService>()));
         builder.Services.AddUnique<IValueSetBuilder<IMedia>, MediaValueSetBuilder>();
         builder.Services.AddUnique<IValueSetBuilder<IMember>, MemberValueSetBuilder>();
         builder.Services.AddSingleton<ExamineIndexRebuilder>();

--- a/src/Umbraco.Infrastructure/Examine/BaseValueSetBuilder.cs
+++ b/src/Umbraco.Infrastructure/Examine/BaseValueSetBuilder.cs
@@ -22,7 +22,11 @@ public abstract class BaseValueSetBuilder<TContent> : IValueSetBuilder<TContent>
     /// <inheritdoc />
     public abstract IEnumerable<ValueSet> GetValueSets(params TContent[] content);
 
+    [Obsolete("Use the overload that specifies availableCultures, scheduled for removal in v14")]
     protected void AddPropertyValue(IProperty property, string? culture, string? segment, IDictionary<string, IEnumerable<object?>>? values)
+        => AddPropertyValue(property, culture, segment, values, Enumerable.Empty<string>());
+
+    protected void AddPropertyValue(IProperty property, string? culture, string? segment, IDictionary<string, IEnumerable<object?>>? values, IEnumerable<string> availableCultures)
     {
         IDataEditor? editor = _propertyEditors[property.PropertyType.PropertyEditorAlias];
         if (editor == null)
@@ -31,7 +35,7 @@ public abstract class BaseValueSetBuilder<TContent> : IValueSetBuilder<TContent>
         }
 
         IEnumerable<KeyValuePair<string, IEnumerable<object?>>> indexVals =
-            editor.PropertyIndexValueFactory.GetIndexValues(property, culture, segment, PublishedValuesOnly);
+            editor.PropertyIndexValueFactory.GetIndexValues(property, culture, segment, PublishedValuesOnly, availableCultures);
         foreach (KeyValuePair<string, IEnumerable<object?>> keyVal in indexVals)
         {
             if (keyVal.Key.IsNullOrWhiteSpace())

--- a/src/Umbraco.Infrastructure/Examine/MediaValueSetBuilder.cs
+++ b/src/Umbraco.Infrastructure/Examine/MediaValueSetBuilder.cs
@@ -65,7 +65,7 @@ public class MediaValueSetBuilder : BaseValueSetBuilder<IMedia>
 
             foreach (IProperty property in m.Properties)
             {
-                AddPropertyValue(property, null, null, values);
+                AddPropertyValue(property, null, null, values, m.AvailableCultures);
             }
 
             var vs = new ValueSet(m.Id.ToInvariantString(), IndexTypes.Media, m.ContentType.Alias, values);

--- a/src/Umbraco.Infrastructure/Examine/MemberValueSetBuilder.cs
+++ b/src/Umbraco.Infrastructure/Examine/MemberValueSetBuilder.cs
@@ -37,7 +37,7 @@ public class MemberValueSetBuilder : BaseValueSetBuilder<IMember>
 
             foreach (IProperty property in m.Properties)
             {
-                AddPropertyValue(property, null, null, values);
+                AddPropertyValue(property, null, null, values, m.AvailableCultures);
             }
 
             var vs = new ValueSet(m.Id.ToInvariantString(), IndexTypes.Member, m.ContentType.Alias, values);

--- a/src/Umbraco.Infrastructure/PropertyEditors/GridPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/GridPropertyIndexValueFactory.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
     /// </summary>
     public class GridPropertyIndexValueFactory : IPropertyIndexValueFactory
     {
-        public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published)
+        public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published, IEnumerable<string> availableCultures)
         {
             var result = new List<KeyValuePair<string, IEnumerable<object?>>>();
 
@@ -88,5 +88,9 @@ namespace Umbraco.Cms.Core.PropertyEditors
 
             return result;
         }
+
+        [Obsolete("Use the overload that specifies availableCultures, scheduled for removal in v14")]
+        public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published)
+            => GetIndexValues(property, culture, segment, published);
     }
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
@@ -305,7 +305,7 @@ public class RichTextPropertyEditor : DataEditor
 
     internal class RichTextPropertyIndexValueFactory : IPropertyIndexValueFactory
     {
-        public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published)
+        public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published, IEnumerable<string> availableCultures)
         {
             var val = property.GetValue(culture, segment, published);
 
@@ -323,5 +323,9 @@ public class RichTextPropertyEditor : DataEditor
             yield return new KeyValuePair<string, IEnumerable<object?>>(
                 $"{UmbracoExamineFieldNames.RawFieldPrefix}{property.Alias}", new object[] { strVal });
         }
+
+        [Obsolete("Use the overload with the 'availableCultures' parameter instead, scheduled for removal in v14")]
+        public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published)
+            => GetIndexValues(property, culture, segment, published);
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexInitializer.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexInitializer.cs
@@ -3,6 +3,7 @@ using Examine.Lucene;
 using Examine.Lucene.Directories;
 using Lucene.Net.Analysis;
 using Lucene.Net.Analysis.Standard;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -18,6 +19,7 @@ using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Infrastructure.Examine;
 using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 using Directory = Lucene.Net.Store.Directory;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Examine.Lucene.UmbracoExamine;
@@ -28,6 +30,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Examine.Lucene.UmbracoExamine;
 public class IndexInitializer
 {
     private readonly IOptions<ContentSettings> _contentSettings;
+    private readonly ILocalizationService _localizationService;
     private readonly ILoggerFactory _loggerFactory;
     private readonly MediaUrlGeneratorCollection _mediaUrlGenerators;
     private readonly PropertyEditorCollection _propertyEditors;
@@ -40,7 +43,8 @@ public class IndexInitializer
         MediaUrlGeneratorCollection mediaUrlGenerators,
         IScopeProvider scopeProvider,
         ILoggerFactory loggerFactory,
-        IOptions<ContentSettings> contentSettings)
+        IOptions<ContentSettings> contentSettings,
+        ILocalizationService localizationService)
     {
         _shortStringHelper = shortStringHelper;
         _propertyEditors = propertyEditors;
@@ -48,6 +52,25 @@ public class IndexInitializer
         _scopeProvider = scopeProvider;
         _loggerFactory = loggerFactory;
         _contentSettings = contentSettings;
+        _localizationService = localizationService;
+    }
+
+    public IndexInitializer(
+        IShortStringHelper shortStringHelper,
+        PropertyEditorCollection propertyEditors,
+        MediaUrlGeneratorCollection mediaUrlGenerators,
+        IScopeProvider scopeProvider,
+        ILoggerFactory loggerFactory,
+        IOptions<ContentSettings> contentSettings)
+        : this(
+        shortStringHelper,
+        propertyEditors,
+        mediaUrlGenerators,
+        scopeProvider,
+        loggerFactory,
+        contentSettings,
+        StaticServiceProvider.Instance.GetRequiredService<ILocalizationService>())
+    {
     }
 
     public ContentValueSetBuilder GetContentValueSetBuilder(bool publishedValuesOnly)
@@ -58,7 +81,8 @@ public class IndexInitializer
             GetMockUserService(),
             _shortStringHelper,
             _scopeProvider,
-            publishedValuesOnly);
+            publishedValuesOnly,
+            _localizationService);
 
         return contentValueSetBuilder;
     }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexTest.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Bogus;
 using Examine;
 using Lucene.Net.Util;
@@ -10,7 +7,6 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Infrastructure.Examine;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
-using Umbraco.Extensions;
 using Constants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Examine.Lucene.UmbracoExamine;
@@ -19,7 +15,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Examine.Lucene.UmbracoExamine;
 ///     Tests the standard indexing capabilities
 /// </summary>
 [TestFixture]
-[UmbracoTest(Database = UmbracoTestOptions.Database.None)]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
 public class IndexTest : ExamineBaseTest
 {
     [Test]


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/14096#issuecomment-1554528945
Apparently we did not cover all use cases, this PR should remedy that.

# Notes
- Pass Available cultures to iterate through them, when property varies by culture

# How to test
- Follow steps in original issue comment
- Varies setups we also need to test works:
- Content varies, block does not
- Content varies, block varies
- Content doesn't vary, block doesn't vary