### PR TITLE
Delivery API: Adding support for "Contains" filters

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Indexing/Filters/NameFilterIndexer.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Indexing/Filters/NameFilterIndexer.cs
@@ -1,0 +1,15 @@
+using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Api.Delivery.Indexing.Filters;
+
+public sealed class NameFilterIndexer : IContentIndexHandler
+{
+    internal const string FieldName = "name";
+
+    public IEnumerable<IndexFieldValue> GetFieldValues(IContent content, string? culture)
+        => new[] { new IndexFieldValue { FieldName = FieldName, Values = new object[] { content.GetCultureName(culture) ?? string.Empty } } };
+
+    public IEnumerable<IndexField> GetFields()
+        => new[] { new IndexField { FieldName = FieldName, FieldType = FieldType.StringAnalyzed, VariesByCulture = true } };
+}

--- a/src/Umbraco.Cms.Api.Delivery/Indexing/Sorts/NameSortIndexer.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Indexing/Sorts/NameSortIndexer.cs
@@ -5,7 +5,7 @@ namespace Umbraco.Cms.Api.Delivery.Indexing.Sorts;
 
 public sealed class NameSortIndexer : IContentIndexHandler
 {
-    internal const string FieldName = "name";
+    internal const string FieldName = "sortName";
 
     public IEnumerable<IndexFieldValue> GetFieldValues(IContent content, string? culture)
         => new[] { new IndexFieldValue { FieldName = FieldName, Values = new object[] { content.GetCultureName(culture) ?? string.Empty } } };

--- a/src/Umbraco.Cms.Api.Delivery/Querying/Filters/NameFilter.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Querying/Filters/NameFilter.cs
@@ -1,6 +1,6 @@
 using Umbraco.Cms.Api.Delivery.Indexing.Filters;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DeliveryApi;
-using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Delivery.Querying.Filters;
 
@@ -16,14 +16,14 @@ public sealed class NameFilter : IFilterHandler
     public FilterOption BuildFilterOption(string filter)
     {
         var value = filter.Substring(NameSpecifier.Length);
+        var negate = value.StartsWith('!');
+        var values = value.TrimStart('!').Split(Constants.CharArrays.Comma);
 
         return new FilterOption
         {
             FieldName = NameFilterIndexer.FieldName,
-            Values = value.IsNullOrWhiteSpace() == false
-                ? new[] { value.TrimStart('!') }
-                : Array.Empty<string>(),
-            Operator = value.StartsWith('!')
+            Values = values,
+            Operator = negate
                 ? FilterOperation.DoesNotContain
                 : FilterOperation.Contains
         };

--- a/src/Umbraco.Cms.Api.Delivery/Querying/Filters/NameFilter.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Querying/Filters/NameFilter.cs
@@ -1,4 +1,4 @@
-using Umbraco.Cms.Api.Delivery.Indexing.Sorts;
+using Umbraco.Cms.Api.Delivery.Indexing.Filters;
 using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Extensions;
 
@@ -19,13 +19,13 @@ public sealed class NameFilter : IFilterHandler
 
         return new FilterOption
         {
-            FieldName = NameSortIndexer.FieldName,
+            FieldName = NameFilterIndexer.FieldName,
             Values = value.IsNullOrWhiteSpace() == false
                 ? new[] { value.TrimStart('!') }
                 : Array.Empty<string>(),
             Operator = value.StartsWith('!')
-                ? FilterOperation.IsNot
-                : FilterOperation.Is
+                ? FilterOperation.DoesNotContain
+                : FilterOperation.Contains
         };
     }
 }

--- a/src/Umbraco.Cms.Api.Delivery/Services/ApiContentQueryProvider.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/ApiContentQueryProvider.cs
@@ -1,0 +1,189 @@
+﻿using Examine;
+using Examine.Lucene.Providers;
+using Examine.Lucene.Search;
+using Examine.Search;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Infrastructure.Examine;
+using Umbraco.Extensions;
+using Umbraco.New.Cms.Core.Models;
+using Constants = Umbraco.Cms.Core.Constants;
+
+namespace Umbraco.Cms.Api.Delivery.Services;
+
+/// <summary>
+/// This is the Examine implementation of content querying for the Delivery API.
+/// </summary>
+internal sealed class ApiContentQueryProvider : IApiContentQueryProvider
+{
+    private const string ItemIdFieldName = "itemId";
+    private readonly IExamineManager _examineManager;
+    private readonly ILogger<ApiContentQueryProvider> _logger;
+    private readonly string _fallbackGuidValue;
+    private readonly Dictionary<string, FieldType> _fieldTypes;
+
+    public ApiContentQueryProvider(
+        IExamineManager examineManager,
+        ContentIndexHandlerCollection indexHandlers,
+        ILogger<ApiContentQueryProvider> logger)
+    {
+        _examineManager = examineManager;
+        _logger = logger;
+
+        // A fallback value is needed for Examine queries in case we don't have a value - we can't pass null or empty string
+        // It is set to a random guid since this would be highly unlikely to yield any results
+        _fallbackGuidValue = Guid.NewGuid().ToString("D");
+
+        // build a look-up dictionary of field types by field name
+        _fieldTypes = indexHandlers
+            .SelectMany(handler => handler.GetFields())
+            .DistinctBy(field => field.FieldName)
+            .ToDictionary(field => field.FieldName, field => field.FieldType, StringComparer.InvariantCultureIgnoreCase);
+    }
+
+    public PagedModel<Guid> ExecuteQuery(SelectorOption selectorOption, IList<FilterOption> filterOptions, IList<SortOption> sortOptions, string culture, int skip, int take)
+    {
+        if (!_examineManager.TryGetIndex(Constants.UmbracoIndexes.DeliveryApiContentIndexName, out IIndex? index))
+        {
+            _logger.LogError("Could not find the index {IndexName} when attempting to execute a query.", Constants.UmbracoIndexes.DeliveryApiContentIndexName);
+            return new PagedModel<Guid>();
+        }
+
+        IBooleanOperation queryOperation = BuildSelectorOperation(selectorOption, index, culture);
+
+        ApplyFiltering(filterOptions, queryOperation);
+        ApplySorting(sortOptions, queryOperation);
+
+        ISearchResults? results = queryOperation
+            .SelectField(ItemIdFieldName)
+            .Execute(QueryOptions.SkipTake(skip, take));
+
+        if (results is null)
+        {
+            // The query yield no results
+            return new PagedModel<Guid>();
+        }
+
+        Guid[] items = results
+            .Where(r => r.Values.ContainsKey(ItemIdFieldName))
+            .Select(r => Guid.Parse(r.Values[ItemIdFieldName]))
+            .ToArray();
+
+        return new PagedModel<Guid>(results.TotalItemCount, items);
+    }
+
+    public SelectorOption AllContentSelectorOption() => new()
+    {
+        FieldName = UmbracoExamineFieldNames.CategoryFieldName, Values = new[] { "content" }
+    };
+
+    private IBooleanOperation BuildSelectorOperation(SelectorOption selectorOption, IIndex index, string culture)
+    {
+        // Needed for enabling leading wildcards searches
+        var searcher = (BaseLuceneSearcher)index.Searcher;
+
+        IQuery query = searcher.CreateQuery(
+            "content",
+            BooleanOperation.And,
+            searcher.LuceneAnalyzer,
+            new LuceneSearchOptions { AllowLeadingWildcard = true });
+
+        IBooleanOperation selectorOperation = selectorOption.Values.Length == 1
+            ? query.Field(selectorOption.FieldName, selectorOption.Values.First())
+            : query.GroupedOr(new[] { selectorOption.FieldName }, selectorOption.Values);
+
+        // Item culture must be either the requested culture or "none"
+        selectorOperation.And().GroupedOr(new[] { UmbracoExamineFieldNames.DeliveryApiContentIndex.Culture }, culture.ToLowerInvariant().IfNullOrWhiteSpace(_fallbackGuidValue), "none");
+
+        return selectorOperation;
+    }
+
+    private void ApplyFiltering(IList<FilterOption> filterOptions, IBooleanOperation queryOperation)
+    {
+        void HandleExact(IQuery query, string fieldName, string[] values)
+        {
+            if (values.Length == 1)
+            {
+                query.Field(fieldName, values[0]);
+            }
+            else
+            {
+                query.GroupedOr(new[] { fieldName }, values);
+            }
+        }
+
+        void HandleContains(IQuery query, string fieldName, string[] values)
+        {
+            if (values.Length == 1)
+            {
+                // The tailing wildcard is added automatically
+                query.Field(fieldName, (IExamineValue)new ExamineValue(Examineness.ComplexWildcard, $"*{values[0]}"));
+            }
+            else
+            {
+                // The tailing wildcard is added automatically
+                var examineValues = values
+                    .Select(value => (IExamineValue)new ExamineValue(Examineness.ComplexWildcard, $"*{value}"))
+                    .ToArray();
+                query.GroupedOr(new[] { fieldName }, examineValues);
+            }
+        }
+
+        foreach (FilterOption filterOption in filterOptions)
+        {
+            var values = filterOption.Values.Any()
+                ? filterOption.Values
+                : new[] { _fallbackGuidValue };
+
+            switch (filterOption.Operator)
+            {
+                case FilterOperation.Is:
+                    HandleExact(queryOperation.And(), filterOption.FieldName, values);
+                    break;
+                case FilterOperation.IsNot:
+                    HandleExact(queryOperation.Not(), filterOption.FieldName, values);
+                    break;
+                case FilterOperation.Contains:
+                    HandleContains(queryOperation.And(), filterOption.FieldName, values);
+                    break;
+                case FilterOperation.DoesNotContain:
+                    HandleContains(queryOperation.Not(), filterOption.FieldName, values);
+                    break;
+                default:
+                    continue;
+            }
+        }
+    }
+
+    private void ApplySorting(IList<SortOption> sortOptions, IOrdering ordering)
+    {
+        foreach (SortOption sort in sortOptions)
+        {
+            if (_fieldTypes.TryGetValue(sort.FieldName, out FieldType fieldType) is false)
+            {
+                _logger.LogWarning(
+                    "Sort implementation for field name {FieldName} does not match an index handler implementation, cannot resolve field type.",
+                    sort.FieldName);
+                continue;
+            }
+
+            SortType sortType = fieldType switch
+            {
+                FieldType.Number => SortType.Int,
+                FieldType.Date => SortType.Long,
+                FieldType.StringRaw => SortType.String,
+                FieldType.StringAnalyzed => SortType.String,
+                FieldType.StringSortable => SortType.String,
+                _ => throw new ArgumentOutOfRangeException(nameof(fieldType))
+            };
+
+            ordering = sort.Direction switch
+            {
+                Direction.Ascending => ordering.OrderBy(new SortableField(sort.FieldName, sortType)),
+                Direction.Descending => ordering.OrderByDescending(new SortableField(sort.FieldName, sortType)),
+                _ => ordering
+            };
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Examine/DeliveryApiContentIndexFieldDefinitionBuilder.cs
+++ b/src/Umbraco.Infrastructure/Examine/DeliveryApiContentIndexFieldDefinitionBuilder.cs
@@ -68,7 +68,7 @@ internal sealed class DeliveryApiContentIndexFieldDefinitionBuilder : IDeliveryA
             FieldType.Number => FieldDefinitionTypes.Integer,
             FieldType.StringRaw => FieldDefinitionTypes.Raw,
             FieldType.StringAnalyzed => FieldDefinitionTypes.FullText,
-            FieldType.StringSortable => FieldDefinitionTypes.FullTextSortable,
+            FieldType.StringSortable => FieldDefinitionTypes.InvariantCultureIgnoreCase,
             _ => throw new ArgumentOutOfRangeException(nameof(field.FieldType))
         };
 


### PR DESCRIPTION
## Details
NB:❗ This PR should be merged after https://github.com/umbraco/Umbraco-CMS/pull/14257 changes are into `release/12.0` branch. It is important to then merge `release/12.0` into this branch to get the `ApiContentQueryProvider` and `IApiContentQueryProvider` implementations.
- Adds support for "Contains" filters for the Query endpoint of the Delivery API.

## Test
- Make sure you can sort and filter on the `"name"` field;
- Test with some exact matches (`FilterOperation.IsNot` and `FilterOperation.Is`) and with contains filters (`FilterOperation.DoesNotContain` and `FilterOperation.Contains`) and verify that the results are correct;
  - You can also try creating new filters and test the filtering functionality.