### PR TITLE
Ensure that blocks always open automatically when added to block list or block grid

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbBlockGridPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbBlockGridPropertyEditor.component.js
@@ -1011,7 +1011,7 @@
                 blockObject = vm.layout[createIndex].$block;
             }
             // edit block if not `hideContentInOverlay` and there is content properties.
-            if(blockObject.hideContentInOverlay !== true && blockObject.content.variants[0].tabs[0]?.properties.length > 0) {
+            if(blockObject.hideContentInOverlay !== true && blockObject.content.variants[0].tabs.find(tab => tab.properties.length > 0) !== undefined) {
                 vm.options.createFlow = true;
                 blockObject.edit();
                 vm.options.createFlow = false;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -621,7 +621,7 @@
                 var blockObject = vm.layout[createIndex].$block;
                 if (inlineEditing === true) {
                     blockObject.activate();
-                } else if (inlineEditing === false && blockObject.hideContentInOverlay !== true && blockObject.content.variants[0].tabs[0]?.properties.length > 0) {
+                } else if (inlineEditing === false && blockObject.hideContentInOverlay !== true && blockObject.content.variants[0].tabs.find(tab => tab.properties.length > 0) !== undefined) {
                     vm.options.createFlow = true;
                     blockObject.edit();
                     vm.options.createFlow = false;


### PR DESCRIPTION
### Prerequisites

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/13906

### Description

In rare conditions, the block editor does not open automatically when new blocks are created in block list or block grid.

It happens if the block is configured having its first tab contain no properties, only groups (with properties). If the first tab has direct properties, or there are no tabs (i.e. only groups with properties), things work just fine.

### Testing this

This has been peer tested due to the special setup prerequisites 😄 

### Regression

This issue was introduced with the block grid and as such it is a regression towards the block list.