### PR TITLE
Empty filter and sort values should not be considered when executing queries

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Services/ApiContentQueryService.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/ApiContentQueryService.cs
@@ -3,6 +3,7 @@ using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Extensions;
 using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Delivery.Services;
@@ -45,7 +46,7 @@ internal sealed class ApiContentQueryService : IApiContentQueryService
         }
 
         var filterOptions = new List<FilterOption>();
-        foreach (var filter in filters)
+        foreach (var filter in filters.Where(filter => filter.IsNullOrWhiteSpace() is false))
         {
             FilterOption? filterOption = GetFilterOption(filter);
             if (filterOption is null)
@@ -58,7 +59,7 @@ internal sealed class ApiContentQueryService : IApiContentQueryService
         }
 
         var sortOptions = new List<SortOption>();
-        foreach (var sort in sorts)
+        foreach (var sort in sorts.Where(sort => sort.IsNullOrWhiteSpace() is false))
         {
             SortOption? sortOption = GetSortOption(sort);
             if (sortOption is null)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The Delivery API fails to execute queries if the `filter` or `sort` parameter is empty in the request - like this:

`/umbraco/delivery/api/v1.0/content/?fetch=children:/&filter=&sort=`

For whatever reason the empty query string parameter is picked up by ASP.Net Core and passed as an `IEnumerable<string>` with one empty string entry. So... this PR filters out these empty strings before attempting to resolve filters and sorts.

### Testing

The request above should not fail, but yield all children of root - unfiltered and unsorted.