### PR TITLE
Fix the namespace for PagedModel

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Controllers/QueryContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/QueryContentApiController.cs
@@ -4,11 +4,11 @@ using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Extensions;
-using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Delivery.Controllers;
 

--- a/src/Umbraco.Cms.Api.Delivery/Services/ApiContentQueryProvider.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/ApiContentQueryProvider.cs
@@ -3,9 +3,9 @@ using Examine.Search;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Infrastructure.Examine;
 using Umbraco.Extensions;
-using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Delivery.Services;
 

--- a/src/Umbraco.Cms.Api.Delivery/Services/ApiContentQueryService.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/ApiContentQueryService.cs
@@ -1,9 +1,9 @@
 using Umbraco.Cms.Api.Delivery.Indexing.Selectors;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Services.OperationStatus;
-using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Api.Delivery.Services;
 

--- a/src/Umbraco.Core/CompatibilitySuppressions.xml
+++ b/src/Umbraco.Core/CompatibilitySuppressions.xml
@@ -2,6 +2,13 @@
 <!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Umbraco.New.Cms.Core.Models.PagedModel`1</Target>
+    <Left>lib/net7.0/Umbraco.Core.dll</Left>
+    <Right>lib/net7.0/Umbraco.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
     <DiagnosticId>CP0005</DiagnosticId>
     <Target>M:Umbraco.Cms.Core.Models.PublishedContent.PublishedPropertyBase.GetDeliveryApiValue(System.Boolean,System.String,System.String)</Target>
     <Left>lib/net7.0/Umbraco.Core.dll</Left>

--- a/src/Umbraco.Core/DeliveryApi/IApiContentQueryProvider.cs
+++ b/src/Umbraco.Core/DeliveryApi/IApiContentQueryProvider.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.New.Cms.Core.Models;
+﻿using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Core.DeliveryApi;
 

--- a/src/Umbraco.Core/DeliveryApi/IApiContentQueryService.cs
+++ b/src/Umbraco.Core/DeliveryApi/IApiContentQueryService.cs
@@ -1,5 +1,5 @@
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services.OperationStatus;
-using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Core.DeliveryApi;
 

--- a/src/Umbraco.Core/DeliveryApi/NoopApiContentQueryService.cs
+++ b/src/Umbraco.Core/DeliveryApi/NoopApiContentQueryService.cs
@@ -1,5 +1,5 @@
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services.OperationStatus;
-using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Core.DeliveryApi;
 

--- a/src/Umbraco.Core/Models/PagedModel.cs
+++ b/src/Umbraco.Core/Models/PagedModel.cs
@@ -1,4 +1,4 @@
-﻿namespace Umbraco.New.Cms.Core.Models;
+﻿namespace Umbraco.Cms.Core.Models;
 
 public class PagedModel<T>
 {

--- a/src/Umbraco.Core/Services/ILocalizationService.cs
+++ b/src/Umbraco.Core/Services/ILocalizationService.cs
@@ -1,5 +1,4 @@
 using Umbraco.Cms.Core.Models;
-using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Core.Services;
 

--- a/src/Umbraco.Core/Services/ITrackedReferencesService.cs
+++ b/src/Umbraco.Core/Services/ITrackedReferencesService.cs
@@ -1,5 +1,4 @@
 using Umbraco.Cms.Core.Models;
-using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Core.Services;
 

--- a/src/Umbraco.Core/Services/TrackedReferencesService.cs
+++ b/src/Umbraco.Core/Services/TrackedReferencesService.cs
@@ -1,7 +1,6 @@
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Scoping;
-using Umbraco.New.Cms.Core.Models;
 
 namespace Umbraco.Cms.Core.Services;
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The `PagedModel` class was copied over from _Project New Backoffice_ ... but we forgot to fix the model namespace, which has then been propagated into various uses throughout the codebase.

We really don't want a `Umbraco.New.Cms.Core.Models` namespace in the core, so this refactoring - while breaking - is necessary 😢 