### PR TITLE
Show summary of Examine search results

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
@@ -608,7 +608,7 @@
     <key alias="indexCannotRebuild">Dette index kan ikke genbygges for det ikke har nogen</key>
     <key alias="iIndexPopulator">IIndexPopulator</key>
     <key alias="noResults">Der blev ikke fundet nogen resultater</key>
-    <key alias="searchResultsFound">Viser %0% af %1% resultat(er)</key>
+    <key alias="searchResultsFound">Viser %0% - %1% af %2% resultat(er) - Side %3% af %4%</key>
   </area>
   <area alias="placeholders">
     <key alias="username">Indtast dit brugernavn</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
@@ -607,6 +607,8 @@
     </key>
     <key alias="indexCannotRebuild">Dette index kan ikke genbygges for det ikke har nogen</key>
     <key alias="iIndexPopulator">IIndexPopulator</key>
+    <key alias="noResults">Der blev ikke fundet nogen resultater</key>
+    <key alias="searchResultsFound">Viser %0% af %1% resultat(er)</key>
   </area>
   <area alias="placeholders">
     <key alias="username">Indtast dit brugernavn</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -628,6 +628,8 @@
     </key>
     <key alias="indexCannotRebuild">This index cannot be rebuilt because it has no assigned</key>
     <key alias="iIndexPopulator">IIndexPopulator</key>
+    <key alias="noResults">No results were found</key>
+    <key alias="searchResultsFound">Showing %0% of %1% result(s)</key>
   </area>
   <area alias="placeholders">
     <key alias="username">Enter your username</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -629,7 +629,7 @@
     <key alias="indexCannotRebuild">This index cannot be rebuilt because it has no assigned</key>
     <key alias="iIndexPopulator">IIndexPopulator</key>
     <key alias="noResults">No results were found</key>
-    <key alias="searchResultsFound">Showing %0% of %1% result(s)</key>
+    <key alias="searchResultsFound">Showing %0% - %1% of %2% result(s) - Page %3% of %4%</key>
   </area>
   <area alias="placeholders">
     <key alias="username">Enter your username</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -645,7 +645,7 @@
     <key alias="indexCannotRebuild">This index cannot be rebuilt because it has no assigned</key>
     <key alias="iIndexPopulator">IIndexPopulator</key>
     <key alias="noResults">No results were found</key>
-    <key alias="searchResultsFound">Showing %0% of %1% result(s)</key>
+    <key alias="searchResultsFound">Showing %0% - %1% of %2% result(s) - Page %3% of %4%</key>
   </area>
   <area alias="placeholders">
     <key alias="username">Enter your username</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -644,6 +644,8 @@
     </key>
     <key alias="indexCannotRebuild">This index cannot be rebuilt because it has no assigned</key>
     <key alias="iIndexPopulator">IIndexPopulator</key>
+    <key alias="noResults">No results were found</key>
+    <key alias="searchResultsFound">Showing %0% of %1% result(s)</key>
   </area>
   <area alias="placeholders">
     <key alias="username">Enter your username</key>

--- a/src/Umbraco.Core/Models/ContentEditing/SearchResults.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/SearchResults.cs
@@ -5,6 +5,9 @@ namespace Umbraco.Cms.Core.Models.ContentEditing;
 [DataContract(Name = "results", Namespace = "")]
 public class SearchResults
 {
+    [DataMember(Name = "pageSize")]
+    public int PageSize { get; set; }
+
     [DataMember(Name = "totalRecords")]
     public long TotalRecords { get; set; }
 

--- a/src/Umbraco.Web.BackOffice/Controllers/ExamineManagementController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ExamineManagementController.cs
@@ -91,6 +91,7 @@ public class ExamineManagementController : UmbracoAuthorizedJsonController
 
         return new SearchResults
         {
+            PageSize = pageSize,
             TotalRecords = results.TotalItemCount,
             Results = results.Select(x => new SearchResult
             {

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.controller.js
@@ -195,21 +195,23 @@ function ExamineManagementController($http, $q, $timeout, umbRequestHelper, loca
 
         searcher.isProcessing = true;
 
+        const pageIndex = pageNumber ? (pageNumber - 1) : 0;
+
         umbRequestHelper.resourcePromise(
                 $http.get(umbRequestHelper.getApiUrl("examineMgmtBaseUrl",
                     "GetSearchResults",
                     {
                         searcherName: searcher.name,
                         query: encodeURIComponent(vm.searchText),
-                        pageIndex: pageNumber ? (pageNumber - 1) : 0
+                        pageIndex: pageIndex
                     })),
                 'Failed to search')
             .then(searchResults => {
                 searcher.isProcessing = false;
-                vm.searchResults = searchResults
+                vm.searchResults = searchResults;
+                vm.searchResults.pageIndex = pageIndex;
                 vm.searchResults.pageNumber = pageNumber ? pageNumber : 1;
-                //20 is page size
-                vm.searchResults.totalPages = Math.ceil(vm.searchResults.totalRecords / 20);
+                vm.searchResults.totalPages = Math.ceil(vm.searchResults.totalRecords / vm.searchResults.pageSize);
                 // add URLs to edit well known entities
                 _.each(vm.searchResults.results, function (result) {
                     var section = result.values["__IndexType"][0];

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
@@ -323,7 +323,9 @@
                                                                     <td class="tr nowrap">
                                                                         <button type="button"
                                                                             class="table__action-overlay color-green"
-                                                                            ng-click="vm.showSearchResultDialog(result.values)">({{ ::result.fieldCount }} <localize key="examineManagement_fields">fields</localize>)</button>
+                                                                            ng-click="vm.showSearchResultDialog(result.values)">
+                                                                          ({{ ::result.fieldCount }} <localize key="examineManagement_fields">fields</localize>)
+                                                                        </button>
                                                                     </td>
                                                                     <td class="tr nowrap umb-avatar--white">
                                                                         <span title="{{ result.score }}">
@@ -332,6 +334,21 @@
                                                                     </td>
                                                                 </tr>
                                                             </tbody>
+                                                            <tfoot>
+                                                                <tr>
+                                                                    <td colspan="{{vm.showSearchResultFields.length + 4}}">
+                                                                      <localize key="examineManagement_noResults" ng-if="::vm.searchResults.totalRecords === 0">
+                                                                        No results were found
+                                                                      </localize>
+                                                                      <localize key="examineManagement_searchResultsFound"
+                                                                                tokens="[vm.searchResults.results.length, vm.searchResults.totalRecords]"
+                                                                                watch-tokens="true"
+                                                                                ng-if="::vm.searchResults.totalRecords > 0">
+                                                                        Showing %0% of %1% result(s)
+                                                                      </localize>
+                                                                    </td>
+                                                                </tr>
+                                                            </tfoot>
                                                         </table>
                                                     </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
@@ -328,7 +328,7 @@
                                                                         </button>
                                                                     </td>
                                                                     <td class="tr nowrap umb-avatar--white">
-                                                                        <span title="{{ result.score }}">
+                                                                        <span ng-attr-title="{{ result.score }}">
                                                                             {{ ::result.score | number:4 }}
                                                                         </span>
                                                                     </td>

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/examinemanagement.html
@@ -341,10 +341,10 @@
                                                                         No results were found
                                                                       </localize>
                                                                       <localize key="examineManagement_searchResultsFound"
-                                                                                tokens="[vm.searchResults.results.length, vm.searchResults.totalRecords]"
+                                                                                tokens="[(vm.searchResults.pageIndex * vm.searchResults.pageSize) + 1, (vm.searchResults.pageIndex * vm.searchResults.pageSize) + vm.searchResults.results.length, vm.searchResults.totalRecords, vm.searchResults.pageNumber, vm.searchResults.totalPages]"
                                                                                 watch-tokens="true"
                                                                                 ng-if="::vm.searchResults.totalRecords > 0">
-                                                                        Showing %0% of %1% result(s)
+                                                                        Showing %0% - %1% of %2% result(s) - Page %3% of %4%
                                                                       </localize>
                                                                     </td>
                                                                 </tr>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
In a current working project, we have a custom index and advanced search/lucene queries often returning many results.
We could inspect the request, but I think it would be nice to see to number of results returned and it can be used to compare with the expected results based on the dataset.

https://github.com/umbraco/Umbraco-CMS/assets/2919859/559555fa-6923-416e-864c-211b33fb63cb
