### PR TITLE
V14: Add information to tree items

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/ChildrenDocumentTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/ChildrenDocumentTreeController.cs
@@ -19,8 +19,9 @@ public class ChildrenDocumentTreeController : DocumentTreeControllerBase
         IDataTypeService dataTypeService,
         IPublicAccessService publicAccessService,
         AppCaches appCaches,
-        IBackOfficeSecurityAccessor backofficeSecurityAccessor)
-        : base(entityService, userStartNodeEntitiesService, dataTypeService, publicAccessService, appCaches, backofficeSecurityAccessor)
+        IBackOfficeSecurityAccessor backofficeSecurityAccessor,
+        IContentTypeService contentTypeService)
+        : base(entityService, userStartNodeEntitiesService, dataTypeService, publicAccessService, appCaches, backofficeSecurityAccessor, contentTypeService)
     {
     }
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/DocumentTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/DocumentTreeControllerBase.cs
@@ -67,9 +67,37 @@ public abstract class DocumentTreeControllerBase : UserStartNodeTreeControllerBa
             }
 
             responseModel.IsEdited &= responseModel.IsPublished;
+
+            responseModel.Variants = MapVariants(documentEntitySlim);
         }
 
         return responseModel;
+    }
+
+    private IEnumerable<VariantTreeItemViewModel> MapVariants(IDocumentEntitySlim entity)
+    {
+        if (entity.Variations.VariesByCulture() is false)
+        {
+            yield return new VariantTreeItemViewModel
+            {
+                Name = entity.Name ?? string.Empty,
+                State = entity.Published ? PublishedState.Published : PublishedState.Unpublished,
+                Culture = null,
+            };
+            yield break;
+        }
+
+        foreach (KeyValuePair<string, string> cultureNamePair in entity.CultureNames)
+        {
+            yield return new VariantTreeItemViewModel
+            {
+                Name = cultureNamePair.Value,
+                Culture = cultureNamePair.Key,
+                State = entity.PublishedCultures.Contains(cultureNamePair.Key)
+                    ? PublishedState.Published
+                    : PublishedState.Unpublished,
+            };
+        }
     }
 
     // TODO: delete these (faking start node setup for unlimited editor)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/RootDocumentTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/RootDocumentTreeController.cs
@@ -19,8 +19,9 @@ public class RootDocumentTreeController : DocumentTreeControllerBase
         IDataTypeService dataTypeService,
         IPublicAccessService publicAccessService,
         AppCaches appCaches,
-        IBackOfficeSecurityAccessor backofficeSecurityAccessor)
-        : base(entityService, userStartNodeEntitiesService, dataTypeService, publicAccessService, appCaches, backofficeSecurityAccessor)
+        IBackOfficeSecurityAccessor backofficeSecurityAccessor,
+        IContentTypeService contentTypeService)
+        : base(entityService, userStartNodeEntitiesService, dataTypeService, publicAccessService, appCaches, backofficeSecurityAccessor, contentTypeService)
     {
     }
 

--- a/src/Umbraco.Cms.Api.Management/Factories/DocumentPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DocumentPresentationFactory.cs
@@ -51,6 +51,9 @@ public class DocumentPresentationFactory : IDocumentPresentationFactory
             Icon = entity.ContentTypeIcon,
         };
 
+        IContentType? contentType = _contentTypeService.Get(entity.ContentTypeAlias);
+        responseModel.ContentTypeId = contentType?.Key ?? Guid.Empty;
+
         if (culture == null || !entity.Variations.VariesByCulture())
         {
             return responseModel;

--- a/src/Umbraco.Cms.Api.Management/Mapping/ContentType/ContentTypeMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/ContentType/ContentTypeMapDefinition.cs
@@ -24,6 +24,7 @@ public abstract class ContentTypeMapDefinition<TContentType, TPropertyTypeRespon
                 new TPropertyTypeResponseModel
                 {
                     Id = propertyType.Key,
+                    SortOrder = propertyType.SortOrder,
                     ContainerId = groupKeysByPropertyKeys.ContainsKey(propertyType.Key)
                         ? groupKeysByPropertyKeys[propertyType.Key]
                         : null,

--- a/src/Umbraco.Cms.Api.Management/ViewModels/ContentType/PropertyTypeResponseModelBase.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/ContentType/PropertyTypeResponseModelBase.cs
@@ -6,6 +6,8 @@ public abstract class PropertyTypeResponseModelBase
 
     public Guid? ContainerId { get; set; }
 
+    public int SortOrder { get; set; }
+
     public string Alias { get; set; } = string.Empty;
 
     public string Name { get; set; } = string.Empty;

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/Item/DocumentItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/Item/DocumentItemResponseModel.cs
@@ -5,4 +5,6 @@ namespace Umbraco.Cms.Api.Management.ViewModels.Document.Item;
 public class DocumentItemResponseModel : ItemResponseModelBase
 {
     public string? Icon { get; set; }
+
+    public Guid ContentTypeId { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Tree/DocumentTreeItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Tree/DocumentTreeItemResponseModel.cs
@@ -7,4 +7,6 @@ public class DocumentTreeItemResponseModel : ContentTreeItemResponseModel
     public bool IsPublished { get; set; }
 
     public bool IsEdited { get; set; }
+
+    public IEnumerable<VariantTreeItemViewModel> Variants { get; set; } = Enumerable.Empty<VariantTreeItemViewModel>();
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Tree/DocumentTreeItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Tree/DocumentTreeItemResponseModel.cs
@@ -8,5 +8,7 @@ public class DocumentTreeItemResponseModel : ContentTreeItemResponseModel
 
     public bool IsEdited { get; set; }
 
+    public Guid ContentTypeId { get; set; }
+
     public IEnumerable<VariantTreeItemViewModel> Variants { get; set; } = Enumerable.Empty<VariantTreeItemViewModel>();
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Tree/VariantTreeItemViewModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Tree/VariantTreeItemViewModel.cs
@@ -1,0 +1,12 @@
+﻿using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.Tree;
+
+public class VariantTreeItemViewModel
+{
+    public required string Name { get; set; }
+
+    public string? Culture { get; set; }
+
+    public required PublishedState State { get; set; }
+}


### PR DESCRIPTION
This PR adds Variant information and the content type key to the Document Tree entities, as well as the missing SortOrder property to the `PropertyTypeResponseModelBaseModel`.

## Testing 

Request the relevant endpoint and check that the data is there 😄 