### PR TITLE
Update YesNoValueConverter to use data type prevalues

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/YesNoValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/YesNoValueConverter.cs
@@ -63,4 +63,14 @@ public class YesNoValueConverter : PropertyValueConverterBase
 
         // source should come from ConvertSource and be a boolean already
         (bool?)inter ?? false ? "1" : "0";
+
+    // get the default value from config if possible
+    private static bool GetDefaultValue(IPublishedPropertyType propertyType)
+    {
+        // try get config for initial state prevalue
+        var config = propertyType.DataType.ConfigurationAs<TrueFalseConfiguration>();
+
+        // if no config default value is: false
+        return config is null ? false : config.Default;
+    }
 }

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/YesNoValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/YesNoValueConverter.cs
@@ -51,8 +51,11 @@ public class YesNoValueConverter : PropertyValueConverterBase
             return (bool)source;
         }
 
-        // default value is: false
-        return false;
+        // try get config for initial state prevalue
+        var config = propertyType.DataType.ConfigurationAs<TrueFalseConfiguration>();
+
+        // if no config default value is: false
+        return config is null ? false : config.Default;
     }
 
     // default ConvertSourceToObject just returns source ie a boolean value

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/YesNoValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/YesNoValueConverter.cs
@@ -22,7 +22,12 @@ public class YesNoValueConverter : PropertyValueConverterBase
         // however there are cases where the value passed to the converter could be a non-string object, e.g. int, bool
         if (source is string s)
         {
-            if (s.Length == 0 || s == "0")
+            if (string.IsNullOrWhiteSpace(s))
+            {
+                return GetDefaultValue(propertyType);
+            }
+
+            if (s == "0")
             {
                 return false;
             }

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/YesNoValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/YesNoValueConverter.cs
@@ -51,11 +51,7 @@ public class YesNoValueConverter : PropertyValueConverterBase
             return (bool)source;
         }
 
-        // try get config for initial state prevalue
-        var config = propertyType.DataType.ConfigurationAs<TrueFalseConfiguration>();
-
-        // if no config default value is: false
-        return config is null ? false : config.Default;
+        return GetDefaultValue(propertyType);
     }
 
     // default ConvertSourceToObject just returns source ie a boolean value

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/YesNoValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/YesNoValueConverter.cs
@@ -37,7 +37,12 @@ public class YesNoValueConverter : PropertyValueConverterBase
                 return true;
             }
 
-            return bool.TryParse(s, out var result) && result;
+            if (bool.TryParse(s, out var result))
+            {
+                return result;
+            }
+
+            return GetDefaultValue(propertyType);
         }
 
         if (source is int)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/PropertyEditorValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/PropertyEditorValueConverterTests.cs
@@ -61,13 +61,29 @@ public class PropertyEditorValueConverterTests
     [TestCase(0, false)]
     [TestCase(false, false)]
     [TestCase("", false)]
+    [TestCase("", true)]
     [TestCase(null, false)]
+    [TestCase(null, true)]
     [TestCase("blah", false)]
+    [TestCase("blah", true)]
     public void CanConvertYesNoPropertyEditor(object value, bool expected)
     {
+        var mockPublishedContentTypeFactory = new Mock<IPublishedContentTypeFactory>();
+        mockPublishedContentTypeFactory.Setup(x => x.GetDataType(123))
+            .Returns(new PublishedDataType(123, "test",
+                new Lazy<object>(() => new TrueFalseConfiguration { Default = expected })));
+
+        var publishedPropType = new PublishedPropertyType(
+            new PublishedContentType(Guid.NewGuid(), 1234, "test", PublishedItemType.Content,
+                Enumerable.Empty<string>(), Enumerable.Empty<PublishedPropertyType>(), ContentVariation.Nothing),
+            new PropertyType(Mock.Of<IShortStringHelper>(), "test", ValueStorageType.Nvarchar) { DataTypeId = 123 },
+            new PropertyValueConverterCollection(() => Enumerable.Empty<IPropertyValueConverter>()),
+            Mock.Of<IPublishedModelFactory>(),
+            mockPublishedContentTypeFactory.Object);
+
         var converter = new YesNoValueConverter();
         var result =
-            converter.ConvertSourceToIntermediate(null, null, value, false); // does not use type for conversion
+            converter.ConvertSourceToIntermediate(null, publishedPropType, value, false); // does not use type for conversion
 
         Assert.AreEqual(expected, result);
     }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/14303
### Description

I updated existing`YesNoValueConverter` to use the TrueFalse data type configuration where ever it appeared the PVC was returning a default of false. This does not impact cases where false was the right choice (e.g. `s == "0"`)

I also updated the tests for `YesNoValueConverter` for cases where the value was "invalid" and would default to false previously. This change uses expected as the initial state value.

Testing this code should be done via running the unit tests or following the steps to reproduce in the issue ticket.

<!-- Thanks for contributing to Umbraco CMS! -->
