### PR TITLE
Fix #14270 - ImageCropperValue.GetCropUrl(alias, imageUrlGenerator) always returns null

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/ImageCropperValue.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/ImageCropperValue.cs
@@ -98,7 +98,7 @@ public class ImageCropperValue : IHtmlEncodedString, IEquatable<ImageCropperValu
         }
 
         ImageUrlGenerationOptions options =
-            GetCropBaseOptions(null, crop, useFocalPoint || string.IsNullOrWhiteSpace(alias));
+            GetCropBaseOptions(Src, crop, useFocalPoint || string.IsNullOrWhiteSpace(alias));
 
         if (crop is not null && useCropDimensions)
         {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/ImageCropperTest.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/ImageCropperTest.cs
@@ -201,7 +201,7 @@ public class ImageCropperTest
     {
         var cropDataSet = CropperJson1.DeserializeImageCropperValue();
         var urlString = cropDataSet.GetCropUrl("thumb", new TestImageUrlGenerator());
-        Assert.AreEqual("?c=0.58729977382575338,0.055768992440203169,0,0.32457553600198386&w=100&h=100", urlString);
+        Assert.AreEqual("/media/1005/img_0671.jpg?c=0.58729977382575338,0.055768992440203169,0,0.32457553600198386&w=100&h=100", urlString);
     }
 
     /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [#14270](https://github.com/umbraco/Umbraco-CMS/issues/14270)

### Description
I have changed 
`GetCropBaseOptions(null, crop, useFocalPoint || string.IsNullOrWhiteSpace(alias))`
to
`GetCropBaseOptions(Src, crop, useFocalPoint || string.IsNullOrWhiteSpace(alias))`
in order to prevent returning null.

Also I have changed GetBaseCropUrlFromModelTest to ensure that the full crop URL is returned, not just the crop parameters.

