### PR TITLE
Expose "expanding" state in API value conversion

### DIFF
--- a/src/Umbraco.Core/CompatibilitySuppressions.xml
+++ b/src/Umbraco.Core/CompatibilitySuppressions.xml
@@ -24,6 +24,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Umbraco.Cms.Core.Models.PublishedContent.IPublishedPropertyType.ConvertInterToDeliveryApiObject(Umbraco.Cms.Core.Models.PublishedContent.IPublishedElement,Umbraco.Cms.Core.PropertyEditors.PropertyCacheLevel,System.Object,System.Boolean,System.Boolean)</Target>
+    <Left>lib/net7.0/Umbraco.Core.dll</Left>
+    <Right>lib/net7.0/Umbraco.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
     <Target>M:Umbraco.Cms.Core.Models.PublishedContent.IPublishedPropertyType.ConvertInterToDeliveryApiObject(Umbraco.Cms.Core.Models.PublishedContent.IPublishedElement,Umbraco.Cms.Core.PropertyEditors.PropertyCacheLevel,System.Object,System.Boolean)</Target>
     <Left>lib/net7.0/Umbraco.Core.dll</Left>
     <Right>lib/net7.0/Umbraco.Core.dll</Right>

--- a/src/Umbraco.Core/Models/PublishedContent/IPublishedPropertyType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/IPublishedPropertyType.cs
@@ -123,5 +123,5 @@ public interface IPublishedPropertyType
     /// <param name="inter">The intermediate value.</param>
     /// <param name="preview">A value indicating whether content should be considered draft.</param>
     /// <returns>The object value.</returns>
-    object? ConvertInterToDeliveryApiObject(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview);
+    object? ConvertInterToDeliveryApiObject(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding);
 }

--- a/src/Umbraco.Core/Models/PublishedContent/IPublishedPropertyType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/IPublishedPropertyType.cs
@@ -122,6 +122,11 @@ public interface IPublishedPropertyType
     /// <param name="referenceCacheLevel">The reference cache level.</param>
     /// <param name="inter">The intermediate value.</param>
     /// <param name="preview">A value indicating whether content should be considered draft.</param>
+    /// <param name="expanding">A value indicating whether the property value should be expanded.</param>
     /// <returns>The object value.</returns>
     object? ConvertInterToDeliveryApiObject(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding);
+
+    [Obsolete($"Use the {nameof(ConvertInterToDeliveryApiObject)} that supports property expansion. Will be removed in V14.")]
+    object? ConvertInterToDeliveryApiObject(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
+        => ConvertInterToDeliveryApiObject(owner, referenceCacheLevel, inter, preview, false);
 }

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedPropertyType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedPropertyType.cs
@@ -301,7 +301,7 @@ namespace Umbraco.Cms.Core.Models.PublishedContent
         }
 
         /// <inheritdoc />
-        public object? ConvertInterToDeliveryApiObject(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
+        public object? ConvertInterToDeliveryApiObject(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding)
         {
             if (!_initialized)
             {
@@ -311,7 +311,7 @@ namespace Umbraco.Cms.Core.Models.PublishedContent
             // use the converter if any, else just return the inter value
             return _converter != null
                 ? _converter is IDeliveryApiPropertyValueConverter deliveryApiPropertyValueConverter
-                    ? deliveryApiPropertyValueConverter.ConvertIntermediateToDeliveryApiObject(owner, this, referenceCacheLevel, inter, preview)
+                    ? deliveryApiPropertyValueConverter.ConvertIntermediateToDeliveryApiObject(owner, this, referenceCacheLevel, inter, preview, expanding)
                     : _converter.ConvertIntermediateToObject(owner, this, referenceCacheLevel, inter, preview)
                 : inter;
         }

--- a/src/Umbraco.Core/Models/PublishedContent/RawValueProperty.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/RawValueProperty.cs
@@ -41,7 +41,7 @@ public class RawValueProperty : PublishedPropertyBase
         _xpathValue = new Lazy<object?>(() =>
             PropertyType.ConvertInterToXPath(content, PropertyCacheLevel.Unknown, interValue?.Value, isPreviewing));
         _deliveryApiValue = new Lazy<object?>(() =>
-            PropertyType.ConvertInterToDeliveryApiObject(content, PropertyCacheLevel.Unknown, interValue?.Value, isPreviewing));
+            PropertyType.ConvertInterToDeliveryApiObject(content, PropertyCacheLevel.Unknown, interValue?.Value, isPreviewing, false));
     }
 
     // RawValueProperty does not (yet?) support variants,

--- a/src/Umbraco.Core/PropertyEditors/DeliveryApi/IDeliveryApiPropertyValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/DeliveryApi/IDeliveryApiPropertyValueConverter.cs
@@ -30,6 +30,7 @@ public interface IDeliveryApiPropertyValueConverter : IPropertyValueConverter
     /// <param name="referenceCacheLevel">The reference cache level.</param>
     /// <param name="inter">The intermediate value.</param>
     /// <param name="preview">A value indicating whether conversion should take place in preview mode.</param>
+    /// <param name="expanding">A value indicating whether the property value should be expanded (if applicable).</param>
     /// <returns>The result of the conversion.</returns>
     /// <remarks>
     ///     <para>
@@ -43,5 +44,9 @@ public interface IDeliveryApiPropertyValueConverter : IPropertyValueConverter
     ///         the cache levels of property values. It is not meant to be used by the converter.
     ///     </para>
     /// </remarks>
-    object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview);
+    object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding);
+
+    [Obsolete($"Use the {nameof(ConvertIntermediateToDeliveryApiObject)} that supports property expansion. Will be removed in V14.")]
+    object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
+            => ConvertIntermediateToDeliveryApiObject(owner, propertyType, referenceCacheLevel, inter, preview, false);
 }

--- a/src/Umbraco.Core/PropertyEditors/TextStringValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/TextStringValueConverter.cs
@@ -62,6 +62,6 @@ public class TextStringValueConverter : PropertyValueConverterBase, IDeliveryApi
     public Type GetDeliveryApiPropertyValueType(IPublishedPropertyType propertyType)
         => GetPropertyValueType(propertyType);
 
-    public object ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
+    public object ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding)
         => ConvertIntermediateToObject(owner, propertyType, referenceCacheLevel, inter, preview);
 }

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/ContentPickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/ContentPickerValueConverter.cs
@@ -100,7 +100,7 @@ public class ContentPickerValueConverter : PropertyValueConverterBase, IDelivery
 
     public Type GetDeliveryApiPropertyValueType(IPublishedPropertyType propertyType) => typeof(IApiContent);
 
-    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
+    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding)
     {
         IPublishedContent? content = GetContent(propertyType, inter);
         if (content == null)

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MediaPickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MediaPickerValueConverter.cs
@@ -126,7 +126,7 @@ public class MediaPickerValueConverter : PropertyValueConverterBase, IDeliveryAp
 
     public Type GetDeliveryApiPropertyValueType(IPublishedPropertyType propertyType) => typeof(IEnumerable<IApiMedia>);
 
-    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
+    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding)
     {
         var isMultiple = IsMultipleDataType(propertyType.DataType);
 

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MemberGroupPickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MemberGroupPickerValueConverter.cs
@@ -35,7 +35,7 @@ public class MemberGroupPickerValueConverter : PropertyValueConverterBase, IDeli
 
     public Type GetDeliveryApiPropertyValueType(IPublishedPropertyType propertyType) => typeof(string[]);
 
-    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
+    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding)
     {
         var memberGroupIds = inter?
             .ToString()?

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MemberPickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MemberPickerValueConverter.cs
@@ -108,6 +108,6 @@ public class MemberPickerValueConverter : PropertyValueConverterBase, IDeliveryA
     public Type GetDeliveryApiPropertyValueType(IPublishedPropertyType propertyType) => typeof(string);
 
     // member picker is unsupported for Delivery API output to avoid leaking member data by accident.
-    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
+    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding)
         => "(unsupported)";
 }

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MultiNodeTreePickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MultiNodeTreePickerValueConverter.cs
@@ -192,7 +192,7 @@ public class MultiNodeTreePickerValueConverter : PropertyValueConverterBase, IDe
         };
 
 
-    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
+    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding)
     {
         IEnumerable<IApiContent> DefaultValue() => Array.Empty<IApiContent>();
 

--- a/src/Umbraco.Core/PublishedCache/PublishedElementPropertyBase.cs
+++ b/src/Umbraco.Core/PublishedCache/PublishedElementPropertyBase.cs
@@ -228,7 +228,7 @@ internal class PublishedElementPropertyBase : PublishedPropertyBase
         {
             CacheValues cacheValues = GetCacheValues(cacheLevel);
 
-            object? GetDeliveryApiObject() => PropertyType.ConvertInterToDeliveryApiObject(Element, referenceCacheLevel, GetInterValue(), IsPreviewing);
+            object? GetDeliveryApiObject() => PropertyType.ConvertInterToDeliveryApiObject(Element, referenceCacheLevel, GetInterValue(), IsPreviewing, expanding);
             return expanding
                 ? GetDeliveryApiExpandedObject(cacheValues, GetDeliveryApiObject)
                 : GetDeliveryApiDefaultObject(cacheValues, GetDeliveryApiObject);

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueConverter.cs
@@ -57,7 +57,7 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
         public Type GetDeliveryApiPropertyValueType(IPublishedPropertyType propertyType)
             => typeof(ApiBlockGridModel);
 
-        public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
+        public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding)
         {
             const int defaultColumns = 12;
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockListPropertyValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockListPropertyValueConverter.cs
@@ -116,7 +116,7 @@ public class BlockListPropertyValueConverter : BlockPropertyValueConverterBase<B
         => typeof(IEnumerable<ApiBlockListModel>);
 
     /// <inheritdoc />
-    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
+    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding)
     {
         BlockListModel? model = ConvertIntermediateToBlockListModel(owner, propertyType, referenceCacheLevel, inter, preview);
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/ImageCropperValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/ImageCropperValueConverter.cs
@@ -72,7 +72,7 @@ public class ImageCropperValueConverter : PropertyValueConverterBase, IDeliveryA
 
     public Type GetDeliveryApiPropertyValueType(IPublishedPropertyType propertyType) => typeof(ApiImageCropperValue);
 
-    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
+    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding)
         => inter is ImageCropperValue {Src: { }} imageCropperValue
             ? new ApiImageCropperValue(imageCropperValue.Src, imageCropperValue.FocalPoint, imageCropperValue.Crops)
             : null;

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MarkdownEditorValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MarkdownEditorValueConverter.cs
@@ -65,7 +65,7 @@ public class MarkdownEditorValueConverter : PropertyValueConverterBase, IDeliver
 
     public Type GetDeliveryApiPropertyValueType(IPublishedPropertyType propertyType) => typeof(string);
 
-    public object ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
+    public object ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding)
     {
         if (inter is not string markdownString || markdownString.IsNullOrWhiteSpace())
         {

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MediaPickerWithCropsValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MediaPickerWithCropsValueConverter.cs
@@ -124,7 +124,7 @@ public class MediaPickerWithCropsValueConverter : PropertyValueConverterBase, ID
 
     public Type GetDeliveryApiPropertyValueType(IPublishedPropertyType propertyType) => typeof(IEnumerable<ApiMediaWithCrops>);
 
-    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
+    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding)
     {
         var isMultiple = IsMultipleDataType(propertyType.DataType);
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
@@ -154,7 +154,7 @@ public class MultiUrlPickerValueConverter : PropertyValueConverterBase, IDeliver
 
     public Type GetDeliveryApiPropertyValueType(IPublishedPropertyType propertyType) => typeof(IEnumerable<ApiLink>);
 
-    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
+    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding)
     {
         IEnumerable<ApiLink> DefaultValue() => Array.Empty<ApiLink>();
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/NestedContentManyValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/NestedContentManyValueConverter.cs
@@ -119,7 +119,7 @@ public class NestedContentManyValueConverter : NestedContentValueConverterBase, 
 
     public Type GetDeliveryApiPropertyValueType(IPublishedPropertyType propertyType) => typeof(IEnumerable<IApiElement>);
 
-    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
+    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding)
     {
         var converted = ConvertIntermediateToObject(owner, propertyType, referenceCacheLevel, inter, preview);
         if (converted is not IEnumerable<IPublishedElement> elements)

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/NestedContentSingleValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/NestedContentSingleValueConverter.cs
@@ -103,7 +103,7 @@ public class NestedContentSingleValueConverter : NestedContentValueConverterBase
 
     public Type GetDeliveryApiPropertyValueType(IPublishedPropertyType propertyType) => typeof(IEnumerable<IApiElement>);
 
-    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
+    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding)
     {
         var converted = ConvertIntermediateToObject(owner, propertyType, referenceCacheLevel, inter, preview);
         if (converted is not IPublishedElement element)

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RteMacroRenderingValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RteMacroRenderingValueConverter.cs
@@ -88,7 +88,7 @@ public class RteMacroRenderingValueConverter : SimpleTinyMceValueConverter, IDel
             ? typeof(IRichTextElement)
             : typeof(RichTextModel);
 
-    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
+    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding)
     {
         var sourceString = inter?.ToString();
         if (sourceString.IsNullOrWhiteSpace())

--- a/src/Umbraco.PublishedCache.NuCache/Property.cs
+++ b/src/Umbraco.PublishedCache.NuCache/Property.cs
@@ -322,7 +322,7 @@ internal class Property : PublishedPropertyBase
             // initial reference cache level always is .Content
             const PropertyCacheLevel initialCacheLevel = PropertyCacheLevel.Element;
 
-            object? GetDeliveryApiObject() => PropertyType.ConvertInterToDeliveryApiObject(_content, initialCacheLevel, GetInterValue(culture, segment), _isPreviewing);
+            object? GetDeliveryApiObject() => PropertyType.ConvertInterToDeliveryApiObject(_content, initialCacheLevel, GetInterValue(culture, segment), _isPreviewing, expanding);
             value = expanding
                 ? GetDeliveryApiExpandedObject(cacheValues, GetDeliveryApiObject)
                 : GetDeliveryApiDefaultObject(cacheValues, GetDeliveryApiObject);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/DeliveryApi/CacheTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/DeliveryApi/CacheTests.cs
@@ -50,7 +50,7 @@ public class CacheTests
         propertyType.SetupGet(p => p.CacheLevel).Returns(cacheLevel);
         propertyType.SetupGet(p => p.DeliveryApiCacheLevel).Returns(cacheLevel);
         propertyType
-            .Setup(p => p.ConvertInterToDeliveryApiObject(It.IsAny<IPublishedElement>(), It.IsAny<PropertyCacheLevel>(), It.IsAny<object?>(), It.IsAny<bool>()))
+            .Setup(p => p.ConvertInterToDeliveryApiObject(It.IsAny<IPublishedElement>(), It.IsAny<PropertyCacheLevel>(), It.IsAny<object?>(), It.IsAny<bool>(), It.IsAny<bool>()))
             .Returns(() => $"Delivery API value: {++invocationCount}");
 
         var prop1 = new Property(propertyType.Object, content, publishedSnapshotAccessor.Object);
@@ -68,6 +68,7 @@ public class CacheTests
                 It.IsAny<IPublishedElement>(),
                 It.IsAny<PropertyCacheLevel>(),
                 It.IsAny<object?>(),
+                It.IsAny<bool>(),
                 It.IsAny<bool>()),
             Times.Exactly(expectedConverterHits));
     }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/CacheTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/CacheTests.cs
@@ -27,6 +27,7 @@ public class CacheTests : DeliveryApiTests
             It.IsAny<IPublishedPropertyType>(),
             It.IsAny<PropertyCacheLevel>(),
             It.IsAny<object?>(),
+            It.IsAny<bool>(),
             It.IsAny<bool>())
         ).Returns(() => $"Delivery API value: {++invocationCount}");
         propertyValueConverter.Setup(p => p.IsConverter(It.IsAny<IPublishedPropertyType>())).Returns(true);
@@ -54,6 +55,7 @@ public class CacheTests : DeliveryApiTests
                 It.IsAny<IPublishedPropertyType>(),
                 It.IsAny<PropertyCacheLevel>(),
                 It.IsAny<object?>(),
+                It.IsAny<bool>(),
                 It.IsAny<bool>()),
             Times.Exactly(expectedConverterHits));
     }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ContentPickerValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ContentPickerValueConverterTests.cs
@@ -34,6 +34,7 @@ public class ContentPickerValueConverterTests : PropertyValueConverterTests
             publishedPropertyType.Object,
             PropertyCacheLevel.Element,
             new GuidUdi(Constants.UdiEntityType.Document, PublishedContent.Key),
+            false,
             false) as IApiContent;
 
         Assert.NotNull(result);
@@ -59,6 +60,7 @@ public class ContentPickerValueConverterTests : PropertyValueConverterTests
             publishedPropertyType.Object,
             PropertyCacheLevel.Element,
             new GuidUdi(Constants.UdiEntityType.Document, PublishedContent.Key),
+            false,
             false) as IApiContent;
 
         Assert.NotNull(result);
@@ -95,6 +97,7 @@ public class ContentPickerValueConverterTests : PropertyValueConverterTests
             publishedPropertyType.Object,
             PropertyCacheLevel.Element,
             new GuidUdi(Constants.UdiEntityType.Document, key),
+            false,
             false) as IApiContent;
 
         Assert.NotNull(result);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/DeliveryApiTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/DeliveryApiTests.cs
@@ -27,6 +27,7 @@ public class DeliveryApiTests
             It.IsAny<IPublishedPropertyType>(),
             It.IsAny<PropertyCacheLevel>(),
             It.IsAny<object?>(),
+            It.IsAny<bool>(),
             It.IsAny<bool>())
         ).Returns("Delivery API value");
         deliveryApiPropertyValueConverter.Setup(p => p.ConvertIntermediateToObject(

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ImageCropperValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ImageCropperValueConverterTests.cs
@@ -48,7 +48,7 @@ public class ImageCropperValueConverterTests : PropertyValueConverterTests
             }
         );
         var inter = valueConverter.ConvertSourceToIntermediate(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, source, false);
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false) as ApiImageCropperValue;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false, false) as ApiImageCropperValue;
         Assert.NotNull(result);
         Assert.AreEqual("/some/file.jpg", result.Url);
         Assert.NotNull(result.FocalPoint);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MarkdownEditorValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MarkdownEditorValueConverterTests.cs
@@ -29,7 +29,7 @@ public class MarkdownEditorValueConverterTests : PropertyValueConverterTests
         var valueConverter = new MarkdownEditorValueConverter(linkParser, urlParser);
 
         Assert.AreEqual(typeof(string), valueConverter.GetDeliveryApiPropertyValueType(Mock.Of<IPublishedPropertyType>()));
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), Mock.Of<IPublishedPropertyType>(), PropertyCacheLevel.Element, inter, false);
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), Mock.Of<IPublishedPropertyType>(), PropertyCacheLevel.Element, inter, false, false);
         Assert.AreEqual(expected, result);
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MediaPickerValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MediaPickerValueConverterTests.cs
@@ -29,7 +29,7 @@ public class MediaPickerValueConverterTests : PropertyValueConverterTests
 
         var inter = new[] {new GuidUdi(Constants.UdiEntityType.MediaType, PublishedMedia.Key)};
 
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType, PropertyCacheLevel.Element, inter, false) as IEnumerable<IApiMedia>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<IApiMedia>;
 
         Assert.NotNull(result);
         Assert.AreEqual(1, result.Count());
@@ -65,7 +65,7 @@ public class MediaPickerValueConverterTests : PropertyValueConverterTests
 
         var inter = new[] { new GuidUdi(Constants.UdiEntityType.MediaType, PublishedMedia.Key), new GuidUdi(Constants.UdiEntityType.MediaType, otherMediaKey) };
 
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType, PropertyCacheLevel.Element, inter, false) as IEnumerable<IApiMedia>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<IApiMedia>;
 
         Assert.NotNull(result);
         Assert.AreEqual(2, result.Count());

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MediaPickerWithCropsValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MediaPickerWithCropsValueConverterTests.cs
@@ -59,7 +59,7 @@ public class MediaPickerWithCropsValueConverterTests : PropertyValueConverterTes
             }
         });
 
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType, PropertyCacheLevel.Element, inter, false) as IEnumerable<ApiMediaWithCrops>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<ApiMediaWithCrops>;
         Assert.NotNull(result);
         Assert.AreEqual(1, result.Count());
         var first = result.Single();
@@ -117,7 +117,7 @@ public class MediaPickerWithCropsValueConverterTests : PropertyValueConverterTes
             }
         });
 
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType, PropertyCacheLevel.Element, inter, false) as IEnumerable<ApiMediaWithCrops>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<ApiMediaWithCrops>;
         Assert.NotNull(result);
         Assert.AreEqual(2, result.Count());
         var first = result.First();
@@ -184,7 +184,7 @@ public class MediaPickerWithCropsValueConverterTests : PropertyValueConverterTes
             }
         });
 
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType, PropertyCacheLevel.Element, inter, false) as IEnumerable<ApiMediaWithCrops>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<ApiMediaWithCrops>;
         Assert.NotNull(result);
         Assert.AreEqual(1, result.Count());
         var mediaWithCrops = result.Single();
@@ -246,7 +246,7 @@ public class MediaPickerWithCropsValueConverterTests : PropertyValueConverterTes
             }
         });
 
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType, PropertyCacheLevel.Element, inter, false) as IEnumerable<ApiMediaWithCrops>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<ApiMediaWithCrops>;
         Assert.NotNull(result);
         Assert.AreEqual(1, result.Count());
         var mediaWithCrops = result.Single();
@@ -273,7 +273,7 @@ public class MediaPickerWithCropsValueConverterTests : PropertyValueConverterTes
 
         var valueConverter = MediaPickerWithCropsValueConverter();
 
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType, PropertyCacheLevel.Element, inter, false) as IEnumerable<ApiMediaWithCrops>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<ApiMediaWithCrops>;
         Assert.NotNull(result);
         Assert.IsEmpty(result);
     }
@@ -288,7 +288,7 @@ public class MediaPickerWithCropsValueConverterTests : PropertyValueConverterTes
 
         var valueConverter = MediaPickerWithCropsValueConverter();
 
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType, PropertyCacheLevel.Element, inter, false) as IEnumerable<ApiMediaWithCrops>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<ApiMediaWithCrops>;
         Assert.NotNull(result);
         Assert.IsEmpty(result);
     }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MultiNodeTreePickerValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MultiNodeTreePickerValueConverterTests.cs
@@ -52,7 +52,7 @@ public class MultiNodeTreePickerValueConverterTests : PropertyValueConverterTest
         Assert.AreEqual(typeof(IEnumerable<IApiContent>), valueConverter.GetDeliveryApiPropertyValueType(publishedPropertyType.Object));
 
         var inter = new Udi[] { new GuidUdi(Constants.UdiEntityType.Document, PublishedContent.Key) };
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false) as IEnumerable<IApiContent>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<IApiContent>;
         Assert.NotNull(result);
         Assert.AreEqual(1, result.Count());
         Assert.AreEqual(PublishedContent.Name, result.First().Name);
@@ -78,7 +78,7 @@ public class MultiNodeTreePickerValueConverterTests : PropertyValueConverterTest
         Assert.AreEqual(typeof(IEnumerable<IApiContent>), valueConverter.GetDeliveryApiPropertyValueType(publishedPropertyType.Object));
 
         var inter = new Udi[] { new GuidUdi(Constants.UdiEntityType.Document, PublishedContent.Key), new GuidUdi(Constants.UdiEntityType.Document, otherContentKey) };
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false) as IEnumerable<IApiContent>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<IApiContent>;
         Assert.NotNull(result);
         Assert.AreEqual(2, result.Count());
 
@@ -123,7 +123,7 @@ public class MultiNodeTreePickerValueConverterTests : PropertyValueConverterTest
         Assert.AreEqual(typeof(IEnumerable<IApiContent>), valueConverter.GetDeliveryApiPropertyValueType(publishedPropertyType.Object));
 
         var inter = new Udi[] { new GuidUdi(Constants.UdiEntityType.Document, key) };
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false) as IEnumerable<IApiContent>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<IApiContent>;
         Assert.NotNull(result);
         Assert.AreEqual(1, result.Count());
         Assert.AreEqual("The page", result.First().Name);
@@ -147,7 +147,7 @@ public class MultiNodeTreePickerValueConverterTests : PropertyValueConverterTest
         Assert.AreEqual(typeof(IEnumerable<IApiMedia>), valueConverter.GetDeliveryApiPropertyValueType(publishedPropertyType.Object));
 
         var inter = new Udi[] { new GuidUdi(Constants.UdiEntityType.Media, PublishedMedia.Key) };
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false) as IEnumerable<IApiMedia>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<IApiMedia>;
         Assert.NotNull(result);
         Assert.AreEqual(1, result.Count());
         Assert.AreEqual(PublishedMedia.Name, result.First().Name);
@@ -172,7 +172,7 @@ public class MultiNodeTreePickerValueConverterTests : PropertyValueConverterTest
         Assert.AreEqual(typeof(IEnumerable<IApiMedia>), valueConverter.GetDeliveryApiPropertyValueType(publishedPropertyType.Object));
 
         var inter = new Udi[] { new GuidUdi(Constants.UdiEntityType.Media, PublishedMedia.Key), new GuidUdi(Constants.UdiEntityType.Media, otherMediaKey) };
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false) as IEnumerable<IApiMedia>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<IApiMedia>;
         Assert.NotNull(result);
         Assert.AreEqual(2, result.Count());
         Assert.AreEqual(PublishedMedia.Name, result.First().Name);
@@ -197,7 +197,7 @@ public class MultiNodeTreePickerValueConverterTests : PropertyValueConverterTest
         Assert.AreEqual(typeof(IEnumerable<IApiContent>), valueConverter.GetDeliveryApiPropertyValueType(publishedPropertyType.Object));
 
         var inter = new Udi[] { new GuidUdi(Constants.UdiEntityType.Media, PublishedMedia.Key), new GuidUdi(Constants.UdiEntityType.Document, PublishedContent.Key) };
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false) as IEnumerable<IApiContent>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<IApiContent>;
         Assert.NotNull(result);
         Assert.AreEqual(1, result.Count());
         Assert.AreEqual(PublishedContent.Name, result.First().Name);
@@ -218,7 +218,7 @@ public class MultiNodeTreePickerValueConverterTests : PropertyValueConverterTest
         Assert.AreEqual(typeof(IEnumerable<IApiMedia>), valueConverter.GetDeliveryApiPropertyValueType(publishedPropertyType.Object));
 
         var inter = new Udi[] { new GuidUdi(Constants.UdiEntityType.Media, PublishedMedia.Key), new GuidUdi(Constants.UdiEntityType.Document, PublishedContent.Key) };
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false) as IEnumerable<IApiMedia>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<IApiMedia>;
         Assert.NotNull(result);
         Assert.AreEqual(1, result.Count());
         Assert.AreEqual(PublishedMedia.Name, result.First().Name);
@@ -240,7 +240,7 @@ public class MultiNodeTreePickerValueConverterTests : PropertyValueConverterTest
         Assert.AreEqual(typeof(string), valueConverter.GetDeliveryApiPropertyValueType(publishedPropertyType.Object));
 
         var inter = new Udi[] { new GuidUdi(Constants.UdiEntityType.Media, PublishedMedia.Key), new GuidUdi(Constants.UdiEntityType.Document, PublishedContent.Key) };
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false) as string;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false, false) as string;
         Assert.NotNull(result);
         Assert.AreEqual("(unsupported)", result);
     }
@@ -256,7 +256,7 @@ public class MultiNodeTreePickerValueConverterTests : PropertyValueConverterTest
 
         var valueConverter = MultiNodeTreePickerValueConverter();
 
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false) as IEnumerable<IApiContent>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<IApiContent>;
         Assert.NotNull(result);
         Assert.IsEmpty(result);
     }
@@ -272,7 +272,7 @@ public class MultiNodeTreePickerValueConverterTests : PropertyValueConverterTest
 
         var valueConverter = MultiNodeTreePickerValueConverter();
 
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false) as IEnumerable<IApiContent>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<IApiContent>;
         Assert.NotNull(result);
         Assert.IsEmpty(result);
     }
@@ -289,7 +289,7 @@ public class MultiNodeTreePickerValueConverterTests : PropertyValueConverterTest
         var valueConverter = MultiNodeTreePickerValueConverter(routeBuilder.Object);
 
         var inter = new Udi[] { new GuidUdi(Constants.UdiEntityType.Document, PublishedContent.Key) };
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false) as IEnumerable<IApiContent>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<IApiContent>;
         Assert.NotNull(result);
         Assert.IsEmpty(result);
     }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MultiUrlPickerValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MultiUrlPickerValueConverterTests.cs
@@ -35,7 +35,7 @@ public class MultiUrlPickerValueConverterTests : PropertyValueConverterTests
                 Udi = new GuidUdi(Constants.UdiEntityType.Document, PublishedContent.Key)
             }
         });
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false) as IEnumerable<ApiLink>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<ApiLink>;
         Assert.NotNull(result);
         Assert.AreEqual(1, result.Count());
         var link = result.First();
@@ -67,7 +67,7 @@ public class MultiUrlPickerValueConverterTests : PropertyValueConverterTests
                 Udi = new GuidUdi(Constants.UdiEntityType.Media, PublishedMedia.Key)
             }
         });
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false) as IEnumerable<ApiLink>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<ApiLink>;
         Assert.NotNull(result);
         Assert.AreEqual(1, result.Count());
         var link = result.First();
@@ -108,7 +108,7 @@ public class MultiUrlPickerValueConverterTests : PropertyValueConverterTests
                 Url = "https://umbraco.com/"
             }
         });
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false) as IEnumerable<ApiLink>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<ApiLink>;
         Assert.NotNull(result);
         Assert.AreEqual(3, result.Count());
 
@@ -152,7 +152,7 @@ public class MultiUrlPickerValueConverterTests : PropertyValueConverterTests
                 Url = "https://umbraco.com/"
             }
         });
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false) as IEnumerable<ApiLink>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<ApiLink>;
         Assert.NotNull(result);
         Assert.AreEqual(1, result.Count());
         var link = result.First();
@@ -182,7 +182,7 @@ public class MultiUrlPickerValueConverterTests : PropertyValueConverterTests
                 Target = "_blank"
             }
         });
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false) as IEnumerable<ApiLink>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<ApiLink>;
         Assert.NotNull(result);
         Assert.AreEqual(1, result.Count());
         var link = result.First();
@@ -212,7 +212,7 @@ public class MultiUrlPickerValueConverterTests : PropertyValueConverterTests
                 QueryString = "?something=true"
             }
         });
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false) as IEnumerable<ApiLink>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<ApiLink>;
         Assert.NotNull(result);
         Assert.AreEqual(1, result.Count());
         var link = result.First();
@@ -235,7 +235,7 @@ public class MultiUrlPickerValueConverterTests : PropertyValueConverterTests
 
         var valueConverter = MultiUrlPickerValueConverter();
 
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false) as IEnumerable<ApiLink>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<ApiLink>;
         Assert.NotNull(result);
         Assert.IsEmpty(result);
     }
@@ -251,7 +251,7 @@ public class MultiUrlPickerValueConverterTests : PropertyValueConverterTests
 
         var valueConverter = MultiUrlPickerValueConverter();
 
-        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false) as IEnumerable<ApiLink>;
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, false, false) as IEnumerable<ApiLink>;
         Assert.NotNull(result);
         Assert.IsEmpty(result);
     }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/NestedContentValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/NestedContentValueConverterTests.cs
@@ -44,8 +44,8 @@ public class NestedContentValueConverterTests : PropertyValueConverterTests
             .Setup(p => p.ConvertSourceToInter(It.IsAny<IPublishedElement>(), It.IsAny<object>(), It.IsAny<bool>()))
             .Returns((IPublishedElement owner, object? source, bool preview) => source);
         publishedPropertyType
-            .Setup(p => p.ConvertInterToDeliveryApiObject(It.IsAny<IPublishedElement>(), PropertyCacheLevel.Element, It.IsAny<object>(), It.IsAny<bool>()))
-            .Returns((IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview) => inter?.ToString());
+            .Setup(p => p.ConvertInterToDeliveryApiObject(It.IsAny<IPublishedElement>(), PropertyCacheLevel.Element, It.IsAny<object>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .Returns((IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding) => inter?.ToString());
         _publishedPropertyType = publishedPropertyType.Object;
 
         var publishedContentType = new Mock<IPublishedContentType>();
@@ -69,7 +69,7 @@ public class NestedContentValueConverterTests : PropertyValueConverterTests
     public void NestedContentSingleValueConverter_WithOneItem_ConvertsItemToListOfElements()
     {
         var nestedContentValue = "[{\"ncContentTypeAlias\": \"contentType1\",\"key\": \"1E68FB92-727A-4473-B10C-FA108ADCF16F\",\"prop1\": \"Hello, world\"}]";
-        var result = _nestedContentSingleValueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), _publishedPropertyType, PropertyCacheLevel.Element, nestedContentValue, false) as IEnumerable<IApiElement>;
+        var result = _nestedContentSingleValueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), _publishedPropertyType, PropertyCacheLevel.Element, nestedContentValue, false, false) as IEnumerable<IApiElement>;
 
         Assert.IsNotNull(result);
         Assert.AreEqual(1, result.Count());
@@ -83,7 +83,7 @@ public class NestedContentValueConverterTests : PropertyValueConverterTests
     public void NestedContentSingleValueConverter_WithMultipleItems_ConvertsFirstItemToListOfElements()
     {
         var nestedContentValue = "[{\"ncContentTypeAlias\": \"contentType1\",\"key\": \"1E68FB92-727A-4473-B10C-FA108ADCF16F\",\"prop1\": \"Hello, world\"},{\"ncContentTypeAlias\": \"contentType1\",\"key\": \"40F59DD9-7E9F-4053-BD32-89FB086D18C9\",\"prop1\": \"One more\"}]";
-        var result = _nestedContentSingleValueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), _publishedPropertyType, PropertyCacheLevel.Element, nestedContentValue, false) as IEnumerable<IApiElement>;
+        var result = _nestedContentSingleValueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), _publishedPropertyType, PropertyCacheLevel.Element, nestedContentValue, false, false) as IEnumerable<IApiElement>;
 
         Assert.IsNotNull(result);
         Assert.AreEqual(1, result.Count());
@@ -96,7 +96,7 @@ public class NestedContentValueConverterTests : PropertyValueConverterTests
     [Test]
     public void NestedContentSingleValueConverter_WithNoData_ReturnsEmptyArray()
     {
-        var result = _nestedContentSingleValueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), _publishedPropertyType, PropertyCacheLevel.Element, null, false) as IEnumerable<IApiElement>;
+        var result = _nestedContentSingleValueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), _publishedPropertyType, PropertyCacheLevel.Element, null, false, false) as IEnumerable<IApiElement>;
 
         Assert.IsNotNull(result);
         Assert.IsEmpty(result);
@@ -111,7 +111,7 @@ public class NestedContentValueConverterTests : PropertyValueConverterTests
     public void NestedContentManyValueConverter_WithOneItem_ConvertsItemToListOfElements()
     {
         var nestedContentValue = "[{\"ncContentTypeAlias\": \"contentType1\",\"key\": \"1E68FB92-727A-4473-B10C-FA108ADCF16F\",\"prop1\": \"Hello, world\"}]";
-        var result = _nestedContentManyValueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), _publishedPropertyType, PropertyCacheLevel.Element, nestedContentValue, false) as IEnumerable<IApiElement>;
+        var result = _nestedContentManyValueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), _publishedPropertyType, PropertyCacheLevel.Element, nestedContentValue, false, false) as IEnumerable<IApiElement>;
 
         Assert.IsNotNull(result);
         Assert.AreEqual(1, result.Count());
@@ -126,7 +126,7 @@ public class NestedContentValueConverterTests : PropertyValueConverterTests
     public void NestedContentManyValueConverter_WithMultipleItems_ConvertsAllItemsToElements()
     {
         var nestedContentValue = "[{\"ncContentTypeAlias\": \"contentType1\",\"key\": \"1E68FB92-727A-4473-B10C-FA108ADCF16F\",\"prop1\": \"Hello, world\"},{\"ncContentTypeAlias\": \"contentType1\",\"key\": \"40F59DD9-7E9F-4053-BD32-89FB086D18C9\",\"prop1\": \"One more\"}]";
-        var result = _nestedContentManyValueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), _publishedPropertyType, PropertyCacheLevel.Element, nestedContentValue, false) as IEnumerable<IApiElement>;
+        var result = _nestedContentManyValueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), _publishedPropertyType, PropertyCacheLevel.Element, nestedContentValue, false, false) as IEnumerable<IApiElement>;
 
         Assert.IsNotNull(result);
         Assert.AreEqual(2, result.Count());
@@ -145,7 +145,7 @@ public class NestedContentValueConverterTests : PropertyValueConverterTests
     [Test]
     public void NestedContentManyValueConverter_WithNoData_ReturnsEmptyArray()
     {
-        var result = _nestedContentManyValueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), _publishedPropertyType, PropertyCacheLevel.Element, null, false) as IEnumerable<IApiElement>;
+        var result = _nestedContentManyValueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), _publishedPropertyType, PropertyCacheLevel.Element, null, false, false) as IEnumerable<IApiElement>;
 
         Assert.IsNotNull(result);
         Assert.IsEmpty(result);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/OutputExpansionStrategyTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/OutputExpansionStrategyTests.cs
@@ -547,6 +547,7 @@ public class OutputExpansionStrategyTests : PropertyValueConverterTests
                 It.IsAny<IPublishedPropertyType>(),
                 It.IsAny<PropertyCacheLevel>(),
                 It.IsAny<object?>(),
+                It.IsAny<bool>(),
                 It.IsAny<bool>()))
             .Returns(() => apiElementBuilder.Build(element.Object));
         elementValueConverter.Setup(p => p.IsConverter(It.IsAny<IPublishedPropertyType>())).Returns(true);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/PublishedPropertyTypeTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/PublishedPropertyTypeTests.cs
@@ -11,7 +11,7 @@ public class PublishedPropertyTypeTests : DeliveryApiTests
     [Test]
     public void PropertyDeliveryApiValue_UsesDeliveryApiValueForDeliveryApiOutput()
     {
-        var result = DeliveryApiPropertyType.ConvertInterToDeliveryApiObject(new Mock<IPublishedElement>().Object, PropertyCacheLevel.None, null, false);
+        var result = DeliveryApiPropertyType.ConvertInterToDeliveryApiObject(new Mock<IPublishedElement>().Object, PropertyCacheLevel.None, null, false, false);
         Assert.NotNull(result);
         Assert.AreEqual("Delivery API value", result);
     }
@@ -27,7 +27,7 @@ public class PublishedPropertyTypeTests : DeliveryApiTests
     [Test]
     public void NonDeliveryApiPropertyValueConverter_PerformsFallbackToDefaultValueForDeliveryApiOutput()
     {
-        var result = DefaultPropertyType.ConvertInterToDeliveryApiObject(new Mock<IPublishedElement>().Object, PropertyCacheLevel.None, null, false);
+        var result = DefaultPropertyType.ConvertInterToDeliveryApiObject(new Mock<IPublishedElement>().Object, PropertyCacheLevel.None, null, false, false);
         Assert.NotNull(result);
         Assert.AreEqual("Default value", result);
     }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Published/NestedContentTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Published/NestedContentTests.cs
@@ -279,6 +279,6 @@ public class NestedContentTests
             throw new InvalidOperationException("This method won't be implemented.");
 
         public override object GetDeliveryApiValue(bool expanding, string culture = null, string segment = null) =>
-            PropertyType.ConvertInterToDeliveryApiObject(_owner, ReferenceCacheLevel, InterValue, _preview);
+            PropertyType.ConvertInterToDeliveryApiObject(_owner, ReferenceCacheLevel, InterValue, _preview, false);
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR ensures that the "expanding" state is exposed/propagated to the API property value converters, allowing them to generate different output depending on the current property expansion.

### Testing this PR

The easiest way to test this is to attach a debugger to any API property value converter (i.e. the Content Picker value converter), and verify that the `expanding` parameter in `ConvertIntermediateToDeliveryApiObject` honours the property expansion defined in the API request.

Note that property level cache might interfere with these tests. Most API property value converters will only be hit once per expansion state, at least until performing a republish of the requested content.