### PR TITLE
Hide the 'Content' content app in a folder.

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/MediaController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MediaController.cs
@@ -191,6 +191,7 @@ public class MediaController : ContentControllerBase
 
         MediaItemDisplay? mediaItemDisplay = _umbracoMapper.Map<MediaItemDisplay>(foundMedia);
 
+        // if the media item is a folder with no properties, hide the 'Content' content app.
         if(mediaItemDisplay?.ContentType?.Alias == Constants.Conventions.MediaTypes.Folder
             && (mediaItemDisplay!.Properties == null || !mediaItemDisplay.Properties.Any()))
         {

--- a/src/Umbraco.Web.BackOffice/Controllers/MediaController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MediaController.cs
@@ -189,7 +189,15 @@ public class MediaController : ContentControllerBase
             return null;
         }
 
-        return _umbracoMapper.Map<MediaItemDisplay>(foundMedia);
+        MediaItemDisplay? mediaItemDisplay = _umbracoMapper.Map<MediaItemDisplay>(foundMedia);
+
+        if(mediaItemDisplay?.ContentType?.Alias == Constants.Conventions.MediaTypes.Folder
+            && (mediaItemDisplay!.Properties == null || !mediaItemDisplay.Properties.Any()))
+        {
+            mediaItemDisplay!.ContentApps = mediaItemDisplay!.ContentApps.Where(x => x.Alias != "umbContent");
+        }
+
+        return mediaItemDisplay;
     }
 
     /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This affects all .NET Core versions.

When you browse to a `Folder` in the media section, there is a content app called `Content` and that content app has absolutely nothing on it. It is a waste of time being there. If you click on it, it is empty.

## Before

![image](https://github.com/umbraco/Umbraco-CMS/assets/9142936/0249cb10-6ab9-4b47-8524-54ef1d243131)

This PR removes the `Content` content app from a folder if the folder has no properties on it, which it doesn't normally anyway.

This is what it looks like after:

## After

![image](https://github.com/umbraco/Umbraco-CMS/assets/9142936/21525445-b9c6-4ef8-a40d-ffccaef24216)

Replication steps:

1. Spin up a new site without this PR and create a folder. When you are in that folder, see the empty content app.
2. The run this branch and spin up a new site, create a folder and see that there is no `Content` content app in it.

Voila.