### PR TITLE
Swapped the sortCreateDateAscending and sortCreateDateDescending translation values to match the intended behavior

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/bs.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/bs.xml
@@ -2238,8 +2238,8 @@ Da upravljate svojom web lokacijom, jednostavno otvorite Umbraco backoffice i po
     <key alias="stateInactive">Neaktivan</key>
     <key alias="sortNameAscending">Ime (A-Z)</key>
     <key alias="sortNameDescending">Ime (Z-A)</key>
-    <key alias="sortCreateDateAscending">Najnovije</key>
-    <key alias="sortCreateDateDescending">Najstarije</key>
+    <key alias="sortCreateDateAscending">Najstarije</key>
+    <key alias="sortCreateDateDescending">Najnovije</key>
     <key alias="sortLastLoginDateDescending">Zadnja prijava</key>
     <key alias="noUserGroupsAdded">Nijedna korisnička grupa nije dodana</key>
     <key alias="2faDisableText">Ako želite da onemogućite ovog dvofaktorskog provajdera, onda morate uneti kod prikazan na vašem uređaju za autentifikaciju:</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/cs.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/cs.xml
@@ -1869,8 +1869,8 @@
     <key alias="stateInactive">Neaktivní</key>
     <key alias="sortNameAscending">Jméno (A-Z)</key>
     <key alias="sortNameDescending">Jméno (Z-A)</key>
-    <key alias="sortCreateDateAscending">Nejnovější</key>
-    <key alias="sortCreateDateDescending">Nejstarší</key>
+    <key alias="sortCreateDateAscending">Nejstarší</key>
+    <key alias="sortCreateDateDescending">Nejnovější</key>
     <key alias="sortLastLoginDateDescending">Poslední přihlášení</key>
     <key alias="noUserGroupsAdded">Nebyly přidány žádné skupiny uživatelů</key>
   </area>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
@@ -1927,8 +1927,8 @@ Mange hilsner fra Umbraco robotten
     <key alias="stateInactive">Inaktiv</key>
     <key alias="sortNameAscending">Navn (A-Å)</key>
     <key alias="sortNameDescending">Navn (Å-A)</key>
-    <key alias="sortCreateDateAscending">Nyeste</key>
-    <key alias="sortCreateDateDescending">Ældste</key>
+    <key alias="sortCreateDateAscending">Ældste</key>
+    <key alias="sortCreateDateDescending">Nyeste</key>
     <key alias="sortLastLoginDateDescending">Sidst logget ind</key>
     <key alias="noUserGroupsAdded">Ingen brugere er blevet tilføjet</key>
     <key alias="2faDisableText">Hvis du ønsker at slå denne totrinsbekræftelse fra, så skal du nu indtaste koden fra din enhed:</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/de.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/de.xml
@@ -2179,8 +2179,8 @@
     <key alias="stateInactive">Nicht aktiv</key>
     <key alias="sortNameAscending">Name (A-Z)</key>
     <key alias="sortNameDescending">Name (Z-A)</key>
-    <key alias="sortCreateDateAscending">Newest</key>
-    <key alias="sortCreateDateDescending">Oldest</key>
+    <key alias="sortCreateDateAscending">Oldest</key>
+    <key alias="sortCreateDateDescending">Newest</key>
     <key alias="sortLastLoginDateDescending">Last login</key>
   </area>
   <area alias="validation">

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -2246,8 +2246,8 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="stateInactive">Inactive</key>
     <key alias="sortNameAscending">Name (A-Z)</key>
     <key alias="sortNameDescending">Name (Z-A)</key>
-    <key alias="sortCreateDateAscending">Newest</key>
-    <key alias="sortCreateDateDescending">Oldest</key>
+    <key alias="sortCreateDateAscending">Oldest</key>
+    <key alias="sortCreateDateDescending">Newest</key>
     <key alias="sortLastLoginDateDescending">Last login</key>
     <key alias="noUserGroupsAdded">No user groups have been added</key>
     <key alias="2faDisableText">If you wish to disable this two-factor provider, then you must enter the code shown on your authentication device:</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -2343,8 +2343,8 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="stateInactive">Inactive</key>
     <key alias="sortNameAscending">Name (A-Z)</key>
     <key alias="sortNameDescending">Name (Z-A)</key>
-    <key alias="sortCreateDateAscending">Newest</key>
-    <key alias="sortCreateDateDescending">Oldest</key>
+    <key alias="sortCreateDateAscending">Oldest</key>
+    <key alias="sortCreateDateDescending">Newest</key>
     <key alias="sortLastLoginDateDescending">Last login</key>
     <key alias="noUserGroupsAdded">No user groups have been added</key>
     <key alias="2faDisableText">If you wish to disable this two-factor provider, then you must enter the code shown on your authentication device:</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/fr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/fr.xml
@@ -1910,8 +1910,8 @@ Pour gérer votre site, ouvrez simplement le backoffice Umbraco et commencez à 
     <key alias="stateInactive">Inactif</key>
     <key alias="sortNameAscending">Nom (A-Z)</key>
     <key alias="sortNameDescending">Nom (Z-A)</key>
-    <key alias="sortCreateDateAscending">Plus récent</key>
-    <key alias="sortCreateDateDescending">Plus ancien</key>
+    <key alias="sortCreateDateAscending">Plus ancien</key>
+    <key alias="sortCreateDateDescending">Plus récent</key>
     <key alias="sortLastLoginDateDescending">Dernière connexion</key>
   </area>
   <area alias="validation">

--- a/src/Umbraco.Core/EmbeddedResources/Lang/it.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/it.xml
@@ -2319,8 +2319,8 @@ Per gestire il tuo sito web, è sufficiente aprire il backoffice di Umbraco e in
     <key alias="stateInactive">Inattivi</key>
     <key alias="sortNameAscending">Nome (A-Z)</key>
     <key alias="sortNameDescending">Nome (Z-A)</key>
-    <key alias="sortCreateDateAscending"><![CDATA[Più nuovi]]></key>
-    <key alias="sortCreateDateDescending"><![CDATA[Più vecchi]]></key>
+    <key alias="sortCreateDateAscending"><![CDATA[Più vecchi]]></key>
+    <key alias="sortCreateDateDescending"><![CDATA[Più nuovi]]></key>
     <key alias="sortLastLoginDateDescending">Ultimo login</key>
     <key alias="noUserGroupsAdded">Non sono stati aggiunti gruppi di utenti</key>
   </area>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
@@ -2059,8 +2059,8 @@ Echter, Runway biedt een gemakkelijke basis om je snel op weg te helpen. Als je 
     <key alias="stateInactive">Inactief</key>
     <key alias="sortNameAscending">Naam (A-Z)</key>
     <key alias="sortNameDescending">Naam (Z-A)</key>
-    <key alias="sortCreateDateAscending">Nieuwste</key>
-    <key alias="sortCreateDateDescending">Oudste</key>
+    <key alias="sortCreateDateAscending">Oudste</key>
+    <key alias="sortCreateDateDescending">Nieuwste</key>
     <key alias="sortLastLoginDateDescending">Laatste login</key>
     <key alias="noUserGroupsAdded">Er zijn geen gebruikersgroepen toegevoegd</key>
   </area>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/pt.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/pt.xml
@@ -822,6 +822,8 @@ Você pode publicar esta página e todas suas sub-páginas ao selecionar <em>pub
     <key alias="usertype">Tipo de usuário</key>
     <key alias="userTypes">Tipos de usuários</key>
     <key alias="writer">Escrevente</key>
+    <key alias="sortCreateDateAscending">Mais antigo</key>
+    <key alias="sortCreateDateDescending">Mais recente</key>
   </area>
   <area alias="logViewer">
     <key alias="selectAllLogLevelFilters">Selecionar tudo</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/sv.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/sv.xml
@@ -1018,8 +1018,8 @@
     <key alias="writer">Skribent</key>
     <key alias="yourHistory">Din nuvarande historik</key>
     <key alias="yourProfile">Din profil</key>
-    <key alias="sortCreateDateAscending">Nyast</key>
-    <key alias="sortCreateDateDescending">Äldst</key>
+    <key alias="sortCreateDateAscending">Äldst</key>
+    <key alias="sortCreateDateDescending">Nyast</key>
     <key alias="sortLastLoginDateDescending">Senaste login</key>
   </area>
   <area alias="logViewer">

--- a/src/Umbraco.Core/EmbeddedResources/Lang/tr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/tr.xml
@@ -1996,8 +1996,8 @@ Web sitenizi yönetmek için, Umbraco'nun arka ofisini açın ve içerik eklemey
     <key alias="stateInactive">Etkin Değil</key>
     <key alias="sortNameAscending">Ad (AZ)</key>
     <key alias="sortNameDescending">Ad (ZA)</key>
-    <key alias="sortCreateDateAscending">En yeni</key>
-    <key alias="sortCreateDateDescending">En eski</key>
+    <key alias="sortCreateDateAscending">En eski</key>
+    <key alias="sortCreateDateDescending">En yeni</key>
     <key alias="sortLastLoginDateDescending">Son giriş</key>
     <key alias="noUserGroupsAdded">Hiçbir kullanıcı grubu eklenmedi</key>
   </area>


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

This PR fixes [Issue 14213](https://github.com/umbraco/Umbraco-CMS/issues/14213)

### Description
As described in the original issue, I swapped the sortCreateDateAscending translations with the sortCreateDateDescending translations for all the languages where the keys existed (except for Welsh that seemed to be correct).

As a bonus I added the Portuguese translation for these keys (they were missing).

**Steps to reproduce**

1. Go to the Umbraco backoffice site.
2. Click on the "Users" tab
3. Create a few sample users
4. Order by "Oldest" or "Newest"

After this change, the sorting order should match the translation. When you sort on "Oldest", the users should be sorted on create date in ascending order and when you sort on "Newest", the users should be sorted on create date create in descending order.
