### PR TITLE
V10: Handle blob images

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/TinyMceController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/TinyMceController.cs
@@ -114,7 +114,7 @@ public class TinyMceController : UmbracoAuthorizedApiController
             await formFile.CopyToAsync(stream);
         }
 
-        return Ok(new {tmpLocation = relativeNewFilePath});
+        return Ok(new { tmpLocation = relativeNewFilePath });
     }
 
     // Use private method istead of _ioHelper.GetRelativePath as that is relative for the webroot and not the content root.

--- a/src/Umbraco.Web.BackOffice/Controllers/TinyMceController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/TinyMceController.cs
@@ -26,6 +26,19 @@ public class TinyMceController : UmbracoAuthorizedApiController
     private readonly IIOHelper _ioHelper;
     private readonly IShortStringHelper _shortStringHelper;
 
+    private readonly Dictionary<string, string> _fileContentTypeMappings =
+        new()
+        {
+            { "image/png", ".png" },
+            { "image/jpeg", ".jpg" },
+            { "image/gif", ".gif" },
+            { "image/bmp", ".bmp" },
+            { "image/x-icon", ".ico" },
+            { "image/svg+xml", ".svg" },
+            { "image/tiff", ".tiff" },
+            { "image/webp", ".webp" },
+        };
+
     public TinyMceController(
         IHostingEnvironment hostingEnvironment,
         IShortStringHelper shortStringHelper,
@@ -43,16 +56,6 @@ public class TinyMceController : UmbracoAuthorizedApiController
     [HttpPost]
     public async Task<IActionResult> UploadImage(List<IFormFile> file)
     {
-        // Create an unique folder path to help with concurrent users to avoid filename clash
-        var imageTempPath =
-            _hostingEnvironment.MapPathContentRoot(Constants.SystemDirectories.TempImageUploads + "/" + Guid.NewGuid());
-
-        // Ensure image temp path exists
-        if (Directory.Exists(imageTempPath) == false)
-        {
-            Directory.CreateDirectory(imageTempPath);
-        }
-
         // Must have a file
         if (file.Count == 0)
         {
@@ -65,13 +68,36 @@ public class TinyMceController : UmbracoAuthorizedApiController
             return new UmbracoProblemResult("Only one file can be uploaded at a time", HttpStatusCode.BadRequest);
         }
 
+        // Create an unique folder path to help with concurrent users to avoid filename clash
+        var imageTempPath =
+            _hostingEnvironment.MapPathContentRoot(Constants.SystemDirectories.TempImageUploads + "/" + Guid.NewGuid());
+
+        // Ensure image temp path exists
+        if (Directory.Exists(imageTempPath) == false)
+        {
+            Directory.CreateDirectory(imageTempPath);
+        }
+
         IFormFile formFile = file.First();
 
         // Really we should only have one file per request to this endpoint
         //  var file = result.FileData[0];
-        var fileName = formFile.FileName.Trim(new[] { '\"' }).TrimEnd();
+        var fileName = formFile.FileName.Trim(new[] {'\"'}).TrimEnd();
         var safeFileName = fileName.ToSafeFileName(_shortStringHelper);
-        var ext = safeFileName.Substring(safeFileName.LastIndexOf('.') + 1).ToLowerInvariant();
+        string ext;
+        var fileExtensionIndex = safeFileName.LastIndexOf('.');
+        if (fileExtensionIndex is not -1)
+        {
+            ext = safeFileName.Substring(fileExtensionIndex + 1).ToLowerInvariant();
+        }
+        else
+        {
+            _fileContentTypeMappings.TryGetValue(formFile.ContentType, out var fileExtension);
+            ext = fileExtension ?? string.Empty;
+
+            // safeFileName will not have a file extension, so we need to add it back
+            safeFileName += ext;
+        }
 
         if (_contentSettings.IsFileAllowedForUpload(ext) == false ||
             _imageUrlGenerator.IsSupportedImageFormat(ext) == false)
@@ -88,7 +114,7 @@ public class TinyMceController : UmbracoAuthorizedApiController
             await formFile.CopyToAsync(stream);
         }
 
-        return Ok(new { tmpLocation = relativeNewFilePath });
+        return Ok(new {tmpLocation = relativeNewFilePath});
     }
 
     // Use private method istead of _ioHelper.GetRelativePath as that is relative for the webroot and not the content root.

--- a/src/Umbraco.Web.BackOffice/Controllers/TinyMceController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/TinyMceController.cs
@@ -29,14 +29,14 @@ public class TinyMceController : UmbracoAuthorizedApiController
     private readonly Dictionary<string, string> _fileContentTypeMappings =
         new()
         {
-            { "image/png", ".png" },
-            { "image/jpeg", ".jpg" },
-            { "image/gif", ".gif" },
-            { "image/bmp", ".bmp" },
-            { "image/x-icon", ".ico" },
-            { "image/svg+xml", ".svg" },
-            { "image/tiff", ".tiff" },
-            { "image/webp", ".webp" },
+            { "image/png", "png" },
+            { "image/jpeg", "jpg" },
+            { "image/gif", "gif" },
+            { "image/bmp", "bmp" },
+            { "image/x-icon", "ico" },
+            { "image/svg+xml", "svg" },
+            { "image/tiff", "tiff" },
+            { "image/webp", "webp" },
         };
 
     public TinyMceController(
@@ -96,7 +96,7 @@ public class TinyMceController : UmbracoAuthorizedApiController
             ext = fileExtension ?? string.Empty;
 
             // safeFileName will not have a file extension, so we need to add it back
-            safeFileName += ext;
+            safeFileName += $".{ext}";
         }
 
         if (_contentSettings.IsFileAllowedForUpload(ext) == false ||


### PR DESCRIPTION
# Notes
- Move file checking (count and errors) to the top, so we do not create a folder, if we have no file.
- Added handling of blob images, that will try to map a file extension, as it doesn't have one

# How to test
- Create a document type with a rich text editor property
- Create a content node with that document type
- Open source code for rich text editor and put in `<p> </p>`
-  past in this base64 image between the paragraph tags: https://github.com/umbraco/Umbraco.Deploy.Issues/files/10091102/base64image.txt
- This should now result in a upload of the file, and it should also show in the media library 👍 