### PR TITLE
V14: umbraco-package.json schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,12 +107,13 @@ preserve.belle
 # Ignore auto-generated schema
 /src/Umbraco.Cms.Targets/tasks/
 /src/Umbraco.Cms.Targets/appsettings-schema.*.json
+/src/Umbraco.Cms.Targets/umbraco-package-schema.json
 /src/Umbraco.Web.UI/appsettings-schema.json
 /src/Umbraco.Web.UI/appsettings-schema.*.json
-/src/Umbraco.Cms.Targets/umbraco-package-schema.json
 /src/Umbraco.Web.UI/umbraco-package-schema.json
 /tests/Umbraco.Tests.Integration/appsettings-schema.json
 /tests/Umbraco.Tests.Integration/appsettings-schema.*.json
+/tests/Umbraco.Tests.Integration/umbraco-package-schema.json
 /src/Umbraco.Cms/appsettings-schema.json
 playwright-report
 trace.zip

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,8 @@ preserve.belle
 /src/Umbraco.Cms.Targets/appsettings-schema.*.json
 /src/Umbraco.Web.UI/appsettings-schema.json
 /src/Umbraco.Web.UI/appsettings-schema.*.json
+/src/Umbraco.Cms.Targets/umbraco-package-schema.json
+/src/Umbraco.Web.UI/umbraco-package-schema.json
 /tests/Umbraco.Tests.Integration/appsettings-schema.json
 /tests/Umbraco.Tests.Integration/appsettings-schema.*.json
 /src/Umbraco.Cms/appsettings-schema.json

--- a/src/Umbraco.Cms.Targets/Umbraco.Cms.Targets.csproj
+++ b/src/Umbraco.Cms.Targets/Umbraco.Cms.Targets.csproj
@@ -53,6 +53,11 @@
     <Delete Files="$(_UmbracoCmsJsonSchemaReference)" />
   </Target>
 
+  <!-- Remove generated JSON package schema on clean -->
+  <Target Name="RemovePackageSchema" AfterTargets="Clean" Condition="Exists('$(_UmbracoCmsPackageSchemaReference)')">
+    <Delete Files="$(_UmbracoCmsPackageSchemaReference)" />
+  </Target>
+
   <!-- Create and pack empty file to add TFM dependency -->
   <Target Name="GetTargetFrameworkPackageFiles" BeforeTargets="GenerateNuspec">
     <WriteLinesToFile File="$(IntermediateOutputPath)_._" />

--- a/src/Umbraco.Cms.Targets/Umbraco.Cms.Targets.csproj
+++ b/src/Umbraco.Cms.Targets/Umbraco.Cms.Targets.csproj
@@ -21,12 +21,14 @@
   <!-- Add JSON schema references (and include MSBuild task) -->
   <PropertyGroup>
     <_UmbracoCmsJsonSchemaReference>appsettings-schema.Umbraco.Cms.json</_UmbracoCmsJsonSchemaReference>
+    <_UmbracoCmsPackageSchemaReference>umbraco-package-schema.json</_UmbracoCmsPackageSchemaReference>
     <NoWarn>NU5100;NU5128</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Umbraco.JsonSchema.Extensions" Version="0.3.0" PrivateAssets="all" GeneratePathProperty="true" />
     <None Include="$(PkgUmbraco_JsonSchema_Extensions)\tasks\netstandard2.0\**" Pack="true" PackagePath="tasks\netstandard2.0" Visible="false" />
     <Content Include="$(_UmbracoCmsJsonSchemaReference)" PackagePath="" Visible="false" />
+    <Content Include="$(_UmbracoCmsPackageSchemaReference)" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <!-- We also need physical copies in the right location relative to the Umbraco.Cms.Targets.targets file, as that's directly referenced in projects -->
@@ -57,5 +59,10 @@
     <ItemGroup>
       <_PackageFiles Include="$(IntermediateOutputPath)_._" PackagePath="lib\$(TargetFramework)" />
     </ItemGroup>
+  </Target>
+
+  <Target Name="GenerateUmbracoPackageSchema" BeforeTargets="Build;CopyUmbracoJsonSchemaFiles" Condition="!Exists('$(_UmbracoCmsPackageSchemaReference)')">
+    <Message Text="Generating $(_UmbracoCmsPackageSchemaReference) because it doesn't exist" Importance="high" />
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)..\Umbraco.Web.UI.New.Client\dist-cms\umbraco-package-schema.json" DestinationFiles="$(_UmbracoCmsPackageSchemaReference)" />
   </Target>
 </Project>

--- a/src/Umbraco.Cms.Targets/Umbraco.Cms.Targets.csproj
+++ b/src/Umbraco.Cms.Targets/Umbraco.Cms.Targets.csproj
@@ -53,11 +53,6 @@
     <Delete Files="$(_UmbracoCmsJsonSchemaReference)" />
   </Target>
 
-  <!-- Remove generated JSON package schema on clean -->
-  <Target Name="RemovePackageSchema" AfterTargets="Clean" Condition="Exists('$(_UmbracoCmsPackageSchemaReference)')">
-    <Delete Files="$(_UmbracoCmsPackageSchemaReference)" />
-  </Target>
-
   <!-- Create and pack empty file to add TFM dependency -->
   <Target Name="GetTargetFrameworkPackageFiles" BeforeTargets="GenerateNuspec">
     <WriteLinesToFile File="$(IntermediateOutputPath)_._" />
@@ -66,8 +61,14 @@
     </ItemGroup>
   </Target>
 
+  <!-- Generate JSON package schema on build (and before copying to project) -->
   <Target Name="GenerateUmbracoPackageSchema" BeforeTargets="Build;CopyUmbracoJsonSchemaFiles" Condition="!Exists('$(_UmbracoCmsPackageSchemaReference)')">
     <Message Text="Generating $(_UmbracoCmsPackageSchemaReference) because it doesn't exist" Importance="high" />
-    <Copy SourceFiles="$(MSBuildThisFileDirectory)..\Umbraco.Web.UI.New.Client\dist-cms\umbraco-package-schema.json" DestinationFiles="$(_UmbracoCmsPackageSchemaReference)" />
+    <Exec WorkingDirectory="$(MsBuildThisFileDirectory)..\Umbraco.Web.UI.New.Client" Command="npm run generate:jsonschema -- --out &quot;$(MSBuildThisFileDirectory)$(_UmbracoCmsPackageSchemaReference)&quot; tsconfig.json UmbracoPackage" />
+  </Target>
+
+  <!-- Remove generated JSON package schema on clean -->
+  <Target Name="RemovePackageSchema" AfterTargets="Clean" Condition="Exists('$(_UmbracoCmsPackageSchemaReference)')">
+    <Delete Files="$(_UmbracoCmsPackageSchemaReference)" />
   </Target>
 </Project>

--- a/src/Umbraco.Cms.Targets/buildTransitive/Umbraco.Cms.Targets.props
+++ b/src/Umbraco.Cms.Targets/buildTransitive/Umbraco.Cms.Targets.props
@@ -12,5 +12,6 @@
   <ItemGroup>
     <UmbracoJsonSchemaReferences Include="https://json.schemastore.org/appsettings.json" Weight="-100" />
     <UmbracoJsonSchemaFiles Include="$(MSBuildThisFileDirectory)..\appsettings-schema.Umbraco.Cms.json" Weight="-90" />
+    <UmbracoPackageSchemaFiles Include="$(MSBuildThisFileDirectory)..\umbraco-package-schema.json" Weight="-90" />
   </ItemGroup>
 </Project>

--- a/src/Umbraco.Cms.Targets/buildTransitive/Umbraco.Cms.Targets.targets
+++ b/src/Umbraco.Cms.Targets/buildTransitive/Umbraco.Cms.Targets.targets
@@ -8,11 +8,14 @@
       <DependentUpon>appsettings-schema.json</DependentUpon>
     </Content>
   </ItemGroup>
-  
+
   <!-- Copy JSON schema files into the project directory -->
   <Target Name="CopyUmbracoJsonSchemaFiles" BeforeTargets="Build">
     <Message Text="Copying JSON schema files into project directory: @(UmbracoJsonSchemaFiles->'%(Filename)%(Extension)')" Importance="high" />
     <Copy SourceFiles="@(UmbracoJsonSchemaFiles)" DestinationFolder="$(MSBuildProjectDirectory)" SkipUnchangedFiles="true" />
+
+    <Message Text="Copying JSON schema files into project directory: @(UmbracoPackageSchemaFiles->'%(Filename)%(Extension)')" Importance="high" />
+    <Copy SourceFiles="@(UmbracoPackageSchemaFiles)" DestinationFolder="$(MSBuildProjectDirectory)" SkipUnchangedFiles="true" />
   </Target>
 
   <!-- Add references to the JSON schema in the project directory -->

--- a/templates/Umbraco.Templates.csproj
+++ b/templates/Umbraco.Templates.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Title>Umbraco CMS - Templates</Title>
-    <Description>Coontains templates for Umbraco CMS.</Description>
+    <Description>Contains templates for Umbraco CMS.</Description>
     <PackageType>Template</PackageType>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>

--- a/templates/UmbracoProject/.gitignore
+++ b/templates/UmbracoProject/.gitignore
@@ -463,6 +463,9 @@ $RECYCLE.BIN/
 appsettings-schema.json
 appsettings-schema.*.json
 
+# JSON schema file for umbraco-package.json
+umbraco-package-schema.json
+
 # Packages created from the backoffice (package.xml/package.zip)
 /umbraco/Data/CreatedPackages/
 

--- a/templates/UmbracoProject/UmbracoProject.csproj
+++ b/templates/UmbracoProject/UmbracoProject.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Umbraco.Cms.Targets" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
     <PackageReference Include="Umbraco.Cms" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
   </ItemGroup>
 
@@ -26,7 +27,7 @@
     <RazorCompileOnBuild>false</RazorCompileOnBuild>
     <RazorCompileOnPublish>false</RazorCompileOnPublish>
   </PropertyGroup>
-  
+
   <Import Project="..\PACKAGE_PROJECT_NAME_FROM_TEMPLATE\buildTransitive\PACKAGE_PROJECT_NAME_FROM_TEMPLATE.targets" Condition="'$(PackageProjectName)' != ''" />
   <ItemGroup Condition="'$(PackageProjectName)' != ''">
     <ProjectReference Include="..\PACKAGE_PROJECT_NAME_FROM_TEMPLATE\PACKAGE_PROJECT_NAME_FROM_TEMPLATE.csproj" />

--- a/templates/UmbracoProject/UmbracoProject.csproj
+++ b/templates/UmbracoProject/UmbracoProject.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Umbraco.Cms.Targets" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
     <PackageReference Include="Umbraco.Cms" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
   </ItemGroup>
 
@@ -27,7 +26,7 @@
     <RazorCompileOnBuild>false</RazorCompileOnBuild>
     <RazorCompileOnPublish>false</RazorCompileOnPublish>
   </PropertyGroup>
-
+  
   <Import Project="..\PACKAGE_PROJECT_NAME_FROM_TEMPLATE\buildTransitive\PACKAGE_PROJECT_NAME_FROM_TEMPLATE.targets" Condition="'$(PackageProjectName)' != ''" />
   <ItemGroup Condition="'$(PackageProjectName)' != ''">
     <ProjectReference Include="..\PACKAGE_PROJECT_NAME_FROM_TEMPLATE\PACKAGE_PROJECT_NAME_FROM_TEMPLATE.csproj" />


### PR DESCRIPTION
### Description

This PR aims to ensure that the generated schema file for the new `umbraco-package.json` format is preserved through the Cms.Targets project, which in turn copies it out to any referencing projects such as `Umbraco.Web.UI.New`.

### How to test

**Source version**

1. Build the startup project
2. Check that `umbraco-package-schema.json` is copied into the root of that project

**Packed version**

1. Run `dotnet pack -o .artifacts`
2. Add `.artifacts` as a  nuget source and install `./artifacts/Umbraco.Templates.xxxxxxx` 
3. Create a new project from the "umbraco" template
4. Verify that `umbraco-package-schema.json" and `appsettings-schema.json` are both present in the project folder

### Caveats

The old executable `Umbraco.Web.UI` also references the "Cms.Targets" projects and thus gets the same file, which it of course cannot use. However, this project is not included in the v14 distribution and will eventually be removed entirely.
