### PR TITLE
Change "Media Picker" in RTE to "Image Picker"

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -603,7 +603,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
     createMediaPicker: function (editor, callback) {
       editor.ui.registry.addButton('umbmediapicker', {
         icon: 'image',
-        tooltip: 'Media Picker',
+        tooltip: 'Image Picker',
         stateSelector: 'img[data-udi]',
         onAction: function () {
 


### PR DESCRIPTION
### Prerequisites

If there's an existing issue for this PR then this fixes #14320

### Description

Changed the tinymce tooltip from "Media Picker" to "Image Picker"
