### PR TITLE
Fix for User null from IP address "::1" has logged out

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/AuthenticationController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/AuthenticationController.cs
@@ -633,7 +633,7 @@ public class AuthenticationController : UmbracoApiControllerBase
         await _signInManager.SignOutAsync();
 
         _logger.LogInformation("User {UserName} from IP address {RemoteIpAddress} has logged out",
-            User.Identity == null ? "UNKNOWN" : User.Identity.Name, HttpContext.Connection.RemoteIpAddress);
+            result.Principal.Identity == null ? "UNKNOWN" : result.Principal.Identity.Name, HttpContext.Connection.RemoteIpAddress);
 
         var userId = result.Principal.Identity?.GetUserId();
         SignOutSuccessResult args = _userManager.NotifyLogoutSuccess(User, userId);


### PR DESCRIPTION
### Prerequisites

This fixes https://github.com/umbraco/Umbraco-CMS/issues/14281

### Description

As per the comment // force authentication to occur since this is not an authorized endpoint
So in order to get the username of the user that logged out we need to look at the result of 
`AuthenticateResult result = await this.AuthenticateBackOfficeAsync();`


