### PR TITLE
V14: Update template controllers

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/ByKeyTemplateController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/ByKeyTemplateController.cs
@@ -1,8 +1,8 @@
 ﻿using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.Template;
-using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 
@@ -12,12 +12,14 @@ namespace Umbraco.Cms.Api.Management.Controllers.Template;
 public class ByKeyTemplateController : TemplateControllerBase
 {
     private readonly ITemplateService _templateService;
-    private readonly IUmbracoMapper _umbracoMapper;
+    private readonly ITemplatePresentationFactory _templatePresentationFactory;
 
-    public ByKeyTemplateController(ITemplateService templateService, IUmbracoMapper umbracoMapper)
+    public ByKeyTemplateController(
+        ITemplateService templateService,
+        ITemplatePresentationFactory templatePresentationFactory)
     {
         _templateService = templateService;
-        _umbracoMapper = umbracoMapper;
+        _templatePresentationFactory = templatePresentationFactory;
     }
 
     [HttpGet("{id:guid}")]
@@ -29,6 +31,6 @@ public class ByKeyTemplateController : TemplateControllerBase
         ITemplate? template = await _templateService.GetAsync(id);
         return template == null
             ? NotFound()
-            : Ok(_umbracoMapper.Map<TemplateResponseModel>(template));
+            : Ok(await _templatePresentationFactory.CreateTemplateResponseModelAsync(template));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Item/ItemTemplateItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Item/ItemTemplateItemController.cs
@@ -12,13 +12,13 @@ namespace Umbraco.Cms.Api.Management.Controllers.Template.Item;
 [ApiVersion("1.0")]
 public class ItemTemplateItemController : TemplateItemControllerBase
 {
-    private readonly IEntityService _entityService;
     private readonly IUmbracoMapper _mapper;
+    private readonly ITemplateService _templateService;
 
-    public ItemTemplateItemController(IEntityService entityService, IUmbracoMapper mapper)
+    public ItemTemplateItemController(IUmbracoMapper mapper, ITemplateService templateService)
     {
-        _entityService = entityService;
         _mapper = mapper;
+        _templateService = templateService;
     }
 
     [HttpGet("item")]
@@ -26,8 +26,10 @@ public class ItemTemplateItemController : TemplateItemControllerBase
     [ProducesResponseType(typeof(IEnumerable<TemplateItemResponseModel>), StatusCodes.Status200OK)]
     public async Task<IActionResult> Item([FromQuery(Name = "id")] SortedSet<Guid> ids)
     {
-        IEnumerable<IEntitySlim> templates = _entityService.GetAll(UmbracoObjectTypes.Template, ids.ToArray());
-        List<TemplateItemResponseModel> responseModels = _mapper.MapEnumerable<IEntitySlim, TemplateItemResponseModel>(templates);
+        // This is far from ideal, that we pick out the entire model, however, we must do this to get the alias.
+        // This is (for one) needed for when specifying master template, since alias + .cshtml
+        IEnumerable<ITemplate> templates = await _templateService.GetAllAsync(ids.ToArray());
+        List<TemplateItemResponseModel> responseModels = _mapper.MapEnumerable<ITemplate, TemplateItemResponseModel>(templates);
         return Ok(responseModels);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/ScaffoldTemplateController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/ScaffoldTemplateController.cs
@@ -3,6 +3,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Template;
 using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Template;
 
@@ -10,19 +12,25 @@ namespace Umbraco.Cms.Api.Management.Controllers.Template;
 public class ScaffoldTemplateController : TemplateControllerBase
 {
     private readonly IDefaultViewContentProvider _defaultViewContentProvider;
+    private readonly ITemplateService _templateService;
 
-    public ScaffoldTemplateController(IDefaultViewContentProvider defaultViewContentProvider)
-        => _defaultViewContentProvider = defaultViewContentProvider;
+    public ScaffoldTemplateController(
+        IDefaultViewContentProvider defaultViewContentProvider,
+        ITemplateService templateService)
+    {
+        _defaultViewContentProvider = defaultViewContentProvider;
+        _templateService = templateService;
+    }
 
     [HttpGet("scaffold")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(TemplateScaffoldResponseModel), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<TemplateScaffoldResponseModel>> Scaffold()
+    public async Task<ActionResult<TemplateScaffoldResponseModel>> Scaffold([FromQuery(Name = "masterTemplateId")] Guid? masterTemplateId)
     {
         var scaffoldViewModel = new TemplateScaffoldResponseModel
         {
-            Content = _defaultViewContentProvider.GetDefaultFileContent()
+            Content = await _templateService.GetScaffoldAsync(masterTemplateId),
         };
 
         return await Task.FromResult(Ok(scaffoldViewModel));

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/ScaffoldTemplateController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/ScaffoldTemplateController.cs
@@ -11,16 +11,9 @@ namespace Umbraco.Cms.Api.Management.Controllers.Template;
 [ApiVersion("1.0")]
 public class ScaffoldTemplateController : TemplateControllerBase
 {
-    private readonly IDefaultViewContentProvider _defaultViewContentProvider;
     private readonly ITemplateService _templateService;
 
-    public ScaffoldTemplateController(
-        IDefaultViewContentProvider defaultViewContentProvider,
-        ITemplateService templateService)
-    {
-        _defaultViewContentProvider = defaultViewContentProvider;
-        _templateService = templateService;
-    }
+    public ScaffoldTemplateController(ITemplateService templateService) => _templateService = templateService;
 
     [HttpGet("scaffold")]
     [MapToApiVersion("1.0")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/TemplateControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/TemplateControllerBase.cs
@@ -25,6 +25,10 @@ public class TemplateControllerBase : ManagementApiControllerBase
                 .WithTitle("Cancelled by notification")
                 .WithDetail("A notification handler prevented the template operation.")
                 .Build()),
+            TemplateOperationStatus.DuplicateAlias => BadRequest(new ProblemDetailsBuilder()
+                .WithTitle("Duplicate alias")
+                .WithDetail("A template with that alias already exists.")
+                .Build()),
             _ => StatusCode(StatusCodes.Status500InternalServerError, "Unknown template operation status")
         };
 }

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/TemplateBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/TemplateBuilderExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Umbraco.Cms.Core.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Api.Management.Mapping.Template;
 using Umbraco.Cms.Core.Mapping;
 
@@ -9,6 +11,7 @@ internal static class TemplateBuilderExtensions
     internal static IUmbracoBuilder AddTemplates(this IUmbracoBuilder builder)
     {
         builder.WithCollectionBuilder<MapDefinitionCollectionBuilder>().Add<TemplateViewModelMapDefinition>();
+        builder.Services.AddTransient<ITemplatePresentationFactory, TemplatePresentationFactory>();
 
         return builder;
     }

--- a/src/Umbraco.Cms.Api.Management/Factories/ITemplatePresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/ITemplatePresentationFactory.cs
@@ -1,0 +1,9 @@
+﻿using Umbraco.Cms.Api.Management.ViewModels.Template;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Api.Management.Factories;
+
+public interface ITemplatePresentationFactory
+{
+    Task<TemplateResponseModel> CreateTemplateResponseModelAsync(ITemplate template);
+}

--- a/src/Umbraco.Cms.Api.Management/Factories/TemplatePresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/TemplatePresentationFactory.cs
@@ -20,7 +20,13 @@ public class TemplatePresentationFactory : ITemplatePresentationFactory
 
     public async Task<TemplateResponseModel> CreateTemplateResponseModelAsync(ITemplate template)
     {
-        TemplateResponseModel responseModel = _mapper.Map<TemplateResponseModel>(template)!;
+        TemplateResponseModel responseModel = new()
+        {
+            Id = template.Key,
+            Name = template.Name ?? string.Empty,
+            Alias = template.Alias,
+            Content = template.Content
+        };
 
         if (template.MasterTemplateAlias is not null)
         {

--- a/src/Umbraco.Cms.Api.Management/Factories/TemplatePresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/TemplatePresentationFactory.cs
@@ -1,0 +1,33 @@
+﻿using Umbraco.Cms.Api.Management.ViewModels.Template;
+using Umbraco.Cms.Core.Mapping;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Factories;
+
+public class TemplatePresentationFactory : ITemplatePresentationFactory
+{
+    private readonly ITemplateService _templateService;
+    private readonly IUmbracoMapper _mapper;
+
+    public TemplatePresentationFactory(
+        ITemplateService templateService,
+        IUmbracoMapper mapper)
+    {
+        _templateService = templateService;
+        _mapper = mapper;
+    }
+
+    public async Task<TemplateResponseModel> CreateTemplateResponseModelAsync(ITemplate template)
+    {
+        TemplateResponseModel responseModel = _mapper.Map<TemplateResponseModel>(template)!;
+
+        if (template.MasterTemplateAlias is not null)
+        {
+            ITemplate? parentTemplate = await _templateService.GetAsync(template.MasterTemplateAlias);
+            responseModel.MasterTemplateId = parentTemplate?.Key;
+        }
+
+        return responseModel;
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Mapping/Items/ItemTypeMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Items/ItemTypeMapDefinition.cs
@@ -28,7 +28,7 @@ public class ItemTypeMapDefinition : IMapDefinition
         mapper.Define<IContentType, DocumentTypeItemResponseModel>((_, _) => new DocumentTypeItemResponseModel(), Map);
         mapper.Define<IMediaType, MediaTypeItemResponseModel>((_, _) => new MediaTypeItemResponseModel(), Map);
         mapper.Define<IEntitySlim, MemberGroupItemReponseModel>((_, _) => new MemberGroupItemReponseModel(), Map);
-        mapper.Define<IEntitySlim, TemplateItemResponseModel>((_, _) => new TemplateItemResponseModel(), Map);
+        mapper.Define<ITemplate, TemplateItemResponseModel>((_, _) => new TemplateItemResponseModel { Alias = string.Empty }, Map);
         mapper.Define<IMemberType, MemberTypeItemResponseModel>((_, _) => new MemberTypeItemResponseModel(), Map);
         mapper.Define<IRelationType, RelationTypeItemResponseModel>((_, _) => new RelationTypeItemResponseModel(), Map);
         mapper.Define<IMediaEntitySlim, MediaItemResponseModel>((_, _) => new MediaItemResponseModel(), Map);
@@ -84,10 +84,11 @@ public class ItemTypeMapDefinition : IMapDefinition
     }
 
     // Umbraco.Code.MapAll
-    private static void Map(IEntitySlim source, TemplateItemResponseModel target, MapperContext context)
+    private static void Map(ITemplate source, TemplateItemResponseModel target, MapperContext context)
     {
         target.Name = source.Name ?? string.Empty;
         target.Id = source.Key;
+        target.Alias = source.Alias;
     }
 
     // Umbraco.Code.MapAll

--- a/src/Umbraco.Cms.Api.Management/Mapping/Template/TemplateViewModelMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Template/TemplateViewModelMapDefinition.cs
@@ -18,7 +18,7 @@ public class TemplateViewModelMapDefinition : IMapDefinition
         mapper.Define<UpdateTemplateRequestModel, ITemplate>((source, _) => new Core.Models.Template(_shortStringHelper, source.Name, source.Alias), Map);
     }
 
-    // Umbraco.Code.MapAll
+    // Umbraco.Code.MapAll -MasterTemplateId
     private void Map(ITemplate source, TemplateResponseModel target, MapperContext context)
     {
         target.Id = source.Key;

--- a/src/Umbraco.Cms.Api.Management/Mapping/Template/TemplateViewModelMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Template/TemplateViewModelMapDefinition.cs
@@ -14,17 +14,7 @@ public class TemplateViewModelMapDefinition : IMapDefinition
 
     public void DefineMaps(IUmbracoMapper mapper)
     {
-        mapper.Define<ITemplate, TemplateResponseModel>((_, _) => new TemplateResponseModel(), Map);
         mapper.Define<UpdateTemplateRequestModel, ITemplate>((source, _) => new Core.Models.Template(_shortStringHelper, source.Name, source.Alias), Map);
-    }
-
-    // Umbraco.Code.MapAll -MasterTemplateId
-    private void Map(ITemplate source, TemplateResponseModel target, MapperContext context)
-    {
-        target.Id = source.Key;
-        target.Name = source.Name ?? string.Empty;
-        target.Alias = source.Alias;
-        target.Content = source.Content;
     }
 
     // Umbraco.Code.MapAll -Id -Key -CreateDate -UpdateDate -DeleteDate

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Template/Item/TemplateItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Template/Item/TemplateItemResponseModel.cs
@@ -4,4 +4,5 @@ namespace Umbraco.Cms.Api.Management.ViewModels.Template.Item;
 
 public class TemplateItemResponseModel : ItemResponseModelBase
 {
+    public required string Alias { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Template/TemplateResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Template/TemplateResponseModel.cs
@@ -3,4 +3,6 @@
 public class TemplateResponseModel : TemplateModelBase, INamedEntityPresentationModel
 {
     public Guid Id { get; set; }
+
+    public Guid? MasterTemplateId { get; set; }
 }

--- a/src/Umbraco.Core/Services/ITemplateService.cs
+++ b/src/Umbraco.Core/Services/ITemplateService.cs
@@ -8,8 +8,14 @@ public interface ITemplateService : IService
     /// <summary>
     ///     Gets a list of all <see cref="ITemplate" /> objects
     /// </summary>
-    /// <returns>An enumerable list of <see cref="ITemplate" /> objects</returns>
+    /// <returns>An enumerable list of <see cref="ITemplate" />.</returns>
     Task<IEnumerable<ITemplate>> GetAllAsync(params string[] aliases);
+
+    /// <summary>
+    ///     Gets a list of all <see cref="ITemplate" /> objects
+    /// </summary>
+    /// <returns>An enumerable list of <see cref="ITemplate" />.</returns>
+    Task<IEnumerable<ITemplate>> GetAllAsync(Guid[] keys);
 
     /// <summary>
     ///     Gets a list of all <see cref="ITemplate" /> objects

--- a/src/Umbraco.Core/Services/ITemplateService.cs
+++ b/src/Umbraco.Core/Services/ITemplateService.cs
@@ -45,6 +45,13 @@ public interface ITemplateService : IService
     Task<ITemplate?> GetAsync(Guid id);
 
     /// <summary>
+    /// Gets the scaffold code for a template.
+    /// </summary>
+    /// <param name="masterTemplateKey"></param>
+    /// <returns></returns>
+    Task<string> GetScaffoldAsync(Guid? masterTemplateKey);
+
+    /// <summary>
     ///     Gets the template descendants
     /// </summary>
     /// <param name="masterTemplateId"></param>

--- a/src/Umbraco.Core/Services/OperationStatus/TemplateOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/TemplateOperationStatus.cs
@@ -5,6 +5,7 @@ public enum TemplateOperationStatus
     Success,
     CancelledByNotification,
     InvalidAlias,
+    DuplicateAlias,
     TemplateNotFound,
     MasterTemplateNotFound
 }

--- a/src/Umbraco.Core/Services/TemplateService.cs
+++ b/src/Umbraco.Core/Services/TemplateService.cs
@@ -119,6 +119,17 @@ public class TemplateService : RepositoryService, ITemplateService
     }
 
     /// <inheritdoc />
+    public Task<IEnumerable<ITemplate>> GetAllAsync(params Guid[] keys)
+    {
+        using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
+
+        IQuery<ITemplate> query = Query<ITemplate>().Where(x => keys.Contains(x.Key));
+        IEnumerable<ITemplate> templates = _templateRepository.Get(query).OrderBy(x => x.Name);
+
+        return Task.FromResult(templates);
+    }
+
+    /// <inheritdoc />
     public async Task<IEnumerable<ITemplate>> GetChildrenAsync(int masterTemplateId)
     {
         using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))

--- a/src/Umbraco.Web.BackOffice/Controllers/TemplateController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/TemplateController.cs
@@ -41,14 +41,14 @@ public class TemplateController : BackOfficeNotificationsController
                                       throw new ArgumentNullException(nameof(defaultViewContentProvider));
     }
 
-        /// <summary>
-        /// Gets data type by alias
-        /// </summary>
-        /// <param name="alias"></param>
-        /// <returns></returns>
-        public TemplateDisplay? GetByAlias(string alias)
-        {
-            ITemplate? template = _templateService.GetAsync(alias).GetAwaiter().GetResult();
+    /// <summary>
+    /// Gets data type by alias
+    /// </summary>
+    /// <param name="alias"></param>
+    /// <returns></returns>
+    public TemplateDisplay? GetByAlias(string alias)
+    {
+        ITemplate? template = _templateService.GetAsync(alias).GetAwaiter().GetResult();
         return template == null ? null : _umbracoMapper.Map<ITemplate, TemplateDisplay>(template);
     }
 

--- a/tests/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTestWithContent.cs
+++ b/tests/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTestWithContent.cs
@@ -34,7 +34,7 @@ public abstract class UmbracoIntegrationTestWithContent : UmbracoIntegrationTest
     public virtual void CreateTestData()
     {
         // NOTE Maybe not the best way to create/save test data as we are using the services, which are being tested.
-        var template = TemplateBuilder.CreateTextPageTemplate();
+        var template = TemplateBuilder.CreateTextPageTemplate("defaultTemplate");
         FileService.SaveTemplate(template);
 
         // Create and Save ContentType "umbTextpage" -> 1051 (template), 1052 (content type)

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Packaging/PackageDataInstallationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Packaging/PackageDataInstallationTests.cs
@@ -547,7 +547,7 @@ public class PackageDataInstallationTests : UmbracoIntegrationTestWithContent
         var fileService = FileService;
 
         // kill default test data
-        fileService.DeleteTemplate("Textpage");
+        fileService.DeleteTemplate("defaultTemplate");
 
         // Act
         var numberOfTemplates = (from doc in templateElement.Elements("Template") select doc).Count();

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DocumentRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DocumentRepositoryTest.cs
@@ -64,7 +64,7 @@ public class DocumentRepositoryTest : UmbracoIntegrationTest
 
     public void CreateTestData()
     {
-        var template = TemplateBuilder.CreateTextPageTemplate();
+        var template = TemplateBuilder.CreateTextPageTemplate("defaultTemplate");
         FileService.SaveTemplate(template);
 
         // Create and Save ContentType "umbTextpage" -> (_contentType.Id)

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServicePerformanceTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServicePerformanceTest.cs
@@ -262,7 +262,7 @@ public class ContentServicePerformanceTest : UmbracoIntegrationTest
 
     public void CreateTestData()
     {
-        var template = TemplateBuilder.CreateTextPageTemplate();
+        var template = TemplateBuilder.CreateTextPageTemplate("defaultTemplate");
         FileService.SaveTemplate(template);
 
         // Create and Save ContentType "textpage" -> ContentType.Id

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/EntityServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/EntityServiceTests.cs
@@ -886,7 +886,7 @@ public class EntityServiceTests : UmbracoIntegrationTest
         {
             s_isSetup = true;
 
-            var template = TemplateBuilder.CreateTextPageTemplate();
+            var template = TemplateBuilder.CreateTextPageTemplate("defaultTemplate");
             FileService.SaveTemplate(template); // else, FK violation on contentType!
 
             // Create and Save ContentType "umbTextpage" -> _contentType.Id


### PR DESCRIPTION
Updates the template controllers to better match the requirements: 

* Adds alias to the document item response - This is needed in case a template is picked as the master template
* Adds master template key to the detailed model - This is needed when opening the editor for a template to populate the name of the master template
* Adds master template key as an optional parameter to scaffolding - This is needed to avoid having to do string magic with the returned scaffold to include the master template, note here that we also need to consider how  we'll handle different models locations/namespaces
* Checks for duplicate aliases when creating/updating templates directly - This boils down to failing fast, previously we'd just change the alias for you, however, this doesn't align very well with the rest of the API, when creating templates for content types, however, this works a bit differently, instead of creating a new template we check to see if one already exists, and if it does we'll use that, so I haven't changed that for now at least.
