### PR TITLE
Temporary CRUD API for content types

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/CreateDocumentTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/CreateDocumentTypeController.cs
@@ -1,0 +1,43 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.DocumentType;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Core.Strings;
+
+namespace Umbraco.Cms.Api.Management.Controllers.DocumentType;
+
+[ApiVersion("1.0")]
+public class CreateDocumentTypeController : CreateUpdateDocumentTypeControllerBase
+{
+    private readonly IShortStringHelper _shortStringHelper;
+
+    public CreateDocumentTypeController(IContentTypeService contentTypeService, IDataTypeService dataTypeService, IShortStringHelper shortStringHelper, ITemplateService templateService)
+        : base(contentTypeService, dataTypeService, shortStringHelper, templateService)
+        => _shortStringHelper = shortStringHelper;
+
+    [HttpPost]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Create(CreateDocumentTypeRequestModel requestModel)
+    {
+        // FIXME: support document type folders (and creation within folders)
+        const int parentId = Constants.System.Root;
+
+        if (requestModel.Compositions.Any())
+        {
+            return await Task.FromResult(BadRequest("Compositions and inheritance is not yet supported by this endpoint"));
+        }
+
+        IContentType contentType = new ContentType(_shortStringHelper, parentId);
+        ContentTypeOperationStatus result = HandleRequest<CreateDocumentTypeRequestModel, CreateDocumentTypePropertyTypeRequestModel, CreateDocumentTypePropertyTypeContainerRequestModel>(contentType, requestModel);
+
+        return result == ContentTypeOperationStatus.Success
+            ? CreatedAtAction<ByKeyDocumentTypeController>(controller => nameof(controller.ByKey), contentType.Key)
+            : BadRequest(result);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/CreateUpdateDocumentTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/CreateUpdateDocumentTypeControllerBase.cs
@@ -174,6 +174,7 @@ public abstract class CreateUpdateDocumentTypeControllerBase : DocumentTypeContr
 
                 if (properties.Any() is false && parentContainerNamesById.ContainsKey(container.Id) is false)
                 {
+                    // FIXME: if at all possible, retain empty containers (bad DX to remove stuff that's been attempted saved)
                     return null;
                 }
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/CreateUpdateDocumentTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/CreateUpdateDocumentTypeControllerBase.cs
@@ -120,11 +120,14 @@ public abstract class CreateUpdateDocumentTypeControllerBase : DocumentTypeContr
                 container => container.ParentId!.Value,
                 container => requestModel.Containers.First(c => c.Id == container.ParentId).Name!);
 
+        // FIXME: when refactoring for media and member types, this needs to be some kind of abstract implementation - media and member types do not support publishing
+        const bool supportsPublishing = true;
+
         // update properties and groups
         PropertyGroup[] propertyGroups = requestModel.Containers.Select(container =>
             {
                 PropertyGroup propertyGroup = contentType.PropertyGroups.FirstOrDefault(group => group.Key == container.Id) ??
-                                              new PropertyGroup(false);
+                                              new PropertyGroup(supportsPublishing);
                 // NOTE: eventually group.Type should be a string to make the client more flexible; for now we'll have to parse the string value back to its expected enum
                 propertyGroup.Type = Enum.Parse<PropertyGroupType>(container.Type);
                 propertyGroup.Name = container.Name;
@@ -176,8 +179,6 @@ public abstract class CreateUpdateDocumentTypeControllerBase : DocumentTypeContr
 
                 if (propertyGroup.PropertyTypes == null || propertyGroup.PropertyTypes.SequenceEqual(properties) is false)
                 {
-                    // FIXME: when refactoring for media and member types, this needs to be some kind of abstract implementation - media and member types do not support publishing
-                    const bool supportsPublishing = true;
                     propertyGroup.PropertyTypes = new PropertyTypeCollection(supportsPublishing, properties);
                 }
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/CreateUpdateDocumentTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/CreateUpdateDocumentTypeControllerBase.cs
@@ -1,0 +1,220 @@
+﻿using Umbraco.Cms.Api.Management.ViewModels.ContentType;
+using Umbraco.Cms.Api.Management.ViewModels.DocumentType;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Core.Strings;
+using Umbraco.Extensions;
+using ContentTypeSort = Umbraco.Cms.Core.Models.ContentTypeSort;
+
+namespace Umbraco.Cms.Api.Management.Controllers.DocumentType;
+
+// FIXME: pretty much everything here should be moved to mappers and possibly new services for content type editing - like the ContentEditingService for content
+public abstract class CreateUpdateDocumentTypeControllerBase : DocumentTypeControllerBase
+{
+    private readonly IContentTypeService _contentTypeService;
+    private readonly IDataTypeService _dataTypeService;
+    private readonly IShortStringHelper _shortStringHelper;
+    private readonly ITemplateService _templateService;
+
+    protected CreateUpdateDocumentTypeControllerBase(IContentTypeService contentTypeService, IDataTypeService dataTypeService, IShortStringHelper shortStringHelper, ITemplateService templateService)
+    {
+        _contentTypeService = contentTypeService;
+        _dataTypeService = dataTypeService;
+        _shortStringHelper = shortStringHelper;
+        _templateService = templateService;
+    }
+
+    protected ContentTypeOperationStatus HandleRequest<TRequestModel, TPropertyType, TPropertyTypeContainer>(IContentType contentType, TRequestModel requestModel)
+        where TRequestModel : ContentTypeModelBase<TPropertyType, TPropertyTypeContainer>, IDocumentTypeRequestModel
+        where TPropertyType : PropertyTypeModelBase
+        where TPropertyTypeContainer : PropertyTypeContainerModelBase
+    {
+        // validate content type alias
+        if (contentType.Alias.Equals(requestModel.Alias) is false)
+        {
+            if (_contentTypeService.GetAllContentTypeAliases().Contains(requestModel.Alias))
+            {
+                return ContentTypeOperationStatus.DuplicateAlias;
+            }
+
+            var reservedModelAliases = new[] { "system" };
+            if (reservedModelAliases.InvariantContains(requestModel.Alias))
+            {
+                return ContentTypeOperationStatus.InvalidAlias;
+            }
+        }
+
+        // validate properties
+        var reservedPropertyTypeNames = typeof(IPublishedContent).GetProperties().Select(x => x.Name)
+            .Union(typeof(IPublishedContent).GetMethods().Select(x => x.Name))
+            .ToArray();
+        foreach (TPropertyType propertyType in requestModel.Properties)
+        {
+            if (propertyType.Alias.Equals(requestModel.Alias, StringComparison.OrdinalIgnoreCase))
+            {
+                return ContentTypeOperationStatus.InvalidPropertyTypeAlias;
+            }
+
+            if (reservedPropertyTypeNames.InvariantContains(propertyType.Alias))
+            {
+                return ContentTypeOperationStatus.InvalidPropertyTypeAlias;
+            }
+        }
+
+        // validate property data types
+        Guid[] dataTypeKeys = requestModel.Properties.Select(property => property.DataTypeId).ToArray();
+        var dataTypesByKey = dataTypeKeys
+            // FIXME: create GetAllAsync(params Guid[] keys) method on IDataTypeService
+            .Select(async key => await _dataTypeService.GetAsync(key))
+            .Select(t => t.Result)
+            .WhereNotNull()
+            .ToDictionary(dataType => dataType.Key);
+        if (dataTypeKeys.Length != dataTypesByKey.Count())
+        {
+            return ContentTypeOperationStatus.InvalidDataType;
+        }
+
+        // filter out properties and containers with no name/alias
+        requestModel.Properties = requestModel.Properties.Where(propertyType => propertyType.Alias.IsNullOrWhiteSpace() is false).ToArray();
+        requestModel.Containers = requestModel.Containers.Where(container => container.Name.IsNullOrWhiteSpace() is false).ToArray();
+
+        // update basic content type settings
+        contentType.Alias = requestModel.Alias;
+        contentType.Description = requestModel.Description;
+        contentType.Icon = requestModel.Icon;
+        contentType.IsElement = requestModel.IsElement;
+        contentType.Name = requestModel.Name;
+        contentType.AllowedAsRoot = requestModel.AllowedAsRoot;
+        contentType.SetVariesBy(ContentVariation.Culture, requestModel.VariesByCulture);
+        contentType.SetVariesBy(ContentVariation.Segment, requestModel.VariesBySegment);
+
+        // update allowed content types
+        var allowedContentTypesUnchanged = contentType.AllowedContentTypes?
+            .OrderBy(contentTypeSort => contentTypeSort.SortOrder)
+            .Select(contentTypeSort => contentTypeSort.Key)
+            .SequenceEqual(requestModel.AllowedContentTypes
+                .OrderBy(contentTypeSort => contentTypeSort.SortOrder)
+                .Select(contentTypeSort => contentTypeSort.Id)) ?? false;
+        if (allowedContentTypesUnchanged is false)
+        {
+            // need the content type IDs here - yet, anyway - see FIXME in Umbraco.Cms.Core.Models.ContentTypeSort
+            var allContentTypesByKey = _contentTypeService.GetAll().ToDictionary(c => c.Key);
+            contentType.AllowedContentTypes = requestModel
+                .AllowedContentTypes
+                .Select((contentTypeSort, index) => allContentTypesByKey.TryGetValue(contentTypeSort.Id, out IContentType? ct)
+                    ? new ContentTypeSort(new Lazy<int>(() => ct.Id), contentTypeSort.Id, index, ct.Alias)
+                    : null)
+                .WhereNotNull()
+                .ToArray();
+        }
+
+        // build a dictionary of parent container IDs and their names (we need it when mapping property groups)
+        var parentContainerNamesById = requestModel
+            .Containers
+            .Where(container => container.ParentId is not null)
+            .DistinctBy(container => container.ParentId)
+            .ToDictionary(
+                container => container.ParentId!.Value,
+                container => requestModel.Containers.First(c => c.Id == container.ParentId).Name!);
+
+        // update properties and groups
+        PropertyGroup[] propertyGroups = requestModel.Containers.Select(container =>
+            {
+                PropertyGroup propertyGroup = contentType.PropertyGroups.FirstOrDefault(group => group.Key == container.Id) ??
+                                              new PropertyGroup(false);
+                // NOTE: eventually group.Type should be a string to make the client more flexible; for now we'll have to parse the string value back to its expected enum
+                propertyGroup.Type = Enum.Parse<PropertyGroupType>(container.Type);
+                propertyGroup.Name = container.Name;
+                // this is not pretty, but this is how the data structure is at the moment; we just have to live with it for the time being.
+                var alias = container.Name!;
+                if (container.ParentId is not null)
+                {
+                    alias = $"{parentContainerNamesById[container.ParentId.Value]}/{alias}";
+                }
+                propertyGroup.Alias = alias;
+                propertyGroup.SortOrder = container.SortOrder;
+
+                IPropertyType[] properties = requestModel
+                    .Properties
+                    .Where(property => property.ContainerId == container.Id)
+                    .Select(property =>
+                    {
+                        // get the selected data type
+                        // NOTE: this only works because we already ensured that the data type is present in the dataTypesByKey dictionary
+                        IDataType dataType = dataTypesByKey[property.DataTypeId];
+
+                        // get the current property type (if it exists)
+                        IPropertyType propertyType = contentType.PropertyTypes.FirstOrDefault(pt => pt.Key == property.Id)
+                                                     ?? new Core.Models.PropertyType(_shortStringHelper, dataType);
+
+                        propertyType.Name = property.Name;
+                        propertyType.DataTypeId = dataType.Id;
+                        propertyType.DataTypeKey = dataType.Key;
+                        propertyType.Mandatory = property.Validation.Mandatory;
+                        propertyType.MandatoryMessage = property.Validation.MandatoryMessage;
+                        propertyType.ValidationRegExp = property.Validation.RegEx;
+                        propertyType.ValidationRegExpMessage = property.Validation.RegExMessage;
+                        propertyType.SetVariesBy(ContentVariation.Culture, property.VariesByCulture);
+                        propertyType.SetVariesBy(ContentVariation.Segment, property.VariesBySegment);
+                        propertyType.PropertyGroupId = new Lazy<int>(() => propertyGroup.Id, false);
+                        propertyType.Alias = property.Alias;
+                        propertyType.Description = property.Description;
+                        propertyType.SortOrder = property.SortOrder;
+                        propertyType.LabelOnTop = property.Appearance.LabelOnTop;
+
+                        return propertyType;
+                    })
+                    .ToArray();
+
+                if (properties.Any() is false && parentContainerNamesById.ContainsKey(container.Id) is false)
+                {
+                    return null;
+                }
+
+                if (propertyGroup.PropertyTypes == null || propertyGroup.PropertyTypes.SequenceEqual(properties) is false)
+                {
+                    // FIXME: when refactoring for media and member types, this needs to be some kind of abstract implementation - media and member types do not support publishing
+                    const bool supportsPublishing = true;
+                    propertyGroup.PropertyTypes = new PropertyTypeCollection(supportsPublishing, properties);
+                }
+
+                return propertyGroup;
+            })
+            .WhereNotNull()
+            .ToArray();
+
+        if (contentType.PropertyGroups.SequenceEqual(propertyGroups) is false)
+        {
+            contentType.PropertyGroups = new PropertyGroupCollection(propertyGroups);
+        }
+
+        // FIXME: handle properties outside containers ("generic properties") if they still exist
+        // FIXME: handle compositions (yeah, that)
+
+        // update content type history clean-up
+        contentType.HistoryCleanup ??= new HistoryCleanup();
+        contentType.HistoryCleanup.PreventCleanup = requestModel.Cleanup.PreventCleanup;
+        contentType.HistoryCleanup.KeepAllVersionsNewerThanDays = requestModel.Cleanup.KeepAllVersionsNewerThanDays;
+        contentType.HistoryCleanup.KeepLatestVersionPerDayForDays = requestModel.Cleanup.KeepLatestVersionPerDayForDays;
+
+        // update allowed templates and assign default template
+        ITemplate[] allowedTemplates = requestModel.AllowedTemplateIds
+            .Select(async templateId => await _templateService.GetAsync(templateId))
+            .Select(t => t.Result)
+            .WhereNotNull()
+            .ToArray();
+        contentType.AllowedTemplates = allowedTemplates;
+        // NOTE: incidentally this also covers removing the default template; when requestModel.DefaultTemplateId is null,
+        //       contentType.SetDefaultTemplate() will be called with a null value, which will reset the default template.
+        contentType.SetDefaultTemplate(allowedTemplates.FirstOrDefault(t => t.Key == requestModel.DefaultTemplateId));
+
+        // save content type
+        // FIXME: create and use an async get method here.
+        _contentTypeService.Save(contentType);
+
+        return ContentTypeOperationStatus.Success;
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/DeleteDocumentTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/DeleteDocumentTypeController.cs
@@ -1,0 +1,36 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.DocumentType;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.DocumentType;
+
+[ApiVersion("1.0")]
+public class DeleteDocumentTypeController : DocumentTypeControllerBase
+{
+    private readonly IContentTypeService _contentTypeService;
+
+    public DeleteDocumentTypeController(IContentTypeService contentTypeService)
+        => _contentTypeService = contentTypeService;
+
+    [HttpDelete("{id:guid}")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(DocumentTypeResponseModel), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Delete(Guid id)
+    {
+        // FIXME: create and use an async get method here.
+        IContentType? contentType = _contentTypeService.Get(id);
+        if (contentType == null)
+        {
+            return NotFound();
+        }
+
+        // FIXME: create overload that accepts user key
+        _contentTypeService.Delete(contentType, Constants.Security.SuperUserId);
+        return await Task.FromResult(Ok());
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/UpdateDocumentTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/UpdateDocumentTypeController.cs
@@ -1,0 +1,45 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.DocumentType;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Core.Strings;
+
+namespace Umbraco.Cms.Api.Management.Controllers.DocumentType;
+
+[ApiVersion("1.0")]
+public class UpdateDocumentTypeController : CreateUpdateDocumentTypeControllerBase
+{
+    private readonly IContentTypeService _contentTypeService;
+
+    public UpdateDocumentTypeController(IContentTypeService contentTypeService, IDataTypeService dataTypeService, IShortStringHelper shortStringHelper, ITemplateService templateService)
+        : base(contentTypeService, dataTypeService, shortStringHelper, templateService)
+        => _contentTypeService = contentTypeService;
+
+    [HttpPut("{id:guid}")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Update(Guid id, UpdateDocumentTypeRequestModel requestModel)
+    {
+        if (requestModel.Compositions.Any())
+        {
+            return await Task.FromResult(BadRequest("Compositions and inheritance is not yet supported by this endpoint"));
+        }
+
+        IContentType? contentType = _contentTypeService.Get(id);
+        if (contentType is null)
+        {
+            return NotFound();
+        }
+
+        ContentTypeOperationStatus result = HandleRequest<UpdateDocumentTypeRequestModel, UpdateDocumentTypePropertyTypeRequestModel, UpdateDocumentTypePropertyTypeContainerRequestModel>(contentType, requestModel);
+
+        return result == ContentTypeOperationStatus.Success
+            ? Ok()
+            : BadRequest(result);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Mapping/ContentType/ContentTypeMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/ContentType/ContentTypeMapDefinition.cs
@@ -6,12 +6,12 @@ using ContentTypeSort = Umbraco.Cms.Api.Management.ViewModels.ContentType.Conten
 
 namespace Umbraco.Cms.Api.Management.Mapping.ContentType;
 
-public abstract class ContentTypeMapDefinition<TContentType, TPropertyTypeResponseModel, TPropertyTypeContainerResponseModel>
+public abstract class ContentTypeMapDefinition<TContentType, TPropertyTypeModel, TPropertyTypeContainerModel>
     where TContentType : IContentTypeBase
-    where TPropertyTypeResponseModel : PropertyTypeResponseModelBase, new()
-    where TPropertyTypeContainerResponseModel : PropertyTypeContainerResponseModelBase, new()
+    where TPropertyTypeModel : PropertyTypeModelBase, new()
+    where TPropertyTypeContainerModel : PropertyTypeContainerModelBase, new()
 {
-    protected IEnumerable<TPropertyTypeResponseModel> MapPropertyTypes(TContentType source)
+    protected IEnumerable<TPropertyTypeModel> MapPropertyTypes(TContentType source)
     {
         // create a mapping table between properties and their associated groups
         var groupKeysByPropertyKeys = source
@@ -21,7 +21,7 @@ public abstract class ContentTypeMapDefinition<TContentType, TPropertyTypeRespon
             .ToDictionary(map => map.PropertyTypeKey, map => map.GroupKey);
 
         return source.PropertyTypes.Select(propertyType =>
-                new TPropertyTypeResponseModel
+                new TPropertyTypeModel
                 {
                     Id = propertyType.Key,
                     SortOrder = propertyType.SortOrder,
@@ -49,7 +49,7 @@ public abstract class ContentTypeMapDefinition<TContentType, TPropertyTypeRespon
             .ToArray();
     }
 
-    protected IEnumerable<TPropertyTypeContainerResponseModel> MapPropertyTypeContainers(TContentType source)
+    protected IEnumerable<TPropertyTypeContainerModel> MapPropertyTypeContainers(TContentType source)
     {
         // create a mapping table between property group aliases and keys
         var groupKeysByGroupAliases = source
@@ -67,13 +67,13 @@ public abstract class ContentTypeMapDefinition<TContentType, TPropertyTypeRespon
         return source
             .PropertyGroups
             .Select(propertyGroup =>
-                new TPropertyTypeContainerResponseModel
+                new TPropertyTypeContainerModel
                 {
                     Id = propertyGroup.Key,
                     ParentId = ParentGroupKey(propertyGroup),
                     Type = propertyGroup.Type.ToString(),
                     SortOrder = propertyGroup.SortOrder,
-                    Name = propertyGroup.Name,
+                    Name = propertyGroup.Name ?? "-",
                 })
             .ToArray();
     }

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -1408,6 +1408,35 @@
         }
       }
     },
+    "/umbraco/management/api/v1/document-type": {
+      "post": {
+        "tags": [
+          "Document Type"
+        ],
+        "operationId": "PostDocumentType",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateDocumentTypeRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Bad Request"
+          }
+        }
+      }
+    },
     "/umbraco/management/api/v1/document-type/{id}": {
       "get": {
         "tags": [
@@ -1439,6 +1468,83 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Document Type"
+        ],
+        "operationId": "DeleteDocumentTypeById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DocumentTypeResponseModel"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Document Type"
+        ],
+        "operationId": "PutDocumentTypeById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateDocumentTypeRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Bad Request"
           },
           "404": {
             "description": "Not Found"
@@ -8896,10 +9002,6 @@
       "ContentTypeResponseModelBaseDocumentTypePropertyTypeResponseModelDocumentTypePropertyTypeContainerResponseModel": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
           "alias": {
             "type": "string"
           },
@@ -8964,6 +9066,10 @@
                 }
               ]
             }
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
           }
         },
         "additionalProperties": false
@@ -8971,10 +9077,6 @@
       "ContentTypeResponseModelBaseMediaTypePropertyTypeResponseModelMediaTypePropertyTypeContainerResponseModel": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
           "alias": {
             "type": "string"
           },
@@ -9039,6 +9141,10 @@
                 }
               ]
             }
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
           }
         },
         "additionalProperties": false
@@ -9160,6 +9266,77 @@
         },
         "additionalProperties": false
       },
+      "CreateContentTypeRequestModelBaseCreateDocumentTypePropertyTypeRequestModelCreateDocumentTypePropertyTypeContainerRequestModel": {
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "icon": {
+            "type": "string"
+          },
+          "allowedAsRoot": {
+            "type": "boolean"
+          },
+          "variesByCulture": {
+            "type": "boolean"
+          },
+          "variesBySegment": {
+            "type": "boolean"
+          },
+          "isElement": {
+            "type": "boolean"
+          },
+          "properties": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/CreateDocumentTypePropertyTypeRequestModel"
+                }
+              ]
+            }
+          },
+          "containers": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/CreateDocumentTypePropertyTypeContainerRequestModel"
+                }
+              ]
+            }
+          },
+          "allowedContentTypes": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ContentTypeSortModel"
+                }
+              ]
+            }
+          },
+          "compositions": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ContentTypeCompositionModel"
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
+      },
       "CreateDataTypeRequestModel": {
         "type": "object",
         "allOf": [
@@ -9216,6 +9393,66 @@
           }
         },
         "additionalProperties": false
+      },
+      "CreateDocumentTypePropertyTypeContainerRequestModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PropertyTypeContainerModelBaseModel"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "CreateDocumentTypePropertyTypeRequestModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PropertyTypeModelBaseModel"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "CreateDocumentTypeRequestModel": {
+        "required": [
+          "$type"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CreateContentTypeRequestModelBaseCreateDocumentTypePropertyTypeRequestModelCreateDocumentTypePropertyTypeContainerRequestModel"
+          }
+        ],
+        "properties": {
+          "$type": {
+            "type": "string"
+          },
+          "allowedTemplateIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "defaultTemplateId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "cleanup": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ContentTypeCleanupModel"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "discriminator": {
+          "propertyName": "$type",
+          "mapping": {
+            "CreateDocumentTypeRequestModel": "#/components/schemas/CreateDocumentTypeRequestModel"
+          }
+        }
       },
       "CreateFolderRequestModel": {
         "type": "object",
@@ -9772,6 +10009,10 @@
           "icon": {
             "type": "string",
             "nullable": true
+          },
+          "contentTypeId": {
+            "type": "string",
+            "format": "uuid"
           }
         },
         "additionalProperties": false
@@ -9836,6 +10077,20 @@
           },
           "isEdited": {
             "type": "boolean"
+          },
+          "contentTypeId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/VariantTreeItemModel"
+                }
+              ]
+            }
           }
         },
         "additionalProperties": false,
@@ -9868,7 +10123,7 @@
         "type": "object",
         "allOf": [
           {
-            "$ref": "#/components/schemas/PropertyTypeContainerResponseModelBaseModel"
+            "$ref": "#/components/schemas/PropertyTypeContainerModelBaseModel"
           }
         ],
         "additionalProperties": false
@@ -9877,7 +10132,7 @@
         "type": "object",
         "allOf": [
           {
-            "$ref": "#/components/schemas/PropertyTypeResponseModelBaseModel"
+            "$ref": "#/components/schemas/PropertyTypeModelBaseModel"
           }
         ],
         "additionalProperties": false
@@ -10807,7 +11062,7 @@
         "type": "object",
         "allOf": [
           {
-            "$ref": "#/components/schemas/PropertyTypeContainerResponseModelBaseModel"
+            "$ref": "#/components/schemas/PropertyTypeContainerModelBaseModel"
           }
         ],
         "additionalProperties": false
@@ -10816,7 +11071,7 @@
         "type": "object",
         "allOf": [
           {
-            "$ref": "#/components/schemas/PropertyTypeResponseModelBaseModel"
+            "$ref": "#/components/schemas/PropertyTypeModelBaseModel"
           }
         ],
         "additionalProperties": false
@@ -12183,7 +12438,7 @@
         },
         "additionalProperties": false
       },
-      "PropertyTypeContainerResponseModelBaseModel": {
+      "PropertyTypeContainerModelBaseModel": {
         "type": "object",
         "properties": {
           "id": {
@@ -12209,7 +12464,7 @@
         },
         "additionalProperties": false
       },
-      "PropertyTypeResponseModelBaseModel": {
+      "PropertyTypeModelBaseModel": {
         "type": "object",
         "properties": {
           "id": {
@@ -12220,6 +12475,10 @@
             "type": "string",
             "format": "uuid",
             "nullable": true
+          },
+          "sortOrder": {
+            "type": "integer",
+            "format": "int32"
           },
           "alias": {
             "type": "string"
@@ -12278,6 +12537,16 @@
           }
         },
         "additionalProperties": false
+      },
+      "PublishedStateModel": {
+        "enum": [
+          "Published",
+          "Unpublished",
+          "Publishing",
+          "Unpublishing"
+        ],
+        "type": "integer",
+        "format": "int32"
       },
       "RecycleBinItemResponseModel": {
         "required": [
@@ -13177,6 +13446,77 @@
         },
         "additionalProperties": false
       },
+      "UpdateContentTypeRequestModelBaseUpdateDocumentTypePropertyTypeRequestModelUpdateDocumentTypePropertyTypeContainerRequestModel": {
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "icon": {
+            "type": "string"
+          },
+          "allowedAsRoot": {
+            "type": "boolean"
+          },
+          "variesByCulture": {
+            "type": "boolean"
+          },
+          "variesBySegment": {
+            "type": "boolean"
+          },
+          "isElement": {
+            "type": "boolean"
+          },
+          "properties": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/UpdateDocumentTypePropertyTypeRequestModel"
+                }
+              ]
+            }
+          },
+          "containers": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/UpdateDocumentTypePropertyTypeContainerRequestModel"
+                }
+              ]
+            }
+          },
+          "allowedContentTypes": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ContentTypeSortModel"
+                }
+              ]
+            }
+          },
+          "compositions": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ContentTypeCompositionModel"
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
+      },
       "UpdateDataTypeRequestModel": {
         "type": "object",
         "allOf": [
@@ -13222,6 +13562,66 @@
           }
         },
         "additionalProperties": false
+      },
+      "UpdateDocumentTypePropertyTypeContainerRequestModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PropertyTypeContainerModelBaseModel"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "UpdateDocumentTypePropertyTypeRequestModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PropertyTypeModelBaseModel"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "UpdateDocumentTypeRequestModel": {
+        "required": [
+          "$type"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/UpdateContentTypeRequestModelBaseUpdateDocumentTypePropertyTypeRequestModelUpdateDocumentTypePropertyTypeContainerRequestModel"
+          }
+        ],
+        "properties": {
+          "$type": {
+            "type": "string"
+          },
+          "allowedTemplateIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "defaultTemplateId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "cleanup": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ContentTypeCleanupModel"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "discriminator": {
+          "propertyName": "$type",
+          "mapping": {
+            "UpdateDocumentTypeRequestModel": "#/components/schemas/UpdateDocumentTypeRequestModel"
+          }
+        }
       },
       "UpdateDomainsRequestModel": {
         "type": "object",
@@ -13800,6 +14200,22 @@
             "DocumentVariantResponseModel": "#/components/schemas/DocumentVariantResponseModel"
           }
         }
+      },
+      "VariantTreeItemModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "culture": {
+            "type": "string",
+            "nullable": true
+          },
+          "state": {
+            "$ref": "#/components/schemas/PublishedStateModel"
+          }
+        },
+        "additionalProperties": false
       },
       "VersionResponseModel": {
         "type": "object",

--- a/src/Umbraco.Cms.Api.Management/ViewModels/ContentType/ContentTypeModelBase.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/ContentType/ContentTypeModelBase.cs
@@ -1,0 +1,30 @@
+namespace Umbraco.Cms.Api.Management.ViewModels.ContentType;
+
+public abstract class ContentTypeModelBase<TPropertyType, TPropertyTypeContainer>
+    where TPropertyType : PropertyTypeModelBase
+    where TPropertyTypeContainer : PropertyTypeContainerModelBase
+{
+    public string Alias { get; set; } = string.Empty;
+
+    public string Name { get; set; } = string.Empty;
+
+    public string? Description { get; set; }
+
+    public string Icon { get; set; } = string.Empty;
+
+    public bool AllowedAsRoot { get; set; }
+
+    public bool VariesByCulture { get; set; }
+
+    public bool VariesBySegment { get; set; }
+
+    public bool IsElement { get; set; }
+
+    public IEnumerable<TPropertyType> Properties { get; set; } = Array.Empty<TPropertyType>();
+
+    public IEnumerable<TPropertyTypeContainer> Containers { get; set; } = Array.Empty<TPropertyTypeContainer>();
+
+    public IEnumerable<ContentTypeSort> AllowedContentTypes { get; set; } = Array.Empty<ContentTypeSort>();
+
+    public IEnumerable<ContentTypeComposition> Compositions { get; set; } = Array.Empty<ContentTypeComposition>();
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/ContentType/CreateContentTypeRequestModelBase.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/ContentType/CreateContentTypeRequestModelBase.cs
@@ -1,9 +1,8 @@
 ﻿namespace Umbraco.Cms.Api.Management.ViewModels.ContentType;
 
-public abstract class ContentTypeResponseModelBase<TPropertyType, TPropertyTypeContainer>
+public abstract class CreateContentTypeRequestModelBase<TPropertyType, TPropertyTypeContainer>
     : ContentTypeModelBase<TPropertyType, TPropertyTypeContainer>
     where TPropertyType : PropertyTypeModelBase
     where TPropertyTypeContainer : PropertyTypeContainerModelBase
 {
-    public Guid Id { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/ContentType/PropertyTypeContainerModelBase.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/ContentType/PropertyTypeContainerModelBase.cs
@@ -1,6 +1,6 @@
-﻿namespace Umbraco.Cms.Api.Management.ViewModels.ContentType;
+namespace Umbraco.Cms.Api.Management.ViewModels.ContentType;
 
-public abstract class PropertyTypeContainerResponseModelBase
+public abstract class PropertyTypeContainerModelBase
 {
     public Guid Id { get; set; }
 

--- a/src/Umbraco.Cms.Api.Management/ViewModels/ContentType/PropertyTypeModelBase.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/ContentType/PropertyTypeModelBase.cs
@@ -1,6 +1,6 @@
-﻿namespace Umbraco.Cms.Api.Management.ViewModels.ContentType;
+namespace Umbraco.Cms.Api.Management.ViewModels.ContentType;
 
-public abstract class PropertyTypeResponseModelBase
+public abstract class PropertyTypeModelBase
 {
     public Guid Id { get; set; }
 

--- a/src/Umbraco.Cms.Api.Management/ViewModels/ContentType/UpdateContentTypeRequestModelBase.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/ContentType/UpdateContentTypeRequestModelBase.cs
@@ -1,0 +1,8 @@
+namespace Umbraco.Cms.Api.Management.ViewModels.ContentType;
+
+public abstract class UpdateContentTypeRequestModelBase<TPropertyType, TPropertyTypeContainer>
+    : ContentTypeModelBase<TPropertyType, TPropertyTypeContainer>
+    where TPropertyType : PropertyTypeModelBase
+    where TPropertyTypeContainer : PropertyTypeContainerModelBase
+{
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/CreateDocumentTypePropertyTypeContainerRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/CreateDocumentTypePropertyTypeContainerRequestModel.cs
@@ -2,6 +2,6 @@
 
 namespace Umbraco.Cms.Api.Management.ViewModels.DocumentType;
 
-public class DocumentTypePropertyTypeContainerResponseModel : PropertyTypeContainerModelBase
+public class CreateDocumentTypePropertyTypeContainerRequestModel : PropertyTypeContainerModelBase
 {
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/CreateDocumentTypePropertyTypeRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/CreateDocumentTypePropertyTypeRequestModel.cs
@@ -2,6 +2,6 @@
 
 namespace Umbraco.Cms.Api.Management.ViewModels.DocumentType;
 
-public class DocumentTypePropertyTypeContainerResponseModel : PropertyTypeContainerModelBase
+public class CreateDocumentTypePropertyTypeRequestModel : PropertyTypeModelBase
 {
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/CreateDocumentTypeRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/CreateDocumentTypeRequestModel.cs
@@ -1,0 +1,13 @@
+﻿using Umbraco.Cms.Api.Management.ViewModels.ContentType;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.DocumentType;
+
+public class CreateDocumentTypeRequestModel
+    : CreateContentTypeRequestModelBase<CreateDocumentTypePropertyTypeRequestModel, CreateDocumentTypePropertyTypeContainerRequestModel>, IDocumentTypeRequestModel
+{
+    public IEnumerable<Guid> AllowedTemplateIds { get; set; } = Array.Empty<Guid>();
+
+    public Guid? DefaultTemplateId { get; set; }
+
+    public ContentTypeCleanup Cleanup { get; set; } = new();
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/DocumentTypePropertyTypeResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/DocumentTypePropertyTypeResponseModel.cs
@@ -2,6 +2,6 @@
 
 namespace Umbraco.Cms.Api.Management.ViewModels.DocumentType;
 
-public class DocumentTypePropertyTypeResponseModel : PropertyTypeResponseModelBase
+public class DocumentTypePropertyTypeResponseModel : PropertyTypeModelBase
 {
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/IDocumentTypeRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/IDocumentTypeRequestModel.cs
@@ -1,0 +1,12 @@
+﻿using Umbraco.Cms.Api.Management.ViewModels.ContentType;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.DocumentType;
+
+public interface IDocumentTypeRequestModel
+{
+    IEnumerable<Guid> AllowedTemplateIds { get; set; }
+
+    Guid? DefaultTemplateId { get; set; }
+
+    ContentTypeCleanup Cleanup { get; set; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/UpdateDocumentTypePropertyTypeContainerRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/UpdateDocumentTypePropertyTypeContainerRequestModel.cs
@@ -2,6 +2,6 @@
 
 namespace Umbraco.Cms.Api.Management.ViewModels.DocumentType;
 
-public class DocumentTypePropertyTypeContainerResponseModel : PropertyTypeContainerModelBase
+public class UpdateDocumentTypePropertyTypeContainerRequestModel : PropertyTypeContainerModelBase
 {
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/UpdateDocumentTypePropertyTypeRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/UpdateDocumentTypePropertyTypeRequestModel.cs
@@ -1,0 +1,7 @@
+using Umbraco.Cms.Api.Management.ViewModels.ContentType;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.DocumentType;
+
+public class UpdateDocumentTypePropertyTypeRequestModel : PropertyTypeModelBase
+{
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/UpdateDocumentTypeRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/UpdateDocumentTypeRequestModel.cs
@@ -1,0 +1,13 @@
+using Umbraco.Cms.Api.Management.ViewModels.ContentType;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.DocumentType;
+
+public class UpdateDocumentTypeRequestModel
+    : UpdateContentTypeRequestModelBase<UpdateDocumentTypePropertyTypeRequestModel, UpdateDocumentTypePropertyTypeContainerRequestModel>, IDocumentTypeRequestModel
+{
+    public IEnumerable<Guid> AllowedTemplateIds { get; set; } = Array.Empty<Guid>();
+
+    public Guid? DefaultTemplateId { get; set; }
+
+    public ContentTypeCleanup Cleanup { get; set; } = new();
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/MediaType/MediaTypePropertyTypeContainerResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/MediaType/MediaTypePropertyTypeContainerResponseModel.cs
@@ -2,6 +2,6 @@
 
 namespace Umbraco.Cms.Api.Management.ViewModels.MediaType;
 
-public class MediaTypePropertyTypeContainerResponseModel : PropertyTypeContainerResponseModelBase
+public class MediaTypePropertyTypeContainerResponseModel : PropertyTypeContainerModelBase
 {
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/MediaType/MediaTypePropertyTypeResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/MediaType/MediaTypePropertyTypeResponseModel.cs
@@ -2,6 +2,6 @@
 
 namespace Umbraco.Cms.Api.Management.ViewModels.MediaType;
 
-public class MediaTypePropertyTypeResponseModel : PropertyTypeResponseModelBase
+public class MediaTypePropertyTypeResponseModel : PropertyTypeModelBase
 {
 }

--- a/src/Umbraco.Core/Services/OperationStatus/ContentTypeOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/ContentTypeOperationStatus.cs
@@ -1,0 +1,10 @@
+namespace Umbraco.Cms.Core.Services.OperationStatus;
+
+public enum ContentTypeOperationStatus
+{
+    Success,
+    DuplicateAlias,
+    InvalidAlias,
+    InvalidPropertyTypeAlias,
+    InvalidDataType
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This is a temporary measure to make us able to create, update and delete content types in the management API (we can already get them by ID).

The implementation is _not_ written to be pretty. Hopefully it will prove as a starting point for "the actual" server side implementation. It is littered with FIXME's to that end.

The API contract on the other hand should be OK, so please pay special attention to reviewing that.

Test that content types can be created, updated and deleted. Try with different permutations of properties and tabs/groups, particularly groups in tabs 😄 