### PR TITLE
V12: Use hosting environment to get local temp path

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_12_0_0/ResetCache.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_12_0_0/ResetCache.cs
@@ -1,21 +1,20 @@
-﻿using Microsoft.Extensions.Hosting;
-using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Extensions;
+﻿using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
 
 namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_12_0_0;
 
 public class ResetCache : MigrationBase
 {
-    private readonly IHostEnvironment _hostEnvironment;
+    private readonly IHostingEnvironment _hostingEnvironment;
 
-    public ResetCache(IMigrationContext context, IHostEnvironment hostEnvironment)
-        : base(context) => _hostEnvironment = hostEnvironment;
+    public ResetCache(IMigrationContext context, IHostingEnvironment hostingEnvironment)
+        : base(context) =>
+        _hostingEnvironment = hostingEnvironment;
 
     protected override void Migrate()
     {
         RebuildCache = true;
-        var distCacheFolderAbsolutePath = _hostEnvironment.MapPathContentRoot(Constants.SystemDirectories.TempData + "/DistCache");
-        var nuCacheFolderAbsolutePath = _hostEnvironment.MapPathContentRoot(Constants.SystemDirectories.TempData + "/NuCache");
+        var distCacheFolderAbsolutePath = Path.Combine(_hostingEnvironment.LocalTempPath, "DistCache");
+        var nuCacheFolderAbsolutePath = Path.Combine(_hostingEnvironment.LocalTempPath, "NuCache");
         DeleteAllFilesInFolder(distCacheFolderAbsolutePath);
         DeleteAllFilesInFolder(nuCacheFolderAbsolutePath);
     }


### PR DESCRIPTION
# Notes
- use `IHostingEnvironment` to get the local temp path, instead of a static one, as we can configure that path via appsettings

# How to test
- Configure temp path in `AppSettings.Json`
```
"Hosting": {
  "LocalTempStorageLocation": "EnvironmentTemp"
},
```
- Run Umbraco and create a document type with some content to trigger a nucache build
- Upgrade to this branch, and assert the NuCache files get deleted