### PR TITLE
Pass the IContentBase to the IMediaPathScheme instead of the GUID

### DIFF
--- a/src/Umbraco.Core/IO/IMediaPathScheme.cs
+++ b/src/Umbraco.Core/IO/IMediaPathScheme.cs
@@ -1,3 +1,5 @@
+using Umbraco.Cms.Core.Models;
+
 namespace Umbraco.Cms.Core.IO;
 
 /// <summary>
@@ -5,6 +7,16 @@ namespace Umbraco.Cms.Core.IO;
 /// </summary>
 public interface IMediaPathScheme
 {
+    /// <summary>
+    ///     Gets a media file path.
+    /// </summary>
+    /// <param name="fileManager">The media filesystem.</param>
+    /// <param name="content">The (content, media) item.</param>
+    /// <param name="propertyGuid">The property type unique identifier.</param>
+    /// <param name="filename">The file name.</param>
+    /// <returns>The filesystem-relative complete file path.</returns>
+    string GetFilePath(MediaFileManager fileManager, IContentBase content, Guid propertyGuid, string filename);
+
     /// <summary>
     ///     Gets a media file path.
     /// </summary>

--- a/src/Umbraco.Core/IO/MediaFileManager.cs
+++ b/src/Umbraco.Core/IO/MediaFileManager.cs
@@ -94,11 +94,11 @@ public sealed class MediaFileManager
     ///     Gets the file path of a media file.
     /// </summary>
     /// <param name="filename">The file name.</param>
-    /// <param name="cuid">The unique identifier of the content/media owning the file.</param>
+    /// <param name="content">The content/media owning the file.</param>
     /// <param name="puid">The unique identifier of the property type owning the file.</param>
     /// <returns>The filesystem-relative path to the media file.</returns>
     /// <remarks>With the old media path scheme, this CREATES a new media path each time it is invoked.</remarks>
-    public string GetMediaPath(string? filename, Guid cuid, Guid puid)
+    public string GetMediaPath(string? filename, IContentBase content, Guid puid)
     {
         filename = Path.GetFileName(filename);
         if (filename == null)
@@ -108,7 +108,7 @@ public sealed class MediaFileManager
 
         filename = _shortStringHelper.CleanStringForSafeFileName(filename.ToLowerInvariant());
 
-        return _mediaPathScheme.GetFilePath(this, cuid, puid, filename);
+        return _mediaPathScheme.GetFilePath(this, content, puid, filename);
     }
 
     #endregion
@@ -199,7 +199,7 @@ public sealed class MediaFileManager
         }
 
         // get the filepath, store the data
-        var filepath = GetMediaPath(filename, content.Key, propertyType.Key);
+        var filepath = GetMediaPath(filename, content, propertyType.Key);
         FileSystem.AddFile(filepath, filestream);
         return filepath;
     }
@@ -243,7 +243,7 @@ public sealed class MediaFileManager
 
         // get the filepath
         var filename = Path.GetFileName(sourcepath);
-        var filepath = GetMediaPath(filename, content.Key, propertyType.Key);
+        var filepath = GetMediaPath(filename, content, propertyType.Key);
         FileSystem.CopyFile(sourcepath, filepath);
         return filepath;
     }

--- a/src/Umbraco.Core/IO/MediaPathSchemes/CombinedGuidsMediaPathScheme.cs
+++ b/src/Umbraco.Core/IO/MediaPathSchemes/CombinedGuidsMediaPathScheme.cs
@@ -1,3 +1,5 @@
+using Umbraco.Cms.Core.Models;
+
 namespace Umbraco.Cms.Core.IO.MediaPathSchemes;
 
 /// <summary>
@@ -8,6 +10,10 @@ namespace Umbraco.Cms.Core.IO.MediaPathSchemes;
 /// </remarks>
 public class CombinedGuidsMediaPathScheme : IMediaPathScheme
 {
+    /// <inheritdoc />
+    public string GetFilePath(MediaFileManager fileManager, IContentBase content, Guid propertyGuid, string filename) =>
+        GetFilePath(fileManager, content.Key, propertyGuid, filename);
+
     /// <inheritdoc />
     public string GetFilePath(MediaFileManager fileManager, Guid itemGuid, Guid propertyGuid, string filename)
     {

--- a/src/Umbraco.Core/IO/MediaPathSchemes/TwoGuidsMediaPathScheme.cs
+++ b/src/Umbraco.Core/IO/MediaPathSchemes/TwoGuidsMediaPathScheme.cs
@@ -1,3 +1,5 @@
+using Umbraco.Cms.Core.Models;
+
 namespace Umbraco.Cms.Core.IO.MediaPathSchemes;
 
 /// <summary>
@@ -8,6 +10,10 @@ namespace Umbraco.Cms.Core.IO.MediaPathSchemes;
 /// </remarks>
 public class TwoGuidsMediaPathScheme : IMediaPathScheme
 {
+    /// <inheritdoc />
+    public string GetFilePath(MediaFileManager fileManager, IContentBase content, Guid propertyGuid, string filename) =>
+        GetFilePath(fileManager, content.Key, propertyGuid, filename);
+
     /// <inheritdoc />
     public string GetFilePath(MediaFileManager fileManager, Guid itemGuid, Guid propertyGuid, string filename) =>
         Path.Combine(itemGuid.ToString("N"), propertyGuid.ToString("N"), filename).Replace('\\', '/');

--- a/src/Umbraco.Core/IO/MediaPathSchemes/UniqueMediaPathScheme.cs
+++ b/src/Umbraco.Core/IO/MediaPathSchemes/UniqueMediaPathScheme.cs
@@ -1,3 +1,5 @@
+using Umbraco.Cms.Core.Models;
+
 namespace Umbraco.Cms.Core.IO.MediaPathSchemes;
 
 /// <summary>
@@ -9,6 +11,10 @@ namespace Umbraco.Cms.Core.IO.MediaPathSchemes;
 public class UniqueMediaPathScheme : IMediaPathScheme
 {
     private const int DirectoryLength = 8;
+
+    /// <inheritdoc />
+    public string GetFilePath(MediaFileManager fileManager, IContentBase content, Guid propertyGuid, string filename) =>
+        GetFilePath(fileManager, content.Key, propertyGuid, filename);
 
     /// <inheritdoc />
     public string GetFilePath(MediaFileManager fileManager, Guid itemGuid, Guid propertyGuid, string filename)

--- a/src/Umbraco.Core/Models/Editors/ContentPropertyData.cs
+++ b/src/Umbraco.Core/Models/Editors/ContentPropertyData.cs
@@ -26,9 +26,26 @@ public class ContentPropertyData
     public object? DataTypeConfiguration { get; }
 
     /// <summary>
+    ///     Gets or sets the content owning the property.
+    /// </summary>
+    public IContentBase? Content { get; set; }
+
+    /// <summary>
     ///     Gets or sets the unique identifier of the content owning the property.
     /// </summary>
-    public Guid ContentKey { get; set; }
+    public Guid ContentKey
+    {
+        get => Content?.Key ?? Guid.Empty;
+        set
+        {
+            if (Content == null)
+            {
+                return;
+            }
+
+            Content.Key = value;
+        }
+    }
 
     /// <summary>
     ///     Gets or sets the unique identifier of the property type.

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentControllerBase.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentControllerBase.cs
@@ -136,7 +136,7 @@ public abstract class ContentControllerBase : BackOfficeNotificationsController
             // create the property data for the property editor
             var data = new ContentPropertyData(propertyDto.Value, propertyDto.DataType?.Configuration)
             {
-                ContentKey = contentItem.PersistedContent!.Key,
+                Content = contentItem.PersistedContent,
                 PropertyTypeKey = property.PropertyType.Key,
                 Files = files
             };

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/IO/FileSystemsTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/IO/FileSystemsTests.cs
@@ -7,6 +7,8 @@ using NUnit.Framework;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.IO.MediaPathSchemes;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
 
@@ -36,7 +38,11 @@ public class FileSystemsTests : UmbracoIntegrationTest
     {
         var mediaFileManager = GetRequiredService<MediaFileManager>();
         var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes("test"));
-        var virtualPath = mediaFileManager.GetMediaPath("file.txt", Guid.NewGuid(), Guid.NewGuid());
+        var content = new ContentBuilder()
+            .WithId(0)
+            .WithKey(Guid.NewGuid())
+            .Build();
+        var virtualPath = mediaFileManager.GetMediaPath("file.txt", content, Guid.NewGuid());
         mediaFileManager.FileSystem.AddFile(virtualPath, memoryStream);
 
         // ~/media/1234/file.txt exists


### PR DESCRIPTION
Follow up to #14337. The current system has been in place for ages, but severely limits some advanced use case, like being able to apply logic based on specific properties. One particular use-case I'm after is being able to get an Ancestor of the current media item, to decide which blob container the media item should be stored in (or stored to).

While this does not cover scenario's like renaming/moving, it's a start (those could be handled using media events for now). 

Purposely not done as a draft, as I want Github to perform all tests.