### PR TITLE
Update OpenIdDict

### DIFF
--- a/src/Umbraco.Cms.Api.Common/Umbraco.Cms.Api.Common.csproj
+++ b/src/Umbraco.Cms.Api.Common/Umbraco.Cms.Api.Common.csproj
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.8" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="OpenIddict.Abstractions" Version="4.2.0" />
-    <PackageReference Include="OpenIddict.AspNetCore" Version="4.2.0" />
+    <PackageReference Include="OpenIddict.Abstractions" Version="4.4.0" />
+    <PackageReference Include="OpenIddict.AspNetCore" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Umbraco.Core\Umbraco.Core.csproj" />

--- a/src/Umbraco.Cms.Persistence.EFCore/Umbraco.Cms.Persistence.EFCore.csproj
+++ b/src/Umbraco.Cms.Persistence.EFCore/Umbraco.Cms.Persistence.EFCore.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.5" />
-    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="4.2.0" />
+    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In #14279 we downgraded OpenIdDict from `4.3.0` to `4.2.0` because a change in `4.2.0` broke external logins with OpenIdConnect, this has been fixed in the `4.4.0` version of OpenIdDict, so this PR updates it to that version.