### PR TITLE
Fix unlinking with external login tokens

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ExternalLoginRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ExternalLoginRepository.cs
@@ -96,6 +96,9 @@ internal class ExternalLoginRepository : EntityRepositoryBase<int, IIdentityUser
         // do the deletes, updates and inserts
         if (toDelete.Count > 0)
         {
+            // Before we can remove the external login, we must remove the external login tokens associated with that external login,
+            // otherwise we'll get foreign key constraint errors
+            Database.DeleteMany<ExternalLoginTokenDto>().Where(x => toDelete.Contains(x.ExternalLoginId)).Execute();
             Database.DeleteMany<ExternalLoginDto>().Where(x => toDelete.Contains(x.Id)).Execute();
         }
 


### PR DESCRIPTION
If you used something like OpenIdConnect and AzureB2C with tokens enabled, you could not unlink your account.

This was cause by a foreign key constraint between the `umbracoExternalLogin` and `umbracoExternalLoginToken` tables since we did not remove the external login tokens before trying to remove the external logins themselves.

This PR fixes that. 