### PR TITLE
fix to show focus state of checkbox on install screen

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/installer.less
+++ b/src/Umbraco.Web.UI.Client/src/less/installer.less
@@ -1,4 +1,4 @@
-﻿// Core variables and mixins
+// Core variables and mixins
 @import "fonts.less"; // Loading fonts
 @import "variables.less"; // Modify this for custom colors, font-sizes, etc
 @import "colors.less";
@@ -146,6 +146,10 @@ legend {
 
   &[type=checkbox] {
     width: auto;
+
+    &:focus {
+      outline: 2px solid @blueMidLight;
+    }
   }
 }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
Styling added to make the focus state of the checkbox "subscribeToNewsLetter" visible on the Umbraco install screen.

issue raised here #13283

Before: 
- Tabbing onto checkbox and it has no focus state
![before](https://github.com/umbraco/Umbraco-CMS/assets/82643045/6f5000bd-e6f1-48f0-a5ac-f00a947e26fa)


After fix: 
- Tabbing onto the checkbox and it now has a focus state
![after](https://github.com/umbraco/Umbraco-CMS/assets/82643045/cc39ad7f-06a4-4727-b71f-0db13a773279)




<!-- Thanks for contributing to Umbraco CMS! -->
