### PR TITLE
Add location header for CORS requests

### DIFF
--- a/src/Umbraco.Web.UI.New/Startup.cs
+++ b/src/Umbraco.Web.UI.New/Startup.cs
@@ -57,6 +57,7 @@ namespace Umbraco.Cms.Web.UI
                     u.AllowCredentials();
                     u.AllowAnyMethod();
                     u.AllowAnyHeader();
+                    u.WithExposedHeaders("Location");
                     u.WithOrigins(new[] { "http://127.0.0.1:5173", "http://localhost:5173", "https://127.0.0.1:5173", "https://localhost:5173" });
                 });
             }


### PR DESCRIPTION
Add location header for CORS requests

When Vite Server communicates with backend, we are using Fetch calls over CORS, which then omits some headers. Adding this line will approve the Location for CORS requests. Which we need, thanks