### PR TITLE
Fix broken name sorting in the Delivery API

### DIFF
--- a/src/Umbraco.Infrastructure/Examine/DeliveryApiContentIndexFieldDefinitionBuilder.cs
+++ b/src/Umbraco.Infrastructure/Examine/DeliveryApiContentIndexFieldDefinitionBuilder.cs
@@ -69,7 +69,7 @@ internal sealed class DeliveryApiContentIndexFieldDefinitionBuilder : IDeliveryA
             FieldType.Number => FieldDefinitionTypes.Integer,
             FieldType.StringRaw => FieldDefinitionTypes.Raw,
             FieldType.StringAnalyzed => FieldDefinitionTypes.FullText,
-            FieldType.StringSortable => FieldDefinitionTypes.InvariantCultureIgnoreCase,
+            FieldType.StringSortable => FieldDefinitionTypes.FullTextSortable,
             _ => throw new ArgumentOutOfRangeException(nameof(field.FieldType))
         };
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The name sorting is rather broken at the moment. Our Examine implementation of querying does not use the correct field definitions.

### Testing this PR

First and foremost you'll need to rebuild the _DeliveryApiContentIndex_ before testing.

1. Verify that name sorting works both `asc` and `desc` when querying items from the Delivery API.
2. Verify that name sorting is performed case invariant.
