### PR TITLE
V14: Replace usage of SortedSet with HashSets and ISets

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Items/ItemDatatypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Items/ItemDatatypeItemController.cs
@@ -23,7 +23,7 @@ public class ItemDatatypeItemController : DatatypeItemControllerBase
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<DataTypeItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<ActionResult> Item([FromQuery(Name = "id")] SortedSet<Guid> ids)
+    public async Task<ActionResult> Item([FromQuery(Name = "id")] HashSet<Guid> ids)
     {
         var dataTypes = new List<IDataType>();
         foreach (Guid id in ids)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Item/ItemDictionaryItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Item/ItemDictionaryItemController.cs
@@ -23,7 +23,7 @@ public class ItemDictionaryItemController : DictionaryItemControllerBase
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<DictionaryItemItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<ActionResult> Item([FromQuery(Name = "id")] SortedSet<Guid> ids)
+    public async Task<ActionResult> Item([FromQuery(Name = "id")] HashSet<Guid> ids)
     {
         IEnumerable<IDictionaryItem> dictionaryItems = await _dictionaryItemService.GetManyAsync(ids.ToArray());
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/ItemDocumentItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/ItemDocumentItemController.cs
@@ -34,7 +34,7 @@ public class ItemDocumentItemController : DocumentItemControllerBase
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<DocumentItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<ActionResult> Item([FromQuery(Name = "id")] SortedSet<Guid> ids, Guid? dataTypeId = null, string? culture = null)
+    public async Task<ActionResult> Item([FromQuery(Name = "id")] HashSet<Guid> ids, Guid? dataTypeId = null, string? culture = null)
     {
         IEnumerable<IDocumentEntitySlim> documents = _entityService.GetAll(UmbracoObjectTypes.Document, ids.ToArray()).Select(x => x as IDocumentEntitySlim).Where(x => x is not null)!;
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/Item/ItemDocumentBlueprintController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/Item/ItemDocumentBlueprintController.cs
@@ -25,7 +25,7 @@ public class ItemDocumentBlueprintController : DocumentBlueprintItemControllerBa
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<DocumentBlueprintResponseModel>), StatusCodes.Status200OK)]
-    public async Task<ActionResult> Item([FromQuery(Name = "id")] SortedSet<Guid> ids)
+    public async Task<ActionResult> Item([FromQuery(Name = "id")] HashSet<Guid> ids)
     {
         IEnumerable<IDocumentEntitySlim> documents = _entityService.GetAll(UmbracoObjectTypes.Document, ids.ToArray()).Select(x => x as IDocumentEntitySlim).WhereNotNull();
         IEnumerable<DocumentBlueprintResponseModel> responseModels = documents.Select(x => _documentPresentationFactory.CreateBlueprintItemResponseModel(x));

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Item/ItemDocumentTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Item/ItemDocumentTypeItemController.cs
@@ -23,7 +23,7 @@ public class ItemDocumentTypeItemController : DocumentTypeItemControllerBase
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<DocumentTypeItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Item([FromQuery(Name = "id")] SortedSet<Guid> ids)
+    public async Task<IActionResult> Item([FromQuery(Name = "id")] HashSet<Guid> ids)
     {
         IEnumerable<IContentType> contentTypes = _contentTypeService.GetAll(ids);
         List<DocumentTypeItemResponseModel> responseModels = _mapper.MapEnumerable<IContentType, DocumentTypeItemResponseModel>(contentTypes);

--- a/src/Umbraco.Cms.Api.Management/Controllers/Language/Item/ItemsLanguageEntityController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Language/Item/ItemsLanguageEntityController.cs
@@ -23,7 +23,7 @@ public class ItemsLanguageEntityController : LanguageEntityControllerBase
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<LanguageItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<ActionResult> Items([FromQuery(Name = "isoCode")] SortedSet<string> isoCodes)
+    public async Task<ActionResult> Items([FromQuery(Name = "isoCode")] HashSet<string> isoCodes)
     {
         IEnumerable<ILanguage> languages = await _languageService.GetMultipleAsync(isoCodes);
         List<LanguageItemResponseModel> entityResponseModels = _mapper.MapEnumerable<ILanguage, LanguageItemResponseModel>(languages);

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/ItemMediaItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/ItemMediaItemController.cs
@@ -30,7 +30,7 @@ public class ItemMediaItemController : MediaItemControllerBase
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<MediaItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<ActionResult> Item([FromQuery(Name = "id")] SortedSet<Guid> ids, Guid? dataTypeId = null)
+    public async Task<ActionResult> Item([FromQuery(Name = "id")] HashSet<Guid> ids, Guid? dataTypeId = null)
     {
         IEnumerable<IMediaEntitySlim> media = _entityService.GetAll(UmbracoObjectTypes.Media, ids.ToArray()).OfType<IMediaEntitySlim>();
         if (dataTypeId is not null)

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/ItemMediaTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/ItemMediaTypeItemController.cs
@@ -23,7 +23,7 @@ public class ItemMediaTypeItemController : MediaTypeItemControllerBase
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<MediaTypeItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Item([FromQuery(Name = "id")] SortedSet<Guid> ids)
+    public async Task<IActionResult> Item([FromQuery(Name = "id")] HashSet<Guid> ids)
     {
         IEnumerable<IMediaType> mediaTypes = _mediaTypeService.GetAll(ids);
         List<MediaTypeItemResponseModel> responseModels = _mapper.MapEnumerable<IMediaType, MediaTypeItemResponseModel>(mediaTypes);

--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/Item/ItemMemberItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/Item/ItemMemberItemController.cs
@@ -23,7 +23,7 @@ public class ItemMemberItemController : MemberItemControllerBase
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<MemberItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Item([FromQuery(Name = "id")] SortedSet<Guid> ids)
+    public async Task<IActionResult> Item([FromQuery(Name = "id")] HashSet<Guid> ids)
     {
         IEnumerable<IMember> members = await _memberService.GetByKeysAsync(ids.ToArray());
         List<MemberItemResponseModel> responseModels = _mapper.MapEnumerable<IMember, MemberItemResponseModel>(members);

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberGroup/Item/ItemMemberGroupItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberGroup/Item/ItemMemberGroupItemController.cs
@@ -25,7 +25,7 @@ public class ItemMemberGroupItemController : MemberGroupItemControllerBase
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<MemberGroupItemReponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Item([FromQuery(Name = "id")] SortedSet<Guid> ids)
+    public async Task<IActionResult> Item([FromQuery(Name = "id")] HashSet<Guid> ids)
     {
         IEnumerable<IEntitySlim> memberGroups = _entityService.GetAll(UmbracoObjectTypes.MemberGroup, ids.ToArray());
         List<MemberGroupItemReponseModel> responseModel = _mapper.MapEnumerable<IEntitySlim, MemberGroupItemReponseModel>(memberGroups);

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Items/ItemMemberTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Items/ItemMemberTypeItemController.cs
@@ -23,7 +23,7 @@ public class ItemMemberTypeItemController : MemberTypeItemControllerBase
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<MemberTypeItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Item([FromQuery(Name = "id")] SortedSet<Guid> ids)
+    public async Task<IActionResult> Item([FromQuery(Name = "id")] HashSet<Guid> ids)
     {
         IEnumerable<IMemberType> memberTypes = _memberTypeService.GetAll(ids);
         List<MemberTypeItemResponseModel> responseModels = _mapper.MapEnumerable<IMemberType, MemberTypeItemResponseModel>(memberTypes);

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Items/ItemPartialViewItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Items/ItemPartialViewItemController.cs
@@ -22,7 +22,7 @@ public class ItemPartialViewItemController : PartialViewItemControllerBase
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<PartialViewItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Item([FromQuery(Name = "id")] SortedSet<string> paths)
+    public async Task<IActionResult> Item([FromQuery(Name = "id")] HashSet<string> paths)
     {
         IEnumerable<PartialViewItemResponseModel> responseModels = _fileItemPresentationModelFactory.CreatePartialViewResponseModels(paths, _fileSystem);
         return Ok(responseModels);

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Item/ItemRelationTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Item/ItemRelationTypeItemController.cs
@@ -23,7 +23,7 @@ public class ItemRelationTypeItemController : RelationTypeItemControllerBase
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<RelationTypeItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Item([FromQuery(Name = "id")] SortedSet<Guid> ids)
+    public async Task<IActionResult> Item([FromQuery(Name = "id")] HashSet<Guid> ids)
     {
         // relation service does not allow fetching a collection of relation types by their ids; instead it relies
         // heavily on caching, which means this is as fast as it gets - even if it looks less than performant

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/Item/ItemScriptItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/Item/ItemScriptItemController.cs
@@ -22,7 +22,7 @@ public class ItemScriptItemController : ScriptItemControllerBase
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<ScriptItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Item([FromQuery(Name = "path")] SortedSet<string> paths)
+    public async Task<IActionResult> Item([FromQuery(Name = "path")] HashSet<string> paths)
     {
         IEnumerable<ScriptItemResponseModel> reponseModels = _fileItemPresentationModelFactory.CreateScriptItemResponseModels(paths, _fileSystem);
         return Ok(reponseModels);

--- a/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Item/ItemStaticFileItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Item/ItemStaticFileItemController.cs
@@ -22,7 +22,7 @@ public class ItemStaticFileItemController : StaticFileItemControllerBase
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<StaticFileItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Item([FromQuery(Name = "path")] SortedSet<string> paths)
+    public async Task<IActionResult> Item([FromQuery(Name = "path")] HashSet<string> paths)
     {
         IEnumerable<StaticFileItemResponseModel> responseModels = _presentationModelFactory.CreateStaticFileItemResponseModels(paths, _physicalFileSystem);
         return Ok(responseModels);

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Item/ItemStylesheetItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Item/ItemStylesheetItemController.cs
@@ -23,7 +23,7 @@ public class ItemStylesheetItemController : StylesheetItemControllerBase
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<ScriptItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Item([FromQuery(Name = "path")] SortedSet<string> paths)
+    public async Task<IActionResult> Item([FromQuery(Name = "path")] HashSet<string> paths)
     {
         IEnumerable<StylesheetItemResponseModel> responseModels = _fileItemPresentationModelFactory.CreateStylesheetItemResponseModels(paths, _fileSystem);
         return Ok(responseModels);

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Item/ItemTemplateItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Item/ItemTemplateItemController.cs
@@ -24,7 +24,7 @@ public class ItemTemplateItemController : TemplateItemControllerBase
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<TemplateItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Item([FromQuery(Name = "id")] SortedSet<Guid> ids)
+    public async Task<IActionResult> Item([FromQuery(Name = "id")] HashSet<Guid> ids)
     {
         // This is far from ideal, that we pick out the entire model, however, we must do this to get the alias.
         // This is (for one) needed for when specifying master template, since alias + .cshtml

--- a/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/ItemsTrackedReferenceController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/ItemsTrackedReferenceController.cs
@@ -31,7 +31,7 @@ public class ItemsTrackedReferenceController : TrackedReferenceControllerBase
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<RelationItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<PagedViewModel<RelationItemResponseModel>>> GetPagedReferencedItems([FromQuery(Name="id")]SortedSet<Guid> ids, long skip = 0, long take = 20, bool filterMustBeIsDependency = true)
+    public async Task<ActionResult<PagedViewModel<RelationItemResponseModel>>> GetPagedReferencedItems([FromQuery(Name="id")]HashSet<Guid> ids, long skip = 0, long take = 20, bool filterMustBeIsDependency = true)
     {
         PagedModel<RelationItemModel> relationItems = await _trackedReferencesSkipTakeService.GetPagedItemsWithRelationsAsync(ids, skip, take, filterMustBeIsDependency);
         var pagedViewModel = new PagedViewModel<RelationItemResponseModel>

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/FilterUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/FilterUsersController.cs
@@ -47,15 +47,15 @@ public class FilterUserController : UserControllerBase
         int take = 100,
         UserOrder orderBy = UserOrder.UserName,
         Direction orderDirection = Direction.Ascending,
-        [FromQuery] SortedSet<Guid>? userGroupIds = null,
-        [FromQuery] SortedSet<UserState>? userStates = null,
+        [FromQuery] HashSet<Guid>? userGroupIds = null,
+        [FromQuery] HashSet<UserState>? userStates = null,
         string filter = "")
     {
         var userFilter = new UserFilter
         {
             IncludedUserGroups = userGroupIds,
             IncludeUserStates = userStates,
-            NameFilters = string.IsNullOrEmpty(filter) ? null : new SortedSet<string> { filter }
+            NameFilters = string.IsNullOrEmpty(filter) ? null : new HashSet<string> { filter }
         };
 
         Attempt<PagedModel<IUser>, UserOperationStatus> filterAttempt =

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/Item/ItemUserItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/Item/ItemUserItemController.cs
@@ -23,7 +23,7 @@ public class ItemUserItemController : UserItemControllerBase
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<UserItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Item([FromQuery(Name = "id")] SortedSet<Guid> ids)
+    public async Task<IActionResult> Item([FromQuery(Name = "id")] HashSet<Guid> ids)
     {
         IEnumerable<IUser> users = await _userService.GetAsync(ids.ToArray());
         List<UserItemResponseModel> responseModels = _mapper.MapEnumerable<IUser, UserItemResponseModel>(users);

--- a/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/Item/ItemUserGroupItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/Item/ItemUserGroupItemController.cs
@@ -23,7 +23,7 @@ public class ItemUserGroupItemController : UserGroupItemControllerBase
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<UserGroupItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Item([FromQuery(Name = "id")] SortedSet<Guid> ids)
+    public async Task<IActionResult> Item([FromQuery(Name = "id")] HashSet<Guid> ids)
     {
         IEnumerable<IUserGroup> userGroups = await _userGroupService.GetAsync(ids);
         List<UserGroupItemResponseModel> responseModels = _mapper.MapEnumerable<IUserGroup, UserGroupItemResponseModel>(userGroups);

--- a/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
@@ -46,7 +46,7 @@ public class UserPresentationFactory : IUserPresentationFactory
             CreateDate = user.CreateDate,
             UpdateDate = user.UpdateDate,
             State = user.UserState,
-            UserGroupIds = new SortedSet<Guid>(user.Groups.Select(x => x.Key)),
+            UserGroupIds = new HashSet<Guid>(user.Groups.Select(x => x.Key)),
             ContentStartNodeIds = GetKeysFromIds(user.StartContentIds, UmbracoObjectTypes.Document),
             MediaStartNodeIds = GetKeysFromIds(user.StartMediaIds, UmbracoObjectTypes.Media),
             FailedLoginAttempts = user.FailedPasswordAttempts,

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/DisableUserRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/DisableUserRequestModel.cs
@@ -2,5 +2,5 @@
 
 public class DisableUserRequestModel
 {
-    public SortedSet<Guid> UserIds { get; set; } = new();
+    public HashSet<Guid> UserIds { get; set; } = new();
  }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/EnableUserRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/EnableUserRequestModel.cs
@@ -2,5 +2,5 @@
 
 public class EnableUserRequestModel
 {
-    public SortedSet<Guid> UserIds { get; set; } = new();
+    public ISet<Guid> UserIds { get; set; } = new HashSet<Guid>();
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/UnlockUsersRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/UnlockUsersRequestModel.cs
@@ -2,5 +2,5 @@
 
 public class UnlockUsersRequestModel
 {
-    public SortedSet<Guid> UserIds { get; set; } = new();
+    public ISet<Guid> UserIds { get; set; } = new HashSet<Guid>();
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/UpdateUserGroupsOnUserRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/UpdateUserGroupsOnUserRequestModel.cs
@@ -2,7 +2,7 @@
 
 public class UpdateUserGroupsOnUserRequestModel
 {
-    public required SortedSet<Guid> UserIds { get; set; }
+    public required ISet<Guid> UserIds { get; set; }
 
-    public required SortedSet<Guid> UserGroupIds { get; set; }
+    public required ISet<Guid> UserGroupIds { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/UpdateUserRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/UpdateUserRequestModel.cs
@@ -4,7 +4,7 @@ public class UpdateUserRequestModel : UserPresentationBase
 {
     public string LanguageIsoCode { get; set; } = string.Empty;
 
-    public SortedSet<Guid> ContentStartNodeIds { get; set; } = new();
+    public ISet<Guid> ContentStartNodeIds { get; set; } = new HashSet<Guid>();
 
-    public SortedSet<Guid> MediaStartNodeIds { get; set; } = new();
+    public ISet<Guid> MediaStartNodeIds { get; set; } = new HashSet<Guid>();
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/UserPresentationBase.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/UserPresentationBase.cs
@@ -8,5 +8,5 @@ public class UserPresentationBase
 
     public string Name { get; set; } = string.Empty;
 
-    public SortedSet<Guid> UserGroupIds { get; set; } = new();
+    public ISet<Guid> UserGroupIds { get; set; } = new HashSet<Guid>();
 }

--- a/src/Umbraco.Core/Models/Membership/UserFilter.cs
+++ b/src/Umbraco.Core/Models/Membership/UserFilter.cs
@@ -4,13 +4,13 @@ namespace Umbraco.Cms.Core.Models.Membership;
 
 public class UserFilter
 {
-    public SortedSet<Guid>? IncludedUserGroups { get; set; }
+    public ISet<Guid>? IncludedUserGroups { get; set; }
 
-    public SortedSet<Guid>? ExcludeUserGroups { get; set; }
+    public ISet<Guid>? ExcludeUserGroups { get; set; }
 
-    public SortedSet<UserState>? IncludeUserStates { get; set; }
+    public ISet<UserState>? IncludeUserStates { get; set; }
 
-    public SortedSet<string>? NameFilters { get; set; }
+    public ISet<string>? NameFilters { get; set; }
 
 
     /// <summary>
@@ -27,9 +27,9 @@ public class UserFilter
             NameFilters = MergeSet(NameFilters, target.NameFilters)
         };
 
-    private SortedSet<T>? MergeSet<T>(SortedSet<T>? source, SortedSet<T>? target)
+    private ISet<T>? MergeSet<T>(ISet<T>? source, ISet<T>? target)
     {
-        var set = new SortedSet<T>();
+        var set = new HashSet<T>();
 
         if (source is not null)
         {

--- a/src/Umbraco.Core/Models/UserUpdateModel.cs
+++ b/src/Umbraco.Core/Models/UserUpdateModel.cs
@@ -12,9 +12,9 @@ public class UserUpdateModel
 
     public string LanguageIsoCode { get; set; } = string.Empty;
 
-    public SortedSet<Guid> ContentStartNodeKeys { get; set; } = new();
+    public ISet<Guid> ContentStartNodeKeys { get; set; } = new HashSet<Guid>();
 
-    public SortedSet<Guid> MediaStartNodeKeys { get; set; } = new();
+    public ISet<Guid> MediaStartNodeKeys { get; set; } = new HashSet<Guid>();
 
     public ISet<Guid> UserGroupKeys { get; set; } = new HashSet<Guid>();
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserServiceCrudTests.Filter.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserServiceCrudTests.Filter.cs
@@ -33,7 +33,7 @@ public partial class UserServiceCrudTests
             await userService.DisableAsync(Constants.Security.SuperUserKey, new HashSet<Guid>{ createAttempt.Result.CreatedUser!.Key });
         Assert.AreEqual(UserOperationStatus.Success, disableStatus);
 
-        var filter = new UserFilter {IncludeUserStates = new SortedSet<UserState> {includeState}};
+        var filter = new UserFilter {IncludeUserStates = new HashSet<UserState> {includeState}};
 
         var filterAttempt = await userService.FilterAsync(Constants.Security.SuperUserKey, filter, 0, 1000);
         Assert.IsTrue(filterAttempt.Success);
@@ -92,7 +92,7 @@ public partial class UserServiceCrudTests
             await userService.CreateAsync(Constants.Security.SuperUserKey, nonSuperCreateModel, true);
         Assert.IsTrue(createEditorAttempt.Success);
 
-        var filter = new UserFilter {NameFilters = new SortedSet<string> {"admin"}};
+        var filter = new UserFilter {NameFilters = new HashSet<string> {"admin"}};
 
         var filterAttempt = await userService.FilterAsync(Constants.Security.SuperUserKey, filter, 0, 10000);
         Assert.IsTrue(filterAttempt.Success);
@@ -133,7 +133,7 @@ public partial class UserServiceCrudTests
         Assert.IsTrue(createEditorAttempt.Success);
         Assert.IsTrue(createAdminAttempt.Success);
 
-        var filter = new UserFilter {IncludedUserGroups = new SortedSet<Guid> {adminGroup!.Key}};
+        var filter = new UserFilter {IncludedUserGroups = new HashSet<Guid> {adminGroup!.Key}};
 
         var editorFilterAttempt =
             await userService.FilterAsync(createEditorAttempt.Result.CreatedUser!.Key, filter, 0, 10000);
@@ -172,8 +172,8 @@ public partial class UserServiceCrudTests
         Assert.IsTrue(createEditorAttempt.Success);
         Assert.IsTrue(createAdminAttempt.Success);
 
-        var filter = new UserFilter {IncludedUserGroups = new SortedSet<Guid> {adminGroup!.Key}};
- 
+        var filter = new UserFilter {IncludedUserGroups = new HashSet<Guid> {adminGroup!.Key}};
+
         var adminFilterAttempt =
             await userService.FilterAsync(createAdminAttempt.Result.CreatedUser!.Key, filter, 0, 10000);
         Assert.IsTrue(adminFilterAttempt.Success);
@@ -245,7 +245,7 @@ public partial class UserServiceCrudTests
         var writerGroup = await UserGroupService.GetAsync(Constants.Security.WriterGroupAlias);
         var filter = new UserFilter
         {
-            IncludedUserGroups = new SortedSet<Guid> { writerGroup!.Key }
+            IncludedUserGroups = new HashSet<Guid> { writerGroup!.Key }
         };
 
         var onlyWritesResult = await userService.FilterAsync(Constants.Security.SuperUserKey, filter, 0, 1000);
@@ -265,7 +265,7 @@ public partial class UserServiceCrudTests
         var editorGroup = await UserGroupService.GetAsync(Constants.Security.EditorGroupAlias);
         var filter = new UserFilter
         {
-            ExcludeUserGroups = new SortedSet<Guid> { editorGroup!.Key }
+            ExcludeUserGroups = new HashSet<Guid> { editorGroup!.Key }
         };
 
         var noEditorResult = await userService.FilterAsync(Constants.Security.SuperUserKey, filter, 0, 1000);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserServiceCrudTests.Update.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserServiceCrudTests.Update.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Services;
 
 public partial class UserServiceCrudTests
 {
-    private SortedSet<Guid> GetKeysFromIds(IEnumerable<int>? ids, UmbracoObjectTypes type)
+    private ISet<Guid> GetKeysFromIds(IEnumerable<int>? ids, UmbracoObjectTypes type)
     {
         IEnumerable<Guid>? keys = ids?
             .Select(x => EntityService.GetKey(x, type))
@@ -20,8 +20,8 @@ public partial class UserServiceCrudTests
             .Select(x => x.Result);
 
         return keys is null
-            ? new SortedSet<Guid>()
-            : new SortedSet<Guid>(keys);
+            ? new HashSet<Guid>()
+            : new HashSet<Guid>(keys);
     }
 
     private async Task<UserUpdateModel> MapUserToUpdateModel(IUser user)


### PR DESCRIPTION
Replaces the usage of `SortedSet` with `HashSet` for endpoints and `ISet` for models, since we do not care about the order of the items, only that they are unique.