### PR TITLE
V14: UserIdKeyResolver fetch GUID directly 

### DIFF
--- a/src/Umbraco.Infrastructure/Services/Implement/UserIdKeyResolver.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/UserIdKeyResolver.cs
@@ -85,10 +85,8 @@ internal sealed class UserIdKeyResolver : IUserIdKeyResolver
                 .From<UserDto>()
                 .Where<UserDto>(x => x.Id == id);
 
-            string? guidString = await scope.Database.ExecuteScalarAsync<string?>(query);
-            Guid fetchedKey = guidString is not null
-                ? new Guid(guidString)
-                : throw new InvalidOperationException("No user found with the specified id");
+            Guid fetchedKey = scope.Database.ExecuteScalar<Guid?>(query)
+                              ?? throw new InvalidOperationException("No user found with the specified id");
 
             _idToKey[id] = fetchedKey;
 


### PR DESCRIPTION
This fixes a bug where SQLServer wouldn't work. 

This is because SQLServer knows that the key is a GUID, so it cannot be retrieved as a string. 

For some weird reason NPoco refuses to use our custom mapper when using `ExecuteScalarAsync` so I had to change this back to just be `ExecuteScalar`


If all the tests pass we're good to merge 😄 