### PR TITLE
Enable checkbox with Trust server certificate in installer

### DIFF
--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDatabaseProviderMetadata.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDatabaseProviderMetadata.cs
@@ -73,8 +73,37 @@ public class SqlServerDatabaseProviderMetadata : IDatabaseProviderMetadata
     }
 
     /// <inheritdoc />
-    public string GenerateConnectionString(DatabaseModel databaseModel) =>
-        databaseModel.IntegratedAuth
-            ? $"Server={databaseModel.Server};Database={databaseModel.DatabaseName};Integrated Security=true"
-            : $"Server={databaseModel.Server};Database={databaseModel.DatabaseName};User Id={databaseModel.Login};Password={databaseModel.Password}";
+    public string GenerateConnectionString(DatabaseModel databaseModel)
+    {
+        string connectionString = $"Server={databaseModel.Server};Database={databaseModel.DatabaseName};";
+        connectionString = HandleIntegratedAuthentication(connectionString, databaseModel);
+        connectionString = HandleTrustServerCertificate(connectionString, databaseModel);
+
+        return connectionString;
+    }
+
+    private string HandleIntegratedAuthentication(string connectionString, DatabaseModel databaseModel)
+    {
+        if (databaseModel.IntegratedAuth)
+        {
+            connectionString += "Integrated Security=true;";
+        }
+        else
+        {
+            connectionString += $"User Id={databaseModel.Login};Password={databaseModel.Password};";
+        }
+
+        return connectionString;
+    }
+
+    private string HandleTrustServerCertificate(string connectionString, DatabaseModel databaseModel)
+    {
+        if (databaseModel.TrustServerCertificate)
+        {
+            connectionString += "TrustServerCertificate=true;";
+        }
+
+        return connectionString;
+    }
+
 }

--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDatabaseProviderMetadata.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDatabaseProviderMetadata.cs
@@ -86,11 +86,11 @@ public class SqlServerDatabaseProviderMetadata : IDatabaseProviderMetadata
     {
         if (databaseModel.IntegratedAuth)
         {
-            connectionString += "Integrated Security=true;";
+            connectionString += "Integrated Security=true";
         }
         else
         {
-            connectionString += $"User Id={databaseModel.Login};Password={databaseModel.Password};";
+            connectionString += $"User Id={databaseModel.Login};Password={databaseModel.Password}";
         }
 
         return connectionString;
@@ -100,7 +100,7 @@ public class SqlServerDatabaseProviderMetadata : IDatabaseProviderMetadata
     {
         if (databaseModel.TrustServerCertificate)
         {
-            connectionString += "TrustServerCertificate=true;";
+            connectionString += ";TrustServerCertificate=true;";
         }
 
         return connectionString;

--- a/src/Umbraco.Core/DeliveryApi/IApiContentQueryProvider.cs
+++ b/src/Umbraco.Core/DeliveryApi/IApiContentQueryProvider.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Core.DeliveryApi;
 

--- a/src/Umbraco.Core/Install/Models/DatabaseModel.cs
+++ b/src/Umbraco.Core/Install/Models/DatabaseModel.cs
@@ -28,6 +28,9 @@ public class DatabaseModel
     [DataMember(Name = "integratedAuth")]
     public bool IntegratedAuth { get; set; }
 
+    [DataMember(Name = "trustServerCertificate")]
+    public bool TrustServerCertificate { get; set; }
+
     [DataMember(Name = "connectionString")]
     public string? ConnectionString { get; set; }
 }

--- a/src/Umbraco.Web.UI.Client/src/installer/steps/database.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/database.html
@@ -155,6 +155,16 @@
                 Use integrated authentication
               </label>
             </div>
+
+            <div class="controls">
+              <label class="checkbox">
+                <input
+                  type="checkbox"
+                  ng-model="installer.current.model.trustServerCertificate"
+                />
+                Trust the database certificate
+              </label>
+            </div>
           </div>
         </div>
       </div>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "12.0.0-rc4",
+  "version": "12.1.0-rc",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
# Notes
- Add checkbox to SqlServer section in installer
- Add logic to add `TrustServerCertificate` to the connection string, if checkbox enabled
- Refactored building of said connection string.

# How to test
- Create a SQL database (note: this cannot be a LocalDB, but SqlExpress works just fine)
- Install umbraco using the database (remember to enable the new checkbox to trust the certificate)
- This should now no longer throw errors 💪 