### PR TITLE
V12: use database when testing examine

### DIFF
--- a/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexTest.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Examine.Lucene.UmbracoExamine;
 ///     Tests the standard indexing capabilities
 /// </summary>
 [TestFixture]
-[UmbracoTest(Database = UmbracoTestOptions.Database.None)]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
 public class IndexTest : ExamineBaseTest
 {
     [Test]

--- a/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexTest.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Examine.Lucene.UmbracoExamine;
 ///     Tests the standard indexing capabilities
 /// </summary>
 [TestFixture]
-[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerFixture)]
 public class IndexTest : ExamineBaseTest
 {
     [Test]


### PR DESCRIPTION
# Notes
- We need the database for the `IndexTest` as we're now locating the default ISO code in the `ContentValueSetBuilder.GetValueSetsEnumerable` function (mostly used for blocklists in variant/non-variant mixed setups)

# How to test
- The integration tests should now pass :)