### PR TITLE
Update security stamps on logout

### DIFF
--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilder.MembersIdentity.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilder.MembersIdentity.cs
@@ -65,6 +65,7 @@ public static partial class UmbracoBuilderExtensions
 
         services.ConfigureOptions<ConfigureSecurityStampOptions>();
         services.ConfigureOptions<ConfigureMemberCookieOptions>();
+        services.AddScoped<MemberSecurityStampValidator>();
 
         services.AddUnique<IMemberExternalLoginProviders, MemberExternalLoginProviders>();
 

--- a/src/Umbraco.Web.Common/Security/ConfigureMemberCookieOptions.cs
+++ b/src/Umbraco.Web.Common/Security/ConfigureMemberCookieOptions.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Services;
@@ -46,6 +47,14 @@ public sealed class ConfigureMemberCookieOptions : IConfigureNamedOptions<Cookie
                 ctx.HttpContext.SetPrincipalForRequest(ctx.Principal);
 
                 return Task.CompletedTask;
+            },
+            OnValidatePrincipal = async ctx =>
+            {
+                // We need to resolve the BackOfficeSecurityStampValidator per request as a requirement (even in aspnetcore they do this)
+                MemberSecurityStampValidator securityStampValidator =
+                    ctx.HttpContext.RequestServices.GetRequiredService<MemberSecurityStampValidator>();
+
+                await securityStampValidator.ValidateAsync(ctx);
             },
             OnRedirectToAccessDenied = ctx =>
             {

--- a/src/Umbraco.Web.Common/Security/MemberSecurityStampValidator.cs
+++ b/src/Umbraco.Web.Common/Security/MemberSecurityStampValidator.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Security;
+
+namespace Umbraco.Cms.Web.Common.Security;
+
+/// <summary>
+///     A security stamp validator for the back office
+/// </summary>
+public class MemberSecurityStampValidator : SecurityStampValidator<MemberIdentityUser>
+{
+    public MemberSecurityStampValidator(
+        IOptions<MemberSecurityStampValidatorOptions> options,
+        MemberSignInManager signInManager, ISystemClock clock, ILoggerFactory logger)
+        : base(options, signInManager, clock, logger)
+    {
+    }
+
+    public override Task ValidateAsync(CookieValidatePrincipalContext context)
+    {
+        return base.ValidateAsync(context);
+    }
+}

--- a/src/Umbraco.Web.Common/Security/MemberSecurityStampValidatorOptions.cs
+++ b/src/Umbraco.Web.Common/Security/MemberSecurityStampValidatorOptions.cs
@@ -1,0 +1,7 @@
+﻿using Microsoft.AspNetCore.Identity;
+
+namespace Umbraco.Cms.Web.Common.Security;
+
+public class MemberSecurityStampValidatorOptions : SecurityStampValidatorOptions
+{
+}

--- a/src/Umbraco.Web.Common/Security/UmbracoSignInManager.cs
+++ b/src/Umbraco.Web.Common/Security/UmbracoSignInManager.cs
@@ -238,6 +238,14 @@ public abstract class UmbracoSignInManager<TUser> : SignInManager<TUser>
     /// <inheritdoc />
     public override async Task SignOutAsync()
     {
+        // Update the security stamp to sign out everywhere.
+        TUser? user = await UserManager.GetUserAsync(Context.User);
+
+        if (user is not null)
+        {
+            await UserManager.UpdateSecurityStampAsync(user);
+        }
+
         // override to replace IdentityConstants.ApplicationScheme with custom auth types
         // code taken from aspnetcore: https://github.com/dotnet/aspnetcore/blob/master/src/Identity/Core/src/SignInManager.cs
         await Context.SignOutAsync(AuthenticationType);


### PR DESCRIPTION
# Notes
- Issue was that you could logout as a member, but if somebody stole your cookie, they could use that and still be logged in.
- We have now remedied that by updating the security stamp whenever you logout.
- Note that your cookie will only be validated once every 30 mins, so if you want to change this default behavior to more or less time, you'd have to implement your own ConfigureOptions like so: 
```
public class ConfigureSecurityStampValidatorOptions : IConfigureOptions<MemberSecurityStampValidatorOptions>
{
    public void Configure(MemberSecurityStampValidatorOptions options)
    {
        options.ValidationInterval = TimeSpan.FromSeconds(0);
    }
}
```

and remember to register it somewhere: `services.ConfigureOptions<ConfigureSecurityStampValidatorOptions>();`

# How to test
- Implement said `ConfigureSecurityStampValidatorOptions` class from above snippet, so you don't have to wait 30 mins
- create 2 partial view from snippets (Login and login status)
- Create a document type with allow as root
- In the template, insert the 2 partial views.
- Create some content
- Create a member
- Login as said member on the newly created content page.
- Note down your cookie `.AspNetCore.Identity.Application`
- Logout
- Try to use the cookie you just noted down, you should no longer be logged in