### PR TITLE
Make the API versioning and Swagger config less intrusive

### DIFF
--- a/src/Umbraco.Cms.Api.Common/Configuration/ConfigureUmbracoSwaggerGenOptions.cs
+++ b/src/Umbraco.Cms.Api.Common/Configuration/ConfigureUmbracoSwaggerGenOptions.cs
@@ -6,18 +6,25 @@ using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Umbraco.Cms.Api.Common.OpenApi;
-using Umbraco.Cms.Core.Models.DeliveryApi;
 using Umbraco.Extensions;
-using OperationIdRegexes = Umbraco.Cms.Api.Common.OpenApi.OperationIdRegexes;
 
 namespace Umbraco.Cms.Api.Common.Configuration;
 
 public class ConfigureUmbracoSwaggerGenOptions : IConfigureOptions<SwaggerGenOptions>
 {
     private readonly IOptions<ApiVersioningOptions> _apiVersioningOptions;
+    private readonly IOperationIdSelector _operationIdSelector;
+    private readonly ISchemaIdSelector _schemaIdSelector;
 
-    public ConfigureUmbracoSwaggerGenOptions(IOptions<ApiVersioningOptions> apiVersioningOptions)
-        => _apiVersioningOptions = apiVersioningOptions;
+    public ConfigureUmbracoSwaggerGenOptions(
+        IOptions<ApiVersioningOptions> apiVersioningOptions,
+        IOperationIdSelector operationIdSelector,
+        ISchemaIdSelector schemaIdSelector)
+    {
+        _apiVersioningOptions = apiVersioningOptions;
+        _operationIdSelector = operationIdSelector;
+        _schemaIdSelector = schemaIdSelector;
+    }
 
     public void Configure(SwaggerGenOptions swaggerGenOptions)
     {
@@ -30,9 +37,7 @@ public class ConfigureUmbracoSwaggerGenOptions : IConfigureOptions<SwaggerGenOpt
                 Description = "All endpoints not defined under specific APIs"
             });
 
-        swaggerGenOptions.CustomOperationIds(description =>
-            CustomOperationId(description, _apiVersioningOptions.Value));
-
+        swaggerGenOptions.CustomOperationIds(description => _operationIdSelector.OperationId(description, _apiVersioningOptions.Value));
         swaggerGenOptions.DocInclusionPredicate((name, api) =>
         {
             if (string.IsNullOrWhiteSpace(api.GroupName))
@@ -43,97 +48,18 @@ public class ConfigureUmbracoSwaggerGenOptions : IConfigureOptions<SwaggerGenOpt
             if (api.ActionDescriptor is ControllerActionDescriptor controllerActionDescriptor)
             {
                 return controllerActionDescriptor.MethodInfo.HasMapToApiAttribute(name);
-
             }
 
             return false;
         });
         swaggerGenOptions.TagActionsBy(api => new[] { api.GroupName });
         swaggerGenOptions.OrderActionsBy(ActionOrderBy);
-        swaggerGenOptions.DocumentFilter<MimeTypeDocumentFilter>();
         swaggerGenOptions.SchemaFilter<EnumSchemaFilter>();
-        swaggerGenOptions.CustomSchemaIds(SchemaIdGenerator.Generate);
+        swaggerGenOptions.CustomSchemaIds(_schemaIdSelector.SchemaId);
         swaggerGenOptions.SupportNonNullableReferenceTypes();
-        swaggerGenOptions.UseOneOfForPolymorphism();
-        swaggerGenOptions.UseAllOfForInheritance();
-        var cachedApiElementNamespace = typeof(ApiElement).Namespace ?? string.Empty;
-        swaggerGenOptions.SelectDiscriminatorNameUsing(type =>
-        {
-            if (type.Namespace != null && type.Namespace.StartsWith(cachedApiElementNamespace))
-            {
-                // We do not show type on delivery, as it is read only.
-                return null;
-            }
-
-            if (type.GetInterfaces().Any())
-            {
-                return "$type";
-            }
-
-            return null;
-        });
-        swaggerGenOptions.SelectDiscriminatorValueUsing(x => x.Name);
-    }
-
-    private static string CustomOperationId(ApiDescription api, ApiVersioningOptions apiVersioningOptions)
-    {
-        ApiVersion defaultVersion = apiVersioningOptions.DefaultApiVersion;
-        var httpMethod = api.HttpMethod?.ToLower().ToFirstUpper() ?? "Get";
-
-        // if the route info "Name" is supplied we'll use this explicitly as the operation ID
-        // - usage example: [HttpGet("my-api/route}", Name = "MyCustomRoute")]
-        if (string.IsNullOrWhiteSpace(api.ActionDescriptor.AttributeRouteInfo?.Name) == false)
-        {
-            var explicitOperationId = api.ActionDescriptor.AttributeRouteInfo!.Name;
-            return explicitOperationId.InvariantStartsWith(httpMethod)
-                ? explicitOperationId
-                : $"{httpMethod}{explicitOperationId}";
-        }
-
-        var relativePath = api.RelativePath;
-
-        if (string.IsNullOrWhiteSpace(relativePath))
-        {
-            throw new Exception(
-                $"There is no relative path for controller action {api.ActionDescriptor.RouteValues["controller"]}");
-        }
-
-        // Remove the prefixed base path with version, e.g. /umbraco/management/api/v1/tracked-reference/{id} => tracked-reference/{id}
-        var unprefixedRelativePath = OperationIdRegexes
-            .VersionPrefixRegex()
-            .Replace(relativePath, string.Empty);
-
-        // Remove template placeholders, e.g. tracked-reference/{id} => tracked-reference/Id
-        var formattedOperationId = OperationIdRegexes
-            .TemplatePlaceholdersRegex()
-            .Replace(unprefixedRelativePath, m => $"By{m.Groups[1].Value.ToFirstUpper()}");
-
-        // Remove dashes (-) and slashes (/) and convert the following letter to uppercase with
-        // the word "By" in front, e.g. tracked-reference/Id => TrackedReferenceById
-        formattedOperationId = OperationIdRegexes
-            .ToCamelCaseRegex()
-            .Replace(formattedOperationId, m => m.Groups[1].Value.ToUpper());
-
-        //Get map to version attribute
-        string? version = null;
-
-        if (api.ActionDescriptor is ControllerActionDescriptor controllerActionDescriptor)
-        {
-            var versionAttributeValue = controllerActionDescriptor.MethodInfo.GetMapToApiVersionAttributeValue();
-
-            // We only wanna add a version, if it is not the default one.
-            if (string.Equals(versionAttributeValue, defaultVersion.ToString()) == false)
-            {
-                version = versionAttributeValue;
-            }
-        }
-
-        // Return the operation ID with the formatted http method verb in front, e.g. GetTrackedReferenceById
-        return $"{httpMethod}{formattedOperationId.ToFirstUpper()}{version}";
     }
 
     // see https://github.com/domaindrivendev/Swashbuckle.AspNetCore#change-operation-sort-order-eg-for-ui-sorting
     private static string ActionOrderBy(ApiDescription apiDesc)
         => $"{apiDesc.GroupName}_{apiDesc.ActionDescriptor.AttributeRouteInfo?.Template ?? apiDesc.ActionDescriptor.RouteValues["controller"]}_{apiDesc.ActionDescriptor.RouteValues["action"]}_{apiDesc.HttpMethod}";
-
 }

--- a/src/Umbraco.Cms.Api.Common/DependencyInjection/UmbracoBuilderApiExtensions.cs
+++ b/src/Umbraco.Cms.Api.Common/DependencyInjection/UmbracoBuilderApiExtensions.cs
@@ -1,20 +1,9 @@
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.FileProviders;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Options;
-using Microsoft.OpenApi.Models;
-using Swashbuckle.AspNetCore.SwaggerGen;
 using Umbraco.Cms.Api.Common.Configuration;
+using Umbraco.Cms.Api.Common.OpenApi;
 using Umbraco.Cms.Api.Common.Serialization;
-using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Web.Common.ApplicationBuilder;
-using Umbraco.Extensions;
-using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
 
 namespace Umbraco.Cms.Api.Common.DependencyInjection;
 
@@ -25,50 +14,9 @@ public static class UmbracoBuilderApiExtensions
         builder.Services.AddSwaggerGen();
         builder.Services.ConfigureOptions<ConfigureUmbracoSwaggerGenOptions>();
         builder.Services.AddSingleton<IUmbracoJsonTypeInfoResolver, UmbracoJsonTypeInfoResolver>();
-
-        builder.Services.Configure<UmbracoPipelineOptions>(options =>
-        {
-            options.AddFilter(new UmbracoPipelineFilter(
-                "UmbracoApiCommon",
-                applicationBuilder =>
-                {
-
-                },
-                applicationBuilder =>
-                {
-                    IServiceProvider provider = applicationBuilder.ApplicationServices;
-                    IWebHostEnvironment webHostEnvironment = provider.GetRequiredService<IWebHostEnvironment>();
-                    IOptions<SwaggerGenOptions> swaggerGenOptions = provider.GetRequiredService<IOptions<SwaggerGenOptions>>();
-
-
-                    if (!webHostEnvironment.IsProduction())
-                    {
-                        GlobalSettings? settings = provider.GetRequiredService<IOptions<GlobalSettings>>().Value;
-                        IHostingEnvironment hostingEnvironment = provider.GetRequiredService<IHostingEnvironment>();
-                        var umbracoPath = settings.GetBackOfficePath(hostingEnvironment);
-
-                        applicationBuilder.UseSwagger(swaggerOptions =>
-                        {
-                            swaggerOptions.RouteTemplate =
-                                $"{umbracoPath.TrimStart(Constants.CharArrays.ForwardSlash)}/swagger/{{documentName}}/swagger.json";
-                        });
-                        applicationBuilder.UseSwaggerUI(
-                            swaggerUiOptions =>
-                            {
-                                swaggerUiOptions.RoutePrefix = $"{umbracoPath.TrimStart(Constants.CharArrays.ForwardSlash)}/swagger";
-
-                                foreach ((var name, OpenApiInfo? apiInfo) in swaggerGenOptions.Value.SwaggerGeneratorOptions.SwaggerDocs.OrderBy(x=>x.Value.Title))
-                                {
-                                    swaggerUiOptions.SwaggerEndpoint($"{name}/swagger.json", $"{apiInfo.Title}");
-                                }
-                            });
-                    }
-                },
-                applicationBuilder =>
-                {
-
-                }));
-        });
+        builder.Services.AddSingleton<IOperationIdSelector, OperationIdSelector>();
+        builder.Services.AddSingleton<ISchemaIdSelector, SchemaIdSelector>();
+        builder.Services.Configure<UmbracoPipelineOptions>(options => options.AddFilter(new SwaggerRouteTemplatePipelineFilter("UmbracoApiCommon")));
 
         return builder;
     }

--- a/src/Umbraco.Cms.Api.Common/OpenApi/IOperationIdSelector.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/IOperationIdSelector.cs
@@ -1,0 +1,9 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+
+namespace Umbraco.Cms.Api.Common.OpenApi;
+
+public interface IOperationIdSelector
+{
+    string? OperationId(ApiDescription apiDescription, ApiVersioningOptions apiVersioningOptions);
+}

--- a/src/Umbraco.Cms.Api.Common/OpenApi/ISchemaIdSelector.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/ISchemaIdSelector.cs
@@ -1,0 +1,6 @@
+namespace Umbraco.Cms.Api.Common.OpenApi;
+
+public interface ISchemaIdSelector
+{
+    string SchemaId(Type type);
+}

--- a/src/Umbraco.Cms.Api.Common/OpenApi/MimeTypeDocumentFilter.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/MimeTypeDocumentFilter.cs
@@ -5,12 +5,21 @@ using Umbraco.Extensions;
 namespace Umbraco.Cms.Api.Common.OpenApi;
 
 /// <summary>
-/// This filter explicitly removes all other mime types than application/json from the produced OpenAPI document when application/json is accepted.
+/// This filter explicitly removes all other mime types than application/json from a named OpenAPI document when application/json is accepted.
 /// </summary>
 public class MimeTypeDocumentFilter : IDocumentFilter
 {
+    private readonly string _documentName;
+
+    public MimeTypeDocumentFilter(string documentName) => _documentName = documentName;
+
     public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
     {
+        if (context.DocumentName != _documentName)
+        {
+            return;
+        }
+
         OpenApiOperation[] operations = swaggerDoc.Paths
             .SelectMany(path => path.Value.Operations.Values)
             .ToArray();

--- a/src/Umbraco.Cms.Api.Common/OpenApi/OperationIdSelector.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/OperationIdSelector.cs
@@ -1,0 +1,79 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Common.OpenApi;
+
+public class OperationIdSelector : IOperationIdSelector
+{
+    public virtual string? OperationId(ApiDescription apiDescription, ApiVersioningOptions apiVersioningOptions)
+    {
+        if (apiDescription.ActionDescriptor is not ControllerActionDescriptor controllerActionDescriptor
+            || controllerActionDescriptor.ControllerTypeInfo.Namespace?.StartsWith("Umbraco.Cms.Api") is not true)
+        {
+            return null;
+        }
+
+        return UmbracoOperationId(apiDescription, apiVersioningOptions);
+    }
+
+    protected string? UmbracoOperationId(ApiDescription apiDescription, ApiVersioningOptions apiVersioningOptions)
+    {
+        if (apiDescription.ActionDescriptor is not ControllerActionDescriptor controllerActionDescriptor)
+        {
+            return null;
+        }
+
+        ApiVersion defaultVersion = apiVersioningOptions.DefaultApiVersion;
+        var httpMethod = apiDescription.HttpMethod?.ToLower().ToFirstUpper() ?? "Get";
+
+        // if the route info "Name" is supplied we'll use this explicitly as the operation ID
+        // - usage example: [HttpGet("my-api/route}", Name = "MyCustomRoute")]
+        if (string.IsNullOrWhiteSpace(apiDescription.ActionDescriptor.AttributeRouteInfo?.Name) == false)
+        {
+            var explicitOperationId = apiDescription.ActionDescriptor.AttributeRouteInfo!.Name;
+            return explicitOperationId.InvariantStartsWith(httpMethod)
+                ? explicitOperationId
+                : $"{httpMethod}{explicitOperationId}";
+        }
+
+        var relativePath = apiDescription.RelativePath;
+
+        if (string.IsNullOrWhiteSpace(relativePath))
+        {
+            throw new Exception(
+                $"There is no relative path for controller action {apiDescription.ActionDescriptor.RouteValues["controller"]}");
+        }
+
+        // Remove the prefixed base path with version, e.g. /umbraco/management/api/v1/tracked-reference/{id} => tracked-reference/{id}
+        var unprefixedRelativePath = OperationIdRegexes
+            .VersionPrefixRegex()
+            .Replace(relativePath, string.Empty);
+
+        // Remove template placeholders, e.g. tracked-reference/{id} => tracked-reference/Id
+        var formattedOperationId = OperationIdRegexes
+            .TemplatePlaceholdersRegex()
+            .Replace(unprefixedRelativePath, m => $"By{m.Groups[1].Value.ToFirstUpper()}");
+
+        // Remove dashes (-) and slashes (/) and convert the following letter to uppercase with
+        // the word "By" in front, e.g. tracked-reference/Id => TrackedReferenceById
+        formattedOperationId = OperationIdRegexes
+            .ToCamelCaseRegex()
+            .Replace(formattedOperationId, m => m.Groups[1].Value.ToUpper());
+
+        //Get map to version attribute
+        string? version = null;
+
+        var versionAttributeValue = controllerActionDescriptor.MethodInfo.GetMapToApiVersionAttributeValue();
+
+        // We only wanna add a version, if it is not the default one.
+        if (string.Equals(versionAttributeValue, defaultVersion.ToString()) == false)
+        {
+            version = versionAttributeValue;
+        }
+
+        // Return the operation ID with the formatted http method verb in front, e.g. GetTrackedReferenceById
+        return $"{httpMethod}{formattedOperationId.ToFirstUpper()}{version}";
+    }
+}

--- a/src/Umbraco.Cms.Api.Common/OpenApi/SchemaIdSelector.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/SchemaIdSelector.cs
@@ -3,9 +3,12 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Common.OpenApi;
 
-internal static class SchemaIdGenerator
+public class SchemaIdSelector : ISchemaIdSelector
 {
-    public static string Generate(Type type)
+    public virtual string SchemaId(Type type)
+        => type.Namespace?.StartsWith("Umbraco.Cms") is true ? UmbracoSchemaId(type) : type.Name;
+
+    protected string UmbracoSchemaId(Type type)
     {
         string SanitizedTypeName(Type t) => t.Name
             // first grab the "non generic" part of any generic type name (i.e. "PagedViewModel`1" becomes "PagedViewModel")

--- a/src/Umbraco.Cms.Api.Common/OpenApi/SwaggerRouteTemplatePipelineFilter.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/SwaggerRouteTemplatePipelineFilter.cs
@@ -1,0 +1,67 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Web.Common.ApplicationBuilder;
+using Umbraco.Extensions;
+using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
+
+namespace Umbraco.Cms.Api.Common.OpenApi;
+
+public class SwaggerRouteTemplatePipelineFilter : UmbracoPipelineFilter
+{
+    public SwaggerRouteTemplatePipelineFilter(string name)
+        : base(name)
+        => PostPipeline = PostPipelineAction;
+
+    private void PostPipelineAction(IApplicationBuilder applicationBuilder)
+    {
+        if (SwaggerIsEnabled(applicationBuilder) is false)
+        {
+            return;
+        }
+
+        IOptions<SwaggerGenOptions> swaggerGenOptions = applicationBuilder.ApplicationServices.GetRequiredService<IOptions<SwaggerGenOptions>>();
+
+        applicationBuilder.UseSwagger(swaggerOptions =>
+            {
+                swaggerOptions.RouteTemplate = SwaggerRouteTemplate(applicationBuilder);
+            });
+        applicationBuilder.UseSwaggerUI(
+            swaggerUiOptions =>
+            {
+                swaggerUiOptions.RoutePrefix = SwaggerUiRoutePrefix(applicationBuilder);
+
+                foreach ((var name, OpenApiInfo? apiInfo) in swaggerGenOptions.Value.SwaggerGeneratorOptions.SwaggerDocs
+                             .OrderBy(x => x.Value.Title))
+                {
+                    swaggerUiOptions.SwaggerEndpoint($"{name}/swagger.json", $"{apiInfo.Title}");
+                }
+            });
+    }
+
+    protected virtual bool SwaggerIsEnabled(IApplicationBuilder applicationBuilder)
+    {
+        IWebHostEnvironment webHostEnvironment = applicationBuilder.ApplicationServices.GetRequiredService<IWebHostEnvironment>();
+        return webHostEnvironment.IsProduction() is false;
+    }
+
+    protected virtual string SwaggerRouteTemplate(IApplicationBuilder applicationBuilder)
+        => $"{GetUmbracoPath(applicationBuilder).TrimStart(Constants.CharArrays.ForwardSlash)}/swagger/{{documentName}}/swagger.json";
+
+    protected virtual string SwaggerUiRoutePrefix(IApplicationBuilder applicationBuilder)
+        => $"{GetUmbracoPath(applicationBuilder).TrimStart(Constants.CharArrays.ForwardSlash)}/swagger";
+
+    private string GetUmbracoPath(IApplicationBuilder applicationBuilder)
+    {
+        GlobalSettings settings = applicationBuilder.ApplicationServices.GetRequiredService<IOptions<GlobalSettings>>().Value;
+        IHostingEnvironment hostingEnvironment = applicationBuilder.ApplicationServices.GetRequiredService<IHostingEnvironment>();
+
+        return settings.GetBackOfficePath(hostingEnvironment);
+    }
+}

--- a/src/Umbraco.Cms.Api.Delivery/Configuration/ConfigureUmbracoDeliveryApiSwaggerGenOptions.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Configuration/ConfigureUmbracoDeliveryApiSwaggerGenOptions.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
+using Umbraco.Cms.Api.Common.OpenApi;
 
 namespace Umbraco.Cms.Api.Delivery.Configuration;
 
@@ -16,5 +17,7 @@ public class ConfigureUmbracoDeliveryApiSwaggerGenOptions: IConfigureOptions<Swa
                 Title = DeliveryApiConfiguration.ApiTitle,
                 Version = "Latest",
             });
+
+        swaggerGenOptions.DocumentFilter<MimeTypeDocumentFilter>(DeliveryApiConfiguration.ApiName);
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR aims to make the API versioning and Swagger configuration less intrusive than it currently is. With this PR:

- we are no longer forcefully applying operation and schema IDs to custom APIs
- developers can change the location and the availability of the Swagger endpoints and Swagger UI

### Important note

This PR removes the polymorphism configuration from Swagger (specifically [these lines of code](https://github.com/umbraco/Umbraco-CMS/pull/14363/files#diff-76696450bf7a936b8b45695afab30458c063e36e7240724adec3b98233cf3239L57-L75)), because it is not necessary for V12

However, it is crucial for V14. In other words, when merging this to V14, code that is necessary for the new backoffice will likely go missing. @kjac has a local shelveset of the required changes for V14 on hand, so get in touch when merging.

_Note to self: The shelveset is called "API versioning and Swagger options un-intrusive for V14"._

### Testing this PR

Verify that custom APIs no longer are given the Umbraco operation and schema IDs.

Test that it's possible to opt into custom operation and schema IDs - for example by using the following code:

```csharp
using Asp.Versioning;
using Microsoft.AspNetCore.Mvc.ApiExplorer;
using Microsoft.AspNetCore.Mvc.Controllers;
using Umbraco.Cms.Api.Common.OpenApi;

namespace My.Custom.Swagger;

public class MyOperationIdSelector : OperationIdSelector
{
    public override string? OperationId(ApiDescription apiDescription, ApiVersioningOptions apiVersioningOptions)
    {
        // use this if you want to opt into the default Umbraco operation IDs:
        // return UmbracoOperationId(apiDescription, apiVersioningOptions);

        // only handle your own APIs here - make sure to let the base class handle the Umbraco APIs
        if (apiDescription.ActionDescriptor is not ControllerActionDescriptor controllerActionDescriptor
            || controllerActionDescriptor.ControllerTypeInfo.Namespace?.StartsWith("My.Custom.Api") is false)
        {
            return base.OperationId(apiDescription, apiVersioningOptions);
        }

        // build your own logic to generate operation IDs here
        return apiDescription.RelativePath is null
            ? null
            : string.Join(string.Empty, apiDescription.RelativePath.Split(new[] { '/', '-' }).Select(segment => segment.ToFirstUpperInvariant()));
    }
}

public static class MyOperationIdUmbracoBuilderExtensions
{
    public static IUmbracoBuilder ConfigureMyOperationId(this IUmbracoBuilder builder)
    {
        // call this from ConfigureServices() in Startup, i.e.:
        //     services.AddUmbraco(_env, _config)
        //         ...
        //         .ConfigureMyOperationId()
        //         .Build();
        builder.Services.AddSingleton<IOperationIdSelector, MyOperationIdSelector>();
        return builder;
    }
}
```

```csharp
using Umbraco.Cms.Api.Common.OpenApi;

namespace My.Custom.Swagger;

public class MySchemaIdSelector : SchemaIdSelector
{
    public override string SchemaId(Type type)
    {
        // use this if you want to opt into the default Umbraco schema IDs:
        // return UmbracoSchemaId(type);

        // only handle your own types here - make sure to let the base class handle the Umbraco types
        if (type.Namespace?.StartsWith("My.Custom.Api") is false)
        {
            return base.SchemaId(type);
        }

        // build your own logic to generate schema IDs here
        return string.Join(string.Empty, type.FullName!.Replace("My.Custom.Api", string.Empty).Split('.').Reverse());
    }
}

public static class MySchemaIdUmbracoBuilderExtensions
{
    public static IUmbracoBuilder ConfigureMySchemaId(this IUmbracoBuilder builder)
    {
        // call this from ConfigureServices() in Startup, i.e.:
        //     services.AddUmbraco(_env, _config)
        //         ...
        //         .ConfigureMySchemaId()
        //         .Build();
        builder.Services.AddSingleton<ISchemaIdSelector, MySchemaIdSelector>();
        return builder;
    }
}
```

Verify that it's possible to alter the Swagger route and availability - for example by using the following code:

```csharp
using Umbraco.Cms.Api.Common.OpenApi;
using Umbraco.Cms.Web.Common.ApplicationBuilder;

namespace My.Custom.Swagger;

public class MySwaggerRouteTemplatePipelineFilter : SwaggerRouteTemplatePipelineFilter
{
    public MySwaggerRouteTemplatePipelineFilter(string name) : base(name)
    {
    }

    /// <summary>
    /// This is how you change the route template for the Swagger docs.
    /// </summary>
    protected override string SwaggerRouteTemplate(IApplicationBuilder applicationBuilder) => "swagger/{documentName}/swagger.json";

    /// <summary>
    /// This is how you change the route for the Swagger UI.
    /// </summary>
    protected override string SwaggerUiRoutePrefix(IApplicationBuilder applicationBuilder) => "swagger";

    /// <summary>
    /// This is how you configure Swagger to be available always.
    /// Please note that this is NOT recommended.
    /// </summary>
    protected override bool SwaggerIsEnabled(IApplicationBuilder applicationBuilder) => true;
}

public static class MyConfigureSwaggerRouteUmbracoBuilderExtensions
{
    // call this from ConfigureServices() in Startup, i.e.:
    //     services.AddUmbraco(_env, _config)
    //         ...
    //         .ConfigureMySwaggerRoute()
    //         .Build();
    public static IUmbracoBuilder ConfigureMySwaggerRoute(this IUmbracoBuilder builder)
    {
        builder.Services.Configure<UmbracoPipelineOptions>(options =>
        {
            // include this line if you do NOT want the Swagger docs at /umbraco/swagger
            options.PipelineFilters.RemoveAll(filter => filter is SwaggerRouteTemplatePipelineFilter);

            // setup your own Swagger routes
            options.AddFilter(new MySwaggerRouteTemplatePipelineFilter("MyApi"));
        });
        return builder;
    }
}
```

....or get in touch with @kjac who has all the code samples on hand :smile: