### PR TITLE
Make the Delivery API JSON type info resolver un-sealed

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Json/DeliveryApiJsonTypeResolver.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Json/DeliveryApiJsonTypeResolver.cs
@@ -6,8 +6,7 @@ using Umbraco.Cms.Core.Models.DeliveryApi;
 namespace Umbraco.Cms.Api.Delivery.Json;
 
 // see https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/polymorphism?pivots=dotnet-7-0
-// TODO: if this type resolver is to be used for extendable content models (custom IApiContent implementations) we need to work out an extension model for known derived types
-internal sealed class DeliveryApiJsonTypeResolver : DefaultJsonTypeInfoResolver
+public class DeliveryApiJsonTypeResolver : DefaultJsonTypeInfoResolver
 {
     public override JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options)
     {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

At this time, we can't predict if developers will need to add to the Delivery API JSON type info resolver, in order to ensure correct serialization of custom models etc. Therefore I have made the core implementation (`DeliveryApiJsonTypeResolver`) un-sealed, so devs can override it instead of having to re-implement the core type info resolving.

### Testing this PR

1. Create a custom JSON type info resolver based on `DeliveryApiJsonTypeResolver`.
2. Register the custom resolver instead of the core one.
3. Verify that the custom resolver is invoked at runtime when fetching content from the Delivery API - use the debugger and a breakpoint, that's the easiest way 😄 

Here's some code to get the testing going:

```csharp
using System.Text.Json;
using System.Text.Json.Serialization.Metadata;
using Umbraco.Cms.Api.Delivery.Json;
using Umbraco.Cms.Core;
using Umbraco.Cms.Api.Common.DependencyInjection;

namespace Umbraco.Cms.Web.UI.Custom;

public class MyJsonTypeInfoResolver : DeliveryApiJsonTypeResolver
{
    public override JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options)
    {
        // add a breakpoint here to verify that this custom JsonTypeInfoResolver is indeed applied at runtime
        return base.GetTypeInfo(type, options);
    }
}

public static class MyJsonUmbracoBuilderExtensions
{
    public static IUmbracoBuilder ConfigureJson(this IUmbracoBuilder builder)
    {
        builder.Services
            .AddControllers()
            .AddJsonOptions(Constants.JsonOptionsNames.DeliveryApi, options =>
            {
                options.JsonSerializerOptions.TypeInfoResolver = new MyJsonTypeInfoResolver();
            });
        return builder;
    }
}
```

Remember to add `.ConfigureJson()` to `ConfigureServices()` in `Startup` for this code to have any effect.