### PR TITLE
Delivery API: Add query params and headers to Swagger document

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Configuration/ConfigureUmbracoDeliveryApiSwaggerGenOptions.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Configuration/ConfigureUmbracoDeliveryApiSwaggerGenOptions.cs
@@ -19,7 +19,7 @@ public class ConfigureUmbracoDeliveryApiSwaggerGenOptions: IConfigureOptions<Swa
                 Description = $"You can find out more about the Content Delivery API on [our documentation platform]({DeliveryApiConfiguration.ApiDocumentationArticleLink})."
             });
 
-        swaggerGenOptions.OperationFilter<AddCompleteSwaggerDocumentationFilter>();
-        swaggerGenOptions.ParameterFilter<AddCompleteSwaggerDocumentationFilter>();
+        swaggerGenOptions.OperationFilter<CommonSwaggerDocumentationFilter>();
+        swaggerGenOptions.ParameterFilter<CommonSwaggerDocumentationFilter>();
     }
 }

--- a/src/Umbraco.Cms.Api.Delivery/Configuration/ConfigureUmbracoDeliveryApiSwaggerGenOptions.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Configuration/ConfigureUmbracoDeliveryApiSwaggerGenOptions.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
+using Umbraco.Cms.Api.Delivery.Filters;
 
 namespace Umbraco.Cms.Api.Delivery.Configuration;
 
@@ -15,6 +16,10 @@ public class ConfigureUmbracoDeliveryApiSwaggerGenOptions: IConfigureOptions<Swa
             {
                 Title = DeliveryApiConfiguration.ApiTitle,
                 Version = "Latest",
+                Description = $"You can find out more about the Content Delivery API on [our documentation platform]({DeliveryApiConfiguration.ApiDocumentationArticleLink})."
             });
+
+        swaggerGenOptions.OperationFilter<AddCompleteSwaggerDocumentationFilter>();
+        swaggerGenOptions.ParameterFilter<AddCompleteSwaggerDocumentationFilter>();
     }
 }

--- a/src/Umbraco.Cms.Api.Delivery/Configuration/ConfigureUmbracoDeliveryApiSwaggerGenOptions.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Configuration/ConfigureUmbracoDeliveryApiSwaggerGenOptions.cs
@@ -16,10 +16,10 @@ public class ConfigureUmbracoDeliveryApiSwaggerGenOptions: IConfigureOptions<Swa
             {
                 Title = DeliveryApiConfiguration.ApiTitle,
                 Version = "Latest",
-                Description = $"You can find out more about the Content Delivery API on [our documentation platform]({DeliveryApiConfiguration.ApiDocumentationArticleLink})."
+                Description = $"You can find out more about the {DeliveryApiConfiguration.ApiTitle} in [the documentation]({DeliveryApiConfiguration.ApiDocumentationArticleLink})."
             });
 
-        swaggerGenOptions.OperationFilter<CommonSwaggerDocumentationFilter>();
-        swaggerGenOptions.ParameterFilter<CommonSwaggerDocumentationFilter>();
+        swaggerGenOptions.OperationFilter<SwaggerDocumentationFilter>();
+        swaggerGenOptions.ParameterFilter<SwaggerDocumentationFilter>();
     }
 }

--- a/src/Umbraco.Cms.Api.Delivery/Configuration/DeliveryApiConfiguration.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Configuration/DeliveryApiConfiguration.cs
@@ -5,4 +5,6 @@ internal static class DeliveryApiConfiguration
     internal const string ApiTitle = "Umbraco Delivery API";
 
     internal const string ApiName = "delivery";
+
+    internal const string ApiDocumentationArticleLink = "https://docs.umbraco.com/umbraco-cms/v/12.latest/reference/content-delivery-api";
 }

--- a/src/Umbraco.Cms.Api.Delivery/Filters/CommonSwaggerDocumentationFilter.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Filters/CommonSwaggerDocumentationFilter.cs
@@ -1,0 +1,157 @@
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using Umbraco.Cms.Api.Delivery.Configuration;
+
+namespace Umbraco.Cms.Api.Delivery.Filters;
+
+public class AddCompleteSwaggerDocumentationFilter : IOperationFilter, IParameterFilter
+{
+    private const string DocumentationReference =
+        $"*For more information, see the [Query parameters]({DeliveryApiConfiguration.ApiDocumentationArticleLink}#query-parameters) section in our dedicated documentation article.*";
+
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        operation.Parameters ??= new List<OpenApiParameter>();
+
+        operation.Parameters.Add(new OpenApiParameter
+        {
+            Name = "expand",
+            In = ParameterLocation.Query,
+            Required = false,
+            Description = DocumentationReference,
+            Schema = new OpenApiSchema { Type = "String" },
+            Examples = new Dictionary<string, OpenApiExample>
+            {
+                { "Expand none", new OpenApiExample { Value = new OpenApiString("") } },
+                { "Expand all", new OpenApiExample { Value = new OpenApiString("all") } },
+                {
+                    "Expand specific property",
+                    new OpenApiExample { Value = new OpenApiString("property:alias1") }
+                },
+                {
+                    "Expand specific properties",
+                    new OpenApiExample { Value = new OpenApiString("property:alias1,alias2") }
+                }
+            }
+        });
+    }
+
+    public void Apply(OpenApiParameter parameter, ParameterFilterContext context)
+    {
+        switch (parameter.Name)
+        {
+            case "fetch":
+                AddQueryParameterDocumentation(parameter, FetchQueryParameterExamples());
+                break;
+            case "filter":
+                AddQueryParameterDocumentation(parameter, FilterQueryParameterExamples());
+                break;
+            case "sort":
+                AddQueryParameterDocumentation(parameter, SortQueryParameterExamples());
+                break;
+            default:
+                return;
+        }
+    }
+
+    private void AddQueryParameterDocumentation(OpenApiParameter parameter, Dictionary<string, OpenApiExample> examples)
+    {
+        parameter.Description = DocumentationReference;
+        parameter.Examples = examples;
+    }
+
+    private Dictionary<string, OpenApiExample> FetchQueryParameterExamples() =>
+        new()
+        {
+            { "Select all", new OpenApiExample { Value = new OpenApiString("") } },
+            {
+                "Select all ancestors of a node by id",
+                new OpenApiExample { Value = new OpenApiString("ancestors:id") }
+            },
+            {
+                "Select all ancestors of a node by path",
+                new OpenApiExample { Value = new OpenApiString("ancestors:path") }
+            },
+            {
+                "Select all children of a node by id",
+                new OpenApiExample { Value = new OpenApiString("children:id") }
+            },
+            {
+                "Select all children of a node by path",
+                new OpenApiExample { Value = new OpenApiString("children:path") }
+            },
+            {
+                "Select all descendants of a node by id",
+                new OpenApiExample { Value = new OpenApiString("descendants:id") }
+            },
+            {
+                "Select all descendants of a node by path",
+                new OpenApiExample { Value = new OpenApiString("descendants:path") }
+            }
+        };
+
+    private Dictionary<string, OpenApiExample> FilterQueryParameterExamples() =>
+        new()
+        {
+            { "Default filter", new OpenApiExample { Value = new OpenApiString("") } },
+            {
+                "Filter by content type",
+                new OpenApiExample { Value = new OpenApiArray { new OpenApiString("contentType:alias1") } }
+            },
+            {
+                "Filter by name",
+                new OpenApiExample { Value = new OpenApiArray { new OpenApiString("name:nodeName") } }
+            }
+        };
+
+    private Dictionary<string, OpenApiExample> SortQueryParameterExamples() =>
+        new()
+        {
+            { "Default sort", new OpenApiExample { Value = new OpenApiString("") } },
+            {
+                "Sort by create date",
+                new OpenApiExample
+                {
+                    Value = new OpenApiArray
+                    {
+                        new OpenApiString("createDate:asc"), new OpenApiString("createDate:desc")
+                    }
+                }
+            },
+            {
+                "Sort by level",
+                new OpenApiExample
+                {
+                    Value = new OpenApiArray { new OpenApiString("level:asc"), new OpenApiString("level:desc") }
+                }
+            },
+            {
+                "Sort by name",
+                new OpenApiExample
+                {
+                    Value = new OpenApiArray { new OpenApiString("name:asc"), new OpenApiString("name:desc") }
+                }
+            },
+            {
+                "Sort by sort order",
+                new OpenApiExample
+                {
+                    Value = new OpenApiArray
+                    {
+                        new OpenApiString("sortOrder:asc"), new OpenApiString("sortOrder:desc")
+                    }
+                }
+            },
+            {
+                "Sort by update date",
+                new OpenApiExample
+                {
+                    Value = new OpenApiArray
+                    {
+                        new OpenApiString("updateDate:asc"), new OpenApiString("updateDate:desc")
+                    }
+                }
+            }
+        };
+}

--- a/src/Umbraco.Cms.Api.Delivery/Filters/CommonSwaggerDocumentationFilter.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Filters/CommonSwaggerDocumentationFilter.cs
@@ -5,7 +5,7 @@ using Umbraco.Cms.Api.Delivery.Configuration;
 
 namespace Umbraco.Cms.Api.Delivery.Filters;
 
-public class AddCompleteSwaggerDocumentationFilter : IOperationFilter, IParameterFilter
+public class CommonSwaggerDocumentationFilter : IOperationFilter, IParameterFilter
 {
     private const string DocumentationReference =
         $"*For more information, see the [Query parameters]({DeliveryApiConfiguration.ApiDocumentationArticleLink}#query-parameters) section in our dedicated documentation article.*";

--- a/src/Umbraco.Cms.Api.Delivery/Filters/CommonSwaggerDocumentationFilter.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Filters/CommonSwaggerDocumentationFilter.cs
@@ -20,7 +20,7 @@ public class AddCompleteSwaggerDocumentationFilter : IOperationFilter, IParamete
             In = ParameterLocation.Query,
             Required = false,
             Description = DocumentationReference,
-            Schema = new OpenApiSchema { Type = "String" },
+            Schema = new OpenApiSchema { Type = "string" },
             Examples = new Dictionary<string, OpenApiExample>
             {
                 { "Expand none", new OpenApiExample { Value = new OpenApiString("") } },
@@ -34,6 +34,46 @@ public class AddCompleteSwaggerDocumentationFilter : IOperationFilter, IParamete
                     new OpenApiExample { Value = new OpenApiString("property:alias1,alias2") }
                 }
             }
+        });
+
+        operation.Parameters.Add(new OpenApiParameter
+        {
+            Name = "Accept-Language",
+            In = ParameterLocation.Header,
+            Required = false,
+            Schema = new OpenApiSchema { Type = "string" },
+            Examples = new Dictionary<string, OpenApiExample>
+            {
+                { "Default", new OpenApiExample { Value = new OpenApiString("") } },
+                { "English culture", new OpenApiExample { Value = new OpenApiString("en-us") } }
+            }
+        });
+
+        operation.Parameters.Add(new OpenApiParameter
+        {
+            Name = "Api-Key",
+            In = ParameterLocation.Header,
+            Required = false,
+            Description = "API key specified through configuration to authorize access to the API.",
+            Schema = new OpenApiSchema { Type = "string" }
+        });
+
+        operation.Parameters.Add(new OpenApiParameter
+        {
+            Name = "Preview",
+            In = ParameterLocation.Header,
+            Required = false,
+            Description = "Whether to request draft content.",
+            Schema = new OpenApiSchema { Type = "boolean" }
+        });
+
+        operation.Parameters.Add(new OpenApiParameter
+        {
+            Name = "Start-Item",
+            In = ParameterLocation.Header,
+            Required = false,
+            Description = "URL segment or GUID of a root content item.",
+            Schema = new OpenApiSchema { Type = "string" }
         });
     }
 

--- a/src/Umbraco.Cms.Api.Delivery/Filters/SwaggerDocumentationFilter.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Filters/SwaggerDocumentationFilter.cs
@@ -5,11 +5,8 @@ using Umbraco.Cms.Api.Delivery.Configuration;
 
 namespace Umbraco.Cms.Api.Delivery.Filters;
 
-public class CommonSwaggerDocumentationFilter : IOperationFilter, IParameterFilter
+public class SwaggerDocumentationFilter : IOperationFilter, IParameterFilter
 {
-    private const string DocumentationReference =
-        $"*For more information, see the [Query parameters]({DeliveryApiConfiguration.ApiDocumentationArticleLink}#query-parameters) section in our dedicated documentation article.*";
-
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
     {
         operation.Parameters ??= new List<OpenApiParameter>();
@@ -19,7 +16,7 @@ public class CommonSwaggerDocumentationFilter : IOperationFilter, IParameterFilt
             Name = "expand",
             In = ParameterLocation.Query,
             Required = false,
-            Description = DocumentationReference,
+            Description = QueryParameterDescription("Defines the properties that should be expanded in the response"),
             Schema = new OpenApiSchema { Type = "string" },
             Examples = new Dictionary<string, OpenApiExample>
             {
@@ -41,6 +38,7 @@ public class CommonSwaggerDocumentationFilter : IOperationFilter, IParameterFilt
             Name = "Accept-Language",
             In = ParameterLocation.Header,
             Required = false,
+            Description = "Defines the language to return. Use this when querying language variant content items.",
             Schema = new OpenApiSchema { Type = "string" },
             Examples = new Dictionary<string, OpenApiExample>
             {
@@ -82,22 +80,33 @@ public class CommonSwaggerDocumentationFilter : IOperationFilter, IParameterFilt
         switch (parameter.Name)
         {
             case "fetch":
-                AddQueryParameterDocumentation(parameter, FetchQueryParameterExamples());
+                AddQueryParameterDocumentation(parameter, FetchQueryParameterExamples(), "Specifies the content items to fetch");
                 break;
             case "filter":
-                AddQueryParameterDocumentation(parameter, FilterQueryParameterExamples());
+                AddQueryParameterDocumentation(parameter, FilterQueryParameterExamples(), "Defines how to filter the fetched content items");
                 break;
             case "sort":
-                AddQueryParameterDocumentation(parameter, SortQueryParameterExamples());
+                AddQueryParameterDocumentation(parameter, SortQueryParameterExamples(), "Defines how to sort the found content items");
+                break;
+            case "skip":
+                parameter.Description = PaginationDescription(true);
+                break;
+            case "take":
+                parameter.Description = PaginationDescription(false);
                 break;
             default:
                 return;
         }
     }
 
-    private void AddQueryParameterDocumentation(OpenApiParameter parameter, Dictionary<string, OpenApiExample> examples)
+    private string QueryParameterDescription(string description)
+        => $"{description}. Refer to [the documentation]({DeliveryApiConfiguration.ApiDocumentationArticleLink}#query-parameters) for more details on this.";
+
+    private string PaginationDescription(bool skip) => $"Specifies the number of found content items to {(skip ? "skip" : "take")}. Use this to control pagination of the response.";
+
+    private void AddQueryParameterDocumentation(OpenApiParameter parameter, Dictionary<string, OpenApiExample> examples, string description)
     {
-        parameter.Description = DocumentationReference;
+        parameter.Description = QueryParameterDescription(description);
         parameter.Examples = examples;
     }
 


### PR DESCRIPTION
## Details
- Adding missing query params and optional headers;
- Adding descriptions to params - links to our documentation;
- Adding examples to all our query params to showcase the build-in options.

Overall, making it easier for people to get started using the Delivery API through Swagger.

## Test
- Test our endpoints using Swagger;
- Make sure that you still get the correct response when executing `/content` with the newly set default values of params - just press "Try it out" and then "Execute" 😅 ; 
- Try using the examples for our query parameters or headers and make sure the responses from the API are correct;
- Try importing the collection in Postman (from **swagger.json** file in Swagger) and verify that the query params and headers are correctly added (_don't be surprised if you get lorem ipsum or `<string>` values for those or 2 filters and 2 sort params - this is how Postman works_).