### PR TITLE
Fix/delete language error message 14333

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -488,7 +488,7 @@
     <key alias="insertlink">Insert link</key>
     <key alias="insertMacro">Click to add a Macro</key>
     <key alias="inserttable">Insert table</key>
-    <key alias="languagedeletewarning">This will delete the language</key>
+    <key alias="languagedeletewarning">This will delete the language and all content related to the language</key>
     <key alias="languageChangeWarning">Changing the culture for a language may be an expensive operation and will result
       in the content cache and indexes being rebuilt
     </key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -503,7 +503,7 @@
     <key alias="insertlink">Insert link</key>
     <key alias="insertMacro">Click to add a Macro</key>
     <key alias="inserttable">Insert table</key>
-    <key alias="languagedeletewarning">This will delete the language</key>
+    <key alias="languagedeletewarning">This will delete the language and all content related to the language</key>
     <key alias="languageChangeWarning">Changing the culture for a language may be an expensive operation and will result
       in the content cache and indexes being rebuilt
     </key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/hr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/hr.xml
@@ -479,7 +479,7 @@
     <key alias="insertlink">Umetni link</key>
     <key alias="insertMacro">Klikni za dodavanje makro</key>
     <key alias="inserttable">Umetni tablicu</key>
-    <key alias="languagedeletewarning">Ovo će obrisati jezik</key>
+    <key alias="languagedeletewarning">Ovo će izbrisati jezik i sav sadržaj povezan s jezikom</key>
     <key alias="languageChangeWarning">Promjena kulture jezika može biti skupa operacija i rezultirat će promjenama u predmemoriji sadržaja i indeksima koji se rekonstruiraju
     </key>
     <key alias="lastEdited">Zadnje uređivano</key>

--- a/src/Umbraco.Web.BackOffice/EmbeddedResources/Tours/getting-started.json
+++ b/src/Umbraco.Web.BackOffice/EmbeddedResources/Tours/getting-started.json
@@ -146,7 +146,7 @@
       {
         "element": "#dialog [data-element='action-documentType']",
         "title": "Create Document Type",
-        "content": "<p>Click <b>Document Type</b> to create a new document type with a template. The template will be automatically created and set as the default template for this Document Type.</p><p>You will use the template in a later tour to render content.</p>",
+        "content": "<p>Click <b>Document Type with Template</b> to create a new document type with a template. The template will be automatically created and set as the default template for this Document Type.</p><p>You will use the template in a later tour to render content.</p>",
         "event": "click"
       },
       {
@@ -197,8 +197,8 @@
       },
       {
         "element": "[data-element~='editor-property-settings'] [data-element='editor-add']",
-        "title": "Add editor",
-        "content": "When you add an editor you choose what the input method for this property will be. Click <b>Add editor</b> to open the editor picker dialog.",
+        "title": "Select editor",
+        "content": "When you select an editor you choose what the input method for this property will be. Click <b>Select editor</b> to open the editor picker dialog.",
         "event": "click"
       },
       {

--- a/src/Umbraco.Web.UI.Client/src/views/languages/overlays/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/languages/overlays/delete.html
@@ -1,7 +1,7 @@
 <div>
 
     <div ng-if="model.language" class="umb-alert umb-alert--warning mb2">
-        <localize key="defaultdialogs_languagedeletewarning">This will delete the language</localize> <strong>{{model.language.name}} [{{model.language.culture}}]</strong>.
+      <localize key="defaultdialogs_languagedeletewarning">This will delete the language and all content related to the language</localize> <strong>{{model.language.name}} [{{model.language.culture}}]</strong>.
     </div>
 
     <localize key="defaultdialogs_confirmdelete">Are you sure you want to delete</localize>?


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #14333 

### Description
Try to delete a language and see the warning message

Added extra information to the delete language warning to inform the user that it will also delete all content related to the language