### PR TITLE
Add ContentDeletingNotification to EmptyRecycleBin

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -36,20 +36,20 @@ public class ContentService : RepositoryService, IContentService
 
     #region Constructors
 
-        public ContentService(
-        ICoreScopeProvider provider,
-        ILoggerFactory loggerFactory,
-        IEventMessagesFactory eventMessagesFactory,
-        IDocumentRepository documentRepository,
-        IEntityRepository entityRepository,
-        IAuditRepository auditRepository,
-        IContentTypeRepository contentTypeRepository,
-        IDocumentBlueprintRepository documentBlueprintRepository,
-        ILanguageRepository languageRepository,
-        Lazy<IPropertyValidationService> propertyValidationService,
-        IShortStringHelper shortStringHelper,
-        ICultureImpactFactory cultureImpactFactory)
-        : base(provider, loggerFactory, eventMessagesFactory)
+    public ContentService(
+    ICoreScopeProvider provider,
+    ILoggerFactory loggerFactory,
+    IEventMessagesFactory eventMessagesFactory,
+    IDocumentRepository documentRepository,
+    IEntityRepository entityRepository,
+    IAuditRepository auditRepository,
+    IContentTypeRepository contentTypeRepository,
+    IDocumentBlueprintRepository documentBlueprintRepository,
+    ILanguageRepository languageRepository,
+    Lazy<IPropertyValidationService> propertyValidationService,
+    IShortStringHelper shortStringHelper,
+    ICultureImpactFactory cultureImpactFactory)
+    : base(provider, loggerFactory, eventMessagesFactory)
     {
         _documentRepository = documentRepository;
         _entityRepository = entityRepository;
@@ -59,7 +59,7 @@ public class ContentService : RepositoryService, IContentService
         _languageRepository = languageRepository;
         _propertyValidationService = propertyValidationService;
         _shortStringHelper = shortStringHelper;
-            _cultureImpactFactory = cultureImpactFactory;
+        _cultureImpactFactory = cultureImpactFactory;
         _logger = loggerFactory.CreateLogger<ContentService>();
     }
 
@@ -1158,7 +1158,7 @@ public class ContentService : RepositoryService, IContentService
             // if culture is '*', then publish them all (including variants)
 
             // this will create the correct culture impact even if culture is * or null
-                var impact = _cultureImpactFactory.Create(culture, IsDefaultCulture(allLangs, culture), content);
+            var impact = _cultureImpactFactory.Create(culture, IsDefaultCulture(allLangs, culture), content);
 
             // publish the culture(s)
             // we don't care about the response here, this response will be rechecked below but we need to set the culture info values now.
@@ -1845,7 +1845,7 @@ public class ContentService : RepositoryService, IContentService
 
                         // publish the culture values and validate the property values, if validation fails, log the invalid properties so the develeper has an idea of what has failed
                         IProperty[]? invalidProperties = null;
-                            var impact = _cultureImpactFactory.ImpactExplicit(culture, IsDefaultCulture(allLangs.Value, culture));
+                        var impact = _cultureImpactFactory.ImpactExplicit(culture, IsDefaultCulture(allLangs.Value, culture));
                         var tryPublish = d.PublishCulture(impact) &&
                                          _propertyValidationService.Value.IsPropertyDataValid(d, out invalidProperties, impact);
                         if (invalidProperties != null && invalidProperties.Length > 0)
@@ -1929,14 +1929,14 @@ public class ContentService : RepositoryService, IContentService
         {
             return culturesToPublish.All(culture =>
             {
-                    var impact = _cultureImpactFactory.Create(culture, IsDefaultCulture(allLangs, culture), content);
+                var impact = _cultureImpactFactory.Create(culture, IsDefaultCulture(allLangs, culture), content);
                 return content.PublishCulture(impact) &&
                        _propertyValidationService.Value.IsPropertyDataValid(content, out _, impact);
             });
         }
 
-            return content.PublishCulture(_cultureImpactFactory.ImpactInvariant())
-                   && _propertyValidationService.Value.IsPropertyDataValid(content, out _, _cultureImpactFactory.ImpactInvariant());
+        return content.PublishCulture(_cultureImpactFactory.ImpactInvariant())
+               && _propertyValidationService.Value.IsPropertyDataValid(content, out _, _cultureImpactFactory.ImpactInvariant());
     }
 
     // utility 'ShouldPublish' func used by SaveAndPublishBranch
@@ -2434,7 +2434,7 @@ public class ContentService : RepositoryService, IContentService
     /// <param name="userId">Optional Id of the User moving the Content</param>
     public void Move(IContent content, int parentId, int userId = Constants.Security.SuperUserId)
     {
-        if(content.ParentId == parentId)
+        if (content.ParentId == parentId)
         {
             return;
         }
@@ -2951,7 +2951,7 @@ public class ContentService : RepositoryService, IContentService
         {
             scope.Notifications.Publish(new ContentPublishedNotification(published, eventMessages));
         }
-        
+
         return OperationResult.Succeed(eventMessages);
     }
 

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -2585,7 +2585,8 @@ public class ContentService : RepositoryService, IContentService
             IContent[] contents = _documentRepository.Get(query).ToArray();
 
             var emptyingRecycleBinNotification = new ContentEmptyingRecycleBinNotification(contents, eventMessages);
-            if (scope.Notifications.PublishCancelable(emptyingRecycleBinNotification))
+            var deletingContentNotification = new ContentDeletingNotification(contents, eventMessages);
+            if (scope.Notifications.PublishCancelable(emptyingRecycleBinNotification) || scope.Notifications.PublishCancelable(deletingContentNotification))
             {
                 scope.Complete();
                 return OperationResult.Cancel(eventMessages);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #14380

### Description
Adds the `ContentDeletingNotification` to `ContentService.EmptyRecycleBin()`.

To test:

1. Implement simple notification handler with composer like this:

```public class TestComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.AddNotificationHandler<ContentDeletingNotification, ContentDeletingNotificationHandler>();
    }
}

public class ContentDeletingNotificationHandler : INotificationHandler<ContentDeletingNotification>
{
    public void Handle(ContentDeletingNotification notification)
    {
        notification.Cancel = true;
    }
}
```
2. Create a new node.
3. Delete a node (move to the Recycle Bin).
4. Empty the Recycle Bin.

Expected result:

The `ContentDeletingNotification` should be triggered, and no nodes should be deleted, because we've cancelled the operation.

N.B. This highlights a separate bug whereby the notification says the recycle bin is empty even though it isn't.
