### PR TITLE
Updated the IsoDateTimeConverter initialization in the JsonDateTimeFo…

### DIFF
--- a/src/Umbraco.Web.Common/Filters/JsonDateTimeFormatAttribute.cs
+++ b/src/Umbraco.Web.Common/Filters/JsonDateTimeFormatAttribute.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Globalization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Options;
@@ -42,7 +43,7 @@ public sealed class JsonDateTimeFormatAttribute : TypeFilterAttribute
             {
                 var serializerSettings = new JsonSerializerSettings();
                 serializerSettings.Converters.Add(
-                    new IsoDateTimeConverter { DateTimeFormat = _format });
+                    new IsoDateTimeConverter { DateTimeFormat = _format, Culture = CultureInfo.InvariantCulture });
                 objectResult.Formatters.Clear();
                 objectResult.Formatters.Add(
                     new AngularJsonMediaTypeFormatter(serializerSettings, _arrayPool, _options));


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fix for issue [14306](https://github.com/umbraco/Umbraco-CMS/issues/14306)

### Description
Updated the IsoDateTimeConverter initialization in the JsonDateTimeFormatAttribute to set the Culture to InvariantCulture so that the custom DateTime format symbols ( date and time separators) are respected independent of the CurrentCulture being used.

This can be tested by setting the back office language to Danish ("da-DK") and inspecting the response of the Get By Id API (/umbraco/backoffice/umbracoapi/content/GetById?id={node id}). Previously any date time properties were being serialized having . as time separator (example: 13.25.00) and now are being serialized with the format defined in the JsonDateTimeFormatFilter ("yyyy-MM-dd HH:mm:ss")


