### PR TITLE
Fixed typo "optinal" to "optional" for translation dictionary import dialog

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/de.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/de.xml
@@ -2059,7 +2059,7 @@
     <key alias="usergroup">Benutzergruppe</key>
     <key alias="userInvited">wurde eingeladen</key>
     <key alias="userInvitedSuccessHelp">Eine Einladung mit Anweisungen zur Anmeldung im Umbraco-Back-Office wurde dem neuen Benutzer zugeschickt.</key>
-    <key alias="userinviteWelcomeMessage">Hallo und Willkommen bei Umbraco! In nur einer Minute sind Sie bereit loszulegen, Sie müssen nur ein Kennwort festlegen und optinal Ihrem Avatar ein Bild hinzufügen.</key>
+    <key alias="userinviteWelcomeMessage">Hallo und Willkommen bei Umbraco! In nur einer Minute sind Sie bereit loszulegen, Sie müssen nur ein Kennwort festlegen und optional Ihrem Avatar ein Bild hinzufügen.</key>
     <key alias="userinviteExpiredMessage">Willkommen bei Umbraco! Bedauerlicherweise ist Ihre Einladung verfallen. Bitte kontaktieren Sie Ihren Administrator und bitten Sie ihn, diese erneut zu schicken.</key>
     <key alias="userinviteAvatarMessage">Laden Sie ein Foto von sich hoch, um es anderen Benutzern zu erleichtern, sie zu erkennen. Klicken Sie auf den Kreis oben, um Ihr Foto hochzuladen.</key>
     <key alias="writer">Autor</key>

--- a/src/Umbraco.Web.UI.Client/lib/markdown/markdown.editor.js
+++ b/src/Umbraco.Web.UI.Client/lib/markdown/markdown.editor.js
@@ -1,4 +1,4 @@
-﻿// needs Markdown.Converter.js at the moment
+// needs Markdown.Converter.js at the moment
 
 (function () {
 
@@ -1590,7 +1590,7 @@
     };
 
     // takes the line as entered into the add link/as image dialog and makes
-    // sure the URL and the optinal title are "nice".
+    // sure the URL and the optional title are "nice".
     function properlyEncoded(linkdef) {
         return linkdef.replace(/^\s*(.*?)(?:\s+"(.+)")?\s*$/, function (wholematch, link, title) {
             link = link.replace(/\?.*$/, function (querypart) {

--- a/src/Umbraco.Web.UI.Client/src/views/dictionary/import.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dictionary/import.html
@@ -43,7 +43,7 @@
               <localize key="actions_chooseWhereToImport">Chose where to import</localize>
               <localize key="dictionaryListCaption">dictionary items</localize>.
             </strong>
-            (optinal)
+            (optional)
           </p>
 
           <umb-tree section="translation"


### PR DESCRIPTION
Fixed typo "optinal" to "optional" for translation dictionary import dialog and 2 other occurrences.

If there's an existing issue for this PR then this fixes #14401 

### Description

Using the Translation Dictionary import dialog, I noticed a small typo, the word in brackets should be "optional".

Searching the code, I found two other occurrences of the typo "optinal", so I have fixed those two also. I happen to be German, so I can confirm that the fix for the German translation file is correct.

Steps to confirm

- Go to Translation section (enable section for your user type if not enabled)
- Click the meatball icon (...) and select Import
- Select a file
- On the second page of the dialog, note the text in the brackets is corrected: "**Choose where to import dictionary items.** (optional)"

