### PR TITLE
Show SVG icons for toolbar in configuration of richtext editor

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/RichTextEditorSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/RichTextEditorSettings.cs
@@ -115,18 +115,18 @@ public class RichTextEditorSettings
         new Dictionary<string, string> { ["entity_encoding"] = "raw" };
 
     /// <summary>
-    ///     HTML RichText Editor TinyMCE Commands
+    ///     HTML RichText Editor TinyMCE Commands.
     /// </summary>
     /// WB-TODO Custom Array of objects
     public RichTextEditorCommand[] Commands { get; set; } = Default_commands;
 
     /// <summary>
-    ///     HTML RichText Editor TinyMCE Plugins
+    ///     HTML RichText Editor TinyMCE Plugins.
     /// </summary>
     public string[] Plugins { get; set; } = Default_plugins;
 
     /// <summary>
-    ///     HTML RichText Editor TinyMCE Custom Config
+    ///     HTML RichText Editor TinyMCE Custom Config.
     /// </summary>
     /// WB-TODO Custom Dictionary
     public IDictionary<string, string> CustomConfig { get; set; } = Default_custom_config;
@@ -137,7 +137,7 @@ public class RichTextEditorSettings
     public string ValidElements { get; set; } = StaticValidElements;
 
     /// <summary>
-    ///     Invalid HTML elements for RichText Editor
+    ///     Invalid HTML elements for RichText Editor.
     /// </summary>
     [DefaultValue(StaticInvalidElements)]
     public string InvalidElements { get; set; } = StaticInvalidElements;

--- a/src/Umbraco.Web.UI.Client/src/less/main.less
+++ b/src/Umbraco.Web.UI.Client/src/less/main.less
@@ -354,20 +354,25 @@ label:not([for]) {
   margin: 0 !important;
 }
 
+.controls > .vertical-align-items,
 .controls-row > .vertical-align-items {
   display: flex;
   align-items: center;
 }
 
+.controls > .vertical-align-items > input.umb-property-editor-tiny,
+.controls > .vertical-align-items > input.umb-property-editor-small,
 .controls-row > .vertical-align-items > input.umb-property-editor-tiny,
 .controls-row > .vertical-align-items > input.umb-property-editor-small {
-    margin-left: 5px;
-    margin-right: 5px;
+  margin-left: 5px;
+  margin-right: 5px;
 }
 
+.controls > .vertical-align-items > input.umb-property-editor-tiny:first-child
+.controls > .vertical-align-items > input.umb-property-editor-small:first-child,
 .controls-row > .vertical-align-items > input.umb-property-editor-tiny:first-child
 .controls-row > .vertical-align-items > input.umb-property-editor-small:first-child {
-    margin-left: 0;
+  margin-left: 0;
 }
 
 .thumbnails .selected {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
@@ -1,12 +1,12 @@
 angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
-    function ($scope, $timeout, $log, tinyMceService, stylesheetResource, assetsService) {
+    function ($scope, $sce, tinyMceService, stylesheetResource, assetsService) {
         var cfg = tinyMceService.defaultPrevalues();
 
-        if($scope.model.value){
-            if(Utilities.isString($scope.model.value)){
+        if($scope.model.value) {
+            if (Utilities.isString($scope.model.value)){
                 $scope.model.value = cfg;
             }
-        }else{
+        }else {
             $scope.model.value = cfg;
         }
 
@@ -27,14 +27,15 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
             $scope.model.value.mode = 'inline';
         }
 
-        tinyMceService.configuration().then(function(config){
-            $scope.tinyMceConfig = config;
-
+        tinyMceService.configuration().then(config => {
+          $scope.tinyMceConfig = config;
+            
             // extend commands with properties for font-icon and if it is a custom command
-            $scope.tinyMceConfig.commands = _.map($scope.tinyMceConfig.commands, function (obj) {
-                var icon = getFontIcon(obj.alias);
+            $scope.tinyMceConfig.commands = _.map($scope.tinyMceConfig.commands, obj => {
+                const icon = getIcon(obj.alias);
+                console.log("icon", icon);
 
-                var objCmd = Utilities.extend(obj, {
+                const objCmd = Utilities.extend(obj, {
                     fontIcon: icon.name,
                     isCustom: icon.isCustom,
                     selected: $scope.model.value.toolbar.indexOf(obj.alias) >= 0,
@@ -43,9 +44,79 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
 
                 return objCmd;
             });
+
+            assetsService.loadJs("lib/tinymce/icons/default/icons.js", $scope).then(() => {
+                const icons = tinymce.IconManager.get('default').icons;
+                const parser = new DOMParser();
+
+                Utilities.forEach($scope.tinyMceConfig.commands, cmd => {
+
+                  console.log("cmd", cmd);
+
+                  let icon = cmd.alias;
+
+                  switch (cmd.alias) {
+                    case "ace":
+                      icon = "sourcecode";
+                      break;
+                    case "anchor":
+                      icon = "bookmark";
+                      break;
+                    case "alignleft":
+                      icon = "align-left";
+                      break;
+                    case "aligncenter":
+                      icon = "align-center";
+                      break;
+                    case "alignright":
+                      icon = "align-right";
+                      break;
+                    case "alignjustify":
+                      icon = "align-justify";
+                      break;
+                    case "charmap":
+                      icon = "insert-character";
+                      break;
+                    case "hr":
+                      icon = "horizontal-rule";
+                      break;
+                    case "bullist":
+                      icon = "unordered-list";
+                      break;
+                    case "numlist":
+                      icon = "ordered-list";
+                      break;
+                    case "strikethrough":
+                      icon = "strike-through";
+                      break;
+                    case "removeformat":
+                      icon = "remove-formatting";
+                      break;
+                    case "forecolor":
+                      icon = "text-color";
+                      break;
+                    case "hilitecolor":
+                      icon = "highlight-bg-color";
+                      break;
+                  }
+
+                  if (!cmd.isCustom && icons.hasOwnProperty(icon)) {
+                    const svg = icons[icon];
+                    const frag = parser.parseFromString(svg, 'text/html').body.childNodes[0];
+                    const width = frag.getAttribute("width");
+                    const height = frag.getAttribute("height");
+
+                    frag.setAttribute("viewbox", `0 0 ${width} ${height}`);
+                    cmd.svgIcon = $sce.trustAsHtml(frag.outerHTML);
+                    cmd.icon = null;
+                  }
+
+                });
+            });
+            
         });
 
-        stylesheetResource.getAll().then(function(stylesheets){
+        stylesheetResource.getAll().then(stylesheets => {
             $scope.stylesheets = stylesheets;
 
             // if the CSS directory changes, previously assigned stylesheets are retained, but will not be visible
@@ -63,14 +134,14 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
         $scope.selectCommand = function(command){
             var index = $scope.model.value.toolbar.indexOf(command.alias);
 
-            if(command.selected && index === -1){
+            if (command.selected && index === -1){
                 $scope.model.value.toolbar.push(command.alias);
-            }else if(index >= 0){
+            }else if (index >= 0){
                 $scope.model.value.toolbar.splice(index, 1);
             }
         };
 
-        $scope.selectStylesheet = function (css) {
+        $scope.selectStylesheet = css => {
 
             // find out if the stylesheet is already selected; first look for the full stylesheet path (current format)
             var index = $scope.model.value.stylesheets.indexOf(css.path);
@@ -79,15 +150,15 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
                 index = $scope.model.value.stylesheets.indexOf(css.name);
             }
 
-            if(index === -1){
+            if (index === -1){
                 $scope.model.value.stylesheets.push(css.path);
-            }else{
+            }else {
                 $scope.model.value.stylesheets.splice(index, 1);
             }
         };
 
         // map properties for specific commands
-        function getFontIcon(alias) {
+        function getIcon(alias) {
             var icon = { name: alias, isCustom: false };
 
             switch (alias) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
@@ -50,22 +50,19 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
                 const parser = new DOMParser();
 
                 Utilities.forEach($scope.tinyMceConfig.commands, cmd => {
+                    let icon = getTinyIcon(cmd.alias);
 
-                  console.log("cmd", cmd);
+                    if (!cmd.isCustom && icons.hasOwnProperty(icon)) {
+                        const svg = icons[icon];
+                        const frag = parser.parseFromString(svg, 'text/html').body.childNodes[0];
+                        const width = frag.getAttribute("width");
+                        const height = frag.getAttribute("height");
 
-                  let icon = getTinyIcon(cmd.alias);
-
-                  if (!cmd.isCustom && icons.hasOwnProperty(icon)) {
-                    const svg = icons[icon];
-                    const frag = parser.parseFromString(svg, 'text/html').body.childNodes[0];
-                    const width = frag.getAttribute("width");
-                    const height = frag.getAttribute("height");
-
-                    frag.setAttribute("viewBox", `0 0 ${width} ${height}`);
-                    cmd.svgIcon = $sce.trustAsHtml(frag.outerHTML);
-                    cmd.icon = null;
-                  }
-
+                        frag.setAttribute("viewBox", `0 0 ${width} ${height}`);
+                        frag.setAttribute("viewBox", viewBox);
+                        cmd.svgIcon = $sce.trustAsHtml(frag.outerHTML);
+                        cmd.icon = null;
+                    }
                 });
             });
             
@@ -118,6 +115,7 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
 
             switch (alias) {
                 case "ace":
+                case "code":
                     icon = "sourcecode";
                     break;
                 case "anchor":
@@ -163,11 +161,14 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
                     icon = "highlight-bg-color";
                     break;
                 case "wordcount":
-                  icon = "character-count";
-                  break;
+                    icon = "character-count";
+                    break;
                 case "emoticons":
-                  icon = "emoji";
-                  break;
+                    icon = "emoji";
+                    break;
+                case "codesample":
+                    icon = "code-sample";
+                    break;
             }
 
             return icon;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
@@ -53,55 +53,7 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
 
                   console.log("cmd", cmd);
 
-                  let icon = cmd.alias;
-
-                  switch (cmd.alias) {
-                    case "ace":
-                      icon = "sourcecode";
-                      break;
-                    case "anchor":
-                      icon = "bookmark";
-                      break;
-                    case "alignleft":
-                      icon = "align-left";
-                      break;
-                    case "aligncenter":
-                      icon = "align-center";
-                      break;
-                    case "alignright":
-                      icon = "align-right";
-                      break;
-                    case "alignjustify":
-                      icon = "align-justify";
-                      break;
-                    case "charmap":
-                      icon = "insert-character";
-                      break;
-                    case "hr":
-                      icon = "horizontal-rule";
-                      break;
-                    case "bullist":
-                      icon = "unordered-list";
-                      break;
-                    case "numlist":
-                      icon = "ordered-list";
-                      break;
-                    case "strikethrough":
-                      icon = "strike-through";
-                      break;
-                    case "removeformat":
-                      icon = "remove-formatting";
-                      break;
-                    case "blockquote":
-                      icon = "quote";
-                      break;
-                    case "forecolor":
-                      icon = "text-color";
-                      break;
-                    case "hilitecolor":
-                      icon = "highlight-bg-color";
-                      break;
-                  }
+                  let icon = getTinyIcon(cmd.alias);
 
                   if (!cmd.isCustom && icons.hasOwnProperty(icon)) {
                     const svg = icons[icon];
@@ -160,7 +112,62 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
             }
         };
 
-        // map properties for specific commands
+        // Map command alias to icon name.
+        function getTinyIcon(alias) {
+            let icon = alias;
+
+            switch (alias) {
+                case "ace":
+                    icon = "sourcecode";
+                    break;
+                case "anchor":
+                    icon = "bookmark";
+                    break;
+                case "alignleft":
+                    icon = "align-left";
+                    break;
+                case "aligncenter":
+                    icon = "align-center";
+                    break;
+                case "alignright":
+                    icon = "align-right";
+                    break;
+                case "alignjustify":
+                    icon = "align-justify";
+                    break;
+                case "charmap":
+                    icon = "insert-character";
+                    break;
+                case "hr":
+                    icon = "horizontal-rule";
+                    break;
+                case "bullist":
+                    icon = "unordered-list";
+                    break;
+                case "numlist":
+                    icon = "ordered-list";
+                    break;
+                case "strikethrough":
+                    icon = "strike-through";
+                    break;
+                case "removeformat":
+                    icon = "remove-formatting";
+                    break;
+                case "blockquote":
+                    icon = "quote";
+                    break;
+                case "forecolor":
+                    icon = "text-color";
+                    break;
+                case "hilitecolor":
+                    icon = "highlight-bg-color";
+                    break;
+            }
+
+            return icon;
+        }
+
+        // Map properties for specific commands
         function getIcon(alias) {
             var icon = { name: alias, isCustom: false };
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
@@ -92,6 +92,9 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
                     case "removeformat":
                       icon = "remove-formatting";
                       break;
+                    case "blockquote":
+                      icon = "quote";
+                      break;
                     case "forecolor":
                       icon = "text-color";
                       break;
@@ -106,7 +109,7 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
                     const width = frag.getAttribute("width");
                     const height = frag.getAttribute("height");
 
-                    frag.setAttribute("viewbox", `0 0 ${width} ${height}`);
+                    frag.setAttribute("viewBox", `0 0 ${width} ${height}`);
                     cmd.svgIcon = $sce.trustAsHtml(frag.outerHTML);
                     cmd.icon = null;
                   }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
@@ -59,7 +59,6 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
                         const height = frag.getAttribute("height");
 
                         frag.setAttribute("viewBox", `0 0 ${width} ${height}`);
-                        frag.setAttribute("viewBox", viewBox);
                         cmd.svgIcon = $sce.trustAsHtml(frag.outerHTML);
                         cmd.icon = null;
                     }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
@@ -162,6 +162,12 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
                 case "hilitecolor":
                     icon = "highlight-bg-color";
                     break;
+                case "wordcount":
+                  icon = "character-count";
+                  break;
+                case "emoticons":
+                  icon = "emoji";
+                  break;
             }
 
             return icon;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.controller.js
@@ -33,8 +33,7 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
             // extend commands with properties for font-icon and if it is a custom command
             $scope.tinyMceConfig.commands = _.map($scope.tinyMceConfig.commands, obj => {
                 const icon = getIcon(obj.alias);
-                console.log("icon", icon);
-
+                
                 const objCmd = Utilities.extend(obj, {
                     fontIcon: icon.name,
                     isCustom: icon.isCustom,
@@ -103,7 +102,7 @@ angular.module("umbraco").controller("Umbraco.PrevalueEditors.RteController",
 
             if (index === -1){
                 $scope.model.value.stylesheets.push(css.path);
-            }else {
+            } else {
                 $scope.model.value.stylesheets.splice(index, 1);
             }
         };

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.prevalues.html
@@ -5,22 +5,21 @@
             <umb-checkbox
                 model="cmd.selected"
                 on-change="selectCommand(cmd)"
-                icon="{{cmd.icon}}"
-                text="{{cmd.name}}"
                 class="mce-cmd">
+                <umb-icon ng-if="cmd.icon" icon="{{cmd.icon}}"></umb-icon>
+                <span ng-if="!cmd.icon && cmd.svgIcon" ng-bind-html="cmd.svgIcon" class="umb-icon"></span>
+                <span ng-if="cmd.name" class="umb-form-check__text">{{cmd.name}}</span>
             </umb-checkbox>
         </div>
     </umb-control-group>
 
     <umb-control-group label="Stylesheets" description="Pick the stylesheets whose editor styles should be available when editing">
         <div ng-repeat="css in stylesheets">
-
             <umb-checkbox
                 model="css.selected"
                 on-change="selectStylesheet(css)"
                 text="{{css.name}}">
             </umb-checkbox>
-
         </div>
     </umb-control-group>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/14324

### Description
Currently the configuration of richtext didn't show icons for toolbar buttons in configuration after upgrade of TinyMCE v4 to v6 since the old font icons has been replaced by SVG icons: https://www.tiny.cloud/docs/tinymce/6/editor-icon-identifiers/

Further some commands doesn't use icons equal to the alias, e.g. `hr` has the icon `horizontal-rule.svg`.

TinyMCE has as service to get a specific icon set, e.g. `tinymce.IconManager.get('default').icons` to load default icons, but without an instance it just returned an empty object.

In the backoffice rebuild we could use module loading to import the icons (and maybe custom icons):
https://www.tiny.cloud/docs/tinymce/6/bundling-icons/

A few custom toolbar button use existing SVG icons registered in Umbraco, but I think it may be better to register a custom icon pack https://www.tiny.cloud/docs/tinymce/6/creating-an-icon-pack/ e.g. named `umbraco` and if developers add a custom plugin, they could probably register a custom icon pack as well.

For now it just load the `default` icon pack, so we get something similar which we had with TinyMCE v4.

By default the icons didn't have `viewBox` so the icons were not scalable, so I modified these using `DOMParser`:
https://www.fabiofranchino.com/log/using-domparser-to-create-html-and-svg-fragment/

Furthermore the vertical alignment of the fields at dimensions property was no longer reflected.

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/c08f949b-5f6a-41c2-b799-78a2390e75ff)

I also added a few custom commands to richtext editor via `appsettings.json`.
However with multiple commands it seems the first one doesn't show up in the toolbar configuration of richtext editor.

```
"RichTextEditor": {
  "Commands": [
    {
      "Alias": "forecolor",
      "Name": "Text color",
      "Mode": "Selection"
    },
    {
      "Alias": "hilitecolor",
      "Name": "Background color",
      "Mode": "Selection"
    },
    {
      "Alias": "blockquote",
      "Name": "Blockquote",
      "Mode": "Selection"
    },
    {
      "Alias": "wordcount",
      "Name": "Word count",
      "Mode": "All"
    },
    {
      "Alias": "emoticons",
      "Name": "Emoticons",
      "Mode": "All"
    },
    {
      "Alias": "template",
      "Name": "Template",
      "Mode": "All"
    },
    {
      "Alias": "codesample",
      "Name": "Code sample",
      "Mode": "All"
    }
  ],
  "Plugins": [
    "textcolor",
    "colorpicker",
    "codesample",
    "emoticons",
    "template",
    "wordcount"
  ]
}
```

I would have expected text color command to be shown. If I move block quote as first object, this is the one not shown.

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/1611cc40-339d-4b66-9bd0-468fa5a09537)

Reported this issue in https://github.com/umbraco/Umbraco-CMS/issues/14405

There may be a few more commands needed to map the icons.
https://www.tiny.cloud/docs/advanced/editor-command-identifiers/#plugincommands

I wonder if the icon should be part of command object in  future as it may be simpler to map the icons or use custom registered icons?

```
{
    "Alias": "emoticons",
    "Name": "Emoticons",
    "Icon": "emoji",
    "Mode": "All"
}
```

If I have left the existing `icon` property based on icon name (mapped from command alias) and using the SVG icon from `default` icon set if found.