### PR TITLE
README badges review

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,4 +1,11 @@
-# [Umbraco CMS](https://umbraco.com) &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE.md) [![Build status](https://umbraco.visualstudio.com/Umbraco%20Cms/_apis/build/status/Cms%208%20Continuous?branchName=v8/contrib)](https://umbraco.visualstudio.com/Umbraco%20Cms/_build?definitionId=75) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md) [![Twitter](https://img.shields.io/twitter/follow/umbraco.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=umbraco) [![Discord](https://img.shields.io/discord/869656431308189746)](https://discord.gg/umbraco) [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=v11%2Fcontrib&repo=10601208&machine=basicLinux32gb&devcontainer_path=.devcontainer%2Fdevcontainer.json&location=WestEurope)
+# [Umbraco CMS](https://umbraco.com)
+
+[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE.md) 
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md) 
+[![Follow Umbraco on Twitter](https://img.shields.io/badge/Follow-blue?logo=twitter&logoColor=fff)](https://twitter.com/intent/follow?screen_name=umbraco) 
+[![Chat about Umbraco on Discord](https://img.shields.io/discord/869656431308189746?logo=discord&logoColor=fff)](https://discord.gg/umbraco) 
+[![Build status](https://img.shields.io/azure-devops/build/umbraco/Umbraco%2520Cms/301?logo=azurepipelines&label=Azure%20Pipelines)](https://umbraco.visualstudio.com/Umbraco%20Cms/_build?definitionId=301) 
+[![Open in GitHub Codespaces](https://img.shields.io/badge/Open%20in%20GitHub%20Codespaces-525252?logo=github)](https://github.com/codespaces/new?hide_repo_select=true&ref=contrib&repo=10601208&machine=basicLinux32gb&devcontainer_path=.devcontainer%2Fdevcontainer.json&location=WestEurope)
 
 Umbraco is the friendliest, most flexible and fastest growing ASP.NET CMS, and used by more than 500,000 websites worldwide. Our mission is to help you deliver delightful digital experiences by making Umbraco friendly, simpler and social.
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Proposed review of the badges on the README file.

Currently, the badges don't look consistent and overflow to the next line. For the initial badges, this appeared fine, but with the addition of the Codespaces badge, it is larger and feels less consistent.

**Exhibit A**

![A screengrab of the existing Umbraco-CMS README file](https://github.com/umbraco/Umbraco-CMS/assets/209066/e01651df-9230-4935-a2af-7962de8c0dd1)

I'm proposing that the badges could be shifted down to below the header, and tweaked for consistency - using the extra shields.io query parameters for cosmetic updates.

**Exhibit B**

![umbraco-cms-readme-tidy](https://github.com/umbraco/Umbraco-CMS/assets/209066/7176244c-c954-4563-bf9c-83116a7ed5c5)

The changes in detail...

- "Azure Pipelines" - changed to use [shields.io's Azure DevOps badge](https://shields.io/badges/azure-dev-ops-builds-job). Also updated to use the ["Umbraco CMS 9+" pipeline (`definitionId: 301`)](https://umbraco.visualstudio.com/Umbraco%20Cms/_build?definitionId=301), as it was previously pointing at `v8/contrib`.
- "Twitter" - changed from the `social` style to the `flat` style, with consistent icon and colour.
- "Discord" - added the Discord icon.
- "GitHub Codespaces" - changed to use a shields.io badge style, this reduces the size to be consistent with the other badges; also updated the branch from `v8/contrib` to `contrib`.

I have also taken the liberty of re-ordering the badges to follow a sense of community over technical - shifting the "Azure Pipelines" towards the end.

Of course, this is all subjective, but after it was pointed out to me at CodeGarden 23 that I hadn't submitted a PR to Umbraco CMS in a long time, I thought I best try.