### PR TITLE
Fix: Make multi URL Picker indexer noop

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/MultiUrlPickerPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultiUrlPickerPropertyEditor.cs
@@ -43,6 +43,8 @@ public class MultiUrlPickerPropertyEditor : DataEditor
         SupportsReadOnly = true;
     }
 
+    public override IPropertyIndexValueFactory PropertyIndexValueFactory { get; } = new NoopPropertyIndexValueFactory();
+
     protected override IConfigurationEditor CreateConfigurationEditor() =>
         new MultiUrlPickerConfigurationEditor(_ioHelper, _editorConfigurationParser);
 


### PR DESCRIPTION
Fixes #14162.

As specified in the issue the multi-URL picker shows up as json in the examine index. However, it doesn't make much sense to index the URLS by default, so this PR adds a no op indexer to the multi-URL picker. 


Testing: As per the issue, the multi url picker json shows up in the index before this PR, after this PR it is gone. 