### PR TITLE
V12: Add deliver api information to detailed telemetry

### DIFF
--- a/src/Umbraco.Core/Constants-Telemetry.cs
+++ b/src/Umbraco.Core/Constants-Telemetry.cs
@@ -30,5 +30,7 @@ public static partial class Constants
         public static string CurrentServerRole = "CurrentServerRole";
         public static string RuntimeMode = "RuntimeMode";
         public static string BackofficeExternalLoginProviderCount = "BackofficeExternalLoginProviderCount";
+        public static string DeliverApiEnabled = "DeliverApiEnabled";
+        public static string DeliveryApiPublicAccess = "DeliveryApiPublicAccess";
     }
 }

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -3012,7 +3012,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
             <li>Anonymized site ID, Umbraco version, and packages installed.</li>
             <li>Number of: Root nodes, Content nodes, Macros, Media, Document Types, Templates, Languages, Domains, User Group, Users, Members, Backoffice external login providers, and Property Editors in use.</li>
             <li>System information: Webserver, server OS, server framework, server OS language, and database provider.</li>
-            <li>Configuration settings: Modelsbuilder mode, if custom Umbraco path exists, ASP environment, and if you are in debug mode.</li>
+            <li>Configuration settings: Modelsbuilder mode, if custom Umbraco path exists, ASP environment, whether the delivery API is enabled, and allows public access, and if you are in debug mode.</li>
           </ul>
           <em>We might change what we send on the Detailed level in the future. If so, it will be listed above.
           <br>By choosing "Detailed" you agree to current and future anonymized information being collected.</em>

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.TelemetryProviders.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.TelemetryProviders.cs
@@ -19,6 +19,7 @@ public static class UmbracoBuilder_TelemetryProviders
         builder.Services.AddTransient<IDetailedTelemetryProvider, PropertyEditorTelemetryProvider>();
         builder.Services.AddTransient<IDetailedTelemetryProvider, UserTelemetryProvider>();
         builder.Services.AddTransient<IDetailedTelemetryProvider, SystemInformationTelemetryProvider>();
+        builder.Services.AddTransient<IDetailedTelemetryProvider, DeliveryApiTelemetryProvider>();
         return builder;
     }
 }

--- a/src/Umbraco.Infrastructure/Telemetry/Providers/DeliveryApiTelemetryProvider.cs
+++ b/src/Umbraco.Infrastructure/Telemetry/Providers/DeliveryApiTelemetryProvider.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Infrastructure.Telemetry.Interfaces;
+
+namespace Umbraco.Cms.Infrastructure.Telemetry.Providers;
+
+public class DeliveryApiTelemetryProvider : IDetailedTelemetryProvider
+{
+    private readonly DeliveryApiSettings _deliveryApiSettings;
+
+    public DeliveryApiTelemetryProvider(IOptions<DeliveryApiSettings> deliveryApiSettings)
+    {
+        _deliveryApiSettings = deliveryApiSettings.Value;
+    }
+
+    public IEnumerable<UsageInformation> GetInformation()
+    {
+        yield return new UsageInformation(Constants.Telemetry.DeliverApiEnabled, _deliveryApiSettings.Enabled);
+        yield return new UsageInformation(Constants.Telemetry.DeliveryApiPublicAccess, _deliveryApiSettings.PublicAccess);
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
@@ -50,7 +50,9 @@ public class TelemetryServiceTests : UmbracoIntegrationTest
             Constants.Telemetry.DatabaseProvider,
             Constants.Telemetry.CurrentServerRole,
             Constants.Telemetry.BackofficeExternalLoginProviderCount,
-            Constants.Telemetry.RuntimeMode
+            Constants.Telemetry.RuntimeMode,
+            Constants.Telemetry.DeliverApiEnabled,
+            Constants.Telemetry.DeliveryApiPublicAccess
         };
 
         MetricsConsentService.SetConsentLevel(TelemetryLevel.Detailed);


### PR DESCRIPTION
Adds deliver API information to detailed telemetry. In particular, it adds two values: 

* DeliverApiEnabled - True if the delivery API is enabled
* DeliveryApiPublicAccess - True if public access is enabled.