### PR TITLE
Updated nuget packages to latest versions

### DIFF
--- a/src/Umbraco.Cms.Api.Common/Umbraco.Cms.Api.Common.csproj
+++ b/src/Umbraco.Cms.Api.Common/Umbraco.Cms.Api.Common.csproj
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.8" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="OpenIddict.Abstractions" Version="4.4.0" />
-    <PackageReference Include="OpenIddict.AspNetCore" Version="4.4.0" />
+    <PackageReference Include="OpenIddict.Abstractions" Version="4.5.0" />
+    <PackageReference Include="OpenIddict.AspNetCore" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Umbraco.Core\Umbraco.Core.csproj" />

--- a/src/Umbraco.Cms.Persistence.EFCore/Umbraco.Cms.Persistence.EFCore.csproj
+++ b/src/Umbraco.Cms.Persistence.EFCore/Umbraco.Cms.Persistence.EFCore.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.5" />
-    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="4.4.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.7" />
+    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Umbraco.Cms.Persistence.Sqlite/Umbraco.Cms.Persistence.Sqlite.csproj
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Umbraco.Cms.Persistence.Sqlite.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.5" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -8,10 +8,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="7.0.5" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="7.0.7" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="7.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="7.0.7" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />

--- a/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
+++ b/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
@@ -12,21 +12,21 @@
 
   <ItemGroup>
     <PackageReference Include="Examine.Core" Version="3.1.0" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
-    <PackageReference Include="IPNetwork2" Version="2.6.560" />
-    <PackageReference Include="MailKit" Version="4.0.0" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.48" />
+    <PackageReference Include="IPNetwork2" Version="2.6.589" />
+    <PackageReference Include="MailKit" Version="4.1.0" />
     <PackageReference Include="Markdown" Version="2.2.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="7.0.5" />
-    <PackageReference Include="MiniProfiler.Shared" Version="4.2.22" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="7.0.7" />
+    <PackageReference Include="MiniProfiler.Shared" Version="4.3.8" />
     <PackageReference Include="ncrontab" Version="3.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NPoco" Version="5.7.1" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog" Version="3.0.0" />
     <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.2" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Expressions" Version="3.4.1" />
@@ -38,7 +38,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Map" Version="1.0.2" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="7.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="7.0.2" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="7.0.0" />
   </ItemGroup>
 

--- a/src/Umbraco.PublishedCache.NuCache/Umbraco.PublishedCache.NuCache.csproj
+++ b/src/Umbraco.PublishedCache.NuCache/Umbraco.PublishedCache.NuCache.csproj
@@ -10,8 +10,6 @@
     <PackageReference Include="MessagePack" Version="2.5.108" />
     <PackageReference Include="Umbraco.CSharpTest.Net.Collections" Version="15.0.0" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.3.5" />
-    <PackageReference Include="Umbraco.CSharpTest.Net.Collections" Version="14.906.1403.1085" />
-    <PackageReference Include="K4os.Compression.LZ4" Version="1.3.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/src/Umbraco.Web.Common/Profiler/WebProfiler.cs
+++ b/src/Umbraco.Web.Common/Profiler/WebProfiler.cs
@@ -29,7 +29,7 @@ public class WebProfiler : IProfiler
     public void Start()
     {
         MiniProfiler.StartNew();
-        MiniProfilerContext.Value = MiniProfiler.Current;
+        MiniProfilerContext.Value = MiniProfiler.Current!;
     }
 
     public void Stop(bool discardResults = false) => MiniProfilerContext.Value?.Stop(discardResults);
@@ -84,7 +84,7 @@ public class WebProfiler : IProfiler
 
                 if (cookieValue is not null)
                 {
-                    AddSubProfiler(MiniProfiler.FromJson(cookieValue));
+                    AddSubProfiler(MiniProfiler.FromJson(cookieValue)!);
                 }
 
                 // If it is a redirect to a relative path (local redirect)

--- a/src/Umbraco.Web.Common/Profiler/WebProfilerHtml.cs
+++ b/src/Umbraco.Web.Common/Profiler/WebProfilerHtml.cs
@@ -34,7 +34,7 @@ public class WebProfilerHtml : IProfilerHtml
 
         var result = StackExchange.Profiling.Internal.Render.Includes(
             profiler,
-            context is not null ? context.Request.PathBase + path : null,
+            context is not null ? context.Request.PathBase + path : string.Empty,
             true,
             new List<Guid> { profiler.Id },
             RenderPosition.Right,

--- a/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
+++ b/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
@@ -14,11 +14,11 @@
     <PackageReference Include="Asp.Versioning.Mvc" Version="7.0.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="7.0.0" />
     <PackageReference Include="Dazinator.Extensions.FileProviders" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="7.0.5" />
-    <PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.2.22" />
-    <PackageReference Include="Smidge.InMemory" Version="4.2.1" />
-    <PackageReference Include="Smidge.Nuglify" Version="4.2.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="7.0.7" />
+    <PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.3.8" />
+    <PackageReference Include="Smidge.InMemory" Version="4.3.0" />
+    <PackageReference Include="Smidge.Nuglify" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Umbraco.Tests.Common/Umbraco.Tests.Common.csproj
+++ b/tests/Umbraco.Tests.Common/Umbraco.Tests.Common.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.0" />
-    <PackageReference Include="MiniProfiler.AspNetCore" Version="4.2.22" />
+    <PackageReference Include="MiniProfiler.AspNetCore" Version="4.3.8" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="AutoFixture.NUnit3" Version="4.18.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
@@ -11,10 +11,10 @@
 
   <ItemGroup>
     <PackageReference Include="Bogus" Version="34.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" PrivateAssets="all" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" PrivateAssets="all" />
   </ItemGroup>
 
   <Import Project="..\..\src\Umbraco.Cms.Targets\buildTransitive\Umbraco.Cms.Targets.props" />

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Tests.UnitTests.csproj
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Tests.UnitTests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="1.0.1" />
+    <PackageReference Include="AngleSharp" Version="1.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="System.Data.Odbc" Version="7.0.0" />
     <PackageReference Include="System.Data.OleDb" Version="7.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Updated nuget packages

- OpenIddict from 4.4.0 to 4.5.0
- ASP.NET Core / .NET from 7.0.5 to 7.0.7
- MailKit from 4.0.0 to 4.1.0
- Serilog from 2.12.0 to 3.0.0
- Miniprofiler from 4.2.22 to 4.3.8 (Including nullable reference type issues fixed)
- HtmlAgilityPack from 1.11.46 to 1.11.48
- IPNetwork2 from 2.6.560 to 2.6.589
- System.Security.Cryptography.Pkcs from 7.0.1 to 7.0.2
- Smidge from 4.2.1 to 4.3.0

For tests projects only
- NUnit3TestAdapter from 4.4.2 to 4.5.0
- AngleSharp from 1.0.1 to 1.0.3