### PR TITLE
Fix incorrect redirectUrl check with external authentication (#14198)

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
@@ -329,7 +329,8 @@ public class BackOfficeController : UmbracoController
     [AllowAnonymous]
     public ActionResult ExternalLogin(string provider, string? redirectUrl = null)
     {
-        if (redirectUrl == null || Uri.TryCreate(redirectUrl, UriKind.Absolute, out _))
+        
+        if (redirectUrl == null || !redirectUrl.StartsWith("/"))
         {
             redirectUrl = Url.Action(nameof(Default), this.GetControllerName());
         }

--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
@@ -329,7 +329,9 @@ public class BackOfficeController : UmbracoController
     [AllowAnonymous]
     public ActionResult ExternalLogin(string provider, string? redirectUrl = null)
     {
-        if (redirectUrl == null || !redirectUrl.StartsWith("/"))
+        // Only relative urls are accepted as redirect url
+        // We can't simply use Uri.TryCreate with kind Absolute, as in Linux any relative url would be seen as an absolute file uri
+        if (redirectUrl == null || !Uri.TryCreate(redirectUrl, UriKind.RelativeOrAbsolute, out Uri? redirectUri) || redirectUri.IsAbsoluteUri)
         {
             redirectUrl = Url.Action(nameof(Default), this.GetControllerName());
         }

--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
@@ -329,7 +329,6 @@ public class BackOfficeController : UmbracoController
     [AllowAnonymous]
     public ActionResult ExternalLogin(string provider, string? redirectUrl = null)
     {
-        
         if (redirectUrl == null || !redirectUrl.StartsWith("/"))
         {
             redirectUrl = Url.Action(nameof(Default), this.GetControllerName());


### PR DESCRIPTION
### Prerequisites

Fixes #14198 

### Description
When using an external authentication method to sign in to Umbraco back office the `returnUrl` is checked if it's absolute and if so (disallowed) resets it to the start page. The check was incorrect though and resulted in every redirectUrl being reset so the redirect url was never honored. (`Uri.TryCreate` would create an absolute `file://` uri out of anything it got).

NOTE: I would use `IUrlHelper.IsLocalUrl` but it's not available to me and the only difference is it will allow `~/` as well, and it's not relevant here.