### PR TITLE
Obsolete constructor with deprecated IScopeProvider

### DIFF
--- a/src/Umbraco.Infrastructure/Examine/ContentValueSetValidator.cs
+++ b/src/Umbraco.Infrastructure/Examine/ContentValueSetValidator.cs
@@ -41,6 +41,7 @@ public class ContentValueSetValidator : ValueSetValidator, IContentValueSetValid
         _scopeProvider = scopeProvider;
     }
 
+    [Obsolete("This constructor is obsolete, the IScopeProvider will change to Infrastructure.Scoping.ScopeProvider instead, this will be removed in Umbraco 14.")]
     public ContentValueSetValidator(
         bool publishedValuesOnly,
         bool supportProtectedContent,


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/13729

# Notes

I added an obsolete attribute for the `ContentValueSetValidator` constructor.

I can't create a replacement constructor, because it will have an ambiguous signature.