### PR TITLE
Add create and update dates to Delivery API response

### DIFF
--- a/src/Umbraco.Core/DeliveryApi/ApiContentBuilder.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiContentBuilder.cs
@@ -10,6 +10,6 @@ public sealed class ApiContentBuilder : ApiContentBuilderBase<IApiContent>, IApi
     {
     }
 
-    protected override IApiContent Create(IPublishedContent content, Guid id, string name, string contentType, IApiContentRoute route, IDictionary<string, object?> properties)
-        => new ApiContent(id, name, contentType, route, properties);
+    protected override IApiContent Create(IPublishedContent content, string name, IApiContentRoute route, IDictionary<string, object?> properties)
+        => new ApiContent(content.Key, name, content.ContentType.Alias, content.CreateDate, content.UpdateDate, route, properties);
 }

--- a/src/Umbraco.Core/DeliveryApi/ApiContentBuilderBase.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiContentBuilderBase.cs
@@ -17,7 +17,7 @@ public abstract class ApiContentBuilderBase<T>
         _outputExpansionStrategyAccessor = outputExpansionStrategyAccessor;
     }
 
-    protected abstract T Create(IPublishedContent content, Guid id, string name, string contentType, IApiContentRoute route, IDictionary<string, object?> properties);
+    protected abstract T Create(IPublishedContent content, string name, IApiContentRoute route, IDictionary<string, object?> properties);
 
     public virtual T? Build(IPublishedContent content)
     {
@@ -34,9 +34,7 @@ public abstract class ApiContentBuilderBase<T>
 
         return Create(
             content,
-            content.Key,
             _apiContentNameProvider.GetName(content),
-            content.ContentType.Alias,
             route,
             properties);
     }

--- a/src/Umbraco.Core/DeliveryApi/ApiContentResponseBuilder.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiContentResponseBuilder.cs
@@ -13,7 +13,7 @@ public sealed class ApiContentResponseBuilder : ApiContentBuilderBase<IApiConten
         : base(apiContentNameProvider, apiContentRouteBuilder, outputExpansionStrategyAccessor)
         => _apiContentRouteBuilder = apiContentRouteBuilder;
 
-    protected override IApiContentResponse Create(IPublishedContent content, Guid id, string name, string contentType, IApiContentRoute route, IDictionary<string, object?> properties)
+    protected override IApiContentResponse Create(IPublishedContent content, string name, IApiContentRoute route, IDictionary<string, object?> properties)
     {
         var routesByCulture = new Dictionary<string, IApiContentRoute>();
 
@@ -35,6 +35,6 @@ public sealed class ApiContentResponseBuilder : ApiContentBuilderBase<IApiConten
             routesByCulture[publishedCultureInfo.Culture] = cultureRoute;
         }
 
-        return new ApiContentResponse(id, name, contentType, route, properties, routesByCulture);
+        return new ApiContentResponse(content.Key, name, content.ContentType.Alias, content.CreateDate, content.UpdateDate, route, properties, routesByCulture);
     }
 }

--- a/src/Umbraco.Core/Models/DeliveryApi/ApiContent.cs
+++ b/src/Umbraco.Core/Models/DeliveryApi/ApiContent.cs
@@ -2,14 +2,20 @@ namespace Umbraco.Cms.Core.Models.DeliveryApi;
 
 public class ApiContent : ApiElement, IApiContent
 {
-    public ApiContent(Guid id, string name, string contentType, IApiContentRoute route, IDictionary<string, object?> properties)
+    public ApiContent(Guid id, string name, string contentType, DateTime createDate, DateTime updateDate, IApiContentRoute route, IDictionary<string, object?> properties)
         : base(id, contentType, properties)
     {
         Name = name;
+        CreateDate = createDate;
+        UpdateDate = updateDate;
         Route = route;
     }
 
     public string Name { get; }
+
+    public DateTime CreateDate { get; }
+
+    public DateTime UpdateDate { get; }
 
     public IApiContentRoute Route { get; }
 }

--- a/src/Umbraco.Core/Models/DeliveryApi/ApiContentResponse.cs
+++ b/src/Umbraco.Core/Models/DeliveryApi/ApiContentResponse.cs
@@ -4,8 +4,8 @@ namespace Umbraco.Cms.Core.Models.DeliveryApi;
 
 public class ApiContentResponse : ApiContent, IApiContentResponse
 {
-    public ApiContentResponse(Guid id, string name, string contentType, IApiContentRoute route, IDictionary<string, object?> properties, IDictionary<string, IApiContentRoute> cultures)
-        : base(id, name, contentType, route, properties)
+    public ApiContentResponse(Guid id, string name, string contentType, DateTime createDate, DateTime updateDate, IApiContentRoute route, IDictionary<string, object?> properties, IDictionary<string, IApiContentRoute> cultures)
+        : base(id, name, contentType, createDate, updateDate, route, properties)
         => Cultures = cultures;
 
     // a little DX; by default this dictionary will be serialized as the first part of the response due to the inner workings of the serializer.

--- a/src/Umbraco.Core/Models/DeliveryApi/IApiContent.cs
+++ b/src/Umbraco.Core/Models/DeliveryApi/IApiContent.cs
@@ -4,5 +4,9 @@ public interface IApiContent : IApiElement
 {
     string? Name { get; }
 
+    public DateTime CreateDate { get; }
+
+    public DateTime UpdateDate { get; }
+
     IApiContentRoute Route { get; }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ContentBuilderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ContentBuilderTests.cs
@@ -28,6 +28,8 @@ public class ContentBuilderTests : DeliveryApiTests
         var urlSegment = "url-segment";
         var name = "The page";
         ConfigurePublishedContentMock(content, key, name, urlSegment, contentType.Object, new[] { prop1, prop2 });
+        content.SetupGet(c => c.CreateDate).Returns(new DateTime(2023, 06, 01));
+        content.SetupGet(c => c.UpdateDate).Returns(new DateTime(2023, 07, 12));
 
         var publishedUrlProvider = new Mock<IPublishedUrlProvider>();
         publishedUrlProvider
@@ -47,6 +49,8 @@ public class ContentBuilderTests : DeliveryApiTests
         Assert.AreEqual(2, result.Properties.Count);
         Assert.AreEqual("Delivery API value", result.Properties["deliveryApi"]);
         Assert.AreEqual("Default value", result.Properties["default"]);
+        Assert.AreEqual(new DateTime(2023, 06, 01), result.CreateDate);
+        Assert.AreEqual(new DateTime(2023, 07, 12), result.UpdateDate);
     }
 
     [Test]


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The Delivery API response does not contain any date metadata for published content. The Heartcore REST API (V2) does contain these (ref: https://docs.umbraco.com/umbraco-heartcore/api-documentation/content-delivery/content#get-by-id)

<img width="500" alt="image" src="https://github.com/umbraco/Umbraco-CMS/assets/7405322/f55c234a-9efb-4d78-881b-ab6e779fdc8a">

This PR includes create and update date in the API response.

### Testing this PR

Fetch some content through the Delivery API and verify that create and update dates are part of the response:

<img width="443" alt="image" src="https://github.com/umbraco/Umbraco-CMS/assets/7405322/981fc625-dba4-4551-b97f-5d152a41a65a">
