### PR TITLE
Delivery API: Ensure the path parameter starts with forward slash

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Controllers/ByRouteContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/ByRouteContentApiController.cs
@@ -58,7 +58,8 @@ public class ByRouteContentApiController : ContentApiItemControllerBase
             path = WebUtility.UrlDecode(path);
         }
 
-        path = path.EnsureStartsWith("/");
+        path = path.TrimStart("/");
+        path = path.Length == 0 ? "/" : path;
 
         IPublishedContent? contentItem = GetContent(path);
         if (contentItem is not null)

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/ByRouteContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/ByRouteContentApiController.cs
@@ -79,7 +79,7 @@ public class ByRouteContentApiController : ContentApiItemControllerBase
     }
 
     private IPublishedContent? GetContent(string path)
-        => path.StartsWith($"/{Constants.DeliveryApi.Routing.PreviewContentPathPrefix}")
+        => path.StartsWith(Constants.DeliveryApi.Routing.PreviewContentPathPrefix)
             ? GetPreviewContent(path)
             : GetPublishedContent(path);
 
@@ -98,7 +98,7 @@ public class ByRouteContentApiController : ContentApiItemControllerBase
             return null;
         }
 
-        if (Guid.TryParse(path.Trim("/").AsSpan(Constants.DeliveryApi.Routing.PreviewContentPathPrefix.Length), out Guid contentId) is false)
+        if (Guid.TryParse(path.AsSpan(Constants.DeliveryApi.Routing.PreviewContentPathPrefix.Length).TrimEnd("/"), out Guid contentId) is false)
         {
             return null;
         }

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/ByRouteContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/ByRouteContentApiController.cs
@@ -58,7 +58,7 @@ public class ByRouteContentApiController : ContentApiItemControllerBase
             path = WebUtility.UrlDecode(path);
         }
 
-        path = path.EnsureStartsWith("/");
+        path = path.Length == 0 ? "/" : path.TrimStart("/");
 
         IPublishedContent? contentItem = GetContent(path);
         if (contentItem is not null)

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/ByRouteContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/ByRouteContentApiController.cs
@@ -58,7 +58,7 @@ public class ByRouteContentApiController : ContentApiItemControllerBase
             path = WebUtility.UrlDecode(path);
         }
 
-        path = path.Length == 0 ? "/" : path.TrimStart("/");
+        path = path.EnsureStartsWith("/");
 
         IPublishedContent? contentItem = GetContent(path);
         if (contentItem is not null)
@@ -78,7 +78,7 @@ public class ByRouteContentApiController : ContentApiItemControllerBase
     }
 
     private IPublishedContent? GetContent(string path)
-        => path.StartsWith(Constants.DeliveryApi.Routing.PreviewContentPathPrefix)
+        => path.StartsWith($"/{Constants.DeliveryApi.Routing.PreviewContentPathPrefix}")
             ? GetPreviewContent(path)
             : GetPublishedContent(path);
 
@@ -97,7 +97,7 @@ public class ByRouteContentApiController : ContentApiItemControllerBase
             return null;
         }
 
-        if (Guid.TryParse(path.AsSpan(Constants.DeliveryApi.Routing.PreviewContentPathPrefix.Length).TrimEnd("/"), out Guid contentId) is false)
+        if (Guid.TryParse(path.Trim("/").AsSpan(Constants.DeliveryApi.Routing.PreviewContentPathPrefix.Length), out Guid contentId) is false)
         {
             return null;
         }


### PR DESCRIPTION
## Details
- Make sure that the path parameter starts with a forward slash in all cases.

## Test
- Test the Get by path endpoint and verify that things work as expected:
  - With and without passing any path;
    - Also test with `"///"`.
  - Get a node in Preview by path _(pass the preview path of the node - `/preview-GUID`)_;
    - The node has to be Unpublished ❗ .