### PR TITLE
Return raw markdown in the Delivery API

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MarkdownEditorValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MarkdownEditorValueConverter.cs
@@ -72,7 +72,6 @@ public class MarkdownEditorValueConverter : PropertyValueConverterBase, IDeliver
             return string.Empty;
         }
 
-        var mark = new Markdown();
-        return mark.Transform(markdownString);
+        return markdownString;
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MarkdownEditorValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MarkdownEditorValueConverterTests.cs
@@ -17,8 +17,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.DeliveryApi;
 [TestFixture]
 public class MarkdownEditorValueConverterTests : PropertyValueConverterTests
 {
-    [TestCase("hello world", "<p>hello world</p>")]
-    [TestCase("hello *world*", "<p>hello <em>world</em></p>")]
+    [TestCase("hello world", "hello world")]
+    [TestCase("hello *world*", "hello *world*")]
     [TestCase("", "")]
     [TestCase(null, "")]
     [TestCase(123, "")]


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

In the Delivery API, the markdown editor currently returns its value as a HTML transformed representation of the markdown.

This is likely less useful for headless consumption, so this PR ensures that the markdown editor always outputs the raw markdown.

### Testing this PR

1. Create some content with a markdown editor.
2. Fetch the content through the Delivery API.
3. Verify that the markdown editor value is raw markdown, not HTML.