### PR TITLE
Added missing Danish translation for `general_change`

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
@@ -719,6 +719,7 @@
     <key alias="by">af</key>
     <key alias="cancel">Fortryd</key>
     <key alias="cellMargin">Celle margen</key>
+    <key alias="change">Skift</key>
     <key alias="choose">Vælg</key>
     <key alias="clear">Ryd</key>
     <key alias="close">Luk</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -759,6 +759,7 @@
     <key alias="by">by</key>
     <key alias="cancel">Cancel</key>
     <key alias="cellMargin">Cell margin</key>
+    <key alias="change">Change</key>
     <key alias="choose">Choose</key>
     <key alias="clear">Clear</key>
     <key alias="close">Close</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Umbraco's `umbNodePreview` directive supports a change action, but the label doesn't have a Danish translation, so it falls back to the English **Change**, which can seem a bit odd to the user as the other labels related to `umbNodePreview` are translated.

This PR therefore adds a the `general_change` key the Danish language file (`da.xml`) with the value **Skift**.

The key is actually also missing in the English language file (`en_us.xml`), but the English label is still showed correctly as a fallback label is specified in the Angular view. So this PR also adds the `general_change` key to `en_us.xml` with the value **Change**. This way, it should hopefully be easier to see that the translation is missing in other languages.

![image](https://github.com/umbraco/Umbraco-CMS/assets/3634580/04a0105c-b7e3-434e-85f9-f08ca0d4f388)

![image](https://github.com/umbraco/Umbraco-CMS/assets/3634580/ffd66597-c84a-4d43-8b04-6b51d034ed40)

