### PR TITLE
Auto-detect custom Image type on drag and drop

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/MediaController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MediaController.cs
@@ -760,11 +760,25 @@ public class MediaController : ContentControllerBase
                         break;
                     }
 
-                    // If media type is still File then let's check if it's an image.
+                    // If media type is still File then let's check if it's an image or a custom image type.
                     if (mediaTypeAlias == Constants.Conventions.MediaTypes.File &&
                         _imageUrlGenerator.IsSupportedImageFormat(ext))
                     {
-                        mediaTypeAlias = Constants.Conventions.MediaTypes.Image;
+                        if (allowedContentTypes.Any(mt => mt.Alias == Constants.Conventions.MediaTypes.Image))
+                        {
+                            mediaTypeAlias = Constants.Conventions.MediaTypes.Image;
+                        }
+                        else
+                        {
+                            IMediaType? customType = allowedContentTypes.FirstOrDefault(mt =>
+                                mt.CompositionPropertyTypes.Any(pt =>
+                                    pt.PropertyEditorAlias == Constants.PropertyEditors.Aliases.ImageCropper));
+
+                            if (customType is not null)
+                            {
+                                mediaTypeAlias = customType.Alias;
+                            }
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
## Details
- Fixes part of #13602;
- When the default Image type was removed from the permissions of a custom media type and replaced by another custom image type, the following error was returned - `"Failed: Cannot upload this file, the media type with alias 'Image' is not allowed here".`;
  - If we couldn't interpret the type on drag and drop, and the file extension was part of the supported Image formats - we were always defaulting to `Constants.Conventions.MediaTypes.Image` type;
-  Now, we will check if the default Image type is **part of the allowed content types** and if not, we will try to find the first **custom type with an Image Cropper**.

## Test
- In Settings > Media Types create a copy of Image called "Custom Image" under Media Types.  
  - Change the icon, so your custom types are easily distinguishable;  
- In Settings > Media Types create a copy of Folder called "Custom Folder" under Media Types. Add a group called Contents and a property called Contents with a "List View - Media" editor. (This is needed because the copy of Folder doesn't have the built-in, drag and drop UI of the standard Folder type.). 
   - Change the icon, so your custom types are easily distinguishable;  
- Update the permissions on Custom Folder so that the only types it can contain are Custom Folder and Custom Image.  
- In Media create an instance of Custom Folder.  
- Drag and drop a JPEG image file into the custom folder.  
- Verify that an instance of Custom Image is created and the file is uploaded into it.  

- Test with compositions:   
  - Create a new custom media type and add as Composition the default Image - all its properties will be inherited into the new custom media type;
  - Modify the Permissions of the "Custom Folder" - remove "Custom Image" and add the just-created media type;
  - Drag and drop a JPEG image file into the custom folder.
  - Verify that an instance of the second custom media type is created and the file is uploaded into it.

----
For the second case reported in #13602 (auto-picking the custom folder type) - at the moment there isn't really a good way for us to detect a custom folder type and therefore a lot of refactoring will be necessary for a case where you can easily follow the workaround of manually creating the custom folder and uploading to it.

We will discuss and try to improve this workflow for the new Backoffice 🙂 