### PR TITLE
fix: Allows copying from unsaved content

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/clipboard.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/clipboard.service.js
@@ -344,10 +344,14 @@ function clipboardService($window, notificationsService, eventsService, localSto
         // Clean up each entry
         var copiedDatas = datas.map(data => prepareEntryForStorage(type, data, firstLevelClearupMethod));
 
-        // remove previous copies of this entry:
+        // remove previous copies of this entry (Make sure to not remove copies from unsaved content):
         storage.entries = storage.entries.filter(
             (entry) => {
-                return entry.unique !== uniqueKey;
+                if (entry.unique === 0) {
+                    return displayLabel !== entry.label;
+                } else {
+                    return entry.unique !== uniqueKey;
+                }
             }
         );
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #14459

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
This adds a check to the clipboard service that will check if we're copying from an unsaved content node. When we do this we will allow multiple copies based on the display name instead of the unique key. This allows the user to copy multiple lists of blocks from an unsaved content node.

I choose the display name because it's created after the property name and content node name. It will also give a confusing user experience if you could have multiple elements in the clipboard with the same display name.

See the #14459 reproduction section to see how to test the PR 😄 

<!-- Thanks for contributing to Umbraco CMS! -->
