### PR TITLE
Sort manifest file paths alphabetically

### DIFF
--- a/src/Umbraco.Infrastructure/Manifest/ManifestParser.cs
+++ b/src/Umbraco.Infrastructure/Manifest/ManifestParser.cs
@@ -250,6 +250,11 @@ public class ManifestParser : IManifestParser
             return Array.Empty<string>();
         }
 
-        return Directory.GetFiles(_path, "package.manifest", SearchOption.AllDirectories);
+        var files = Directory.GetFiles(_path, "package.manifest", SearchOption.AllDirectories);
+
+        // Ensure a consistent sorting of paths
+        Array.Sort(files);
+
+        return files;
     }
 }

--- a/src/Umbraco.Infrastructure/Manifest/ManifestParser.cs
+++ b/src/Umbraco.Infrastructure/Manifest/ManifestParser.cs
@@ -252,7 +252,7 @@ public class ManifestParser : IManifestParser
 
         var files = Directory.GetFiles(_path, "package.manifest", SearchOption.AllDirectories);
 
-        // Ensure a consistent sorting of paths
+        // Ensure a consistent, alphabetical sorting of paths, because this is not guaranteed to be the same between file systems or OSes
         Array.Sort(files);
 
         return files;


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

This fixes #14462

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
Issue #14462 denotes that on Linux `Directory.GetFiles` as used by `GetManifestFiles` to load package manifest files from disk is not guaranteed to return the list of files in a set order. This is a problem because the order the manifests are loaded also dictates the order any manifest script files are loaded in the back office. This can become a problem if you have scripts that rely on scripts from another package to be loaded first, such as Vendr Checkout needing Vendr to be loaded first.

This PR updates the `GetManifestFiles` method to sort the list of retrieved file paths alphabetically before returning them thus ensuring a consistent and expected behabiour.

<!-- Thanks for contributing to Umbraco CMS! -->
