### PR TITLE
Handle upload error when file size is bigger than the configured value

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/MediaController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MediaController.cs
@@ -579,9 +579,9 @@ public class MediaController : ContentControllerBase
         Directory.CreateDirectory(root);
 
         //must have a file
-        if (file.Count == 0)
+        if (file is null || file.Count == 0)
         {
-            return NotFound();
+            return NotFound("No file was uploaded");
         }
 
         //get the string json from the request


### PR DESCRIPTION
## Details
- Backend fix for #14310;
- The frontend on **Umbraco 10** is broken for this use case - additional fixes are required to close #14310 as completed;
  - No error shown in the backoffice and error in the console:

<img width="1499" alt="Screenshot 2023-06-27 at 13 37 56" src="https://github.com/umbraco/Umbraco-CMS/assets/21998037/88c9c562-8153-4fc3-a004-d1fb2742f3a7">





- In **Umbraco 11**, there is an error in the backoffice, but there is still an error in the console, that has to be handled:

<img width="1495" alt="Screenshot 2023-06-27 at 13 10 29" src="https://github.com/umbraco/Umbraco-CMS/assets/21998037/45d88faa-5a12-4bd4-90c9-314d5e67c192">


## Test
- In appsettings.json add the following configuration:
```json
"CMS": {
      "RuntimeMinification": {
        "UseInMemoryCache": true,
        "CacheBuster": "Timestamp"
      },
      "Runtime": {
        "MaxQueryStringLength": 90,
        "MaxRequestLength": 1000
      }
    }
```
- Upload a file smaller than 1000KB and verify that there are no errors;
- Upload a file **bigger** than 1000KB and verify that you get a Request error Not Found (try that a couple of times);
  - There will be some console errors, but we will fix them in another PR.