### PR TITLE
V14: Cache-Control for Backoffice requests

### DIFF
--- a/src/Umbraco.Web.Common/ApplicationBuilder/UmbracoApplicationBuilder.cs
+++ b/src/Umbraco.Web.Common/ApplicationBuilder/UmbracoApplicationBuilder.cs
@@ -75,7 +75,7 @@ public class UmbracoApplicationBuilder : IUmbracoApplicationBuilder, IUmbracoEnd
 
         AppBuilder.UseUmbracoBackOfficeRewrites();
 
-        AppBuilder.UseStaticFiles();
+        AppBuilder.UseUmbracoStaticFiles();
 
         AppBuilder.UseUmbracoPluginsStaticFiles();
 

--- a/src/Umbraco.Web.Common/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/ApplicationBuilderExtensions.cs
@@ -114,6 +114,25 @@ public static class ApplicationBuilderExtensions
     }
 
     /// <summary>
+    ///     Allow static file access from wwwroot with recommended Cache-Control for Umbraco static files
+    /// </summary>
+    public static IApplicationBuilder UseUmbracoStaticFiles(this IApplicationBuilder app)
+    {
+        app.UseStaticFiles(new StaticFileOptions
+        {
+            OnPrepareResponse = ctx =>
+            {
+                if (ctx.Context.Request.IsBackOfficeRequest())
+                {
+                    ctx.Context.Response.Headers.CacheControl = "public, max-age=31536000, immutable";
+                }
+            },
+        });
+
+        return app;
+    }
+
+    /// <summary>
     ///     Allow static file access for App_Plugins folders
     /// </summary>
     public static IApplicationBuilder UseUmbracoPluginsStaticFiles(this IApplicationBuilder app)


### PR DESCRIPTION
### Description

Add an extension method that wraps `IApplicationBuilder.UseStaticFiles` to add a `Cache-Control` header with sensible values for Backoffice assets. It is now possible to add a very long `max-age` as well as set the responses to `immutable` since all assets are requested through a virtual path with a hash that changes on every Umbraco version and/or bump of the minifier settings.

Read more about immutable and avoiding revalidation: https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#avoiding_revalidation