### PR TITLE
Updated our API acceptance tests to use our updated testHelpers

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@umbraco/json-models-builders": "^1.0.5",
-        "@umbraco/playwright-testhelpers": "2.0.0-beta.1",
+        "@umbraco/playwright-testhelpers": "2.0.0-beta.2",
         "camelize": "^1.0.0",
         "dotenv": "^16.3.1",
         "faker": "^4.1.0",
@@ -141,9 +141,9 @@
       }
     },
     "node_modules/@umbraco/playwright-testhelpers": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-2.0.0-beta.1.tgz",
-      "integrity": "sha512-tuuTqLgVrjXvj0VrYkH2H8Gp5wZAOyGPTYev6vtYxF6AOoegIUmQtMx3zMuadEgD1eRz0Qbd3yM78LGqmPi/jw==",
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-2.0.0-beta.2.tgz",
+      "integrity": "sha512-l3oTEYOgvdCnmFfIcJBzHhwVvp31JvnD8GSNxpWabFBTg6Ov5ZTdU9MaUhuEUdwMdmGdligh20X6zyDoal2eJQ==",
       "dependencies": {
         "@umbraco/json-models-builders": "^1.0.5",
         "camelize": "^1.0.0",

--- a/tests/Umbraco.Tests.AcceptanceTest/package.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@umbraco/json-models-builders": "^1.0.5",
-    "@umbraco/playwright-testhelpers": "2.0.0-beta.1",
+    "@umbraco/playwright-testhelpers": "2.0.0-beta.2",
     "camelize": "^1.0.0",
     "dotenv": "^16.3.1",
     "faker": "^4.1.0",

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/DataType/DataType.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/DataType/DataType.spec.ts
@@ -2,6 +2,8 @@
 import {expect} from "@playwright/test";
 
 test.describe('DataType tests', () => {
+  let dataTypeId = "";
+
   const dataTypeName = "TestType";
   const propertyEditorAlias = "Umbraco.DateTime";
   const dataTypeData = [
@@ -12,88 +14,87 @@ test.describe('DataType tests', () => {
   ];
 
   test.beforeEach(async ({page, umbracoApi}) => {
-    await umbracoApi.dataType.ensureDataTypeNameNotExistsAtRoot(dataTypeName);
+    await umbracoApi.dataType.ensureNameNotExistsAtRoot(dataTypeName);
   });
 
   test.afterEach(async ({page, umbracoApi}) => {
-    await umbracoApi.dataType.ensureDataTypeNameNotExistsAtRoot(dataTypeName);
+    await umbracoApi.dataType.delete(dataTypeId);
   });
 
   test('can create dataType', async ({page, umbracoApi, umbracoUi}) => {
-    await umbracoApi.dataType.createDataType(dataTypeName, propertyEditorAlias, dataTypeData);
+    dataTypeId = await umbracoApi.dataType.create(dataTypeName, propertyEditorAlias, dataTypeData);
 
     // Assert
-    await expect(umbracoApi.dataType.doesDataTypeWithNameExistAtRoot(dataTypeName)).toBeTruthy();
+    await expect(umbracoApi.dataType.exists(dataTypeId)).toBeTruthy();
   });
 
   test('can update dataType', async ({page, umbracoApi, umbracoUi}) => {
-    await umbracoApi.dataType.createDataType(dataTypeName, propertyEditorAlias, []);
+    dataTypeId = await umbracoApi.dataType.create(dataTypeName, propertyEditorAlias, []);
 
-    const dataType = await umbracoApi.dataType.getDataTypeByNameAtRoot(dataTypeName);
+    const dataType = await umbracoApi.dataType.get(dataTypeId);
 
     dataType.values = dataTypeData;
-    await umbracoApi.dataType.updateDataTypeById(dataType.id, dataTypeData);
+    await umbracoApi.dataType.update(dataTypeId, dataType);
 
     // Assert
     // Checks if the data type was updated
-    const updatedDataType = await umbracoApi.dataType.getDataTypeByNameAtRoot(dataTypeName);
-    await expect(updatedDataType.values = dataTypeData).toBeTruthy();
+    const updatedDataType = await umbracoApi.dataType.get(dataTypeId);
+    await expect(updatedDataType.values).toEqual(dataTypeData);
   });
 
   test('can delete dataType', async ({page, umbracoApi, umbracoUi}) => {
-    await umbracoApi.dataType.createDataType(dataTypeName, propertyEditorAlias, dataTypeData);
+    dataTypeId = await umbracoApi.dataType.create(dataTypeName, propertyEditorAlias, dataTypeData);
 
-    await expect(await umbracoApi.dataType.doesDataTypeWithNameExistAtRoot(dataTypeName)).toBeTruthy();
+    await expect(await umbracoApi.dataType.exists(dataTypeId)).toBeTruthy();
 
-    await umbracoApi.dataType.deleteDataTypeByNameAtRoot(dataTypeName);
+    await umbracoApi.dataType.delete(dataTypeId);
 
     // Assert
-    await expect(await umbracoApi.dataType.doesDataTypeWithNameExistAtRoot(dataTypeName)).toBeFalsy();
+    await expect(await umbracoApi.dataType.exists(dataTypeId)).toBeFalsy();
   });
 
   test('can move a dataType to a folder', async ({page, umbracoApi, umbracoUi}) => {
     const folderName = 'FolderToMoveToo';
 
-    await umbracoApi.dataType.ensureDataTypeNameNotExistsAtRoot(folderName);
+    await umbracoApi.dataType.ensureNameNotExistsAtRoot(folderName);
 
-    await umbracoApi.dataType.createDataType(dataTypeName, propertyEditorAlias, dataTypeData);
-    await umbracoApi.dataType.createDataTypeFolder(folderName);
+    dataTypeId = await umbracoApi.dataType.create(dataTypeName, propertyEditorAlias, dataTypeData);
+    const dataTypeFolderId = await umbracoApi.dataType.createFolder(folderName);
 
-    const dataType = await umbracoApi.dataType.getDataTypeByNameAtRoot(dataTypeName);
-    const dataTypeFolder = await umbracoApi.dataType.getDataTypeFolderByName(folderName);
-
-    await umbracoApi.dataType.moveDataTypeToFolderById(dataType.id, dataTypeFolder.id);
+    await umbracoApi.dataType.moveToFolder(dataTypeId, dataTypeFolderId);
 
     // Assert
-    const dataTypeInFolder = await umbracoApi.dataType.getDataTypeChildrenById(dataTypeFolder.id);
-    await expect(dataTypeInFolder.items[0].name === dataTypeName).toBeTruthy();
-    // Since the dataType was moved it should not be in the root anymore
-    await expect(await umbracoApi.dataType.doesDataTypeWithNameExistAtRoot(dataTypeName)).toBeFalsy();
+    // Checks if the datatype has the parentId of the folder
+    const dataTypeInFolder = await umbracoApi.dataType.getChildren(dataTypeFolderId);
+    await expect(dataTypeInFolder.items[0].parentId).toEqual(dataTypeFolderId);
 
     // Clean
-    await umbracoApi.dataType.ensureDataTypeNameNotExistsAtRoot(folderName);
+    await umbracoApi.dataType.deleteFolder(dataTypeFolderId);
   });
 
   test('can copy a dataType to a folder', async ({page, umbracoApi, umbracoUi}) => {
     const folderName = 'FolderToCopyToo';
 
-    await umbracoApi.dataType.ensureDataTypeNameNotExistsAtRoot(folderName);
+    await umbracoApi.dataType.ensureNameNotExistsAtRoot(folderName);
 
-    await umbracoApi.dataType.createDataType(dataTypeName, propertyEditorAlias, dataTypeData);
-    await umbracoApi.dataType.createDataTypeFolder(folderName);
+    dataTypeId = await umbracoApi.dataType.create(dataTypeName, propertyEditorAlias, dataTypeData);
+    const dataTypeFolderId = await umbracoApi.dataType.createFolder(folderName);
 
-    const dataType = await umbracoApi.dataType.getDataTypeByNameAtRoot(dataTypeName);
-    const dataTypeFolder = await umbracoApi.dataType.getDataTypeFolderByName(folderName);
+    const dataType = await umbracoApi.dataType.get(dataTypeId);
+    const dataTypeFolder = await umbracoApi.dataType.getFolder(dataTypeFolderId);
 
-    await umbracoApi.dataType.copyDataTypeToFolderById(dataType.id, dataTypeFolder.id);
+    const copiedDataTypeId = await umbracoApi.dataType.copyToFolder(dataType.id, dataTypeFolder.id);
 
-    const dataTypeInFolder = await umbracoApi.dataType.getDataTypeChildrenById(dataTypeFolder.id);
+    const copiedDataType = await umbracoApi.dataType.get(copiedDataTypeId);
+
+    await expect(copiedDataType.name).toEqual(dataTypeName + ' (copy)');
 
     // Assert
-    await expect(dataTypeInFolder.items[0].name === dataTypeName + ' (copy)').toBeTruthy();
-    await expect(await umbracoApi.dataType.doesDataTypeWithNameExistAtRoot(dataTypeName)).toBeTruthy();
+    // Checks if both dataTypes exists
+    await expect(await umbracoApi.dataType.exists(dataTypeId)).toBeTruthy();
+    await expect(await umbracoApi.dataType.exists(copiedDataTypeId)).toBeTruthy();
 
     // Clean
-    await umbracoApi.dataType.ensureDataTypeNameNotExistsAtRoot(folderName);
+    await umbracoApi.dataType.deleteFolder(dataTypeFolderId);
   });
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/DataType/DataTypeFolder.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/DataType/DataTypeFolder.spec.ts
@@ -2,49 +2,49 @@
 import {expect} from "@playwright/test";
 
 test.describe('DataTypeFolder tests', () => {
+  let dataTypeFolderId = "";
   const dataTypeFolderName = "TestTypeFolder";
 
   test.beforeEach(async ({page, umbracoApi}) => {
-    await umbracoApi.dataType.ensureDataTypeNameNotExistsAtRoot(dataTypeFolderName);
+    await umbracoApi.dataType.ensureNameNotExistsAtRoot(dataTypeFolderName);
   });
 
   test.afterEach(async ({page, umbracoApi}) => {
-    await umbracoApi.dataType.ensureDataTypeNameNotExistsAtRoot(dataTypeFolderName);
+    await umbracoApi.dataType.deleteFolder(dataTypeFolderId);
   });
 
   test('can create a dataType folder', async ({page, umbracoApi, umbracoUi}) => {
-    await umbracoApi.dataType.createDataTypeFolder(dataTypeFolderName);
+    dataTypeFolderId = await umbracoApi.dataType.createFolder(dataTypeFolderName);
 
     // Assert
-    await expect(umbracoApi.dataType.doesDataTypeWithNameExistAtRoot(dataTypeFolderName)).toBeTruthy();
+    await expect(umbracoApi.dataType.folderExists(dataTypeFolderId)).toBeTruthy();
   });
 
   test('can update a dataType folder', async ({page, umbracoApi, umbracoUi}) => {
     const oldDataTypeFolderName = 'Oldie';
 
-    await umbracoApi.dataType.createDataTypeFolder(oldDataTypeFolderName);
-
-    const dataTypeFolder = await umbracoApi.dataType.getDataTypeFolderByName(oldDataTypeFolderName);
+    dataTypeFolderId = await umbracoApi.dataType.createFolder(oldDataTypeFolderName);
+    const dataTypeFolder = await umbracoApi.dataType.getFolder(dataTypeFolderId);
 
     // Updates the dataType folder
     dataTypeFolder.name = dataTypeFolderName;
-    await umbracoApi.dataType.updateDataTypeFolderById(dataTypeFolder.id, dataTypeFolder);
+    await umbracoApi.dataType.updateFolder(dataTypeFolderId, dataTypeFolder);
 
     // Assert
-    await umbracoApi.dataType.doesDataTypeWithNameExistAtRoot(dataTypeFolderName);
+    await expect(umbracoApi.dataType.folderExists(dataTypeFolderId)).toBeTruthy();
     // Checks if the dataType folder was updated
-    const newDataTypeFolderName = await umbracoApi.dataType.getDataTypeFolderById(dataTypeFolder.id);
-    await expect(newDataTypeFolderName.name == dataTypeFolderName).toBeTruthy();
+    const newDataTypeFolderName = await umbracoApi.dataType.getFolder(dataTypeFolderId);
+    await expect(newDataTypeFolderName.name).toEqual(dataTypeFolderName);
   });
 
   test('can delete a dataType folder', async ({page, umbracoApi, umbracoUi}) => {
-    await umbracoApi.dataType.createDataTypeFolder(dataTypeFolderName);
+    await umbracoApi.dataType.createFolder(dataTypeFolderName);
 
-    await expect(umbracoApi.dataType.doesDataTypeWithNameExistAtRoot(dataTypeFolderName)).toBeTruthy();
+    await expect(umbracoApi.dataType.folderExists(dataTypeFolderId)).toBeTruthy();
 
-    await umbracoApi.dataType.deleteDataTypeFolderByName(dataTypeFolderName);
+    await umbracoApi.dataType.delete(dataTypeFolderId);
 
     // Assert
-    await expect(await umbracoApi.dataType.doesDataTypeWithNameExistAtRoot(dataTypeFolderName)).toBeFalsy();
+    await expect(await umbracoApi.dataType.folderExists(dataTypeFolderId)).toBeFalsy();
   });
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/Dictionary/Dictionary.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/Dictionary/Dictionary.spec.ts
@@ -2,14 +2,15 @@ import {test} from '@umbraco/playwright-testhelpers';
 import {expect} from "@playwright/test";
 
 test.describe('Dictionary tests', () => {
+  let dictionaryId = "";
   const dictionaryName = 'Word'
 
   test.beforeEach(async ({page, umbracoApi}) => {
-    await umbracoApi.dictionary.ensureDictionaryNameNotExists(dictionaryName);
+    await umbracoApi.dictionary.ensureNameNotExists(dictionaryName);
   });
 
   test.afterEach(async ({page, umbracoApi}) => {
-    await umbracoApi.dictionary.ensureDictionaryNameNotExists(dictionaryName);
+    await umbracoApi.dictionary.delete(dictionaryId);
   })
 
   test('can create a dictionary', async ({page, umbracoApi, umbracoUi}) => {
@@ -24,60 +25,55 @@ test.describe('Dictionary tests', () => {
       }
     ];
 
-    await umbracoApi.dictionary.createDictionary(dictionaryName, translationData);
+    dictionaryId = await umbracoApi.dictionary.create(dictionaryName, translationData);
 
     // Assert
-    await expect(umbracoApi.dictionary.doesDictionaryWithNameExists(dictionaryName)).toBeTruthy();
+    await expect(umbracoApi.dictionary.exists(dictionaryId)).toBeTruthy();
   });
 
   test('can update a dictionary', async ({page, umbracoApi, umbracoUi}) => {
     const oldDictionaryName = 'OldWord';
 
-    await umbracoApi.dictionary.createDictionary(oldDictionaryName);
+    dictionaryId = await umbracoApi.dictionary.create(oldDictionaryName);
 
-    const dictionary = await umbracoApi.dictionary.getDictionaryByName(oldDictionaryName);
+    const dictionary = await umbracoApi.dictionary.get(dictionaryId);
 
     // Updates the dictionary name
     dictionary.name = dictionaryName;
-    await umbracoApi.dictionary.updateDictionaryById(dictionary.id, dictionary);
+    await umbracoApi.dictionary.update(dictionaryId, dictionary);
 
     // Assert
     // Checks if the dictionary was updated
-    const newDictionary = await umbracoApi.dictionary.getDictionaryById(dictionary.id);
-    await expect(newDictionary.name == dictionaryName).toBeTruthy();
+    const newDictionary = await umbracoApi.dictionary.get(dictionaryId);
+    await expect(newDictionary.name).toEqual(dictionaryName);
 
-    await expect(umbracoApi.dictionary.doesDictionaryWithNameExists(dictionaryName)).toBeTruthy();
+    await expect(umbracoApi.dictionary.exists(dictionaryId)).toBeTruthy();
   });
 
   test('can delete a dictionary', async ({page, umbracoApi, umbracoUi}) => {
-    await umbracoApi.dictionary.createDictionary(dictionaryName);
+    dictionaryId = await umbracoApi.dictionary.create(dictionaryName);
 
-    await expect(umbracoApi.dictionary.doesDictionaryWithNameExists(dictionaryName)).toBeTruthy();
+    await expect(umbracoApi.dictionary.exists(dictionaryId)).toBeTruthy();
 
-    await umbracoApi.dictionary.deleteDictionaryByName(dictionaryName);
+    await umbracoApi.dictionary.delete(dictionaryId);
 
     // Assert
-    await expect(await umbracoApi.dictionary.doesDictionaryWithNameExists(dictionaryName)).toBeFalsy();
+    await expect(await umbracoApi.dictionary.exists(dictionaryId)).toBeFalsy();
   });
 
   test('can create a dictionary item in a dictionary', async ({page, umbracoApi, umbracoUi}) => {
     const parentDictionaryName = 'Book';
 
-    await umbracoApi.dictionary.ensureDictionaryNameNotExists(parentDictionaryName);
+    await umbracoApi.dictionary.ensureNameNotExists(parentDictionaryName);
 
-    await umbracoApi.dictionary.createDictionary(parentDictionaryName);
+    dictionaryId = await umbracoApi.dictionary.create(parentDictionaryName);
 
-    const parentDictionary = await umbracoApi.dictionary.getDictionaryByName(parentDictionaryName);
+    await umbracoApi.dictionary.create(dictionaryName, [], dictionaryId);
 
-    await umbracoApi.dictionary.createDictionary(dictionaryName, [], parentDictionary.id);
-
-    const dictionaryChildren = await umbracoApi.dictionary.getDictionaryChildrenById(parentDictionary.id);
+    const parentDictionaryChildren = await umbracoApi.dictionary.getChildren(dictionaryId);
 
     // Assert
     // Checks if the parent dictionary contains the child dictionary
-    await expect(dictionaryChildren.items[0].name == dictionaryName).toBeTruthy();
-
-    // Clean
-    await umbracoApi.dictionary.ensureDictionaryNameNotExists(parentDictionaryName);
+    await expect(parentDictionaryChildren.items[0].name).toEqual(dictionaryName);
   });
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/Language/Language.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/Language/Language.spec.ts
@@ -6,46 +6,46 @@ test.describe('Language tests', () => {
   const isoCodeDanish = 'da-DK';
 
   test.beforeEach(async ({page, umbracoApi}) => {
-    await umbracoApi.language.ensureIsoCodeNotExists(isoCodeDanish);
+    await umbracoApi.language.delete(isoCodeDanish);
   });
 
   test.afterEach(async ({page, umbracoApi}) => {
-    await umbracoApi.language.ensureIsoCodeNotExists(isoCodeDanish);
+    await umbracoApi.language.delete(isoCodeDanish);
   });
 
-  test('can create new language', async ({page, umbracoApi, umbracoUi}) => {
-    await umbracoApi.language.createLanguage(languageNameDanish, false, false, isoCodeDanish);
+  test('can create a language', async ({page, umbracoApi, umbracoUi}) => {
+    await umbracoApi.language.create(languageNameDanish, false, false, isoCodeDanish);
 
     // Assert
-    await expect(await umbracoApi.language.doesLanguageWithIsoCodeExist(isoCodeDanish)).toBeTruthy();
+    await expect(await umbracoApi.language.exists(isoCodeDanish)).toBeTruthy();
   });
 
-  test('can update language', async ({page, umbracoApi, umbracoUi}) => {
+  test('can update a language', async ({page, umbracoApi, umbracoUi}) => {
     const wrongLanguageName = 'densk';
 
-    await umbracoApi.language.createLanguage(wrongLanguageName, false, false, isoCodeDanish);
+    await umbracoApi.language.create(wrongLanguageName, false, false, isoCodeDanish);
 
-    const language = await umbracoApi.language.getLanguageByName(wrongLanguageName);
+    const language = await umbracoApi.language.get(isoCodeDanish);
 
     // Updates language
     language.name = languageNameDanish;
-    await umbracoApi.language.updateLanguageWithIsoCode(isoCodeDanish, language);
+    await umbracoApi.language.update(isoCodeDanish, language);
 
     // Assert
-    await expect(await umbracoApi.language.doesLanguageWithIsoCodeExist(isoCodeDanish)).toBeTruthy();
+    await expect(await umbracoApi.language.exists(isoCodeDanish)).toBeTruthy();
     // Checks if the language name was updated
-    const updatedLanguage = await umbracoApi.language.getLanguageByIsoCode(isoCodeDanish);
-    await expect(updatedLanguage.name == languageNameDanish).toBeTruthy();
+    const updatedLanguage = await umbracoApi.language.get(isoCodeDanish);
+    await expect(updatedLanguage.name).toEqual(languageNameDanish);
   });
 
-  test('can delete language', async ({page, umbracoApi, umbracoUi}) => {
-    await umbracoApi.language.createLanguage(languageNameDanish, false, false, isoCodeDanish);
+  test('can delete a language', async ({page, umbracoApi, umbracoUi}) => {
+    await umbracoApi.language.create(languageNameDanish, false, false, isoCodeDanish);
 
-    await expect(await umbracoApi.language.doesLanguageWithIsoCodeExist(isoCodeDanish)).toBeTruthy();
+    await expect(await umbracoApi.language.exists(isoCodeDanish)).toBeTruthy();
 
-    await umbracoApi.language.deleteLanguageWithIsoCode(isoCodeDanish);
+    await umbracoApi.language.delete(isoCodeDanish);
 
     // Assert
-    await expect(await umbracoApi.language.doesLanguageWithIsoCodeExist(isoCodeDanish)).toBeFalsy();
+    await expect(await umbracoApi.language.exists(isoCodeDanish)).toBeFalsy();
   });
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/PartialView/PartialView.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/PartialView/PartialView.spec.ts
@@ -2,49 +2,48 @@ import {test} from '@umbraco/playwright-testhelpers';
 import {expect} from "@playwright/test";
 
 test.describe('Partial View tests', () => {
+  let partialViewPath = "";
   const partialViewName = 'partialViewName.cshtml';
 
   test.beforeEach(async ({page, umbracoApi}) => {
-    await umbracoApi.partialView.ensurePartialViewNameNotExistsAtRoot(partialViewName);
+    await umbracoApi.partialView.ensureNameNotExistsAtRoot(partialViewName);
   });
 
   test.afterEach(async ({page, umbracoApi}) => {
-    await umbracoApi.partialView.ensurePartialViewNameNotExistsAtRoot(partialViewName);
+    await umbracoApi.partialView.delete(partialViewPath);
   });
 
-  test('can create partial view', async ({page, umbracoApi, umbracoUi}) => {
-    await umbracoApi.partialView.createPartialView(partialViewName, 'test');
+  test('can create a partial view', async ({page, umbracoApi, umbracoUi}) => {
+    partialViewPath = await umbracoApi.partialView.create(partialViewName, 'test');
 
     // Assert
-    await expect(await umbracoApi.partialView.doesPartialViewWithNameExistAtRoot(partialViewName)).toBeTruthy();
+    await expect(await umbracoApi.partialView.exists(partialViewPath)).toBeTruthy();
   });
 
-  test('can update partial view', async ({page, umbracoApi, umbracoUi}) => {
+  test('can update a partial view', async ({page, umbracoApi, umbracoUi}) => {
     const newContent = 'Howdy';
 
-    await umbracoApi.partialView.createPartialView(partialViewName, 'test');
+    partialViewPath = await umbracoApi.partialView.create(partialViewName, 'test');
 
-    const partialView = await umbracoApi.partialView.getPartialViewByNameAtRoot(partialViewName);
+    const partialView = await umbracoApi.partialView.get(partialViewPath);
 
     partialView.content = newContent;
 
-    await umbracoApi.partialView.updatePartialView(partialView);
+    await umbracoApi.partialView.update(partialView);
 
     // Assert
-    const updatedPartialView = await umbracoApi.partialView.getPartialViewByPath(partialView.path);
-    await expect(updatedPartialView.content === newContent).toBeTruthy();
+    const updatedPartialView = await umbracoApi.partialView.get(partialViewPath);
+    await expect(updatedPartialView.content).toEqual(newContent);
   });
 
-  test('can delete partial view', async ({page, umbracoApi, umbracoUi}) => {
-    await umbracoApi.partialView.createPartialView(partialViewName, 'test');
+  test('can delete a partial view', async ({page, umbracoApi, umbracoUi}) => {
+    partialViewPath = await umbracoApi.partialView.create(partialViewName, 'test');
 
-    await expect(await umbracoApi.partialView.doesPartialViewWithNameExistAtRoot(partialViewName)).toBeTruthy();
+    await expect(await umbracoApi.partialView.exists(partialViewPath)).toBeTruthy();
 
-    const partialView = await umbracoApi.partialView.getPartialViewByNameAtRoot(partialViewName);
-
-    await umbracoApi.partialView.deletePartialViewByPath(partialView.path);
+    await umbracoApi.partialView.delete(partialViewPath);
 
     // Assert
-    await expect(await umbracoApi.partialView.doesPartialViewWithNameExistAtRoot(partialViewName)).toBeFalsy();
+    await expect(await umbracoApi.partialView.exists(partialViewPath)).toBeFalsy();
   });
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/PartialView/PartialViewFolder.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/PartialView/PartialViewFolder.spec.ts
@@ -57,8 +57,8 @@ test.describe('Partial View Folder tests', () => {
     const childOfParent = await umbracoApi.partialView.getFolderChildren(partialViewFolderPath);
 
     // Creates childOfChild folder in child folder
-    await umbracoApi.partialView.createFolder(childOfChildFolderName, childOfParent.childOfParentPath);
-    const childOfChild = await umbracoApi.partialView.getFolderChildren(childOfParent.childOfParentPath);
+    await umbracoApi.partialView.createFolder(childOfChildFolderName, childOfParentPath);
+    const childOfChild = await umbracoApi.partialView.getFolderChildren(childOfParentPath);
 
     // Assert
     // Checks if the partial views folder are in the correct folders

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/PartialView/PartialViewFolder.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/PartialView/PartialViewFolder.spec.ts
@@ -2,47 +2,47 @@ import {test} from '@umbraco/playwright-testhelpers';
 import {expect} from "@playwright/test";
 
 test.describe('Partial View Folder tests', () => {
+  let partialViewFolderPath = "";
   const partialViewFolderName = 'partialViewFolder';
 
   test.beforeEach(async ({page, umbracoApi}) => {
-    await umbracoApi.partialView.ensurePartialViewNameNotExistsAtRoot(partialViewFolderName);
+    await umbracoApi.partialView.ensureNameNotExistsAtRoot(partialViewFolderName);
   });
 
   test.afterEach(async ({page, umbracoApi}) => {
-    await umbracoApi.partialView.ensurePartialViewNameNotExistsAtRoot(partialViewFolderName);
+    await umbracoApi.partialView.deleteFolder(partialViewFolderPath);
   });
 
-  test('can create partial view folder', async ({page, umbracoApi, umbracoUi}) => {
-    await umbracoApi.partialView.createPartialViewFolder(partialViewFolderName);
+  test('can create a partial view folder', async ({page, umbracoApi, umbracoUi}) => {
+    partialViewFolderPath = await umbracoApi.partialView.createFolder(partialViewFolderName);
 
     // Assert
-    await expect(umbracoApi.partialView.doesPartialViewWithNameExistAtRoot(partialViewFolderName)).toBeTruthy();
+    await expect(await umbracoApi.partialView.folderExists(partialViewFolderPath)).toBeTruthy();
   });
 
-  test('can delete partial view folder', async ({page, umbracoApi, umbracoUi}) => {
-    await umbracoApi.partialView.createPartialViewFolder(partialViewFolderName);
+  test('can delete a partial view folder', async ({page, umbracoApi, umbracoUi}) => {
+    partialViewFolderPath = await umbracoApi.partialView.createFolder(partialViewFolderName);
 
-    await expect(await umbracoApi.partialView.doesPartialViewWithNameExistAtRoot(partialViewFolderName)).toBeTruthy();
-    const partialViewFolder = await umbracoApi.partialView.getPartialViewByNameAtRoot(partialViewFolderName);
+    await expect(await umbracoApi.partialView.folderExists(partialViewFolderPath)).toBeTruthy();
 
-    await umbracoApi.partialView.deletePartialViewFolder(partialViewFolder.path);
+    await umbracoApi.partialView.deleteFolder(partialViewFolderPath);
 
     // Assert
-    await expect(await umbracoApi.partialView.doesPartialViewWithNameExistAtRoot(partialViewFolderName)).toBeFalsy();
+    await expect(await umbracoApi.partialView.folderExists(partialViewFolderPath)).toBeFalsy();
   });
 
   test('can add a partial view folder in another', async ({page, umbracoApi, umbracoUi}) => {
     const childFolderName = 'childFolder';
-    await umbracoApi.partialView.createPartialViewFolder(partialViewFolderName);
+    partialViewFolderPath = await umbracoApi.partialView.createFolder(partialViewFolderName);
 
-    const parentFolder = await umbracoApi.partialView.getPartialViewByNameAtRoot(partialViewFolderName);
+    await umbracoApi.partialView.getFolder(partialViewFolderPath);
 
-    await umbracoApi.partialView.createPartialViewFolder(childFolderName, parentFolder.path);
+    await umbracoApi.partialView.createFolder(childFolderName, partialViewFolderPath);
 
-    const children = await umbracoApi.partialView.getChildrenInPartialViewFolderByPath(parentFolder.path);
+    const children = await umbracoApi.partialView.getFolderChildren(partialViewFolderPath);
 
     // Assert
-    await expect(children.items[0].name === childFolderName).toBeTruthy();
+    await expect(children.items[0].name).toEqual(childFolderName);
   });
 
   test('can add a partial view folder in a folder in another folder', async ({page, umbracoApi, umbracoUi}) => {
@@ -50,20 +50,19 @@ test.describe('Partial View Folder tests', () => {
     const childOfChildFolderName = 'childOfChildFolder';
 
     // Creates parent folder
-    await umbracoApi.partialView.createPartialViewFolder(partialViewFolderName);
-    const parentFolder = await umbracoApi.partialView.getPartialViewByNameAtRoot(partialViewFolderName);
+    partialViewFolderPath = await umbracoApi.partialView.createFolder(partialViewFolderName);
 
     // Creates child folder in parent folder
-    await umbracoApi.partialView.createPartialViewFolder(childFolderName, parentFolder.path);
-    const childOfParent = await umbracoApi.partialView.getChildrenInPartialViewFolderByPath(parentFolder.path);
+    const childOfParentPath = await umbracoApi.partialView.createFolder(childFolderName, partialViewFolderPath);
+    const childOfParent = await umbracoApi.partialView.getFolderChildren(partialViewFolderPath);
 
     // Creates childOfChild folder in child folder
-    await umbracoApi.partialView.createPartialViewFolder(childOfChildFolderName, childOfParent.items[0].path);
-    const childOfChild = await umbracoApi.partialView.getChildrenInPartialViewFolderByPath(childOfParent.items[0].path);
+    await umbracoApi.partialView.createFolder(childOfChildFolderName, childOfParent.childOfParentPath);
+    const childOfChild = await umbracoApi.partialView.getFolderChildren(childOfParent.childOfParentPath);
 
     // Assert
     // Checks if the partial views folder are in the correct folders
-    await expect(childOfParent.items[0].name === childFolderName).toBeTruthy();
-    await expect(childOfChild.items[0].name === childOfChildFolderName).toBeTruthy();
+    await expect(childOfParent.items[0].name).toEqual(childFolderName);
+    await expect(childOfChild.items[0].name).toEqual(childOfChildFolderName);
   });
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/Script/Script.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/Script/Script.spec.ts
@@ -2,50 +2,49 @@ import {test} from '@umbraco/playwright-testhelpers';
 import {expect} from "@playwright/test";
 
 test.describe('Script tests', () => {
+  let scriptPath = "";
   const scriptName = 'scriptName.js';
 
   test.beforeEach(async ({page, umbracoApi}) => {
-    await umbracoApi.script.ensureScriptNotNameNotExistsAtRoot(scriptName);
+    await umbracoApi.script.ensureNameNotExistsAtRoot(scriptName);
   });
 
   test.afterEach(async ({page, umbracoApi}) => {
-    await umbracoApi.script.ensureScriptNotNameNotExistsAtRoot(scriptName);
+    await umbracoApi.script.delete(scriptPath);
   });
 
   test('can create a script', async ({page, umbracoApi, umbracoUi}) => {
-    await umbracoApi.script.createScript(scriptName, 'test');
+    scriptPath = await umbracoApi.script.create(scriptName, 'test');
 
     // Assert
-    await expect(await umbracoApi.script.doesScriptWithNameExistAtRoot(scriptName)).toBeTruthy();
+    await expect(await umbracoApi.script.exists(scriptPath)).toBeTruthy();
   });
 
   test('can update a script', async ({page, umbracoApi, umbracoUi}) => {
     const newContent = 'Howdy';
 
-    await umbracoApi.script.createScript(scriptName, 'test');
+    scriptPath = await umbracoApi.script.create(scriptName, 'test');
 
-    const script = await umbracoApi.script.getScriptByNameAtRoot(scriptName);
+    const script = await umbracoApi.script.get(scriptPath);
 
     script.content = newContent;
 
-    await umbracoApi.script.updateScript(script);
+    await umbracoApi.script.update(script);
 
     // Assert
     // Checks if the content was updated for the script
-    const updatedScript = await umbracoApi.script.getScriptByPath(script.path);
-    await expect(updatedScript.content === newContent).toBeTruthy();
+    const updatedScript = await umbracoApi.script.get(scriptPath);
+    await expect(updatedScript.content).toEqual(newContent);
   });
 
   test('can delete a script', async ({page, umbracoApi, umbracoUi}) => {
-    await umbracoApi.script.createScript(scriptName, 'test');
+    scriptPath = await umbracoApi.script.create(scriptName, 'test');
 
-    await expect(await umbracoApi.script.doesScriptWithNameExistAtRoot(scriptName)).toBeTruthy();
+    await expect(await umbracoApi.script.exists(scriptPath)).toBeTruthy();
 
-    const script = await umbracoApi.script.getScriptByNameAtRoot(scriptName);
-
-    await umbracoApi.script.deleteScriptByPath(script.path);
+    await umbracoApi.script.delete(scriptPath);
 
     // Assert
-    await expect(await umbracoApi.script.doesScriptWithNameExistAtRoot(scriptName)).toBeFalsy();
+    await expect(await umbracoApi.script.exists(scriptPath)).toBeFalsy();
   });
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/Stylesheet/Stylesheet.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/Stylesheet/Stylesheet.spec.ts
@@ -2,95 +2,91 @@ import {test} from '@umbraco/playwright-testhelpers';
 import {expect} from "@playwright/test";
 
 test.describe('Stylesheet tests', () => {
+  let stylesheetPath = "";
   const stylesheetName = 'Stylesheet.css';
 
   test.beforeEach(async ({page, umbracoApi}) => {
-    await umbracoApi.stylesheet.ensureStylesheetNameNotExistsAtRoot(stylesheetName);
+    await umbracoApi.stylesheet.ensureNameNotExistsAtRoot(stylesheetName);
   });
 
   test.afterEach(async ({page, umbracoApi}) => {
-    await umbracoApi.stylesheet.ensureStylesheetNameNotExistsAtRoot(stylesheetName);
+    await umbracoApi.stylesheet.delete(stylesheetPath);
   });
 
   test('can create a stylesheet', async ({page, umbracoApi, umbracoUi}) => {
-    await umbracoApi.stylesheet.createStylesheet(stylesheetName, 'content');
+    stylesheetPath = await umbracoApi.stylesheet.create(stylesheetName, 'content');
 
     // Assert
-    await expect(await umbracoApi.stylesheet.doesStylesheetWithNameExistAtRoot(stylesheetName)).toBeTruthy();
+    await expect(await umbracoApi.stylesheet.exists(stylesheetPath)).toBeTruthy();
   });
 
   test('can update a stylesheet', async ({page, umbracoApi, umbracoUi}) => {
     const newContent = 'BetterContent';
 
-    await umbracoApi.stylesheet.createStylesheet(stylesheetName, 'content');
+    stylesheetPath = await umbracoApi.stylesheet.create(stylesheetName, 'content');
 
-    const stylesheet = await umbracoApi.stylesheet.getStylesheetByNameAtRoot(stylesheetName);
+    const stylesheet = await umbracoApi.stylesheet.get(stylesheetPath);
 
     stylesheet.content = newContent;
 
-    await umbracoApi.stylesheet.updateStylesheet(stylesheet);
+    await umbracoApi.stylesheet.update(stylesheet);
 
     // Assert
     // Checks if the content was updated for the stylesheet
-    const updatedStylesheet = await umbracoApi.stylesheet.getStylesheetByPath(stylesheet.path);
-    await expect(updatedStylesheet.content === newContent).toBeTruthy();
+    const updatedStylesheet = await umbracoApi.stylesheet.get(stylesheetPath);
+    await expect(updatedStylesheet.content).toEqual(newContent);
   });
 
   test('can delete a stylesheet', async ({page, umbracoApi, umbracoUi}) => {
-    await umbracoApi.stylesheet.createStylesheet(stylesheetName, 'content');
+    stylesheetPath = await umbracoApi.stylesheet.create(stylesheetName, 'content');
 
-    await expect(await umbracoApi.stylesheet.doesStylesheetWithNameExistAtRoot(stylesheetName)).toBeTruthy();
+    await expect(await umbracoApi.stylesheet.exists(stylesheetPath)).toBeTruthy();
 
-    const stylesheet = await umbracoApi.stylesheet.getStylesheetByNameAtRoot(stylesheetName);
-
-    await umbracoApi.stylesheet.deleteStylesheetByPath(stylesheet.path);
+    await umbracoApi.stylesheet.delete(stylesheetPath);
 
     // Assert
-    await expect(await umbracoApi.stylesheet.doesStylesheetWithNameExistAtRoot(stylesheetName)).toBeFalsy();
+    await expect(await umbracoApi.stylesheet.exists(stylesheetPath)).toBeFalsy();
   });
 
   test('can create a stylesheet in a folder', async ({page, umbracoApi, umbracoUi}) => {
     const folderName = 'StyledFolder';
 
-    await umbracoApi.stylesheet.ensureStylesheetNameNotExistsAtRoot(folderName);
+    await umbracoApi.stylesheet.ensureNameNotExistsAtRoot(folderName);
 
-    await umbracoApi.stylesheet.createStylesheetFolder(folderName);
+    stylesheetPath = await umbracoApi.stylesheet.createFolder(folderName);
 
-    const folder = await umbracoApi.stylesheet.getStylesheetByNameAtRoot(folderName);
-
-    await umbracoApi.stylesheet.createStylesheet(stylesheetName, 'content', folder.path);
+    await umbracoApi.stylesheet.create(stylesheetName, 'content', stylesheetPath);
 
     // Assert
-    const child = await umbracoApi.stylesheet.getChildrenInStylesheetFolderByPath(folder.path);
-    await expect(child.items[0].name === stylesheetName).toBeTruthy();
+    const child = await umbracoApi.stylesheet.getFolderChildren(stylesheetPath);
+    await expect(child.items[0].name).toEqual(stylesheetName);
 
     // Clean
-    await umbracoApi.stylesheet.ensureStylesheetNameNotExistsAtRoot(folderName);
+    await umbracoApi.stylesheet.deleteFolder(stylesheetPath);
   });
 
   test('can delete a stylesheet from a folder', async ({page, umbracoApi, umbracoUi}) => {
     const folderName = 'StyledFolder';
 
-    await umbracoApi.stylesheet.ensureStylesheetNameNotExistsAtRoot(folderName);
+    await umbracoApi.stylesheet.ensureNameNotExistsAtRoot(folderName);
 
-    await umbracoApi.stylesheet.createStylesheetFolder(folderName);
+    stylesheetPath = await umbracoApi.stylesheet.createFolder(folderName);
 
-    const folder = await umbracoApi.stylesheet.getStylesheetByNameAtRoot(folderName);
-
-    await umbracoApi.stylesheet.createStylesheet(stylesheetName, 'deleteMe', folder.path);
+    const stylesheetChildPath = await umbracoApi.stylesheet.create(stylesheetName, 'deleteMe', stylesheetPath);
 
     // Checks if the stylesheet was created
-    const child = await umbracoApi.stylesheet.getChildrenInStylesheetFolderByPath(folder.path);
+    const child = await umbracoApi.stylesheet.getFolderChildren(stylesheetPath);
 
-    await expect(child.items[0].name === stylesheetName).toBeTruthy();
+    // Checks if the child is in the folder
+    await expect(child.items[0].name).toEqual(stylesheetName);
 
-    await umbracoApi.stylesheet.deleteStylesheetByPath(child.items[0].path);
+    await umbracoApi.stylesheet.delete(stylesheetChildPath);
 
     // Assert
-    const noChild = await umbracoApi.stylesheet.getChildrenInStylesheetFolderByPath(folder.path);
-    await expect(noChild.items[0] === undefined).toBeTruthy();
+    const noChild = await umbracoApi.stylesheet.getFolderChildren(stylesheetPath);
+    await expect(noChild.items[0]).toEqual(undefined);
 
     // Clean
-    await umbracoApi.stylesheet.ensureStylesheetNameNotExistsAtRoot(folderName);
+    await umbracoApi.stylesheet.deleteFolder(stylesheetPath);
   });
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/Template/Template.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/Template/Template.spec.ts
@@ -2,50 +2,51 @@
 import {expect} from "@playwright/test";
 
 test.describe('Template tests', () => {
+  let templateId = "";
   const templateName = 'TemplateTester';
   const templateAlias = AliasHelper.toAlias(templateName);
 
   test.beforeEach(async ({page, umbracoApi}) => {
-    await umbracoApi.template.ensureTemplateNameNotExistsAtRoot(templateName);
+    await umbracoApi.template.ensureNameNotExistsAtRoot(templateName);
   });
 
   test.afterEach(async ({page, umbracoApi}) => {
-    await umbracoApi.template.ensureTemplateNameNotExistsAtRoot(templateName);
+    await umbracoApi.template.delete(templateId);
   })
 
   test('can create a template', async ({page, umbracoApi, umbracoUi}) => {
-    await umbracoApi.template.createTemplate(templateName, templateAlias, 'Template Stuff');
+    templateId = await umbracoApi.template.create(templateName, templateAlias, 'Template Stuff');
 
     // Assert
-    await expect(umbracoApi.template.doesTemplateWithNameExistAtRoot(templateName)).toBeTruthy();
+    await expect(umbracoApi.template.exists(templateId)).toBeTruthy();
   });
 
   test('can update a template', async ({page, umbracoApi, umbracoUi}) => {
     const newTemplateAlias = 'betterAlias';
 
-    await umbracoApi.template.createTemplate(templateName, templateAlias, 'Template Stuff');
+    templateId = await umbracoApi.template.create(templateName, templateAlias, 'Template Stuff');
 
-    const templateData = await umbracoApi.template.getTemplateByNameAtRoot(templateName);
+    const templateData = await umbracoApi.template.get(templateId);
 
     // Updates the template
     templateData.alias = newTemplateAlias;
-    await umbracoApi.template.updateTemplateById(templateData.id, templateData);
+    await umbracoApi.template.update(templateId, templateData);
 
     // Assert
-    await expect(umbracoApi.template.doesTemplateWithNameExistAtRoot(templateName)).toBeTruthy();
+    await expect(umbracoApi.template.exists(templateId)).toBeTruthy();
     // Checks if the template alias was updated
-    const updatedTemplate = await umbracoApi.template.getTemplateByNameAtRoot(templateName);
-    await expect(updatedTemplate.alias == newTemplateAlias).toBeTruthy();
+    const updatedTemplate = await umbracoApi.template.get(templateId);
+    await expect(updatedTemplate.alias).toEqual(newTemplateAlias);
   });
 
   test('can delete template', async ({page, umbracoApi, umbracoUi}) => {
-    await umbracoApi.template.createTemplate(templateName, templateAlias, 'More Template Stuff');
+    templateId = await umbracoApi.template.create(templateName, templateAlias, 'More Template Stuff');
 
-    await expect(umbracoApi.template.doesTemplateWithNameExistAtRoot(templateName)).toBeTruthy();
+    await expect(umbracoApi.template.exists(templateId)).toBeTruthy();
 
-    await umbracoApi.template.deleteTemplateByNameAtRoot(templateName);
+    await umbracoApi.template.delete(templateId);
 
     // Assert
-    await expect(await umbracoApi.template.doesTemplateWithNameExistAtRoot(templateName)).toBeFalsy();
+    await expect(await umbracoApi.template.exists(templateId)).toBeFalsy();
   });
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/TemporaryFile/TemporaryFile.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/TemporaryFile/TemporaryFile.spec.ts
@@ -8,28 +8,28 @@ test.describe('Temporary File tests', () => {
   const filePath = './fixtures/mediaLibrary/Umbraco.png';
 
   test.beforeEach(async ({page, umbracoApi}) => {
-    await umbracoApi.temporaryFile.ensureTemporaryFileWithIdNotExists(temporaryFileId);
+    await umbracoApi.temporaryFile.delete(temporaryFileId);
   });
 
   test.afterEach(async ({page, umbracoApi}) => {
-    await umbracoApi.temporaryFile.ensureTemporaryFileWithIdNotExists(temporaryFileId);
+    await umbracoApi.temporaryFile.delete(temporaryFileId);
   });
 
   test('can create temporary file', async ({page, umbracoApi, umbracoUi}) => {
-    await umbracoApi.temporaryFile.createTemporaryFile(temporaryFileId, fileName, mimeType, filePath);
+    await umbracoApi.temporaryFile.create(temporaryFileId, fileName, mimeType, filePath);
 
     // Assert
-    await expect(await umbracoApi.temporaryFile.doesTemporaryFileWithIdExist(temporaryFileId)).toBeTruthy();
+    await expect(await umbracoApi.temporaryFile.exists(temporaryFileId)).toBeTruthy();
   });
 
   test('can delete temporary file', async ({page, umbracoApi, umbracoUi}) => {
-    await umbracoApi.temporaryFile.createTemporaryFile(temporaryFileId, fileName, mimeType, filePath);
+    await umbracoApi.temporaryFile.create(temporaryFileId, fileName, mimeType, filePath);
 
-    await expect(await umbracoApi.temporaryFile.getTemporaryFileById(temporaryFileId)).toBeTruthy();
+    await expect(await umbracoApi.temporaryFile.get(temporaryFileId)).toBeTruthy();
 
-    await umbracoApi.temporaryFile.deleteTemporaryFileById(temporaryFileId);
+    await umbracoApi.temporaryFile.delete(temporaryFileId);
 
     // Assert
-    await expect(await umbracoApi.temporaryFile.doesTemporaryFileWithIdExist(temporaryFileId)).toBeFalsy();
+    await expect(await umbracoApi.temporaryFile.exists(temporaryFileId)).toBeFalsy();
   });
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/User/User.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/User/User.spec.ts
@@ -2,38 +2,39 @@
 import {expect} from "@playwright/test";
 
 test.describe('User Tests', () => {
+  let userId = "";
   const userEmail = "user@email.com";
   const userName = "UserTests";
 
   test.beforeEach(async ({page, umbracoApi}) => {
-    await umbracoApi.user.ensureUserNameNotExists(userName);
+    await umbracoApi.user.ensureNameNotExists(userName);
   });
 
   test.afterEach(async ({page, umbracoApi}) => {
-    await umbracoApi.user.ensureUserNameNotExists(userName);
+    await umbracoApi.user.delete(userId);
   });
 
   test('can create a user', async ({page, umbracoApi, umbracoUi}) => {
     // Gets the id for the writers userGroup
-    const userGroup = await umbracoApi.userGroup.getUserGroupByName("Writers");
+    const userGroup = await umbracoApi.userGroup.getByName("Writers");
     const userGroupId = [userGroup.id];
 
-    await umbracoApi.user.createUser(userEmail, userName, userGroupId);
+    userId = await umbracoApi.user.create(userEmail, userName, userGroupId);
 
     // Assert
-    await expect(await umbracoApi.user.doesUserWithNameExist(userName)).toBeTruthy();
+    await expect(await umbracoApi.user.exists(userId)).toBeTruthy();
   });
 
   test('can update a user', async ({page, umbracoApi, umbracoUi}) => {
     // Gets userGroup data for Writers and Translators
-    const userGroup = await umbracoApi.userGroup.getUserGroupByName("Writers");
-    const anotherUserGroup = await umbracoApi.userGroup.getUserGroupByName("Translators");
+    const userGroup = await umbracoApi.userGroup.getByName("Writers");
+    const anotherUserGroup = await umbracoApi.userGroup.getByName("Translators");
 
     const userGroupId = [userGroup.id];
 
-    await umbracoApi.user.createUser(userEmail, userName, userGroupId);
+    userId = await umbracoApi.user.create(userEmail, userName, userGroupId);
 
-    const userData = await umbracoApi.user.getUserByName(userName);
+    const userData = await umbracoApi.user.get(userId);
 
     const newUserGroupData = [
       userGroup.id,
@@ -42,29 +43,29 @@ test.describe('User Tests', () => {
 
     userData.userGroupIds = newUserGroupData;
 
-    await umbracoApi.user.updateUserById(userData.id, userData);
+    await umbracoApi.user.update(userId, userData);
 
     // Assert
-    await umbracoApi.user.doesUserWithNameExist(userName);
+    await umbracoApi.user.exists(userId);
     // Checks if the user was updated with another userGroupID
-    const updatedUser = await umbracoApi.user.getUserByName(userName);
-    await expect(updatedUser.userGroupIds.toString() == newUserGroupData.toString()).toBeTruthy();
+    const updatedUser = await umbracoApi.user.get(userId);
+    await expect(updatedUser.userGroupIds.toString()).toEqual(newUserGroupData.toString());
   });
 
   test('can delete a user', async ({page, umbracoApi, umbracoUi}) => {
-    const userGroupData = await umbracoApi.userGroup.getUserGroupByName("Writers");
+    const userGroupData = await umbracoApi.userGroup.getByName("Writers");
 
     const userData = [
       userGroupData.id
     ];
 
-    await umbracoApi.user.createUser(userEmail, userName, userData);
+    userId = await umbracoApi.user.create(userEmail, userName, userData);
 
-    await expect(await umbracoApi.user.doesUserWithNameExist(userName)).toBeTruthy();
+    await expect(await umbracoApi.user.exists(userId)).toBeTruthy();
 
-    await umbracoApi.user.deleteUserByName(userName);
+    await umbracoApi.user.delete(userId);
 
     // Assert
-    await expect(await umbracoApi.user.doesUserWithNameExist(userName)).toBeFalsy();
+    await expect(await umbracoApi.user.exists(userId)).toBeFalsy();
   });
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/UserGroup/UserGroup.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/ApiTesting/UserGroup/UserGroup.spec.ts
@@ -2,14 +2,15 @@
 import {expect} from "@playwright/test";
 
 test.describe('User Group Tests', () => {
+  let userGroupId = "";
   const userGroupName = "UserGroupTest";
 
   test.beforeEach(async ({page, umbracoApi}) => {
-    await umbracoApi.userGroup.ensureUserGroupNameNotExists(userGroupName);
+    await umbracoApi.userGroup.ensureNameNotExists(userGroupName);
   });
 
   test.afterEach(async ({page, umbracoApi}) => {
-    await umbracoApi.userGroup.ensureUserGroupNameNotExists(userGroupName);
+    await umbracoApi.userGroup.delete(userGroupId);
   });
 
   test('can create a user group', async ({page, umbracoApi, umbracoUi}) => {
@@ -17,35 +18,32 @@ test.describe('User Group Tests', () => {
       "Umb.Section.Forms",
       "Umb.Section.Media"];
 
-    await umbracoApi.userGroup.createUserGroup(userGroupName, true, sections);
+    userGroupId = await umbracoApi.userGroup.create(userGroupName, true, sections);
 
     // Assert
-    await expect(umbracoApi.userGroup.doesUserGroupWithNameExists(userGroupName)).toBeTruthy();
+    await expect(umbracoApi.userGroup.exist(userGroupId)).toBeTruthy();
   });
 
   test('can update a user group', async ({page, umbracoApi, umbracoUi}) => {
-    await umbracoApi.userGroup.createUserGroup('UserGroupNameTest', true);
+    userGroupId = await umbracoApi.userGroup.create('UserGroupNameTest', true);
 
-    const userGroupData = await umbracoApi.userGroup.getUserGroupByName('UserGroupNameTest');
+    const userGroupData = await umbracoApi.userGroup.get(userGroupId);
 
     // Updates name of the user group
     userGroupData.name = userGroupName;
-    await umbracoApi.userGroup.updateUserGroupById(userGroupData.id, userGroupData);
-
+    await umbracoApi.userGroup.update(userGroupId, userGroupData);
 
     // Assert
-    const updatedUserGroupData = await umbracoApi.userGroup.getUserGroupById(userGroupData.id);
-    await expect(updatedUserGroupData.name == userGroupName).toBeTruthy();
+    const updatedUserGroupData = await umbracoApi.userGroup.get(userGroupId);
+    await expect(updatedUserGroupData.name).toEqual(userGroupName);
   });
 
   test('can delete a user group', async ({page, umbracoApi, umbracoUi}) => {
-    await umbracoApi.userGroup.createUserGroup(userGroupName, true);
+    userGroupId = await umbracoApi.userGroup.create(userGroupName, true);
 
-    const userGroupData = await umbracoApi.userGroup.getUserGroupByName(userGroupName);
-
-    await umbracoApi.userGroup.deleteUserGroupById(userGroupData.id);
+    await umbracoApi.userGroup.delete(userGroupId);
 
     // Assert
-    await expect(await umbracoApi.userGroup.doesUserGroupWithNameExists(userGroupName)).toBeFalsy();
+    await expect(await umbracoApi.userGroup.exist(userGroupId)).toBeFalsy();
   });
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Telemetry.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Telemetry.spec.ts
@@ -4,11 +4,11 @@ import {expect} from "@playwright/test";
 test.describe('Telemetry tests', () => {
 
   test.beforeEach(async ({page, umbracoApi}, testInfo) => {
-    await umbracoApi.telemetry.setTelemetryLevel("Basic");
+    await umbracoApi.telemetry.setLevel("Basic");
   });
 
   test.afterEach(async ({page, umbracoApi}, testInfo) => {
-    await umbracoApi.telemetry.setTelemetryLevel("Basic");
+    await umbracoApi.telemetry.setLevel("Basic");
   });
 
   test('can change telemetry level', async ({page, umbracoApi, umbracoUi}) => {
@@ -27,6 +27,6 @@ test.describe('Telemetry tests', () => {
     await page.reload();
     await expect(await page.locator('[name="telemetryLevel"] >> input[id=input]')).toHaveValue('1');
     // API
-    await expect(await umbracoApi.telemetry.checkTelemetryLevel(expectedLevel)).toBeTruthy();
+    await expect(await umbracoApi.telemetry.checkLevel(expectedLevel)).toBeTruthy();
   });
 });


### PR DESCRIPTION
Updated our API acceptance tests to use our updated testHelpers. With our updated testHelpers we are able to have a more API like approach to these test
