### PR TITLE
V14: Skip and take updates

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/AuditLog/CurrentUserAuditLogController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/AuditLog/CurrentUserAuditLogController.cs
@@ -8,7 +8,6 @@ using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Exceptions;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Membership;
-using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.AuditLog;
@@ -18,18 +17,15 @@ public class CurrentUserAuditLogController : AuditLogControllerBase
 {
     private readonly IAuditService _auditService;
     private readonly IAuditLogPresentationFactory _auditLogPresentationFactory;
-    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
     private readonly IUserService _userService;
 
     public CurrentUserAuditLogController(
         IAuditService auditService,
         IAuditLogPresentationFactory auditLogPresentationFactory,
-        IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
         IUserService userService)
     {
         _auditService = auditService;
         _auditLogPresentationFactory = auditLogPresentationFactory;
-        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
         _userService = userService;
     }
 
@@ -57,7 +53,7 @@ public class CurrentUserAuditLogController : AuditLogControllerBase
             null,
             sinceDate);
 
-        IEnumerable<AuditLogWithUsernameResponseModel> mapped = _auditLogPresentationFactory.CreateAuditLogWithUsernameViewModels(result.Items.Skip(skip).Take(take));
+        IEnumerable<AuditLogWithUsernameResponseModel> mapped = _auditLogPresentationFactory.CreateAuditLogWithUsernameViewModels(result.Items);
         var viewModel = new PagedViewModel<AuditLogWithUsernameResponseModel>
         {
             Total = result.Total,

--- a/src/Umbraco.Cms.Api.Management/Controllers/Help/GetHelpController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Help/GetHelpController.cs
@@ -35,7 +35,7 @@ public class GetHelpController : HelpControllerBase
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(PagedViewModel<HelpPageResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Get(string section, string? tree, int skip, int take, string? baseUrl = "https://our.umbraco.com")
+    public async Task<IActionResult> Get(string section, string? tree, int skip = 0, int take = 100, string? baseUrl = "https://our.umbraco.com")
     {
         if (IsAllowedUrl(baseUrl) is false)
         {

--- a/src/Umbraco.Cms.Api.Management/Controllers/Indexer/AllIndexerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Indexer/AllIndexerController.cs
@@ -30,7 +30,7 @@ public class AllIndexerController : IndexerControllerBase
     [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<IndexResponseModel>), StatusCodes.Status200OK)]
-    public Task<PagedViewModel<IndexResponseModel>> All(int skip, int take)
+    public Task<PagedViewModel<IndexResponseModel>> All(int skip = 0, int take = 100)
     {
         IndexResponseModel[] indexes = _examineManager.Indexes
             .Select(_indexPresentationFactory.Create)

--- a/src/Umbraco.Cms.Api.Management/Controllers/PropertyType/IsUsedPropertyTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PropertyType/IsUsedPropertyTypeController.cs
@@ -21,7 +21,7 @@ public class IsUsedPropertyTypeController : PropertyTypeControllerBase
     [HttpGet("is-used")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(typeof(PagedViewModel<bool>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(bool), StatusCodes.Status200OK)]
     public async Task<IActionResult> Get(Guid contentTypeId, string propertyAlias)
     {
         Attempt<bool, PropertyTypeOperationStatus> result = await _propertyTypeUsageService.HasSavedPropertyValuesAsync(contentTypeId, propertyAlias);

--- a/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/ByKeyRedirectUrlManagementController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/ByKeyRedirectUrlManagementController.cs
@@ -26,7 +26,7 @@ public class ByKeyRedirectUrlManagementController : RedirectUrlManagementControl
     [MapToApiVersion("1.0")]
     [HttpGet("{id:guid}")]
     [ProducesResponseType(typeof(PagedViewModel<RedirectUrlResponseModel>), StatusCodes.Status200OK)]
-    public Task<ActionResult<PagedViewModel<RedirectUrlResponseModel>>> ByKey(Guid id, int skip, int take)
+    public Task<ActionResult<PagedViewModel<RedirectUrlResponseModel>>> ByKey(Guid id, int skip = 0, int take = 100)
     {
         IRedirectUrl[] redirects = _redirectUrlService.GetContentRedirectUrls(id).ToArray();
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/GetAllRedirectUrlManagementController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/GetAllRedirectUrlManagementController.cs
@@ -28,7 +28,7 @@ public class GetAllRedirectUrlManagementController : RedirectUrlManagementContro
     [HttpGet]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(PagedViewModel<RedirectUrlResponseModel>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<PagedViewModel<RedirectUrlResponseModel>>> GetAll(string? filter, int skip, int take)
+    public async Task<ActionResult<PagedViewModel<RedirectUrlResponseModel>>> GetAll(string? filter, int skip = 0, int take  = 100)
     {
         if (PaginationService.ConvertSkipTakeToPaging(skip, take, out long pageNumber, out int pageSize, out ProblemDetails? error) is false)
         {

--- a/src/Umbraco.Cms.Api.Management/Controllers/Relation/ByChildRelationController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Relation/ByChildRelationController.cs
@@ -27,7 +27,7 @@ public class ByChildRelationController : RelationControllerBase
     [HttpGet("child-relation/{childId:int}")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<RelationResponseModel>), StatusCodes.Status200OK)]
-    public async Task<PagedViewModel<RelationResponseModel>> ByChild(int childId, int skip, int take, string? relationTypeAlias = "")
+    public async Task<PagedViewModel<RelationResponseModel>> ByChild(int childId, int skip = 0, int take = 100, string? relationTypeAlias = "")
     {
         IRelation[] relations = _relationService.GetByChildId(childId).ToArray();
         RelationResponseModel[] result = Array.Empty<RelationResponseModel>();

--- a/src/Umbraco.Cms.Api.Management/Controllers/Searcher/AllSearcherController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Searcher/AllSearcherController.cs
@@ -22,7 +22,7 @@ public class AllSearcherController : SearcherControllerBase
     [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<SearcherResponse>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<PagedViewModel<SearcherResponse>>> All(int skip, int take)
+    public async Task<ActionResult<PagedViewModel<SearcherResponse>>> All(int skip = 0, int take = 100)
     {
         var searchers = new List<SearcherResponse>(
             _examineManager.RegisteredSearchers.Select(searcher => new SearcherResponse { Name = searcher.Name })

--- a/src/Umbraco.Cms.Api.Management/Controllers/Searcher/QuerySearcherController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Searcher/QuerySearcherController.cs
@@ -22,7 +22,7 @@ public class QuerySearcherController : SearcherControllerBase
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<SearchResultResponseModel>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<PagedViewModel<SearchResultResponseModel>>> Query(string searcherName, string? term, int skip, int take)
+    public async Task<ActionResult<PagedViewModel<SearchResultResponseModel>>> Query(string searcherName, string? term, int skip = 0, int take = 100)
     {
         term = term?.Trim();
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Telemetry/AllTelemetryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Telemetry/AllTelemetryController.cs
@@ -13,7 +13,7 @@ public class AllTelemetryController : TelemetryControllerBase
     [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<TelemetryResponseModel>), StatusCodes.Status200OK)]
-    public async Task<PagedViewModel<TelemetryResponseModel>> GetAll(int skip, int take)
+    public async Task<PagedViewModel<TelemetryResponseModel>> GetAll(int skip = 0, int take = 100)
     {
         TelemetryLevel[] levels = Enum.GetValues<TelemetryLevel>();
         return await Task.FromResult(new PagedViewModel<TelemetryResponseModel>

--- a/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/ByIdTrackedReferenceController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/ByIdTrackedReferenceController.cs
@@ -33,8 +33,8 @@ public class ByIdTrackedReferenceController : TrackedReferenceControllerBase
     [ProducesResponseType(typeof(PagedViewModel<RelationItemResponseModel>), StatusCodes.Status200OK)]
     public async Task<ActionResult<PagedViewModel<RelationItemResponseModel>>> Get(
         Guid id,
-        long skip = 0,
-        long take = 20,
+        int skip = 0,
+        int take = 20,
         bool filterMustBeIsDependency = false)
     {
         PagedModel<RelationItemModel> relationItems = await _trackedReferencesService.GetPagedRelationsForItemAsync(id, skip, take, filterMustBeIsDependency);

--- a/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/DescendantsTrackedReferenceController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/DescendantsTrackedReferenceController.cs
@@ -32,7 +32,7 @@ public class DescendantsTrackedReferenceController : TrackedReferenceControllerB
     [HttpGet("descendants/{parentId:guid}")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<RelationItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<PagedViewModel<RelationItemResponseModel>>> Descendants(Guid parentId, long skip, long take, bool filterMustBeIsDependency = true)
+    public async Task<ActionResult<PagedViewModel<RelationItemResponseModel>>> Descendants(Guid parentId, int skip = 0, int take = 20, bool filterMustBeIsDependency = true)
     {
         PagedModel<RelationItemModel> relationItems = await _trackedReferencesSkipTakeService.GetPagedDescendantsInReferencesAsync(parentId, skip, take, filterMustBeIsDependency);
         var pagedViewModel = new PagedViewModel<RelationItemResponseModel>

--- a/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/ItemsTrackedReferenceController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/ItemsTrackedReferenceController.cs
@@ -31,7 +31,7 @@ public class ItemsTrackedReferenceController : TrackedReferenceControllerBase
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<RelationItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<PagedViewModel<RelationItemResponseModel>>> GetPagedReferencedItems([FromQuery(Name="id")]HashSet<Guid> ids, long skip = 0, long take = 20, bool filterMustBeIsDependency = true)
+    public async Task<ActionResult<PagedViewModel<RelationItemResponseModel>>> GetPagedReferencedItems([FromQuery(Name="id")]HashSet<Guid> ids, int skip = 0, int take = 20, bool filterMustBeIsDependency = true)
     {
         PagedModel<RelationItemModel> relationItems = await _trackedReferencesSkipTakeService.GetPagedItemsWithRelationsAsync(ids, skip, take, filterMustBeIsDependency);
         var pagedViewModel = new PagedViewModel<RelationItemResponseModel>

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -2518,6 +2518,73 @@
         ]
       }
     },
+    "/umbraco/management/api/v1/document/{id}/allowed-document-types": {
+      "get": {
+        "tags": [
+          "Document"
+        ],
+        "operationId": "GetDocumentByIdAllowedDocumentTypes",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedDocumentTypeResponseModel"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedDocumentTypeResponseModel"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedDocumentTypeResponseModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
     "/umbraco/management/api/v1/document/{id}/copy": {
       "post": {
         "tags": [
@@ -2882,6 +2949,64 @@
                 }
               }
             }
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/document/root/allowed-document-types": {
+      "get": {
+        "tags": [
+          "Document"
+        ],
+        "operationId": "GetDocumentRootAllowedDocumentTypes",
+        "parameters": [
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedDocumentTypeResponseModel"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedDocumentTypeResponseModel"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedDocumentTypeResponseModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
           }
         },
         "security": [
@@ -3414,7 +3539,8 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "format": "int32",
+              "default": 0
             }
           },
           {
@@ -3422,7 +3548,8 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "format": "int32",
+              "default": 100
             }
           },
           {
@@ -3495,7 +3622,8 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "format": "int32",
+              "default": 0
             }
           },
           {
@@ -3503,7 +3631,8 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "format": "int32",
+              "default": 100
             }
           }
         ],
@@ -7189,17 +7318,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedBooleanModel"
+                  "type": "boolean"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedBooleanModel"
+                  "type": "boolean"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedBooleanModel"
+                  "type": "boolean"
                 }
               }
             }
@@ -7320,7 +7449,8 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "format": "int32",
+              "default": 0
             }
           },
           {
@@ -7328,7 +7458,8 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "format": "int32",
+              "default": 100
             }
           }
         ],
@@ -7402,7 +7533,8 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "format": "int32",
+              "default": 0
             }
           },
           {
@@ -7410,7 +7542,8 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "format": "int32",
+              "default": 100
             }
           }
         ],
@@ -7979,7 +8112,8 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "format": "int32",
+              "default": 0
             }
           },
           {
@@ -7987,7 +8121,8 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "format": "int32",
+              "default": 100
             }
           },
           {
@@ -8514,7 +8649,8 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "format": "int32",
+              "default": 0
             }
           },
           {
@@ -8522,7 +8658,8 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "format": "int32",
+              "default": 100
             }
           }
         ],
@@ -8582,7 +8719,8 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "format": "int32",
+              "default": 0
             }
           },
           {
@@ -8590,7 +8728,8 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "format": "int32",
+              "default": 100
             }
           }
         ],
@@ -9672,7 +9811,8 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "format": "int32",
+              "default": 0
             }
           },
           {
@@ -9680,7 +9820,8 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "format": "int32",
+              "default": 100
             }
           }
         ],
@@ -10673,7 +10814,7 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int64",
+              "format": "int32",
               "default": 0
             }
           },
@@ -10682,7 +10823,7 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int64",
+              "format": "int32",
               "default": 20
             }
           },
@@ -10745,7 +10886,8 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int64"
+              "format": "int32",
+              "default": 0
             }
           },
           {
@@ -10753,7 +10895,8 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int64"
+              "format": "int32",
+              "default": 20
             }
           },
           {
@@ -10818,7 +10961,7 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int64",
+              "format": "int32",
               "default": 0
             }
           },
@@ -10827,7 +10970,7 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int64",
+              "format": "int32",
               "default": 20
             }
           },
@@ -15249,26 +15392,6 @@
         },
         "additionalProperties": false
       },
-      "PagedBooleanModel": {
-        "required": [
-          "items",
-          "total"
-        ],
-        "type": "object",
-        "properties": {
-          "total": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "boolean"
-            }
-          }
-        },
-        "additionalProperties": false
-      },
       "PagedContentTreeItemResponseModel": {
         "required": [
           "items",
@@ -15364,6 +15487,26 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/DocumentTreeItemResponseModel"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedDocumentTypeResponseModel": {
+        "required": [
+          "items",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DocumentTypeResponseModel"
             }
           }
         },


### PR DESCRIPTION
## Details
- Aligning on `skip` and `take` for pagination between our controllers.

> **Note**
> At the moment, some controllers don't allow for: _for example `?skip=1&take=100`_, because we have to refactor our services to work with `skip` and `take` instead of `pageNumber` and `pageSize`; </br> Like:
> - /**audit-log**?skip=1&take=100 - throws 500 error;
> - /**culture**?skip=1&take=100 - works.


## Test
- The changes aren't really changing the functional behaviour so there isn't really anything to test...
  - Maybe just verify that `/audit-log` endpoint (_CurrentUserAuditLogController.cs_) works as expected, with the correct skip and take relation, (like `skip = 4, take = 2`, or `skip = 10, take = 5`) as there used to be double pagination. 😉 