### PR TITLE
Add additional preview URLs option

### DIFF
--- a/src/Umbraco.Core/Models/ContentEditing/ContentVariationDisplay.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/ContentVariationDisplay.cs
@@ -14,6 +14,7 @@ public class ContentVariantDisplay : ITabbedContent<ContentPropertyDisplay>, ICo
         Tabs = new List<Tab<ContentPropertyDisplay>>();
         Notifications = new List<BackOfficeNotification>();
         AllowedActions = Enumerable.Empty<string>();
+        AdditionalPreviewUrls = Enumerable.Empty<NamedUrl>();
     }
 
     [DataMember(Name = "allowedActions", IsRequired = true)]
@@ -72,6 +73,9 @@ public class ContentVariantDisplay : ITabbedContent<ContentPropertyDisplay>, ICo
     /// </summary>
     [DataMember(Name = "tabs")]
     public IEnumerable<Tab<ContentPropertyDisplay>> Tabs { get; set; }
+
+    [DataMember(Name = "additionalPreviewUrls")]
+    public IEnumerable<NamedUrl> AdditionalPreviewUrls { get; set; }
 }
 
 public class ContentVariantScheduleDisplay : ContentVariantDisplay

--- a/src/Umbraco.Core/Models/ContentEditing/NamedUrl.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/NamedUrl.cs
@@ -1,0 +1,13 @@
+﻿using System.Runtime.Serialization;
+
+namespace Umbraco.Cms.Core.Models.ContentEditing;
+
+[DataContract(Name = "namedUrl", Namespace = "")]
+public class NamedUrl
+{
+    [DataMember(Name = "name")]
+    public required string Name { get; set; }
+
+    [DataMember(Name = "url")]
+    public required string Url { get; set; }
+}

--- a/src/Umbraco.Web.BackOffice/Mapping/ContentMapDefinition.cs
+++ b/src/Umbraco.Web.BackOffice/Mapping/ContentMapDefinition.cs
@@ -127,6 +127,7 @@ internal class ContentMapDefinition : IMapDefinition
         target.Tabs = source.Tabs;
         target.UpdateDate = source.UpdateDate;
         target.AllowedActions = source.AllowedActions;
+        target.AdditionalPreviewUrls = source.AdditionalPreviewUrls;
     }
 
     // Umbraco.Code.MapAll
@@ -189,6 +190,7 @@ internal class ContentMapDefinition : IMapDefinition
         target.Tabs = source.Tabs;
         target.UpdateDate = source.UpdateDate;
         target.AllowedActions = source.AllowedActions;
+        target.AdditionalPreviewUrls = source.AdditionalPreviewUrls;
 
         // We'll only try and map the ReleaseDate/ExpireDate if the "old" ContentVariantScheduleDisplay is in the context, otherwise we'll just skip it quietly.
         _ = context.Items.TryGetValue(nameof(ContentItemDisplayWithSchedule.Variants), out var variants);
@@ -352,7 +354,7 @@ internal class ContentMapDefinition : IMapDefinition
         return result;
     }
 
-    // Umbraco.Code.MapAll -Segment -Language -DisplayName
+    // Umbraco.Code.MapAll -Segment -Language -DisplayName -AdditionalPreviewUrls
     private void Map(IContent source, ContentVariantDisplay target, MapperContext context)
     {
         target.CreateDate = source.CreateDate;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR adds the server modelling to have additional preview URLs for content.

The intended use for this feature is when using external preview environments for the Delivery API.

### Limitations

This PR does not include the UI handling of additional preview URLs - this will come at a later time.

We won't be building a management UI for external preview environments in v12. This will come after v14. For the time being, one must utilize the `SendingContentNotification` to pass additional preview URLs to the client.

### Testing this PR

Try adding a `SendingContentNotification` notification handler like this:

```csharp
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Models.ContentEditing;
using Umbraco.Cms.Core.Notifications;
using Umbraco.Cms.Core.PublishedCache;

namespace Umbraco.Cms.Web.UI.Custom;

public class AdditionalPreviewUrlsNotificationHandler : INotificationHandler<SendingContentNotification>
{
    private readonly IPublishedSnapshotAccessor _publishedSnapshotAccessor;

    public AdditionalPreviewUrlsNotificationHandler(IPublishedSnapshotAccessor publishedSnapshotAccessor)
        => _publishedSnapshotAccessor = publishedSnapshotAccessor;

    public void Handle(SendingContentNotification notification)
    {
        foreach (ContentVariantDisplay variantDisplay in notification.Content.Variants.Where(variant => variant.PublishDate.HasValue))
        {
            IPublishedSnapshot publishedSnapshot = _publishedSnapshotAccessor.GetRequiredPublishedSnapshot();
            var route = publishedSnapshot.Content?.GetRouteById(true, notification.Content.Id, variantDisplay.Language?.IsoCode);
            if (route == null)
            {
                continue;
            }

            route = route.TrimStart('/');

            variantDisplay.AdditionalPreviewUrls = new[]
            {
                new NamedUrl
                {
                    Name = "Environment One",
                    Url = $"https://environment.one/{route}?culture={variantDisplay.Language?.IsoCode}"
                },
                new NamedUrl
                {
                    Name = "Environment Two",
                    Url = $"https://environment.two/{route}?culture={variantDisplay.Language?.IsoCode}"
                }
            };
        }
    }
}

public class AdditionalPreviewUrlsNotificationHandlerComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
        => builder.AddNotificationHandler<SendingContentNotification, AdditionalPreviewUrlsNotificationHandler>();
}
```

With this added, the `additionalPreviewUrls` array will be populated in the `GetById` response. For simplicity, this notification handler only works with published content, but that's an implementation detail on the consumer end of this PR.

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/75cb6302-74c0-404d-8e08-d810515ffc2a)
