### PR TITLE
Verify user invite token

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/User/CreateInitialPasswordUserController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/CreateInitialPasswordUserController.cs
@@ -20,13 +20,14 @@ public class CreateInitialPasswordUserController : UserControllerBase
     [AllowAnonymous]
     [HttpPost("invite/create-password")]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> CreateInitialPassword(CreateInitialPasswordUserRequestModel model)
     {
         Attempt<PasswordChangedModel, UserOperationStatus> response = await _userService.CreateInitialPasswordAsync(model.UserId, model.Token, model.Password);
 
         return response.Success
-            ? NoContent()
+            ? Ok()
             : UserOperationStatusResult(response.Status, response.Result);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/CreateInitialPasswordUserController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/CreateInitialPasswordUserController.cs
@@ -1,5 +1,6 @@
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.User;
 using Umbraco.Cms.Core;
@@ -19,6 +20,7 @@ public class CreateInitialPasswordUserController : UserControllerBase
     [AllowAnonymous]
     [HttpPost("invite/create-password")]
     [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<IActionResult> CreateInitialPassword(CreateInitialPasswordUserRequestModel model)
     {
         Attempt<PasswordChangedModel, UserOperationStatus> response = await _userService.CreateInitialPasswordAsync(model.UserId, model.Token, model.Password);

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/CreateInitialPasswordUserController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/CreateInitialPasswordUserController.cs
@@ -1,0 +1,30 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.User;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Api.Management.Controllers.User;
+
+[ApiVersion("1.0")]
+public class CreateInitialPasswordUserController : UserControllerBase
+{
+    private readonly IUserService _userService;
+
+    public CreateInitialPasswordUserController(IUserService userService) => _userService = userService;
+
+    [AllowAnonymous]
+    [HttpPost("invite/create-password")]
+    [MapToApiVersion("1.0")]
+    public async Task<IActionResult> CreateInitialPassword(CreateInitialPasswordUserRequestModel model)
+    {
+        Attempt<PasswordChangedModel, UserOperationStatus> response = await _userService.CreateInitialPasswordAsync(model.UserId, model.Token, model.Password);
+
+        return response.Success
+            ? NoContent()
+            : UserOperationStatusResult(response.Status, response.Result);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/UsersControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/UsersControllerBase.cs
@@ -80,7 +80,7 @@ public abstract class UserControllerBase : ManagementApiControllerBase
                 .WithDetail("Some of the provided media start nodes was not found.")
                 .Build()),
             UserOperationStatus.UserNotFound => NotFound(new ProblemDetailsBuilder()
-                .WithTitle("The was not found")
+                .WithTitle("The user was not found")
                 .WithDetail("The specified user was not found.")
                 .Build()),
             UserOperationStatus.CannotDisableInvitedUser => BadRequest(new ProblemDetailsBuilder()
@@ -94,6 +94,10 @@ public abstract class UserControllerBase : ManagementApiControllerBase
             UserOperationStatus.InvalidIsoCode => BadRequest(new ProblemDetailsBuilder()
                 .WithTitle("Invalid ISO code")
                 .WithDetail("The specified ISO code is invalid.")
+                .Build()),
+            UserOperationStatus.InvalidVerificationToken => BadRequest(new ProblemDetailsBuilder()
+                .WithTitle("Invalid verification token")
+                .WithDetail("The specified verification token is invalid.")
                 .Build()),
             UserOperationStatus.MediaNodeNotFound => NotFound(new ProblemDetailsBuilder()
                 .WithTitle("Media node not found")

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/VerifyInviteUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/VerifyInviteUsersController.cs
@@ -1,5 +1,6 @@
 ﻿using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.User;
 using Umbraco.Cms.Core;
@@ -18,6 +19,7 @@ public class VerifyInviteUserController : UserControllerBase
     [AllowAnonymous]
     [HttpPost("invite/verify")]
     [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<IActionResult> Invite(VerifyInviteUserRequestModel model)
     {
         Attempt<UserOperationStatus> result = await _userService.VerifyInviteAsync(model.UserId, model.Token);

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/VerifyInviteUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/VerifyInviteUsersController.cs
@@ -1,0 +1,29 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.User;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Api.Management.Controllers.User;
+
+[ApiVersion("1.0")]
+public class VerifyInviteUserController : UserControllerBase
+{
+    private readonly IUserService _userService;
+
+    public VerifyInviteUserController(IUserService userService) => _userService = userService;
+
+    [AllowAnonymous]
+    [HttpPost("invite/verify")]
+    [MapToApiVersion("1.0")]
+    public async Task<IActionResult> Invite(VerifyInviteUserRequestModel model)
+    {
+        Attempt<UserOperationStatus> result = await _userService.VerifyInviteAsync(model.UserId, model.Token);
+
+        return result.Success
+            ? NoContent()
+            : UserOperationStatusResult(result.Result);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/VerifyInviteUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/VerifyInviteUsersController.cs
@@ -19,13 +19,14 @@ public class VerifyInviteUserController : UserControllerBase
     [AllowAnonymous]
     [HttpPost("invite/verify")]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Invite(VerifyInviteUserRequestModel model)
     {
         Attempt<UserOperationStatus> result = await _userService.VerifyInviteAsync(model.UserId, model.Token);
 
         return result.Success
-            ? NoContent()
+            ? Ok()
             : UserOperationStatusResult(result.Result);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/CreateInitialPasswordUserRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/CreateInitialPasswordUserRequestModel.cs
@@ -1,0 +1,6 @@
+namespace Umbraco.Cms.Api.Management.ViewModels.User;
+
+public class CreateInitialPasswordUserRequestModel : VerifyInviteUserRequestModel
+{
+    public string Password { get; set; } = string.Empty;
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/VerifyInviteUserRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/VerifyInviteUserRequestModel.cs
@@ -1,0 +1,8 @@
+namespace Umbraco.Cms.Api.Management.ViewModels.User;
+
+public class VerifyInviteUserRequestModel
+{
+    public Guid UserId { get; set; } = Guid.Empty;
+
+    public string Token { get; set; } = string.Empty;
+}

--- a/src/Umbraco.Core/Security/ICoreBackOfficeUserManager.cs
+++ b/src/Umbraco.Core/Security/ICoreBackOfficeUserManager.cs
@@ -20,4 +20,6 @@ public interface ICoreBackOfficeUserManager
     Task<Attempt<UserUnlockResult, UserOperationStatus>> UnlockUser(IUser user);
 
     Task<Attempt<ICollection<IIdentityUserLogin>, UserOperationStatus>> GetLoginsAsync(IUser user);
+
+    Task<bool> IsEmailConfirmationTokenValidAsync(IUser user, string token);
 }

--- a/src/Umbraco.Core/Services/IUserService.cs
+++ b/src/Umbraco.Core/Services/IUserService.cs
@@ -59,6 +59,10 @@ public interface IUserService : IMembershipUserService
 
     Task<Attempt<UserInvitationResult, UserOperationStatus>> InviteAsync(Guid performingUserKey, UserInviteModel model);
 
+    Task<Attempt<UserOperationStatus>> VerifyInviteAsync(Guid userKey, string token);
+
+    Task<Attempt<PasswordChangedModel, UserOperationStatus>> CreateInitialPasswordAsync(Guid userKey, string token, string password);
+    
     Task<Attempt<IUser?, UserOperationStatus>> UpdateAsync(Guid performingUserKey, UserUpdateModel model);
 
     Task<UserOperationStatus> SetAvatarAsync(Guid userKey, Guid temporaryFileKey);
@@ -375,4 +379,5 @@ public interface IUserService : IMembershipUserService
     void DeleteUserGroup(IUserGroup userGroup);
 
     #endregion
+
 }

--- a/src/Umbraco.Core/Services/OperationStatus/UserOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/UserOperationStatus.cs
@@ -23,6 +23,7 @@ public enum UserOperationStatus
     OldPasswordRequired,
     InvalidAvatar,
     InvalidIsoCode,
+    InvalidVerificationToken,
     ContentStartNodeNotFound,
     MediaStartNodeNotFound,
     ContentNodeNotFound,

--- a/src/Umbraco.Infrastructure/Security/UmbracoUserManager.cs
+++ b/src/Umbraco.Infrastructure/Security/UmbracoUserManager.cs
@@ -253,7 +253,8 @@ public abstract class UmbracoUserManager<TUser, TPasswordConfig> : UserManager<T
     {
         TUser? user = await FindByNameAsync(username);
 
-        if (user is null)
+
+        if (user is null || user.IsApproved is false)
         {
             return false;
         }

--- a/src/Umbraco.Web.Common/Security/BackOfficeUserManager.cs
+++ b/src/Umbraco.Web.Common/Security/BackOfficeUserManager.cs
@@ -342,4 +342,15 @@ public class BackOfficeUserManager : UmbracoUserManager<BackOfficeIdentityUser, 
         return Attempt.SucceedWithStatus(UserOperationStatus.Success, identityUser.Logins);
     }
 
+    public async Task<bool> IsEmailConfirmationTokenValidAsync(IUser user, string token)
+    {
+        BackOfficeIdentityUser? identityUser = await FindByIdAsync(user.Id.ToString());
+
+        if (identityUser != null && await VerifyUserTokenAsync(identityUser, Options.Tokens.EmailConfirmationTokenProvider, ConfirmEmailTokenPurpose, token).ConfigureAwait(false))
+        {
+            return true;
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
### Summary
This PR adds two new endpoints
- `/umbraco/management/api/v1/user/invite/verify`
  - Used to verify the token. The intension is that the frontend can check this as soon as the link from the email is used.
     If the token is not valid there is no need to ask the user to create a password 
- `/umbraco/management/api/v1/user/invite/create-password`
   - Used to set an initial password using the token.
   
### Out of scope
- The generated email + link is out of scope of this PR
   
### Tests
- Use the existing endpoint to invite a user (`/umbraco/management/api/v1/user/invite`)
  - Remember to setup a fake SMTP and get the link from the email
- Read the email and copy the token from the link
  - A link could look like this: `https://localhost:44339/umbraco/VerifyInvite?invite=1%257CQ2ZESjhHQXdva3dCb1N0RXEzSDVOdklWVWJ2aXpMRnlzRDVpRGxENVJGck05T0ZyNUlsOUVpME9kdzVmaURXdnZHbEtabGVEdWgxai85dkkycStKSG5LQUlJdFJhckUvOHlEbldXSi9vcVpwbGYxc2dLaE1mSW5oRW9EQy9VYWR4YWJFZGd4WUQ1RnVETThVakd2ZE5kVlU5bjBYeksrZEtwMkhQWmgxMlE2N3RXL2V4NEx5a2szMnJKZVBiZ2ZBN0QwbEF3PT0`
 The invite query is today a combination of the userId, a seperator and a token. In this case:
      - UserId: `1` 
      - Seperator: `%257C` 
      - Token: `Q2ZESjhHQXdva3dCb1N0RXEzSDVOdklWVWJ2aXpMRnlzRDVpRGxENVJGck05T0ZyNUlsOUVpME9kdzVmaURXdnZHbEtabGVEdWgxai85dkkycStKSG5LQUlJdFJhckUvOHlEbldXSi9vcVpwbGYxc2dLaE1mSW5oRW9EQy9VYWR4YWJFZGd4WUQ1RnVETThVakd2ZE5kVlU5bjBYeksrZEtwMkhQWmgxMlE2N3RXL2V4NEx5a2szMnJKZVBiZ2ZBN0QwbEF3PT0`
 
 - Use the `/umbraco/management/api/v1/user/invite/verify` endpoint to verify the token is correct.
   - Also test unhappy paths, with invalid token and user key.
  - Use the `/umbraco/management/api/v1/user/invite/create-password` endpoint.
    - First test unhappy paths
       - Invalid user key
       - Invalid token
       - Invalid password combination (e.g. too short)
     - Then test happy path.
 - Verify you can sign-in with the newly created user and password
  
   
 