### PR TITLE
V12: Tabs should be rendered to register default values

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-sub-views.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-sub-views.html
@@ -5,7 +5,7 @@
     ng-repeat="subView in subViews track by subView.alias"
     ng-class="'sub-view-' + subView.name"
     val-sub-view="subView"
-    ng-if="subView.active"
+    ng-show="subView.active"
   >
     <div class="umb-editor-sub-view__content" ng-include="subView.view"></div>
   </div>


### PR DESCRIPTION
### Description

Fixes #13134 

Render all tabs in the background by replacing `ng-if` with `ng-show`. This ensures they register their initial state on any `$scope.model` in the stack.

Sometimes a tab, e.g. a "block list settings model" might register some default values, but if the user never clicks on the tab, then they are not recorded because of the way AngularJS renders views with "ng-if".

The history of this file is as follows:
- Initially, we had `ng-show` on the _inner sub_view_content_. This must have worked for blocks as well as other tabs for content.
- Due to being able to show certain tabs in full height (the new Marketplace initially), we had to remove the superfluous HTML and moved the `ng-show` to the _outer element_ and changed it to an `ng-if`
- This change semi-reverts it back to an `ng-show` but keeps it on the _outer element_ which seems to work for full-height tabs such as the marketplace.
