### PR TITLE
Add ReSharperTestRunner64 to the assembly exclusion list in TypeFinder

### DIFF
--- a/src/Umbraco.Core/Composing/TypeFinder.cs
+++ b/src/Umbraco.Core/Composing/TypeFinder.cs
@@ -34,7 +34,7 @@ public class TypeFinder : ITypeFinder
         "ServiceStack.", "SqlCE4Umbraco,", "Superpower,", // used by Serilog
         "System.", "TidyNet,", "TidyNet.", "WebDriver,", "itextsharp,", "mscorlib,", "NUnit,", "NUnit.", "NUnit3.",
         "Selenium.", "ImageProcessor", "MiniProfiler.", "Owin,", "SQLite",
-        "ReSharperTestRunner32", // used by resharper testrunner
+        "ReSharperTestRunner32", "ReSharperTestRunner64", // These are used by the Jetbrains Rider IDE and Visual Studio ReSharper Extension
     };
 
     private static readonly ConcurrentDictionary<string, Type?> TypeNamesCache = new();


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description

When running tests in the JetBrains Rider IDE in a project that calls `.AddUmbraco()`, a `System.IO.FileNotFoundException` is thrown, with an assembly loading error mentioning `ReSharperTestRunner64` not being found. Seems like Umbraco is processing all loaded assemblies in a way that fails when this one is present. By following the stack trace, I noticed that `TypeFinder` already has a "32" version of the assembly name in its exclusion list, so this PR adds the "64" version, which I believe should fix the issue.

Whether this issue is triggered on a given setup probably depends on stuff like OS and Rider version. But I assume one could reproduce by installing the latest version of JetBrains Rider on a 64-bit Windows machine, setting up a new Umbraco project with a test, and finally run the test through the test runner in Rider.