### PR TITLE
Adding SourceWidth and SourceHeight to ImageUrlGenerationOptions

### DIFF
--- a/src/Umbraco.Core/Models/ImageUrlGenerationOptions.cs
+++ b/src/Umbraco.Core/Models/ImageUrlGenerationOptions.cs
@@ -9,6 +9,8 @@ public class ImageUrlGenerationOptions : IEquatable<ImageUrlGenerationOptions>
 
     public string? ImageUrl { get; }
 
+    public int? SourceWidth { get; set; }
+    public int? SourceHeight { get; set; }
     public int? Width { get; set; }
 
     public int? Height { get; set; }

--- a/src/Umbraco.Web.Common/Extensions/FriendlyImageCropperTemplateExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/FriendlyImageCropperTemplateExtensions.cs
@@ -258,6 +258,8 @@ public static class FriendlyImageCropperTemplateExtensions
     /// furtherOptions: "bgcolor=fff"
     /// ]]></example>
     /// </param>
+    /// <param name="sourceWidth">The width of the source image.</param>
+    /// <param name="sourceHeight">The height of the source image.</param>
     /// <returns>
     ///     The URL of the cropped image.
     /// </returns>
@@ -273,7 +275,9 @@ public static class FriendlyImageCropperTemplateExtensions
         bool preferFocalPoint = false,
         bool useCropDimensions = false,
         string? cacheBusterValue = null,
-        string? furtherOptions = null)
+        string? furtherOptions = null,
+        int? sourceWidth = null,
+        int? sourceHeight = null)
         => imageUrl.GetCropUrl(
             ImageUrlGenerator,
             width,
@@ -286,7 +290,9 @@ public static class FriendlyImageCropperTemplateExtensions
             preferFocalPoint,
             useCropDimensions,
             cacheBusterValue,
-            furtherOptions);
+            furtherOptions,
+            sourceWidth,
+            sourceHeight);
 
     /// <summary>
     ///     Gets the underlying image processing service URL from the image path.
@@ -318,6 +324,8 @@ public static class FriendlyImageCropperTemplateExtensions
     /// furtherOptions: "bgcolor=fff"
     /// ]]></example>
     /// </param>
+    /// <param name="sourceWidth">The width of the source image.</param>
+    /// <param name="sourceHeight">The height of the source image.</param>
     /// <returns>
     ///     The URL of the cropped image.
     /// </returns>
@@ -333,7 +341,9 @@ public static class FriendlyImageCropperTemplateExtensions
         bool preferFocalPoint = false,
         bool useCropDimensions = false,
         string? cacheBusterValue = null,
-        string? furtherOptions = null)
+        string? furtherOptions = null,
+        int? sourceWidth = null,
+        int? sourceHeight = null)
         => imageUrl.GetCropUrl(
             ImageUrlGenerator,
             cropDataSet,
@@ -346,5 +356,8 @@ public static class FriendlyImageCropperTemplateExtensions
             preferFocalPoint,
             useCropDimensions,
             cacheBusterValue,
-            furtherOptions);
+            furtherOptions,
+            sourceWidth,
+            sourceHeight
+            );
 }

--- a/src/Umbraco.Web.Common/Extensions/ImageCropperTemplateCoreExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/ImageCropperTemplateCoreExtensions.cs
@@ -342,6 +342,8 @@ public static class ImageCropperTemplateCoreExtensions
     /// furtherOptions: "bgcolor=fff"
     /// ]]></example>
     /// </param>
+    /// <param name="sourceWidth">The width of the source image.</param>
+    /// <param name="sourceHeight">The height of the source image.</param>
     /// <returns>
     ///     The URL of the cropped image.
     /// </returns>
@@ -358,7 +360,9 @@ public static class ImageCropperTemplateCoreExtensions
         bool preferFocalPoint = false,
         bool useCropDimensions = false,
         string? cacheBusterValue = null,
-        string? furtherOptions = null)
+        string? furtherOptions = null,
+        int? sourceWidth = null,
+        int? sourceHeight = null)
     {
         if (string.IsNullOrWhiteSpace(imageUrl))
         {
@@ -385,7 +389,9 @@ public static class ImageCropperTemplateCoreExtensions
             preferFocalPoint,
             useCropDimensions,
             cacheBusterValue,
-            furtherOptions);
+            furtherOptions,
+            sourceWidth,
+            sourceHeight);
     }
 
     /// <summary>
@@ -422,6 +428,8 @@ public static class ImageCropperTemplateCoreExtensions
     /// furtherOptions: "bgcolor=fff"
     /// ]]></example>
     /// </param>
+    /// <param name="sourceWidth">The width of the source image.</param>
+    /// <param name="sourceHeight">The height of the source image.</param>
     /// <returns>
     ///     The URL of the cropped image.
     /// </returns>
@@ -438,7 +446,9 @@ public static class ImageCropperTemplateCoreExtensions
         bool preferFocalPoint = false,
         bool useCropDimensions = false,
         string? cacheBusterValue = null,
-        string? furtherOptions = null)
+        string? furtherOptions = null,
+        int? sourceWidth = null,
+        int? sourceHeight = null)
     {
         if (string.IsNullOrWhiteSpace(imageUrl))
         {
@@ -491,6 +501,8 @@ public static class ImageCropperTemplateCoreExtensions
         options.Height = height;
         options.FurtherOptions = furtherOptions;
         options.CacheBusterValue = cacheBusterValue;
+        options.SourceWidth = sourceWidth;
+        options.SourceHeight = sourceHeight;
 
         return imageUrlGenerator.GetImageUrl(options);
     }
@@ -560,6 +572,9 @@ public static class ImageCropperTemplateCoreExtensions
         var cacheBusterValue =
             cacheBuster ? mediaItem.UpdateDate.ToFileTimeUtc().ToString("x", CultureInfo.InvariantCulture) : null;
 
+        var sourceWidth = mediaItem.Value<int?>(Constants.Conventions.Media.Width);
+        var sourceHeight = mediaItem.Value<int?>(Constants.Conventions.Media.Height);
+
         return GetCropUrl(
             mediaItemUrl,
             imageUrlGenerator,
@@ -573,6 +588,8 @@ public static class ImageCropperTemplateCoreExtensions
             preferFocalPoint,
             useCropDimensions,
             cacheBusterValue,
-            furtherOptions);
+            furtherOptions,
+            sourceWidth,
+            sourceHeight);
     }
 }


### PR DESCRIPTION
In order to be able to convert the coordinates provided by a pre-defined crop for various image processing services the source image width and source image height are required. Currently, these values are not available to a ImageUrlGenerator so in this draft PR I'm adding them to ImageUrlGenerationOptions.

For example, this then makes it possible to convert the crop coordinates to use Cloudflare's trim command I need to do the following:

``` c#
  if (options.Crop is not null && options.SourceWidth is not null && options.SourceHeight is not null)
  {
      var top = Math.Round(options.Crop.Top * (decimal)options.SourceHeight);
      var left = Math.Round(options.Crop.Left * (decimal)options.SourceWidth);
      var bottom = Math.Round(options.Crop.Bottom * (decimal)options.SourceHeight);
      var right = Math.Round(options.Crop.Right * (decimal)options.SourceWidth);

      cfCommands.Add("trim",string.Join(';',top,left,bottom,right));
  }
```

I've also looked at Cloudinary and that would also require the source width and height in order to generate a valid command.

Adding these values to ImageUrlGenerationOptions is one approach to solving this problem, there are others... Open to suggestions....