### PR TITLE
V8: TinyMCE - Images upload, drag & drop, and resize

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/mediahelper.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/mediahelper.service.js
@@ -1,9 +1,9 @@
 ﻿/**
-* @ngdoc service
-* @name umbraco.services.mediaHelper
-* @description A helper object used for dealing with media items
-**/
-function mediaHelper(umbRequestHelper, $log) {
+ * @ngdoc service
+ * @name umbraco.services.mediaHelper
+ * @description A helper object used for dealing with media items
+ **/
+function mediaHelper(umbRequestHelper, $http, $log) {
 
     //container of fileresolvers
     var _mediaFileResolvers = {};
@@ -304,11 +304,6 @@ function mediaHelper(umbRequestHelper, $log) {
                 return imagePath;
             }
 
-            // Check if file is a svg
-            if (this.getFileExtension(imagePath) === "svg") {
-                return imagePath;
-            }
-
             // If the path is not an image we cannot get a thumb
             if (!this.detectIfImageByExtension(imagePath)) {
                 return null;
@@ -399,6 +394,61 @@ function mediaHelper(umbRequestHelper, $log) {
             var lowered = filePath.toLowerCase();
             var ext = lowered.substr(lowered.lastIndexOf(".") + 1);
             return ext;
+        },
+
+        /**
+         * @ngdoc function
+         * @name umbraco.services.mediaHelper#getProcessedImageUrl
+         * @methodOf umbraco.services.mediaHelper
+         * @function
+         *
+         * @description
+         * Returns image URL with configured crop and other processing parameters.
+         *
+         * @param {string} imagePath Raw image path
+         * @param {object} options Object describing image generation parameters:
+         *  {
+         *      width: <int>
+         *      height: <int>
+         *      focalPoint: {
+         *          left: <int>
+         *          top: <int>
+         *      },
+         *      mode: <string>
+         *      cacheBusterValue: <string>
+         *      crop: {
+         *          x1: <int>
+         *          x2: <int>
+         *          y1: <int>
+         *          y2: <int>
+         *      },
+         *  }
+         */
+        getProcessedImageUrl: function (imagePath, options) {
+
+            if (!options) {
+                return imagePath;
+            }
+
+            return umbRequestHelper.resourcePromise(
+                $http.get(
+                    umbRequestHelper.getApiUrl(
+                        "imagesApiBaseUrl",
+                        "GetProcessedImageUrl",
+                        {
+                            imagePath,
+                            width: options.width,
+                            height: options.height,
+                            focalPointLeft: options.focalPoint ? options.focalPoint.left : null,
+                            focalPointTop:  options.focalPoint ? options.focalPoint.top : null,
+                            mode: options.mode,
+                            cacheBusterValue: options.cacheBusterValue,
+                            cropX1: options.crop ? options.crop.x1 : null,
+                            cropX2: options.crop ? options.crop.x2 : null,
+                            cropY1: options.crop ? options.crop.y1 : null,
+                            cropY2: options.crop ? options.crop.y2 : null
+                        })),
+                "Failed to retrieve processed image URL for image: " + imagePath);
         }
 
     };

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -1250,7 +1250,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
 
             // the href might be an external url, so check the value for an anchor/qs
             // href has the anchor re-appended later, hence the reset here to avoid duplicating the anchor
-            if (!target.anchor) {
+            if (!target.anchor && href) {
                 var urlParts = href.split(/(#|\?)/);
                 if (urlParts.length === 3) {
                     href = urlParts[0];

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -222,9 +222,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
     }
 
     function uploadImageHandler(blobInfo, success, failure, progress){
-        let xhr, formData;
-
-        xhr = new XMLHttpRequest();
+        const xhr = new XMLHttpRequest();
         xhr.open('POST', Umbraco.Sys.ServerVariables.umbracoUrls.tinyMceApiBaseUrl + 'UploadImage');
 
         xhr.onloadstart = function(e) {
@@ -255,10 +253,24 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                 return;
             }
 
-            json = JSON.parse(xhr.responseText);
+            const data = xhr.responseText;
+
+            if (!data.length > 1) {
+                failure('Unrecognized text string: ' + data);
+                return;
+            }
+
+            let json = {};
+
+            try {
+                json = JSON.parse(data);
+            } catch (e) {
+                failure('Invalid JSON: ' + data + ' - ' + e.message);
+                return;
+            }
 
             if (!json || typeof json.tmpLocation !== 'string') {
-                failure('Invalid JSON: ' + xhr.responseText);
+                failure('Invalid JSON: ' + data);
                 return;
             }
 
@@ -271,7 +283,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
             success(blobInfo.blobUri());
         };
 
-        formData = new FormData();
+        const formData = new FormData();
         formData.append('file', blobInfo.blob(), blobInfo.blob().name);
 
         xhr.send(formData);

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -445,7 +445,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
 
 
                 if (args.htmlId) {
-                    config.selector = "#" + args.htmlId;
+                    config.selector = `[id="${args.htmlId}"]`;
                 } else if (args.target) {
                     config.target = args.target;
                 }

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -694,7 +694,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                     userService.getCurrentUser().then(function (userData) {
                         if (callback) {
                             angularHelper.safeApply($rootScope, function() {
-                                callback(currentTarget, userData, imgDomElement);
+                                callback(currentTarget, userData);
                             });
                         }
                     });

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -1451,7 +1451,8 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
             // Then we need to add an event listener to the editor
             // That will update native browser drag & drop events
             // To update the icon to show you can NOT drop something into the editor
-            var toolbarItems = args.editor.settings.toolbar.split(" ");
+
+            var toolbarItems = args.editor.settings.toolbar === false ? [] : args.editor.settings.toolbar.split(" ");
             if(isMediaPickerEnabled(toolbarItems) === false){
                 // Wire up the event listener
                 args.editor.on('dragend dragover draggesture dragdrop drop drag', function (e) {

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -7,7 +7,7 @@
  * A service containing all logic for all of the Umbraco TinyMCE plugins
  */
 function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, stylesheetResource, macroResource, macroService,
-                        $routeParams, umbRequestHelper, angularHelper, userService, editorService, entityResource, eventsService, localStorageService) {
+                        $routeParams, umbRequestHelper, angularHelper, userService, editorService, entityResource, eventsService, localStorageService, mediaHelper) {
 
     //These are absolutely required in order for the macros to render inline
     //we put these as extended elements because they get merged on top of the normal allowed elements by tiny mce
@@ -246,8 +246,6 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
         };
 
         xhr.onload = function () {
-            let json;
-
             if (xhr.status < 200 || xhr.status >= 300) {
                 failure('HTTP Error: ' + xhr.status);
                 return;
@@ -304,21 +302,25 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
     }
 
     function sizeImageInEditor(editor, imageDomElement, imgUrl) {
-
         var size = editor.dom.getSize(imageDomElement);
 
         if (editor.settings.maxImageSize && editor.settings.maxImageSize !== 0) {
             var newSize = imageHelper.scaleToMaxSize(editor.settings.maxImageSize, size.w, size.h);
-
 
             editor.dom.setAttrib(imageDomElement, 'width', newSize.width);
             editor.dom.setAttrib(imageDomElement, 'height', newSize.height);
 
             // Images inserted via Media Picker will have a URL we can use for ImageResizer QueryStrings
             // Images pasted/dragged in are not persisted to media until saved & thus will need to be added
-            if(imgUrl){
-                var src = imgUrl + "?width=" + newSize.width + "&height=" + newSize.height;
-                editor.dom.setAttrib(imageDomElement, 'data-mce-src', src);
+            if (imgUrl) {
+                mediaHelper.getProcessedImageUrl(imgUrl,
+                    {
+                        width: newSize.width,
+                        height: newSize.height
+                    })
+                    .then(function (resizedImgUrl) {
+                        editor.dom.setAttrib(imageDomElement, 'data-mce-src', resizedImgUrl);
+                    });
             }
 
             editor.execCommand("mceAutoResize", false, null, null);
@@ -663,21 +665,19 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                 stateSelector: 'img[data-udi]',
                 onclick: function () {
 
-
                     var selectedElm = editor.selection.getNode(),
-                        currentTarget,
-                        imgDomElement;
+                        currentTarget;
 
                     if (selectedElm.nodeName === 'IMG') {
                         var img = $(selectedElm);
-                        imgDomElement = selectedElm;
 
                         var hasUdi = img.attr("data-udi") ? true : false;
                         var hasDataTmpImg = img.attr("data-tmpimg") ? true : false;
 
                         currentTarget = {
                             altText: img.attr("alt"),
-                            url: img.attr("src")
+                            url: img.attr("src"),
+                            caption: img.attr('data-caption')
                         };
 
                         if (hasUdi) {
@@ -701,78 +701,73 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                 }
             });
         },
-
-        insertMediaInEditor: function (editor, img, imgDomElement) {
+        /**
+         * @ngdoc method
+         * @name umbraco.services.tinyMceService#insetMediaInEditor
+         * @methodOf umbraco.services.tinyMceService
+         *
+         * @description
+         * Inserts the image element in tinymce plugin
+         *
+         * @param {Object} editor the TinyMCE editor instance
+         */
+        insertMediaInEditor: function (editor, img) {
             if (img) {
-                // imgElement is only definied if updating an image
-                // if null/undefinied then its a BRAND new image
-                if(imgDomElement){
-                    // Check if the img src has changed
-                    // If it has we will need to do some resizing/recalc again
-                    var hasImageSrcChanged = false;
+                // We need to create a NEW DOM <img> element to insert
+                // setting an attribute of ID to __mcenew, so we can gather a reference to the node, to be able to update its size accordingly to the size of the image.
+                var data = {
+                    alt: img.altText || "",
+                    src: (img.url) ? img.url : "nothing.jpg",
+                    id: "__mcenew",
+                    "data-udi": img.udi,
+                    "data-caption": img.caption
+                };
+                var newImage = editor.dom.createHTML('img', data);
+                var parentElement = editor.selection.getNode().parentElement;
 
-                    if(img.url !==  editor.dom.getAttrib(imgDomElement, "src")){
-                        hasImageSrcChanged = true;
+                if (img.caption) {
+                    var figCaption = editor.dom.createHTML('figcaption', {}, img.caption);
+                    var combined = newImage + figCaption;
+
+                    if (parentElement.nodeName !== 'FIGURE') {
+                        var fragment = editor.dom.createHTML('figure', {}, combined);
+                        editor.selection.setContent(fragment);
                     }
-
-                    // If null/undefinied it will remove the attribute
-                    editor.dom.setAttrib(imgDomElement, "alt", img.altText);
-
-                    // It's possible to pick a NEW image - so need to ensure this gets updated
-                    if(img.udi){
-                        editor.dom.setAttrib(imgDomElement, "data-udi", img.udi);
+                    else {
+                        parentElement.innerHTML = combined;
                     }
-
-                    // It's possible to pick a NEW image - so need to ensure this gets updated
-                    if(img.url){
-                        editor.dom.setAttrib(imgDomElement, "src", img.url);
-                    }
-
-                    // Remove width & height attributes (ONLY if imgSrc changed)
-                    // So native image size is used as this needed to re-calc width & height
-                    // For the function sizeImageInEditor() & apply the image resizing querystrings etc..
-                    if(hasImageSrcChanged){
-                        editor.dom.setAttrib(imgDomElement, "width", null);
-                        editor.dom.setAttrib(imgDomElement, "height", null);
-
-                        //Re-calc the image dimensions
-                        sizeImageInEditor(editor, imgDomElement, img.url);
-                    }
-
-                } else{
-                    // We need to create a NEW DOM <img> element to insert
-                    // setting an attribute of ID to __mcenew, so we can gather a reference to the node, to be able to update its size accordingly to the size of the image.
-                    var data = {
-                        alt: img.altText || "",
-                        src: (img.url) ? img.url : "nothing.jpg",
-                        id: "__mcenew",
-                        "data-udi": img.udi
-                    };
-
-                    editor.selection.setContent(editor.dom.createHTML('img', data));
-
-                    // Using settimeout to wait for a DoM-render, so we can find the new element by ID.
-                    $timeout(function () {
-
-                        var imgElm = editor.dom.get("__mcenew");
-                        editor.dom.setAttrib(imgElm, "id", null);
-
-                        // When image is loaded we are ready to call sizeImageInEditor.
-                        var onImageLoaded = function() {
-                            sizeImageInEditor(editor, imgElm, img.url);
-                            editor.fire("Change");
-                        }
-
-                        // Check if image already is loaded.
-                        if(imgElm.complete === true) {
-                            onImageLoaded();
-                        } else {
-                            imgElm.onload = onImageLoaded;
-                        }
-
-                    });
-
                 }
+                else {
+                    //if caption is removed, remove the figure element
+                    if (parentElement.nodeName === 'FIGURE') {
+                        parentElement.parentElement.innerHTML = newImage;
+                    }
+                    else {
+                        editor.selection.setContent(newImage);
+                    }
+                }
+
+                // Using settimeout to wait for a DoM-render, so we can find the new element by ID.
+                $timeout(function () {
+
+                    var imgElm = editor.dom.get("__mcenew");
+                    editor.dom.setAttrib(imgElm, "id", null);
+
+                    // When image is loaded we are ready to call sizeImageInEditor.
+                    var onImageLoaded = function() {
+                        sizeImageInEditor(editor, imgElm, img.url);
+                        editor.fire("Change");
+                    }
+
+                    // Check if image already is loaded.
+                    if(imgElm.complete === true) {
+                        onImageLoaded();
+                    } else {
+                        imgElm.onload = onImageLoaded;
+                    }
+
+                });
+
             }
         },
 
@@ -1614,17 +1609,27 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
                 syncContent();
             });
 
+            // When the element is removed from the DOM, we need to terminate
+            // any active watchers to ensure scopes are disposed and do not leak.
+            // No need to sync content as that has already happened.
+            args.editor.on('remove', () => stopWatch());
+
             args.editor.on('ObjectResized', function (e) {
-                var qs = "?width=" + e.width + "&height=" + e.height + "&mode=max";
                 var srcAttr = $(e.target).attr("src");
                 var path = srcAttr.split("?")[0];
-                $(e.target).attr("data-mce-src", path + qs);
+                mediaHelper.getProcessedImageUrl(path, {
+                    width: e.width,
+                    height: e.height,
+                    mode: "max"
+                }).then(function (resizedPath) {
+                    $(e.target).attr("data-mce-src", resizedPath);
+                });
 
                 syncContent();
             });
 
             args.editor.on('Dirty', function (e) {
-            	syncContent(); // Set model.value to the RTE's content
+                syncContent(); // Set model.value to the RTE's content
             });
 
             let self = this;

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -11,7 +11,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
 
     //These are absolutely required in order for the macros to render inline
     //we put these as extended elements because they get merged on top of the normal allowed elements by tiny mce
-    var extendedValidElements = "@[id|class|style],-div[id|dir|class|align|style],ins[datetime|cite],-ul[class|style],-li[class|style],-h1[id|dir|class|align|style],-h2[id|dir|class|align|style],-h3[id|dir|class|align|style],-h4[id|dir|class|align|style],-h5[id|dir|class|align|style],-h6[id|style|dir|class|align],span[id|class|style|lang]";
+    var extendedValidElements = "@[id|class|style],-div[id|dir|class|align|style],ins[datetime|cite],-ul[class|style],-li[class|style],-h1[id|dir|class|align|style],-h2[id|dir|class|align|style],-h3[id|dir|class|align|style],-h4[id|dir|class|align|style],-h5[id|dir|class|align|style],-h6[id|style|dir|class|align],span[id|class|style|lang],figure,figcaption";
     var fallbackStyles = [{ title: "Page header", block: "h2" }, { title: "Section header", block: "h3" }, { title: "Paragraph header", block: "h4" }, { title: "Normal", block: "p" }, { title: "Quote", block: "blockquote" }, { title: "Code", block: "code" }];
     // these languages are available for localization
     var availableLanguages = [

--- a/src/Umbraco.Web/Editors/ImagesController.cs
+++ b/src/Umbraco.Web/Editors/ImagesController.cs
@@ -6,10 +6,8 @@ using Umbraco.Core.Composing;
 using Umbraco.Core.Configuration.UmbracoSettings;
 using Umbraco.Core.IO;
 using Umbraco.Core.Models;
-using Umbraco.Web.Media;
 using Umbraco.Web.Mvc;
 using Umbraco.Web.WebApi;
-using Constants = Umbraco.Core.Constants;
 
 namespace Umbraco.Web.Editors
 {
@@ -73,7 +71,7 @@ namespace Umbraco.Web.Editors
             try
             {
                 imageLastModified = _mediaFileSystem.GetLastModified(imagePath);
-                
+
             }
             catch (Exception)
             {
@@ -89,6 +87,59 @@ namespace Umbraco.Web.Editors
             response.Headers.Location = new Uri(imageUrl, UriKind.RelativeOrAbsolute);
             return response;
         }
-        
+
+        /// <summary>
+        ///     Gets a processed image for the image at the given path
+        /// </summary>
+        /// <param name="imagePath"></param>
+        /// <param name="width"></param>
+        /// <param name="height"></param>
+        /// <param name="focalPointLeft"></param>
+        /// <param name="focalPointTop"></param>
+        /// <param name="mode"></param>
+        /// <param name="cacheBusterValue"></param>
+        /// <param name="cropX1"></param>
+        /// <param name="cropX2"></param>
+        /// <param name="cropY1"></param>
+        /// <param name="cropY2"></param>
+        /// <returns></returns>
+        /// <remarks>
+        ///     If there is no media, image property or image file is found then this will return not found.
+        /// </remarks>
+        public string GetProcessedImageUrl(
+            string imagePath,
+            int? width = null,
+            int? height = null,
+            decimal? focalPointLeft = null,
+            decimal? focalPointTop = null,
+            string mode = "max",
+            string cacheBusterValue = "",
+            decimal? cropX1 = null,
+            decimal? cropX2 = null,
+            decimal? cropY1 = null,
+            decimal? cropY2 = null)
+        {
+            var options = new ImageUrlGenerationOptions(imagePath)
+            {
+                Width = width,
+                Height = height,
+                ImageCropMode = mode,
+                CacheBusterValue = cacheBusterValue
+            };
+
+            if (focalPointLeft.HasValue && focalPointTop.HasValue)
+            {
+                options.FocalPoint =
+                    new ImageUrlGenerationOptions.FocalPointPosition(focalPointLeft.Value, focalPointTop.Value);
+            }
+            else if (cropX1.HasValue && cropX2.HasValue && cropY1.HasValue && cropY2.HasValue)
+            {
+                options.Crop =
+                    new ImageUrlGenerationOptions.CropCoordinates(cropX1.Value, cropY1.Value, cropX2.Value, cropY2.Value);
+            }
+
+            return _imageUrlGenerator.GetImageUrl(options);
+        }
+
     }
 }


### PR DESCRIPTION
### Description
This updates v8 with the latest bug fixes from v10 that we were able to cherry-pick regarding the TinyMCE editor and related media handlers.

### What was fixed
- Drag & Drop images will now correctly call the imageProcessHandler and get a temporary file location for the image to append to a data attribute. If this process fails, TinyMCE will revert to storing the image as base64 which can get rather large, so this fix is very important.
- Resizing images will now call a new endpoint to get an updated crop URL to use in the editor ensuring, that we not only set width & height on the `img` element but also reflect that in the URL.
- Sometimes the rich text editor could not be activated on a grid editor if the id started with a number, which is not supported in HTML out-of-the-box, but by wrapping the selector in clams it works again.