### PR TITLE
Add PreRouting and PostRouting pipeline filters

### DIFF
--- a/src/Umbraco.Web.Common/ApplicationBuilder/IUmbracoApplicationBuilderContext.cs
+++ b/src/Umbraco.Web.Common/ApplicationBuilder/IUmbracoApplicationBuilderContext.cs
@@ -1,30 +1,47 @@
 namespace Umbraco.Cms.Web.Common.ApplicationBuilder;
 
 /// <summary>
-///     The context object used during
+/// The context object used when building the Umbraco application.
 /// </summary>
+/// <seealso cref="Umbraco.Cms.Web.Common.ApplicationBuilder.IUmbracoApplicationBuilderServices" />
 public interface IUmbracoApplicationBuilderContext : IUmbracoApplicationBuilderServices
 {
     /// <summary>
-    ///     Called to include the core umbraco middleware.
+    /// Called to include the core Umbraco middlewares.
     /// </summary>
     void UseUmbracoCoreMiddleware();
 
     /// <summary>
-    ///     Manually runs the <see cref="IUmbracoPipelineFilter" /> pre pipeline filters
+    /// Manually runs the <see cref="IUmbracoPipelineFilter" /> pre pipeline filters.
     /// </summary>
     void RunPrePipeline();
 
     /// <summary>
-    ///     Manually runs the <see cref="IUmbracoPipelineFilter " /> post pipeline filters
+    /// Manually runs the <see cref="IUmbracoPipelineFilter" /> pre routing filters.
+    /// </summary>
+    void RunPreRouting()
+    {
+        // TODO: Remove default implementation in Umbraco 13
+    }
+
+    /// <summary>
+    /// Manually runs the <see cref="IUmbracoPipelineFilter" /> post routing filters.
+    /// </summary>
+    void RunPostRouting()
+    {
+        // TODO: Remove default implementation in Umbraco 13
+    }
+
+    /// <summary>
+    /// Manually runs the <see cref="IUmbracoPipelineFilter" /> post pipeline filters.
     /// </summary>
     void RunPostPipeline();
 
     /// <summary>
-    ///     Called to include all of the default umbraco required middleware.
+    /// Called to include all of the default Umbraco required middleware.
     /// </summary>
     /// <remarks>
-    ///     If using this method, there is no need to use <see cref="UseUmbracoCoreMiddleware" />
+    /// If using this method, there is no need to use <see cref="UseUmbracoCoreMiddleware" />.
     /// </remarks>
     void RegisterDefaultRequiredMiddleware();
 }

--- a/src/Umbraco.Web.Common/ApplicationBuilder/IUmbracoPipelineFilter.cs
+++ b/src/Umbraco.Web.Common/ApplicationBuilder/IUmbracoPipelineFilter.cs
@@ -3,37 +3,58 @@ using Microsoft.AspNetCore.Builder;
 namespace Umbraco.Cms.Web.Common.ApplicationBuilder;
 
 /// <summary>
-///     Used to modify the <see cref="IApplicationBuilder" /> pipeline before and after Umbraco registers it's core
-///     middlewares.
+/// Used to modify the <see cref="IApplicationBuilder" /> pipeline before and after Umbraco registers it's middlewares.
+/// middlewares.
 /// </summary>
 /// <remarks>
-///     Mainly used for package developers.
+/// Mainly used for package developers.
 /// </remarks>
 public interface IUmbracoPipelineFilter
 {
     /// <summary>
-    ///     The name of the filter
+    /// The name of the filter.
     /// </summary>
+    /// <value>
+    /// The name.
+    /// </value>
     /// <remarks>
-    ///     This can be used by developers to see what is registered and if anything should be re-ordered, removed, etc...
+    /// This can be used by developers to see what is registered and if anything should be re-ordered, removed, etc...
     /// </remarks>
     string Name { get; }
 
     /// <summary>
-    ///     Executes before Umbraco middlewares are registered
+    /// Executes before any default Umbraco middlewares are registered.
     /// </summary>
-    /// <param name="app"></param>
+    /// <param name="app">The application.</param>
     void OnPrePipeline(IApplicationBuilder app);
 
     /// <summary>
-    ///     Executes after core Umbraco middlewares are registered and before any Endpoints are declared
+    /// Executes after static files middlewares are registered and just before the routing middleware is registered.
     /// </summary>
-    /// <param name="app"></param>
+    /// <param name="app">The application.</param>
+    void OnPreRouting(IApplicationBuilder app)
+    {
+        // TODO: Remove default implementation in Umbraco 13
+    }
+
+    /// <summary>
+    /// Executes after the routing middleware is registered and just before the authentication and authorization middlewares are registered. This can be used to add CORS policies.
+    /// </summary>
+    /// <param name="app">The application.</param>
+    void OnPostRouting(IApplicationBuilder app)
+    {
+        // TODO: Remove default implementation in Umbraco 13
+    }
+
+    /// <summary>
+    /// Executes after core Umbraco middlewares are registered and before any endpoints are declared.
+    /// </summary>
+    /// <param name="app">The application.</param>
     void OnPostPipeline(IApplicationBuilder app);
 
     /// <summary>
-    ///     Executes after <see cref="OnPostPipeline(IApplicationBuilder)" /> just before any Umbraco endpoints are declared.
+    /// Executes after the middlewares are registered and just before any Umbraco endpoints are declared.
     /// </summary>
-    /// <param name="app"></param>
+    /// <param name="app">The application.</param>
     void OnEndpoints(IApplicationBuilder app);
 }

--- a/src/Umbraco.Web.Common/ApplicationBuilder/UmbracoApplicationBuilder.cs
+++ b/src/Umbraco.Web.Common/ApplicationBuilder/UmbracoApplicationBuilder.cs
@@ -82,7 +82,10 @@ public class UmbracoApplicationBuilder : IUmbracoApplicationBuilder, IUmbracoEnd
         // https://docs.microsoft.com/en-us/aspnet/core/fundamentals/routing?view=aspnetcore-5.0
         // where we need to have UseAuthentication and UseAuthorization proceeding this call but before
         // endpoints are defined.
+        RunPreRouting();
         AppBuilder.UseRouting();
+        RunPostRouting();
+
         AppBuilder.UseAuthentication();
         AppBuilder.UseAuthorization();
 
@@ -111,6 +114,22 @@ public class UmbracoApplicationBuilder : IUmbracoApplicationBuilder, IUmbracoEnd
         foreach (IUmbracoPipelineFilter filter in _umbracoPipelineStartupOptions.Value.PipelineFilters)
         {
             filter.OnPrePipeline(AppBuilder);
+        }
+    }
+
+    public void RunPreRouting()
+    {
+        foreach (IUmbracoPipelineFilter filter in _umbracoPipelineStartupOptions.Value.PipelineFilters)
+        {
+            filter.OnPreRouting(AppBuilder);
+        }
+    }
+
+    public void RunPostRouting()
+    {
+        foreach (IUmbracoPipelineFilter filter in _umbracoPipelineStartupOptions.Value.PipelineFilters)
+        {
+            filter.OnPostRouting(AppBuilder);
         }
     }
 

--- a/src/Umbraco.Web.Common/ApplicationBuilder/UmbracoPipelineFilter.cs
+++ b/src/Umbraco.Web.Common/ApplicationBuilder/UmbracoPipelineFilter.cs
@@ -2,43 +2,112 @@ using Microsoft.AspNetCore.Builder;
 
 namespace Umbraco.Cms.Web.Common.ApplicationBuilder;
 
-/// <summary>
-///     Used to modify the <see cref="IApplicationBuilder" /> pipeline before and after Umbraco registers it's core
-///     middlewares.
-/// </summary>
-/// <remarks>
-///     Mainly used for package developers.
-/// </remarks>
+/// <inheritdoc />
 public class UmbracoPipelineFilter : IUmbracoPipelineFilter
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UmbracoPipelineFilter" /> class.
+    /// </summary>
+    /// <param name="name">The name.</param>
     public UmbracoPipelineFilter(string name)
-        : this(name, null, null, null)
-    {
-    }
+        : this(name, null, null, null, null, null)
+    { }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UmbracoPipelineFilter" /> class.
+    /// </summary>
+    /// <param name="name">The name.</param>
+    /// <param name="prePipeline">The pre pipeline callback.</param>
+    /// <param name="postPipeline">The post pipeline callback.</param>
+    /// <param name="endpointCallback">The endpoint callback.</param>
     public UmbracoPipelineFilter(
         string name,
         Action<IApplicationBuilder>? prePipeline,
         Action<IApplicationBuilder>? postPipeline,
         Action<IApplicationBuilder>? endpointCallback)
+        : this(name, prePipeline, null, null, postPipeline, endpointCallback)
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UmbracoPipelineFilter" /> class.
+    /// </summary>
+    /// <param name="name">The name.</param>
+    /// <param name="prePipeline">The pre pipeline callback.</param> 
+    /// <param name="preRouting">The pre routing callback.</param>
+    /// <param name="postRouting">The post routing callback.</param>
+    /// <param name="postPipeline">The post pipeline callback.</param>
+    /// <param name="endpoints">The endpoints callback.</param>
+    public UmbracoPipelineFilter(
+        string name,
+        Action<IApplicationBuilder>? prePipeline = null,
+        Action<IApplicationBuilder>? preRouting = null,
+        Action<IApplicationBuilder>? postRouting = null,
+        Action<IApplicationBuilder>? postPipeline = null,
+        Action<IApplicationBuilder>? endpoints = null)
     {
         Name = name ?? throw new ArgumentNullException(nameof(name));
         PrePipeline = prePipeline;
+        PreRouting = preRouting;
+        PostRouting = postRouting;
         PostPipeline = postPipeline;
-        Endpoints = endpointCallback;
+        Endpoints = endpoints;
     }
 
+    /// <summary>
+    /// Gets or sets the pre pipeline callback.
+    /// </summary>
+    /// <value>
+    /// The pre pipeline callback.
+    /// </value>
     public Action<IApplicationBuilder>? PrePipeline { get; set; }
 
+    /// <summary>
+    /// Gets or sets the pre routing.
+    /// </summary>
+    /// <value>
+    /// The pre routing.
+    /// </value>
+    public Action<IApplicationBuilder>? PreRouting { get; set; }
+
+    /// <summary>
+    /// Gets or sets the post routing callback.
+    /// </summary>
+    /// <value>
+    /// The post routing callback.
+    /// </value>
+    public Action<IApplicationBuilder>? PostRouting { get; set; }
+
+    /// <summary>
+    /// Gets or sets the post pipeline callback.
+    /// </summary>
+    /// <value>
+    /// The post pipeline callback.
+    /// </value>
     public Action<IApplicationBuilder>? PostPipeline { get; set; }
 
+    /// <summary>
+    /// Gets or sets the endpoints callback.
+    /// </summary>
+    /// <value>
+    /// The endpoints callback.
+    /// </value>
     public Action<IApplicationBuilder>? Endpoints { get; set; }
 
+    /// <inheritdoc />
     public string Name { get; }
 
+    /// <inheritdoc />
     public void OnPrePipeline(IApplicationBuilder app) => PrePipeline?.Invoke(app);
 
+    /// <inheritdoc />
+    public void OnPreRouting(IApplicationBuilder app) => PreRouting?.Invoke(app);
+
+    /// <inheritdoc />
+    public void OnPostRouting(IApplicationBuilder app) => PostRouting?.Invoke(app);
+
+    /// <inheritdoc />
     public void OnPostPipeline(IApplicationBuilder app) => PostPipeline?.Invoke(app);
 
+    /// <inheritdoc />
     public void OnEndpoints(IApplicationBuilder app) => Endpoints?.Invoke(app);
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This extends the options discussed in issue https://github.com/umbraco/Umbraco-CMS/issues/10682 and added in PR https://github.com/umbraco/Umbraco-CMS/pull/10702.

### Description
Enabling CORS in Umbraco currently requires you to swap the `WithMiddleware()` call in `Startup.cs` to `WithCustomMiddleware()` and manually register all default Umbraco middleware, just to be able to add `UseCors()` in the right order (after routing, but before authentication/authorization, see [Paul Seals blogpost](https://codeshare.co.uk/blog/how-to-set-up-a-cors-policy-in-umbraco-12/)).

You can already add middleware in different places by using `IUmbracoPipelineFilter` and the `PrePipeline`, `PostPipeline` and `Endpoints` callbacks, so this PR extends these options with `PreRouting` and `PostRouting` callbacks.

You can use `PreRouting` to add middleware that needs to run after the Umbraco static file middlewares are added, but before the routing middleware. And you can now use `PostRouting` to add middleware (like CORS) after routing, but before authentication/authorization. See the recommended [middleware order](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/middleware/?view=aspnetcore-7.0#middleware-order).

Testing this PR can be done by adding the following composer:
```c#
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Web.Common.ApplicationBuilder;

public class CorsComposer : IComposer
{
    public const string AllowAnyOriginPolicyName = nameof(AllowAnyOriginPolicyName);

    public void Compose(IUmbracoBuilder builder)
        => builder.Services
        .AddCors(options => options.AddPolicy(AllowAnyOriginPolicyName, policy => policy.AllowAnyOrigin()))
        .Configure<UmbracoPipelineOptions>(options => options.AddFilter(new UmbracoPipelineFilter("Cors", postRouting: app => app.UseCors())))
        // For testing only
        .Configure<UmbracoPipelineOptions>(options => options.AddFilter(new UmbracoPipelineFilter("CorsTest", endpoints: app => app.UseEndpoints(endpoints =>
        {
            endpoints.MapGet("/echo", context => context.Response.WriteAsync("echo")).RequireCors(AllowAnyOriginPolicyName);
            endpoints.MapGet("/echo2", context => context.Response.WriteAsync("echo2"));
        }))));
}
```

You should be able to request `/echo` from any origin, but get an error when trying to fetch `/echo2`. You can easily test this by pasting the following JavaScript code in your browser console when not on the local Umbraco website (e.g. on umbraco.com):
```js
fetch('https://localhost:44331/echo', {method: 'GET'}).then(result => result.text().then(text => console.log(text)));
fetch('https://localhost:44331/echo2', {method: 'GET'}).then(result => result.text().then(text => console.log(text)));
```

This should return the following:
![Browser console CORS tests](https://github.com/umbraco/Umbraco-CMS/assets/1051287/2adeb6ba-5915-403f-a8e7-93cc8c1eb70e)

An additional bonus is that this doesn't require any changes in your `Startup.cs` file and also allows packages to enable CORS and configure their own policies. Users that currently use `WithCustomMiddleware()` will need to add calls to `RunPreRouting()` and `RunPostRouting()`, but that's similar to Umbraco adding additional middleware in future versions...