### PR TITLE
Only show groups when any filtered results in group

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockpicker/blockpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockpicker/blockpicker.controller.js
@@ -3,11 +3,14 @@ angular.module("umbraco")
     function ($scope, localizationService, $filter) {
 
         var unsubscribe = [];
-        var vm = this;
+        const vm = this;
 
         vm.navigation = [];
 
-        vm.filterSearchTerm = '';
+        vm.filter = {
+            searchTerm: ""
+        };
+
         vm.filteredItems = [];
 
         // Ensure groupKey value, as we need it to be present for the filtering logic.
@@ -15,11 +18,18 @@ angular.module("umbraco")
             item.blockConfigModel.groupKey = item.blockConfigModel.groupKey || null;
         });
 
-        unsubscribe.push($scope.$watch('vm.filterSearchTerm', updateFiltering));
+        unsubscribe.push($scope.$watch('vm.filter.searchTerm', updateFiltering));
 
         function updateFiltering() {
-            vm.filteredItems = $filter('umbCmsBlockCard')($scope.model.availableItems, vm.filterSearchTerm);
+            vm.filteredItems = $filter('umbCmsBlockCard')($scope.model.availableItems, vm.filter.searchTerm);
         }
+
+        vm.filterByGroup = function (group) {
+
+            const items = $filter('filter')(vm.filteredItems, { blockConfigModel: { groupKey: group?.key || null } });
+
+            return items;
+        };
 
         localizationService.localizeMany(["blockEditor_tabCreateEmpty", "blockEditor_tabClipboard"]).then(
             function (data) {
@@ -47,9 +57,7 @@ angular.module("umbraco")
                 } else {
                     vm.activeTab = vm.navigation[0];
                 }
-
-
-
+                
                 vm.activeTab.active = true;
             }
         );
@@ -61,12 +69,13 @@ angular.module("umbraco")
         };
 
         vm.clickClearClipboard = function () {
-            vm.model.clipboardItems = [];// This dialog is not connected via the clipboardService events, so we need to update manually.
+            vm.model.clipboardItems = []; // This dialog is not connected via the clipboardService events, so we need to update manually.
             vm.model.clickClearClipboard();
+            
             if (vm.model.singleBlockMode !== true && vm.model.openClipboard !== true)
             {
                 vm.onNavigationChanged(vm.navigation[0]);
-                vm.navigation[1].disabled = true;// disabled ws determined when creating the navigation, so we need to update it here.
+                vm.navigation[1].disabled = true; // disabled ws determined when creating the navigation, so we need to update it here.
             }
             else {
                 vm.close();

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockpicker/blockpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/blockpicker/blockpicker.html
@@ -19,7 +19,7 @@
                 <div class="umb-control-group" ng-if="vm.model.filter === true" style="margin-bottom: 20px;">
                     <umb-search-filter
                         input-id="block-search"
-                        model="vm.filterSearchTerm"
+                        model="vm.filter.searchTerm"
                         label-key="placeholders_filter"
                         text="Type to filter..."
                         css-class="w-100"
@@ -27,11 +27,11 @@
                     </umb-search-filter>
                 </div>
 
-                <div class="umb-block-card-grid" ng-if="vm.filteredItems.length > 0">
+                <div class="umb-block-card-grid" ng-if="vm.filterByGroup(null).length > 0">
 
                     <umb-block-card
                         class="umb-outline"
-                        ng-repeat="block in (vm.filteredItems | filter:{blockConfigModel:{groupKey: null}})"
+                        ng-repeat="block in vm.filterByGroup(null)"
                         block-config-model="block.blockConfigModel"
                         element-type-model="block.elementTypeModel"
                         ng-click="vm.selectItem(block, $event)">
@@ -39,14 +39,14 @@
 
                 </div>
                 
-                <div ng-repeat="blockGroup in model.blockGroups" ng-if="vm.filteredItems.length > 0">
+                <div ng-repeat="blockGroup in model.blockGroups" ng-if="vm.filterByGroup(blockGroup).length > 0">
                     <h5>{{blockGroup.name}}</h5>
 
                     <div class="umb-block-card-grid">
 
                         <umb-block-card
                             class="umb-outline"
-                            ng-repeat="block in (vm.filteredItems | filter:{blockConfigModel:{groupKey: blockGroup.key}})"
+                            ng-repeat="block in vm.filterByGroup(blockGroup)"
                             block-config-model="block.blockConfigModel"
                             element-type-model="block.elementTypeModel"
                             ng-click="vm.selectItem(block, $event)">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
As we start getting more blocks in Block List /  Block Grid editor and thus creating several groups, we may end up with empty groups when filtering these in block picker.

I think it is cleaner only to show each group, which has any filtered result - currently it check filtered results in any group (or non-grouped blocks).

I also updated search term filtering to be consistent with other freetext filtering, where we have a `searchTerm` as property on a `filter` object.

![chrome_P35gRfNcZ7](https://github.com/umbraco/Umbraco-CMS/assets/2919859/76041371-4c90-4722-9b38-f7ed30424d78)

**Result**

https://github.com/umbraco/Umbraco-CMS/assets/2919859/2625063a-a4f3-49c1-934e-b235088cd709
