### PR TITLE
Store tags as text (instead of nvarchar)

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -6,6 +6,7 @@ using Umbraco.Cms.Infrastructure.Migrations.Upgrade.Common;
 using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_10_0_0;
 using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_10_2_0;
 using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_10_5_0;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_10_7_0;
 using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_8_0_0;
 using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_8_0_1;
 using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_8_1_0;
@@ -303,5 +304,8 @@ public class UmbracoPlan : MigrationPlan
 
         // to 10.5.0
         To<AddPrimaryKeyConstrainToContentVersionCleanupDtos>("{83AF7945-DADE-4A02-9041-F3F6EBFAC319}");
+
+        // to 10.7.0
+        To<MigrateTagsFromNVarcharToNText>("{EF93F398-1385-4F07-808A-D3C518984442}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_10_7_0/MigrateTagsFromNVarcharToNText.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_10_7_0/MigrateTagsFromNVarcharToNText.cs
@@ -1,0 +1,46 @@
+using NPoco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_10_7_0;
+
+public class MigrateTagsFromNVarcharToNText : MigrationBase
+{
+    public MigrateTagsFromNVarcharToNText(IMigrationContext context)
+        : base(context)
+    {
+    }
+
+    protected override void Migrate()
+    {
+        // Firstly change the storage type for the Umbraco.Tags property editor
+        Sql<ISqlContext> updateDbTypeForTagsQuery = Database.SqlContext.Sql()
+            .Update<DataTypeDto>(x => x.Set(dt => dt.DbType, ValueStorageType.Ntext.ToString()))
+            .Where<DataTypeDto>(dt => dt.EditorAlias == Constants.PropertyEditors.Aliases.Tags);
+
+        Database.Execute(updateDbTypeForTagsQuery);
+
+        // Then migrate the data from "varcharValue" column to "textValue"
+        Sql<ISqlContext> tagsDataTypeIdQuery = Database.SqlContext.Sql()
+            .Select<DataTypeDto>(dt => dt.NodeId)
+            .From<DataTypeDto>()
+            .Where<DataTypeDto>(dt => dt.EditorAlias == Constants.PropertyEditors.Aliases.Tags);
+
+        Sql<ISqlContext> tagsPropertyTypeIdQuery = Database.SqlContext.Sql()
+            .Select<PropertyTypeDto>(pt => pt.Id)
+            .From<PropertyTypeDto>()
+            .WhereIn<PropertyTypeDto>(pt => pt.DataTypeId, tagsDataTypeIdQuery);
+
+        Sql<ISqlContext> updatePropertyDataColumnsQuery = Database.SqlContext.Sql()
+            .Update<PropertyDataDto>()
+            .Append("SET textValue = varcharValue, varcharValue = null")
+            .WhereIn<PropertyDataDto>(pd => pd.PropertyTypeId, tagsPropertyTypeIdQuery)
+            .Where<PropertyDataDto>(pd => pd.TextValue == null)
+            .Where<PropertyDataDto>(pd => pd.VarcharValue != null);
+
+        Database.Execute(updatePropertyDataColumnsQuery);
+    }
+}

--- a/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs
@@ -25,7 +25,9 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     "Tags",
     "tags",
     Icon = "icon-tags",
-    ValueEditorIsReusable = true)]
+    ValueEditorIsReusable = true,
+    ValueType = ValueTypes.Text)]
+
 public class TagsPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;

--- a/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs
@@ -27,7 +27,6 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     Icon = "icon-tags",
     ValueEditorIsReusable = true,
     ValueType = ValueTypes.Text)]
-
 public class TagsPropertyEditor : DataEditor
 {
     private readonly IEditorConfigurationParser _editorConfigurationParser;


### PR DESCRIPTION
## Details
- Fixes: #14457;
- Changing the `Umbraco.Tags` property editor to explicitly use the `"TEXT"` value type instead of the implicit (default) `"STRING"`:
  - Setting the db type for `Umbraco.Tags` to `NText` database type;
    - By doing so, we remove the limit (_512_) on the amount of the data allowed to be filled in for this property editor;
    - This is the case with both Tags storage types - _JSON or CSV_;
    - Previously, the CSV storage type, changed the db type to `STRING` which mapped to `NVarchar`.
- Adding a migration that moves the Tags data from the `umbracoPropertyData.varcharValue` column to the `umbracoPropertyData.textValue` column, while also sets the `umbracoDataType.dbType` for the Tags prop editor to `NText`.

## Test
- Test on both SQLite and SQL Server;
- Test with both a clean install and an old version so you can trigger the migration;
- Test that you can rerun the migration without a problem; </br></br>
### With a migration:
> Pre-migration:
  - **Stay on v10/dev** ❗
  - Set up a document type with a **single** tags property (_adding more will not reproduce the faulty behaviour of #14457_) and a few more properties (_like a textString, numeric, date, etc._ - so we can make sure that only the tags props are migrated)
  - Create some content and add some tags
  - Change the Storage Type for the Tags prop editor to `CSV`
  - Add another set of tags, like `a,b,c`
  - Save and Publish
  - Check `umbracoDataType` table in the DB for the `Umbraco.Tags` row:
    - Initially, the `dbType` value is set by default to `Ntext` which will store the Tags data in `umbracoPropertyData.textValue` column, but now the `CSV` storage type caused the change to `Nvarchar`
  - Check the end of the `umbracoPropertyData` table in the DB 
    - The tags data is moved to the `umbracoPropertyData.varcharValue` column
  - Change to this PR branch and execute the migration

> Post-migration:
  - Confirm that the migration completes successfully
  -  Verify that the `Umbraco.Tags` row in the `umbracoDataType` table has the `dbType` set correctly to `Ntext`
  -  Verify that the Tags data is migrated correctly from `umbracoPropertyData.varcharValue` column to the `umbracoPropertyData.textValue` column
  - Confirm that the other properties of the content node (_like the textString, numeric, date, etc._) are still in their correct columns in `umbracoPropData` table
  - Add more tags to the content node and verify they are stored correctly.
