### PR TITLE
v8: Null check for RelatedLinks during migration from v7

### DIFF
--- a/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/ConvertRelatedLinksToMultiUrlPicker.cs
+++ b/src/Umbraco.Core/Migrations/Upgrade/V_8_0_0/ConvertRelatedLinksToMultiUrlPicker.cs
@@ -60,6 +60,9 @@ namespace Umbraco.Core.Migrations.Upgrade.V_8_0_0
                 var links = new List<LinkDto>();
                 foreach (var relatedLink in relatedLinks)
                 {
+                    if (relatedLink == null)
+                        continue;
+
                     GuidUdi udi = null;
                     if (relatedLink.IsInternal)
                     {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Added a check for null `RelatedLink` objects while converting `RelatedLinks` and `RelatedLinks2` properties to `MultiUrlPicker` during the database migration process.
Without this check, it's possible under certain (unknown) circumstances for a `NullReferenceException` to occur on line 64.

Steps to test this contribution:
1. Create an Umbraco v7.15.10 project
2. Add a document type that uses a `RelatedLinks2` editor
3. Add some content that uses said document type, some with related links left blank and others with a variation of internal pages and external links
4. Perform a database migration to Umbraco v8.18.8

To be clear, I am not 100% sure what the root cause of this issue was in the first place - it seems to be undocumented otherwise, and I was not able to find any anomalies in my project's database. Regardless, it is a small addition that should not have any side-effects.

More details on the exact issue I was experiencing can be found [here.](https://our.umbraco.com/forum/using-umbraco-and-getting-started/112192)

<!-- Thanks for contributing to Umbraco CMS! -->
