### PR TITLE
Revert "Enable ForceCreateDatabase for SqlServer"

### DIFF
--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDatabaseProviderMetadata.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDatabaseProviderMetadata.cs
@@ -50,7 +50,7 @@ public class SqlServerDatabaseProviderMetadata : IDatabaseProviderMetadata
     public bool RequiresConnectionTest => true;
 
     /// <inheritdoc />
-    public bool ForceCreateDatabase => true;
+    public bool ForceCreateDatabase => false;
 
     /// <inheritdoc />
     public bool CanRecognizeConnectionString(string? connectionString)


### PR DESCRIPTION
Reverts umbraco/Umbraco-CMS#14234 as mentioned in https://github.com/umbraco/Umbraco-CMS/pull/14234#issuecomment-1625477875. This should be included in the next v11 and v12 patches, since it could result in creating an empty Umbraco installation when you (accidentally) misconfigured your SQL Server connection string.