### PR TITLE
Fixes an incorrect property name used for generating JSON schema.

### DIFF
--- a/src/JsonSchema/AppSettings.cs
+++ b/src/JsonSchema/AppSettings.cs
@@ -88,7 +88,7 @@ namespace JsonSchema
 
                 public HelpPageSettings? HelpPage { get; set; }
 
-                public InstallDefaultDataSettings? DefaultDataCreation { get; set; }
+                public InstallDefaultDataSettings? InstallDefaultData { get; set; }
 
                 public DataTypesSettings? DataTypes { get; set; }
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Issue was raised in discussion [here](https://github.com/umbraco/Umbraco-CMS/discussions/14431#discussioncomment-6356476).

### Description

Currently the JSON schema generated for the configuration of default install data uses an incorrect property name.  This PR updates it to align with [what is referenced in the documentation](https://docs.umbraco.com/umbraco-cms/reference/configuration/installdefaultdatasettings) and [used in configuration](https://github.com/umbraco/Umbraco-CMS/blob/0c595ccc5f88750a8f547e4bbbe58c457864094d/src/Umbraco.Core/Constants-Configuration.cs#L64).

To Test:

- Check out the PR and run the `JsonSchema` project.
- Open the generated file `appsettings-schema.json`.
- Confirm reference to configuration setting `InstallDefaultData`:
- Copy file into an Umbraco 10 project running in VSCode and check the Intellisense for the property matches the documentation,

I've created this PR for V10 as the bug should be fixed there and merged up.
