### PR TITLE
Add overload extension methods allowing to pass in view data

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/BlockGridTemplateExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/BlockGridTemplateExtensions.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Core.Models.PublishedContent;
 
@@ -19,7 +20,7 @@ public static class BlockGridTemplateExtensions
     #region Async
 
     /// <summary>
-    /// Renders a block grid model into a grid layout
+    /// Renders a block grid model into a grid layout.
     /// </summary>
     /// <remarks>
     /// By default this method uses a set of built-in partial views for rendering the blocks and areas in the grid model.
@@ -58,11 +59,28 @@ public static class BlockGridTemplateExtensions
     public static async Task<IHtmlContent> GetBlockGridItemsHtmlAsync(this IHtmlHelper html, IEnumerable<BlockGridItem> items, string template = DefaultItemsTemplate)
         => await html.PartialAsync(DefaultFolderTemplate(template), items);
 
-    public static async Task<IHtmlContent> GetBlockGridItemAreasHtmlAsync(this IHtmlHelper html, BlockGridItem item, string template = DefaultItemAreasTemplate)
-        => await html.PartialAsync(DefaultFolderTemplate(template), item);
+    public static async Task<IHtmlContent> GetBlockGridItemsHtmlAsync(this IHtmlHelper html, IEnumerable<BlockGridItem> items, string template = DefaultItemsTemplate, ViewDataDictionary? viewData = null)
+        => await html.PartialAsync(DefaultFolderTemplate(template), items, viewData);
 
     public static async Task<IHtmlContent> GetBlockGridItemAreaHtmlAsync(this IHtmlHelper html, BlockGridArea area, string template = DefaultItemAreaTemplate)
         => await html.PartialAsync(DefaultFolderTemplate(template), area);
+
+    public static async Task<IHtmlContent> GetBlockGridItemAreaHtmlAsync(this IHtmlHelper html, BlockGridArea area, string template = DefaultItemAreaTemplate, ViewDataDictionary? viewData = null)
+        => await html.PartialAsync(DefaultFolderTemplate(template), area, viewData);
+
+    public static async Task<IHtmlContent> GetBlockGridItemAreasHtmlAsync(this IHtmlHelper html, BlockGridItem item, string template = DefaultItemAreasTemplate)
+        => await html.PartialAsync(DefaultFolderTemplate(template), item);
+
+    public static async Task<IHtmlContent> GetBlockGridItemAreaHtmlAsync(this IHtmlHelper html, BlockGridItem item, string areaAlias, string template = DefaultItemAreaTemplate, ViewDataDictionary? viewData = null)
+    {
+        BlockGridArea? area = item.Areas.FirstOrDefault(a => a.Alias == areaAlias);
+        if (area == null)
+        {
+            return new HtmlString(string.Empty);
+        }
+
+        return await GetBlockGridItemAreaHtmlAsync(html, area, template, viewData);
+    }
 
     public static async Task<IHtmlContent> GetBlockGridItemAreaHtmlAsync(this IHtmlHelper html, BlockGridItem item, string areaAlias, string template = DefaultItemAreaTemplate)
     {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
When working with Block Grid editor, e.g. based on example project here https://github.com/umbraco/Umbraco.BlockGrid.Example.Website we can have some layout blocks.

Blocks itself as easy access to settings configured on block, but sometimes one may want to inherit or fallback to layout block settings.

E.g. a layout block "Two Column Layout" with areas "left" and "right" and then an Image block inserted either in left or right area (column).

If the layout block has settings, it doesn't seem the block has easy access to this, but I managed to make a few extension methods to handle this:

```
public static async Task<IHtmlContent> GetBlockGridItemAreaHtmlAsync(this IHtmlHelper html, BlockGridArea area, string template = "area", ViewDataDictionary? viewData = null)
    => await html.PartialAsync($"blockgrid/{template}", area, viewData);

public static async Task<IHtmlContent> GetBlockGridItemsHtmlAsync(this IHtmlHelper html, IEnumerable<BlockGridItem> items, string template = "items", ViewDataDictionary? viewData = null)
    => await html.PartialAsync($"blockgrid/{template}", items, viewData);
```

Then I updated a few of the default block grid partial views.

**default.cshtml**

```
<div class="umb-block-grid"
     data-grid-columns="@(Model.GridColumns?.ToString() ?? "12");"
     style="--umb-block-grid--grid-columns: @(Model.GridColumns?.ToString() ?? "12");">
    //@await Html.GetBlockGridItemsHtmlAsync(Model)
    @await Html.GetBlockGridItemsHtmlAsync(Model, viewData: new ViewDataDictionary(ViewData))
</div>
```

**items.cshtml**
```
..
//@await Html.PartialAsync(partialViewName, item)
@await Html.PartialAsync(partialViewName, item, new ViewDataDictionary(ViewData))
..
```

**areas.chtml**
```
<div class="umb-block-grid__area-container"
     style="--umb-block-grid--area-grid-columns: @(Model.AreaGridColumns?.ToString() ?? Model.GridColumns?.ToString() ?? "12");">
    @foreach (var area in Model.Areas)
    {
        //@await Html.GetBlockGridItemAreaHtmlAsync(area)
        @await Html.GetBlockGridItemAreaHtmlAsync(area, viewData: new ViewDataDictionary(ViewData) { { $"{area.Alias}_settingsSection", Model.Settings as BlockSettingsSection }})
    }
</div>
```

**area.chtml**
```
<div class="umb-block-grid__area"
     data-area-col-span="@Model.ColumnSpan"
     data-area-row-span="@Model.RowSpan"
     data-area-alias="@Model.Alias"
     style="--umb-block-grid--grid-columns: @Model.ColumnSpan;--umb-block-grid--area-column-span: @Model.ColumnSpan; --umb-block-grid--area-row-span: @Model.RowSpan;">
    //@await Html.GetBlockGridItemsHtmlAsync(Model)
    @await Html.GetBlockGridItemsHtmlAsync(Model, viewData: new ViewDataDictionary(ViewData))
</div>
```

Inside **BlockImage.cshtml** I can then access the setting from view data.

```
var settingsSection = ViewData[$"left_settingsSection"] != null ? ViewData[$"left_settingsSection"] as BlockSettingsSection : null;
```

Maybe we should also have overload of `GetBlockGridHtmlAsync()` as well accepting `ViewDataDictionary` and in Block List extensions too?