### PR TITLE
Render block as component otherwise as partial view

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/BlockGrid/items.cshtml
+++ b/src/Umbraco.Core/EmbeddedResources/BlockGrid/items.cshtml
@@ -1,8 +1,11 @@
-@using Umbraco.Cms.Core.Models.Blocks
 @inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<IEnumerable<BlockGridItem>>
+@using Microsoft.AspNetCore.Mvc.ViewComponents;
+@using Umbraco.Cms.Core.Models.Blocks;
 @{
     if (Model?.Any() != true) { return; }
 }
+
+@inject IViewComponentSelector _selector;
 
 <div class="umb-block-grid__layout-container">
     @foreach (var item in Model)
@@ -17,9 +20,17 @@
             style=" --umb-block-grid--item-column-span: @item.ColumnSpan; --umb-block-grid--item-row-span: @item.RowSpan; ">
             @{
                 var partialViewName = "blockgrid/Components/" + item.Content.ContentType.Alias;
+
                 try
                 {
-                    @await Html.PartialAsync(partialViewName, item)
+                    if (_selector.SelectComponent(item.Content.ContentType.Alias) is not null)
+                    {
+                        @await Component.InvokeAsync(item.Content.ContentType.Alias, item.Content)
+                    }
+                    else
+                    {
+                        @await Html.PartialAsync(partialViewName, item)
+                    }
                 }
                 catch (InvalidOperationException)
                 {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Since the Block Grid has been introduced, we have replaced the `items.cshtml` with our own, so it use a view component if exists otherwise a partial view as it currently does.

Not sure where I saw this originally in the community though, but I think it would be nice if it was standard.
