### PR TITLE
V14: Fix pipelines

### DIFF
--- a/src/Umbraco.Cms.Api.Common/Serialization/UmbracoJsonTypeInfoResolver.cs
+++ b/src/Umbraco.Cms.Api.Common/Serialization/UmbracoJsonTypeInfoResolver.cs
@@ -22,7 +22,7 @@ public sealed class UmbracoJsonTypeInfoResolver : DefaultJsonTypeInfoResolver, I
             return cachedResult;
         }
 
-        var result = _typeFinder.FindClassesOfType(type).ToHashSet();
+        var result = _typeFinder.FindClassesOfType(type).OrderBy(x => x.Name).ToHashSet();
         _subTypesCache.TryAdd(type, result);
         return result;
     }

--- a/src/Umbraco.Cms.Api.Management/Configuration/ConfigureUmbracoManagementApiSwaggerGenOptions.cs
+++ b/src/Umbraco.Cms.Api.Management/Configuration/ConfigureUmbracoManagementApiSwaggerGenOptions.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;

--- a/src/Umbraco.Cms.Api.Management/Configuration/ConfigureUmbracoManagementApiSwaggerGenOptions.cs
+++ b/src/Umbraco.Cms.Api.Management/Configuration/ConfigureUmbracoManagementApiSwaggerGenOptions.cs
@@ -31,14 +31,14 @@ public class ConfigureUmbracoManagementApiSwaggerGenOptions : IConfigureOptions<
                 Description = "This shows all APIs available in this version of Umbraco - including all the legacy apis that are available for backward compatibility",
             });
 
-        swaggerGenOptions.UseOneOfForPolymorphism();
-        swaggerGenOptions.UseAllOfForInheritance();
         swaggerGenOptions.OperationFilter<ResponseHeaderOperationFilter>();
         swaggerGenOptions.SelectSubTypesUsing(_umbracoJsonTypeInfoResolver.FindSubTypes);
+        swaggerGenOptions.UseOneOfForPolymorphism();
+        swaggerGenOptions.UseAllOfForInheritance();
 
         swaggerGenOptions.AddSecurityDefinition(
             ManagementApiConfiguration.ApiSecurityName,
-             new OpenApiSecurityScheme
+            new OpenApiSecurityScheme
              {
                  In = ParameterLocation.Header,
                  Name = "Umbraco",

--- a/src/Umbraco.Cms.Api.Management/Configuration/ConfigureUmbracoManagementApiSwaggerGenOptions.cs
+++ b/src/Umbraco.Cms.Api.Management/Configuration/ConfigureUmbracoManagementApiSwaggerGenOptions.cs
@@ -31,8 +31,8 @@ public class ConfigureUmbracoManagementApiSwaggerGenOptions : IConfigureOptions<
 
         swaggerGenOptions.OperationFilter<ResponseHeaderOperationFilter>();
         swaggerGenOptions.SelectSubTypesUsing(_umbracoJsonTypeInfoResolver.FindSubTypes);
-        swaggerGenOptions.UseOneOfForPolymorphism();
-        swaggerGenOptions.UseAllOfForInheritance();
+        // swaggerGenOptions.UseOneOfForPolymorphism();
+        // swaggerGenOptions.UseAllOfForInheritance();
 
         swaggerGenOptions.AddSecurityDefinition(
             ManagementApiConfiguration.ApiSecurityName,

--- a/src/Umbraco.Cms.Api.Management/Configuration/ConfigureUmbracoManagementApiSwaggerGenOptions.cs
+++ b/src/Umbraco.Cms.Api.Management/Configuration/ConfigureUmbracoManagementApiSwaggerGenOptions.cs
@@ -21,6 +21,7 @@ public class ConfigureUmbracoManagementApiSwaggerGenOptions : IConfigureOptions<
 
     public void Configure(SwaggerGenOptions swaggerGenOptions)
     {
+
         swaggerGenOptions.SwaggerDoc(
             ManagementApiConfiguration.ApiName,
             new OpenApiInfo
@@ -30,14 +31,10 @@ public class ConfigureUmbracoManagementApiSwaggerGenOptions : IConfigureOptions<
                 Description = "This shows all APIs available in this version of Umbraco - including all the legacy apis that are available for backward compatibility",
             });
 
-        swaggerGenOptions.OperationFilter<ResponseHeaderOperationFilter>();
-        swaggerGenOptions.SelectSubTypesUsing(_umbracoJsonTypeInfoResolver.FindSubTypes);
         swaggerGenOptions.UseOneOfForPolymorphism();
         swaggerGenOptions.UseAllOfForInheritance();
-        swaggerGenOptions.TagActionsBy(api => new[] { api.GroupName });
-        swaggerGenOptions.OrderActionsBy(ActionOrderBy);
-
-
+        swaggerGenOptions.OperationFilter<ResponseHeaderOperationFilter>();
+        swaggerGenOptions.SelectSubTypesUsing(_umbracoJsonTypeInfoResolver.FindSubTypes);
 
         swaggerGenOptions.AddSecurityDefinition(
             ManagementApiConfiguration.ApiSecurityName,
@@ -62,6 +59,4 @@ public class ConfigureUmbracoManagementApiSwaggerGenOptions : IConfigureOptions<
         swaggerGenOptions.OperationFilter<BackOfficeSecurityRequirementsOperationFilter>();
     }
 
-    private static string ActionOrderBy(ApiDescription apiDesc)
-        => $"{apiDesc.GroupName}_{apiDesc.ActionDescriptor.AttributeRouteInfo?.Template ?? apiDesc.ActionDescriptor.RouteValues["controller"]}_{apiDesc.ActionDescriptor.RouteValues["action"]}_{apiDesc.HttpMethod}";
 }

--- a/src/Umbraco.Cms.Api.Management/Configuration/ConfigureUmbracoManagementApiSwaggerGenOptions.cs
+++ b/src/Umbraco.Cms.Api.Management/Configuration/ConfigureUmbracoManagementApiSwaggerGenOptions.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
@@ -31,8 +32,12 @@ public class ConfigureUmbracoManagementApiSwaggerGenOptions : IConfigureOptions<
 
         swaggerGenOptions.OperationFilter<ResponseHeaderOperationFilter>();
         swaggerGenOptions.SelectSubTypesUsing(_umbracoJsonTypeInfoResolver.FindSubTypes);
-        // swaggerGenOptions.UseOneOfForPolymorphism();
-        // swaggerGenOptions.UseAllOfForInheritance();
+        swaggerGenOptions.UseOneOfForPolymorphism();
+        swaggerGenOptions.UseAllOfForInheritance();
+        swaggerGenOptions.TagActionsBy(api => new[] { api.GroupName });
+        swaggerGenOptions.OrderActionsBy(ActionOrderBy);
+
+
 
         swaggerGenOptions.AddSecurityDefinition(
             ManagementApiConfiguration.ApiSecurityName,
@@ -56,4 +61,7 @@ public class ConfigureUmbracoManagementApiSwaggerGenOptions : IConfigureOptions<
         // Sets Security requirement on backoffice apis
         swaggerGenOptions.OperationFilter<BackOfficeSecurityRequirementsOperationFilter>();
     }
+
+    private static string ActionOrderBy(ApiDescription apiDesc)
+        => $"{apiDesc.GroupName}_{apiDesc.ActionDescriptor.AttributeRouteInfo?.Template ?? apiDesc.ActionDescriptor.RouteValues["controller"]}_{apiDesc.ActionDescriptor.RouteValues["action"]}_{apiDesc.HttpMethod}";
 }

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -291,29 +291,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateDataTypeRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateDataTypeRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateDataTypeRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateDataTypeRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateDataTypeRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateDataTypeRequestModel"
               }
             }
           }
@@ -386,29 +374,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/DataTypeResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/DataTypeResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/DataTypeResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/DataTypeResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/DataTypeResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/DataTypeResponseModel"
                 }
               }
             }
@@ -493,29 +469,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateDataTypeRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateDataTypeRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateDataTypeRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateDataTypeRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateDataTypeRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateDataTypeRequestModel"
               }
             }
           }
@@ -576,29 +540,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CopyDataTypeRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CopyDataTypeRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CopyDataTypeRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CopyDataTypeRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CopyDataTypeRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CopyDataTypeRequestModel"
               }
             }
           }
@@ -698,29 +650,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/MoveDataTypeRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/MoveDataTypeRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/MoveDataTypeRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/MoveDataTypeRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/MoveDataTypeRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/MoveDataTypeRequestModel"
               }
             }
           }
@@ -765,11 +705,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/DataTypeReferenceResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/DataTypeReferenceResponseModel"
                   }
                 }
               },
@@ -777,11 +713,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/DataTypeReferenceResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/DataTypeReferenceResponseModel"
                   }
                 }
               },
@@ -789,11 +721,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/DataTypeReferenceResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/DataTypeReferenceResponseModel"
                   }
                 }
               }
@@ -820,29 +748,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateFolderRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateFolderRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateFolderRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateFolderRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateFolderRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateFolderRequestModel"
               }
             }
           }
@@ -892,29 +808,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/FolderReponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/FolderReponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/FolderReponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/FolderReponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/FolderReponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/FolderReponseModel"
                 }
               }
             }
@@ -979,29 +883,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateFolderReponseModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateFolderReponseModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateFolderReponseModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateFolderReponseModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateFolderReponseModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateFolderReponseModel"
               }
             }
           }
@@ -1049,11 +941,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/DataTypeItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/DataTypeItemResponseModel"
                   }
                 }
               },
@@ -1061,11 +949,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/DataTypeItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/DataTypeItemResponseModel"
                   }
                 }
               },
@@ -1073,11 +957,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/DataTypeItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/DataTypeItemResponseModel"
                   }
                 }
               }
@@ -1113,29 +993,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/DataTypeItemResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/DataTypeItemResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/DataTypeItemResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/DataTypeItemResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/DataTypeItemResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/DataTypeItemResponseModel"
                 }
               }
             }
@@ -1345,29 +1213,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateDictionaryItemRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateDictionaryItemRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateDictionaryItemRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateDictionaryItemRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateDictionaryItemRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateDictionaryItemRequestModel"
               }
             }
           }
@@ -1460,29 +1316,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/DictionaryItemResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/DictionaryItemResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/DictionaryItemResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/DictionaryItemResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/DictionaryItemResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/DictionaryItemResponseModel"
                 }
               }
             }
@@ -1567,29 +1411,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateDictionaryItemRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateDictionaryItemRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateDictionaryItemRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateDictionaryItemRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateDictionaryItemRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateDictionaryItemRequestModel"
               }
             }
           }
@@ -1710,29 +1542,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/MoveDictionaryRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/MoveDictionaryRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/MoveDictionaryRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/MoveDictionaryRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/MoveDictionaryRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/MoveDictionaryRequestModel"
               }
             }
           }
@@ -1782,29 +1602,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/ImportDictionaryRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/ImportDictionaryRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/ImportDictionaryRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/ImportDictionaryRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/ImportDictionaryRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/ImportDictionaryRequestModel"
               }
             }
           }
@@ -1882,11 +1690,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/DictionaryItemItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/DictionaryItemItemResponseModel"
                   }
                 }
               },
@@ -1894,11 +1698,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/DictionaryItemItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/DictionaryItemItemResponseModel"
                   }
                 }
               },
@@ -1906,11 +1706,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/DictionaryItemItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/DictionaryItemItemResponseModel"
                   }
                 }
               }
@@ -2070,11 +1866,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/DocumentBlueprintResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/DocumentBlueprintResponseModel"
                   }
                 }
               },
@@ -2082,11 +1874,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/DocumentBlueprintResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/DocumentBlueprintResponseModel"
                   }
                 }
               },
@@ -2094,11 +1882,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/DocumentBlueprintResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/DocumentBlueprintResponseModel"
                   }
                 }
               }
@@ -2177,29 +1961,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateDocumentTypeRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateDocumentTypeRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateDocumentTypeRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateDocumentTypeRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateDocumentTypeRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateDocumentTypeRequestModel"
               }
             }
           }
@@ -2242,29 +2014,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/DocumentTypeResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/DocumentTypeResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/DocumentTypeResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/DocumentTypeResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/DocumentTypeResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/DocumentTypeResponseModel"
                 }
               }
             }
@@ -2301,29 +2061,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/DocumentTypeResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/DocumentTypeResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/DocumentTypeResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/DocumentTypeResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/DocumentTypeResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/DocumentTypeResponseModel"
                 }
               }
             }
@@ -2358,29 +2106,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateDocumentTypeRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateDocumentTypeRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateDocumentTypeRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateDocumentTypeRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateDocumentTypeRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateDocumentTypeRequestModel"
               }
             }
           }
@@ -2431,11 +2167,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/DocumentTypeItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/DocumentTypeItemResponseModel"
                   }
                 }
               },
@@ -2443,11 +2175,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/DocumentTypeItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/DocumentTypeItemResponseModel"
                   }
                 }
               },
@@ -2455,11 +2183,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/DocumentTypeItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/DocumentTypeItemResponseModel"
                   }
                 }
               }
@@ -2617,29 +2341,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateDocumentRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateDocumentRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateDocumentRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateDocumentRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateDocumentRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateDocumentRequestModel"
               }
             }
           }
@@ -2695,29 +2407,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/DocumentResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/DocumentResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/DocumentResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/DocumentResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/DocumentResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/DocumentResponseModel"
                 }
               }
             }
@@ -2785,29 +2485,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateDocumentRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateDocumentRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateDocumentRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateDocumentRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateDocumentRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateDocumentRequestModel"
               }
             }
           }
@@ -2918,29 +2606,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CopyDocumentRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CopyDocumentRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CopyDocumentRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CopyDocumentRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CopyDocumentRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CopyDocumentRequestModel"
               }
             }
           }
@@ -3021,29 +2697,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateDomainsRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateDomainsRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateDomainsRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateDomainsRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateDomainsRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateDomainsRequestModel"
               }
             }
           }
@@ -3081,29 +2745,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/MoveDocumentRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/MoveDocumentRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/MoveDocumentRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/MoveDocumentRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/MoveDocumentRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/MoveDocumentRequestModel"
               }
             }
           }
@@ -3151,11 +2803,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/DocumentNotificationResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/DocumentNotificationResponseModel"
                   }
                 }
               },
@@ -3163,11 +2811,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/DocumentNotificationResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/DocumentNotificationResponseModel"
                   }
                 }
               },
@@ -3175,11 +2819,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/DocumentNotificationResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/DocumentNotificationResponseModel"
                   }
                 }
               }
@@ -3215,29 +2855,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateDocumentNotificationsRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateDocumentNotificationsRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateDocumentNotificationsRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateDocumentNotificationsRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateDocumentNotificationsRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateDocumentNotificationsRequestModel"
               }
             }
           }
@@ -3278,29 +2906,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/PublicAccessRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/PublicAccessRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/PublicAccessRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/PublicAccessRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/PublicAccessRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/PublicAccessRequestModel"
               }
             }
           }
@@ -3409,29 +3025,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/PublicAccessRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/PublicAccessRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/PublicAccessRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/PublicAccessRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/PublicAccessRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/PublicAccessRequestModel"
               }
             }
           }
@@ -3497,11 +3101,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/DocumentItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/DocumentItemResponseModel"
                   }
                 }
               },
@@ -3509,11 +3109,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/DocumentItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/DocumentItemResponseModel"
                   }
                 }
               },
@@ -3521,11 +3117,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/DocumentItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/DocumentItemResponseModel"
                   }
                 }
               }
@@ -3949,29 +3541,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/HealthCheckGroupPresentationModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/HealthCheckGroupPresentationModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/HealthCheckGroupPresentationModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/HealthCheckGroupPresentationModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/HealthCheckGroupPresentationModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/HealthCheckGroupPresentationModel"
                 }
               }
             }
@@ -4009,29 +3589,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/HealthCheckGroupWithResultResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/HealthCheckGroupWithResultResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/HealthCheckGroupWithResultResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/HealthCheckGroupWithResultResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/HealthCheckGroupWithResultResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/HealthCheckGroupWithResultResponseModel"
                 }
               }
             }
@@ -4054,29 +3622,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/HealthCheckActionRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/HealthCheckActionRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/HealthCheckActionRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/HealthCheckActionRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/HealthCheckActionRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/HealthCheckActionRequestModel"
               }
             }
           }
@@ -4107,29 +3663,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/HealthCheckResultResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/HealthCheckResultResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/HealthCheckResultResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/HealthCheckResultResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/HealthCheckResultResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/HealthCheckResultResponseModel"
                 }
               }
             }
@@ -4336,29 +3880,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/IndexResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/IndexResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/IndexResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/IndexResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/IndexResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/IndexResponseModel"
                 }
               }
             }
@@ -4488,29 +4020,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/InstallSettingsResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/InstallSettingsResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/InstallSettingsResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/InstallSettingsResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/InstallSettingsResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/InstallSettingsResponseModel"
                 }
               }
             }
@@ -4528,29 +4048,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/InstallVResponseModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/InstallVResponseModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/InstallVResponseModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/InstallVResponseModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/InstallVResponseModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/InstallVResponseModel"
               }
             }
           }
@@ -4612,29 +4120,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/DatabaseInstallResponseModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/DatabaseInstallResponseModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/DatabaseInstallResponseModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/DatabaseInstallResponseModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/DatabaseInstallResponseModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/DatabaseInstallResponseModel"
               }
             }
           }
@@ -4729,29 +4225,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateLanguageRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateLanguageRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateLanguageRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateLanguageRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateLanguageRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateLanguageRequestModel"
               }
             }
           }
@@ -4826,29 +4310,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/LanguageResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/LanguageResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/LanguageResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/LanguageResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/LanguageResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/LanguageResponseModel"
                 }
               }
             }
@@ -4945,29 +4417,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateLanguageRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateLanguageRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateLanguageRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateLanguageRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateLanguageRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateLanguageRequestModel"
               }
             }
           }
@@ -5034,11 +4494,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/LanguageItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/LanguageItemResponseModel"
                   }
                 }
               },
@@ -5046,11 +4502,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/LanguageItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/LanguageItemResponseModel"
                   }
                 }
               },
@@ -5058,11 +4510,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/LanguageItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/LanguageItemResponseModel"
                   }
                 }
               }
@@ -5181,29 +4629,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/LogLevelCountsReponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/LogLevelCountsReponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/LogLevelCountsReponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/LogLevelCountsReponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/LogLevelCountsReponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/LogLevelCountsReponseModel"
                 }
               }
             }
@@ -5465,29 +4901,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/SavedLogSearchRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/SavedLogSearchRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/SavedLogSearchRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/SavedLogSearchRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/SavedLogSearchRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/SavedLogSearchRequestModel"
               }
             }
           }
@@ -5559,29 +4983,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/SavedLogSearchResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/SavedLogSearchResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/SavedLogSearchResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/SavedLogSearchResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/SavedLogSearchResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/SavedLogSearchResponseModel"
                 }
               }
             }
@@ -5702,29 +5114,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/MediaTypeResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/MediaTypeResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/MediaTypeResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/MediaTypeResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/MediaTypeResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/MediaTypeResponseModel"
                 }
               }
             }
@@ -5768,11 +5168,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/MediaTypeItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/MediaTypeItemResponseModel"
                   }
                 }
               },
@@ -5780,11 +5176,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/MediaTypeItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/MediaTypeItemResponseModel"
                   }
                 }
               },
@@ -5792,11 +5184,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/MediaTypeItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/MediaTypeItemResponseModel"
                   }
                 }
               }
@@ -5954,29 +5342,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateMediaRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateMediaRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateMediaRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateMediaRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateMediaRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateMediaRequestModel"
               }
             }
           }
@@ -6032,29 +5408,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/DocumentResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/DocumentResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/DocumentResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/DocumentResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/DocumentResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/DocumentResponseModel"
                 }
               }
             }
@@ -6122,29 +5486,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateMediaRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateMediaRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateMediaRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateMediaRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateMediaRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateMediaRequestModel"
               }
             }
           }
@@ -6188,29 +5540,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/MoveMediaRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/MoveMediaRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/MoveMediaRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/MoveMediaRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/MoveMediaRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/MoveMediaRequestModel"
               }
             }
           }
@@ -6269,11 +5609,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/MediaItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/MediaItemResponseModel"
                   }
                 }
               },
@@ -6281,11 +5617,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/MediaItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/MediaItemResponseModel"
                   }
                 }
               },
@@ -6293,11 +5625,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/MediaItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/MediaItemResponseModel"
                   }
                 }
               }
@@ -6541,11 +5869,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/MediaTreeItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/MediaTreeItemResponseModel"
                   }
                 }
               },
@@ -6553,11 +5877,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/MediaTreeItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/MediaTreeItemResponseModel"
                   }
                 }
               },
@@ -6565,11 +5885,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/MediaTreeItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/MediaTreeItemResponseModel"
                   }
                 }
               }
@@ -6674,11 +5990,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/MemberGroupItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/MemberGroupItemResponseModel"
                   }
                 }
               },
@@ -6686,11 +5998,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/MemberGroupItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/MemberGroupItemResponseModel"
                   }
                 }
               },
@@ -6698,11 +6006,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/MemberGroupItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/MemberGroupItemResponseModel"
                   }
                 }
               }
@@ -6799,11 +6103,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/MemberTypeItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/MemberTypeItemResponseModel"
                   }
                 }
               },
@@ -6811,11 +6111,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/MemberTypeItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/MemberTypeItemResponseModel"
                   }
                 }
               },
@@ -6823,11 +6119,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/MemberTypeItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/MemberTypeItemResponseModel"
                   }
                 }
               }
@@ -6924,11 +6216,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/MemberItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/MemberItemResponseModel"
                   }
                 }
               },
@@ -6936,11 +6224,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/MemberItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/MemberItemResponseModel"
                   }
                 }
               },
@@ -6948,11 +6232,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/MemberItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/MemberItemResponseModel"
                   }
                 }
               }
@@ -7016,29 +6296,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/ModelsBuilderResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/ModelsBuilderResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/ModelsBuilderResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/ModelsBuilderResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/ModelsBuilderResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/ModelsBuilderResponseModel"
                 }
               }
             }
@@ -7063,29 +6331,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/OutOfDateStatusResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/OutOfDateStatusResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/OutOfDateStatusResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/OutOfDateStatusResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/OutOfDateStatusResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/OutOfDateStatusResponseModel"
                 }
               }
             }
@@ -7267,29 +6523,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreatePackageRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreatePackageRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreatePackageRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreatePackageRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreatePackageRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreatePackageRequestModel"
               }
             }
           }
@@ -7365,29 +6609,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/PackageDefinitionResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/PackageDefinitionResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/PackageDefinitionResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/PackageDefinitionResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/PackageDefinitionResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/PackageDefinitionResponseModel"
                 }
               }
             }
@@ -7449,29 +6681,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdatePackageRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdatePackageRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdatePackageRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdatePackageRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdatePackageRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdatePackageRequestModel"
               }
             }
           }
@@ -7557,11 +6777,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/PackageManifestResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/PackageManifestResponseModel"
                   }
                 }
               },
@@ -7569,11 +6785,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/PackageManifestResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/PackageManifestResponseModel"
                   }
                 }
               },
@@ -7581,11 +6793,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/PackageManifestResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/PackageManifestResponseModel"
                   }
                 }
               }
@@ -7675,29 +6883,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/PartialViewResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/PartialViewResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/PartialViewResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/PartialViewResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/PartialViewResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/PartialViewResponseModel"
                 }
               }
             }
@@ -7718,29 +6914,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreatePartialViewRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreatePartialViewRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreatePartialViewRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreatePartialViewRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreatePartialViewRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreatePartialViewRequestModel"
               }
             }
           }
@@ -7800,29 +6984,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdatePartialViewRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdatePartialViewRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdatePartialViewRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdatePartialViewRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdatePartialViewRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdatePartialViewRequestModel"
               }
             }
           }
@@ -7874,29 +7046,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreatePathFolderRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreatePathFolderRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreatePathFolderRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreatePathFolderRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreatePathFolderRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreatePathFolderRequestModel"
               }
             }
           }
@@ -7965,11 +7125,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/PartialViewItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/PartialViewItemResponseModel"
                   }
                 }
               },
@@ -7977,11 +7133,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/PartialViewItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/PartialViewItemResponseModel"
                   }
                 }
               },
@@ -7989,11 +7141,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/PartialViewItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/PartialViewItemResponseModel"
                   }
                 }
               }
@@ -8084,29 +7232,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/PartialViewSnippetResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/PartialViewSnippetResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/PartialViewSnippetResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/PartialViewSnippetResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/PartialViewSnippetResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/PartialViewSnippetResponseModel"
                 }
               }
             }
@@ -8248,29 +7384,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/ProfilingStatusResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/ProfilingStatusResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/ProfilingStatusResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/ProfilingStatusResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/ProfilingStatusResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/ProfilingStatusResponseModel"
                 }
               }
             }
@@ -8291,29 +7415,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/ProfilingStatusRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/ProfilingStatusRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/ProfilingStatusRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/ProfilingStatusRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/ProfilingStatusRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/ProfilingStatusRequestModel"
               }
             }
           }
@@ -8676,29 +7788,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/RedirectUrlStatusResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/RedirectUrlStatusResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/RedirectUrlStatusResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/RedirectUrlStatusResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/RedirectUrlStatusResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/RedirectUrlStatusResponseModel"
                 }
               }
             }
@@ -8746,29 +7846,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateRelationTypeRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateRelationTypeRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateRelationTypeRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateRelationTypeRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateRelationTypeRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateRelationTypeRequestModel"
               }
             }
           }
@@ -8838,29 +7926,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/RelationTypeResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/RelationTypeResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/RelationTypeResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/RelationTypeResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/RelationTypeResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/RelationTypeResponseModel"
                 }
               }
             }
@@ -8942,29 +8018,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateRelationTypeRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateRelationTypeRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateRelationTypeRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateRelationTypeRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateRelationTypeRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateRelationTypeRequestModel"
               }
             }
           }
@@ -8975,29 +8039,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/RelationTypeResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/RelationTypeResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/RelationTypeResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/RelationTypeResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/RelationTypeResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/RelationTypeResponseModel"
                 }
               }
             }
@@ -9078,11 +8130,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/RelationTypeItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/RelationTypeItemResponseModel"
                   }
                 }
               },
@@ -9090,11 +8138,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/RelationTypeItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/RelationTypeItemResponseModel"
                   }
                 }
               },
@@ -9102,11 +8146,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/RelationTypeItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/RelationTypeItemResponseModel"
                   }
                 }
               }
@@ -9198,29 +8238,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/RelationResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/RelationResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/RelationResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/RelationResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/RelationResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/RelationResponseModel"
                 }
               }
             }
@@ -9393,29 +8421,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/ScriptResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/ScriptResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/ScriptResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/ScriptResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/ScriptResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/ScriptResponseModel"
                 }
               }
             }
@@ -9436,29 +8452,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateScriptRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateScriptRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateScriptRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateScriptRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateScriptRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateScriptRequestModel"
               }
             }
           }
@@ -9518,29 +8522,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateScriptRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateScriptRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateScriptRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateScriptRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateScriptRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateScriptRequestModel"
               }
             }
           }
@@ -9592,29 +8584,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreatePathFolderRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreatePathFolderRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreatePathFolderRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreatePathFolderRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreatePathFolderRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreatePathFolderRequestModel"
               }
             }
           }
@@ -9683,11 +8663,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/ScriptItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/ScriptItemResponseModel"
                   }
                 }
               },
@@ -9695,11 +8671,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/ScriptItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/ScriptItemResponseModel"
                   }
                 }
               },
@@ -9707,11 +8679,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/ScriptItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/ScriptItemResponseModel"
                   }
                 }
               }
@@ -10010,29 +8978,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/LoginRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/LoginRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/LoginRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/LoginRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/LoginRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/LoginRequestModel"
               }
             }
           }
@@ -10076,29 +9032,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/ServerStatusResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/ServerStatusResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/ServerStatusResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/ServerStatusResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/ServerStatusResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/ServerStatusResponseModel"
                 }
               }
             }
@@ -10138,29 +9082,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/VersionResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/VersionResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/VersionResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/VersionResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/VersionResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/VersionResponseModel"
                 }
               }
             }
@@ -10200,11 +9132,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/StaticFileItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/StaticFileItemResponseModel"
                   }
                 }
               },
@@ -10212,11 +9140,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/StaticFileItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/StaticFileItemResponseModel"
                   }
                 }
               },
@@ -10224,11 +9148,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/StaticFileItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/StaticFileItemResponseModel"
                   }
                 }
               }
@@ -10380,29 +9300,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/StylesheetResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/StylesheetResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/StylesheetResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/StylesheetResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/StylesheetResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/StylesheetResponseModel"
                 }
               }
             }
@@ -10423,29 +9331,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateStylesheetRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateStylesheetRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateStylesheetRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateStylesheetRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateStylesheetRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateStylesheetRequestModel"
               }
             }
           }
@@ -10505,29 +9401,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateStylesheetRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateStylesheetRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateStylesheetRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateStylesheetRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateStylesheetRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateStylesheetRequestModel"
               }
             }
           }
@@ -10634,29 +9518,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreatePathFolderRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreatePathFolderRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreatePathFolderRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreatePathFolderRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreatePathFolderRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreatePathFolderRequestModel"
               }
             }
           }
@@ -10725,11 +9597,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/ScriptItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/ScriptItemResponseModel"
                   }
                 }
               },
@@ -10737,11 +9605,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/ScriptItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/ScriptItemResponseModel"
                   }
                 }
               },
@@ -10749,11 +9613,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/ScriptItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/ScriptItemResponseModel"
                   }
                 }
               }
@@ -10777,29 +9637,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesRequestModel"
               }
             }
           }
@@ -10810,29 +9658,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesResponseModel"
                 }
               }
             }
@@ -10855,29 +9691,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/InterpolateRichTextStylesheetRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/InterpolateRichTextStylesheetRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/InterpolateRichTextStylesheetRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/InterpolateRichTextStylesheetRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/InterpolateRichTextStylesheetRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/InterpolateRichTextStylesheetRequestModel"
               }
             }
           }
@@ -10888,29 +9712,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/InterpolateRichTextStylesheetResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/InterpolateRichTextStylesheetResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/InterpolateRichTextStylesheetResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/InterpolateRichTextStylesheetResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/InterpolateRichTextStylesheetResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/InterpolateRichTextStylesheetResponseModel"
                 }
               }
             }
@@ -10944,38 +9756,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/RichTextStylesheetRulesResponseModel"
-                    },
-                    {
-                      "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/RichTextStylesheetRulesResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/RichTextStylesheetRulesResponseModel"
-                    },
-                    {
-                      "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/RichTextStylesheetRulesResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/RichTextStylesheetRulesResponseModel"
-                    },
-                    {
-                      "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/RichTextStylesheetRulesResponseModel"
                 }
               }
             }
@@ -11248,29 +10039,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/TelemetryResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TelemetryResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/TelemetryResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TelemetryResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/TelemetryResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TelemetryResponseModel"
                 }
               }
             }
@@ -11291,29 +10070,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/TelemetryRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/TelemetryRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/TelemetryRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/TelemetryRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/TelemetryRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/TelemetryRequestModel"
               }
             }
           }
@@ -11360,29 +10127,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateTemplateRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateTemplateRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateTemplateRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateTemplateRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateTemplateRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateTemplateRequestModel"
               }
             }
           }
@@ -11455,29 +10210,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/TemplateResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TemplateResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/TemplateResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TemplateResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/TemplateResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TemplateResponseModel"
                 }
               }
             }
@@ -11562,29 +10305,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateTemplateRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateTemplateRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateTemplateRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateTemplateRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateTemplateRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateTemplateRequestModel"
               }
             }
           }
@@ -11652,11 +10383,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/TemplateItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/TemplateItemResponseModel"
                   }
                 }
               },
@@ -11664,11 +10391,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/TemplateItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/TemplateItemResponseModel"
                   }
                 }
               },
@@ -11676,11 +10399,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/TemplateItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/TemplateItemResponseModel"
                   }
                 }
               }
@@ -11704,29 +10423,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/TemplateQueryExecuteModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/TemplateQueryExecuteModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/TemplateQueryExecuteModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/TemplateQueryExecuteModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/TemplateQueryExecuteModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/TemplateQueryExecuteModel"
               }
             }
           }
@@ -11737,29 +10444,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/TemplateQueryResultResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TemplateQueryResultResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/TemplateQueryResultResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TemplateQueryResultResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/TemplateQueryResultResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TemplateQueryResultResponseModel"
                 }
               }
             }
@@ -11784,29 +10479,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/TemplateQuerySettingsResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TemplateQuerySettingsResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/TemplateQuerySettingsResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TemplateQuerySettingsResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/TemplateQuerySettingsResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TemplateQuerySettingsResponseModel"
                 }
               }
             }
@@ -11841,29 +10524,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/TemplateScaffoldResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TemplateScaffoldResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/TemplateScaffoldResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TemplateScaffoldResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/TemplateScaffoldResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TemplateScaffoldResponseModel"
                 }
               }
             }
@@ -12135,29 +10806,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/TemporaryFileResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TemporaryFileResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/TemporaryFileResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TemporaryFileResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/TemporaryFileResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/TemporaryFileResponseModel"
                 }
               }
             }
@@ -12249,29 +10908,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/UserTourStatusesResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/UserTourStatusesResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/UserTourStatusesResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/UserTourStatusesResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/UserTourStatusesResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/UserTourStatusesResponseModel"
                 }
               }
             }
@@ -12292,29 +10939,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/SetTourStatusRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/SetTourStatusRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/SetTourStatusRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/SetTourStatusRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/SetTourStatusRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/SetTourStatusRequestModel"
               }
             }
           }
@@ -12620,29 +11255,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/UpgradeSettingsResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/UpgradeSettingsResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/UpgradeSettingsResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/UpgradeSettingsResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/UpgradeSettingsResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/UpgradeSettingsResponseModel"
                 }
               }
             }
@@ -12685,29 +11308,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateUserGroupRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateUserGroupRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateUserGroupRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateUserGroupRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateUserGroupRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateUserGroupRequestModel"
               }
             }
           }
@@ -12830,29 +11441,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/UserGroupResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/UserGroupResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/UserGroupResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/UserGroupResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/UserGroupResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/UserGroupResponseModel"
                 }
               }
             }
@@ -12917,29 +11516,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateUserGroupRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateUserGroupRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateUserGroupRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateUserGroupRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateUserGroupRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateUserGroupRequestModel"
               }
             }
           }
@@ -12987,11 +11574,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/UserGroupItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/UserGroupItemResponseModel"
                   }
                 }
               },
@@ -12999,11 +11582,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/UserGroupItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/UserGroupItemResponseModel"
                   }
                 }
               },
@@ -13011,11 +11590,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/UserGroupItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/UserGroupItemResponseModel"
                   }
                 }
               }
@@ -13039,38 +11614,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateUserRequestModel"
-                  },
-                  {
-                    "$ref": "#/components/schemas/InviteUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateUserRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateUserRequestModel"
-                  },
-                  {
-                    "$ref": "#/components/schemas/InviteUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateUserRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateUserRequestModel"
-                  },
-                  {
-                    "$ref": "#/components/schemas/InviteUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateUserRequestModel"
               }
             }
           }
@@ -13081,29 +11635,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/CreateUserResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/CreateUserResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/CreateUserResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/CreateUserResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/CreateUserResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/CreateUserResponseModel"
                 }
               }
             }
@@ -13212,29 +11754,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/UserResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/UserResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/UserResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/UserResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/UserResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/UserResponseModel"
                 }
               }
             }
@@ -13296,29 +11826,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateUserRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateUserRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateUserRequestModel"
               }
             }
           }
@@ -13383,29 +11901,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/SetAvatarRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/SetAvatarRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/SetAvatarRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/SetAvatarRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/SetAvatarRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/SetAvatarRequestModel"
               }
             }
           }
@@ -13463,29 +11969,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
               }
             }
           }
@@ -13514,29 +12008,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/CurrentUserResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/CurrentUserResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/CurrentUserResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/CurrentUserResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/CurrentUserResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/CurrentUserResponseModel"
                 }
               }
             }
@@ -13559,29 +12041,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/SetAvatarRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/SetAvatarRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/SetAvatarRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/SetAvatarRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/SetAvatarRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/SetAvatarRequestModel"
               }
             }
           }
@@ -13608,29 +12078,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
               }
             }
           }
@@ -13659,29 +12117,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/UserDataResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/UserDataResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/UserDataResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/UserDataResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/UserDataResponseModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/UserDataResponseModel"
                 }
               }
             }
@@ -13706,29 +12152,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/LinkedLoginsRequestModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/LinkedLoginsRequestModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/LinkedLoginsRequestModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/LinkedLoginsRequestModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/LinkedLoginsRequestModel"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/LinkedLoginsRequestModel"
                 }
               }
             }
@@ -13769,11 +12203,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/UserPermissionsResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/UserPermissionsResponseModel"
                   }
                 }
               },
@@ -13781,11 +12211,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/UserPermissionsResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/UserPermissionsResponseModel"
                   }
                 }
               },
@@ -13793,11 +12219,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/UserPermissionsResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/UserPermissionsResponseModel"
                   }
                 }
               }
@@ -13839,11 +12261,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/UserPermissionsResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/UserPermissionsResponseModel"
                   }
                 }
               },
@@ -13851,11 +12269,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/UserPermissionsResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/UserPermissionsResponseModel"
                   }
                 }
               },
@@ -13863,11 +12277,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/UserPermissionsResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/UserPermissionsResponseModel"
                   }
                 }
               }
@@ -13909,11 +12319,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/UserPermissionsResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/UserPermissionsResponseModel"
                   }
                 }
               },
@@ -13921,11 +12327,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/UserPermissionsResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/UserPermissionsResponseModel"
                   }
                 }
               },
@@ -13933,11 +12335,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/UserPermissionsResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/UserPermissionsResponseModel"
                   }
                 }
               }
@@ -13961,29 +12359,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/DisableUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/DisableUserRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/DisableUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/DisableUserRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/DisableUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/DisableUserRequestModel"
               }
             }
           }
@@ -14030,29 +12416,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/EnableUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/EnableUserRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/EnableUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/EnableUserRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/EnableUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/EnableUserRequestModel"
               }
             }
           }
@@ -14182,29 +12556,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/InviteUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/InviteUserRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/InviteUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/InviteUserRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/InviteUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/InviteUserRequestModel"
               }
             }
           }
@@ -14241,29 +12603,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateInitialPasswordUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateInitialPasswordUserRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateInitialPasswordUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateInitialPasswordUserRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateInitialPasswordUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateInitialPasswordUserRequestModel"
               }
             }
           }
@@ -14288,38 +12638,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/VerifyInviteUserRequestModel"
-                  },
-                  {
-                    "$ref": "#/components/schemas/CreateInitialPasswordUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/VerifyInviteUserRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/VerifyInviteUserRequestModel"
-                  },
-                  {
-                    "$ref": "#/components/schemas/CreateInitialPasswordUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/VerifyInviteUserRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/VerifyInviteUserRequestModel"
-                  },
-                  {
-                    "$ref": "#/components/schemas/CreateInitialPasswordUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/VerifyInviteUserRequestModel"
               }
             }
           }
@@ -14362,11 +12691,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/UserItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/UserItemResponseModel"
                   }
                 }
               },
@@ -14374,11 +12699,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/UserItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/UserItemResponseModel"
                   }
                 }
               },
@@ -14386,11 +12707,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/UserItemResponseModel"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/UserItemResponseModel"
                   }
                 }
               }
@@ -14414,29 +12731,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateUserGroupsOnUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateUserGroupsOnUserRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateUserGroupsOnUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateUserGroupsOnUserRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateUserGroupsOnUserRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UpdateUserGroupsOnUserRequestModel"
               }
             }
           }
@@ -14463,29 +12768,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UnlockUsersRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UnlockUsersRequestModel"
               }
             },
             "text/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UnlockUsersRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UnlockUsersRequestModel"
               }
             },
             "application/*+json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/UnlockUsersRequestModel"
-                  }
-                ]
+                "$ref": "#/components/schemas/UnlockUsersRequestModel"
               }
             }
           }
@@ -14525,7 +12818,7 @@
   },
   "components": {
     "schemas": {
-      "AuditLogBaseModel": {
+      "AuditLogResponseModel": {
         "type": "object",
         "properties": {
           "userId": {
@@ -14559,23 +12852,37 @@
         },
         "additionalProperties": false
       },
-      "AuditLogResponseModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/AuditLogBaseModel"
-          }
-        ],
-        "additionalProperties": false
-      },
       "AuditLogWithUsernameResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/AuditLogBaseModel"
-          }
-        ],
         "properties": {
+          "userId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "entityId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "logType": {
+            "$ref": "#/components/schemas/AuditTypeModel"
+          },
+          "entityType": {
+            "type": "string",
+            "nullable": true
+          },
+          "comment": {
+            "type": "string",
+            "nullable": true
+          },
+          "parameters": {
+            "type": "string",
+            "nullable": true
+          },
           "userName": {
             "type": "string",
             "nullable": true
@@ -14645,40 +12952,6 @@
         },
         "additionalProperties": false
       },
-      "ContentResponseModelBaseDocumentValueModelDocumentVariantResponseModel": {
-        "type": "object",
-        "properties": {
-          "values": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/DocumentValueModel"
-                }
-              ]
-            }
-          },
-          "variants": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/DocumentVariantResponseModel"
-                }
-              ]
-            }
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "contentTypeId": {
-            "type": "string",
-            "format": "uuid"
-          }
-        },
-        "additionalProperties": false
-      },
       "ContentStateModel": {
         "enum": [
           "NotCreated",
@@ -14688,27 +12961,6 @@
         ],
         "type": "integer",
         "format": "int32"
-      },
-      "ContentTreeItemResponseModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/EntityTreeItemResponseModel"
-          }
-        ],
-        "properties": {
-          "noAccess": {
-            "type": "boolean"
-          },
-          "isTrashed": {
-            "type": "boolean"
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          }
-        },
-        "additionalProperties": false
       },
       "ContentTypeCleanupModel": {
         "type": "object",
@@ -14749,156 +13001,6 @@
         ],
         "type": "integer",
         "format": "int32"
-      },
-      "ContentTypeResponseModelBaseDocumentTypePropertyTypeResponseModelDocumentTypePropertyTypeContainerResponseModel": {
-        "type": "object",
-        "properties": {
-          "alias": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string",
-            "nullable": true
-          },
-          "icon": {
-            "type": "string"
-          },
-          "allowedAsRoot": {
-            "type": "boolean"
-          },
-          "variesByCulture": {
-            "type": "boolean"
-          },
-          "variesBySegment": {
-            "type": "boolean"
-          },
-          "isElement": {
-            "type": "boolean"
-          },
-          "properties": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/DocumentTypePropertyTypeResponseModel"
-                }
-              ]
-            }
-          },
-          "containers": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/DocumentTypePropertyTypeContainerResponseModel"
-                }
-              ]
-            }
-          },
-          "allowedContentTypes": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/ContentTypeSortModel"
-                }
-              ]
-            }
-          },
-          "compositions": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/ContentTypeCompositionModel"
-                }
-              ]
-            }
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          }
-        },
-        "additionalProperties": false
-      },
-      "ContentTypeResponseModelBaseMediaTypePropertyTypeResponseModelMediaTypePropertyTypeContainerResponseModel": {
-        "type": "object",
-        "properties": {
-          "alias": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string",
-            "nullable": true
-          },
-          "icon": {
-            "type": "string"
-          },
-          "allowedAsRoot": {
-            "type": "boolean"
-          },
-          "variesByCulture": {
-            "type": "boolean"
-          },
-          "variesBySegment": {
-            "type": "boolean"
-          },
-          "isElement": {
-            "type": "boolean"
-          },
-          "properties": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/MediaTypePropertyTypeResponseModel"
-                }
-              ]
-            }
-          },
-          "containers": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/MediaTypePropertyTypeContainerResponseModel"
-                }
-              ]
-            }
-          },
-          "allowedContentTypes": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/ContentTypeSortModel"
-                }
-              ]
-            }
-          },
-          "compositions": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/ContentTypeCompositionModel"
-                }
-              ]
-            }
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          }
-        },
-        "additionalProperties": false
       },
       "ContentTypeSortModel": {
         "type": "object",
@@ -14955,27 +13057,48 @@
         },
         "additionalProperties": false
       },
-      "CreateContentRequestModelBaseDocumentValueModelDocumentVariantRequestModel": {
+      "CreateDataTypeRequestModel": {
         "type": "object",
         "properties": {
+          "name": {
+            "type": "string"
+          },
+          "propertyEditorAlias": {
+            "type": "string"
+          },
+          "propertyEditorUiAlias": {
+            "type": "string",
+            "nullable": true
+          },
           "values": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/DocumentValueModel"
-                }
-              ]
+              "$ref": "#/components/schemas/DataTypePropertyPresentationModel"
             }
           },
-          "variants": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "parentId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateDictionaryItemRequestModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "translations": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/DocumentVariantRequestModel"
-                }
-              ]
+              "$ref": "#/components/schemas/DictionaryItemTranslationModel"
             }
           },
           "parentId": {
@@ -14986,30 +13109,31 @@
         },
         "additionalProperties": false
       },
-      "CreateContentRequestModelBaseMediaValueModelMediaVariantRequestModel": {
+      "CreateDocumentRequestModel": {
         "type": "object",
         "properties": {
           "values": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/MediaValueModel"
-                }
-              ]
+              "$ref": "#/components/schemas/DocumentValueModel"
             }
           },
           "variants": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/MediaVariantRequestModel"
-                }
-              ]
+              "$ref": "#/components/schemas/DocumentVariantRequestModel"
             }
           },
           "parentId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "contentTypeId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "templateId": {
             "type": "string",
             "format": "uuid",
             "nullable": true
@@ -15017,7 +13141,78 @@
         },
         "additionalProperties": false
       },
-      "CreateContentTypeRequestModelBaseCreateDocumentTypePropertyTypeRequestModelCreateDocumentTypePropertyTypeContainerRequestModel": {
+      "CreateDocumentTypePropertyTypeContainerRequestModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "parentId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string"
+          },
+          "sortOrder": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateDocumentTypePropertyTypeRequestModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "containerId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "sortOrder": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "dataTypeId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "variesByCulture": {
+            "type": "boolean"
+          },
+          "variesBySegment": {
+            "type": "boolean"
+          },
+          "validation": {
+            "$ref": "#/components/schemas/PropertyTypeValidationModel"
+          },
+          "appearance": {
+            "$ref": "#/components/schemas/PropertyTypeAppearanceModel"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateDocumentTypeRequestModel": {
         "type": "object",
         "properties": {
           "alias": {
@@ -15048,129 +13243,27 @@
           "properties": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/CreateDocumentTypePropertyTypeRequestModel"
-                }
-              ]
+              "$ref": "#/components/schemas/CreateDocumentTypePropertyTypeRequestModel"
             }
           },
           "containers": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/CreateDocumentTypePropertyTypeContainerRequestModel"
-                }
-              ]
+              "$ref": "#/components/schemas/CreateDocumentTypePropertyTypeContainerRequestModel"
             }
           },
           "allowedContentTypes": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/ContentTypeSortModel"
-                }
-              ]
+              "$ref": "#/components/schemas/ContentTypeSortModel"
             }
           },
           "compositions": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/ContentTypeCompositionModel"
-                }
-              ]
+              "$ref": "#/components/schemas/ContentTypeCompositionModel"
             }
-          }
-        },
-        "additionalProperties": false
-      },
-      "CreateDataTypeRequestModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/DataTypeModelBaseModel"
-          }
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
           },
-          "parentId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "CreateDictionaryItemRequestModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/DictionaryItemModelBaseModel"
-          }
-        ],
-        "properties": {
-          "parentId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "CreateDocumentRequestModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CreateContentRequestModelBaseDocumentValueModelDocumentVariantRequestModel"
-          }
-        ],
-        "properties": {
-          "contentTypeId": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "templateId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "CreateDocumentTypePropertyTypeContainerRequestModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/PropertyTypeContainerModelBaseModel"
-          }
-        ],
-        "additionalProperties": false
-      },
-      "CreateDocumentTypePropertyTypeRequestModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/PropertyTypeModelBaseModel"
-          }
-        ],
-        "additionalProperties": false
-      },
-      "CreateDocumentTypeRequestModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CreateContentTypeRequestModelBaseCreateDocumentTypePropertyTypeRequestModelCreateDocumentTypePropertyTypeContainerRequestModel"
-          }
-        ],
-        "properties": {
           "allowedTemplateIds": {
             "type": "array",
             "items": {
@@ -15184,23 +13277,17 @@
             "nullable": true
           },
           "cleanup": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/ContentTypeCleanupModel"
-              }
-            ]
+            "$ref": "#/components/schemas/ContentTypeCleanupModel"
           }
         },
         "additionalProperties": false
       },
       "CreateFolderRequestModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/FolderModelBaseModel"
-          }
-        ],
         "properties": {
+          "name": {
+            "type": "string"
+          },
           "id": {
             "type": "string",
             "format": "uuid",
@@ -15216,12 +13303,14 @@
       },
       "CreateInitialPasswordUserRequestModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/VerifyInviteUserRequestModel"
-          }
-        ],
         "properties": {
+          "userId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "token": {
+            "type": "string"
+          },
           "password": {
             "type": "string"
           }
@@ -15230,12 +13319,20 @@
       },
       "CreateLanguageRequestModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/LanguageModelBaseModel"
-          }
-        ],
         "properties": {
+          "name": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          },
+          "isMandatory": {
+            "type": "boolean"
+          },
+          "fallbackIsoCode": {
+            "type": "string",
+            "nullable": true
+          },
           "isoCode": {
             "type": "string"
           }
@@ -15244,12 +13341,24 @@
       },
       "CreateMediaRequestModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CreateContentRequestModelBaseMediaValueModelMediaVariantRequestModel"
-          }
-        ],
         "properties": {
+          "values": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MediaValueModel"
+            }
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MediaVariantRequestModel"
+            }
+          },
+          "parentId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
           "contentTypeId": {
             "type": "string",
             "format": "uuid"
@@ -15259,30 +13368,106 @@
       },
       "CreatePackageRequestModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/PackageModelBaseModel"
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "contentNodeId": {
+            "type": "string",
+            "nullable": true
+          },
+          "contentLoadChildNodes": {
+            "type": "boolean"
+          },
+          "mediaIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "mediaLoadChildNodes": {
+            "type": "boolean"
+          },
+          "documentTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "mediaTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "dataTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "templates": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "partialViews": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "stylesheets": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "scripts": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "dictionaryItems": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
-        ],
+        },
         "additionalProperties": false
       },
       "CreatePartialViewRequestModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CreateTextFileViewModelBaseModel"
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "parentPath": {
+            "type": "string",
+            "nullable": true
           }
-        ],
+        },
         "additionalProperties": false
       },
       "CreatePathFolderRequestModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/PathFolderModelBaseModel"
-          }
-        ],
         "properties": {
+          "name": {
+            "type": "string"
+          },
           "parentPath": {
             "type": "string",
             "nullable": true
@@ -15292,12 +13477,26 @@
       },
       "CreateRelationTypeRequestModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/RelationTypeBaseModel"
-          }
-        ],
         "properties": {
+          "name": {
+            "type": "string"
+          },
+          "isBidirectional": {
+            "type": "boolean"
+          },
+          "parentObjectType": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "childObjectType": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "isDependency": {
+            "type": "boolean"
+          },
           "id": {
             "type": "string",
             "format": "uuid",
@@ -15308,40 +13507,46 @@
       },
       "CreateScriptRequestModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CreateTextFileViewModelBaseModel"
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "parentPath": {
+            "type": "string",
+            "nullable": true
           }
-        ],
+        },
         "additionalProperties": false
       },
       "CreateStylesheetRequestModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CreateTextFileViewModelBaseModel"
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "parentPath": {
+            "type": "string",
+            "nullable": true
           }
-        ],
+        },
         "additionalProperties": false
       },
       "CreateTemplateRequestModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TemplateModelBaseModel"
-          }
-        ],
-        "additionalProperties": false
-      },
-      "CreateTextFileViewModelBaseModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TextFileViewModelBaseModel"
-          }
-        ],
         "properties": {
-          "parentPath": {
+          "name": {
+            "type": "string"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "content": {
             "type": "string",
             "nullable": true
           }
@@ -15350,20 +13555,70 @@
       },
       "CreateUserGroupRequestModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/UserGroupBaseModel"
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string",
+            "nullable": true
+          },
+          "sections": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "hasAccessToAllLanguages": {
+            "type": "boolean"
+          },
+          "documentStartNodeId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "mediaStartNodeId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "permissions": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
-        ],
+        },
         "additionalProperties": false
       },
       "CreateUserRequestModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/UserPresentationBaseModel"
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "userName": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "userGroupIds": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
-        ],
+        },
         "additionalProperties": false
       },
       "CreateUserResponseModel": {
@@ -15455,41 +13710,17 @@
       },
       "DataTypeItemResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
-          }
-        ],
-        "properties": {
-          "icon": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "DataTypeModelBaseModel": {
-        "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
-          "propertyEditorAlias": {
-            "type": "string"
+          "id": {
+            "type": "string",
+            "format": "uuid"
           },
-          "propertyEditorUiAlias": {
+          "icon": {
             "type": "string",
             "nullable": true
-          },
-          "values": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/DataTypePropertyPresentationModel"
-                }
-              ]
-            }
           }
         },
         "additionalProperties": false
@@ -15531,11 +13762,7 @@
           "properties": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/DataTypePropertyReferenceModel"
-                }
-              ]
+              "$ref": "#/components/schemas/DataTypePropertyReferenceModel"
             }
           }
         },
@@ -15543,12 +13770,23 @@
       },
       "DataTypeResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/DataTypeModelBaseModel"
-          }
-        ],
         "properties": {
+          "name": {
+            "type": "string"
+          },
+          "propertyEditorAlias": {
+            "type": "string"
+          },
+          "propertyEditorUiAlias": {
+            "type": "string",
+            "nullable": true
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataTypePropertyPresentationModel"
+            }
+          },
           "id": {
             "type": "string",
             "format": "uuid"
@@ -15563,12 +13801,31 @@
       },
       "DataTypeTreeItemResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/FolderTreeItemResponseModel"
-          }
-        ],
         "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "hasChildren": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "isContainer": {
+            "type": "boolean"
+          },
+          "parentId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "isFolder": {
+            "type": "boolean"
+          },
           "icon": {
             "type": "string",
             "nullable": true
@@ -15663,14 +13920,18 @@
       },
       "DictionaryItemItemResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
           }
-        ],
+        },
         "additionalProperties": false
       },
-      "DictionaryItemModelBaseModel": {
+      "DictionaryItemResponseModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -15679,24 +13940,9 @@
           "translations": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/DictionaryItemTranslationModel"
-                }
-              ]
+              "$ref": "#/components/schemas/DictionaryItemTranslationModel"
             }
-          }
-        },
-        "additionalProperties": false
-      },
-      "DictionaryItemResponseModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/DictionaryItemModelBaseModel"
-          }
-        ],
-        "properties": {
+          },
           "id": {
             "type": "string",
             "format": "uuid"
@@ -15765,21 +14011,41 @@
       },
       "DocumentBlueprintResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
           }
-        ],
+        },
         "additionalProperties": false
       },
       "DocumentBlueprintTreeItemResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/EntityTreeItemResponseModel"
-          }
-        ],
         "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "hasChildren": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "isContainer": {
+            "type": "boolean"
+          },
+          "parentId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
           "documentTypeId": {
             "type": "string",
             "format": "uuid"
@@ -15796,12 +14062,14 @@
       },
       "DocumentItemResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
-          }
-        ],
         "properties": {
+          "name": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
           "icon": {
             "type": "string",
             "nullable": true
@@ -15827,20 +14095,31 @@
       },
       "DocumentResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ContentResponseModelBaseDocumentValueModelDocumentVariantResponseModel"
-          }
-        ],
         "properties": {
+          "values": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DocumentValueModel"
+            }
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DocumentVariantResponseModel"
+            }
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "contentTypeId": {
+            "type": "string",
+            "format": "uuid"
+          },
           "urls": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/ContentUrlInfoModel"
-                }
-              ]
+              "$ref": "#/components/schemas/ContentUrlInfoModel"
             }
           },
           "templateId": {
@@ -15853,12 +14132,34 @@
       },
       "DocumentTreeItemResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ContentTreeItemResponseModel"
-          }
-        ],
         "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "hasChildren": {
+            "type": "boolean"
+          },
+          "isContainer": {
+            "type": "boolean"
+          },
+          "parentId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "noAccess": {
+            "type": "boolean"
+          },
+          "isTrashed": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
           "isProtected": {
             "type": "boolean"
           },
@@ -15875,11 +14176,7 @@
           "variants": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/VariantTreeItemModel"
-                }
-              ]
+              "$ref": "#/components/schemas/VariantTreeItemModel"
             }
           },
           "icon": {
@@ -15890,12 +14187,14 @@
       },
       "DocumentTypeItemResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
-          }
-        ],
         "properties": {
+          "name": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
           "isElement": {
             "type": "boolean"
           },
@@ -15908,30 +14207,131 @@
       },
       "DocumentTypePropertyTypeContainerResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/PropertyTypeContainerModelBaseModel"
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "parentId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string"
+          },
+          "sortOrder": {
+            "type": "integer",
+            "format": "int32"
           }
-        ],
+        },
         "additionalProperties": false
       },
       "DocumentTypePropertyTypeResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/PropertyTypeModelBaseModel"
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "containerId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "sortOrder": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "dataTypeId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "variesByCulture": {
+            "type": "boolean"
+          },
+          "variesBySegment": {
+            "type": "boolean"
+          },
+          "validation": {
+            "$ref": "#/components/schemas/PropertyTypeValidationModel"
+          },
+          "appearance": {
+            "$ref": "#/components/schemas/PropertyTypeAppearanceModel"
           }
-        ],
+        },
         "additionalProperties": false
       },
       "DocumentTypeResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ContentTypeResponseModelBaseDocumentTypePropertyTypeResponseModelDocumentTypePropertyTypeContainerResponseModel"
-          }
-        ],
         "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "icon": {
+            "type": "string"
+          },
+          "allowedAsRoot": {
+            "type": "boolean"
+          },
+          "variesByCulture": {
+            "type": "boolean"
+          },
+          "variesBySegment": {
+            "type": "boolean"
+          },
+          "isElement": {
+            "type": "boolean"
+          },
+          "properties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DocumentTypePropertyTypeResponseModel"
+            }
+          },
+          "containers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DocumentTypePropertyTypeContainerResponseModel"
+            }
+          },
+          "allowedContentTypes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContentTypeSortModel"
+            }
+          },
+          "compositions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContentTypeCompositionModel"
+            }
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
           "allowedTemplateIds": {
             "type": "array",
             "items": {
@@ -15945,23 +14345,38 @@
             "nullable": true
           },
           "cleanup": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/ContentTypeCleanupModel"
-              }
-            ]
+            "$ref": "#/components/schemas/ContentTypeCleanupModel"
           }
         },
         "additionalProperties": false
       },
       "DocumentTypeTreeItemResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/FolderTreeItemResponseModel"
-          }
-        ],
         "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "hasChildren": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "isContainer": {
+            "type": "boolean"
+          },
+          "parentId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "isFolder": {
+            "type": "boolean"
+          },
           "isElement": {
             "type": "boolean"
           },
@@ -15973,30 +14388,63 @@
       },
       "DocumentValueModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ValueModelBaseModel"
+        "properties": {
+          "culture": {
+            "type": "string",
+            "nullable": true
+          },
+          "segment": {
+            "type": "string",
+            "nullable": true
+          },
+          "alias": {
+            "type": "string"
+          },
+          "value": {
+            "nullable": true
           }
-        ],
+        },
         "additionalProperties": false
       },
       "DocumentVariantRequestModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/VariantModelBaseModel"
+        "properties": {
+          "culture": {
+            "type": "string",
+            "nullable": true
+          },
+          "segment": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string"
           }
-        ],
+        },
         "additionalProperties": false
       },
       "DocumentVariantResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/VariantResponseModelBaseModel"
-          }
-        ],
         "properties": {
+          "culture": {
+            "type": "string",
+            "nullable": true
+          },
+          "segment": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string"
+          },
+          "createDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updateDate": {
+            "type": "string",
+            "format": "date-time"
+          },
           "state": {
             "$ref": "#/components/schemas/ContentStateModel"
           },
@@ -16020,35 +14468,6 @@
         },
         "additionalProperties": false
       },
-      "DomainsPresentationModelBaseModel": {
-        "type": "object",
-        "properties": {
-          "defaultIsoCode": {
-            "type": "string",
-            "nullable": true
-          },
-          "domains": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/DomainPresentationModel"
-                }
-              ]
-            }
-          }
-        },
-        "additionalProperties": false
-      },
-      "DomainsResponseModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/DomainsPresentationModelBaseModel"
-          }
-        ],
-        "additionalProperties": false
-      },
       "EnableUserRequestModel": {
         "type": "object",
         "properties": {
@@ -16065,12 +14484,16 @@
       },
       "EntityTreeItemResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TreeItemPresentationModel"
-          }
-        ],
         "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "hasChildren": {
+            "type": "boolean"
+          },
           "id": {
             "type": "string",
             "format": "uuid"
@@ -16097,11 +14520,14 @@
       },
       "ExtractRichTextStylesheetRulesResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/RichTextStylesheetRulesResponseModel"
+        "properties": {
+          "rules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextRuleModel"
+            }
           }
-        ],
+        },
         "additionalProperties": false
       },
       "FieldPresentationModel": {
@@ -16119,29 +14545,18 @@
         },
         "additionalProperties": false
       },
-      "FileItemResponseModelBaseModel": {
+      "FileSystemTreeItemPresentationModel": {
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
-          "path": {
+          "type": {
             "type": "string"
           },
-          "icon": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "FileSystemTreeItemPresentationModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TreeItemPresentationModel"
-          }
-        ],
-        "properties": {
+          "hasChildren": {
+            "type": "boolean"
+          },
           "path": {
             "type": "string"
           },
@@ -16151,23 +14566,12 @@
         },
         "additionalProperties": false
       },
-      "FolderModelBaseModel": {
+      "FolderReponseModel": {
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "FolderReponseModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/FolderModelBaseModel"
-          }
-        ],
-        "properties": {
+          },
           "id": {
             "type": "string",
             "format": "uuid"
@@ -16176,20 +14580,6 @@
             "type": "string",
             "format": "uuid",
             "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "FolderTreeItemResponseModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/EntityTreeItemResponseModel"
-          }
-        ],
-        "properties": {
-          "isFolder": {
-            "type": "boolean"
           }
         },
         "additionalProperties": false
@@ -16231,31 +14621,16 @@
         },
         "additionalProperties": false
       },
-      "HealthCheckGroupPresentationBaseModel": {
+      "HealthCheckGroupPresentationModel": {
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "HealthCheckGroupPresentationModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/HealthCheckGroupPresentationBaseModel"
-          }
-        ],
-        "properties": {
+          },
           "checks": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/HealthCheckModel"
-                }
-              ]
+              "$ref": "#/components/schemas/HealthCheckModel"
             }
           }
         },
@@ -16263,11 +14638,11 @@
       },
       "HealthCheckGroupResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/HealthCheckGroupPresentationBaseModel"
+        "properties": {
+          "name": {
+            "type": "string"
           }
-        ],
+        },
         "additionalProperties": false
       },
       "HealthCheckGroupWithResultResponseModel": {
@@ -16276,11 +14651,7 @@
           "checks": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/HealthCheckWithResultPresentationModel"
-                }
-              ]
+              "$ref": "#/components/schemas/HealthCheckWithResultPresentationModel"
             }
           }
         },
@@ -16288,28 +14659,17 @@
       },
       "HealthCheckModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/HealthCheckModelBaseModel"
-          }
-        ],
         "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
           "name": {
             "type": "string"
           },
           "description": {
             "type": "string",
             "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "HealthCheckModelBaseModel": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
           }
         },
         "additionalProperties": false
@@ -16326,11 +14686,7 @@
           "actions": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/HealthCheckActionRequestModel"
-                }
-              ]
+              "$ref": "#/components/schemas/HealthCheckActionRequestModel"
             },
             "nullable": true
           },
@@ -16343,20 +14699,15 @@
       },
       "HealthCheckWithResultPresentationModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/HealthCheckModelBaseModel"
-          }
-        ],
         "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
           "results": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/HealthCheckResultResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/HealthCheckResultResponseModel"
             },
             "nullable": true
           }
@@ -16451,20 +14802,12 @@
         "type": "object",
         "properties": {
           "user": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/UserSettingsModel"
-              }
-            ]
+            "$ref": "#/components/schemas/UserSettingsModel"
           },
           "databases": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/DatabaseSettingsPresentationModel"
-                }
-              ]
+              "$ref": "#/components/schemas/DatabaseSettingsPresentationModel"
             }
           }
         },
@@ -16478,18 +14821,10 @@
         "type": "object",
         "properties": {
           "user": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/UserInstallResponseModel"
-              }
-            ]
+            "$ref": "#/components/schemas/UserInstallResponseModel"
           },
           "database": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/DatabaseInstallResponseModel"
-              }
-            ]
+            "$ref": "#/components/schemas/DatabaseInstallResponseModel"
           },
           "telemetryLevel": {
             "$ref": "#/components/schemas/TelemetryLevelModel"
@@ -16507,11 +14842,7 @@
           "rules": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/RichTextRuleModel"
-                }
-              ]
+              "$ref": "#/components/schemas/RichTextRuleModel"
             },
             "nullable": true
           }
@@ -16529,28 +14860,27 @@
       },
       "InviteUserRequestModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CreateUserRequestModel"
-          }
-        ],
         "properties": {
-          "message": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "ItemResponseModelBaseModel": {
-        "type": "object",
-        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "userName": {
+            "type": "string"
+          },
           "name": {
             "type": "string"
           },
-          "id": {
+          "userGroupIds": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "message": {
             "type": "string",
-            "format": "uuid"
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -16567,7 +14897,7 @@
         },
         "additionalProperties": false
       },
-      "LanguageModelBaseModel": {
+      "LanguageResponseModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -16582,18 +14912,7 @@
           "fallbackIsoCode": {
             "type": "string",
             "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "LanguageResponseModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/LanguageModelBaseModel"
-          }
-        ],
-        "properties": {
+          },
           "isoCode": {
             "type": "string"
           }
@@ -16618,11 +14937,7 @@
           "linkedLogins": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/LinkedLoginModel"
-                }
-              ]
+              "$ref": "#/components/schemas/LinkedLoginModel"
             }
           }
         },
@@ -16700,11 +15015,7 @@
           "properties": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/LogMessagePropertyPresentationModel"
-                }
-              ]
+              "$ref": "#/components/schemas/LogMessagePropertyPresentationModel"
             }
           },
           "exception": {
@@ -16754,12 +15065,14 @@
       },
       "MediaItemResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
-          }
-        ],
         "properties": {
+          "name": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
           "icon": {
             "type": "string",
             "nullable": true
@@ -16769,12 +15082,34 @@
       },
       "MediaTreeItemResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ContentTreeItemResponseModel"
-          }
-        ],
         "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "hasChildren": {
+            "type": "boolean"
+          },
+          "isContainer": {
+            "type": "boolean"
+          },
+          "parentId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "noAccess": {
+            "type": "boolean"
+          },
+          "isTrashed": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
           "icon": {
             "type": "string"
           }
@@ -16783,12 +15118,14 @@
       },
       "MediaTypeItemResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
-          }
-        ],
         "properties": {
+          "name": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
           "icon": {
             "type": "string",
             "nullable": true
@@ -16798,39 +15135,161 @@
       },
       "MediaTypePropertyTypeContainerResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/PropertyTypeContainerModelBaseModel"
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "parentId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string"
+          },
+          "sortOrder": {
+            "type": "integer",
+            "format": "int32"
           }
-        ],
+        },
         "additionalProperties": false
       },
       "MediaTypePropertyTypeResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/PropertyTypeModelBaseModel"
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "containerId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "sortOrder": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "dataTypeId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "variesByCulture": {
+            "type": "boolean"
+          },
+          "variesBySegment": {
+            "type": "boolean"
+          },
+          "validation": {
+            "$ref": "#/components/schemas/PropertyTypeValidationModel"
+          },
+          "appearance": {
+            "$ref": "#/components/schemas/PropertyTypeAppearanceModel"
           }
-        ],
+        },
         "additionalProperties": false
       },
       "MediaTypeResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ContentTypeResponseModelBaseMediaTypePropertyTypeResponseModelMediaTypePropertyTypeContainerResponseModel"
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "icon": {
+            "type": "string"
+          },
+          "allowedAsRoot": {
+            "type": "boolean"
+          },
+          "variesByCulture": {
+            "type": "boolean"
+          },
+          "variesBySegment": {
+            "type": "boolean"
+          },
+          "isElement": {
+            "type": "boolean"
+          },
+          "properties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MediaTypePropertyTypeResponseModel"
+            }
+          },
+          "containers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MediaTypePropertyTypeContainerResponseModel"
+            }
+          },
+          "allowedContentTypes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContentTypeSortModel"
+            }
+          },
+          "compositions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContentTypeCompositionModel"
+            }
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
           }
-        ],
+        },
         "additionalProperties": false
       },
       "MediaTypeTreeItemResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/FolderTreeItemResponseModel"
-          }
-        ],
         "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "hasChildren": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "isContainer": {
+            "type": "boolean"
+          },
+          "parentId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "isFolder": {
+            "type": "boolean"
+          },
           "icon": {
             "type": "string"
           }
@@ -16839,48 +15298,64 @@
       },
       "MediaValueModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ValueModelBaseModel"
+        "properties": {
+          "culture": {
+            "type": "string",
+            "nullable": true
+          },
+          "segment": {
+            "type": "string",
+            "nullable": true
+          },
+          "alias": {
+            "type": "string"
+          },
+          "value": {
+            "nullable": true
           }
-        ],
+        },
         "additionalProperties": false
       },
       "MediaVariantRequestModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/VariantModelBaseModel"
+        "properties": {
+          "culture": {
+            "type": "string",
+            "nullable": true
+          },
+          "segment": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string"
           }
-        ],
-        "additionalProperties": false
-      },
-      "MediaVariantResponseModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/VariantResponseModelBaseModel"
-          }
-        ],
+        },
         "additionalProperties": false
       },
       "MemberGroupItemResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
           }
-        ],
+        },
         "additionalProperties": false
       },
       "MemberItemResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
-          }
-        ],
         "properties": {
+          "name": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
           "icon": {
             "type": "string",
             "nullable": true
@@ -16890,12 +15365,14 @@
       },
       "MemberTypeItemResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
-          }
-        ],
         "properties": {
+          "name": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
           "icon": {
             "type": "string",
             "nullable": true
@@ -17045,53 +15522,6 @@
       },
       "PackageDefinitionResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/PackageModelBaseModel"
-          }
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "packagePath": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "PackageManifestResponseModel": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "version": {
-            "type": "string",
-            "nullable": true
-          },
-          "extensions": {
-            "type": "array",
-            "items": { }
-          }
-        },
-        "additionalProperties": false
-      },
-      "PackageMigrationStatusResponseModel": {
-        "type": "object",
-        "properties": {
-          "packageName": {
-            "type": "string"
-          },
-          "hasPendingMigrations": {
-            "type": "boolean"
-          }
-        },
-        "additionalProperties": false
-      },
-      "PackageModelBaseModel": {
-        "type": "object",
         "properties": {
           "name": {
             "type": "string"
@@ -17166,6 +15596,42 @@
             "items": {
               "type": "string"
             }
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "packagePath": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PackageManifestResponseModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string",
+            "nullable": true
+          },
+          "extensions": {
+            "type": "array",
+            "items": { }
+          }
+        },
+        "additionalProperties": false
+      },
+      "PackageMigrationStatusResponseModel": {
+        "type": "object",
+        "properties": {
+          "packageName": {
+            "type": "string"
+          },
+          "hasPendingMigrations": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false
@@ -17184,11 +15650,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/AuditLogResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/AuditLogResponseModel"
             }
           }
         },
@@ -17208,11 +15670,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/AuditLogWithUsernameResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/AuditLogWithUsernameResponseModel"
             }
           }
         },
@@ -17232,11 +15690,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/CultureReponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/CultureReponseModel"
             }
           }
         },
@@ -17256,11 +15710,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/DataTypeTreeItemResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/DataTypeTreeItemResponseModel"
             }
           }
         },
@@ -17280,11 +15730,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/DictionaryOverviewResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/DictionaryOverviewResponseModel"
             }
           }
         },
@@ -17304,11 +15750,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/DocumentBlueprintTreeItemResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/DocumentBlueprintTreeItemResponseModel"
             }
           }
         },
@@ -17328,11 +15770,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/DocumentTreeItemResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/DocumentTreeItemResponseModel"
             }
           }
         },
@@ -17352,11 +15790,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/DocumentTypeResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/DocumentTypeResponseModel"
             }
           }
         },
@@ -17376,11 +15810,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/DocumentTypeTreeItemResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/DocumentTypeTreeItemResponseModel"
             }
           }
         },
@@ -17400,35 +15830,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/EntityTreeItemResponseModel"
-                },
-                {
-                  "$ref": "#/components/schemas/ContentTreeItemResponseModel"
-                },
-                {
-                  "$ref": "#/components/schemas/DocumentBlueprintTreeItemResponseModel"
-                },
-                {
-                  "$ref": "#/components/schemas/DocumentTreeItemResponseModel"
-                },
-                {
-                  "$ref": "#/components/schemas/DocumentTypeTreeItemResponseModel"
-                },
-                {
-                  "$ref": "#/components/schemas/FolderTreeItemResponseModel"
-                },
-                {
-                  "$ref": "#/components/schemas/MediaTreeItemResponseModel"
-                },
-                {
-                  "$ref": "#/components/schemas/MediaTypeTreeItemResponseModel"
-                },
-                {
-                  "$ref": "#/components/schemas/DataTypeTreeItemResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/EntityTreeItemResponseModel"
             }
           }
         },
@@ -17448,11 +15850,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/FileSystemTreeItemPresentationModel"
-                }
-              ]
+              "$ref": "#/components/schemas/FileSystemTreeItemPresentationModel"
             }
           }
         },
@@ -17472,11 +15870,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/HealthCheckGroupResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/HealthCheckGroupResponseModel"
             }
           }
         },
@@ -17496,11 +15890,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/HelpPageResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/HelpPageResponseModel"
             }
           }
         },
@@ -17520,11 +15910,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/IndexResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/IndexResponseModel"
             }
           }
         },
@@ -17544,11 +15930,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/LanguageResponseModel"
             }
           }
         },
@@ -17568,11 +15950,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/LogMessageResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/LogMessageResponseModel"
             }
           }
         },
@@ -17592,11 +15970,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/LogTemplateResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/LogTemplateResponseModel"
             }
           }
         },
@@ -17616,11 +15990,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/LoggerResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/LoggerResponseModel"
             }
           }
         },
@@ -17640,11 +16010,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/MediaTreeItemResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/MediaTreeItemResponseModel"
             }
           }
         },
@@ -17664,11 +16030,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/MediaTypeTreeItemResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/MediaTypeTreeItemResponseModel"
             }
           }
         },
@@ -17688,11 +16050,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/ObjectTypeResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/ObjectTypeResponseModel"
             }
           }
         },
@@ -17712,11 +16070,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/PackageDefinitionResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/PackageDefinitionResponseModel"
             }
           }
         },
@@ -17736,11 +16090,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/PackageMigrationStatusResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/PackageMigrationStatusResponseModel"
             }
           }
         },
@@ -17760,11 +16110,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/RecycleBinItemResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/RecycleBinItemResponseModel"
             }
           }
         },
@@ -17784,11 +16130,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/RedirectUrlResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/RedirectUrlResponseModel"
             }
           }
         },
@@ -17808,11 +16150,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/RelationItemResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/RelationItemResponseModel"
             }
           }
         },
@@ -17832,11 +16170,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/RelationResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/RelationResponseModel"
             }
           }
         },
@@ -17856,11 +16190,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/SavedLogSearchResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/SavedLogSearchResponseModel"
             }
           }
         },
@@ -17880,11 +16210,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/SearchResultResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/SearchResultResponseModel"
             }
           }
         },
@@ -17904,11 +16230,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/SearcherResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/SearcherResponseModel"
             }
           }
         },
@@ -17928,11 +16250,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/SnippetItemResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/SnippetItemResponseModel"
             }
           }
         },
@@ -17952,11 +16270,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/StylesheetOverviewResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/StylesheetOverviewResponseModel"
             }
           }
         },
@@ -17976,11 +16290,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/TagResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/TagResponseModel"
             }
           }
         },
@@ -18000,11 +16310,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/TelemetryResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/TelemetryResponseModel"
             }
           }
         },
@@ -18024,11 +16330,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/UserGroupResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/UserGroupResponseModel"
             }
           }
         },
@@ -18048,11 +16350,7 @@
           "items": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/UserResponseModel"
-                }
-              ]
+              "$ref": "#/components/schemas/UserResponseModel"
             }
           }
         },
@@ -18060,20 +16358,32 @@
       },
       "PartialViewItemResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/FileItemResponseModelBaseModel"
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
           }
-        ],
+        },
         "additionalProperties": false
       },
       "PartialViewResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TextFileResponseModelBaseModel"
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
           }
-        ],
+        },
         "additionalProperties": false
       },
       "PartialViewSnippetResponseModel": {
@@ -18084,43 +16394,6 @@
           },
           "content": {
             "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "PartialViewUpdateModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TextFileUpdateModel"
-          }
-        ],
-        "additionalProperties": false
-      },
-      "PathFolderModelBaseModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/FolderModelBaseModel"
-          }
-        ],
-        "additionalProperties": false
-      },
-      "PathFolderResponseModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/FolderModelBaseModel"
-          }
-        ],
-        "properties": {
-          "parentPath": {
-            "type": "string",
-            "nullable": true
-          },
-          "path": {
-            "type": "string",
-            "readOnly": true
           }
         },
         "additionalProperties": false
@@ -18179,85 +16452,6 @@
         },
         "additionalProperties": false
       },
-      "PropertyTypeContainerModelBaseModel": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "parentId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "name": {
-            "type": "string",
-            "nullable": true
-          },
-          "type": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "integer",
-            "format": "int32"
-          }
-        },
-        "additionalProperties": false
-      },
-      "PropertyTypeModelBaseModel": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "containerId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "sortOrder": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "alias": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string",
-            "nullable": true
-          },
-          "dataTypeId": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "variesByCulture": {
-            "type": "boolean"
-          },
-          "variesBySegment": {
-            "type": "boolean"
-          },
-          "validation": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/PropertyTypeValidationModel"
-              }
-            ]
-          },
-          "appearance": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/PropertyTypeAppearanceModel"
-              }
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
       "PropertyTypeValidationModel": {
         "type": "object",
         "properties": {
@@ -18279,7 +16473,7 @@
         },
         "additionalProperties": false
       },
-      "PublicAccessBaseModel": {
+      "PublicAccessRequestModel": {
         "type": "object",
         "properties": {
           "loginPageId": {
@@ -18289,18 +16483,7 @@
           "errorPageId": {
             "type": "string",
             "format": "uuid"
-          }
-        },
-        "additionalProperties": false
-      },
-      "PublicAccessRequestModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/PublicAccessBaseModel"
-          }
-        ],
-        "properties": {
+          },
           "memberUserNames": {
             "type": "array",
             "items": {
@@ -18311,37 +16494,6 @@
             "type": "array",
             "items": {
               "type": "string"
-            }
-          }
-        },
-        "additionalProperties": false
-      },
-      "PublicAccessResponseModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/PublicAccessBaseModel"
-          }
-        ],
-        "properties": {
-          "members": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/MemberItemResponseModel"
-                }
-              ]
-            }
-          },
-          "groups": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/MemberGroupItemResponseModel"
-                }
-              ]
             }
           }
         },
@@ -18509,7 +16661,20 @@
         },
         "additionalProperties": false
       },
-      "RelationTypeBaseModel": {
+      "RelationTypeItemResponseModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "RelationTypeResponseModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -18530,27 +16695,7 @@
           },
           "isDependency": {
             "type": "boolean"
-          }
-        },
-        "additionalProperties": false
-      },
-      "RelationTypeItemResponseModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
-          }
-        ],
-        "additionalProperties": false
-      },
-      "RelationTypeResponseModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/RelationTypeBaseModel"
-          }
-        ],
-        "properties": {
+          },
           "id": {
             "type": "string",
             "format": "uuid"
@@ -18597,11 +16742,7 @@
           "rules": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/RichTextRuleModel"
-                }
-              ]
+              "$ref": "#/components/schemas/RichTextRuleModel"
             }
           }
         },
@@ -18619,7 +16760,7 @@
         "type": "integer",
         "format": "int32"
       },
-      "SavedLogSearchPresenationBaseModel": {
+      "SavedLogSearchRequestModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -18631,58 +16772,46 @@
         },
         "additionalProperties": false
       },
-      "SavedLogSearchRequestModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/SavedLogSearchPresenationBaseModel"
-          }
-        ],
-        "additionalProperties": false
-      },
       "SavedLogSearchResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/SavedLogSearchPresenationBaseModel"
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "query": {
+            "type": "string"
           }
-        ],
+        },
         "additionalProperties": false
       },
       "ScriptItemResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/FileItemResponseModelBaseModel"
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
           }
-        ],
+        },
         "additionalProperties": false
       },
       "ScriptResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TextFileResponseModelBaseModel"
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
           }
-        ],
-        "additionalProperties": false
-      },
-      "ScriptUpdateModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TextFileUpdateModel"
-          }
-        ],
-        "additionalProperties": false
-      },
-      "ScriptViewModelBaseModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TextFileViewModelBaseModel"
-          }
-        ],
+        },
         "additionalProperties": false
       },
       "SearchResultResponseModel": {
@@ -18703,11 +16832,7 @@
           "fields": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/FieldPresentationModel"
-                }
-              ]
+              "$ref": "#/components/schemas/FieldPresentationModel"
             }
           }
         },
@@ -18743,11 +16868,17 @@
       },
       "SetTourStatusRequestModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TourStatusModel"
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "completed": {
+            "type": "boolean"
+          },
+          "disabled": {
+            "type": "boolean"
           }
-        ],
+        },
         "additionalProperties": false
       },
       "SnippetItemResponseModel": {
@@ -18761,11 +16892,17 @@
       },
       "StaticFileItemResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/FileItemResponseModelBaseModel"
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
           }
-        ],
+        },
         "additionalProperties": false
       },
       "StatusResultTypeModel": {
@@ -18777,15 +16914,6 @@
         ],
         "type": "integer",
         "format": "int32"
-      },
-      "StylesheetItemResponseModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/FileItemResponseModelBaseModel"
-          }
-        ],
-        "additionalProperties": false
       },
       "StylesheetOverviewResponseModel": {
         "type": "object",
@@ -18801,20 +16929,17 @@
       },
       "StylesheetResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TextFileResponseModelBaseModel"
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
           }
-        ],
-        "additionalProperties": false
-      },
-      "StylesheetUpdateModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TextFileUpdateModel"
-          }
-        ],
+        },
         "additionalProperties": false
       },
       "TagResponseModel": {
@@ -18848,7 +16973,7 @@
         "type": "integer",
         "format": "int32"
       },
-      "TelemetryRepresentationBaseModel": {
+      "TelemetryRequestModel": {
         "type": "object",
         "properties": {
           "telemetryLevel": {
@@ -18857,50 +16982,27 @@
         },
         "additionalProperties": false
       },
-      "TelemetryRequestModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TelemetryRepresentationBaseModel"
-          }
-        ],
-        "additionalProperties": false
-      },
       "TelemetryResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TelemetryRepresentationBaseModel"
-          }
-        ],
-        "additionalProperties": false
-      },
-      "TemplateItemResponseModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
-          }
-        ],
         "properties": {
-          "alias": {
-            "type": "string"
+          "telemetryLevel": {
+            "$ref": "#/components/schemas/TelemetryLevelModel"
           }
         },
         "additionalProperties": false
       },
-      "TemplateModelBaseModel": {
+      "TemplateItemResponseModel": {
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
           "alias": {
             "type": "string"
-          },
-          "content": {
-            "type": "string",
-            "nullable": true
           }
         },
         "additionalProperties": false
@@ -18935,21 +17037,12 @@
           "filters": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/TemplateQueryExecuteFilterPresentationModel"
-                }
-              ]
+              "$ref": "#/components/schemas/TemplateQueryExecuteFilterPresentationModel"
             },
             "nullable": true
           },
           "sort": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/TemplateQueryExecuteSortModel"
-              }
-            ],
-            "nullable": true
+            "$ref": "#/components/schemas/TemplateQueryExecuteSortModel"
           },
           "take": {
             "type": "integer",
@@ -19028,11 +17121,7 @@
           "sampleResults": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/TemplateQueryResultItemPresentationModel"
-                }
-              ]
+              "$ref": "#/components/schemas/TemplateQueryResultItemPresentationModel"
             }
           },
           "resultCount": {
@@ -19058,21 +17147,13 @@
           "properties": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/TemplateQueryPropertyPresentationModel"
-                }
-              ]
+              "$ref": "#/components/schemas/TemplateQueryPropertyPresentationModel"
             }
           },
           "operators": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/TemplateQueryOperatorModel"
-                }
-              ]
+              "$ref": "#/components/schemas/TemplateQueryOperatorModel"
             }
           }
         },
@@ -19080,12 +17161,17 @@
       },
       "TemplateResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TemplateModelBaseModel"
-          }
-        ],
         "properties": {
+          "name": {
+            "type": "string"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string",
+            "nullable": true
+          },
           "id": {
             "type": "string",
             "format": "uuid"
@@ -19125,47 +17211,6 @@
         },
         "additionalProperties": false
       },
-      "TextFileResponseModelBaseModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TextFileViewModelBaseModel"
-          }
-        ],
-        "properties": {
-          "path": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "TextFileUpdateModel": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          },
-          "existingPath": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "TextFileViewModelBaseModel": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
       "TourStatusModel": {
         "type": "object",
         "properties": {
@@ -19176,21 +17221,6 @@
             "type": "boolean"
           },
           "disabled": {
-            "type": "boolean"
-          }
-        },
-        "additionalProperties": false
-      },
-      "TreeItemPresentationModel": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "hasChildren": {
             "type": "boolean"
           }
         },
@@ -19210,59 +17240,150 @@
         },
         "additionalProperties": false
       },
-      "UpdateContentRequestModelBaseDocumentValueModelDocumentVariantRequestModel": {
+      "UpdateDataTypeRequestModel": {
         "type": "object",
         "properties": {
+          "name": {
+            "type": "string"
+          },
+          "propertyEditorAlias": {
+            "type": "string"
+          },
+          "propertyEditorUiAlias": {
+            "type": "string",
+            "nullable": true
+          },
           "values": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/DocumentValueModel"
-                }
-              ]
-            }
-          },
-          "variants": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/DocumentVariantRequestModel"
-                }
-              ]
+              "$ref": "#/components/schemas/DataTypePropertyPresentationModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "UpdateContentRequestModelBaseMediaValueModelMediaVariantRequestModel": {
+      "UpdateDictionaryItemRequestModel": {
         "type": "object",
         "properties": {
-          "values": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/MediaValueModel"
-                }
-              ]
-            }
+          "name": {
+            "type": "string"
           },
-          "variants": {
+          "translations": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/MediaVariantRequestModel"
-                }
-              ]
+              "$ref": "#/components/schemas/DictionaryItemTranslationModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "UpdateContentTypeRequestModelBaseUpdateDocumentTypePropertyTypeRequestModelUpdateDocumentTypePropertyTypeContainerRequestModel": {
+      "UpdateDocumentNotificationsRequestModel": {
+        "type": "object",
+        "properties": {
+          "subscribedActionIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateDocumentRequestModel": {
+        "type": "object",
+        "properties": {
+          "values": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DocumentValueModel"
+            }
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DocumentVariantRequestModel"
+            }
+          },
+          "templateId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateDocumentTypePropertyTypeContainerRequestModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "parentId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string"
+          },
+          "sortOrder": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateDocumentTypePropertyTypeRequestModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "containerId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "sortOrder": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "dataTypeId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "variesByCulture": {
+            "type": "boolean"
+          },
+          "variesBySegment": {
+            "type": "boolean"
+          },
+          "validation": {
+            "$ref": "#/components/schemas/PropertyTypeValidationModel"
+          },
+          "appearance": {
+            "$ref": "#/components/schemas/PropertyTypeAppearanceModel"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateDocumentTypeRequestModel": {
         "type": "object",
         "properties": {
           "alias": {
@@ -19293,118 +17414,27 @@
           "properties": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/UpdateDocumentTypePropertyTypeRequestModel"
-                }
-              ]
+              "$ref": "#/components/schemas/UpdateDocumentTypePropertyTypeRequestModel"
             }
           },
           "containers": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/UpdateDocumentTypePropertyTypeContainerRequestModel"
-                }
-              ]
+              "$ref": "#/components/schemas/UpdateDocumentTypePropertyTypeContainerRequestModel"
             }
           },
           "allowedContentTypes": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/ContentTypeSortModel"
-                }
-              ]
+              "$ref": "#/components/schemas/ContentTypeSortModel"
             }
           },
           "compositions": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/ContentTypeCompositionModel"
-                }
-              ]
+              "$ref": "#/components/schemas/ContentTypeCompositionModel"
             }
-          }
-        },
-        "additionalProperties": false
-      },
-      "UpdateDataTypeRequestModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/DataTypeModelBaseModel"
-          }
-        ],
-        "additionalProperties": false
-      },
-      "UpdateDictionaryItemRequestModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/DictionaryItemModelBaseModel"
-          }
-        ],
-        "additionalProperties": false
-      },
-      "UpdateDocumentNotificationsRequestModel": {
-        "type": "object",
-        "properties": {
-          "subscribedActionIds": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "additionalProperties": false
-      },
-      "UpdateDocumentRequestModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/UpdateContentRequestModelBaseDocumentValueModelDocumentVariantRequestModel"
-          }
-        ],
-        "properties": {
-          "templateId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "UpdateDocumentTypePropertyTypeContainerRequestModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/PropertyTypeContainerModelBaseModel"
-          }
-        ],
-        "additionalProperties": false
-      },
-      "UpdateDocumentTypePropertyTypeRequestModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/PropertyTypeModelBaseModel"
-          }
-        ],
-        "additionalProperties": false
-      },
-      "UpdateDocumentTypeRequestModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/UpdateContentTypeRequestModelBaseUpdateDocumentTypePropertyTypeRequestModelUpdateDocumentTypePropertyTypeContainerRequestModel"
-          }
-        ],
-        "properties": {
+          },
           "allowedTemplateIds": {
             "type": "array",
             "items": {
@@ -19418,59 +17448,150 @@
             "nullable": true
           },
           "cleanup": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/ContentTypeCleanupModel"
-              }
-            ]
+            "$ref": "#/components/schemas/ContentTypeCleanupModel"
           }
         },
         "additionalProperties": false
       },
       "UpdateDomainsRequestModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/DomainsPresentationModelBaseModel"
+        "properties": {
+          "defaultIsoCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "domains": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DomainPresentationModel"
+            }
           }
-        ],
+        },
         "additionalProperties": false
       },
       "UpdateFolderReponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/FolderModelBaseModel"
+        "properties": {
+          "name": {
+            "type": "string"
           }
-        ],
+        },
         "additionalProperties": false
       },
       "UpdateLanguageRequestModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/LanguageModelBaseModel"
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          },
+          "isMandatory": {
+            "type": "boolean"
+          },
+          "fallbackIsoCode": {
+            "type": "string",
+            "nullable": true
           }
-        ],
+        },
         "additionalProperties": false
       },
       "UpdateMediaRequestModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/UpdateContentRequestModelBaseMediaValueModelMediaVariantRequestModel"
+        "properties": {
+          "values": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MediaValueModel"
+            }
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MediaVariantRequestModel"
+            }
           }
-        ],
+        },
         "additionalProperties": false
       },
       "UpdatePackageRequestModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/PackageModelBaseModel"
-          }
-        ],
         "properties": {
+          "name": {
+            "type": "string"
+          },
+          "contentNodeId": {
+            "type": "string",
+            "nullable": true
+          },
+          "contentLoadChildNodes": {
+            "type": "boolean"
+          },
+          "mediaIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "mediaLoadChildNodes": {
+            "type": "boolean"
+          },
+          "documentTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "mediaTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "dataTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "templates": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "partialViews": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "stylesheets": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "scripts": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "dictionaryItems": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "packagePath": {
             "type": "string"
           }
@@ -19479,70 +17600,133 @@
       },
       "UpdatePartialViewRequestModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TextFileUpdateModel"
-          }
-        ],
-        "additionalProperties": false
-      },
-      "UpdateRelationTypeRequestModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/RelationTypeBaseModel"
-          }
-        ],
-        "additionalProperties": false
-      },
-      "UpdateScriptRequestModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/UpdateTextFileViewModelBaseModel"
-          }
-        ],
-        "additionalProperties": false
-      },
-      "UpdateStylesheetRequestModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/UpdateTextFileViewModelBaseModel"
-          }
-        ],
-        "additionalProperties": false
-      },
-      "UpdateTemplateRequestModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TemplateModelBaseModel"
-          }
-        ],
-        "additionalProperties": false
-      },
-      "UpdateTextFileViewModelBaseModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TextFileViewModelBaseModel"
-          }
-        ],
         "properties": {
+          "name": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
           "existingPath": {
             "type": "string"
           }
         },
         "additionalProperties": false
       },
+      "UpdateRelationTypeRequestModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "isBidirectional": {
+            "type": "boolean"
+          },
+          "parentObjectType": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "childObjectType": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "isDependency": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateScriptRequestModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "existingPath": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateStylesheetRequestModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "existingPath": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateTemplateRequestModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "UpdateUserGroupRequestModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/UserGroupBaseModel"
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string",
+            "nullable": true
+          },
+          "sections": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "hasAccessToAllLanguages": {
+            "type": "boolean"
+          },
+          "documentStartNodeId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "mediaStartNodeId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "permissions": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
-        ],
+        },
         "additionalProperties": false
       },
       "UpdateUserGroupsOnUserRequestModel": {
@@ -19569,12 +17753,24 @@
       },
       "UpdateUserRequestModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/UserPresentationBaseModel"
-          }
-        ],
         "properties": {
+          "email": {
+            "type": "string"
+          },
+          "userName": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "userGroupIds": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
           "languageIsoCode": {
             "type": "string"
           },
@@ -19637,17 +17833,30 @@
           "userData": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/UserDataModel"
-                }
-              ]
+              "$ref": "#/components/schemas/UserDataModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "UserGroupBaseModel": {
+      "UserGroupItemResponseModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "icon": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UserGroupResponseModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -19688,33 +17897,7 @@
             "items": {
               "type": "string"
             }
-          }
-        },
-        "additionalProperties": false
-      },
-      "UserGroupItemResponseModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
-          }
-        ],
-        "properties": {
-          "icon": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "UserGroupResponseModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/UserGroupBaseModel"
-          }
-        ],
-        "properties": {
+          },
           "id": {
             "type": "string",
             "format": "uuid"
@@ -19753,11 +17936,15 @@
       },
       "UserItemResponseModel": {
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
           }
-        ],
+        },
         "additionalProperties": false
       },
       "UserOrderModel": {
@@ -19798,17 +17985,13 @@
           "permissions": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/UserPermissionModel"
-                }
-              ]
+              "$ref": "#/components/schemas/UserPermissionModel"
             }
           }
         },
         "additionalProperties": false
       },
-      "UserPresentationBaseModel": {
+      "UserResponseModel": {
         "type": "object",
         "properties": {
           "email": {
@@ -19827,18 +18010,7 @@
               "type": "string",
               "format": "uuid"
             }
-          }
-        },
-        "additionalProperties": false
-      },
-      "UserResponseModel": {
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/UserPresentationBaseModel"
-          }
-        ],
-        "properties": {
+          },
           "id": {
             "type": "string",
             "format": "uuid"
@@ -19916,11 +18088,7 @@
           "consentLevels": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/ConsentLevelPresentationModel"
-                }
-              ]
+              "$ref": "#/components/schemas/ConsentLevelPresentationModel"
             }
           }
         },
@@ -19944,77 +18112,8 @@
           "tourStatuses": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/TourStatusModel"
-                },
-                {
-                  "$ref": "#/components/schemas/SetTourStatusRequestModel"
-                }
-              ]
+              "$ref": "#/components/schemas/TourStatusModel"
             }
-          }
-        },
-        "additionalProperties": false
-      },
-      "ValueModelBaseModel": {
-        "type": "object",
-        "properties": {
-          "culture": {
-            "type": "string",
-            "nullable": true
-          },
-          "segment": {
-            "type": "string",
-            "nullable": true
-          },
-          "alias": {
-            "type": "string"
-          },
-          "value": {
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "VariantModelBaseModel": {
-        "type": "object",
-        "properties": {
-          "culture": {
-            "type": "string",
-            "nullable": true
-          },
-          "segment": {
-            "type": "string",
-            "nullable": true
-          },
-          "name": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "VariantResponseModelBaseModel": {
-        "type": "object",
-        "properties": {
-          "culture": {
-            "type": "string",
-            "nullable": true
-          },
-          "segment": {
-            "type": "string",
-            "nullable": true
-          },
-          "name": {
-            "type": "string"
-          },
-          "createDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updateDate": {
-            "type": "string",
-            "format": "date-time"
           }
         },
         "additionalProperties": false

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -291,17 +291,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateDataTypeRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateDataTypeRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateDataTypeRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateDataTypeRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateDataTypeRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateDataTypeRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -374,17 +386,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DataTypeResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DataTypeResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DataTypeResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DataTypeResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/DataTypeResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DataTypeResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -469,17 +493,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateDataTypeRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateDataTypeRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateDataTypeRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateDataTypeRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateDataTypeRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateDataTypeRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -540,17 +576,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CopyDataTypeRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CopyDataTypeRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/CopyDataTypeRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CopyDataTypeRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/CopyDataTypeRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CopyDataTypeRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -650,17 +698,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/MoveDataTypeRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/MoveDataTypeRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/MoveDataTypeRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/MoveDataTypeRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/MoveDataTypeRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/MoveDataTypeRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -705,7 +765,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DataTypeReferenceResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DataTypeReferenceResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -713,7 +777,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DataTypeReferenceResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DataTypeReferenceResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -721,7 +789,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DataTypeReferenceResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DataTypeReferenceResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -748,17 +820,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateFolderRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateFolderRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateFolderRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateFolderRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateFolderRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateFolderRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -808,17 +892,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/FolderReponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/FolderReponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/FolderReponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/FolderReponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/FolderReponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/FolderReponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -883,17 +979,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateFolderReponseModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateFolderReponseModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateFolderReponseModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateFolderReponseModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateFolderReponseModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateFolderReponseModel"
+                  }
+                ]
               }
             }
           }
@@ -941,7 +1049,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DataTypeItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DataTypeItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -949,7 +1061,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DataTypeItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DataTypeItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -957,7 +1073,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DataTypeItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DataTypeItemResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -993,17 +1113,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DataTypeItemResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DataTypeItemResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DataTypeItemResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DataTypeItemResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/DataTypeItemResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DataTypeItemResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -1213,17 +1345,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateDictionaryItemRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateDictionaryItemRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateDictionaryItemRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateDictionaryItemRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateDictionaryItemRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateDictionaryItemRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -1316,17 +1460,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DictionaryItemResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DictionaryItemResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DictionaryItemResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DictionaryItemResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/DictionaryItemResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DictionaryItemResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -1411,17 +1567,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateDictionaryItemRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateDictionaryItemRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateDictionaryItemRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateDictionaryItemRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateDictionaryItemRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateDictionaryItemRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -1542,17 +1710,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/MoveDictionaryRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/MoveDictionaryRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/MoveDictionaryRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/MoveDictionaryRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/MoveDictionaryRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/MoveDictionaryRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -1602,17 +1782,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ImportDictionaryRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ImportDictionaryRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/ImportDictionaryRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ImportDictionaryRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/ImportDictionaryRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ImportDictionaryRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -1690,7 +1882,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DictionaryItemItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DictionaryItemItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -1698,7 +1894,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DictionaryItemItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DictionaryItemItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -1706,7 +1906,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DictionaryItemItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DictionaryItemItemResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -1866,7 +2070,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DocumentBlueprintResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DocumentBlueprintResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -1874,7 +2082,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DocumentBlueprintResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DocumentBlueprintResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -1882,7 +2094,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DocumentBlueprintResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DocumentBlueprintResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -1961,17 +2177,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateDocumentTypeRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateDocumentTypeRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateDocumentTypeRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateDocumentTypeRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateDocumentTypeRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateDocumentTypeRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -2014,17 +2242,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DocumentTypeResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DocumentTypeResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DocumentTypeResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DocumentTypeResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/DocumentTypeResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DocumentTypeResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -2061,17 +2301,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DocumentTypeResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DocumentTypeResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DocumentTypeResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DocumentTypeResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/DocumentTypeResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DocumentTypeResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -2106,17 +2358,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateDocumentTypeRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateDocumentTypeRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateDocumentTypeRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateDocumentTypeRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateDocumentTypeRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateDocumentTypeRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -2167,7 +2431,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DocumentTypeItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DocumentTypeItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -2175,7 +2443,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DocumentTypeItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DocumentTypeItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -2183,7 +2455,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DocumentTypeItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DocumentTypeItemResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -2341,17 +2617,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateDocumentRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateDocumentRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateDocumentRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateDocumentRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateDocumentRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateDocumentRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -2407,17 +2695,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DocumentResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DocumentResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DocumentResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DocumentResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/DocumentResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DocumentResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -2485,17 +2785,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateDocumentRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateDocumentRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateDocumentRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateDocumentRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateDocumentRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateDocumentRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -2606,17 +2918,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CopyDocumentRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CopyDocumentRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/CopyDocumentRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CopyDocumentRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/CopyDocumentRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CopyDocumentRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -2697,17 +3021,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateDomainsRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateDomainsRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateDomainsRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateDomainsRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateDomainsRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateDomainsRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -2745,17 +3081,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/MoveDocumentRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/MoveDocumentRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/MoveDocumentRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/MoveDocumentRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/MoveDocumentRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/MoveDocumentRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -2803,7 +3151,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DocumentNotificationResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DocumentNotificationResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -2811,7 +3163,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DocumentNotificationResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DocumentNotificationResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -2819,7 +3175,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DocumentNotificationResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DocumentNotificationResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -2855,17 +3215,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateDocumentNotificationsRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateDocumentNotificationsRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateDocumentNotificationsRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateDocumentNotificationsRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateDocumentNotificationsRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateDocumentNotificationsRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -2906,17 +3278,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PublicAccessRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/PublicAccessRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/PublicAccessRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/PublicAccessRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/PublicAccessRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/PublicAccessRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -3025,17 +3409,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PublicAccessRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/PublicAccessRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/PublicAccessRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/PublicAccessRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/PublicAccessRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/PublicAccessRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -3101,7 +3497,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DocumentItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DocumentItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -3109,7 +3509,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DocumentItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DocumentItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -3117,7 +3521,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/DocumentItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DocumentItemResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -3541,17 +3949,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HealthCheckGroupPresentationModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/HealthCheckGroupPresentationModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HealthCheckGroupPresentationModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/HealthCheckGroupPresentationModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/HealthCheckGroupPresentationModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/HealthCheckGroupPresentationModel"
+                    }
+                  ]
                 }
               }
             }
@@ -3589,17 +4009,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HealthCheckGroupWithResultResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/HealthCheckGroupWithResultResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HealthCheckGroupWithResultResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/HealthCheckGroupWithResultResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/HealthCheckGroupWithResultResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/HealthCheckGroupWithResultResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -3622,17 +4054,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/HealthCheckActionRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/HealthCheckActionRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/HealthCheckActionRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/HealthCheckActionRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/HealthCheckActionRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/HealthCheckActionRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -3663,17 +4107,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HealthCheckResultResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/HealthCheckResultResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HealthCheckResultResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/HealthCheckResultResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/HealthCheckResultResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/HealthCheckResultResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -3880,17 +4336,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/IndexResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/IndexResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/IndexResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/IndexResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/IndexResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/IndexResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -4020,17 +4488,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/InstallSettingsResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/InstallSettingsResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/InstallSettingsResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/InstallSettingsResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/InstallSettingsResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/InstallSettingsResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -4048,17 +4528,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/InstallVResponseModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/InstallVResponseModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/InstallVResponseModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/InstallVResponseModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/InstallVResponseModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/InstallVResponseModel"
+                  }
+                ]
               }
             }
           }
@@ -4120,17 +4612,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/DatabaseInstallResponseModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/DatabaseInstallResponseModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/DatabaseInstallResponseModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/DatabaseInstallResponseModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/DatabaseInstallResponseModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/DatabaseInstallResponseModel"
+                  }
+                ]
               }
             }
           }
@@ -4225,17 +4729,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateLanguageRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateLanguageRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateLanguageRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateLanguageRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateLanguageRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateLanguageRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -4310,17 +4826,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/LanguageResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/LanguageResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/LanguageResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/LanguageResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/LanguageResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/LanguageResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -4417,17 +4945,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateLanguageRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateLanguageRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateLanguageRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateLanguageRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateLanguageRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateLanguageRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -4494,7 +5034,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/LanguageItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/LanguageItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -4502,7 +5046,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/LanguageItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/LanguageItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -4510,7 +5058,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/LanguageItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/LanguageItemResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -4629,17 +5181,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/LogLevelCountsReponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/LogLevelCountsReponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/LogLevelCountsReponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/LogLevelCountsReponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/LogLevelCountsReponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/LogLevelCountsReponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -4901,17 +5465,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SavedLogSearchRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SavedLogSearchRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/SavedLogSearchRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SavedLogSearchRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/SavedLogSearchRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SavedLogSearchRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -4983,17 +5559,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SavedLogSearchResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/SavedLogSearchResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SavedLogSearchResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/SavedLogSearchResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/SavedLogSearchResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/SavedLogSearchResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -5114,17 +5702,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/MediaTypeResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/MediaTypeResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/MediaTypeResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/MediaTypeResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/MediaTypeResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/MediaTypeResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -5168,7 +5768,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/MediaTypeItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MediaTypeItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -5176,7 +5780,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/MediaTypeItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MediaTypeItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -5184,7 +5792,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/MediaTypeItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MediaTypeItemResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -5342,17 +5954,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateMediaRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateMediaRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateMediaRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateMediaRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateMediaRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateMediaRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -5408,17 +6032,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DocumentResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DocumentResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DocumentResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DocumentResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/DocumentResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DocumentResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -5486,17 +6122,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateMediaRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateMediaRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateMediaRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateMediaRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateMediaRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateMediaRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -5540,17 +6188,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/MoveMediaRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/MoveMediaRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/MoveMediaRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/MoveMediaRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/MoveMediaRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/MoveMediaRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -5609,7 +6269,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/MediaItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MediaItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -5617,7 +6281,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/MediaItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MediaItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -5625,7 +6293,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/MediaItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MediaItemResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -5869,7 +6541,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/MediaTreeItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MediaTreeItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -5877,7 +6553,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/MediaTreeItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MediaTreeItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -5885,7 +6565,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/MediaTreeItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MediaTreeItemResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -5990,7 +6674,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/MemberGroupItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MemberGroupItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -5998,7 +6686,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/MemberGroupItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MemberGroupItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -6006,7 +6698,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/MemberGroupItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MemberGroupItemResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -6103,7 +6799,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/MemberTypeItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MemberTypeItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -6111,7 +6811,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/MemberTypeItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MemberTypeItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -6119,7 +6823,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/MemberTypeItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MemberTypeItemResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -6216,7 +6924,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/MemberItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MemberItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -6224,7 +6936,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/MemberItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MemberItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -6232,7 +6948,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/MemberItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MemberItemResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -6296,17 +7016,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ModelsBuilderResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ModelsBuilderResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ModelsBuilderResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ModelsBuilderResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/ModelsBuilderResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ModelsBuilderResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -6331,17 +7063,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/OutOfDateStatusResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/OutOfDateStatusResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/OutOfDateStatusResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/OutOfDateStatusResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/OutOfDateStatusResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/OutOfDateStatusResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -6523,17 +7267,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreatePackageRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreatePackageRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreatePackageRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreatePackageRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/CreatePackageRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreatePackageRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -6609,17 +7365,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PackageDefinitionResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PackageDefinitionResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PackageDefinitionResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PackageDefinitionResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/PackageDefinitionResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PackageDefinitionResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -6681,17 +7449,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdatePackageRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdatePackageRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdatePackageRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdatePackageRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdatePackageRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdatePackageRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -6777,7 +7557,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/PackageManifestResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/PackageManifestResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -6785,7 +7569,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/PackageManifestResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/PackageManifestResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -6793,7 +7581,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/PackageManifestResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/PackageManifestResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -6883,17 +7675,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PartialViewResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PartialViewResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PartialViewResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PartialViewResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/PartialViewResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PartialViewResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -6914,17 +7718,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreatePartialViewRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreatePartialViewRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreatePartialViewRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreatePartialViewRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/CreatePartialViewRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreatePartialViewRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -6984,17 +7800,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdatePartialViewRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdatePartialViewRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdatePartialViewRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdatePartialViewRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdatePartialViewRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdatePartialViewRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -7046,17 +7874,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreatePathFolderRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreatePathFolderRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreatePathFolderRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreatePathFolderRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/CreatePathFolderRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreatePathFolderRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -7125,7 +7965,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/PartialViewItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/PartialViewItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -7133,7 +7977,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/PartialViewItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/PartialViewItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -7141,7 +7989,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/PartialViewItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/PartialViewItemResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -7232,17 +8084,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PartialViewSnippetResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PartialViewSnippetResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PartialViewSnippetResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PartialViewSnippetResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/PartialViewSnippetResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PartialViewSnippetResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -7384,17 +8248,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProfilingStatusResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ProfilingStatusResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProfilingStatusResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ProfilingStatusResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProfilingStatusResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ProfilingStatusResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -7415,17 +8291,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ProfilingStatusRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ProfilingStatusRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/ProfilingStatusRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ProfilingStatusRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/ProfilingStatusRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ProfilingStatusRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -7788,17 +8676,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RedirectUrlStatusResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/RedirectUrlStatusResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RedirectUrlStatusResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/RedirectUrlStatusResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/RedirectUrlStatusResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/RedirectUrlStatusResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -7846,17 +8746,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRelationTypeRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateRelationTypeRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRelationTypeRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateRelationTypeRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRelationTypeRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateRelationTypeRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -7926,17 +8838,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RelationTypeResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/RelationTypeResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RelationTypeResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/RelationTypeResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/RelationTypeResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/RelationTypeResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -8018,17 +8942,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateRelationTypeRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateRelationTypeRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateRelationTypeRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateRelationTypeRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateRelationTypeRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateRelationTypeRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -8039,17 +8975,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RelationTypeResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/RelationTypeResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RelationTypeResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/RelationTypeResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/RelationTypeResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/RelationTypeResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -8130,7 +9078,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/RelationTypeItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/RelationTypeItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -8138,7 +9090,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/RelationTypeItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/RelationTypeItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -8146,7 +9102,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/RelationTypeItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/RelationTypeItemResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -8238,17 +9198,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RelationResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/RelationResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RelationResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/RelationResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/RelationResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/RelationResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -8421,17 +9393,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ScriptResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ScriptResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ScriptResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ScriptResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/ScriptResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ScriptResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -8452,17 +9436,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateScriptRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateScriptRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateScriptRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateScriptRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateScriptRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateScriptRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -8522,17 +9518,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateScriptRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateScriptRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateScriptRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateScriptRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateScriptRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateScriptRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -8584,17 +9592,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreatePathFolderRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreatePathFolderRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreatePathFolderRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreatePathFolderRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/CreatePathFolderRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreatePathFolderRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -8663,7 +9683,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/ScriptItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/ScriptItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -8671,7 +9695,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/ScriptItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/ScriptItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -8679,7 +9707,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/ScriptItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/ScriptItemResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -8978,17 +10010,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/LoginRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/LoginRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/LoginRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/LoginRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/LoginRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/LoginRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -9032,17 +10076,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ServerStatusResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ServerStatusResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ServerStatusResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ServerStatusResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/ServerStatusResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ServerStatusResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -9082,17 +10138,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/VersionResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/VersionResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/VersionResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/VersionResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/VersionResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/VersionResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -9132,7 +10200,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/StaticFileItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/StaticFileItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -9140,7 +10212,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/StaticFileItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/StaticFileItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -9148,7 +10224,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/StaticFileItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/StaticFileItemResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -9300,17 +10380,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/StylesheetResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/StylesheetResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/StylesheetResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/StylesheetResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/StylesheetResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/StylesheetResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -9331,17 +10423,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateStylesheetRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateStylesheetRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateStylesheetRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateStylesheetRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateStylesheetRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateStylesheetRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -9401,17 +10505,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateStylesheetRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateStylesheetRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateStylesheetRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateStylesheetRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateStylesheetRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateStylesheetRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -9518,17 +10634,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreatePathFolderRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreatePathFolderRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreatePathFolderRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreatePathFolderRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/CreatePathFolderRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreatePathFolderRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -9597,7 +10725,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/ScriptItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/ScriptItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -9605,7 +10737,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/ScriptItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/ScriptItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -9613,7 +10749,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/ScriptItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/ScriptItemResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -9637,17 +10777,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -9658,17 +10810,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -9691,17 +10855,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/InterpolateRichTextStylesheetRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/InterpolateRichTextStylesheetRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/InterpolateRichTextStylesheetRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/InterpolateRichTextStylesheetRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/InterpolateRichTextStylesheetRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/InterpolateRichTextStylesheetRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -9712,17 +10888,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/InterpolateRichTextStylesheetResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/InterpolateRichTextStylesheetResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/InterpolateRichTextStylesheetResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/InterpolateRichTextStylesheetResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/InterpolateRichTextStylesheetResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/InterpolateRichTextStylesheetResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -9756,17 +10944,38 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RichTextStylesheetRulesResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/RichTextStylesheetRulesResponseModel"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RichTextStylesheetRulesResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/RichTextStylesheetRulesResponseModel"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/RichTextStylesheetRulesResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/RichTextStylesheetRulesResponseModel"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ExtractRichTextStylesheetRulesResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -10039,17 +11248,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TelemetryResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/TelemetryResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TelemetryResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/TelemetryResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/TelemetryResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/TelemetryResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -10070,17 +11291,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TelemetryRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/TelemetryRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/TelemetryRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/TelemetryRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/TelemetryRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/TelemetryRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -10127,17 +11360,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateTemplateRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateTemplateRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateTemplateRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateTemplateRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateTemplateRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateTemplateRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -10210,17 +11455,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TemplateResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/TemplateResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TemplateResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/TemplateResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/TemplateResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/TemplateResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -10305,17 +11562,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateTemplateRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateTemplateRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateTemplateRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateTemplateRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateTemplateRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateTemplateRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -10383,7 +11652,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/TemplateItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/TemplateItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -10391,7 +11664,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/TemplateItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/TemplateItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -10399,7 +11676,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/TemplateItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/TemplateItemResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -10423,17 +11704,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TemplateQueryExecuteModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/TemplateQueryExecuteModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/TemplateQueryExecuteModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/TemplateQueryExecuteModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/TemplateQueryExecuteModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/TemplateQueryExecuteModel"
+                  }
+                ]
               }
             }
           }
@@ -10444,17 +11737,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TemplateQueryResultResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/TemplateQueryResultResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TemplateQueryResultResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/TemplateQueryResultResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/TemplateQueryResultResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/TemplateQueryResultResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -10479,17 +11784,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TemplateQuerySettingsResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/TemplateQuerySettingsResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TemplateQuerySettingsResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/TemplateQuerySettingsResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/TemplateQuerySettingsResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/TemplateQuerySettingsResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -10524,17 +11841,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TemplateScaffoldResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/TemplateScaffoldResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TemplateScaffoldResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/TemplateScaffoldResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/TemplateScaffoldResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/TemplateScaffoldResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -10806,17 +12135,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TemporaryFileResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/TemporaryFileResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TemporaryFileResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/TemporaryFileResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/TemporaryFileResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/TemporaryFileResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -10908,17 +12249,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserTourStatusesResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/UserTourStatusesResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserTourStatusesResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/UserTourStatusesResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserTourStatusesResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/UserTourStatusesResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -10939,17 +12292,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SetTourStatusRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SetTourStatusRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/SetTourStatusRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SetTourStatusRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/SetTourStatusRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SetTourStatusRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -11255,17 +12620,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UpgradeSettingsResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/UpgradeSettingsResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UpgradeSettingsResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/UpgradeSettingsResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/UpgradeSettingsResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/UpgradeSettingsResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -11308,17 +12685,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateUserGroupRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateUserGroupRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateUserGroupRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateUserGroupRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateUserGroupRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateUserGroupRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -11441,17 +12830,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserGroupResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/UserGroupResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserGroupResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/UserGroupResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserGroupResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/UserGroupResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -11516,17 +12917,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateUserGroupRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateUserGroupRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateUserGroupRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateUserGroupRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateUserGroupRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateUserGroupRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -11574,7 +12987,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/UserGroupItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/UserGroupItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -11582,7 +12999,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/UserGroupItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/UserGroupItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -11590,7 +13011,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/UserGroupItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/UserGroupItemResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -11614,17 +13039,38 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateUserRequestModel"
+                  },
+                  {
+                    "$ref": "#/components/schemas/InviteUserRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateUserRequestModel"
+                  },
+                  {
+                    "$ref": "#/components/schemas/InviteUserRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateUserRequestModel"
+                  },
+                  {
+                    "$ref": "#/components/schemas/InviteUserRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -11635,17 +13081,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreateUserResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/CreateUserResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreateUserResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/CreateUserResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreateUserResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/CreateUserResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -11754,17 +13212,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/UserResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/UserResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/UserResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -11826,17 +13296,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateUserRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateUserRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateUserRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -11901,17 +13383,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SetAvatarRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SetAvatarRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/SetAvatarRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SetAvatarRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/SetAvatarRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SetAvatarRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -11969,17 +13463,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -12008,17 +13514,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CurrentUserResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/CurrentUserResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CurrentUserResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/CurrentUserResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/CurrentUserResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/CurrentUserResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -12041,17 +13559,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SetAvatarRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SetAvatarRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/SetAvatarRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SetAvatarRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/SetAvatarRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SetAvatarRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -12078,17 +13608,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ChangePasswordUserRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -12117,17 +13659,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserDataResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/UserDataResponseModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserDataResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/UserDataResponseModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserDataResponseModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/UserDataResponseModel"
+                    }
+                  ]
                 }
               }
             }
@@ -12152,17 +13706,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/LinkedLoginsRequestModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/LinkedLoginsRequestModel"
+                    }
+                  ]
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/LinkedLoginsRequestModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/LinkedLoginsRequestModel"
+                    }
+                  ]
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/LinkedLoginsRequestModel"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/LinkedLoginsRequestModel"
+                    }
+                  ]
                 }
               }
             }
@@ -12203,7 +13769,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/UserPermissionsResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/UserPermissionsResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -12211,7 +13781,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/UserPermissionsResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/UserPermissionsResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -12219,7 +13793,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/UserPermissionsResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/UserPermissionsResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -12261,7 +13839,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/UserPermissionsResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/UserPermissionsResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -12269,7 +13851,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/UserPermissionsResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/UserPermissionsResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -12277,7 +13863,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/UserPermissionsResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/UserPermissionsResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -12319,7 +13909,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/UserPermissionsResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/UserPermissionsResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -12327,7 +13921,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/UserPermissionsResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/UserPermissionsResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -12335,7 +13933,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/UserPermissionsResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/UserPermissionsResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -12359,17 +13961,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/DisableUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/DisableUserRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/DisableUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/DisableUserRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/DisableUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/DisableUserRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -12416,17 +14030,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/EnableUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/EnableUserRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/EnableUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/EnableUserRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/EnableUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/EnableUserRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -12556,17 +14182,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/InviteUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/InviteUserRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/InviteUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/InviteUserRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/InviteUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/InviteUserRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -12603,17 +14241,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateInitialPasswordUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateInitialPasswordUserRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateInitialPasswordUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateInitialPasswordUserRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateInitialPasswordUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateInitialPasswordUserRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -12638,17 +14288,38 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/VerifyInviteUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/VerifyInviteUserRequestModel"
+                  },
+                  {
+                    "$ref": "#/components/schemas/CreateInitialPasswordUserRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/VerifyInviteUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/VerifyInviteUserRequestModel"
+                  },
+                  {
+                    "$ref": "#/components/schemas/CreateInitialPasswordUserRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/VerifyInviteUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/VerifyInviteUserRequestModel"
+                  },
+                  {
+                    "$ref": "#/components/schemas/CreateInitialPasswordUserRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -12691,7 +14362,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/UserItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/UserItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -12699,7 +14374,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/UserItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/UserItemResponseModel"
+                      }
+                    ]
                   }
                 }
               },
@@ -12707,7 +14386,11 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/UserItemResponseModel"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/UserItemResponseModel"
+                      }
+                    ]
                   }
                 }
               }
@@ -12731,17 +14414,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateUserGroupsOnUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateUserGroupsOnUserRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateUserGroupsOnUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateUserGroupsOnUserRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateUserGroupsOnUserRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateUserGroupsOnUserRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -12768,17 +14463,29 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UnlockUsersRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UnlockUsersRequestModel"
+                  }
+                ]
               }
             },
             "text/json": {
               "schema": {
-                "$ref": "#/components/schemas/UnlockUsersRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UnlockUsersRequestModel"
+                  }
+                ]
               }
             },
             "application/*+json": {
               "schema": {
-                "$ref": "#/components/schemas/UnlockUsersRequestModel"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UnlockUsersRequestModel"
+                  }
+                ]
               }
             }
           }
@@ -12818,7 +14525,7 @@
   },
   "components": {
     "schemas": {
-      "AuditLogResponseModel": {
+      "AuditLogBaseModel": {
         "type": "object",
         "properties": {
           "userId": {
@@ -12852,37 +14559,23 @@
         },
         "additionalProperties": false
       },
+      "AuditLogResponseModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AuditLogBaseModel"
+          }
+        ],
+        "additionalProperties": false
+      },
       "AuditLogWithUsernameResponseModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AuditLogBaseModel"
+          }
+        ],
         "properties": {
-          "userId": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "entityId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "timestamp": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "logType": {
-            "$ref": "#/components/schemas/AuditTypeModel"
-          },
-          "entityType": {
-            "type": "string",
-            "nullable": true
-          },
-          "comment": {
-            "type": "string",
-            "nullable": true
-          },
-          "parameters": {
-            "type": "string",
-            "nullable": true
-          },
           "userName": {
             "type": "string",
             "nullable": true
@@ -12952,6 +14645,40 @@
         },
         "additionalProperties": false
       },
+      "ContentResponseModelBaseDocumentValueModelDocumentVariantResponseModel": {
+        "type": "object",
+        "properties": {
+          "values": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DocumentValueModel"
+                }
+              ]
+            }
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DocumentVariantResponseModel"
+                }
+              ]
+            }
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "contentTypeId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
       "ContentStateModel": {
         "enum": [
           "NotCreated",
@@ -12961,6 +14688,27 @@
         ],
         "type": "integer",
         "format": "int32"
+      },
+      "ContentTreeItemResponseModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/EntityTreeItemResponseModel"
+          }
+        ],
+        "properties": {
+          "noAccess": {
+            "type": "boolean"
+          },
+          "isTrashed": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
       },
       "ContentTypeCleanupModel": {
         "type": "object",
@@ -13001,6 +14749,156 @@
         ],
         "type": "integer",
         "format": "int32"
+      },
+      "ContentTypeResponseModelBaseDocumentTypePropertyTypeResponseModelDocumentTypePropertyTypeContainerResponseModel": {
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "icon": {
+            "type": "string"
+          },
+          "allowedAsRoot": {
+            "type": "boolean"
+          },
+          "variesByCulture": {
+            "type": "boolean"
+          },
+          "variesBySegment": {
+            "type": "boolean"
+          },
+          "isElement": {
+            "type": "boolean"
+          },
+          "properties": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DocumentTypePropertyTypeResponseModel"
+                }
+              ]
+            }
+          },
+          "containers": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DocumentTypePropertyTypeContainerResponseModel"
+                }
+              ]
+            }
+          },
+          "allowedContentTypes": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ContentTypeSortModel"
+                }
+              ]
+            }
+          },
+          "compositions": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ContentTypeCompositionModel"
+                }
+              ]
+            }
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ContentTypeResponseModelBaseMediaTypePropertyTypeResponseModelMediaTypePropertyTypeContainerResponseModel": {
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "icon": {
+            "type": "string"
+          },
+          "allowedAsRoot": {
+            "type": "boolean"
+          },
+          "variesByCulture": {
+            "type": "boolean"
+          },
+          "variesBySegment": {
+            "type": "boolean"
+          },
+          "isElement": {
+            "type": "boolean"
+          },
+          "properties": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/MediaTypePropertyTypeResponseModel"
+                }
+              ]
+            }
+          },
+          "containers": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/MediaTypePropertyTypeContainerResponseModel"
+                }
+              ]
+            }
+          },
+          "allowedContentTypes": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ContentTypeSortModel"
+                }
+              ]
+            }
+          },
+          "compositions": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ContentTypeCompositionModel"
+                }
+              ]
+            }
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
       },
       "ContentTypeSortModel": {
         "type": "object",
@@ -13057,162 +14955,69 @@
         },
         "additionalProperties": false
       },
-      "CreateDataTypeRequestModel": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "propertyEditorAlias": {
-            "type": "string"
-          },
-          "propertyEditorUiAlias": {
-            "type": "string",
-            "nullable": true
-          },
-          "values": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DataTypePropertyPresentationModel"
-            }
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "parentId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "CreateDictionaryItemRequestModel": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "translations": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DictionaryItemTranslationModel"
-            }
-          },
-          "parentId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "CreateDocumentRequestModel": {
+      "CreateContentRequestModelBaseDocumentValueModelDocumentVariantRequestModel": {
         "type": "object",
         "properties": {
           "values": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DocumentValueModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DocumentValueModel"
+                }
+              ]
             }
           },
           "variants": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DocumentVariantRequestModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DocumentVariantRequestModel"
+                }
+              ]
             }
           },
           "parentId": {
             "type": "string",
             "format": "uuid",
             "nullable": true
-          },
-          "contentTypeId": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "templateId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
           }
         },
         "additionalProperties": false
       },
-      "CreateDocumentTypePropertyTypeContainerRequestModel": {
+      "CreateContentRequestModelBaseMediaValueModelMediaVariantRequestModel": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
+          "values": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/MediaValueModel"
+                }
+              ]
+            }
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/MediaVariantRequestModel"
+                }
+              ]
+            }
           },
           "parentId": {
             "type": "string",
             "format": "uuid",
             "nullable": true
-          },
-          "name": {
-            "type": "string",
-            "nullable": true
-          },
-          "type": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "integer",
-            "format": "int32"
           }
         },
         "additionalProperties": false
       },
-      "CreateDocumentTypePropertyTypeRequestModel": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "containerId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "sortOrder": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "alias": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string",
-            "nullable": true
-          },
-          "dataTypeId": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "variesByCulture": {
-            "type": "boolean"
-          },
-          "variesBySegment": {
-            "type": "boolean"
-          },
-          "validation": {
-            "$ref": "#/components/schemas/PropertyTypeValidationModel"
-          },
-          "appearance": {
-            "$ref": "#/components/schemas/PropertyTypeAppearanceModel"
-          }
-        },
-        "additionalProperties": false
-      },
-      "CreateDocumentTypeRequestModel": {
+      "CreateContentTypeRequestModelBaseCreateDocumentTypePropertyTypeRequestModelCreateDocumentTypePropertyTypeContainerRequestModel": {
         "type": "object",
         "properties": {
           "alias": {
@@ -13243,27 +15048,129 @@
           "properties": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CreateDocumentTypePropertyTypeRequestModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/CreateDocumentTypePropertyTypeRequestModel"
+                }
+              ]
             }
           },
           "containers": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CreateDocumentTypePropertyTypeContainerRequestModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/CreateDocumentTypePropertyTypeContainerRequestModel"
+                }
+              ]
             }
           },
           "allowedContentTypes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ContentTypeSortModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ContentTypeSortModel"
+                }
+              ]
             }
           },
           "compositions": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ContentTypeCompositionModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ContentTypeCompositionModel"
+                }
+              ]
             }
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateDataTypeRequestModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DataTypeModelBaseModel"
+          }
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
           },
+          "parentId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateDictionaryItemRequestModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DictionaryItemModelBaseModel"
+          }
+        ],
+        "properties": {
+          "parentId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateDocumentRequestModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CreateContentRequestModelBaseDocumentValueModelDocumentVariantRequestModel"
+          }
+        ],
+        "properties": {
+          "contentTypeId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "templateId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateDocumentTypePropertyTypeContainerRequestModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PropertyTypeContainerModelBaseModel"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "CreateDocumentTypePropertyTypeRequestModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PropertyTypeModelBaseModel"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "CreateDocumentTypeRequestModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CreateContentTypeRequestModelBaseCreateDocumentTypePropertyTypeRequestModelCreateDocumentTypePropertyTypeContainerRequestModel"
+          }
+        ],
+        "properties": {
           "allowedTemplateIds": {
             "type": "array",
             "items": {
@@ -13277,17 +15184,23 @@
             "nullable": true
           },
           "cleanup": {
-            "$ref": "#/components/schemas/ContentTypeCleanupModel"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ContentTypeCleanupModel"
+              }
+            ]
           }
         },
         "additionalProperties": false
       },
       "CreateFolderRequestModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FolderModelBaseModel"
+          }
+        ],
         "properties": {
-          "name": {
-            "type": "string"
-          },
           "id": {
             "type": "string",
             "format": "uuid",
@@ -13303,14 +15216,12 @@
       },
       "CreateInitialPasswordUserRequestModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VerifyInviteUserRequestModel"
+          }
+        ],
         "properties": {
-          "userId": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "token": {
-            "type": "string"
-          },
           "password": {
             "type": "string"
           }
@@ -13319,20 +15230,12 @@
       },
       "CreateLanguageRequestModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/LanguageModelBaseModel"
+          }
+        ],
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "isDefault": {
-            "type": "boolean"
-          },
-          "isMandatory": {
-            "type": "boolean"
-          },
-          "fallbackIsoCode": {
-            "type": "string",
-            "nullable": true
-          },
           "isoCode": {
             "type": "string"
           }
@@ -13341,24 +15244,12 @@
       },
       "CreateMediaRequestModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CreateContentRequestModelBaseMediaValueModelMediaVariantRequestModel"
+          }
+        ],
         "properties": {
-          "values": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/MediaValueModel"
-            }
-          },
-          "variants": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/MediaVariantRequestModel"
-            }
-          },
-          "parentId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
           "contentTypeId": {
             "type": "string",
             "format": "uuid"
@@ -13368,106 +15259,30 @@
       },
       "CreatePackageRequestModel": {
         "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "contentNodeId": {
-            "type": "string",
-            "nullable": true
-          },
-          "contentLoadChildNodes": {
-            "type": "boolean"
-          },
-          "mediaIds": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          "mediaLoadChildNodes": {
-            "type": "boolean"
-          },
-          "documentTypes": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "mediaTypes": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "dataTypes": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "templates": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "partialViews": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "stylesheets": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "scripts": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "languages": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "dictionaryItems": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PackageModelBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "CreatePartialViewRequestModel": {
         "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          },
-          "parentPath": {
-            "type": "string",
-            "nullable": true
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CreateTextFileViewModelBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "CreatePathFolderRequestModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PathFolderModelBaseModel"
+          }
+        ],
         "properties": {
-          "name": {
-            "type": "string"
-          },
           "parentPath": {
             "type": "string",
             "nullable": true
@@ -13477,26 +15292,12 @@
       },
       "CreateRelationTypeRequestModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RelationTypeBaseModel"
+          }
+        ],
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "isBidirectional": {
-            "type": "boolean"
-          },
-          "parentObjectType": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "childObjectType": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "isDependency": {
-            "type": "boolean"
-          },
           "id": {
             "type": "string",
             "format": "uuid",
@@ -13507,46 +15308,40 @@
       },
       "CreateScriptRequestModel": {
         "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          },
-          "parentPath": {
-            "type": "string",
-            "nullable": true
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CreateTextFileViewModelBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "CreateStylesheetRequestModel": {
         "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          },
-          "parentPath": {
-            "type": "string",
-            "nullable": true
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CreateTextFileViewModelBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "CreateTemplateRequestModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TemplateModelBaseModel"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "CreateTextFileViewModelBaseModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TextFileViewModelBaseModel"
+          }
+        ],
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "alias": {
-            "type": "string"
-          },
-          "content": {
+          "parentPath": {
             "type": "string",
             "nullable": true
           }
@@ -13555,70 +15350,20 @@
       },
       "CreateUserGroupRequestModel": {
         "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "icon": {
-            "type": "string",
-            "nullable": true
-          },
-          "sections": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "languages": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "hasAccessToAllLanguages": {
-            "type": "boolean"
-          },
-          "documentStartNodeId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "mediaStartNodeId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "permissions": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/UserGroupBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "CreateUserRequestModel": {
         "type": "object",
-        "properties": {
-          "email": {
-            "type": "string"
-          },
-          "userName": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "userGroupIds": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "uuid"
-            }
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/UserPresentationBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "CreateUserResponseModel": {
@@ -13710,17 +15455,41 @@
       },
       "DataTypeItemResponseModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
+          }
+        ],
+        "properties": {
+          "icon": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DataTypeModelBaseModel": {
+        "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
-          "id": {
-            "type": "string",
-            "format": "uuid"
+          "propertyEditorAlias": {
+            "type": "string"
           },
-          "icon": {
+          "propertyEditorUiAlias": {
             "type": "string",
             "nullable": true
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DataTypePropertyPresentationModel"
+                }
+              ]
+            }
           }
         },
         "additionalProperties": false
@@ -13762,7 +15531,11 @@
           "properties": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DataTypePropertyReferenceModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DataTypePropertyReferenceModel"
+                }
+              ]
             }
           }
         },
@@ -13770,23 +15543,12 @@
       },
       "DataTypeResponseModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DataTypeModelBaseModel"
+          }
+        ],
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "propertyEditorAlias": {
-            "type": "string"
-          },
-          "propertyEditorUiAlias": {
-            "type": "string",
-            "nullable": true
-          },
-          "values": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DataTypePropertyPresentationModel"
-            }
-          },
           "id": {
             "type": "string",
             "format": "uuid"
@@ -13801,31 +15563,12 @@
       },
       "DataTypeTreeItemResponseModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FolderTreeItemResponseModel"
+          }
+        ],
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "hasChildren": {
-            "type": "boolean"
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "isContainer": {
-            "type": "boolean"
-          },
-          "parentId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "isFolder": {
-            "type": "boolean"
-          },
           "icon": {
             "type": "string",
             "nullable": true
@@ -13920,18 +15663,14 @@
       },
       "DictionaryItemItemResponseModel": {
         "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
-      "DictionaryItemResponseModel": {
+      "DictionaryItemModelBaseModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -13940,9 +15679,24 @@
           "translations": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DictionaryItemTranslationModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DictionaryItemTranslationModel"
+                }
+              ]
             }
-          },
+          }
+        },
+        "additionalProperties": false
+      },
+      "DictionaryItemResponseModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DictionaryItemModelBaseModel"
+          }
+        ],
+        "properties": {
           "id": {
             "type": "string",
             "format": "uuid"
@@ -14011,41 +15765,21 @@
       },
       "DocumentBlueprintResponseModel": {
         "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "DocumentBlueprintTreeItemResponseModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/EntityTreeItemResponseModel"
+          }
+        ],
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "hasChildren": {
-            "type": "boolean"
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "isContainer": {
-            "type": "boolean"
-          },
-          "parentId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
           "documentTypeId": {
             "type": "string",
             "format": "uuid"
@@ -14062,14 +15796,12 @@
       },
       "DocumentItemResponseModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
+          }
+        ],
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
           "icon": {
             "type": "string",
             "nullable": true
@@ -14095,31 +15827,20 @@
       },
       "DocumentResponseModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ContentResponseModelBaseDocumentValueModelDocumentVariantResponseModel"
+          }
+        ],
         "properties": {
-          "values": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DocumentValueModel"
-            }
-          },
-          "variants": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DocumentVariantResponseModel"
-            }
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "contentTypeId": {
-            "type": "string",
-            "format": "uuid"
-          },
           "urls": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ContentUrlInfoModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ContentUrlInfoModel"
+                }
+              ]
             }
           },
           "templateId": {
@@ -14132,34 +15853,12 @@
       },
       "DocumentTreeItemResponseModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ContentTreeItemResponseModel"
+          }
+        ],
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "hasChildren": {
-            "type": "boolean"
-          },
-          "isContainer": {
-            "type": "boolean"
-          },
-          "parentId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "noAccess": {
-            "type": "boolean"
-          },
-          "isTrashed": {
-            "type": "boolean"
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
           "isProtected": {
             "type": "boolean"
           },
@@ -14176,7 +15875,11 @@
           "variants": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/VariantTreeItemModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/VariantTreeItemModel"
+                }
+              ]
             }
           },
           "icon": {
@@ -14187,14 +15890,12 @@
       },
       "DocumentTypeItemResponseModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
+          }
+        ],
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
           "isElement": {
             "type": "boolean"
           },
@@ -14207,131 +15908,30 @@
       },
       "DocumentTypePropertyTypeContainerResponseModel": {
         "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "parentId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "name": {
-            "type": "string",
-            "nullable": true
-          },
-          "type": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "integer",
-            "format": "int32"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PropertyTypeContainerModelBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "DocumentTypePropertyTypeResponseModel": {
         "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "containerId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "sortOrder": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "alias": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string",
-            "nullable": true
-          },
-          "dataTypeId": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "variesByCulture": {
-            "type": "boolean"
-          },
-          "variesBySegment": {
-            "type": "boolean"
-          },
-          "validation": {
-            "$ref": "#/components/schemas/PropertyTypeValidationModel"
-          },
-          "appearance": {
-            "$ref": "#/components/schemas/PropertyTypeAppearanceModel"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PropertyTypeModelBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "DocumentTypeResponseModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ContentTypeResponseModelBaseDocumentTypePropertyTypeResponseModelDocumentTypePropertyTypeContainerResponseModel"
+          }
+        ],
         "properties": {
-          "alias": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string",
-            "nullable": true
-          },
-          "icon": {
-            "type": "string"
-          },
-          "allowedAsRoot": {
-            "type": "boolean"
-          },
-          "variesByCulture": {
-            "type": "boolean"
-          },
-          "variesBySegment": {
-            "type": "boolean"
-          },
-          "isElement": {
-            "type": "boolean"
-          },
-          "properties": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DocumentTypePropertyTypeResponseModel"
-            }
-          },
-          "containers": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DocumentTypePropertyTypeContainerResponseModel"
-            }
-          },
-          "allowedContentTypes": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ContentTypeSortModel"
-            }
-          },
-          "compositions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ContentTypeCompositionModel"
-            }
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
           "allowedTemplateIds": {
             "type": "array",
             "items": {
@@ -14345,38 +15945,23 @@
             "nullable": true
           },
           "cleanup": {
-            "$ref": "#/components/schemas/ContentTypeCleanupModel"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ContentTypeCleanupModel"
+              }
+            ]
           }
         },
         "additionalProperties": false
       },
       "DocumentTypeTreeItemResponseModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FolderTreeItemResponseModel"
+          }
+        ],
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "hasChildren": {
-            "type": "boolean"
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "isContainer": {
-            "type": "boolean"
-          },
-          "parentId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "isFolder": {
-            "type": "boolean"
-          },
           "isElement": {
             "type": "boolean"
           },
@@ -14388,63 +15973,30 @@
       },
       "DocumentValueModel": {
         "type": "object",
-        "properties": {
-          "culture": {
-            "type": "string",
-            "nullable": true
-          },
-          "segment": {
-            "type": "string",
-            "nullable": true
-          },
-          "alias": {
-            "type": "string"
-          },
-          "value": {
-            "nullable": true
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ValueModelBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "DocumentVariantRequestModel": {
         "type": "object",
-        "properties": {
-          "culture": {
-            "type": "string",
-            "nullable": true
-          },
-          "segment": {
-            "type": "string",
-            "nullable": true
-          },
-          "name": {
-            "type": "string"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VariantModelBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "DocumentVariantResponseModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VariantResponseModelBaseModel"
+          }
+        ],
         "properties": {
-          "culture": {
-            "type": "string",
-            "nullable": true
-          },
-          "segment": {
-            "type": "string",
-            "nullable": true
-          },
-          "name": {
-            "type": "string"
-          },
-          "createDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updateDate": {
-            "type": "string",
-            "format": "date-time"
-          },
           "state": {
             "$ref": "#/components/schemas/ContentStateModel"
           },
@@ -14468,6 +16020,35 @@
         },
         "additionalProperties": false
       },
+      "DomainsPresentationModelBaseModel": {
+        "type": "object",
+        "properties": {
+          "defaultIsoCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "domains": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DomainPresentationModel"
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "DomainsResponseModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DomainsPresentationModelBaseModel"
+          }
+        ],
+        "additionalProperties": false
+      },
       "EnableUserRequestModel": {
         "type": "object",
         "properties": {
@@ -14484,16 +16065,12 @@
       },
       "EntityTreeItemResponseModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TreeItemPresentationModel"
+          }
+        ],
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "hasChildren": {
-            "type": "boolean"
-          },
           "id": {
             "type": "string",
             "format": "uuid"
@@ -14520,14 +16097,11 @@
       },
       "ExtractRichTextStylesheetRulesResponseModel": {
         "type": "object",
-        "properties": {
-          "rules": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/RichTextRuleModel"
-            }
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RichTextStylesheetRulesResponseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "FieldPresentationModel": {
@@ -14545,18 +16119,29 @@
         },
         "additionalProperties": false
       },
-      "FileSystemTreeItemPresentationModel": {
+      "FileItemResponseModelBaseModel": {
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
-          "type": {
+          "path": {
             "type": "string"
           },
-          "hasChildren": {
-            "type": "boolean"
-          },
+          "icon": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "FileSystemTreeItemPresentationModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TreeItemPresentationModel"
+          }
+        ],
+        "properties": {
           "path": {
             "type": "string"
           },
@@ -14566,12 +16151,23 @@
         },
         "additionalProperties": false
       },
-      "FolderReponseModel": {
+      "FolderModelBaseModel": {
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
-          },
+          }
+        },
+        "additionalProperties": false
+      },
+      "FolderReponseModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FolderModelBaseModel"
+          }
+        ],
+        "properties": {
           "id": {
             "type": "string",
             "format": "uuid"
@@ -14580,6 +16176,20 @@
             "type": "string",
             "format": "uuid",
             "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "FolderTreeItemResponseModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/EntityTreeItemResponseModel"
+          }
+        ],
+        "properties": {
+          "isFolder": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false
@@ -14621,16 +16231,31 @@
         },
         "additionalProperties": false
       },
-      "HealthCheckGroupPresentationModel": {
+      "HealthCheckGroupPresentationBaseModel": {
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
-          },
+          }
+        },
+        "additionalProperties": false
+      },
+      "HealthCheckGroupPresentationModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/HealthCheckGroupPresentationBaseModel"
+          }
+        ],
+        "properties": {
           "checks": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/HealthCheckModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/HealthCheckModel"
+                }
+              ]
             }
           }
         },
@@ -14638,11 +16263,11 @@
       },
       "HealthCheckGroupResponseModel": {
         "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/HealthCheckGroupPresentationBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "HealthCheckGroupWithResultResponseModel": {
@@ -14651,7 +16276,11 @@
           "checks": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/HealthCheckWithResultPresentationModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/HealthCheckWithResultPresentationModel"
+                }
+              ]
             }
           }
         },
@@ -14659,17 +16288,28 @@
       },
       "HealthCheckModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/HealthCheckModelBaseModel"
+          }
+        ],
         "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
           "name": {
             "type": "string"
           },
           "description": {
             "type": "string",
             "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "HealthCheckModelBaseModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
           }
         },
         "additionalProperties": false
@@ -14686,7 +16326,11 @@
           "actions": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/HealthCheckActionRequestModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/HealthCheckActionRequestModel"
+                }
+              ]
             },
             "nullable": true
           },
@@ -14699,15 +16343,20 @@
       },
       "HealthCheckWithResultPresentationModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/HealthCheckModelBaseModel"
+          }
+        ],
         "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
           "results": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/HealthCheckResultResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/HealthCheckResultResponseModel"
+                }
+              ]
             },
             "nullable": true
           }
@@ -14802,12 +16451,20 @@
         "type": "object",
         "properties": {
           "user": {
-            "$ref": "#/components/schemas/UserSettingsModel"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/UserSettingsModel"
+              }
+            ]
           },
           "databases": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DatabaseSettingsPresentationModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DatabaseSettingsPresentationModel"
+                }
+              ]
             }
           }
         },
@@ -14821,10 +16478,18 @@
         "type": "object",
         "properties": {
           "user": {
-            "$ref": "#/components/schemas/UserInstallResponseModel"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/UserInstallResponseModel"
+              }
+            ]
           },
           "database": {
-            "$ref": "#/components/schemas/DatabaseInstallResponseModel"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/DatabaseInstallResponseModel"
+              }
+            ]
           },
           "telemetryLevel": {
             "$ref": "#/components/schemas/TelemetryLevelModel"
@@ -14842,7 +16507,11 @@
           "rules": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/RichTextRuleModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/RichTextRuleModel"
+                }
+              ]
             },
             "nullable": true
           }
@@ -14860,27 +16529,28 @@
       },
       "InviteUserRequestModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CreateUserRequestModel"
+          }
+        ],
         "properties": {
-          "email": {
-            "type": "string"
-          },
-          "userName": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "userGroupIds": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
           "message": {
             "type": "string",
             "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ItemResponseModelBaseModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
           }
         },
         "additionalProperties": false
@@ -14897,7 +16567,7 @@
         },
         "additionalProperties": false
       },
-      "LanguageResponseModel": {
+      "LanguageModelBaseModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -14912,7 +16582,18 @@
           "fallbackIsoCode": {
             "type": "string",
             "nullable": true
-          },
+          }
+        },
+        "additionalProperties": false
+      },
+      "LanguageResponseModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/LanguageModelBaseModel"
+          }
+        ],
+        "properties": {
           "isoCode": {
             "type": "string"
           }
@@ -14937,7 +16618,11 @@
           "linkedLogins": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/LinkedLoginModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/LinkedLoginModel"
+                }
+              ]
             }
           }
         },
@@ -15015,7 +16700,11 @@
           "properties": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/LogMessagePropertyPresentationModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/LogMessagePropertyPresentationModel"
+                }
+              ]
             }
           },
           "exception": {
@@ -15065,14 +16754,12 @@
       },
       "MediaItemResponseModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
+          }
+        ],
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
           "icon": {
             "type": "string",
             "nullable": true
@@ -15082,34 +16769,12 @@
       },
       "MediaTreeItemResponseModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ContentTreeItemResponseModel"
+          }
+        ],
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "hasChildren": {
-            "type": "boolean"
-          },
-          "isContainer": {
-            "type": "boolean"
-          },
-          "parentId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "noAccess": {
-            "type": "boolean"
-          },
-          "isTrashed": {
-            "type": "boolean"
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
           "icon": {
             "type": "string"
           }
@@ -15118,14 +16783,12 @@
       },
       "MediaTypeItemResponseModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
+          }
+        ],
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
           "icon": {
             "type": "string",
             "nullable": true
@@ -15135,161 +16798,39 @@
       },
       "MediaTypePropertyTypeContainerResponseModel": {
         "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "parentId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "name": {
-            "type": "string",
-            "nullable": true
-          },
-          "type": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "integer",
-            "format": "int32"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PropertyTypeContainerModelBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "MediaTypePropertyTypeResponseModel": {
         "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "containerId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "sortOrder": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "alias": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string",
-            "nullable": true
-          },
-          "dataTypeId": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "variesByCulture": {
-            "type": "boolean"
-          },
-          "variesBySegment": {
-            "type": "boolean"
-          },
-          "validation": {
-            "$ref": "#/components/schemas/PropertyTypeValidationModel"
-          },
-          "appearance": {
-            "$ref": "#/components/schemas/PropertyTypeAppearanceModel"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PropertyTypeModelBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "MediaTypeResponseModel": {
         "type": "object",
-        "properties": {
-          "alias": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string",
-            "nullable": true
-          },
-          "icon": {
-            "type": "string"
-          },
-          "allowedAsRoot": {
-            "type": "boolean"
-          },
-          "variesByCulture": {
-            "type": "boolean"
-          },
-          "variesBySegment": {
-            "type": "boolean"
-          },
-          "isElement": {
-            "type": "boolean"
-          },
-          "properties": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/MediaTypePropertyTypeResponseModel"
-            }
-          },
-          "containers": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/MediaTypePropertyTypeContainerResponseModel"
-            }
-          },
-          "allowedContentTypes": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ContentTypeSortModel"
-            }
-          },
-          "compositions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ContentTypeCompositionModel"
-            }
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ContentTypeResponseModelBaseMediaTypePropertyTypeResponseModelMediaTypePropertyTypeContainerResponseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "MediaTypeTreeItemResponseModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FolderTreeItemResponseModel"
+          }
+        ],
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "hasChildren": {
-            "type": "boolean"
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "isContainer": {
-            "type": "boolean"
-          },
-          "parentId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "isFolder": {
-            "type": "boolean"
-          },
           "icon": {
             "type": "string"
           }
@@ -15298,64 +16839,48 @@
       },
       "MediaValueModel": {
         "type": "object",
-        "properties": {
-          "culture": {
-            "type": "string",
-            "nullable": true
-          },
-          "segment": {
-            "type": "string",
-            "nullable": true
-          },
-          "alias": {
-            "type": "string"
-          },
-          "value": {
-            "nullable": true
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ValueModelBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "MediaVariantRequestModel": {
         "type": "object",
-        "properties": {
-          "culture": {
-            "type": "string",
-            "nullable": true
-          },
-          "segment": {
-            "type": "string",
-            "nullable": true
-          },
-          "name": {
-            "type": "string"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VariantModelBaseModel"
           }
-        },
+        ],
+        "additionalProperties": false
+      },
+      "MediaVariantResponseModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VariantResponseModelBaseModel"
+          }
+        ],
         "additionalProperties": false
       },
       "MemberGroupItemResponseModel": {
         "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "MemberItemResponseModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
+          }
+        ],
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
           "icon": {
             "type": "string",
             "nullable": true
@@ -15365,14 +16890,12 @@
       },
       "MemberTypeItemResponseModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
+          }
+        ],
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
           "icon": {
             "type": "string",
             "nullable": true
@@ -15522,6 +17045,53 @@
       },
       "PackageDefinitionResponseModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PackageModelBaseModel"
+          }
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "packagePath": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PackageManifestResponseModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string",
+            "nullable": true
+          },
+          "extensions": {
+            "type": "array",
+            "items": { }
+          }
+        },
+        "additionalProperties": false
+      },
+      "PackageMigrationStatusResponseModel": {
+        "type": "object",
+        "properties": {
+          "packageName": {
+            "type": "string"
+          },
+          "hasPendingMigrations": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PackageModelBaseModel": {
+        "type": "object",
         "properties": {
           "name": {
             "type": "string"
@@ -15596,42 +17166,6 @@
             "items": {
               "type": "string"
             }
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "packagePath": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "PackageManifestResponseModel": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "version": {
-            "type": "string",
-            "nullable": true
-          },
-          "extensions": {
-            "type": "array",
-            "items": { }
-          }
-        },
-        "additionalProperties": false
-      },
-      "PackageMigrationStatusResponseModel": {
-        "type": "object",
-        "properties": {
-          "packageName": {
-            "type": "string"
-          },
-          "hasPendingMigrations": {
-            "type": "boolean"
           }
         },
         "additionalProperties": false
@@ -15650,7 +17184,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/AuditLogResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/AuditLogResponseModel"
+                }
+              ]
             }
           }
         },
@@ -15670,7 +17208,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/AuditLogWithUsernameResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/AuditLogWithUsernameResponseModel"
+                }
+              ]
             }
           }
         },
@@ -15690,7 +17232,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CultureReponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/CultureReponseModel"
+                }
+              ]
             }
           }
         },
@@ -15710,7 +17256,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DataTypeTreeItemResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DataTypeTreeItemResponseModel"
+                }
+              ]
             }
           }
         },
@@ -15730,7 +17280,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DictionaryOverviewResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DictionaryOverviewResponseModel"
+                }
+              ]
             }
           }
         },
@@ -15750,7 +17304,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DocumentBlueprintTreeItemResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DocumentBlueprintTreeItemResponseModel"
+                }
+              ]
             }
           }
         },
@@ -15770,7 +17328,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DocumentTreeItemResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DocumentTreeItemResponseModel"
+                }
+              ]
             }
           }
         },
@@ -15790,7 +17352,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DocumentTypeResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DocumentTypeResponseModel"
+                }
+              ]
             }
           }
         },
@@ -15810,7 +17376,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DocumentTypeTreeItemResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DocumentTypeTreeItemResponseModel"
+                }
+              ]
             }
           }
         },
@@ -15830,7 +17400,35 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/EntityTreeItemResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/EntityTreeItemResponseModel"
+                },
+                {
+                  "$ref": "#/components/schemas/ContentTreeItemResponseModel"
+                },
+                {
+                  "$ref": "#/components/schemas/DocumentBlueprintTreeItemResponseModel"
+                },
+                {
+                  "$ref": "#/components/schemas/DocumentTreeItemResponseModel"
+                },
+                {
+                  "$ref": "#/components/schemas/DocumentTypeTreeItemResponseModel"
+                },
+                {
+                  "$ref": "#/components/schemas/FolderTreeItemResponseModel"
+                },
+                {
+                  "$ref": "#/components/schemas/MediaTreeItemResponseModel"
+                },
+                {
+                  "$ref": "#/components/schemas/MediaTypeTreeItemResponseModel"
+                },
+                {
+                  "$ref": "#/components/schemas/DataTypeTreeItemResponseModel"
+                }
+              ]
             }
           }
         },
@@ -15850,7 +17448,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/FileSystemTreeItemPresentationModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/FileSystemTreeItemPresentationModel"
+                }
+              ]
             }
           }
         },
@@ -15870,7 +17472,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/HealthCheckGroupResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/HealthCheckGroupResponseModel"
+                }
+              ]
             }
           }
         },
@@ -15890,7 +17496,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/HelpPageResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/HelpPageResponseModel"
+                }
+              ]
             }
           }
         },
@@ -15910,7 +17520,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/IndexResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/IndexResponseModel"
+                }
+              ]
             }
           }
         },
@@ -15930,7 +17544,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/LanguageResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageResponseModel"
+                }
+              ]
             }
           }
         },
@@ -15950,7 +17568,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/LogMessageResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/LogMessageResponseModel"
+                }
+              ]
             }
           }
         },
@@ -15970,7 +17592,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/LogTemplateResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/LogTemplateResponseModel"
+                }
+              ]
             }
           }
         },
@@ -15990,7 +17616,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/LoggerResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/LoggerResponseModel"
+                }
+              ]
             }
           }
         },
@@ -16010,7 +17640,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/MediaTreeItemResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/MediaTreeItemResponseModel"
+                }
+              ]
             }
           }
         },
@@ -16030,7 +17664,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/MediaTypeTreeItemResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/MediaTypeTreeItemResponseModel"
+                }
+              ]
             }
           }
         },
@@ -16050,7 +17688,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ObjectTypeResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ObjectTypeResponseModel"
+                }
+              ]
             }
           }
         },
@@ -16070,7 +17712,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/PackageDefinitionResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/PackageDefinitionResponseModel"
+                }
+              ]
             }
           }
         },
@@ -16090,7 +17736,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/PackageMigrationStatusResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/PackageMigrationStatusResponseModel"
+                }
+              ]
             }
           }
         },
@@ -16110,7 +17760,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/RecycleBinItemResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/RecycleBinItemResponseModel"
+                }
+              ]
             }
           }
         },
@@ -16130,7 +17784,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/RedirectUrlResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/RedirectUrlResponseModel"
+                }
+              ]
             }
           }
         },
@@ -16150,7 +17808,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/RelationItemResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/RelationItemResponseModel"
+                }
+              ]
             }
           }
         },
@@ -16170,7 +17832,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/RelationResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/RelationResponseModel"
+                }
+              ]
             }
           }
         },
@@ -16190,7 +17856,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/SavedLogSearchResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/SavedLogSearchResponseModel"
+                }
+              ]
             }
           }
         },
@@ -16210,7 +17880,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/SearchResultResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/SearchResultResponseModel"
+                }
+              ]
             }
           }
         },
@@ -16230,7 +17904,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/SearcherResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/SearcherResponseModel"
+                }
+              ]
             }
           }
         },
@@ -16250,7 +17928,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/SnippetItemResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/SnippetItemResponseModel"
+                }
+              ]
             }
           }
         },
@@ -16270,7 +17952,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/StylesheetOverviewResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/StylesheetOverviewResponseModel"
+                }
+              ]
             }
           }
         },
@@ -16290,7 +17976,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TagResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/TagResponseModel"
+                }
+              ]
             }
           }
         },
@@ -16310,7 +18000,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TelemetryResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/TelemetryResponseModel"
+                }
+              ]
             }
           }
         },
@@ -16330,7 +18024,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/UserGroupResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/UserGroupResponseModel"
+                }
+              ]
             }
           }
         },
@@ -16350,7 +18048,11 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/UserResponseModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/UserResponseModel"
+                }
+              ]
             }
           }
         },
@@ -16358,32 +18060,20 @@
       },
       "PartialViewItemResponseModel": {
         "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "path": {
-            "type": "string"
-          },
-          "icon": {
-            "type": "string"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FileItemResponseModelBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "PartialViewResponseModel": {
         "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          },
-          "path": {
-            "type": "string"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TextFileResponseModelBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "PartialViewSnippetResponseModel": {
@@ -16394,6 +18084,43 @@
           },
           "content": {
             "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PartialViewUpdateModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TextFileUpdateModel"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "PathFolderModelBaseModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FolderModelBaseModel"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "PathFolderResponseModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FolderModelBaseModel"
+          }
+        ],
+        "properties": {
+          "parentPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "path": {
+            "type": "string",
+            "readOnly": true
           }
         },
         "additionalProperties": false
@@ -16452,6 +18179,85 @@
         },
         "additionalProperties": false
       },
+      "PropertyTypeContainerModelBaseModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "parentId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string"
+          },
+          "sortOrder": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PropertyTypeModelBaseModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "containerId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "sortOrder": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "dataTypeId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "variesByCulture": {
+            "type": "boolean"
+          },
+          "variesBySegment": {
+            "type": "boolean"
+          },
+          "validation": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/PropertyTypeValidationModel"
+              }
+            ]
+          },
+          "appearance": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/PropertyTypeAppearanceModel"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
       "PropertyTypeValidationModel": {
         "type": "object",
         "properties": {
@@ -16473,7 +18279,7 @@
         },
         "additionalProperties": false
       },
-      "PublicAccessRequestModel": {
+      "PublicAccessBaseModel": {
         "type": "object",
         "properties": {
           "loginPageId": {
@@ -16483,7 +18289,18 @@
           "errorPageId": {
             "type": "string",
             "format": "uuid"
-          },
+          }
+        },
+        "additionalProperties": false
+      },
+      "PublicAccessRequestModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PublicAccessBaseModel"
+          }
+        ],
+        "properties": {
           "memberUserNames": {
             "type": "array",
             "items": {
@@ -16494,6 +18311,37 @@
             "type": "array",
             "items": {
               "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "PublicAccessResponseModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PublicAccessBaseModel"
+          }
+        ],
+        "properties": {
+          "members": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/MemberItemResponseModel"
+                }
+              ]
+            }
+          },
+          "groups": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/MemberGroupItemResponseModel"
+                }
+              ]
             }
           }
         },
@@ -16661,20 +18509,7 @@
         },
         "additionalProperties": false
       },
-      "RelationTypeItemResponseModel": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          }
-        },
-        "additionalProperties": false
-      },
-      "RelationTypeResponseModel": {
+      "RelationTypeBaseModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -16695,7 +18530,27 @@
           },
           "isDependency": {
             "type": "boolean"
-          },
+          }
+        },
+        "additionalProperties": false
+      },
+      "RelationTypeItemResponseModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "RelationTypeResponseModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RelationTypeBaseModel"
+          }
+        ],
+        "properties": {
           "id": {
             "type": "string",
             "format": "uuid"
@@ -16742,7 +18597,11 @@
           "rules": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/RichTextRuleModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/RichTextRuleModel"
+                }
+              ]
             }
           }
         },
@@ -16760,7 +18619,7 @@
         "type": "integer",
         "format": "int32"
       },
-      "SavedLogSearchRequestModel": {
+      "SavedLogSearchPresenationBaseModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -16770,48 +18629,60 @@
             "type": "string"
           }
         },
+        "additionalProperties": false
+      },
+      "SavedLogSearchRequestModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SavedLogSearchPresenationBaseModel"
+          }
+        ],
         "additionalProperties": false
       },
       "SavedLogSearchResponseModel": {
         "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "query": {
-            "type": "string"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SavedLogSearchPresenationBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "ScriptItemResponseModel": {
         "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "path": {
-            "type": "string"
-          },
-          "icon": {
-            "type": "string"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FileItemResponseModelBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "ScriptResponseModel": {
         "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          },
-          "path": {
-            "type": "string"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TextFileResponseModelBaseModel"
           }
-        },
+        ],
+        "additionalProperties": false
+      },
+      "ScriptUpdateModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TextFileUpdateModel"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "ScriptViewModelBaseModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TextFileViewModelBaseModel"
+          }
+        ],
         "additionalProperties": false
       },
       "SearchResultResponseModel": {
@@ -16832,7 +18703,11 @@
           "fields": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/FieldPresentationModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/FieldPresentationModel"
+                }
+              ]
             }
           }
         },
@@ -16868,17 +18743,11 @@
       },
       "SetTourStatusRequestModel": {
         "type": "object",
-        "properties": {
-          "alias": {
-            "type": "string"
-          },
-          "completed": {
-            "type": "boolean"
-          },
-          "disabled": {
-            "type": "boolean"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TourStatusModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "SnippetItemResponseModel": {
@@ -16892,17 +18761,11 @@
       },
       "StaticFileItemResponseModel": {
         "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "path": {
-            "type": "string"
-          },
-          "icon": {
-            "type": "string"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FileItemResponseModelBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "StatusResultTypeModel": {
@@ -16914,6 +18777,15 @@
         ],
         "type": "integer",
         "format": "int32"
+      },
+      "StylesheetItemResponseModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FileItemResponseModelBaseModel"
+          }
+        ],
+        "additionalProperties": false
       },
       "StylesheetOverviewResponseModel": {
         "type": "object",
@@ -16929,17 +18801,20 @@
       },
       "StylesheetResponseModel": {
         "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          },
-          "path": {
-            "type": "string"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TextFileResponseModelBaseModel"
           }
-        },
+        ],
+        "additionalProperties": false
+      },
+      "StylesheetUpdateModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TextFileUpdateModel"
+          }
+        ],
         "additionalProperties": false
       },
       "TagResponseModel": {
@@ -16973,36 +18848,59 @@
         "type": "integer",
         "format": "int32"
       },
-      "TelemetryRequestModel": {
+      "TelemetryRepresentationBaseModel": {
         "type": "object",
         "properties": {
           "telemetryLevel": {
             "$ref": "#/components/schemas/TelemetryLevelModel"
           }
         },
+        "additionalProperties": false
+      },
+      "TelemetryRequestModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TelemetryRepresentationBaseModel"
+          }
+        ],
         "additionalProperties": false
       },
       "TelemetryResponseModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TelemetryRepresentationBaseModel"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "TemplateItemResponseModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
+          }
+        ],
         "properties": {
-          "telemetryLevel": {
-            "$ref": "#/components/schemas/TelemetryLevelModel"
+          "alias": {
+            "type": "string"
           }
         },
         "additionalProperties": false
       },
-      "TemplateItemResponseModel": {
+      "TemplateModelBaseModel": {
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
           "alias": {
             "type": "string"
+          },
+          "content": {
+            "type": "string",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -17037,12 +18935,21 @@
           "filters": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TemplateQueryExecuteFilterPresentationModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/TemplateQueryExecuteFilterPresentationModel"
+                }
+              ]
             },
             "nullable": true
           },
           "sort": {
-            "$ref": "#/components/schemas/TemplateQueryExecuteSortModel"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TemplateQueryExecuteSortModel"
+              }
+            ],
+            "nullable": true
           },
           "take": {
             "type": "integer",
@@ -17121,7 +19028,11 @@
           "sampleResults": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TemplateQueryResultItemPresentationModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/TemplateQueryResultItemPresentationModel"
+                }
+              ]
             }
           },
           "resultCount": {
@@ -17147,13 +19058,21 @@
           "properties": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TemplateQueryPropertyPresentationModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/TemplateQueryPropertyPresentationModel"
+                }
+              ]
             }
           },
           "operators": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TemplateQueryOperatorModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/TemplateQueryOperatorModel"
+                }
+              ]
             }
           }
         },
@@ -17161,17 +19080,12 @@
       },
       "TemplateResponseModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TemplateModelBaseModel"
+          }
+        ],
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "alias": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string",
-            "nullable": true
-          },
           "id": {
             "type": "string",
             "format": "uuid"
@@ -17211,6 +19125,47 @@
         },
         "additionalProperties": false
       },
+      "TextFileResponseModelBaseModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TextFileViewModelBaseModel"
+          }
+        ],
+        "properties": {
+          "path": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TextFileUpdateModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "existingPath": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TextFileViewModelBaseModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
       "TourStatusModel": {
         "type": "object",
         "properties": {
@@ -17221,6 +19176,21 @@
             "type": "boolean"
           },
           "disabled": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TreeItemPresentationModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "hasChildren": {
             "type": "boolean"
           }
         },
@@ -17240,150 +19210,59 @@
         },
         "additionalProperties": false
       },
-      "UpdateDataTypeRequestModel": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "propertyEditorAlias": {
-            "type": "string"
-          },
-          "propertyEditorUiAlias": {
-            "type": "string",
-            "nullable": true
-          },
-          "values": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DataTypePropertyPresentationModel"
-            }
-          }
-        },
-        "additionalProperties": false
-      },
-      "UpdateDictionaryItemRequestModel": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "translations": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DictionaryItemTranslationModel"
-            }
-          }
-        },
-        "additionalProperties": false
-      },
-      "UpdateDocumentNotificationsRequestModel": {
-        "type": "object",
-        "properties": {
-          "subscribedActionIds": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "additionalProperties": false
-      },
-      "UpdateDocumentRequestModel": {
+      "UpdateContentRequestModelBaseDocumentValueModelDocumentVariantRequestModel": {
         "type": "object",
         "properties": {
           "values": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DocumentValueModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DocumentValueModel"
+                }
+              ]
             }
           },
           "variants": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DocumentVariantRequestModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DocumentVariantRequestModel"
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateContentRequestModelBaseMediaValueModelMediaVariantRequestModel": {
+        "type": "object",
+        "properties": {
+          "values": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/MediaValueModel"
+                }
+              ]
             }
           },
-          "templateId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
+          "variants": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/MediaVariantRequestModel"
+                }
+              ]
+            }
           }
         },
         "additionalProperties": false
       },
-      "UpdateDocumentTypePropertyTypeContainerRequestModel": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "parentId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "name": {
-            "type": "string",
-            "nullable": true
-          },
-          "type": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "integer",
-            "format": "int32"
-          }
-        },
-        "additionalProperties": false
-      },
-      "UpdateDocumentTypePropertyTypeRequestModel": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "containerId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "sortOrder": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "alias": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string",
-            "nullable": true
-          },
-          "dataTypeId": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "variesByCulture": {
-            "type": "boolean"
-          },
-          "variesBySegment": {
-            "type": "boolean"
-          },
-          "validation": {
-            "$ref": "#/components/schemas/PropertyTypeValidationModel"
-          },
-          "appearance": {
-            "$ref": "#/components/schemas/PropertyTypeAppearanceModel"
-          }
-        },
-        "additionalProperties": false
-      },
-      "UpdateDocumentTypeRequestModel": {
+      "UpdateContentTypeRequestModelBaseUpdateDocumentTypePropertyTypeRequestModelUpdateDocumentTypePropertyTypeContainerRequestModel": {
         "type": "object",
         "properties": {
           "alias": {
@@ -17414,27 +19293,118 @@
           "properties": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/UpdateDocumentTypePropertyTypeRequestModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/UpdateDocumentTypePropertyTypeRequestModel"
+                }
+              ]
             }
           },
           "containers": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/UpdateDocumentTypePropertyTypeContainerRequestModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/UpdateDocumentTypePropertyTypeContainerRequestModel"
+                }
+              ]
             }
           },
           "allowedContentTypes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ContentTypeSortModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ContentTypeSortModel"
+                }
+              ]
             }
           },
           "compositions": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ContentTypeCompositionModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ContentTypeCompositionModel"
+                }
+              ]
             }
-          },
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateDataTypeRequestModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DataTypeModelBaseModel"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "UpdateDictionaryItemRequestModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DictionaryItemModelBaseModel"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "UpdateDocumentNotificationsRequestModel": {
+        "type": "object",
+        "properties": {
+          "subscribedActionIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateDocumentRequestModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/UpdateContentRequestModelBaseDocumentValueModelDocumentVariantRequestModel"
+          }
+        ],
+        "properties": {
+          "templateId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateDocumentTypePropertyTypeContainerRequestModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PropertyTypeContainerModelBaseModel"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "UpdateDocumentTypePropertyTypeRequestModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PropertyTypeModelBaseModel"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "UpdateDocumentTypeRequestModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/UpdateContentTypeRequestModelBaseUpdateDocumentTypePropertyTypeRequestModelUpdateDocumentTypePropertyTypeContainerRequestModel"
+          }
+        ],
+        "properties": {
           "allowedTemplateIds": {
             "type": "array",
             "items": {
@@ -17448,150 +19418,59 @@
             "nullable": true
           },
           "cleanup": {
-            "$ref": "#/components/schemas/ContentTypeCleanupModel"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ContentTypeCleanupModel"
+              }
+            ]
           }
         },
         "additionalProperties": false
       },
       "UpdateDomainsRequestModel": {
         "type": "object",
-        "properties": {
-          "defaultIsoCode": {
-            "type": "string",
-            "nullable": true
-          },
-          "domains": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DomainPresentationModel"
-            }
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DomainsPresentationModelBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "UpdateFolderReponseModel": {
         "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FolderModelBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "UpdateLanguageRequestModel": {
         "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "isDefault": {
-            "type": "boolean"
-          },
-          "isMandatory": {
-            "type": "boolean"
-          },
-          "fallbackIsoCode": {
-            "type": "string",
-            "nullable": true
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/LanguageModelBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "UpdateMediaRequestModel": {
         "type": "object",
-        "properties": {
-          "values": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/MediaValueModel"
-            }
-          },
-          "variants": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/MediaVariantRequestModel"
-            }
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/UpdateContentRequestModelBaseMediaValueModelMediaVariantRequestModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "UpdatePackageRequestModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PackageModelBaseModel"
+          }
+        ],
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "contentNodeId": {
-            "type": "string",
-            "nullable": true
-          },
-          "contentLoadChildNodes": {
-            "type": "boolean"
-          },
-          "mediaIds": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          "mediaLoadChildNodes": {
-            "type": "boolean"
-          },
-          "documentTypes": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "mediaTypes": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "dataTypes": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "templates": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "partialViews": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "stylesheets": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "scripts": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "languages": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "dictionaryItems": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
           "packagePath": {
             "type": "string"
           }
@@ -17600,133 +19479,70 @@
       },
       "UpdatePartialViewRequestModel": {
         "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          },
-          "existingPath": {
-            "type": "string"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TextFileUpdateModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "UpdateRelationTypeRequestModel": {
         "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "isBidirectional": {
-            "type": "boolean"
-          },
-          "parentObjectType": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "childObjectType": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "isDependency": {
-            "type": "boolean"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RelationTypeBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "UpdateScriptRequestModel": {
         "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          },
-          "existingPath": {
-            "type": "string"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/UpdateTextFileViewModelBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "UpdateStylesheetRequestModel": {
         "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          },
-          "existingPath": {
-            "type": "string"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/UpdateTextFileViewModelBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "UpdateTemplateRequestModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TemplateModelBaseModel"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "UpdateTextFileViewModelBaseModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TextFileViewModelBaseModel"
+          }
+        ],
         "properties": {
-          "name": {
+          "existingPath": {
             "type": "string"
-          },
-          "alias": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string",
-            "nullable": true
           }
         },
         "additionalProperties": false
       },
       "UpdateUserGroupRequestModel": {
         "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "icon": {
-            "type": "string",
-            "nullable": true
-          },
-          "sections": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "languages": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "hasAccessToAllLanguages": {
-            "type": "boolean"
-          },
-          "documentStartNodeId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "mediaStartNodeId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "permissions": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/UserGroupBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "UpdateUserGroupsOnUserRequestModel": {
@@ -17753,24 +19569,12 @@
       },
       "UpdateUserRequestModel": {
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/UserPresentationBaseModel"
+          }
+        ],
         "properties": {
-          "email": {
-            "type": "string"
-          },
-          "userName": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "userGroupIds": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
           "languageIsoCode": {
             "type": "string"
           },
@@ -17833,30 +19637,17 @@
           "userData": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/UserDataModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/UserDataModel"
+                }
+              ]
             }
           }
         },
         "additionalProperties": false
       },
-      "UserGroupItemResponseModel": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "icon": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "UserGroupResponseModel": {
+      "UserGroupBaseModel": {
         "type": "object",
         "properties": {
           "name": {
@@ -17897,7 +19688,33 @@
             "items": {
               "type": "string"
             }
-          },
+          }
+        },
+        "additionalProperties": false
+      },
+      "UserGroupItemResponseModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
+          }
+        ],
+        "properties": {
+          "icon": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UserGroupResponseModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/UserGroupBaseModel"
+          }
+        ],
+        "properties": {
           "id": {
             "type": "string",
             "format": "uuid"
@@ -17936,15 +19753,11 @@
       },
       "UserItemResponseModel": {
         "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ItemResponseModelBaseModel"
           }
-        },
+        ],
         "additionalProperties": false
       },
       "UserOrderModel": {
@@ -17985,13 +19798,17 @@
           "permissions": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/UserPermissionModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/UserPermissionModel"
+                }
+              ]
             }
           }
         },
         "additionalProperties": false
       },
-      "UserResponseModel": {
+      "UserPresentationBaseModel": {
         "type": "object",
         "properties": {
           "email": {
@@ -18010,7 +19827,18 @@
               "type": "string",
               "format": "uuid"
             }
-          },
+          }
+        },
+        "additionalProperties": false
+      },
+      "UserResponseModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/UserPresentationBaseModel"
+          }
+        ],
+        "properties": {
           "id": {
             "type": "string",
             "format": "uuid"
@@ -18088,7 +19916,11 @@
           "consentLevels": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ConsentLevelPresentationModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ConsentLevelPresentationModel"
+                }
+              ]
             }
           }
         },
@@ -18112,8 +19944,77 @@
           "tourStatuses": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TourStatusModel"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/TourStatusModel"
+                },
+                {
+                  "$ref": "#/components/schemas/SetTourStatusRequestModel"
+                }
+              ]
             }
+          }
+        },
+        "additionalProperties": false
+      },
+      "ValueModelBaseModel": {
+        "type": "object",
+        "properties": {
+          "culture": {
+            "type": "string",
+            "nullable": true
+          },
+          "segment": {
+            "type": "string",
+            "nullable": true
+          },
+          "alias": {
+            "type": "string"
+          },
+          "value": {
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "VariantModelBaseModel": {
+        "type": "object",
+        "properties": {
+          "culture": {
+            "type": "string",
+            "nullable": true
+          },
+          "segment": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "VariantResponseModelBaseModel": {
+        "type": "object",
+        "properties": {
+          "culture": {
+            "type": "string",
+            "nullable": true
+          },
+          "segment": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string"
+          },
+          "createDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updateDate": {
+            "type": "string",
+            "format": "date-time"
           }
         },
         "additionalProperties": false

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -17408,6 +17408,9 @@
                   "$ref": "#/components/schemas/ContentTreeItemResponseModel"
                 },
                 {
+                  "$ref": "#/components/schemas/DataTypeTreeItemResponseModel"
+                },
+                {
                   "$ref": "#/components/schemas/DocumentBlueprintTreeItemResponseModel"
                 },
                 {
@@ -17424,9 +17427,6 @@
                 },
                 {
                   "$ref": "#/components/schemas/MediaTypeTreeItemResponseModel"
-                },
-                {
-                  "$ref": "#/components/schemas/DataTypeTreeItemResponseModel"
                 }
               ]
             }

--- a/tests/Umbraco.Tests.Integration/NewBackoffice/OpenAPIContractTest.cs
+++ b/tests/Umbraco.Tests.Integration/NewBackoffice/OpenAPIContractTest.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using Umbraco.Cms.Api.Delivery.Controllers;
 using Umbraco.Cms.Api.Management;
 using Umbraco.Cms.Api.Management.Controllers.Install;
 using Umbraco.Cms.Core.Configuration.Models;
@@ -25,6 +26,7 @@ internal sealed class OpenAPIContractTest : UmbracoTestServerTestBase
         builder.AddMvcAndRazor(mvcBuilder =>
         {
             // Adds Umbraco.Cms.Api.Management
+            mvcBuilder.AddApplicationPart(typeof(ByIdContentApiController).Assembly);
             mvcBuilder.AddApplicationPart(typeof(InstallControllerBase).Assembly);
         });
 

--- a/tests/Umbraco.Tests.Integration/NewBackoffice/OpenAPIContractTest.cs
+++ b/tests/Umbraco.Tests.Integration/NewBackoffice/OpenAPIContractTest.cs
@@ -67,7 +67,7 @@ internal sealed class OpenAPIContractTest : UmbracoTestServerTestBase
             originalGeneratedContract.Remove(key);
             mergedContract.Remove(key);
         }
-
+        Assert.AreEqual(originalGeneratedContract.ToString(Formatting.Indented), mergedContract.ToString(Formatting.Indented), $"Generated API do not respect the contract:{Environment.NewLine}Expected:{Environment.NewLine}{originalGeneratedContract.ToString(Formatting.Indented)}{Environment.NewLine}{Environment.NewLine}Actual:{Environment.NewLine}{mergedContract.ToString(Formatting.Indented)}");
         Assert.AreEqual(originalGeneratedContract.ToString(Formatting.Indented), mergedContract.ToString(Formatting.Indented), $"Generated API do not respect the contract.");
     }
 }

--- a/tests/Umbraco.Tests.Integration/NewBackoffice/OpenAPIContractTest.cs
+++ b/tests/Umbraco.Tests.Integration/NewBackoffice/OpenAPIContractTest.cs
@@ -46,7 +46,8 @@ internal sealed class OpenAPIContractTest : UmbracoTestServerTestBase
     public async Task Validate_OpenApi_Contract_is_implemented()
     {
         string[] keysToIgnore = { "servers", "x-generator" };
-
+        Console.WriteLine($"\nCurrent culture: {Thread.CurrentThread.CurrentCulture.Name}");
+        Console.WriteLine($"Current UI culture: {Thread.CurrentThread.CurrentUICulture.Name}");
         var officePath = GlobalSettings.GetBackOfficePath(HostingEnvironment);
 
         var urlToContract = $"{officePath}/management/api/openapi.json";

--- a/tests/Umbraco.Tests.Integration/NewBackoffice/OpenAPIContractTest.cs
+++ b/tests/Umbraco.Tests.Integration/NewBackoffice/OpenAPIContractTest.cs
@@ -46,8 +46,6 @@ internal sealed class OpenAPIContractTest : UmbracoTestServerTestBase
     public async Task Validate_OpenApi_Contract_is_implemented()
     {
         string[] keysToIgnore = { "servers", "x-generator" };
-        Console.WriteLine($"\nCurrent culture: {Thread.CurrentThread.CurrentCulture.Name}");
-        Console.WriteLine($"Current UI culture: {Thread.CurrentThread.CurrentUICulture.Name}");
         var officePath = GlobalSettings.GetBackOfficePath(HostingEnvironment);
 
         var urlToContract = $"{officePath}/management/api/openapi.json";
@@ -68,7 +66,6 @@ internal sealed class OpenAPIContractTest : UmbracoTestServerTestBase
             originalGeneratedContract.Remove(key);
             mergedContract.Remove(key);
         }
-        Assert.AreEqual(originalGeneratedContract.ToString(Formatting.Indented), mergedContract.ToString(Formatting.Indented), $"Generated API do not respect the contract:{Environment.NewLine}Expected:{Environment.NewLine}{originalGeneratedContract.ToString(Formatting.Indented)}{Environment.NewLine}{Environment.NewLine}Actual:{Environment.NewLine}{mergedContract.ToString(Formatting.Indented)}");
         Assert.AreEqual(originalGeneratedContract.ToString(Formatting.Indented), mergedContract.ToString(Formatting.Indented), $"Generated API do not respect the contract.");
     }
 }

--- a/tests/Umbraco.Tests.Integration/NewBackoffice/OpenAPIContractTest.cs
+++ b/tests/Umbraco.Tests.Integration/NewBackoffice/OpenAPIContractTest.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
-using Umbraco.Cms.Api.Delivery.Controllers;
 using Umbraco.Cms.Api.Management;
 using Umbraco.Cms.Api.Management.Controllers.Install;
 using Umbraco.Cms.Core.Configuration.Models;
@@ -26,7 +25,6 @@ internal sealed class OpenAPIContractTest : UmbracoTestServerTestBase
         builder.AddMvcAndRazor(mvcBuilder =>
         {
             // Adds Umbraco.Cms.Api.Management
-            mvcBuilder.AddApplicationPart(typeof(ByIdContentApiController).Assembly);
             mvcBuilder.AddApplicationPart(typeof(InstallControllerBase).Assembly);
         });
 

--- a/tests/Umbraco.Tests.Integration/NewBackoffice/OpenAPIContractTest.cs
+++ b/tests/Umbraco.Tests.Integration/NewBackoffice/OpenAPIContractTest.cs
@@ -66,6 +66,7 @@ internal sealed class OpenAPIContractTest : UmbracoTestServerTestBase
             originalGeneratedContract.Remove(key);
             mergedContract.Remove(key);
         }
+
         Assert.AreEqual(originalGeneratedContract.ToString(Formatting.Indented), mergedContract.ToString(Formatting.Indented), $"Generated API do not respect the contract.");
     }
 }


### PR DESCRIPTION
This fixes the pipelines after #14512

Interestingly it wasn't actually that PR that broke the pipelines, it was sometime before that. Nonetheless, I found that the reason was that for some reason the types found by our typefinder were different on the pipeline. This made our tests fail, because it changed the order of the `oneOff` list in the generate openapi spec. I've fixed this by ordering the found types. 

Testing: The integration tests need to pass 