### PR TITLE
V12: Add ISO codes to make the migration from language IDs easier

### DIFF
--- a/src/Umbraco.Core/Models/ContentEditing/Language.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/Language.cs
@@ -22,7 +22,7 @@ public class Language
     [DataMember(Name = "isMandatory")]
     public bool IsMandatory { get; set; }
 
-    [Obsolete("This will be replaced by fallback language ISO code in V14.")]
+    [Obsolete("This will be replaced by fallback language ISO code in V13.")]
     [DataMember(Name = "fallbackLanguageId")]
     public int? FallbackLanguageId { get; set; }
 }

--- a/src/Umbraco.Core/Models/ContentEditing/Language.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/Language.cs
@@ -22,7 +22,7 @@ public class Language
     [DataMember(Name = "isMandatory")]
     public bool IsMandatory { get; set; }
 
-    [Obsolete("This will be replaced by fallback language ISO code in V13.")]
+    [Obsolete("This will be replaced by fallback language ISO code in V14.")]
     [DataMember(Name = "fallbackLanguageId")]
     public int? FallbackLanguageId { get; set; }
 }

--- a/src/Umbraco.Core/Models/DictionaryItem.cs
+++ b/src/Umbraco.Core/Models/DictionaryItem.cs
@@ -34,7 +34,7 @@ public class DictionaryItem : EntityBase, IDictionaryItem
         _translations = new List<IDictionaryTranslation>();
     }
 
-    [Obsolete("This will be removed in V13.")]
+    [Obsolete("This will be removed in V14.")]
     public Func<int, ILanguage?>? GetLanguage { get; set; }
 
     /// <summary>

--- a/src/Umbraco.Core/Models/DictionaryItemExtensions.cs
+++ b/src/Umbraco.Core/Models/DictionaryItemExtensions.cs
@@ -10,7 +10,7 @@ public static class DictionaryItemExtensions
     /// <param name="d"></param>
     /// <param name="languageId"></param>
     /// <returns></returns>
-    [Obsolete("This will be replaced in V13 by a corresponding method accepting language ISO code instead of language ID.")]
+    [Obsolete("This will be replaced in V14 by a corresponding method accepting language ISO code instead of language ID.")]
     public static string? GetTranslatedValue(this IDictionaryItem d, int languageId)
     {
         IDictionaryTranslation? trans = d.Translations.FirstOrDefault(x => x.LanguageId == languageId);
@@ -22,7 +22,7 @@ public static class DictionaryItemExtensions
     /// </summary>
     /// <param name="d"></param>
     /// <returns></returns>
-    [Obsolete("Warning: This method ONLY works in very specific scenarios. It will be removed in V13.")]
+    [Obsolete("Warning: This method ONLY works in very specific scenarios. It will be removed in V14.")]
     public static string? GetDefaultValue(this IDictionaryItem d)
     {
         IDictionaryTranslation? defaultTranslation = d.Translations.FirstOrDefault(x => x.Language?.Id == 1);

--- a/src/Umbraco.Core/Models/DictionaryTranslation.cs
+++ b/src/Umbraco.Core/Models/DictionaryTranslation.cs
@@ -86,7 +86,7 @@ public class DictionaryTranslation : EntityBase, IDictionaryTranslation
         }
     }
 
-    [Obsolete("This will be replaced by language ISO code in V13.")]
+    [Obsolete("This will be replaced by language ISO code in V14.")]
     public int LanguageId { get; private set; }
 
     /// <summary>

--- a/src/Umbraco.Core/Models/DictionaryTranslation.cs
+++ b/src/Umbraco.Core/Models/DictionaryTranslation.cs
@@ -36,14 +36,14 @@ public class DictionaryTranslation : EntityBase, IDictionaryTranslation
         Key = uniqueId;
     }
 
-    [Obsolete("Please use constructor that accepts ILanguage. This will be removed in V13.")]
+    [Obsolete("Please use constructor that accepts ILanguage. This will be removed in V14.")]
     public DictionaryTranslation(int languageId, string value)
     {
         LanguageId = languageId;
         _value = value;
     }
 
-    [Obsolete("Please use constructor that accepts ILanguage. This will be removed in V13.")]
+    [Obsolete("Please use constructor that accepts ILanguage. This will be removed in V14.")]
     public DictionaryTranslation(int languageId, string value, Guid uniqueId)
     {
         LanguageId = languageId;
@@ -64,7 +64,7 @@ public class DictionaryTranslation : EntityBase, IDictionaryTranslation
     ///     returned
     ///     on a callback.
     /// </remarks>
-    [Obsolete("This will be removed in V13. From V13 onwards you should get languages by ISO code from ILanguageService.")]
+    [Obsolete("This will be removed in V14. From V14 onwards you should get languages by ISO code from ILanguageService.")]
     [DataMember]
     [DoNotClone]
     public ILanguage? Language
@@ -110,7 +110,7 @@ public class DictionaryTranslation : EntityBase, IDictionaryTranslation
     {
         get
         {
-            // TODO: this won't be necessary after obsoleted ctors are removed in v13.
+            // TODO: this won't be necessary after obsoleted ctors are removed in v14.
             if (_languageIsoCode is null)
             {
                 var _languageService = StaticServiceProvider.Instance.GetRequiredService<ILocalizationService>();

--- a/src/Umbraco.Core/Models/DictionaryTranslation.cs
+++ b/src/Umbraco.Core/Models/DictionaryTranslation.cs
@@ -1,5 +1,8 @@
 using System.Runtime.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models.Entities;
+using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Core.Models;
 
@@ -11,6 +14,7 @@ namespace Umbraco.Cms.Core.Models;
 public class DictionaryTranslation : EntityBase, IDictionaryTranslation
 {
     private ILanguage? _language;
+    private string? _languageIsoCode;
 
     // note: this will be memberwise cloned
     private string _value;
@@ -20,6 +24,7 @@ public class DictionaryTranslation : EntityBase, IDictionaryTranslation
         _language = language ?? throw new ArgumentNullException("language");
         LanguageId = _language.Id;
         _value = value;
+        LanguageIsoCode = language.IsoCode;
     }
 
     public DictionaryTranslation(ILanguage language, string value, Guid uniqueId)
@@ -27,6 +32,7 @@ public class DictionaryTranslation : EntityBase, IDictionaryTranslation
         _language = language ?? throw new ArgumentNullException("language");
         LanguageId = _language.Id;
         _value = value;
+        LanguageIsoCode = language.IsoCode;
         Key = uniqueId;
     }
 
@@ -97,6 +103,24 @@ public class DictionaryTranslation : EntityBase, IDictionaryTranslation
     {
         get => _value;
         set => SetPropertyValueAndDetectChanges(value, ref _value!, nameof(Value));
+    }
+
+    /// <inheritdoc />
+    public string LanguageIsoCode
+    {
+        get
+        {
+            // TODO: this won't be necessary after obsoleted ctors are removed in v13.
+            if (_languageIsoCode is null)
+            {
+                var _languageService = StaticServiceProvider.Instance.GetRequiredService<ILocalizationService>();
+                _languageIsoCode = _languageService.GetLanguageById(LanguageId)?.IsoCode ?? string.Empty;
+            }
+
+            return _languageIsoCode;
+        }
+
+        private set => SetPropertyValueAndDetectChanges(value, ref _languageIsoCode!, nameof(LanguageIsoCode));
     }
 
     protected override void PerformDeepClone(object clone)

--- a/src/Umbraco.Core/Models/IDictionaryTranslation.cs
+++ b/src/Umbraco.Core/Models/IDictionaryTranslation.cs
@@ -8,7 +8,7 @@ public interface IDictionaryTranslation : IEntity, IRememberBeingDirty
     /// <summary>
     ///     Gets or sets the <see cref="Language" /> for the translation.
     /// </summary>
-    [Obsolete("This will be removed in V13. From V13 onwards you should get languages by ISO code from ILanguageService.")]
+    [Obsolete("This will be removed in V14. From V14 onwards you should get languages by ISO code from ILanguageService.")]
     [DataMember]
     ILanguage? Language { get; set; }
 

--- a/src/Umbraco.Core/Models/IDictionaryTranslation.cs
+++ b/src/Umbraco.Core/Models/IDictionaryTranslation.cs
@@ -6,17 +6,17 @@ namespace Umbraco.Cms.Core.Models;
 public interface IDictionaryTranslation : IEntity, IRememberBeingDirty
 {
     /// <summary>
-    ///     Gets or sets the <see cref="Language" /> for the translation
+    ///     Gets or sets the <see cref="Language" /> for the translation.
     /// </summary>
     [Obsolete("This will be removed in V13. From V13 onwards you should get languages by ISO code from ILanguageService.")]
     [DataMember]
     ILanguage? Language { get; set; }
 
-    [Obsolete("This will be replaced by language ISO code in V13.")]
+    [Obsolete("This will be replaced by language ISO code in V14.")]
     int LanguageId { get; }
 
     /// <summary>
-    ///     Gets or sets the translated text
+    ///     Gets or sets the translated text.
     /// </summary>
     [DataMember]
     string Value { get; set; }

--- a/src/Umbraco.Core/Models/IDictionaryTranslation.cs
+++ b/src/Umbraco.Core/Models/IDictionaryTranslation.cs
@@ -20,4 +20,10 @@ public interface IDictionaryTranslation : IEntity, IRememberBeingDirty
     /// </summary>
     [DataMember]
     string Value { get; set; }
+
+    /// <summary>
+    ///     Gets the ISO code of the language.
+    /// </summary>
+    [DataMember]
+    string LanguageIsoCode { get; }
 }

--- a/src/Umbraco.Core/Models/ILanguage.cs
+++ b/src/Umbraco.Core/Models/ILanguage.cs
@@ -55,7 +55,7 @@ public interface ILanguage : IEntity, IRememberBeingDirty
     ///         define fallback strategies when a value does not exist for a requested language.
     ///     </para>
     /// </remarks>
-    [Obsolete("This will be replaced by fallback language ISO code in V13.")]
+    [Obsolete("This will be replaced by fallback language ISO code in V14.")]
     [DataMember]
     int? FallbackLanguageId { get; set; }
 }

--- a/src/Umbraco.Core/Models/ILanguage.cs
+++ b/src/Umbraco.Core/Models/ILanguage.cs
@@ -58,4 +58,17 @@ public interface ILanguage : IEntity, IRememberBeingDirty
     [Obsolete("This will be replaced by fallback language ISO code in V14.")]
     [DataMember]
     int? FallbackLanguageId { get; set; }
+
+
+    /// <summary>
+    ///     Gets or sets the ISO code of a fallback language.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The fallback language can be used in multi-lingual scenarios, to help
+    ///         define fallback strategies when a value does not exist for a requested language.
+    ///     </para>
+    /// </remarks>
+    [DataMember]
+    string? FallbackIsoCode { get; set; }
 }

--- a/src/Umbraco.Core/Models/Language.cs
+++ b/src/Umbraco.Core/Models/Language.cs
@@ -13,6 +13,7 @@ public class Language : EntityBase, ILanguage
 {
     private string _cultureName;
     private int? _fallbackLanguageId;
+    private string? _fallbackLanguageIsoCode;
     private bool _isDefaultVariantLanguage;
     private string _isoCode;
     private bool _mandatory;
@@ -78,5 +79,12 @@ public class Language : EntityBase, ILanguage
     {
         get => _fallbackLanguageId;
         set => SetPropertyValueAndDetectChanges(value, ref _fallbackLanguageId, nameof(FallbackLanguageId));
+    }
+
+    /// <inheritdoc />
+    public string? FallbackIsoCode
+    {
+        get => _fallbackLanguageIsoCode;
+        set => SetPropertyValueAndDetectChanges(value, ref _fallbackLanguageIsoCode, nameof(FallbackIsoCode));
     }
 }

--- a/src/Umbraco.Core/Models/Language.cs
+++ b/src/Umbraco.Core/Models/Language.cs
@@ -1,6 +1,5 @@
 using System.Globalization;
 using System.Runtime.Serialization;
-using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models.Entities;
 
 namespace Umbraco.Cms.Core.Models;
@@ -74,7 +73,7 @@ public class Language : EntityBase, ILanguage
     }
 
     /// <inheritdoc />
-    [Obsolete("This will be replaced by fallback language ISO code in V13.")]
+    [Obsolete("This will be replaced by fallback language ISO code in V14.")]
     public int? FallbackLanguageId
     {
         get => _fallbackLanguageId;

--- a/src/Umbraco.Infrastructure/Persistence/Factories/LanguageFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Factories/LanguageFactory.cs
@@ -6,7 +6,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Factories;
 
 internal static class LanguageFactory
 {
-    public static ILanguage BuildEntity(LanguageDto dto)
+    public static ILanguage BuildEntity(LanguageDto dto, string? fallbackIsoCode)
     {
         ArgumentNullException.ThrowIfNull(dto);
         if (dto.IsoCode is null)
@@ -22,6 +22,7 @@ internal static class LanguageFactory
             IsDefault = dto.IsDefault,
             IsMandatory = dto.IsMandatory,
             FallbackLanguageId = dto.FallbackLanguageId,
+            FallbackIsoCode = fallbackIsoCode
         };
 
         // Reset dirty initial properties

--- a/tests/Umbraco.Tests.Common/Builders/LanguageBuilder.cs
+++ b/tests/Umbraco.Tests.Common/Builders/LanguageBuilder.cs
@@ -95,7 +95,7 @@ public class LanguageBuilder<TParent>
         return this;
     }
 
-    [Obsolete("This will be replaced in V13 by a corresponding method accepting language ISO code instead of language ID.")]
+    [Obsolete("This will be replaced in V14 by a corresponding method accepting language ISO code instead of language ID.")]
     public LanguageBuilder<TParent> WithFallbackLanguageId(int fallbackLanguageId)
     {
         _fallbackLanguageId = fallbackLanguageId;


### PR DESCRIPTION
## Details
- In relation to the concerns from https://github.com/umbraco/Umbraco-CMS/pull/13753, this PR introduces `IDictionaryTranslation.LanguageIsoCode` and `DictionaryTranslation.LanguageIsoCode` and `ILanguage.FallbackIsoCode` and `Language.FallbackIsoCode` properties, to make the migration from language IDs easier;
  - The obsoletion messages related to language IDs are changed to V14 _(instead of 13)_.

## Test
- Use the following test controller and the debugger to inspect each object in `dictionaryItem.Translations` and `allLanguages` as it says in the comments in the code:

```c#
using Microsoft.AspNetCore.Mvc;
using Umbraco.Cms.Core.Services;
using Umbraco.Cms.Web.Common.Controllers;

namespace Umbraco.Cms.Web.UI;

public class TestController : UmbracoApiController
{
    private readonly ILocalizationService _localizationService;

    public TestController(ILocalizationService localizationService)
    {
        _localizationService = localizationService;
    }

    // /umbraco/api/test/test
    public IActionResult Test()
    {
        // check that each translation has a valid LanguageIsoCode now
        var dictionaryItem = _localizationService.GetDictionaryItemByKey("test");

        // check that each language has a valid FallbackIsoCode (compare with FallbackLanguageId)
        //      when FallbackLanguageId is null, FallbackIsoCode is also null
        //      when FallbackLanguageId is set, FallbackIsoCode value should correspond to the given FallbackLanguageId
        var allLanguages = _localizationService.GetAllLanguages();

        return Ok("Working");
    }
}

```