### PR TITLE
Extends JSON schema/Intellisense to full details of InstallDefaultData settings.

### DIFF
--- a/src/JsonSchema/AppSettings.cs
+++ b/src/JsonSchema/AppSettings.cs
@@ -88,11 +88,25 @@ namespace JsonSchema
 
                 public HelpPageSettings? HelpPage { get; set; }
 
-                public InstallDefaultDataSettings? InstallDefaultData { get; set; }
+                public InstallDefaultData? InstallDefaultData { get; set; }
 
                 public DataTypesSettings? DataTypes { get; set; }
 
                 public MarketplaceSettings? Marketplace { get; set; }
+            }
+
+            /// <summary>
+            ///     Configurations for the Umbraco CMS InstallDefaultData configuration.
+            /// </summary>
+            public class InstallDefaultData
+            {
+                public InstallDefaultDataSettings? Languages { get; set; }
+
+                public InstallDefaultDataSettings? DataTypes { get; set; }
+
+                public InstallDefaultDataSettings? MediaTypes { get; set; }
+
+                public InstallDefaultDataSettings? MemberTypes { get; set; }
             }
 
             /// <summary>

--- a/src/JsonSchema/AppSettings.cs
+++ b/src/JsonSchema/AppSettings.cs
@@ -88,7 +88,7 @@ namespace JsonSchema
 
                 public HelpPageSettings? HelpPage { get; set; }
 
-                public InstallDefaultDataSettings? DefaultDataCreation { get; set; }
+                public InstallDefaultDataSettings? InstallDefaultData { get; set; }
 
                 public DataTypesSettings? DataTypes { get; set; }
 

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseSchemaCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseSchemaCreator.cs
@@ -87,7 +87,7 @@ public class DatabaseSchemaCreator
     };
 
     private readonly IUmbracoDatabase _database;
-    private readonly IOptionsMonitor<InstallDefaultDataSettings> _defaultDataCreationSettings;
+    private readonly IOptionsMonitor<InstallDefaultDataSettings> _installDefaultDataSettings;
     private readonly IEventAggregator _eventAggregator;
     private readonly ILogger<DatabaseSchemaCreator> _logger;
     private readonly ILoggerFactory _loggerFactory;
@@ -118,7 +118,7 @@ public class DatabaseSchemaCreator
         _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
         _umbracoVersion = umbracoVersion ?? throw new ArgumentNullException(nameof(umbracoVersion));
         _eventAggregator = eventAggregator;
-        _defaultDataCreationSettings = defaultDataCreationSettings;
+        _installDefaultDataSettings = defaultDataCreationSettings;  // TODO (V13): Rename this parameter to installDefaultDataSettings.
 
         if (_database?.SqlContext?.SqlSyntax == null)
         {
@@ -178,7 +178,7 @@ public class DatabaseSchemaCreator
             var dataCreation = new DatabaseDataCreator(
                 _database, _loggerFactory.CreateLogger<DatabaseDataCreator>(),
                 _umbracoVersion,
-                _defaultDataCreationSettings);
+                _installDefaultDataSettings);
             foreach (Type table in _orderedTables)
             {
                 CreateTable(false, table, dataCreation);
@@ -455,7 +455,7 @@ public class DatabaseSchemaCreator
                 _database,
                 _loggerFactory.CreateLogger<DatabaseDataCreator>(),
                 _umbracoVersion,
-                _defaultDataCreationSettings));
+                _installDefaultDataSettings));
     }
 
     /// <summary>


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Part two of [this PR](https://github.com/umbraco/Umbraco-CMS/pull/14542).  Sorry @nikolajlauridsen... I missed pushing a commit from the last one.

### Description

The previous PR fixed the name used in configuration, and in this update I've also added schema/Intellisense support for the dictionary keys (e.g. "Language", "DataTypes") found within this configuration section.

Also resolved a comment from the last PR related to a private variable name.

To Test:
 - See linked PR.