### PR TITLE
Changed translations for passwordMismatch

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
@@ -1863,7 +1863,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="passwordCurrent">Nuværende kodeord</key>
     <key alias="passwordInvalid">ugyldig nuværende kodeord</key>
     <key alias="passwordIsDifferent">Dit nye kodeord og dit bekræftede kodeord var ikke ens, forsøg venligst igen!</key>
-    <key alias="passwordMismatch">Det bekræftede kodeord matcher ikke det nye kodeord</key>
+    <key alias="passwordMismatch">Der var et mismatch af kodeord!</key>
     <key alias="permissionReplaceChildren">Erstat underelement-rettigheder</key>
     <key alias="permissionSelectedPages">Du ændrer i øjeblikket rettigheder for siderne:</key>
     <key alias="permissionSelectPages">Vælg sider for at ændre deres rettigheder</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -2094,7 +2094,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="passwordIsDifferent">There was a difference between the new password and the confirmed password. Please
       try again!
     </key>
-    <key alias="passwordMismatch">The confirmed password doesn't match the new password!</key>
+    <key alias="passwordMismatch">There was a password mismatch!</key>
     <key alias="permissionReplaceChildren">Replace child node permissions</key>
     <key alias="permissionSelectedPages">You are currently modifying permissions for the pages:</key>
     <key alias="permissionSelectPages">Select pages to modify their permissions</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -2179,7 +2179,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="passwordIsDifferent">There was a difference between the new password and the confirmed password. Please
       try again!
     </key>
-    <key alias="passwordMismatch">The confirmed password doesn't match the new password!</key>
+    <key alias="passwordMismatch">There was a password mismatch!</key>
     <key alias="passwordRequiresDigit">The password must have at least one digit ('0'-'9')</key>
     <key alias="passwordRequiresLower">The password must have at least one lowercase ('a'-'z')</key>
     <key alias="passwordRequiresNonAlphanumeric">The password must have at least one non alphanumeric character</key>


### PR DESCRIPTION
Fixes #14528 

# Description
Because of ASP standards, they give us the errorCode "PasswordMismatch" for both changing a password and creating a new one.
Thus we can't have two different translations. This is also why the current translation is misleading when changing password and the current password is a mismatch.

- Changed translations for passwordMismatch to be less misleading and more generic.

# How to test
- Create a member
- Create the member with mismatching passwords
- Assert you get the new translation
- Change password of the member with mismathcing current password
- This can be done in a NotificationHandler like:
```
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Notifications;
using Umbraco.Cms.Core.Security;

namespace Umbraco.Cms.Web.UI;

public class MyNotificationHandler : INotificationHandler<UmbracoApplicationStartedNotification>
{
    private readonly IMemberManager _memberManager;

    public MyNotificationHandler(IMemberManager memberManager) => _memberManager = memberManager;

    public void Handle(UmbracoApplicationStartedNotification notification)
    {
        var identityMember = _memberManager.FindByIdAsync({YourMemberId}).GetAwaiter().GetResult();
        var resetResult = _memberManager.ChangePasswordAsync(identityMember!, "WrongPassword", "AnyPassword");
    }
}

public class MyComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder) => builder.AddNotificationHandler<UmbracoApplicationStartedNotification, MyNotificationHandler>();
}
```
- Assert you get the new translation