### PR TITLE
V12: Suppress execution context flow when queuing email task

### DIFF
--- a/src/Umbraco.Core/Services/NotificationService.cs
+++ b/src/Umbraco.Core/Services/NotificationService.cs
@@ -565,49 +565,58 @@ public class NotificationService : INotificationService
         }
     }
 
-    private void Process(BlockingCollection<NotificationRequest> notificationRequests) =>
-        ThreadPool.QueueUserWorkItem(state =>
+    private void Process(BlockingCollection<NotificationRequest> notificationRequests)
+    {
+        // We need to suppress the flow of the ExecutionContext when starting a new thread.
+        // Otherwise our scope stack will leak into the context of the new thread, leading to disposing race conditions.
+        using (ExecutionContext.SuppressFlow())
         {
-            if (_logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+            ThreadPool.QueueUserWorkItem(state =>
             {
-                _logger.LogDebug("Begin processing notifications.");
-            }
-            while (true)
-            {
-                // stay on for 8s
-                while (notificationRequests.TryTake(out NotificationRequest? request, 8 * 1000))
+                if (_logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
                 {
-                    try
+                    _logger.LogDebug("Begin processing notifications.");
+                }
+
+                while (true)
+                {
+                    // stay on for 8s
+                    while (notificationRequests.TryTake(out NotificationRequest? request, 8 * 1000))
                     {
-                        _emailSender.SendAsync(request.Mail, Constants.Web.EmailTypes.Notification).GetAwaiter()
-                            .GetResult();
-                        if (_logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+                        try
                         {
-                            _logger.LogDebug("Notification '{Action}' sent to {Username} ({Email})", request.Action, request.UserName, request.Email);
+                            _emailSender.SendAsync(request.Mail, Constants.Web.EmailTypes.Notification).GetAwaiter()
+                                .GetResult();
+                            if (_logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+                            {
+                                _logger.LogDebug("Notification '{Action}' sent to {Username} ({Email})", request.Action, request.UserName, request.Email);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, "An error occurred sending notification");
                         }
                     }
-                    catch (Exception ex)
+
+                    lock (Locker)
                     {
-                        _logger.LogError(ex, "An error occurred sending notification");
+                        if (notificationRequests.Count > 0)
+                        {
+                            continue; // last chance
+                        }
+
+                        _running = false; // going down
+                        break;
                     }
                 }
 
-                lock (Locker)
+                if (_logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
                 {
-                    if (notificationRequests.Count > 0)
-                    {
-                        continue; // last chance
-                    }
-
-                    _running = false; // going down
-                    break;
+                    _logger.LogDebug("Done processing notifications.");
                 }
-            }
-            if (_logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
-            {
-                _logger.LogDebug("Done processing notifications.");
-            }
-        });
+            });
+        }
+    }
 
     private class NotificationRequest
     {


### PR DESCRIPTION
Suppresses the execution context flow when queuing a task for sending notification emails. This is required because otherwise, the execution context would leak into the async thread that won't be joined. 

This caused issues when trying to replace the `IEmailSender` with a different implementation that creates a scope since the execution context was flowed, it gets added to the same scope stack as the other thread, leading to race conditions that would throw errors because a child scope on the other thread wasn't disposed. This should no longer happen.

It looks like there's a lot of changes in the PR, but all I did was wrapping the implementation of `NotificationService.Process` in a `using (ExecutionContext.SuppressFlow())` block.

## Testing

Since this is essentially a race condition it's pretty hard to test, but I was able to reproduce the issue somewhat reliably with the following approach (Thanks to the heartcore team for the test setup and heads up 💪):

1. Add a custom `IEmailSender` that calls `UserService.GetByEmail` (see below for example)
2. Replace it in `ConfigureServices` with: `services.Replace(ServiceDescriptor.Singleton<IEmailSender, HeadlessEmailSender>());`
3. Create a simple document type and content node (doesn't need any content) 
4. Set up notifications on publish
5. Restart Umbraco
6. Click `Save and publish` as the first action

This will throw a `System.InvalidOperationException`, not all the time, but more often than not.

After checking out this branch the error should no longer occur. 


### Code snippet: 

```C#
using Umbraco.Cms.Core.Mail;
using Umbraco.Cms.Core.Models.Email;
using Umbraco.Cms.Core.Services;

namespace Umbraco.Cms.Web.UI;

public class HeadlessEmailSender : IEmailSender
{
    private IUserService _userService;

    public HeadlessEmailSender(IUserService userService)
    {
        _userService = userService;
    }

    public bool CanSendRequiredEmail()
    {
        return true;
    }

    public Task SendAsync(EmailMessage message, string emailType)
    {
        _userService.GetByEmail(message.To.Single()!);
        return Task.CompletedTask;
    }

    public Task SendAsync(EmailMessage message, string emailType, bool enableNotification)
    {
        throw new NotImplementedException();
    }
}
```