### PR TITLE
Restored order of operations on scope dispose to that used in Umbraco 11 before refactor into Scope inheriting CoreScope.

### DIFF
--- a/src/Umbraco.Core/Scoping/CoreScope.cs
+++ b/src/Umbraco.Core/Scoping/CoreScope.cs
@@ -231,7 +231,7 @@ public class CoreScope : ICoreScope
         }
     }
 
-    private void HandleScopedFileSystems()
+    protected void HandleScopedFileSystems()
     {
         if (_shouldScopeFileSystems == true)
         {
@@ -250,7 +250,7 @@ public class CoreScope : ICoreScope
         _parentScope = coreScope;
     }
 
-    private void HandleScopedNotifications() => _notificationPublisher?.ScopeExit(Completed.HasValue && Completed.Value);
+    protected void HandleScopedNotifications() => _notificationPublisher?.ScopeExit(Completed.HasValue && Completed.Value);
 
     private void EnsureNotDisposed()
     {


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/14572

### Description
This PR restored order of operations on scope dispose to that used in Umbraco 11 before refactor into Scope inheriting CoreScope.

Can be tested to confirm it resolves a specific issue with Deploy 12 as noted in the issue, but primarily this needs a visual inspections for any oversights.

