### PR TITLE
#14190: Save all languages sent to approval in audit log

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/sendtopublish.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/sendtopublish.controller.js
@@ -5,6 +5,7 @@
 
         var vm = this;
         vm.loading = true;
+        vm.selectedVariants = [];
 
         vm.changeSelection = changeSelection;
 
@@ -22,38 +23,42 @@
             vm.variants.forEach(variant => {
                 variant.isMandatory = isMandatoryFilter(variant);
             });
-            
+
             vm.availableVariants = vm.variants.filter(publishableVariantFilter);
-            
+
             if (vm.availableVariants.length !== 0) {
 
                 vm.availableVariants = contentEditingHelper.getSortedVariantsAndSegments(vm.availableVariants);
-
-                vm.availableVariants.forEach(v => {
-                    if(v.active) {
-                        v.save = true;
-                    }
-                });
-
-            } else {
-                //disable save button if we have nothing to save
-                $scope.model.disableSubmitButton = true;
             }
 
+            $scope.model.disableSubmitButton = true;
             vm.loading = false;
-            
         }
 
         function allowSendToPublish (variant) {
             return variant.allowedActions.includes("H");
         }
 
-        function changeSelection() {
-            var firstSelected = vm.variants.find(v => v.save);
-            $scope.model.disableSubmitButton = !firstSelected; //disable submit button if there is none selected
+        function changeSelection(variant) {
+          let foundVariant = vm.selectedVariants.find(x => x.compositeId === variant.compositeId);
+
+          if (foundVariant === undefined) {
+            variant.save = true;
+            vm.selectedVariants.push(variant);
+          } else {
+            variant.save = false;
+            let index = vm.selectedVariants.indexOf(foundVariant);
+            if (index !== -1) {
+              vm.selectedVariants.splice(index, 1);
+            }
+          }
+
+          let firstSelected = vm.variants.find(v => v.save);
+          $scope.model.disableSubmitButton = !firstSelected;
         }
 
-        function isMandatoryFilter(variant) {
+
+      function isMandatoryFilter(variant) {
             //determine a variant is 'dirty' (meaning it will show up as publish-able) if it's
             // * has a mandatory language
             // * without having a segment, segments cant be mandatory at current state of code.
@@ -79,9 +84,7 @@
         });
 
         onInit();
-
     }
 
     angular.module("umbraco").controller("Umbraco.Overlays.SendToPublishController", SendToPublishController);
-
 })();


### PR DESCRIPTION
Fixes #14190 

# Preface
I'm not a frontender. This was labeled as a backend issue. 
But while debugging it appeared that the request payload was wrong.
Anyways..
Feel free to leave suggestions for better code solutions.

# Description
The SendToPublish would only the active culture to save = true.
That's why only one language showed up in the audit log. 

- Remove setting the active variant to true
- Disabled sent to approval button as default as no items are selected by default. (I'm not experienced enough in frontend to select the active variant by default :( )
- Updated changeSelection function to add selected variants to array and set save for those variants to true
- Updated changeSelection function to remove unselected variants from array and set save to false for those variants

# How to test
- Go to user groups and allow admins to Send To Publish
- Create multiple languages
- Create a doctype with Allow vary by culture = true and Allow as root = true
- Create a content node with multiple languages
- Change the content nodes for multiple languages
- Save and Send For Approval
- Go to audit log and confirm all the languages has been logged as Send For Approval
![image](https://github.com/umbraco/Umbraco-CMS/assets/25791861/1aaeed8b-2477-4529-b26a-753b9caf009f)
