### PR TITLE
Block grid area allowance editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/umb-block-grid-area-allowance-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/umb-block-grid-area-allowance-editor.html
@@ -8,9 +8,8 @@
             <select 
                 ng-model="allowance.$chosenValue"
                 localize="title"
-                title="blockEditor_pickSpecificAllowance"
-                required
-            >
+                title="@blockEditor_pickSpecificAllowance"
+                required>
                 <option ng-repeat="blockGroup in vm.allBlockGroups" value="groupKey:{{blockGroup.key}}">{{blockGroup.name}}</option>
                 <option disabled value="">---------</option>
                 <option ng-repeat="blockType in vm.allBlockTypes" ng-init="elementType = vm.getElementTypeByKey(blockType.contentElementTypeKey)" value="elementTypeKey:{{elementType.key}}">{{elementType.name}}</option>
@@ -24,8 +23,8 @@
                 placeholder="0"
                 ng-model="allowance.minAllowed"
                 localize="title"
-                title="blockEditor_allowanceMinimum"
-                fix-number/>
+                title="@blockEditor_allowanceMinimum"
+                fix-number />
             <span>–</span>
             <input 
                 type="number"
@@ -35,13 +34,13 @@
                 placeholder="∞"
                 ng-min="model.value.min || 0"
                 localize="title"
-                title="blockEditor_allowanceMaximum"
-                fix-number/>
+                title="@blockEditor_allowanceMaximum"
+                fix-number />
             <button 
                 type="button" 
                 class="btn-reset umb-outline"
                 localize="title"
-                title="actions_delete"
+                title="@actions_delete"
                 ng-click="vm.deleteAllowance(allowance);">
                 <umb-icon icon="icon-trash" class="icon"></umb-icon>
                 <span class="sr-only">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/umb-block-grid-area-allowance-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/umb-block-grid-area-allowance-editor.html
@@ -17,6 +17,7 @@
             </select>
             <input 
                 type="number"
+                pattern="[0-9]*"
                 name="label"
                 min="0"
                 ng-max="model.value.max"
@@ -28,6 +29,7 @@
             <span>–</span>
             <input 
                 type="number"
+                pattern="[0-9]*"
                 name="label"
                 ng-model="allowance.maxAllowed"
                 placeholder="∞"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/umb-block-grid-area-allowance-editor.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/umb-block-grid-area-allowance-editor.less
@@ -28,18 +28,18 @@
 }
 
 .umb-block-grid-area-allowance-editor__entry button {
+    position: relative;
     border-radius: 3px;
     color: @ui-action-type;
-
     height: 32px;
     display: inline-flex;
     justify-content: center;
     align-items: center;
     width: 32px;
-
     margin-left: 5px;
     align-self: normal;
 }
+
 .umb-block-grid-area-allowance-editor__entry button:hover {
     background-color: @ui-action-hover;
     color: @ui-action-type-hover;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/umb-block-grid-area-editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/umb-block-grid-area-editor.html
@@ -2,7 +2,7 @@
 
     <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
 
-<div ng-if="vm.loading === false"
+    <div ng-if="vm.loading === false"
         class="umb-block-grid-area-editor__grid-wrapper"
         style="--umb-block-grid--block-grid-columns: {{vm.block.areaGridColumns || vm.rootLayoutColumns}}"
         umb-block-grid-sorter="::vm.sorterOptions"

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/umb-block-grid-configuration-area-entry.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/umb-block-grid-configuration-area-entry.html
@@ -33,4 +33,4 @@
     <div class="umb-block-grid-area-editor__scale-label">
         {{vm.area.columnSpan}} x {{vm.area.rowSpan}}
     </div>
-<div>
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/umb-block-grid-configuration-area-entry.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/umb-block-grid-configuration-area-entry.html
@@ -1,17 +1,21 @@
 <div>
-
     <div class="__label">{{vm.area.alias}}</div>
 
     <div class="umb-block-grid__area--actions">
-
-        <button type="button" class="btn-reset umb-outline action --edit" localize="title" title="blockEditor_configureArea"
+        <button type="button"
+                class="btn-reset umb-outline action --edit"
+                localize="title"
+                title="@blockEditor_configureArea"
                 ng-click="vm.onEditClick($event);">
             <umb-icon icon="icon-edit" class="icon"></umb-icon>
             <span class="sr-only">
                 <localize key="blockEditor_configureArea">Edit</localize>
             </span>
         </button>
-        <button type="button" class="btn-reset umb-outline action --delete" localize="title" title="blockEditor_deleteArea"
+        <button type="button"
+                class="btn-reset umb-outline action --delete"
+                localize="title"
+                title="@blockEditor_deleteArea"
                 ng-click="vm.onDeleteClick($event);">
             <umb-icon icon="icon-trash" class="icon"></umb-icon>
             <span class="sr-only">
@@ -19,9 +23,13 @@
             </span>
         </button>
     </div>
-
-    <button type="button" class="btn-reset umb-block-grid-area-editor__scale-handler umb-outline" ng-mousedown="vm.scaleHandlerMouseDown($event)" ng-keyup="vm.scaleHandlerKeyUp($event)">
+    
+    <button type="button"
+            class="btn-reset umb-block-grid-area-editor__scale-handler umb-outline"
+            ng-mousedown="vm.scaleHandlerMouseDown($event)"
+            ng-keyup="vm.scaleHandlerKeyUp($event)">
     </button>
+    
     <div class="umb-block-grid-area-editor__scale-label">
         {{vm.area.columnSpan}} x {{vm.area.rowSpan}}
     </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
This PR fixes a few issues in block grid area allowance editor, e.g. outline of delete button mentioned here https://github.com/umbraco/Umbraco-CMS/pull/14518#issuecomment-1624417702 which was because of the custom `umb-outline` class and that the button didn't had `position: relative` and it position the outline absolute https://github.com/umbraco/Umbraco-CMS/blob/a936fe09ab9c9c36130d5f8468dd21143ca39dc5/src/Umbraco.Web.UI.Client/src/less/application/umb-outline.less#L10, so the closest relative element was the parent container.

actually I am not sure why we have this?
https://github.com/umbraco/Umbraco-CMS/blob/a936fe09ab9c9c36130d5f8468dd21143ca39dc5/src/Umbraco.Web.UI.Client/src/less/modals.less#L122-L124

why not always `position: relative` when element as `btn` and `umb-outline` class? or maybe event moved to `umb-outline` class itself, because otherwise the outline would not be positioned at the element, but could be a parent container as in this case.

https://github.com/umbraco/Umbraco-CMS/blob/a936fe09ab9c9c36130d5f8468dd21143ca39dc5/src/Umbraco.Web.UI.Client/src/less/application/umb-outline.less#L6

- Outline of delete button
- Missing localization of title attribute due missing `@` prefix
- Added `pattern="[0-9]*"` which would give a more specific numeric virtual keyboard on e.g. tablets for number input.
- Incorrect end-closing `</div>`

https://github.com/umbraco/Umbraco-CMS/assets/2919859/bb071136-5cc2-4dcb-aa3f-f33c0717992e
