### PR TITLE
AddMapDefinition Extension Method

### DIFF
--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
@@ -1,6 +1,7 @@
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Dashboards;
 using Umbraco.Cms.Core.Manifest;
+using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Media;
 using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Routing;
@@ -118,6 +119,18 @@ public static partial class UmbracoBuilderExtensions
         where T : class, IUrlProvider
     {
         builder.UrlProviders().Append<T>();
+        return builder;
+    }
+
+    /// <summary>
+    /// Add an IMapDefinition to the MapDefinitionCollectionBuilder
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="builder"></param>
+    /// <returns></returns>
+    public static IUmbracoBuilder AddMapDefinition<T>(this IUmbracoBuilder builder) where T : IMapDefinition
+    {
+        builder.WithCollectionBuilder<MapDefinitionCollectionBuilder>().Add<T>();
         return builder;
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Add a simple extension method so that it's possible to register MapDefinitions directly from the Startup.cs class. 

Steps to test: 

- [x] Add a new IMapDefinition let's say `ProductMappingDefinition` or so.
- [x] Register the definition in the 'ConfigureServices' method in the `Startup.cs` class.
- [x] Use the Mapper somewhere in the code.
