### PR TITLE
Set max length of text input in tab creation

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/contenttype/umb-content-type-tab.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/contenttype/umb-content-type-tab.html
@@ -46,6 +46,7 @@
                     umb-auto-resize
                     val-server-field="{{ vm.valServerFieldName }}"
                     data-lpignore="true"
+                    maxlength="255"
                     required />
 
                 <div class="umb-group-builder__tab-val-message" ng-messages="tabNameForm.tabName.$error" show-validation-on-submit>


### PR DESCRIPTION
… to avoid server error due character lenth in database.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
If creating a tab with more than 255 characters (yeah I know it's a pretty long tab name and probably never happen in real world use-case - I hope not 😅) it would cause a server error due the maximum length in database, where the column length is 255 characters. 
It is similar issue in node name, where we have `maxlength="255"` set, so let's make this consistent.

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/7d4a2887-fcbf-435f-bfcb-11a5d1217f61)

