### PR TITLE
Replace attribute with `noPasswordManager` directive

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/contenttype/umb-content-type-group.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/contenttype/umb-content-type-group.html
@@ -22,7 +22,7 @@
                         ng-focus="vm.whenNameFocus()"
                         required
                         val-server-field="{{vm.valServerFieldName}}"
-                        data-lpignore="true" />
+                        no-password-manager />
 
                 <div class="umb-group-builder__group-title-val-message" ng-messages="groupNameForm.groupName.$error" show-validation-on-submit>
                     <div class="umb-validation-label -arrow-left" ng-message="valServerField">{{groupNameForm.groupName.errorMsg}}</div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/contenttype/umb-content-type-tab.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/contenttype/umb-content-type-tab.html
@@ -45,7 +45,7 @@
                     umb-auto-focus
                     umb-auto-resize
                     val-server-field="{{ vm.valServerFieldName }}"
-                    data-lpignore="true"
+                    no-password-manager
                     required />
 
                 <div class="umb-group-builder__tab-val-message" ng-messages="tabNameForm.tabName.$error" show-validation-on-submit>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR replaces a few ` data-lpignore="true"` I noticed with the `no-password-manager` added a while ago, which handle this https://github.com/umbraco/Umbraco-CMS/blob/1527b2577e7273157cfede70444c65f838a87225/src/Umbraco.Web.UI.Client/src/common/directives/util/noPasswordManager.directive.js#L21

but also other password managers in case added later.