### PR TITLE
Allow Media Picker 3 to be used as macro parameter editor

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/MediaPicker3PropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MediaPicker3PropertyEditor.cs
@@ -20,7 +20,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 /// </summary>
 [DataEditor(
     Constants.PropertyEditors.Aliases.MediaPicker3,
-    EditorType.PropertyValue,
+    EditorType.PropertyValue | EditorType.MacroParameter,
     "Media Picker",
     "mediapicker3",
     ValueType = ValueTypes.Json,

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/macroparameterpicker/macroparameterpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/macroparameterpicker/macroparameterpicker.html
@@ -31,7 +31,7 @@
 
                     <div ng-if="!vm.filterResult">
                         <div ng-repeat="(key,value) in vm.parameterEditors">
-                            <h5>{{key}}</h5>
+                            <h5>{{key | umbCmsTitleCase}}</h5>
                             <ul class="umb-card-grid -four-in-row" ng-mouseleave="vm.hideDetailsOverlay()">
                                 <li ng-repeat="parameterEditor in value | orderBy:'name'"
                                     data-element="editor-{{parameterEditor.name}}">
@@ -55,7 +55,7 @@
                         <div ng-if="vm.filterResult.totalResults > 0">
                             <div ng-repeat="result in vm.filterResult.parameterEditors">
                                 <div ng-if="result.parameterEditors.length > 0">
-                                    <h5>{{result.group}}</h5>
+                                    <h5>{{result.group | umbCmsTitleCase}}</h5>
                                     <ul class="umb-card-grid -four-in-row" ng-mouseleave="vm.hideDetailsOverlay()">
                                         <li ng-repeat="parameterEditor in result.parameterEditors | orderBy:'name'">
                                             <div ng-if="parameterEditor.loading" class="umb-card-grid-item__loading">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
I noticed we only have the legacy media picker as macro parameter editor. I think we should have a macro parameter editor to allow using Media Picker 3 instead of the legacy  media picker, because when/if `Umbraco.MediaPicker` and `Umbraco.MultipleMediaPicker` at some point are removed the macro parameter editors will stop working or be removed as well.

By default it use default configuration of property editor, but we could create more specific macro parameter editors.

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/2ff9d2b6-6610-426a-b6ff-4dad1ec14438)

In the screenshot above I also have this following, but it including this we probably don't need the pipe syntax to enable the property editor as macro parameter (using default configuration) as we explicit create a macro parameter editor.

```
using Umbraco.Cms.Core.IO;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Serialization;
using Umbraco.Cms.Core.Services;
using Umbraco.Cms.Core.Strings;

namespace Umbraco.Cms.Core.PropertyEditors.ParameterEditors;

/// <summary>
///     Represents a image picker macro parameter editor.
/// </summary>
[DataEditor(
    Constants.PropertyEditors.Aliases.MediaPicker3,
    EditorType.MacroParameter,
    "Image Picker",
    "imagepicker",
    ValueType = ValueTypes.Text)]
public class ImagePickerParameterEditor : DataEditor
{
    /// <summary>
    ///     Initializes a new instance of the <see cref="ImagePickerParameterEditor" /> class.
    /// </summary>
    public ImagePickerParameterEditor(
        IDataValueEditorFactory dataValueEditorFactory)
        : base(dataValueEditorFactory)
    {
        DefaultConfiguration.Add("multiple", "0");
        DefaultConfiguration.Add("validationLimit", "{ \"min\": 0, \"max\": 1 }");
        SupportsReadOnly = true;
    }

    protected override IDataValueEditor CreateValueEditor() =>
        DataValueEditorFactory.Create<MultipleMediaPickerPropertyValueEditor>(Attribute!);

    internal class MultipleMediaPickerPropertyValueEditor : MultiplePickerParamateterValueEditorBase
    {
        public MultipleMediaPickerPropertyValueEditor(
            ILocalizedTextService localizedTextService,
            IShortStringHelper shortStringHelper,
            IJsonSerializer jsonSerializer,
            IIOHelper ioHelper,
            DataEditorAttribute attribute,
            IEntityService entityService)
            : base(localizedTextService, shortStringHelper, jsonSerializer, ioHelper, attribute, entityService)
        {
        }

        public override string UdiEntityType { get; } = Constants.UdiEntityType.Media;

        public override UmbracoObjectTypes UmbracoObjectType { get; } = UmbracoObjectTypes.Media;
    }
}
```

Unlike data types I noticed macro parameters didn't title case the group key using `umbCmsTitleCase` filter, but it could potentially use `group` from first result in group (assuming the group has results):

https://github.com/umbraco/Umbraco-CMS/blob/1527b2577e7273157cfede70444c65f838a87225/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypepicker/datatypepicker.html#L32

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/be298945-8e7a-4c46-ac48-53a6b6b2d785)
