### PR TITLE
Change 'Comment' to 'Commentaar' in Dutch translation file

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
@@ -698,7 +698,7 @@
     <key alias="close">Sluiten</key>
     <key alias="closewindow">Sluit venster</key>
     <key alias="closepane">Sluit paneel</key>
-    <key alias="comment">Comment</key>
+    <key alias="comment">Commentaar</key>
     <key alias="confirm">Bevestig</key>
     <key alias="constrain">Beperken</key>
     <key alias="constrainProportions">Verhoudingen behouden</key>


### PR DESCRIPTION
Fix wrong translation in Dutch language file. Change 'comment' to 'Commentaar'