### PR TITLE
Fix method invoke.

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/GridPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/GridPropertyIndexValueFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 using System.Text;
@@ -91,6 +91,6 @@ namespace Umbraco.Cms.Core.PropertyEditors
 
         [Obsolete("Use the overload that specifies availableCultures, scheduled for removal in v14")]
         public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published)
-            => GetIndexValues(property, culture, segment, published);
+            => GetIndexValues(property, culture, segment, published, Enumerable.Empty<string>());
     }
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
@@ -328,6 +328,6 @@ public class RichTextPropertyEditor : DataEditor
 
         [Obsolete("Use the overload with the 'availableCultures' parameter instead, scheduled for removal in v14")]
         public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published)
-            => GetIndexValues(property, culture, segment, published);
+            => GetIndexValues(property, culture, segment, published, Enumerable.Empty<string>());
     }
 }


### PR DESCRIPTION
Fix issue #14556 by changing the method invocation for `Rich Text Editor` and `Grid Legacy` property editors.