### PR TITLE
Ensure that the Slider does not crash the back-office

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/SliderConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/SliderConfiguration.cs
@@ -14,12 +14,12 @@ public class SliderConfiguration
     [ConfigurationField("initVal2", "Initial value 2", "number", Description = "Used when range is enabled")]
     public decimal InitialValue2 { get; set; }
 
-    [ConfigurationField("minVal", "Minimum value", "number")]
+    [ConfigurationField("minVal", "Minimum value", "number", Description = "Must be smaller than the Maximum value")]
     public decimal MinimumValue { get; set; }
 
-    [ConfigurationField("maxVal", "Maximum value", "number")]
+    [ConfigurationField("maxVal", "Maximum value", "number", Description = "Must be larger than the Minimum value")]
     public decimal MaximumValue { get; set; }
 
-    [ConfigurationField("step", "Step increments", "number")]
+    [ConfigurationField("step", "Step increments", "number", Description = "Must be a positive value")]
     public decimal StepIncrements { get; set; }
 }

--- a/src/Umbraco.Core/PropertyEditors/SliderConfigurationEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/SliderConfigurationEditor.cs
@@ -25,4 +25,19 @@ public class SliderConfigurationEditor : ConfigurationEditor<SliderConfiguration
         ioHelper, editorConfigurationParser)
     {
     }
+
+    public override Dictionary<string, object> ToConfigurationEditor(SliderConfiguration? configuration)
+    {
+        // negative step increments can be configured in the back-office. they will cause the slider to
+        // crash the entire back-office. as we can't configure min and max values for the number prevalue
+        // editor, we have to this instead to limit the damage.
+        // logically, the step increments should be inverted instead of hardcoding them to 1, but the
+        // latter might point people in the direction of their misconfiguration.
+        if (configuration?.StepIncrements <= 0)
+        {
+            configuration.StepIncrements = 1;
+        }
+
+        return base.ToConfigurationEditor(configuration);
+    }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/14591

### Description

A negative value for the Slider step increments can crash the entire back-office. Unfortunately we can't limit the "number" prevalue editor to only positive values. Thus we have to be reactive instead, before the misconfiguration is applied.

This PR explicitly forces a step increment value of `1` if it's configured to a negative value - no matter what the configured negative value actually is. Likely the functionally correct thing would be to invert the configured value to its positive counterpart. However, this hardcoded `1` value will hopefully point people in the direction of their misconfiguration to fix it.

To further aid people configuring the Slider, I have added some field descriptions to the configuration:

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/d2018f18-f049-444a-8e52-bf72e8366ae5)

### Testing this PR

To test this PR, create a Slider with a negative step increment value and save it. After saving, the step increment value should reload and become `1`. 

Use the same slider in a doctype and create content of said type. The back-office should not crash 😛 and the step increments should be `1`.
