### PR TITLE
Ignore 1Password as well in `noPasswordManager` directive

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/util/noPasswordManager.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/util/noPasswordManager.directive.js
@@ -1,10 +1,10 @@
-﻿/**
+/**
 * @ngdoc directive
 * @name umbraco.directives.directive:noPasswordManager
 * @attribte
 * @function
 * @description
-* Added attributes to block password manager elements should as LastPass
+* Added attributes to tell password managers to ignore specific input fields and not inject elements via browser extensions.
 
 * @example
 * <example module="umbraco.directives">
@@ -18,7 +18,9 @@ angular.module("umbraco.directives")
         return {
             restrict: 'A',            
             link: function (scope, element, attrs) {                
-                element.attr("data-lpignore", "true");
+              element
+                .attr("data-lpignore", "true") // LastPass
+                .attr("data-1p-ignore", ""); // 1Password
             }
         }
     });

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-content-header.html
@@ -32,6 +32,7 @@
                                umb-auto-focus
                                focus-on-filled="true"
                                val-server-field="{{serverValidationNameField}}"
+                               no-password-manager
                                required
                                aria-required="true"
                                aria-invalid="{{contentForm.headerNameForm.headerName.$invalid ? true : false}}"

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-header.html
@@ -34,13 +34,12 @@
                 <div class="umb-editor-header__name-wrapper" ng-show="!nameLocked || !hideAlias">
                     <label for="headerName" class="sr-only" ng-show="accessibility.a11yNameVisible">{{accessibility.a11yName}}</label>
                     <ng-form name="headerNameForm">
-                        <input data-element="editor-name-field"
-                               no-password-manager
-                               type="text"
+                        <input type="text"
                                id="headerName"
                                class="umb-editor-header__name-input"
                                localize="placeholder"
                                placeholder="@placeholders_entername"
+                               data-element="editor-name-field"
                                name="headerName"
                                ng-show="!nameLocked"
                                ng-model="name"
@@ -48,6 +47,7 @@
                                umb-auto-focus
                                focus-on-filled="true"
                                val-server-field="Name"
+                               no-password-manager
                                ng-required="nameRequired != null ? nameRequired : true"
                                aria-required="{{nameRequired != null ? nameRequired : true}}"
                                aria-invalid="{{contentForm.headerNameForm.headerName.$invalid ? true : false}}"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
After my comment in https://github.com/umbraco/Umbraco-CMS/pull/14593#issuecomment-1651962698 I investigated this further and came across the thread started by @greystate here https://1password.community/discussion/117501/as-a-web-developer-how-can-i-disable-1password-filling-for-a-specific-field

I have come across that previously, but nothing seemed to happen besides hacky workaround like changing input type to e.g. `search` input type, which was a terrible idea.
But after several years it seems they finally went with the `data-*` attribute solution as well: https://1password.community/discussion/comment/677269/#Comment_677269

and even documented here: https://developer.1password.com/docs/web/compatible-website-design/#build-logical-forms

**Before**

![chrome_RcT48TRoia](https://github.com/umbraco/Umbraco-CMS/assets/2919859/b76b97ee-de08-40f1-a7cc-b3b07aa1f807)


**After**

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/f81abcd2-3fd7-4361-bdf6-5e37ae2058fd)



I noticed 1Password was also added the node name input, so I ensured it was added in header form as well. However it seems LastPass sometimes seems to ignore this. I noticed a few times the LastPass icon was added initially and then removed shortly after.

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/697ad680-aeab-4764-b23c-e5dd30867a65)

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/a1ed5965-834f-4ea1-83d2-17911852c5ac)
