### PR TITLE
Compile css for icons style

### DIFF
--- a/src/Umbraco.Web.UI.Client/gulp/config.js
+++ b/src/Umbraco.Web.UI.Client/gulp/config.js
@@ -36,6 +36,7 @@ module.exports = {
             preview: { files: "./src/less/canvas-designer.less", watch: "./src/less/**/*.less", out: "canvasdesigner.min.css" },
             umbraco: { files: "./src/less/belle.less", watch: "./src/**/*.less", out: "umbraco.min.css" },
             rteContent: { files: "./src/less/rte-content.less", watch: "./src/less/**/*.less", out: "rte-content.css" },
+            icons: { files: "./src/less/icons.less", watch: "./src/less/**/*.less", out: "icons.css" },
             blockgridui: { files: "./src/views/propertyeditors/blockgrid/blockgridui.less", watch: "./src/views/propertyeditors/blockgrid/blockgridui.less", out: "blockgridui.css" }
         },
 

--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -73,7 +73,8 @@
 @import "modals.less";
 @import "panel.less";
 @import "sections.less";
-@import "helveticons.less";
+//@import "helveticons.less";
+@import "icons.less";
 @import "main.less";
 @import "listview.less";
 @import "gridview.less";
@@ -150,7 +151,7 @@
 @import "components/umb-color-swatches.less";
 @import "components/check-circle.less";
 @import "components/umb-file-icon.less";
-@import "components/umb-icon.less";
+//@import "components/umb-icon.less";
 @import "components/umb-iconpicker.less";
 @import "components/umb-insert-code-box.less";
 @import "components/umb-packages.less";

--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -73,7 +73,6 @@
 @import "modals.less";
 @import "panel.less";
 @import "sections.less";
-//@import "helveticons.less";
 @import "icons.less";
 @import "main.less";
 @import "listview.less";

--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -150,7 +150,6 @@
 @import "components/umb-color-swatches.less";
 @import "components/check-circle.less";
 @import "components/umb-file-icon.less";
-//@import "components/umb-icon.less";
 @import "components/umb-iconpicker.less";
 @import "components/umb-insert-code-box.less";
 @import "components/umb-packages.less";

--- a/src/Umbraco.Web.UI.Client/src/less/icons.less
+++ b/src/Umbraco.Web.UI.Client/src/less/icons.less
@@ -1,0 +1,2 @@
+@import "helveticons.less";
+@import "components/umb-icon.less";

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridentryeditors/gridblock/gridblock.editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridentryeditors/gridblock/gridblock.editor.html
@@ -1,18 +1,5 @@
 <style>
-
-    .umb-icon {
-        display: inline-block;
-        width: 1em;
-        height: 1em;
-        flex-shrink: 0;
-    }
-
-    .umb-icon svg {
-        width: 100%;
-        height: 100%;
-        fill: currentColor;
-        animation: inherit;
-    }
+    @import 'assets/css/icons.css';
 
     .blockelement-gridblock-editor {
         position: relative;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridentryeditors/gridinlineblock/gridinlineblock.editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridentryeditors/gridinlineblock/gridinlineblock.editor.html
@@ -1,19 +1,5 @@
 <style>
-
-
-    .umb-icon {
-        display: inline-block;
-        width: 1em;
-        height: 1em;
-        flex-shrink: 0;
-    }
-
-    .umb-icon svg {
-        width: 100%;
-        height: 100%;
-        fill: currentColor;
-        animation: inherit;
-    }
+    @import 'assets/css/icons.css';
 
     .blockelement-gridinlineblock-editor {
         position: relative;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridentryeditors/gridsortblock/gridsortblock.editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridentryeditors/gridsortblock/gridsortblock.editor.html
@@ -1,23 +1,13 @@
 <style>
+    @import 'assets/css/icons.css';
+
     @keyframes umb-icon-jump {
         0%, 100% { transform: rotate(6deg); }
         50% { transform: rotate(-6deg); }
     }
 
     .umb-icon {
-        display: inline-block;
-        width: 1em;
-        height: 1em;
-        flex-shrink: 0;
-
         animation: umb-icon-jump 1s infinite ease-in-out;
-    }
-
-    .umb-icon svg {
-        width: 100%;
-        height: 100%;
-        fill: currentColor;
-        animation: inherit;
     }
 
     .blockelement-gridsortblock-editor {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridentryeditors/unsupportedblock/unsupportedblock.editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridentryeditors/unsupportedblock/unsupportedblock.editor.html
@@ -1,19 +1,5 @@
 <style>
-
-
-    .umb-icon {
-        display: inline-block;
-        width: 1em;
-        height: 1em;
-        flex-shrink: 0;
-    }
-
-    .umb-icon svg {
-        width: 100%;
-        height: 100%;
-        fill: currentColor;
-        animation: inherit;
-    }
+    @import 'assets/css/icons.css';
 
     .blockelement-unsupportedblock-editor {
         position: relative;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridui.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridui.less
@@ -1,5 +1,6 @@
 @import "../../../less/variables.less";
 @import "../../../less/mixins.less";
+@import "../../../less/helveticons.less";
 @import "../../../less/buttons.less";
 @import "../../../less/accessibility/sr-only.less";
 @import "../../../less/components/umb-icon.less";


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/14614

### Description
When rendering icons inside `<umb-block-grid-root>` and `<umb-block-grid-block>` it only rendered SVG icons and not legacy font icons like `icon-science` which doesn't have a SVG version here: https://github.com/umbraco/Umbraco-CMS/tree/contrib/src/Umbraco.Web.UI.Client/src/assets/icons

We should probably also add `icon-science.svg`, but font icons are still supported and developers may still use custom font icons (font packages) although SVG icons are the modern approach.

The PR also remove some redundant style if we sometime later need to adjust style of `<umb-icon>` component, this ensure icons in block grid are consistent. 

In the block grid view we probably need to adjust the CSS to include cache buster  like here:

https://github.com/umbraco/Umbraco-CMS/blob/71d990504ee583204b76f45e7bf6d336b5e04882/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbblockgridroot.component.js#L39

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/0d832959-b431-4a93-bf42-a3015e64ab6d)
