### PR TITLE
Allow newlines in invite emails

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
@@ -607,7 +607,7 @@ public class UsersController : BackOfficeNotificationsController
         var emailBody = _localizedTextService.Localize("user", "inviteEmailCopyFormat",
             // Ensure the culture of the found user is used for the email!
             UmbracoUserExtensions.GetUserCulture(to?.Language, _localizedTextService, _globalSettings),
-            new[] { userDisplay?.Name, from, message, inviteUri.ToString(), senderEmail });
+            new[] { userDisplay?.Name, from, WebUtility.HtmlEncode(message)!.ReplaceLineEndings("<br/>"), inviteUri.ToString(), senderEmail });
 
         // This needs to be in the correct mailto format including the name, else
         // the name cannot be captured in the email sending notification.


### PR DESCRIPTION
Allow newlines in invite email body.

# Test
- Invite a user (Requires SMTP to be setup)
  - Use message with new lines (Ensure replaced with html in mail)
  - Use message with html (Ensure encoded)