### PR TITLE
Fixes #14351 - Using Fallback to default langauge on a specific item changes the whole VariationContext 

### DIFF
--- a/src/Umbraco.Core/Extensions/PublishedElementExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedElementExtensions.cs
@@ -134,27 +134,6 @@ public static class PublishedElementExtensions
 
     #endregion
 
-    #region CheckVariation
-    /// <summary>
-    /// Method to check if VariationContext culture differs from culture parameter, if so it will update the VariationContext for the PublishedValueFallback.
-    /// </summary>
-    /// <param name="publishedValueFallback">The requested PublishedValueFallback.</param>
-    /// <param name="culture">The requested culture.</param>
-    /// <param name="segment">The requested segment.</param>
-    /// <returns></returns>
-    private static void EventuallyUpdateVariationContext(IPublishedValueFallback publishedValueFallback, string? culture, string? segment)
-    {
-        IVariationContextAccessor? variationContextAccessor = publishedValueFallback.VariationContextAccessor;
-
-        //If there is a difference in requested culture and the culture that is set in the VariationContext, it will pick wrong localized content.
-        //This happens for example using links to localized content in a RichText Editor.
-        if (!string.IsNullOrEmpty(culture) && variationContextAccessor?.VariationContext?.Culture != culture)
-        {
-            variationContextAccessor!.VariationContext = new VariationContext(culture, segment);
-        }
-    }
-    #endregion
-
     #region Value<T>
 
     /// <summary>
@@ -194,8 +173,6 @@ public static class PublishedElementExtensions
         T? defaultValue = default)
     {
         IPublishedProperty? property = content.GetProperty(alias);
-
-        EventuallyUpdateVariationContext(publishedValueFallback, culture, segment);
 
         // if we have a property, and it has a value, return that value
         if (property != null && property.HasValue(culture, segment))

--- a/src/Umbraco.Core/Models/PublishedContent/IPublishedValueFallback.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/IPublishedValueFallback.cs
@@ -6,11 +6,6 @@ namespace Umbraco.Cms.Core.Models.PublishedContent;
 public interface IPublishedValueFallback
 {
     /// <summary>
-    /// VariationContextAccessor that is not required to be implemented, therefore throws NotImplementedException as default.
-    /// </summary>
-    IVariationContextAccessor VariationContextAccessor { get { throw new NotImplementedException(); } set { throw new NotImplementedException(); } }
-
-    /// <summary>
     ///     Tries to get a fallback value for a property.
     /// </summary>
     /// <param name="property">The property.</param>

--- a/src/Umbraco.Core/Models/PublishedContent/IPublishedValueFallback.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/IPublishedValueFallback.cs
@@ -5,6 +5,12 @@ namespace Umbraco.Cms.Core.Models.PublishedContent;
 /// </summary>
 public interface IPublishedValueFallback
 {
+    [Obsolete("Scheduled for removal in v14")]
+    /// <summary>
+    /// VariationContextAccessor that is not required to be implemented, therefore throws NotImplementedException as default.
+    /// </summary>
+    IVariationContextAccessor VariationContextAccessor { get { throw new NotImplementedException(); } set { throw new NotImplementedException(); } }
+
     /// <summary>
     ///     Tries to get a fallback value for a property.
     /// </summary>

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedValueFallback.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedValueFallback.cs
@@ -20,8 +20,6 @@ public class PublishedValueFallback : IPublishedValueFallback
         _variationContextAccessor = variationContextAccessor;
     }
 
-    public IVariationContextAccessor VariationContextAccessor { get { return _variationContextAccessor; } }
-
     /// <inheritdoc />
     public bool TryGetValue(IPublishedProperty property, string? culture, string? segment, Fallback fallback, object? defaultValue, out object? value) =>
         TryGetValue<object>(property, culture, segment, fallback, defaultValue, out value);

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedValueFallback.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedValueFallback.cs
@@ -20,6 +20,9 @@ public class PublishedValueFallback : IPublishedValueFallback
         _variationContextAccessor = variationContextAccessor;
     }
 
+    [Obsolete("Scheduled for removal in v14")]
+    public IVariationContextAccessor VariationContextAccessor { get { return _variationContextAccessor; } }
+
     /// <inheritdoc />
     public bool TryGetValue(IPublishedProperty property, string? culture, string? segment, Fallback fallback, object? defaultValue, out object? value) =>
         TryGetValue<object>(property, culture, segment, fallback, defaultValue, out value);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [#14351](https://github.com/umbraco/Umbraco-CMS/issues/14351)

### Description
Fixing the bug where if using the the `.Value()` method with either a culture parameter or the fallback the whole site change state of the initial language set from the PublishedRouter.

This delete code was introduce by the PR [#13889](https://github.com/umbraco/Umbraco-CMS/pull/13889) but it made the VariationContext change now only for the current operation but the rest of the request. This means that if having a Danish site with fallback to english. So if you said `model.Value("someAlias", fallback: "en");` or using `model.Value("someAlias", "en");` the site end result for the users is a mismatch or both Danish and English content.

The best current solution is to reset it and avoid this bug is to do something like this:
```
var realContent = model.Value("someAlias", "en");
_ = model.Value("someAlias", "da");
```

Looking back to the original bug [#13889](https://github.com/umbraco/Umbraco-CMS/pull/13889)
The problem was inside a Blazor app where there was a language selector, so you could change the App from English to Swedish and back. The initial state was English. So clicked on the Swedish you hit this method.
```
private void SetEnglish()
{
  Content = "English";
  var en = new CultureInfo("en");
  CultureInfo.CurrentCulture = en;
  CultureInfo.CurrentUICulture = en;
  
  using (var scope = ScopeProvider.CreateScope(autoComplete: true))
  {
    using (var context = UmbracoContextFactory.EnsureUmbracoContext())
    {
    var settings = (Settings)context.UmbracoContext.Content.GetAtRoot().ElementAtOrDefault(1);
    Content = settings.Body.ToHtmlString();
    }
  }
}
```

But here we only changing the CultureInfo witch don´t change the way how the ModelsBuild choose the content. So the idea behind the bug and PR was with great intentions.

Problem is, that when navigating to a Blazor app, it either goes thouge the `PublishedRouter` and get set the correct VariationContext, or VariationContext is set to the default language set inside Umbraco. But all interaction is now in the app. So changing the language with the method above where we skip the routing pipeline, do not change the VariationContext for the request. The best way is to compare a Blazor App with Api Endpoint where the VariationContext is skipped as well.

So in the end if the method above was like this where we change the VariationContextAccessor.
```
private void SetEnglish()
{
  Content = "English";
  var en = new CultureInfo("en");
  CultureInfo.CurrentCulture = en;
  CultureInfo.CurrentUICulture = en;
  _variationContextAccessor.VariationContext = new VariationContext("en");
  
  using (var scope = ScopeProvider.CreateScope(autoComplete: true))
  {
    using (var context = UmbracoContextFactory.EnsureUmbracoContext())
    {
    var settings = (Settings)context.UmbracoContext.Content.GetAtRoot().ElementAtOrDefault(1);
    Content = settings.Body.ToHtmlString();
    }
  }
}
```
The bug was solved, and is streamline with what we normal do inside a Api-endpoint again where the variationContext setter is skipped so we need to manual set it, change or what we need to do, it is not enouge to change the systems CultureInfo.

This bug is affecting both Umbraco 10.5.0 and up, Umbraco 11.3 and up and Umbraco 12 and up.
Also, this bug renders all the documentation about fallbacks useless https://docs.umbraco.com/umbraco-cms/reference/querying/ipublishedcontent/properties#fallbacks do to the fact that the language for the entire request is changed as mentioned earlier.
This has been a huge breaking change, and has caused us a lot of headache in both tracking the bug down and afterwards trying to get it rectified by HQ. Hopefully we can get this fix in soon :slightly_smiling_face:

