### PR TITLE
Add cache buster to injected icons CSS in block grid

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridentryeditors/gridblock/gridblock.editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridentryeditors/gridblock/gridblock.editor.html
@@ -1,5 +1,5 @@
 <style>
-    .blockelement-gridblok-editor {
+    .blockelement-gridblock-editor {
         position: relative;
         border-radius: 3px;
         height: 100%;/* Add this to fill the cell fully */

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridentryeditors/gridblock/gridblock.editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridentryeditors/gridblock/gridblock.editor.html
@@ -1,7 +1,5 @@
 <style>
-    @import 'assets/css/icons.css';
-
-    .blockelement-gridblock-editor {
+    .blockelement-gridblok-editor {
         position: relative;
         border-radius: 3px;
         height: 100%;/* Add this to fill the cell fully */

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridentryeditors/gridinlineblock/gridinlineblock.editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridentryeditors/gridinlineblock/gridinlineblock.editor.html
@@ -1,6 +1,4 @@
 <style>
-    @import 'assets/css/icons.css';
-
     .blockelement-gridinlineblock-editor {
         position: relative;
         border-radius: 3px;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridentryeditors/gridsortblock/gridsortblock.editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridentryeditors/gridsortblock/gridsortblock.editor.html
@@ -1,6 +1,4 @@
 <style>
-    @import 'assets/css/icons.css';
-
     @keyframes umb-icon-jump {
         0%, 100% { transform: rotate(6deg); }
         50% { transform: rotate(-6deg); }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridentryeditors/unsupportedblock/unsupportedblock.editor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridentryeditors/unsupportedblock/unsupportedblock.editor.html
@@ -1,6 +1,4 @@
 <style>
-    @import 'assets/css/icons.css';
-
     .blockelement-unsupportedblock-editor {
         position: relative;
         display: block;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridui.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/blockgridui.less
@@ -1,9 +1,8 @@
 @import "../../../less/variables.less";
 @import "../../../less/mixins.less";
-@import "../../../less/helveticons.less";
+@import "../../../less/icons.less";
 @import "../../../less/buttons.less";
 @import "../../../less/accessibility/sr-only.less";
-@import "../../../less/components/umb-icon.less";
 
 @umb-block-grid__item_minimum_height: 48px;
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbblockgridblock.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbblockgridblock.component.js
@@ -49,16 +49,20 @@
             var shadowRoot = $element[0].attachShadow({ mode: 'open' });
             shadowRoot.innerHTML = 
             `
+                <style>@import "assets/css/icons.css?umb__rnd=${Umbraco.Sys.ServerVariables.application.cacheBuster}"</style>
+            
                 ${ model.stylesheet ? `
                     <style>
                         @import "${model.stylesheet}?umb__rnd=${Umbraco.Sys.ServerVariables.application.cacheBuster}"
                     </style>`
                     : ''
                 }
+                
                 <div 
                     style="display:contents;" 
                     ng-class="{'show-validation': vm.blockEditorApi.internal.showValidation}"
-                    ng-include="api.internal.sortMode ? api.internal.sortModeView : '${model.view}'"></div>
+                    ng-include="api.internal.sortMode ? api.internal.sortModeView : '${model.view}'">
+                </div>
             `;
             $compile(shadowRoot)($scope);
             


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Follow up on https://github.com/umbraco/Umbraco-CMS/pull/14615

### Description
Injecting icons CSS via Shadow DOM in block grid block with cache buster.

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/8a56219c-9c82-4516-8db9-faebde27fd7a)
