### PR TITLE
Fixed issue with disposed objects in async notifications

### DIFF
--- a/src/Umbraco.Core/Events/EventAggregator.Notifications.cs
+++ b/src/Umbraco.Core/Events/EventAggregator.Notifications.cs
@@ -238,7 +238,7 @@ internal class NotificationAsyncHandlerWrapperImpl<TNotificationType> : Notifica
     ///         confusion.
     ///     </para>
     /// </remarks>
-    public override Task HandleAsync<TNotification, TNotificationHandler>(
+    public override async Task HandleAsync<TNotification, TNotificationHandler>(
         IEnumerable<TNotification> notifications,
         CancellationToken cancellationToken,
         ServiceFactory serviceFactory,
@@ -256,7 +256,7 @@ internal class NotificationAsyncHandlerWrapperImpl<TNotificationType> : Notifica
             .Select(x => new Func<IEnumerable<TNotification>, CancellationToken, Task>(
                 (handlerNotifications, handlerCancellationToken) => x.HandleAsync(handlerNotifications.Cast<TNotificationType>(), handlerCancellationToken)));
 
-        return publish(handlers, notifications, cancellationToken);
+        await publish(handlers, notifications, cancellationToken);
     }
 }
 

--- a/src/Umbraco.Core/Events/EventAggregator.cs
+++ b/src/Umbraco.Core/Events/EventAggregator.cs
@@ -42,13 +42,13 @@ public partial class EventAggregator : IEventAggregator
     }
 
     /// <inheritdoc />
-    public Task PublishAsync<TNotification, TNotificationHandler>(IEnumerable<TNotification> notifications, CancellationToken cancellationToken = default)
+    public async Task PublishAsync<TNotification, TNotificationHandler>(IEnumerable<TNotification> notifications, CancellationToken cancellationToken = default)
         where TNotification : INotification
         where TNotificationHandler : INotificationHandler
     {
         PublishNotifications<TNotification, TNotificationHandler>(notifications);
 
-        return PublishNotificationsAsync<TNotification, TNotificationHandler>(notifications, cancellationToken);
+        await PublishNotificationsAsync<TNotification, TNotificationHandler>(notifications, cancellationToken);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/14574

### Description
Adds missing async-awaits on async methods related to async notifications.

### Tests
- See description on https://github.com/umbraco/Umbraco-CMS/issues/14574