### PR TITLE
V12: Remove avatar step from login

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/bs.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/bs.xml
@@ -1948,7 +1948,7 @@ Da upravljate svojom web lokacijom, jednostavno otvorite Umbraco backoffice i po
     <key alias="mailBody"><![CDATA[
       Zdravo %0%
 
-      Ovo je automatska pošta koja vas obavještava da je za 
+      Ovo je automatska pošta koja vas obavještava da je za
 	  dokument '%1%' zatražen prevod na '%5%' od %2%.
 
       Idi na http://%3%/translation/details.aspx?id=%4% za uređivanje.
@@ -2116,14 +2116,9 @@ Da upravljate svojom web lokacijom, jednostavno otvorite Umbraco backoffice i po
     <key alias="userInvitedSuccessHelp">Novom korisniku je poslana pozivnica s detaljima o tome kako se prijaviti
       Umbraco.
     </key>
-    <key alias="userinviteWelcomeMessage">Pozdrav i dobrodošli u Umbraco! Za samo 1 minut možete krenuti, mi
-      samo trebate postaviti lozinku i dodati sliku za svoj avatar.
-    </key>
+    <key alias="userinviteWelcomeMessage">Pozdrav i dobrodošli u Umbraco! Za samo 1 minut možete krenuti, mi samo trebate postaviti lozinku.</key>
     <key alias="userinviteExpiredMessage">Dobrodošli u Umbraco! Nažalost, vaš poziv je istekao. Molimo kontaktirajte svoju
       administratora i zamolite ih da ga ponovo pošalju.
-    </key>
-    <key alias="userinviteAvatarMessage">Ako otpremite svoju fotografiju, drugi korisnici će ga lako prepoznati
-       ti. Kliknite na krug iznad da otpremite svoju fotografiju.
     </key>
     <key alias="writer">Pisac</key>
     <key alias="change">Promjena</key>
@@ -2296,7 +2291,7 @@ Da upravljate svojom web lokacijom, jednostavno otvorite Umbraco backoffice i po
 		   1: Recommended value
 	  -->
     <key alias="macroErrorModeCheckSuccessMessage">Makro greške su postavljene na '%0%'.</key>
-    <key alias="macroErrorModeCheckErrorMessage">Greške makroa su postavljene na '%0%' što će spriječiti potpuno učitavanje nekih ili svih stranica 
+    <key alias="macroErrorModeCheckErrorMessage">Greške makroa su postavljene na '%0%' što će spriječiti potpuno učitavanje nekih ili svih stranica
 	  na vašem sajtu ako postoje greške u makroima. Ako ovo ispravite, vrijednost će biti postavljena na '%1%'.
     </key>
     <!-- The following keys get these tokens passed in:

--- a/src/Umbraco.Core/EmbeddedResources/Lang/cs.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/cs.xml
@@ -1754,9 +1754,8 @@
     <key alias="usergroup">Uživatelská skupina</key>
     <key alias="userInvited">byl pozván</key>
     <key alias="userInvitedSuccessHelp">Novému uživateli byla zaslána pozvánka s informacemi, jak se přihlásit do Umbraco.</key>
-    <key alias="userinviteWelcomeMessage">Dobrý den, vítejte v Umbraco! Za pouhou 1 minutu budete moci používat Umbraco. Jenom od vás potřebujeme, abyste si nastavili heslo a přidali obrázek pro svůj avatar.</key>
+    <key alias="userinviteWelcomeMessage">Dobrý den, vítejte v Umbraco! Za pouhou 1 minutu budete moci používat Umbraco. Jenom od vás potřebujeme, abyste si nastavili heslo.</key>
     <key alias="userinviteExpiredMessage">Vítejte v Umbraco! Vaše pozvánka bohužel vypršela. Obraťte se na svého správce a požádejte jej, aby jí znovu odeslal.</key>
-    <key alias="userinviteAvatarMessage">Nahrání vaší fotografie usnadní ostatním uživatelům, aby vás poznali. Kliknutím na kruh výše nahrajte svou fotku.</key>
     <key alias="writer">Spisovatel</key>
     <key alias="change">Změnit</key>
     <key alias="yourProfile" version="7.0">Váš profil</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/cy.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/cy.xml
@@ -576,7 +576,7 @@
   <area alias="dictionary">
     <key alias="noItems">Nid oes unrhyw eitemau geiriadur.</key>
     <key alias="importDictionaryItemHelp">
-      I fewnforio eitem geiriadur, dewch o hyd i'r ffeil ".udt" ar eich cyfrifiadur trwy glicio 
+      I fewnforio eitem geiriadur, dewch o hyd i'r ffeil ".udt" ar eich cyfrifiadur trwy glicio
       ar y botwm "Mewnforio" (bydd gofyn i chi am gadarnhad ar y sgrin nesaf)
     </key>
     <key alias="itemDoesNotExists">Nid yw eitem geiriadur yn bodoli.</key>
@@ -2308,9 +2308,8 @@ Er mwyn gweinyddu eich gwefan, agorwch swyddfa gefn Umbraco a dechreuwch ychwang
     <key alias="userGroups">Grwpiau defnyddiwr</key>
     <key alias="userInvited">wedi'i wahodd</key>
     <key alias="userInvitedSuccessHelp">Mae gwahoddiad wedi cael ei anfon at y defnyddiwr newydd gyda manylion ar sut i fewngofnodi i Umbraco.</key>
-    <key alias="userinviteWelcomeMessage">Helo a chroeso i Umbraco! Mewn 1 munud yn unig, byddech chi'n barod i fynd, rydym dim ond angen gosod cyfrinair a llun ar gyfer eich avatar.</key>
+    <key alias="userinviteWelcomeMessage">Helo a chroeso i Umbraco! Mewn 1 munud yn unig, byddech chi'n barod i fynd, rydym dim ond angen gosod cyfrinair.</key>
     <key alias="userinviteExpiredMessage">Croeso i Umbraco! Yn anffodus, mae eich gwahoddiad wedi terfynu. Cysylltwch â'ch gweinyddwr a gofynnwch iddynt ail-anfon.</key>
-    <key alias="userinviteAvatarMessage">Lanlwythwch lun i wneud o'n haws i boble eich adnabod chi.</key>
     <key alias="writer">Ysgrifennydd</key>
     <key alias="translator">Cyfieithydd</key>
     <key alias="change">Newid</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
@@ -1897,13 +1897,10 @@ Mange hilsner fra Umbraco robotten
       logger ind i Umbraco.
     </key>
     <key alias="userinviteWelcomeMessage">Hej og velkommen til Umbraco! På bare 1 minut vil du være klar til at komme i
-      gang, vi skal bare have dig til at oprette en adgangskode og tilføje et billede til din avatar.
+      gang, vi skal bare have dig til at oprette en adgangskode.
     </key>
     <key alias="userinviteExpiredMessage">Velkommen til Umbraco! Desværre er din invitation udløbet. Kontakt din
       administrator og bed om at gensende invitationen.
-    </key>
-    <key alias="userinviteAvatarMessage">Hvis du uploader et billede af dig selv, gør du det nemt for andre brugere at
-      genkende dig. Klik på cirklen ovenfor for at uploade et billede.
     </key>
     <key alias="writer">Forfatter</key>
     <key alias="configureTwoFactor">Konfigurer totrinsbekræftelse</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/de.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/de.xml
@@ -110,7 +110,7 @@
      Außerdem werden Pfade mit erstem URL-Segment unterstützt z. B.: "example.com/en" or "/en".]]></key>
     <key alias="inherit">Vererben</key>
     <key alias="setLanguage">Kultur</key>
-    <key alias="setLanguageHelp">Definiert die Kultureinstellung für untergeordnete Elemente dieses Elements oder vererbt vom übergeordneten Element. 
+    <key alias="setLanguageHelp">Definiert die Kultureinstellung für untergeordnete Elemente dieses Elements oder vererbt vom übergeordneten Element.
     Wird auch auf das aktuelle Element angewendet, sofern auf tieferer Ebene keine Domain zugeordnet ist.</key>
     <key alias="setDomains">Domainen</key>
   </area>
@@ -232,10 +232,10 @@
     <key alias="noMediaLink">Dieses Media-Element hat keinen Link</key>
     <key alias="noProperties">Diesem Element kann kein Inhalt zugewiesen werden</key>
     <key alias="otherElements">Eigenschaften</key>
-    <key alias="parentNotPublished">Dieses Dokument ist veröffentlicht aber nicht sichtbar, 
+    <key alias="parentNotPublished">Dieses Dokument ist veröffentlicht aber nicht sichtbar,
       da das übergeordnete Dokument '%0%' nicht publiziert ist
     </key>
-    <key alias="parentCultureNotPublished">Diese Kultur wurde veröffentlicht, aber wird nicht angezeigt, 
+    <key alias="parentCultureNotPublished">Diese Kultur wurde veröffentlicht, aber wird nicht angezeigt,
       weil sie auf dem Oberknoten '%0%' unveröffentlicht ist
     </key>
     <key alias="parentNotPublishedAnomaly">Ups! Dieses Dokument ist veröffentlicht aber nicht im internen Cache aufzufinden: Systemfehler.</key>
@@ -255,7 +255,7 @@
     <key alias="removeDate">Datum entfernen</key>
     <key alias="setDate">Datum wählen</key>
     <key alias="sortDone">Sortierung abgeschlossen</key>
-    <key alias="sortHelp">Um die Dokumente zu sortieren, ziehen Sie sie einfach an die gewünschte Position. 
+    <key alias="sortHelp">Um die Dokumente zu sortieren, ziehen Sie sie einfach an die gewünschte Position.
       Sie können mehrere Zeilen markieren indem Sie die Umschalttaste ("Shift") oder die Steuerungstaste ("Strg") gedrückt halten
     </key>
     <key alias="statistics">Statistiken</key>
@@ -281,7 +281,7 @@
       <![CDATA[<a href="https://docs.umbraco.com/umbraco-cms/fundamentals/data/scheduled-publishing#timezones" target="_blank" rel="noopener">Was bedeutet dies?</a>]]></key>
     <key alias="nestedContentDeleteItem">Wollen Sie dieses Element wirklich entfernen?</key>
     <key alias="nestedContentDeleteAllItems">Sicher das Sie alle Elemente entfernen wollen?</key>
-    <key alias="nestedContentEditorNotSupported">Eigenschaft %0% verwendet Editor %1%, 
+    <key alias="nestedContentEditorNotSupported">Eigenschaft %0% verwendet Editor %1%,
       welcher nicht von Nested Content unterstützt wird.
     </key>
     <key alias="nestedContentNoContentTypes">Keine Dokument-Typen für diese Eigenschaft konfiguriert.</key>
@@ -299,14 +299,14 @@
     <key alias="removeTextBox">Entferne dieses Textfeld</key>
     <key alias="contentRoot">Inhalt-Basis</key>
     <key alias="includeUnpublished">Inklusive Entwürfen: veröffentliche auch unveröffentlichte Elemente.</key>
-    <key alias="isSensitiveValue">Dieser Wert ist verborgen. 
+    <key alias="isSensitiveValue">Dieser Wert ist verborgen.
       Wenn Sie diesen Wert einsehen müssen, wenden Sie sich bitte an einen Administrator.
     </key>
     <key alias="isSensitiveValue_short">Dieser Wert ist verborgen.</key>
     <key alias="languagesToPublish">Welche Sprache möchten Sie veröffentlichen?</key>
     <key alias="languagesToSendForApproval">Welche Sprachen möchten Sie zur Freigabe schicken?</key>
     <key alias="languagesToSchedule">Welche Sprachen möchten Sie zu einer bestimmten Zeit veröffentlichen?</key>
-    <key alias="languagesToUnpublish">Wählen Sie die Sprachen, deren Veröffentlichung zurück genommen werden soll. 
+    <key alias="languagesToUnpublish">Wählen Sie die Sprachen, deren Veröffentlichung zurück genommen werden soll.
       Das Zurücknehmen der Veröffentlichung einer Pflichtsprache betrifft alle Sprachen.
     </key>
     <key alias="variantsWillBeSaved">Alle neuen Variationen werden gespeichert.</key>
@@ -335,7 +335,7 @@
     <key alias="createdBlueprintHeading">Inhaltsvorlage erzeugt</key>
     <key alias="createdBlueprintMessage">Inhaltsvorlage von '%0%' wurde erzeugt</key>
     <key alias="duplicateBlueprintMessage">Eine gleichnamige Inhaltsvorlage ist bereits vorhanden</key>
-    <key alias="blueprintDescription">Eine Inhaltsvorlage ist vordefinierter Inhalt, 
+    <key alias="blueprintDescription">Eine Inhaltsvorlage ist vordefinierter Inhalt,
       den ein Redakteur als Basis für neuen Inhalt verwenden kann
     </key>
   </area>
@@ -343,7 +343,7 @@
     <key alias="clickToUpload">Für Upload klicken</key>
     <key alias="orClickHereToUpload">oder klicken Sie hier um eine Datei zu wählen</key>
     <key alias="disallowedFileType">Dieser Dateityp darf nicht hochgeladen werden</key>
-    
+
     <key alias="invalidFileName">Diese Datei kann nicht hochgeladen werden wil der Dateiname ungültig ist.</key><key alias="disallowedMediaType">Diese Datei kann nicht hochgeladen werden, der Medienttype mit dem Alias '%0%' ist hier nicht erlaubt.</key>
     <key alias="maxFileSize">Max. Dateigröße ist</key>
     <key alias="mediaRoot">Media-Basis</key>
@@ -386,16 +386,16 @@
       <![CDATA[Es stehen keine erlaubten Dokumenttypen zur Verfügung. Sie müssen diese in den Einstellungen (unter "Dokumenttypen") aktivieren.]]></key>
     <key alias="noDocumentTypesAtRoot">
       <![CDATA[Es stehen keine erlaubten Dokumenttypen zur Verfügung. Sie müssen diese in den Einstellungen (unter "Dokumenttypen") aktivieren.]]></key>
-    <key alias="noDocumentTypesWithNoSettingsAccess">Die im Inhaltsbaum ausgewählte Seite 
+    <key alias="noDocumentTypesWithNoSettingsAccess">Die im Inhaltsbaum ausgewählte Seite
       erlaubt keine Unterseiten.
     </key>
     <key alias="noDocumentTypesEditPermissions">Bearbeitungsrechte für diesen Dokumenttyp</key>
     <key alias="noDocumentTypesCreateNew">Neuen Dokumenttypen erstellen</key>
     <key alias="noDocumentTypesAllowedAtRoot">
       <![CDATA[Keine Dokumenttypen vorhanden welche hier eingefügt werden dürfen. Sie müssen diese in den Einstellungen (unter "Dokumenttypen") aktivieren.]]></key>
-    <key alias="noMediaTypes" version="7.0"><![CDATA[Es stehen keine erlaubten Medientypen zur Verfügung. 
+    <key alias="noMediaTypes" version="7.0"><![CDATA[Es stehen keine erlaubten Medientypen zur Verfügung.
       Sie müssen diese in den Einstellungen (unter "Medientypen") aktivieren.]]></key>
-    <key alias="noMediaTypesWithNoSettingsAccess">Das im Strukturbaum ausgewählte Medienelement 
+    <key alias="noMediaTypesWithNoSettingsAccess">Das im Strukturbaum ausgewählte Medienelement
       erlaubt keine untergeordneten Elemente.
     </key>
     <key alias="noMediaTypesEditPermissions">Bearbeitungsrechte für diesen Medientyp</key>
@@ -444,15 +444,15 @@
     <key alias="stay">Bleiben</key>
     <key alias="discardChanges">Änderungen verwerfen</key>
     <key alias="unsavedChanges">Es gibt ungesicherte Änderungen</key>
-    <key alias="unsavedChangesWarning">Wollen Sie diese Seite wirklich verlassen? 
+    <key alias="unsavedChangesWarning">Wollen Sie diese Seite wirklich verlassen?
       - es gibt ungesicherte Änderungen
     </key>
     <key alias="confirmListViewPublish">Veröffentlichen macht die ausgewählten Elemente auf der Website sichtbar.</key>
-    <key alias="confirmListViewUnpublish">Aufheben der Veröffentlichung entfernt die ausgewählten Elemente 
+    <key alias="confirmListViewUnpublish">Aufheben der Veröffentlichung entfernt die ausgewählten Elemente
       und ihre Unterknoten von der Website.
     </key>
     <key alias="confirmUnpublish">Aufheben der Veröffentlichung entfernt diese Seite und ihre Unterseiten von der Website.</key>
-    <key alias="doctypeChangeWarning">Es gibt ungesicherte Änderungen. 
+    <key alias="doctypeChangeWarning">Es gibt ungesicherte Änderungen.
       Ändern des Dokumenttyps macht diese rückgängig.
     </key>
   </area>
@@ -518,7 +518,7 @@
     <key alias="permissionsSet">Berechtigungen vergeben für</key>
     <key alias="permissionsSetForGroup">Berechtigungen vergeben für %0% für Benutzer-Gruppe %1%</key>
     <key alias="permissionsHelp">Wählen Sie die Benutzer-Gruppe, deren Berechtigungen Sie setzen möchten</key>
-    <key alias="recycleBinDeleting">Der Papierkorb wird geleert. 
+    <key alias="recycleBinDeleting">Der Papierkorb wird geleert.
       Bitte warten Sie und schließen Sie das Fenster erst, wenn der Vorgang abgeschlossen ist.
     </key>
     <key alias="recycleBinIsEmpty">Der Papierkorb ist leer</key>
@@ -531,10 +531,10 @@
     <key alias="removeMacro">Macro entfernen</key>
     <key alias="requiredField">Pflichtfeld</key>
     <key alias="sitereindexed">Die Website-Index wurd neu erstellt</key>
-    <key alias="siterepublished">Der Zwischenspeicher der Website wurde aktualisiert und alle veröffentlichten Inhalte sind jetzt auf dem neuesten Stand. 
+    <key alias="siterepublished">Der Zwischenspeicher der Website wurde aktualisiert und alle veröffentlichten Inhalte sind jetzt auf dem neuesten Stand.
       Bisher unveröffentliche Inhalte wurden dabei nicht veröffentlicht.
     </key>
-    <key alias="siterepublishHelp">Der Zwischenspeicher der Website wird aktualisiert und der veröffentlichte Inhalt auf den neuesten Stand gebracht. 
+    <key alias="siterepublishHelp">Der Zwischenspeicher der Website wird aktualisiert und der veröffentlichte Inhalt auf den neuesten Stand gebracht.
       Unveröffentlichte Inhalte bleiben dabei weiterhin unveröffentlicht.
     </key>
     <key alias="tableColumns">Anzahl der Spalten</key>
@@ -696,21 +696,21 @@
     <key alias="wasMoved">wurde verschoben in</key>
     <key alias="hasReferencesDeleteConsequence">
       <![CDATA[Löschen von <strong>%0%</strong> wird die Eigenschaften und Daten von folgenden Element löschen]]></key>
-    <key alias="acceptDeleteConsequence">Ich verstehe das diese Aktion Eigenschaften und Daten basierend auf diesem 
+    <key alias="acceptDeleteConsequence">Ich verstehe das diese Aktion Eigenschaften und Daten basierend auf diesem
       DataTyps löschen wird.
     </key>
   </area>
   <area alias="errorHandling">
-    <key alias="errorButDataWasSaved">Ihre Daten wurden gespeichert. 
+    <key alias="errorButDataWasSaved">Ihre Daten wurden gespeichert.
       Bevor Sie diese Seite jedoch veröffentlichen können, müssen Sie die folgenden Korrekturen vornehmen:
     </key>
-    <key alias="errorChangingProviderPassword">Der aktuelle Mitgliedschaftsanbieter erlaubt keine Kennwortänderung 
+    <key alias="errorChangingProviderPassword">Der aktuelle Mitgliedschaftsanbieter erlaubt keine Kennwortänderung
       (EnablePasswordRetrieval muss auf "true" gesetzt sein)
     </key>
     <key alias="errorExistsWithoutTab">'%0%' ist bereits vorhanden</key>
     <key alias="errorHeader">Bitte prüfen und korrigieren:</key>
     <key alias="errorHeaderWithoutTab">Bitte prüfen und korrigieren:</key>
-    <key alias="errorInPasswordFormat">Für das Kennwort ist eine Mindestlänge von %0% Zeichen vorgesehen, 
+    <key alias="errorInPasswordFormat">Für das Kennwort ist eine Mindestlänge von %0% Zeichen vorgesehen,
       wovon mindestens %1% Sonderzeichen (nicht alphanumerisch) sein müssen
     </key>
     <key alias="errorIntegerWithoutTab">'%0%' muss eine Zahl sein</key>
@@ -724,7 +724,7 @@
     <key alias="concurrencyError">Optimistic concurrency Fehler, Objekte wurde geändert.</key>
     <key alias="receivedErrorFromServer">Der Server hat einen Fehler gemeldet</key>
     <key alias="dissallowedMediaType">Dieser Dateityp wird durch die Systemeinstellungen blockiert</key>
-    <key alias="codemirroriewarning">ACHTUNG! Obwohl CodeMirror in den Einstellungen aktiviert ist, 
+    <key alias="codemirroriewarning">ACHTUNG! Obwohl CodeMirror in den Einstellungen aktiviert ist,
       bleibt das Modul wegen mangelnder Stabilität in Internet Explorer deaktiviert.
     </key>
     <key alias="contentTypeAliasAndNameNotNull">Bitte geben Sie die Bezeichnung und den Alias des neuen Dokumenttyps ein.</key>
@@ -732,7 +732,7 @@
     <key alias="macroErrorLoadingPartialView">Fehler beim Laden einer "Partial View Kodedatei" (Datei: %0%)</key>
     <key alias="missingTitle">Bitte geben Sie einen Titel ein</key>
     <key alias="missingType">Bitte wählen Sie einen Typ</key>
-    <key alias="pictureResizeBiggerThanOrg">Soll die Abbildung wirklich über die 
+    <key alias="pictureResizeBiggerThanOrg">Soll die Abbildung wirklich über die
       Originalgröße hinaus vergrößert werden?
     </key>
     <key alias="startNodeDoesNotExists">Startelement gelöscht, bitte kontaktieren Sie den System-Administrator.</key>
@@ -957,7 +957,7 @@
       <![CDATA[
     Klicken Sie auf <strong>Installieren</strong>, um die Datenbank für Umbraco %0% einzurichten.
     ]]></key>
-    <key alias="databaseInstallDone">Die Datenbank wurde für Umbraco %0% konfiguriert. 
+    <key alias="databaseInstallDone">Die Datenbank wurde für Umbraco %0% konfiguriert.
       Klicken Sie auf &lt;strong&gt;weiter&lt;/strong&gt;, um fortzufahren.</key>
     <key alias="databaseText">Um diesen Schritt abzuschließen, müssen Sie die notwendigen Informationen zur Datenbankverbindung angeben.&lt;br /&gt;Bitte kontaktieren Sie Ihren Provider bzw. Server-Administrator für weitere Informationen.</key>
     <key alias="databaseUpgrade">
@@ -2059,9 +2059,8 @@
     <key alias="usergroup">Benutzergruppe</key>
     <key alias="userInvited">wurde eingeladen</key>
     <key alias="userInvitedSuccessHelp">Eine Einladung mit Anweisungen zur Anmeldung im Umbraco-Back-Office wurde dem neuen Benutzer zugeschickt.</key>
-    <key alias="userinviteWelcomeMessage">Hallo und Willkommen bei Umbraco! In nur einer Minute sind Sie bereit loszulegen, Sie müssen nur ein Kennwort festlegen und optional Ihrem Avatar ein Bild hinzufügen.</key>
+    <key alias="userinviteWelcomeMessage">Hallo und Willkommen bei Umbraco! In nur einer Minute sind Sie bereit loszulegen, Sie müssen nur ein Kennwort festlegen.</key>
     <key alias="userinviteExpiredMessage">Willkommen bei Umbraco! Bedauerlicherweise ist Ihre Einladung verfallen. Bitte kontaktieren Sie Ihren Administrator und bitten Sie ihn, diese erneut zu schicken.</key>
-    <key alias="userinviteAvatarMessage">Laden Sie ein Foto von sich hoch, um es anderen Benutzern zu erleichtern, sie zu erkennen. Klicken Sie auf den Kreis oben, um Ihr Foto hochzuladen.</key>
     <key alias="writer">Autor</key>
     <key alias="change">Änderung</key>
     <!--???-->
@@ -2339,7 +2338,7 @@
   </area>
   <area alias="contentTemplatesDashboard">
     <key alias="whatHeadline">Was sind Inhaltsvorlagen?</key>
-    <key alias="whatDescription">Inhaltsvorlagen sind vordefinierte Inhalte die ausgewählt werden können 
+    <key alias="whatDescription">Inhaltsvorlagen sind vordefinierte Inhalte die ausgewählt werden können
       wenn Sie einen neuen Inhaltsknoten anlegen wollen.
     </key>
     <key alias="createHeadline">Wie erstelle ich eine Inhaltsvorlage?</key>
@@ -2381,7 +2380,7 @@
     <key alias="FileWritingForPackages">Dateien durch Packages erstellen lassen</key>
     <key alias="FileWriting">Dateien schreiben</key>
     <key alias="MediaFolderCreation">Medien Ordner stellen</key>
-  </area>  
+  </area>
   <area alias="treeSearch">
     <key alias="searchResult">Element zurückgegeben</key>
     <key alias="searchResults">Elemente zurückgegeben</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -2127,13 +2127,10 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
       Umbraco.
     </key>
     <key alias="userinviteWelcomeMessage">Hello there and welcome to Umbraco! In just 1 minute you’ll be good to go, we
-      just need you to setup a password and add a picture for your avatar.
+      just need you to setup a password.
     </key>
     <key alias="userinviteExpiredMessage">Welcome to Umbraco! Unfortunately your invite has expired. Please contact your
       administrator and ask them to resend it.
-    </key>
-    <key alias="userinviteAvatarMessage">Uploading a photo of yourself will make it easy for other users to recognize
-      you. Click the circle above to upload your photo.
     </key>
     <key alias="writer">Writer</key>
     <key alias="change">Change</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -2224,13 +2224,10 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
       Umbraco.
     </key>
     <key alias="userinviteWelcomeMessage">Hello there and welcome to Umbraco! In just 1 minute you’ll be good to go, we
-      just need you to setup a password and add a picture for your avatar.
+      just need you to setup a password.
     </key>
     <key alias="userinviteExpiredMessage">Welcome to Umbraco! Unfortunately your invite has expired. Please contact your
       administrator and ask them to resend it.
-    </key>
-    <key alias="userinviteAvatarMessage">Uploading a photo of yourself will make it easy for other users to recognize
-      you. Click the circle above to upload your photo.
     </key>
     <key alias="writer">Writer</key>
     <key alias="configureTwoFactor">Configure Two-Factor</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/es.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/es.xml
@@ -1394,8 +1394,7 @@
     <key alias="usergroup">Grupo de usuario</key>
     <key alias="userInvited">ha sido invitado</key>
     <key alias="userInvitedSuccessHelp">Se ha enviado una invitación al nuevo usuario con detalles sobre cómo acceder a Umbraco.</key>
-    <key alias="userinviteWelcomeMessage">¡Hola y bienvenido a Umbraco!. En un minuto todo estará listo para empezar, sólo necesitamos que configures tu contraseña y una imagen para tu avatar.</key>
-    <key alias="userinviteAvatarMessage">Sube una foto para que otros usuarios te reconozcan más fácilmente.</key>
+    <key alias="userinviteWelcomeMessage">¡Hola y bienvenido a Umbraco!. En un minuto todo estará listo para empezar, sólo necesitamos que configures tu contraseña.</key>
     <key alias="writer">Redactor</key>
     <key alias="change">Cambiar</key>
     <key alias="yourProfile" version="7.0">Tu perfil</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/fr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/fr.xml
@@ -1795,9 +1795,8 @@ Pour gérer votre site, ouvrez simplement le backoffice Umbraco et commencez à 
     <key alias="usergroup">Groupe d'utilisateurs</key>
     <key alias="userInvited">a été invité</key>
     <key alias="userInvitedSuccessHelp">Une invitation a été envoyée au nouvel utilisateur avec les détails concernant la connexion à Umbraco.</key>
-    <key alias="userinviteWelcomeMessage">Bien le bonjour et bienvenue dans Umbraco! Vous serez prêt.e dans moins d'1 minute, vous devez encore simplement configurer votre mot de passe et ajouter une photo pour votre avatar.</key>
+    <key alias="userinviteWelcomeMessage">Bien le bonjour et bienvenue dans Umbraco! Vous serez prêt.e dans moins d'1 minute, vous devez encore simplement configurer votre mot de passe.</key>
     <key alias="userinviteExpiredMessage">Bienvenue dans Umbraco! Malheureusement, votre invitation a expiré. Veuillez contacter votre administrateur et demandez-lui de vous l'envoyer à nouveau.</key>
-    <key alias="userinviteAvatarMessage">Chargez une photo afin que les autres utilisateurs puissent vous reconnaître facilement. Cliquez sur le cercle ci-dessus pour charger votre photo.</key>
     <key alias="writer">Rédacteur</key>
     <key alias="change">Modifier</key>
     <key alias="yourProfile" version="7.0">Votre profil</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/hr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/hr.xml
@@ -1920,7 +1920,7 @@ Da bi upravljali svojom web lokacijom, jednostavno otvorite Umbraco backoffice i
     <key alias="mailBody"><![CDATA[
       Zdravo %0%
 
-      Ovo je automatska pošta koja vas obavještava da je za 
+      Ovo je automatska pošta koja vas obavještava da je za
 	  dokument '%1%' zatražen prijevod na '%5%' od %2%.
 
       Idi na http://%3%/translation/details.aspx?id=%4% za uređivanje.
@@ -2078,9 +2078,8 @@ Da bi upravljali svojom web lokacijom, jednostavno otvorite Umbraco backoffice i
     <key alias="usergroup">Grupa korisnika</key>
     <key alias="userInvited">je pozvan</key>
     <key alias="userInvitedSuccessHelp">Novom korisniku je poslana pozivnica s detaljima o tome kako se prijaviti u Umbraco.</key>
-    <key alias="userinviteWelcomeMessage">Pozdrav i dobrodošli u Umbraco! Jedna minuta bit će vam potrebna da postavite svoju lozinku i dodate svoju profilnu sliku.</key>
+    <key alias="userinviteWelcomeMessage">Pozdrav i dobrodošli u Umbraco! Jedna minuta bit će vam potrebna da postavite svoju lozinku.</key>
     <key alias="userinviteExpiredMessage">Dobrodošli u Umbraco! Nažalost pozivnica je istekla. Molimo kontaktirajte svog administratora i od njega tražite da ju ponovno pošalje.</key>
-    <key alias="userinviteAvatarMessage">AAko postavite svoju fotografiju, drugi korisnici će vas lako prepoznati. Kliknite krug iznad da biste prenijeli svoju fotografiju.</key>
     <key alias="writer">Pisac</key>
     <key alias="change">Promjeni</key>
     <key alias="yourProfile" version="7.0">Vaš profil</key>
@@ -2250,7 +2249,7 @@ Da bi upravljali svojom web lokacijom, jednostavno otvorite Umbraco backoffice i
 		   1: Recommended value
 	  -->
     <key alias="macroErrorModeCheckSuccessMessage">Makro greške su postavljene na '%0%'.</key>
-    <key alias="macroErrorModeCheckErrorMessage">Greške makroa su postavljene na '%0%' što će spriječiti potpuno učitavanje nekih ili svih stranica 
+    <key alias="macroErrorModeCheckErrorMessage">Greške makroa su postavljene na '%0%' što će spriječiti potpuno učitavanje nekih ili svih stranica
 	  na vašem sajtu ako postoje greške u makroima. Ako ovo ispravite, vrijednost će biti postavljena na '%1%'.
     </key>
     <!-- The following keys get these tokens passed in:

--- a/src/Umbraco.Core/EmbeddedResources/Lang/it.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/it.xml
@@ -2197,13 +2197,10 @@ Per gestire il tuo sito web, è sufficiente aprire il backoffice di Umbraco e in
     <key alias="userInvitedSuccessHelp">
       <![CDATA[Un invito è stato invitato al nuovo utente con le istruzioni su come effettuare il login in Umbraco.]]></key>
     <key alias="userinviteWelcomeMessage">Ciao e benvenuto su Umbraco! In solo 1 minuto sarai pronto a partire, dovrai
-      solamente impostare una password e aggiungere una foto profilo.
+      solamente impostare una password.
     </key>
     <key alias="userinviteExpiredMessage">
       <![CDATA[Benvenuto su Umbraco! Purtroppo il tuo invito è scaduto. Per favore contatta l'amministratore e chiedigli di rispedirlo.]]></key>
-    <key alias="userinviteAvatarMessage">Caricando una tua foto, gli altri utenti potranno riconoscerti facilmente. Fai
-      clic sul cerchio sopra per caricare la tua foto.
-    </key>
     <key alias="writer">Autore</key>
     <key alias="change">Modifica</key>
     <key alias="yourProfile" version="7.0">Il tuo profilo</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
@@ -1940,12 +1940,11 @@ Echter, Runway biedt een gemakkelijke basis om je snel op weg te helpen. Als je 
       te loggen in Umbraco
     </key>
     <key alias="userinviteWelcomeMessage">Hallo en welkom in Umbraco! Binnen ongeveer één minuut kan je aan de slag. Je
-      moet enkel je wachtwoord instellen en een foto toevoegen.
+      moet enkel je wachtwoord instellen.
     </key>
     <key alias="userinviteExpiredMessage">Welkom bij Umbraco! Helaas is je uitnodiging vervallen. Vraag aan je
       administrator om de uitnodiging opnieuw te versturen.
     </key>
-    <key alias="userinviteAvatarMessage">Wijzig je foto zodat andere gebruikers je makkelijk kunnen herkennen.</key>
     <key alias="writer">Auteur</key>
     <key alias="configureTwoFactor">Configureer tweestapsverificatie</key>
     <key alias="change">Wijzig</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/ru.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/ru.xml
@@ -1703,8 +1703,7 @@
     <key alias="usergroup">Группа пользователей</key>
     <key alias="userInvited"> был приглашен</key>
     <key alias="userInvitedSuccessHelp">Новому пользователю было отправлено приглашение, в котором содержатся инструкции для входа в панель Umbraco.</key>
-    <key alias="userinviteWelcomeMessage">Здравствуйте и добро пожаловать в Umbraco! Все будет готово в течении пары минут, нам лишь нужно задать Ваш пароль для входа и добавить аватар.</key>
-    <key alias="userinviteAvatarMessage">Загрузите изображение, это поможет другим пользователям идентифицировать Вас.</key>
+    <key alias="userinviteWelcomeMessage">Здравствуйте и добро пожаловать в Umbraco! Все будет готово в течении пары минут, нам лишь нужно задать Ваш пароль для входа.</key>
     <key alias="userManagement">Управление пользователями</key>
     <key alias="userPermissions">Разрешения для пользователя</key>
     <key alias="writer">Автор</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/tr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/tr.xml
@@ -1879,9 +1879,8 @@ Web sitenizi yönetmek için, Umbraco'nun arka ofisini açın ve içerik eklemey
     <key alias="usergroup">Kullanıcı grubu</key>
     <key alias="userInvited">davet edildi</key>
     <key alias="userInvitedSuccessHelp">Yeni kullanıcıya, Umbraco'da nasıl oturum açılacağına ilişkin ayrıntıları içeren bir davetiye gönderildi.</key>
-    <key alias="userinviteWelcomeMessage">Merhabalar, Umbraco'ya hoş geldiniz! Sadece 1 dakika içinde hazır olacaksınız, sadece bir şifre belirlemeniz ve avatarınız için bir resim eklemeniz gerekiyor.</key>
+    <key alias="userinviteWelcomeMessage">Merhabalar, Umbraco'ya hoş geldiniz! Sadece 1 dakika içinde hazır olacaksınız, sadece bir şifre belirlemeniz.</key>
     <key alias="userinviteExpiredMessage">Umbraco'ya hoş geldiniz! Maalesef davetinizin süresi doldu. Lütfen yöneticinizle iletişime geçin ve yeniden göndermesini isteyin.</key>
-    <key alias="userinviteAvatarMessage">Kendi fotoğrafınızı yüklemek, diğer kullanıcıların sizi tanımasını kolaylaştıracaktır. Fotoğrafınızı yüklemek için yukarıdaki daireyi tıklayın.</key>
     <key alias="writer">Yazar</key>
     <key alias="change">Değiştir</key>
     <key alias="yourProfile" version="7.0">Profiliniz</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/ua.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/ua.xml
@@ -1703,8 +1703,7 @@
     <key alias="usergroup">Група користувачів</key>
     <key alias="userInvited"> був запрошений</key>
     <key alias="userInvitedSuccessHelp">Новому користувачеві було надіслано запрошення, яке містить інструкції для входу в панель Umbraco.</key>
-    <key alias="userinviteWelcomeMessage">Привіт і ласкаво просимо до Umbraco! Все буде готове протягом декількох хвилин, нам потрібно задати пароль для входу і додати аватар.</key>
-    <key alias="userinviteAvatarMessage">Завантажте зображення, що допоможе іншим користувачам ідентифікувати Вас.</key>
+    <key alias="userinviteWelcomeMessage">Привіт і ласкаво просимо до Umbraco! Все буде готове протягом декількох хвилин, нам потрібно задати пароль для входу.</key>
     <key alias="userManagement">Управління користувачами</key>
     <key alias="userPermissions">Дозволи для користувача</key>
     <key alias="writer">Автор</key>

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
@@ -51,54 +51,6 @@
                 </div>
             </form>
 
-            <div class="form" ng-if="vm.inviteStep === 2">
-
-                <div class="flex justify-center items-center">
-
-                    <ng-form name="vm.avatarForm">
-
-                        <umb-progress-bar style="max-width: 100px; margin-bottom: 5px;"
-                                          ng-show="vm.avatarFile.uploadStatus === 'uploading'"
-                                          progress="{{ vm.avatarFile.uploadProgress }}"
-                                          size="s">
-                        </umb-progress-bar>
-
-                        <div class="umb-info-local-item text-error mt3" ng-if="vm.avatarFile.uploadStatus === 'error'">
-                            {{ vm.avatarFile.serverErrorMessage }}
-                        </div>
-
-                        <a class="umb-avatar-btn"
-                           ngf-select
-                           ng-model="vm.avatarFile.filesHolder"
-                           ngf-change="vm.changeAvatar($files, $event)"
-                           ngf-multiple="false"
-                           ngf-pattern="{{vm.avatarFile.acceptedFileTypes}}"
-                           ngf-max-size="{{ vm.avatarFile.maxFileSize }}">
-
-                            <umb-avatar color="gray"
-                                        size="xl"
-                                        unknown-char="+"
-                                        img-src="{{vm.invitedUser.avatars[3]}}"
-                                        img-srcset="{{vm.invitedUser.avatars[4]}} 2x, {{vm.invitedUser.avatars[4]}} 3x">
-                            </umb-avatar>
-                        </a>
-
-                    </ng-form>
-                </div>
-
-                <h1 style="margin-bottom: 10px;">Upload a photo</h1>
-                <p style="text-align: center; margin-bottom: 25px; line-height: 1.6em;">
-                    <localize key="user_userinviteAvatarMessage">Uploading a photo of yourself will make it easy for other users to recognize you. Click the circle above to upload your photo.</localize>
-                </p>
-                <div class="flex justify-center items-center">
-                    <umb-button type="button"
-                                button-style="success"
-                                label="Done"
-                                action="vm.getStarted()">
-                    </umb-button>
-                </div>
-            </div>
-
         </div>
         <div ng-show="vm.invitedUser == null && vm.inviteStep === 3" ng-if="!vm.denyLocalLogin && vm.inviteStep === 3" class="umb-login-container">
             <div class="form">

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
@@ -11,7 +11,7 @@
         <div ng-if="!vm.denyLocalLogin" ng-show="vm.invitedUser != null" class="umb-login-container">
 
             <form name="vm.inviteUserPasswordForm" novalidate="" ng-submit="vm.inviteSavePassword()" val-form-manager>
-                <div class="form" ng-if="vm.inviteStep === 1 || vm.inviteStep === 2">
+                <div class="form" ng-if="vm.inviteStep === 1">
                     <h1 style="margin-bottom: 10px; text-align: left;">Hi, {{vm.invitedUser.name}}</h1>
                     <p style="line-height: 1.6; margin-bottom: 25px;">
                         <localize key="user_userinviteWelcomeMessage">Welcome to Umbraco! Just need to get your password setup and then you're good to go</localize>
@@ -50,6 +50,10 @@
                         </div>
                     </div>
 
+                </div>
+                <div class="form" ng-if="vm.inviteStep === 2">
+                  <h1 style="margin-bottom: 10px; text-align: left;">
+                    <localize key="general_welcome">Welcome...</localize></h1>
                 </div>
             </form>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
@@ -58,6 +58,11 @@
                 <p style="line-height: 1.6; margin-bottom: 25px;">
                     <localize key="user_userinviteExpiredMessage">Welcome to Umbraco! Unfortunately your invite has expired. Please contact your administrator and ask them to resend it.</localize>
                 </p>
+                <p>
+                  <a href="#" ng-href="#/login" style="text-decoration: underline;">
+                    <localize key="login_returnToLogin">Return to login form</localize>
+                  </a>
+                </p>
             </div>
         </div>
         <div ng-show="vm.invitedUser == null && !vm.inviteStep" class="umb-login-container">

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
@@ -11,41 +11,43 @@
         <div ng-if="!vm.denyLocalLogin" ng-show="vm.invitedUser != null" class="umb-login-container">
 
             <form name="vm.inviteUserPasswordForm" novalidate="" ng-submit="vm.inviteSavePassword()" val-form-manager>
-                <div class="form" ng-if="vm.inviteStep === 1">
+                <div class="form" ng-if="vm.inviteStep === 1 || vm.inviteStep === 2">
                     <h1 style="margin-bottom: 10px; text-align: left;">Hi, {{vm.invitedUser.name}}</h1>
                     <p style="line-height: 1.6; margin-bottom: 25px;">
-                        <localize key="user_userinviteWelcomeMessage">Welcome to Umbraco! Just need to get your password and avatar setup and then you're good to go</localize>
+                        <localize key="user_userinviteWelcomeMessage">Welcome to Umbraco! Just need to get your password setup and then you're good to go</localize>
                     </p>
 
-                    <div class="control-group" ng-class="{error: vm.setPasswordForm.password.$invalid}">
-                        <label for="umb-passwordOne">
-                            <localize key="user_newPassword">New password</localize>
-                            <small style="font-size: 13px;">{{vm.invitedUserPasswordModel.passwordPolicyText}}</small>
-                        </label>
-                        <input type="password" ng-model="vm.invitedUserPasswordModel.password" name="password" id="umb-passwordOne" class="-full-width-input" umb-auto-focus required val-server-field="value" ng-minlength="{{vm.invitedUserPasswordModel.passwordPolicies.minPasswordLength}}" spellcheck="false" />
-                        <span ng-messages="inviteUserPasswordForm.password.$error" show-validation-on-submit>
-                            <span class="help-inline" ng-message="required"><localize key="user_passwordIsBlank">Your new password cannot be blank!</localize></span>
-                            <span class="help-inline" ng-message="minlength">Minimum {{vm.invitedUserPasswordModel.passwordPolicies.minPasswordLength}} characters</span>
-                            <span class="help-inline" ng-message="valServerField">{{inviteUserPasswordForm.password.errorMsg}}</span>
-                        </span>
-                    </div>
+                    <div ng-if="vm.inviteStep === 1">
+                        <div class="control-group" ng-class="{error: vm.setPasswordForm.password.$invalid}">
+                            <label for="umb-passwordOne">
+                                <localize key="user_newPassword">New password</localize>
+                                <small style="font-size: 13px;">{{vm.invitedUserPasswordModel.passwordPolicyText}}</small>
+                            </label>
+                            <input type="password" ng-model="vm.invitedUserPasswordModel.password" name="password" id="umb-passwordOne" class="-full-width-input" umb-auto-focus required val-server-field="value" ng-minlength="{{vm.invitedUserPasswordModel.passwordPolicies.minPasswordLength}}" spellcheck="false" />
+                            <span ng-messages="inviteUserPasswordForm.password.$error" show-validation-on-submit>
+                                <span class="help-inline" ng-message="required"><localize key="user_passwordIsBlank">Your new password cannot be blank!</localize></span>
+                                <span class="help-inline" ng-message="minlength">Minimum {{vm.invitedUserPasswordModel.passwordPolicies.minPasswordLength}} characters</span>
+                                <span class="help-inline" ng-message="valServerField">{{inviteUserPasswordForm.password.errorMsg}}</span>
+                            </span>
+                        </div>
 
-                    <div class="control-group" ng-class="{error: vm.setPasswordForm.confirmPassword.$invalid}">
-                        <label for="umb-confirmPasswordOne"><localize key="user_confirmNewPassword">Confirm new password</localize></label>
-                        <input type="password" ng-model="vm.invitedUserPasswordModel.confirmPassword" name="confirmPassword" id="umb-confirmPasswordOne" class="-full-width-input" required val-compare="password" spellcheck="false"/>
-                        <span ng-messages="inviteUserPasswordForm.confirmPassword.$error" show-validation-on-submit>
-                            <span class="help-inline" ng-message="required"><localize key="general_required">Required</localize></span>
-                            <span class="help-inline" ng-message="valCompare"><localize key="user_passwordMismatch">The confirmed password doesn't match the new password!</localize></span>
-                        </span>
+                        <div class="control-group" ng-class="{error: vm.setPasswordForm.confirmPassword.$invalid}">
+                            <label for="umb-confirmPasswordOne"><localize key="user_confirmNewPassword">Confirm new password</localize></label>
+                            <input type="password" ng-model="vm.invitedUserPasswordModel.confirmPassword" name="confirmPassword" id="umb-confirmPasswordOne" class="-full-width-input" required val-compare="password" spellcheck="false"/>
+                            <span ng-messages="inviteUserPasswordForm.confirmPassword.$error" show-validation-on-submit>
+                                <span class="help-inline" ng-message="required"><localize key="general_required">Required</localize></span>
+                                <span class="help-inline" ng-message="valCompare"><localize key="user_passwordMismatch">The confirmed password doesn't match the new password!</localize></span>
+                            </span>
 
-                    </div>
+                        </div>
 
-                    <div class="flex justify-between items-center">
-                        <umb-button type="submit"
-                                    button-style="success"
-                                    state="vm.invitedUserPasswordModel.buttonState"
-                                    label="Save password">
-                        </umb-button>
+                        <div class="flex justify-between items-center">
+                            <umb-button type="submit"
+                                        button-style="success"
+                                        state="vm.invitedUserPasswordModel.buttonState"
+                                        label="Save password">
+                            </umb-button>
+                        </div>
                     </div>
 
                 </div>


### PR DESCRIPTION
### Description

Resolves #13727

The avatar screen on the user invite flow on the login page has not worked since around the release of v10. There have been a lot of issues around uploading on the login screen, and it is a potential attack vector, so we have decided to remove the avatar step altogether.

Instead of landing on "step 2: upload avatar" the invite form will now be hidden and you will be redirected to the backoffice shortly thereafter when the app has been initialized:

https://github.com/umbraco/Umbraco-CMS/assets/752371/c6b07289-1481-4182-9fc0-c5adc5a7d177

