### PR TITLE
feat: Show published state in tree picker

### DIFF
--- a/src/Umbraco.Infrastructure/Models/Mapping/EntityMapDefinition.cs
+++ b/src/Umbraco.Infrastructure/Models/Mapping/EntityMapDefinition.cs
@@ -276,6 +276,11 @@ public class EntityMapDefinition : IMapDefinition
         {
             target.AdditionalData.Add("contentType", source.Values[ExamineFieldNames.ItemTypeFieldName]);
         }
+
+        if (source.Values.ContainsKey(UmbracoExamineFieldNames.PublishedFieldName))
+        {
+            target.AdditionalData.Add("published", string.Equals(source.Values[UmbracoExamineFieldNames.PublishedFieldName], "y", StringComparison.InvariantCultureIgnoreCase));
+        }
     }
 
     private static string? MapContentTypeIcon(IEntitySlim entity)

--- a/src/Umbraco.Infrastructure/Search/UmbracoTreeSearcherFields.cs
+++ b/src/Umbraco.Infrastructure/Search/UmbracoTreeSearcherFields.cs
@@ -73,6 +73,8 @@ public class UmbracoTreeSearcherFields : IUmbracoTreeSearcherFields
             fields.Add(field);
         }
 
+        fields.Add(UmbracoExamineFieldNames.PublishedFieldName);
+
         return fields;
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/tree/umb-tree.less
@@ -257,6 +257,9 @@ body.touch .umb-tree {
     > .umb-tree-item__inner > a {
         opacity: 0.6;
     }
+    &.umb-search-group-item {
+        opacity: 0.6;
+    }
 }
 
 .not-allowed {

--- a/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-results.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tree/umb-tree-search-results.html
@@ -7,7 +7,7 @@
     <ul class="umb-tree">
         <li class="root">
             <ul class="umb-search-group">
-                <li class="umb-search-group-item" ng-repeat="result in results">
+                <li class="umb-search-group-item" ng-class="{ 'not-published': !result.metaData.published }" ng-repeat="result in results">
                     <div ng-class="{ 'umb-tree-node-checked': result.selected }">
                         <button type="button"
                                 class="btn-reset umb-search-group-item-link"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #14590

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

This adds the 0.6 opacity on nodes that are not published
![image](https://github.com/umbraco/Umbraco-CMS/assets/24605285/8270dae3-1eb8-44a9-b1d3-8fd7e0a97765)

To test create a multi-node tree picker and have som content that is published and not published and try searching for it. The unpublished content will show as more transparent.

<!-- Thanks for contributing to Umbraco CMS! -->
