### PR TITLE
Fix Switching property from Block Grid to Block List errors

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorValues.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorValues.cs
@@ -14,14 +14,14 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 /// </summary>
 internal class BlockEditorValues
 {
-    private readonly Lazy<Dictionary<Guid, IContentType>> _contentTypes;
     private readonly BlockEditorDataConverter _dataConverter;
+    private readonly IContentTypeService _contentTypeService;
     private readonly ILogger _logger;
 
     public BlockEditorValues(BlockEditorDataConverter dataConverter, IContentTypeService contentTypeService, ILogger logger)
     {
-        _contentTypes = new Lazy<Dictionary<Guid, IContentType>>(() => contentTypeService.GetAll().ToDictionary(c => c.Key));
         _dataConverter = dataConverter;
+        _contentTypeService = contentTypeService;
         _logger = logger;
     }
 
@@ -66,11 +66,7 @@ internal class BlockEditorValues
         return blockEditorData;
     }
 
-    private IContentType? GetElementType(BlockItemData item)
-    {
-        _contentTypes.Value.TryGetValue(item.ContentTypeKey, out IContentType? contentType);
-        return contentType;
-    }
+    private IContentType? GetElementType(BlockItemData item) => _contentTypeService.Get(item.ContentTypeKey);
 
     private bool ResolveBlockItemData(BlockItemData block, Dictionary<string, Dictionary<string, IPropertyType>> contentTypePropertyTypes)
     {


### PR DESCRIPTION
### Linked issue
#14433 

### Description
Bugfix 31584 - Remove Lazy "caching" that retains keys of deleted Content Types which causes unnecessary validation errors

The validation errors should not happen as the model mapping cleans up block data for entity types that do not longer exist (which is checked on the aforementioned key)

### Reproduction steps
- Create an element doctype named "Asset" with any number of properties
- Create a datatype named "BL - Assets" with property editor "Block List" and add the "Asset" element type to the available blocks
- Create a datatype named "BG - Assets" with property editor "Block Grid" and add the "Asset" element type to the available blocks
- Create an element doctype named "Assets" with a single property named "items" of datatype "BG - Assets"

- Create a datatype named "Grid" with property editor "Block Grid" and add the "Assets" element type to the available blocks
- Create a document type with a property of type "Grid" (enable allow as root)

- Create a test page of the newly create doctype and fill in all the properties, Save And Publish
- Change the datatype of the "items" property on the "Assets" doctype from "BG - Assets" to "BL - Assets" and save the datatype
- Delete datatype "BG - Assets"
- Save and publish the test page without opening the property.

No error should show up.