### PR TITLE
Add config so it is configurable whether to explicitly index each nested property

### DIFF
--- a/src/JsonSchema/AppSettings.cs
+++ b/src/JsonSchema/AppSettings.cs
@@ -51,6 +51,7 @@ namespace JsonSchema
                 public ImagingSettings? Imaging { get; set; }
 
                 public IndexCreatorSettings? Examine { get; set; }
+                public IndexingSettings? Indexing { get; set; }
 
                 public KeepAliveSettings? KeepAlive { get; set; }
 

--- a/src/Umbraco.Core/Configuration/Models/IndexCreatorSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/IndexCreatorSettings.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using System.ComponentModel;
-
 namespace Umbraco.Cms.Core.Configuration.Models;
 
 /// <summary>
@@ -11,16 +9,8 @@ namespace Umbraco.Cms.Core.Configuration.Models;
 [UmbracoOptions(Constants.Configuration.ConfigExamine)]
 public class IndexCreatorSettings
 {
-    private const bool StaticExplicitlyIndexEachNestedProperty = true;
-
     /// <summary>
     ///     Gets or sets a value for lucene directory factory type.
     /// </summary>
     public LuceneDirectoryFactory LuceneDirectoryFactory { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value for whether each nested property should have it's own indexed value. Requires a rebuild of indexes when changed.
-    /// </summary>
-    [DefaultValue(StaticExplicitlyIndexEachNestedProperty)]
-    public bool ExplicitlyIndexEachNestedProperty { get; set; } = StaticExplicitlyIndexEachNestedProperty;
 }

--- a/src/Umbraco.Core/Configuration/Models/IndexCreatorSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/IndexCreatorSettings.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System.ComponentModel;
+
 namespace Umbraco.Cms.Core.Configuration.Models;
 
 /// <summary>
@@ -9,8 +11,16 @@ namespace Umbraco.Cms.Core.Configuration.Models;
 [UmbracoOptions(Constants.Configuration.ConfigExamine)]
 public class IndexCreatorSettings
 {
+    private const bool StaticExplicitlyIndexEachNestedProperty = true;
+
     /// <summary>
     ///     Gets or sets a value for lucene directory factory type.
     /// </summary>
     public LuceneDirectoryFactory LuceneDirectoryFactory { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value for whether each nested property should have it's own indexed value. Requires a rebuild of indexes when changed.
+    /// </summary>
+    [DefaultValue(StaticExplicitlyIndexEachNestedProperty)]
+    public bool ExplicitlyIndexEachNestedProperty { get; set; } = StaticExplicitlyIndexEachNestedProperty;
 }

--- a/src/Umbraco.Core/Configuration/Models/IndexingSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/IndexingSettings.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel;
+
+namespace Umbraco.Cms.Core.Configuration.Models;
+
+/// <summary>
+///     Typed configuration options for index creator settings.
+/// </summary>
+[UmbracoOptions(Constants.Configuration.ConfigIndexing)]
+public class IndexingSettings
+{
+    private const bool StaticExplicitlyIndexEachNestedProperty = true;
+
+    /// <summary>
+    /// Gets or sets a value for whether each nested property should have it's own indexed value. Requires a rebuild of indexes when changed.
+    /// </summary>
+    [DefaultValue(StaticExplicitlyIndexEachNestedProperty)]
+    public bool ExplicitlyIndexEachNestedProperty { get; set; } = StaticExplicitlyIndexEachNestedProperty;
+}

--- a/src/Umbraco.Core/Constants-Configuration.cs
+++ b/src/Umbraco.Core/Constants-Configuration.cs
@@ -38,6 +38,7 @@ public static partial class Constants
         public const string ConfigHosting = ConfigPrefix + "Hosting";
         public const string ConfigImaging = ConfigPrefix + "Imaging";
         public const string ConfigExamine = ConfigPrefix + "Examine";
+        public const string ConfigIndexing = ConfigPrefix + "Indexing";
         public const string ConfigKeepAlive = ConfigPrefix + "KeepAlive";
         public const string ConfigLogging = ConfigPrefix + "Logging";
         public const string ConfigMemberPassword = ConfigPrefix + "Security:MemberPassword";

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Configuration.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Configuration.cs
@@ -65,7 +65,7 @@ public static partial class UmbracoBuilderExtensions
             .AddUmbracoOptions<HealthChecksSettings>()
             .AddUmbracoOptions<HostingSettings>()
             .AddUmbracoOptions<ImagingSettings>()
-            .AddUmbracoOptions<IndexCreatorSettings>()
+            .AddUmbracoOptions<IndexingSettings>()
             .AddUmbracoOptions<KeepAliveSettings>()
             .AddUmbracoOptions<LoggingSettings>()
             .AddUmbracoOptions<MemberPasswordConfigurationSettings>()

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Configuration.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Configuration.cs
@@ -50,6 +50,7 @@ public static partial class UmbracoBuilderExtensions
         builder
             .AddUmbracoOptions<ModelsBuilderSettings>()
             .AddUmbracoOptions<ActiveDirectorySettings>()
+            .AddUmbracoOptions<IndexCreatorSettings>()
             .AddUmbracoOptions<MarketplaceSettings>()
             .AddUmbracoOptions<ContentSettings>()
             .AddUmbracoOptions<CoreDebugSettings>()

--- a/src/Umbraco.Core/PropertyEditors/JsonPropertyIndexValueFactoryBase.cs
+++ b/src/Umbraco.Core/PropertyEditors/JsonPropertyIndexValueFactoryBase.cs
@@ -15,18 +15,18 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 public abstract class JsonPropertyIndexValueFactoryBase<TSerialized> : IPropertyIndexValueFactory
 {
     private readonly IJsonSerializer _jsonSerializer;
-    private IndexCreatorSettings _indexCreatorSettings;
+    private IndexingSettings _indexingSettings;
 
     protected bool ForceExplicitlyIndexEachNestedProperty { get; set; }
 
     /// <summary>
     ///  Constructor for the JsonPropertyIndexValueFactoryBase.
     /// </summary>
-    protected JsonPropertyIndexValueFactoryBase(IJsonSerializer jsonSerializer, IOptionsMonitor<IndexCreatorSettings> indexCreatorSettings)
+    protected JsonPropertyIndexValueFactoryBase(IJsonSerializer jsonSerializer, IOptionsMonitor<IndexingSettings> indexingSettings)
     {
         _jsonSerializer = jsonSerializer;
-        _indexCreatorSettings = indexCreatorSettings.CurrentValue;
-        indexCreatorSettings.OnChange(x => _indexCreatorSettings = x);
+        _indexingSettings = indexingSettings.CurrentValue;
+        indexingSettings.OnChange(x => _indexingSettings = x);
     }
 
 
@@ -34,7 +34,7 @@ public abstract class JsonPropertyIndexValueFactoryBase<TSerialized> : IProperty
     ///  Constructor for the JsonPropertyIndexValueFactoryBase.
     /// </summary>
     [Obsolete("Use non-obsolete constructor. This will be removed in Umbraco 14.")]
-    protected JsonPropertyIndexValueFactoryBase(IJsonSerializer jsonSerializer): this(jsonSerializer, StaticServiceProvider.Instance.GetRequiredService<IOptionsMonitor<IndexCreatorSettings>>())
+    protected JsonPropertyIndexValueFactoryBase(IJsonSerializer jsonSerializer): this(jsonSerializer, StaticServiceProvider.Instance.GetRequiredService<IOptionsMonitor<IndexingSettings>>())
     {
 
     }
@@ -78,7 +78,7 @@ public abstract class JsonPropertyIndexValueFactoryBase<TSerialized> : IProperty
         }
 
         IEnumerable<KeyValuePair<string, IEnumerable<object?>>> summary = HandleResume(result, property, culture, segment, published);
-        if (_indexCreatorSettings.ExplicitlyIndexEachNestedProperty || ForceExplicitlyIndexEachNestedProperty)
+        if (_indexingSettings.ExplicitlyIndexEachNestedProperty || ForceExplicitlyIndexEachNestedProperty)
         {
             result.AddRange(summary);
             return result;

--- a/src/Umbraco.Core/PropertyEditors/JsonPropertyIndexValueFactoryBase.cs
+++ b/src/Umbraco.Core/PropertyEditors/JsonPropertyIndexValueFactoryBase.cs
@@ -26,7 +26,7 @@ public abstract class JsonPropertyIndexValueFactoryBase<TSerialized> : IProperty
     {
         _jsonSerializer = jsonSerializer;
         _indexingSettings = indexingSettings.CurrentValue;
-        indexingSettings.OnChange(x => _indexingSettings = x);
+        indexingSettings.OnChange(newValue => _indexingSettings = newValue);
     }
 
 

--- a/src/Umbraco.Core/PropertyEditors/TagPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Core/PropertyEditors/TagPropertyIndexValueFactory.cs
@@ -1,12 +1,27 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
 public class TagPropertyIndexValueFactory : JsonPropertyIndexValueFactoryBase<string[]>, ITagPropertyIndexValueFactory
 {
-    public TagPropertyIndexValueFactory(IJsonSerializer jsonSerializer) : base(jsonSerializer)
+    public TagPropertyIndexValueFactory(
+        IJsonSerializer jsonSerializer,
+        IOptionsMonitor<IndexCreatorSettings> indexCreatorSettings)
+        : base(jsonSerializer, indexCreatorSettings)
     {
+        ForceExplicitlyIndexEachNestedProperty = true;
+    }
+
+    [Obsolete("Use non-obsolete constructor. This will be removed in Umbraco 14.")]
+    public TagPropertyIndexValueFactory(IJsonSerializer jsonSerializer)
+        : this(jsonSerializer, StaticServiceProvider.Instance.GetRequiredService<IOptionsMonitor<IndexCreatorSettings>>())
+    {
+
     }
 
     protected override IEnumerable<KeyValuePair<string, IEnumerable<object?>>> Handle(

--- a/src/Umbraco.Core/PropertyEditors/TagPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Core/PropertyEditors/TagPropertyIndexValueFactory.cs
@@ -11,15 +11,15 @@ public class TagPropertyIndexValueFactory : JsonPropertyIndexValueFactoryBase<st
 {
     public TagPropertyIndexValueFactory(
         IJsonSerializer jsonSerializer,
-        IOptionsMonitor<IndexCreatorSettings> indexCreatorSettings)
-        : base(jsonSerializer, indexCreatorSettings)
+        IOptionsMonitor<IndexingSettings> indexingSettings)
+        : base(jsonSerializer, indexingSettings)
     {
         ForceExplicitlyIndexEachNestedProperty = true;
     }
 
     [Obsolete("Use non-obsolete constructor. This will be removed in Umbraco 14.")]
     public TagPropertyIndexValueFactory(IJsonSerializer jsonSerializer)
-        : this(jsonSerializer, StaticServiceProvider.Instance.GetRequiredService<IOptionsMonitor<IndexCreatorSettings>>())
+        : this(jsonSerializer, StaticServiceProvider.Instance.GetRequiredService<IOptionsMonitor<IndexingSettings>>())
     {
 
     }

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyIndexValueFactory.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyIndexValueFactory.cs
@@ -1,10 +1,14 @@
 ﻿// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
@@ -14,12 +18,22 @@ internal sealed class BlockValuePropertyIndexValueFactory :
 {
     private readonly IContentTypeService _contentTypeService;
 
+    public BlockValuePropertyIndexValueFactory(
+        PropertyEditorCollection propertyEditorCollection,
+        IContentTypeService contentTypeService,
+        IJsonSerializer jsonSerializer,
+        IOptionsMonitor<IndexCreatorSettings> indexCreatorSettings)
+        : base(propertyEditorCollection, jsonSerializer, indexCreatorSettings)
+    {
+        _contentTypeService = contentTypeService;
+    }
 
+    [Obsolete("Use non-obsolete constructor. This will be removed in Umbraco 14.")]
     public BlockValuePropertyIndexValueFactory(
         PropertyEditorCollection propertyEditorCollection,
         IContentTypeService contentTypeService,
         IJsonSerializer jsonSerializer)
-        : base(propertyEditorCollection, jsonSerializer)
+        : this(propertyEditorCollection, contentTypeService, jsonSerializer, StaticServiceProvider.Instance.GetRequiredService<IOptionsMonitor<IndexCreatorSettings>>())
     {
         _contentTypeService = contentTypeService;
     }

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyIndexValueFactory.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyIndexValueFactory.cs
@@ -22,8 +22,8 @@ internal sealed class BlockValuePropertyIndexValueFactory :
         PropertyEditorCollection propertyEditorCollection,
         IContentTypeService contentTypeService,
         IJsonSerializer jsonSerializer,
-        IOptionsMonitor<IndexCreatorSettings> indexCreatorSettings)
-        : base(propertyEditorCollection, jsonSerializer, indexCreatorSettings)
+        IOptionsMonitor<IndexingSettings> indexingSettings)
+        : base(propertyEditorCollection, jsonSerializer, indexingSettings)
     {
         _contentTypeService = contentTypeService;
     }
@@ -33,7 +33,7 @@ internal sealed class BlockValuePropertyIndexValueFactory :
         PropertyEditorCollection propertyEditorCollection,
         IContentTypeService contentTypeService,
         IJsonSerializer jsonSerializer)
-        : this(propertyEditorCollection, contentTypeService, jsonSerializer, StaticServiceProvider.Instance.GetRequiredService<IOptionsMonitor<IndexCreatorSettings>>())
+        : this(propertyEditorCollection, contentTypeService, jsonSerializer, StaticServiceProvider.Instance.GetRequiredService<IOptionsMonitor<IndexingSettings>>())
     {
         _contentTypeService = contentTypeService;
     }

--- a/src/Umbraco.Infrastructure/PropertyEditors/NestedContentPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/NestedContentPropertyIndexValueFactory.cs
@@ -1,9 +1,13 @@
 ﻿// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
@@ -15,11 +19,22 @@ internal sealed class NestedContentPropertyIndexValueFactory
 {
     private readonly IContentTypeService _contentTypeService;
 
-
     public NestedContentPropertyIndexValueFactory(
         PropertyEditorCollection propertyEditorCollection,
         IContentTypeService contentTypeService,
-        IJsonSerializer jsonSerializer) : base(propertyEditorCollection, jsonSerializer)
+        IJsonSerializer jsonSerializer,
+        IOptionsMonitor<IndexCreatorSettings> indexCreatorSettings)
+        : base(propertyEditorCollection, jsonSerializer, indexCreatorSettings)
+    {
+        _contentTypeService = contentTypeService;
+    }
+
+    [Obsolete("Use non-obsolete constructor. This will be removed in Umbraco 14.")]
+    public NestedContentPropertyIndexValueFactory(
+        PropertyEditorCollection propertyEditorCollection,
+        IContentTypeService contentTypeService,
+        IJsonSerializer jsonSerializer)
+        : this(propertyEditorCollection, contentTypeService, jsonSerializer, StaticServiceProvider.Instance.GetRequiredService<IOptionsMonitor<IndexCreatorSettings>>())
     {
         _contentTypeService = contentTypeService;
     }

--- a/src/Umbraco.Infrastructure/PropertyEditors/NestedContentPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/NestedContentPropertyIndexValueFactory.cs
@@ -23,8 +23,8 @@ internal sealed class NestedContentPropertyIndexValueFactory
         PropertyEditorCollection propertyEditorCollection,
         IContentTypeService contentTypeService,
         IJsonSerializer jsonSerializer,
-        IOptionsMonitor<IndexCreatorSettings> indexCreatorSettings)
-        : base(propertyEditorCollection, jsonSerializer, indexCreatorSettings)
+        IOptionsMonitor<IndexingSettings> indexingSettings)
+        : base(propertyEditorCollection, jsonSerializer, indexingSettings)
     {
         _contentTypeService = contentTypeService;
     }
@@ -34,7 +34,7 @@ internal sealed class NestedContentPropertyIndexValueFactory
         PropertyEditorCollection propertyEditorCollection,
         IContentTypeService contentTypeService,
         IJsonSerializer jsonSerializer)
-        : this(propertyEditorCollection, contentTypeService, jsonSerializer, StaticServiceProvider.Instance.GetRequiredService<IOptionsMonitor<IndexCreatorSettings>>())
+        : this(propertyEditorCollection, contentTypeService, jsonSerializer, StaticServiceProvider.Instance.GetRequiredService<IOptionsMonitor<IndexingSettings>>())
     {
         _contentTypeService = contentTypeService;
     }

--- a/src/Umbraco.Infrastructure/PropertyEditors/NestedPropertyIndexValueFactoryBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/NestedPropertyIndexValueFactoryBase.cs
@@ -18,8 +18,8 @@ internal abstract class NestedPropertyIndexValueFactoryBase<TSerialized, TItem> 
     protected NestedPropertyIndexValueFactoryBase(
         PropertyEditorCollection propertyEditorCollection,
         IJsonSerializer jsonSerializer,
-        IOptionsMonitor<IndexCreatorSettings> indexCreatorSettings)
-        : base(jsonSerializer, indexCreatorSettings)
+        IOptionsMonitor<IndexingSettings> indexingSettings)
+        : base(jsonSerializer, indexingSettings)
     {
         _propertyEditorCollection = propertyEditorCollection;
     }
@@ -28,7 +28,7 @@ internal abstract class NestedPropertyIndexValueFactoryBase<TSerialized, TItem> 
     protected NestedPropertyIndexValueFactoryBase(
         PropertyEditorCollection propertyEditorCollection,
         IJsonSerializer jsonSerializer)
-        : this(propertyEditorCollection, jsonSerializer, StaticServiceProvider.Instance.GetRequiredService<IOptionsMonitor<IndexCreatorSettings>>())
+        : this(propertyEditorCollection, jsonSerializer, StaticServiceProvider.Instance.GetRequiredService<IOptionsMonitor<IndexingSettings>>())
     {
 
     }

--- a/src/Umbraco.Infrastructure/PropertyEditors/NestedPropertyIndexValueFactoryBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/NestedPropertyIndexValueFactoryBase.cs
@@ -1,7 +1,11 @@
 using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Infrastructure.Examine;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
@@ -10,12 +14,23 @@ internal abstract class NestedPropertyIndexValueFactoryBase<TSerialized, TItem> 
 {
     private readonly PropertyEditorCollection _propertyEditorCollection;
 
+
+    protected NestedPropertyIndexValueFactoryBase(
+        PropertyEditorCollection propertyEditorCollection,
+        IJsonSerializer jsonSerializer,
+        IOptionsMonitor<IndexCreatorSettings> indexCreatorSettings)
+        : base(jsonSerializer, indexCreatorSettings)
+    {
+        _propertyEditorCollection = propertyEditorCollection;
+    }
+
+    [Obsolete("Use non-obsolete constructor. This will be removed in Umbraco 14.")]
     protected NestedPropertyIndexValueFactoryBase(
         PropertyEditorCollection propertyEditorCollection,
         IJsonSerializer jsonSerializer)
-        : base(jsonSerializer)
+        : this(propertyEditorCollection, jsonSerializer, StaticServiceProvider.Instance.GetRequiredService<IOptionsMonitor<IndexCreatorSettings>>())
     {
-        _propertyEditorCollection = propertyEditorCollection;
+
     }
 
     [Obsolete("Use the overload that specifies availableCultures, scheduled for removal in v14")]


### PR DESCRIPTION
### Description
Added new configuration "Umbraco:CMS:Examine:ExplicitlyIndexEachNestedProperty" that can be used to avoid nested properties like block grid to index each property individually.

### Test
- Create content with at least one each of these:
   - Block list
   - Block grid
   - Tags
   - Nested Content
- Set `Umbraco:CMS:Indexing:ExplicitlyIndexEachNestedProperty` to `false`
   - Verify nested properties are not index, but only available in the summary
- Set `Umbraco:CMS:Indexing:ExplicitlyIndexEachNestedProperty` to `true` (default value)
   - Verify everything is indexed like before.