### PR TITLE
Fix color of warning icon in health check dashboard

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/healthcheck.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/healthcheck.html
@@ -105,7 +105,7 @@
                         <div class="umb-panel-group__details-status" ng-repeat="status in check.status">
                             <div class="umb-panel-group__details-status-icon-container" aria-hidden="true">
                                 <umb-icon icon="icon-check" class="umb-healthcheck-status-icon color-green" ng-if="status.resultType === 'Success'"></umb-icon>
-                                <umb-icon icon="icon-alert" class="umb-healthcheck-status-icon color-yellow" ng-if="status.resultType === 'Warning'"></umb-icon>
+                                <umb-icon icon="icon-alert" class="umb-healthcheck-status-icon color-orange" ng-if="status.resultType === 'Warning'"></umb-icon>
                                 <umb-icon icon="icon-delete" class="umb-healthcheck-status-icon color-red" ng-if="status.resultType === 'Error'"></umb-icon>
                                 <umb-icon icon="icon-info" class="umb-healthcheck-status-icon" ng-if="status.resultType === 'Info'"></umb-icon>
                             </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed in health check dashboard, when warnings are shown the alert color is yellow and too low contract with the white background color.
In the overview boxes it did use the orange color though.

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/62e3906a-f1b7-4504-8899-9870077c0cf5)

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/6ff4909d-beb3-4714-8d1a-67f933459629)

With changes in this PR:

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/5ba34d19-f8ef-4972-90b1-b459f224a349)
