### PR TITLE
Use generic Content Type instead of Document Type

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
@@ -1589,15 +1589,15 @@ Mange hilsner fra Umbraco robotten
     <key alias="childNodesHeading">Tilladte typer</key>
     <key alias="childNodesDescription">Tillad at oprette indhold af en specifik type under denne.</key>
     <key alias="chooseChildNode">Vælg child node</key>
-    <key alias="compositionsDescription">Nedarv faner og egenskaber fra en anden dokumenttype. Nye faner vil blive
-      tilføjet den nuværende dokumenttype eller sammenflettet hvis fanenavnene er ens.
+    <key alias="compositionsDescription">Nedarv faner og egenskaber fra en anden indholdstype. Nye faner vil blive
+      tilføjet den nuværende indholdstype eller sammenflettet hvis fanenavnene er ens.
     </key>
     <key alias="compositionInUse">Indholdstypen bliver brugt i en komposition og kan derfor ikke blive anvendt som
       komposition
     </key>
     <key alias="noAvailableCompositions">Der er ingen indholdstyper tilgængelige at bruge som komposition</key>
     <key alias="compositionRemoveWarning">Når du fjerner en komposition vil alle associerede indholdsdata blive slettet.
-      Når først dokumenttypen er gemt, er der ingen vej tilbage.
+      Når først indholdstypen er gemt, er der ingen vej tilbage.
     </key>
     <key alias="availableEditors">Opret ny indstilling</key>
     <key alias="reuse">Genbrug</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/de.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/de.xml
@@ -679,7 +679,7 @@
     <key alias="folderWasRenamed">%0% wurde umbenannt in %1%</key>
   </area>
   <area alias="editdatatype">
-  <key alias="canChangePropertyEditorHelp">Ändern des Editors in einem Datatyps mit gespeicherten Werten ist nicht erlaubt. Um es zu erlauben müssen Sie die Umbraco:CMS:DataTypes:CanBeChanged Einstellung in der appsettings.json ändern.</key>
+    <key alias="canChangePropertyEditorHelp">Ändern des Editors in einem Datatyps mit gespeicherten Werten ist nicht erlaubt. Um es zu erlauben müssen Sie die Umbraco:CMS:DataTypes:CanBeChanged Einstellung in der appsettings.json ändern.</key>
     <key alias="addPrevalue">Neuer Vorgabewert</key>
     <key alias="dataBaseDatatype">Feldtyp in der Datenbank</key>
     <key alias="guid">Datentyp-GUID</key>
@@ -1780,10 +1780,9 @@
       Erlaubt es Inhalt der angegebenen Typen unterhalb Inhalten dieses Typs anzulegen
     </key>
     <key alias="chooseChildNode">Wählen Sie einen Unterknoten</key>
-    <!--???-->
-    <key alias="compositionsDescription">Übernimm Tabs und Eigenschaften vone einem vorhandenen Dokumenttyp. Neue Tabs werden zum vorliegenden Dokumenttyp hinzugefügt oder mit einem gleichnamigen Tab zusammengeführt.</key>
-    <key alias="compositionInUse">Dieser Dokumenttyp wird in einer Mischung verwendet und kann deshalb nicht selbst zusammengemischt werden.</key>
-    <key alias="noAvailableCompositions">Es sind keine Dokumenttypen für eine Mischung vorhanden.</key>
+    <key alias="compositionsDescription">Übernimm Tabs und Eigenschaften vone einem vorhandenen Inhaltstyp. Neue Tabs werden zum vorliegenden Inhaltstyp hinzugefügt oder mit einem gleichnamigen Tab zusammengeführt.</key>
+    <key alias="compositionInUse">Dieser Inhaltstyp wird in einer Mischung verwendet und kann deshalb nicht selbst zusammengemischt werden.</key>
+    <key alias="noAvailableCompositions">Es sind keine Inhaltstypen für eine Mischung vorhanden.</key>
     <key alias="availableEditors">Neu anlegen</key>
     <key alias="reuse">Vorhandenen nutzen</key>
     <key alias="editorSettings">Editor-Einstellungen</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -1803,14 +1803,14 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
       type.
     </key>
     <key alias="chooseChildNode">Choose child node</key>
-    <key alias="compositionsDescription">Inherit tabs and properties from an existing Document Type. New tabs will be
-      added to the current Document Type or merged if a tab with an identical name exists.
+    <key alias="compositionsDescription">Inherit tabs and properties from an existing Content Type. New tabs will be
+      added to the current Content Type or merged if a tab with an identical name exists.
     </key>
     <key alias="compositionInUse">This Content Type is used in a composition, and therefore cannot be composed itself.
     </key>
     <key alias="noAvailableCompositions">There are no Content Types available to use as a composition.</key>
     <key alias="compositionRemoveWarning">Removing a composition will delete all the associated property data. Once you
-      save the Document Type there's no way back.
+      save the Content Type there's no way back.
     </key>
     <key alias="availableEditors">Create new</key>
     <key alias="reuse">Use existing</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -1867,14 +1867,14 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
       type.
     </key>
     <key alias="chooseChildNode">Choose child node</key>
-    <key alias="compositionsDescription">Inherit tabs and properties from an existing Document Type. New tabs will be
-      added to the current Document Type or merged if a tab with an identical name exists.
+    <key alias="compositionsDescription">Inherit tabs and properties from an existing Content Type. New tabs will be
+      added to the current Content Type or merged if a tab with an identical name exists.
     </key>
     <key alias="compositionInUse">This Content Type is used in a composition, and therefore cannot be composed itself.
     </key>
     <key alias="noAvailableCompositions">There are no Content Types available to use as a composition.</key>
     <key alias="compositionRemoveWarning">Removing a composition will delete all the associated property data. Once you
-      save the Document Type there's no way back.
+      save the Content Type there's no way back.
     </key>
     <key alias="availableEditors">Create new</key>
     <key alias="reuse">Use existing</key>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/14654

### Description
Since description for composition is used for both document, media and now member type as well, we should use the generic term "Content Type".

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/9108de82-14c8-4ec4-9d38-427d2b466903)

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/870f8b26-5996-4430-8b1f-72cf16d85b9f)


![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/657f8971-6a53-4aa8-acb4-02fa52a526ec)

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/a38d8464-4e4d-417f-adb4-27dc19ff0a7b)
