### PR TITLE
Moved EFCoreDbContext registration to Umbraco core registrations

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Delivery/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -31,8 +31,7 @@ public static class UmbracoBuilderExtensions
 
         builder.Services.ConfigureOptions<ConfigureUmbracoDeliveryApiSwaggerGenOptions>();
         builder.AddUmbracoApiOpenApiUI();
-
-        builder.AddUmbracoEFCoreDbContext();
+        
         builder
             .Services
             .AddControllers()

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -170,6 +170,8 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddUnique<IApplicationShutdownRegistry, AspNetCoreApplicationShutdownRegistry>();
         builder.Services.AddTransient<IIpAddressUtilities, IpAddressUtilities>();
 
+        builder.AddUmbracoEFCoreDbContext();
+
         return builder;
     }
 

--- a/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
+++ b/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Umbraco.Cms.Persistence.EFCore\Umbraco.Cms.Persistence.EFCore.csproj" />
     <ProjectReference Include="..\Umbraco.Examine.Lucene\Umbraco.Examine.Lucene.csproj" />
     <ProjectReference Include="..\Umbraco.PublishedCache.NuCache\Umbraco.PublishedCache.NuCache.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Fix for https://github.com/umbraco/Umbraco-CMS/issues/14658

Removing the deliveryapi registrations from the startup chain should allow umbraco to boot.

### reproduction
Spin up a fresh instance of 12.1 and remove `.AddDeliveryApi()` from `ConfigureServices` in `Startup.cs`, run and no dependency errors should show up