### PR TITLE
fix: Pass correct user id to Audit log

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1097,7 +1097,8 @@ public class ContentService : RepositoryService, IContentService
             scope.Notifications.Publish(
                 new ContentTreeChangeNotification(contentsA, TreeChangeTypes.RefreshNode, eventMessages));
 
-            Audit(AuditType.Save, userId == -1 ? 0 : userId, Constants.System.Root, "Saved multiple content");
+            string contentIds = string.Join(", ", contentsA.Select(x => x.Id));
+            Audit(AuditType.Save, userId, Constants.System.Root, $"Saved multiple content items ({contentIds})");
 
             scope.Complete();
         }
@@ -2820,7 +2821,7 @@ public class ContentService : RepositoryService, IContentService
             }
             else
             {
-                Audit(AuditType.SendToPublish, content.WriterId, content.Id);
+                Audit(AuditType.SendToPublish, userId, content.Id);
             }
 
             return saveResult.Success;
@@ -3562,7 +3563,7 @@ public class ContentService : RepositoryService, IContentService
 
             _documentBlueprintRepository.Save(content);
 
-            Audit(AuditType.Save, Constants.Security.SuperUserId, content.Id, $"Saved content template: {content.Name}");
+            Audit(AuditType.Save, userId, content.Id, $"Saved content template: {content.Name}");
 
             scope.Notifications.Publish(new ContentSavedBlueprintNotification(content, evtMsgs));
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

This PR corrects the user id passed to the Audit log.

### `Save(IEnumerable<IContent> contents, int userId = Constants.Security.SuperUserId)`

Here the user id was for some reason set to 0 which isn't a valid user id in modern Umbraco see #14639
In the best-case scenario, this would anyway audit the incorrect user id.
I've also updated the message to include the content ids as these are not passed in Node id thereby making it easier to track.

### `SendToPublication(IContent? content, int userId = Constants.Security.SuperUserId)`

Here I've changed the id to come from `userId` like the statement just above it.

### `SaveBlueprint(IContent content, int userId = Constants.Security.SuperUserId)`

Here the super user id was passed instead of the user id argument.

<!-- Thanks for contributing to Umbraco CMS! -->
