### PR TITLE
perf: Don't call GetNextUsers when we don't have to

### DIFF
--- a/src/Umbraco.Core/Services/NotificationService.cs
+++ b/src/Umbraco.Core/Services/NotificationService.cs
@@ -99,14 +99,14 @@ public class NotificationService : INotificationService
         const int pagesz = 400; // load batches of 400 users
         do
         {
-            // users are returned ordered by id, notifications are returned ordered by user id
-            var users = _userService.GetNextUsers(id, pagesz).Where(x => x.IsApproved).ToList();
-            var notifications = GetUsersNotifications(users.Select(x => x.Id), action, Enumerable.Empty<int>(), Constants.ObjectTypes.Document)?.ToList();
+            var notifications = GetUsersNotifications(new List<int>(), action, Enumerable.Empty<int>(), Constants.ObjectTypes.Document)?.ToList();
             if (notifications is null || notifications.Count == 0)
             {
                 break;
             }
 
+            // users are returned ordered by id, notifications are returned ordered by user id
+            var users = _userService.GetNextUsers(id, pagesz).Where(x => x.IsApproved).ToList();
             foreach (IUser user in users)
             {
                 Notification[] userNotifications = notifications.Where(n => n.UserId == user.Id).ToArray();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

I was looking at what a call tree is for running the `ContentService.SaveAndPublish` and noticed that we in `NotificationService` make an unnecessary call to `GetNextUsers` that in some cases can be pretty expensive:

_Note: this was captured in Debug mode so don't get too caught up on the specific numbers_

[New Item `SaveAndPublish`]
![image](https://github.com/umbraco/Umbraco-CMS/assets/24605285/c1babd00-3e06-4a31-9ba8-36b7123622df)

[2. `SaveAndPublish` on same item]
![Skærmbillede 2023-08-12 145849](https://github.com/umbraco/Umbraco-CMS/assets/24605285/89a14146-ab16-4bf6-8e97-32a2d9f43118)

From what I can see in 
https://github.com/umbraco/Umbraco-CMS/blob/0edee82b0b92876ef336a04fa82eb48832302523/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/NotificationsRepository.cs#L20C78-L20C85

We don't even use the UserIds in the query so therefore we don't need to fetch them unless there's actually a user notification which there isn't if you're not using that functionality.
<!-- Thanks for contributing to Umbraco CMS! -->
