### PR TITLE
feat: Internal attribute analyzer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,7 +30,7 @@
   <!-- Package Validation -->
   <PropertyGroup>
     <GenerateCompatibilitySuppressionFile>false</GenerateCompatibilitySuppressionFile>
-    <EnablePackageValidation>true</EnablePackageValidation>
+    <EnablePackageValidation>false</EnablePackageValidation>
     <PackageValidationBaselineVersion>12.0.0</PackageValidationBaselineVersion>
     <EnableStrictModeForCompatibleFrameworksInPackage>true</EnableStrictModeForCompatibleFrameworksInPackage>
     <EnableStrictModeForCompatibleTfms>true</EnableStrictModeForCompatibleTfms>

--- a/src/Umbraco.Cms.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Umbraco.Cms.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,0 +1,10 @@
+; Shipped analyzer releases
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+## Release 12.2.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+UM1001 | Usage | Warning | InternalUsageDiagnosticAnalyzer

--- a/src/Umbraco.Cms.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Umbraco.Cms.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,2 @@
+﻿; Unshipped analyzer release
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/src/Umbraco.Cms.Analyzers/InternalUsageDiagnosticAnalyzer.cs
+++ b/src/Umbraco.Cms.Analyzers/InternalUsageDiagnosticAnalyzer.cs
@@ -1,0 +1,316 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using CSharpSyntax = Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Umbraco.Cms.Core.Analyzers;
+
+/// <summary>
+/// Analyzes the usage of internal APIs.
+/// </summary>
+/// <remarks>
+/// Inspired by: https://github.com/dotnet/efcore/blob/main/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class InternalUsageDiagnosticAnalyzer : DiagnosticAnalyzer
+{
+    public const string Id = "UM1001";
+
+    public static readonly DiagnosticDescriptor Descriptor
+        // HACK: Work around dotnet/roslyn-analyzers#5890 by not using target-typed new
+        = new DiagnosticDescriptor(
+            Id,
+            title: "Internal Umbraco API usage",
+            messageFormat: "{0} is an internal API of Umbraco CMS and not subject to the same compatibility standards as public APIs. It may be changed or removed without notice in any release.",
+            category: "Usage",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        => ImmutableArray.Create(Descriptor);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+        context.RegisterOperationAction(
+            AnalyzeNode,
+            OperationKind.FieldReference,
+            OperationKind.PropertyReference,
+            OperationKind.MethodReference,
+            OperationKind.EventReference,
+            OperationKind.Invocation,
+            OperationKind.ObjectCreation,
+            OperationKind.VariableDeclaration,
+            OperationKind.TypeOf);
+
+        context.RegisterSymbolAction(
+            AnalyzeSymbol,
+            SymbolKind.NamedType,
+            SymbolKind.Method,
+            SymbolKind.Property,
+            SymbolKind.Field,
+            SymbolKind.Event);
+    }
+
+    private static void AnalyzeNode(OperationAnalysisContext context)
+    {
+        switch (context.Operation)
+        {
+            case IFieldReferenceOperation fieldReference:
+                AnalyzeMember(context, fieldReference.Field);
+                break;
+
+            case IPropertyReferenceOperation propertyReference:
+                AnalyzeMember(context, propertyReference.Property);
+                break;
+
+            case IEventReferenceOperation eventReference:
+                AnalyzeMember(context, eventReference.Event);
+                break;
+
+            case IMethodReferenceOperation methodReference:
+                AnalyzeMember(context, methodReference.Method);
+                break;
+
+            case IObjectCreationOperation { Constructor: { } constructor }:
+                AnalyzeMember(context, constructor);
+                break;
+
+            case IInvocationOperation invocation:
+                AnalyzeInvocation(context, invocation);
+                break;
+
+            case IVariableDeclarationOperation variableDeclaration:
+                AnalyzeVariableDeclaration(context, variableDeclaration);
+                break;
+
+            case ITypeOfOperation typeOf:
+                AnalyzeTypeof(context, typeOf);
+                break;
+
+            default:
+                throw new ArgumentException($"Unexpected operation: {context.Operation.Kind}");
+        }
+    }
+
+    private static void AnalyzeMember(OperationAnalysisContext context, ISymbol symbol)
+    {
+        if (symbol.ContainingAssembly?.Equals(context.Compilation.Assembly, SymbolEqualityComparer.Default) == true)
+        {
+            // Skip all methods inside the same assembly - internal access is fine
+            return;
+        }
+
+        INamedTypeSymbol containingType = symbol.ContainingType;
+
+        if (HasInternalAttribute(symbol))
+        {
+            ReportDiagnostic(context, symbol.Name == WellKnownMemberNames.InstanceConstructorName ? containingType : $"{containingType}.{symbol.Name}");
+            return;
+        }
+
+        if (IsInternal(context, containingType))
+        {
+            ReportDiagnostic(context, containingType);
+        }
+    }
+
+    private static void AnalyzeInvocation(OperationAnalysisContext context, IInvocationOperation invocation)
+    {
+        // First check for any internal type parameters
+        foreach (ITypeSymbol typeSymbol in invocation.TargetMethod.TypeArguments)
+        {
+            if (IsInternal(context, typeSymbol))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, context.Operation.Syntax.GetLocation(), typeSymbol));
+            }
+        }
+
+        // Then check the method being invoked
+        AnalyzeMember(context, invocation.TargetMethod);
+    }
+
+    private static void AnalyzeVariableDeclaration(OperationAnalysisContext context, IVariableDeclarationOperation variableDeclaration)
+    {
+        foreach (IVariableDeclaratorOperation declarator in variableDeclaration.Declarators)
+        {
+            if (IsInternal(context, declarator.Symbol.Type))
+            {
+                SyntaxNode syntax = context.Operation.Syntax switch
+                {
+                    CSharpSyntax.VariableDeclarationSyntax s => s.Type,
+                    _ => context.Operation.Syntax,
+                };
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, syntax.GetLocation(), declarator.Symbol.Type));
+                return;
+            }
+        }
+    }
+
+    private static void AnalyzeTypeof(OperationAnalysisContext context, ITypeOfOperation typeOf)
+    {
+        if (IsInternal(context, typeOf.TypeOperand))
+        {
+            ReportDiagnostic(context, typeOf.TypeOperand);
+        }
+    }
+
+    private static void AnalyzeSymbol(SymbolAnalysisContext context)
+    {
+        switch (context.Symbol)
+        {
+            case INamedTypeSymbol symbol:
+                AnalyzeNamedTypeSymbol(context, symbol);
+                break;
+
+            case IMethodSymbol symbol:
+                AnalyzeMethodTypeSymbol(context, symbol);
+                break;
+
+            case IFieldSymbol symbol:
+                AnalyzeMemberDeclarationTypeSymbol(context, symbol, symbol.Type);
+                break;
+
+            case IPropertySymbol symbol:
+                AnalyzeMemberDeclarationTypeSymbol(context, symbol, symbol.Type);
+                break;
+
+            case IEventSymbol symbol:
+                AnalyzeMemberDeclarationTypeSymbol(context, symbol, symbol.Type);
+                break;
+
+            default:
+                throw new ArgumentException($"Unexpected {nameof(ISymbol)}: {context.Symbol.GetType().Name}");
+        }
+    }
+
+    private static void AnalyzeNamedTypeSymbol(SymbolAnalysisContext context, INamedTypeSymbol symbol)
+    {
+        if (symbol.BaseType is ITypeSymbol baseSymbol
+            && IsInternal(context, baseSymbol))
+        {
+            foreach (SyntaxReference declaringSyntax in symbol.DeclaringSyntaxReferences)
+            {
+                Location location = declaringSyntax.GetSyntax() switch
+                {
+                    CSharpSyntax.ClassDeclarationSyntax { BaseList.Types.Count: > 0 } s => s.BaseList.Types[0].GetLocation(),
+                    { } otherSyntax => otherSyntax.GetLocation(),
+                };
+
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, location, baseSymbol));
+            }
+        }
+
+        foreach (INamedTypeSymbol? @interface in symbol.Interfaces.Where(i => IsInternal(context, i)))
+        {
+            foreach (SyntaxReference declaringSyntax in symbol.DeclaringSyntaxReferences)
+            {
+                Location location = declaringSyntax.GetSyntax() switch
+                {
+                    CSharpSyntax.ClassDeclarationSyntax s => s.Identifier.GetLocation(),
+                    { } otherSyntax => otherSyntax.GetLocation(),
+                };
+
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, location, @interface));
+            }
+        }
+    }
+
+    private static void AnalyzeMethodTypeSymbol(SymbolAnalysisContext context, IMethodSymbol symbol)
+    {
+        if (symbol.MethodKind is MethodKind.PropertyGet or MethodKind.PropertySet)
+        {
+            // Property getters/setters are handled via IPropertySymbol
+            return;
+        }
+
+        if (IsInternal(context, symbol.ReturnType))
+        {
+            foreach (SyntaxReference declaringSyntax in symbol.DeclaringSyntaxReferences)
+            {
+                Location location = declaringSyntax.GetSyntax() switch
+                {
+                    CSharpSyntax.MethodDeclarationSyntax s => s.ReturnType.GetLocation(),
+                    { } otherSyntax => otherSyntax.GetLocation(),
+                };
+
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, location, symbol.ReturnType));
+            }
+        }
+
+        foreach (IParameterSymbol? paramSymbol in symbol.Parameters.Where(ps => IsInternal(context, ps.Type)))
+        {
+            foreach (SyntaxReference declaringSyntax in paramSymbol.DeclaringSyntaxReferences)
+            {
+                Location location = declaringSyntax.GetSyntax() switch
+                {
+                    CSharpSyntax.ParameterSyntax { Type: not null } s => s.Type.GetLocation(),
+
+                    { } otherSyntax => otherSyntax.GetLocation()
+                };
+
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, location, paramSymbol.Type));
+            }
+        }
+    }
+
+    private static void AnalyzeMemberDeclarationTypeSymbol(
+        SymbolAnalysisContext context,
+        ISymbol declarationSymbol,
+        ITypeSymbol typeSymbol)
+    {
+        if (IsInternal(context, typeSymbol))
+        {
+            foreach (SyntaxReference declaringSyntax in declarationSymbol.DeclaringSyntaxReferences)
+            {
+                ReportDiagnostic(context, declaringSyntax.GetSyntax(), typeSymbol);
+            }
+        }
+    }
+
+    private static void ReportDiagnostic(OperationAnalysisContext context, object messageArg)
+        => context.ReportDiagnostic(
+            Diagnostic.Create(Descriptor, NarrowDownSyntax(context.Operation.Syntax).GetLocation(), messageArg));
+
+    private static void ReportDiagnostic(SymbolAnalysisContext context, SyntaxNode syntax, object messageArg)
+        => context.ReportDiagnostic(Diagnostic.Create(Descriptor, NarrowDownSyntax(syntax).GetLocation(), messageArg));
+
+    /// <summary>
+    ///     Given a syntax node, pattern matches some known types and returns a narrowed-down node for the type syntax which
+    ///     should be reported in diagnostics.
+    /// </summary>
+    private static SyntaxNode NarrowDownSyntax(SyntaxNode syntax)
+        => syntax switch
+        {
+            CSharpSyntax.InvocationExpressionSyntax { Expression: CSharpSyntax.MemberAccessExpressionSyntax memberAccessSyntax } => memberAccessSyntax.Name,
+            CSharpSyntax.MemberAccessExpressionSyntax s => s.Name,
+            CSharpSyntax.ObjectCreationExpressionSyntax s => s.Type,
+            CSharpSyntax.PropertyDeclarationSyntax s => s.Type,
+            CSharpSyntax.VariableDeclaratorSyntax declarator
+                => declarator.Parent is CSharpSyntax.VariableDeclarationSyntax declaration
+                    ? declaration.Type
+                    : declarator,
+            CSharpSyntax.TypeOfExpressionSyntax s => s.Type,
+
+            _ => syntax,
+        };
+
+    private static bool IsInternal(SymbolAnalysisContext context, ITypeSymbol symbol)
+        => symbol.ContainingAssembly?.Equals(context.Compilation.Assembly, SymbolEqualityComparer.Default) != true
+            && HasInternalAttribute(symbol);
+
+    private static bool IsInternal(OperationAnalysisContext context, ITypeSymbol symbol)
+        => symbol.ContainingAssembly?.Equals(context.Compilation.Assembly, SymbolEqualityComparer.Default) != true
+            && HasInternalAttribute(symbol);
+
+    private static bool HasInternalAttribute(ISymbol symbol)
+        => symbol.GetAttributes().Any(
+            a =>
+                a.AttributeClass!.ToDisplayString()
+                == "Umbraco.Cms.Core.Attributes.UmbracoInternalAttribute");
+}

--- a/src/Umbraco.Cms.Analyzers/Umbraco.Cms.Analyzers.csproj
+++ b/src/Umbraco.Cms.Analyzers/Umbraco.Cms.Analyzers.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <PackageId>Umbraco.Cms.Analyzers</PackageId>
+    <Title>Umbraco CMS - Analyzers</Title>
+    <Description>Contains the Analyzers for Umbraco CMS.</Description>
+    <RootNamespace>Umbraco.Cms.Analyzers</RootNamespace>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+  </ItemGroup>
+</Project>

--- a/src/Umbraco.Cms.Analyzers/Umbraco.Cms.Analyzers.csproj
+++ b/src/Umbraco.Cms.Analyzers/Umbraco.Cms.Analyzers.csproj
@@ -6,14 +6,22 @@
     <RootNamespace>Umbraco.Cms.Analyzers</RootNamespace>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" PrivateAssets="all" />
+    <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
     <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
     <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)\$(AssemblyName).pdb" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="_._" Pack="true" PackagePath="lib/$(TargetFramework)" Visible="false" />
   </ItemGroup>
 </Project>

--- a/src/Umbraco.Cms.Persistence.EFCore/Migrations/IMigrationProvider.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/Migrations/IMigrationProvider.cs
@@ -1,5 +1,8 @@
+using Umbraco.Cms.Core.Attributes;
+
 namespace Umbraco.Cms.Persistence.EFCore.Migrations;
 
+[UmbracoInternal]
 public interface IMigrationProvider
 {
     string ProviderName { get; }

--- a/src/Umbraco.Cms.Persistence.EFCore/UmbracoDbContext.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/UmbracoDbContext.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Attributes;
 
 namespace Umbraco.Cms.Persistence.EFCore;
 
@@ -14,6 +15,7 @@ namespace Umbraco.Cms.Persistence.EFCore;
 /// To find documentation about this way of working with the context see
 /// https://learn.microsoft.com/en-us/ef/core/managing-schemas/migrations/providers?tabs=dotnet-core-cli#using-one-context-type
 /// </remarks>
+[UmbracoInternal]
 public class UmbracoDbContext : DbContext
 {
     public UmbracoDbContext(DbContextOptions<UmbracoDbContext> options)

--- a/src/Umbraco.Cms/Umbraco.Cms.csproj
+++ b/src/Umbraco.Cms/Umbraco.Cms.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Umbraco.Cms.Analyzers\Umbraco.Cms.Analyzers.csproj" />
     <ProjectReference Include="..\Umbraco.Cms.Targets\Umbraco.Cms.Targets.csproj" />
     <ProjectReference Include="..\Umbraco.Cms.Imaging.ImageSharp\Umbraco.Cms.Imaging.ImageSharp.csproj" />
     <ProjectReference Include="..\Umbraco.Cms.Persistence.Sqlite\Umbraco.Cms.Persistence.Sqlite.csproj" />

--- a/src/Umbraco.Core/Attributes/UmbracoInternalAttribute.cs
+++ b/src/Umbraco.Core/Attributes/UmbracoInternalAttribute.cs
@@ -1,0 +1,25 @@
+namespace Umbraco.Cms.Core.Attributes;
+
+/// <summary>
+///     Marks an API as internal to Umbraco. These APIs are not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use such APIs directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Umbraco release.
+/// </summary>
+/// <remarks>
+/// This approch was inspired by: https://github.com/dotnet/efcore/blob/main/src/EFCore/Infrastructure/EntityFrameworkInternalAttribute.cs
+/// </remarks>
+[AttributeUsage(
+    AttributeTargets.Enum
+    | AttributeTargets.Class
+    | AttributeTargets.Struct
+    | AttributeTargets.Interface
+    | AttributeTargets.Event
+    | AttributeTargets.Field
+    | AttributeTargets.Method
+    | AttributeTargets.Delegate
+    | AttributeTargets.Property
+    | AttributeTargets.Constructor)]
+public sealed class UmbracoInternalAttribute : Attribute
+{
+}

--- a/tests/Umbraco.Tests.Analyzers/InternalUsageDiagnosticAnalyzerTests.cs
+++ b/tests/Umbraco.Tests.Analyzers/InternalUsageDiagnosticAnalyzerTests.cs
@@ -1,0 +1,209 @@
+using Microsoft.CodeAnalysis;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Analyzers;
+
+using VerifyCS = Umbraco.Cms.Tests.Analyzers.Utilities.CSharpAnalyzerVerifier<Umbraco.Cms.Core.Analyzers.InternalUsageDiagnosticAnalyzer>;
+
+namespace Umbraco.Cms.Tests.Analyzers;
+
+/// <summary>
+/// Tests the <see cref="InternalUsageDiagnosticAnalyzer"/> class.
+/// </summary>
+/// <remarks>
+/// Type links to types used in tests:
+/// Tests with <see cref="Umbraco.Cms.Persistence.EFCore.UmbracoDbContext"/> and <see cref="Microsoft.EntityFrameworkCore.DbContextOptions{TContext}"/> of <see cref="Umbraco.Cms.Persistence.EFCore.UmbracoDbContext"/>
+/// Tests with <see cref="Umbraco.Cms.Persistence.EFCore.Migrations.IMigrationProvider"/>
+/// Tests with <see cref="Umbraco.Cms.Core.GuidUdi"/>
+///
+/// Inspired by: https://github.com/dotnet/efcore/blob/main/test/EFCore.Analyzers.Tests/InternalUsageDiagnosticAnalyzerTests.cs
+/// </remarks>
+public class InternalUsageDiagnosticAnalyzerTests
+{
+    [Test]
+    public Task Instantiation_on_internal_type()
+        => VerifySingleInternalUsageAsync(
+"""
+class C
+{
+    void M()
+    {
+        new {|#0:Umbraco.Cms.Persistence.EFCore.UmbracoDbContext|}(new Microsoft.EntityFrameworkCore.DbContextOptions<Umbraco.Cms.Persistence.EFCore.UmbracoDbContext>());
+    }
+}
+""",
+"Umbraco.Cms.Persistence.EFCore.UmbracoDbContext");
+
+    [Test]
+    public async Task Base_type()
+    {
+        var source = """
+class MyClass : {|#0:Umbraco.Cms.Persistence.EFCore.UmbracoDbContext|}
+{
+    MyClass() {|#1:: base(new Microsoft.EntityFrameworkCore.DbContextOptions<Umbraco.Cms.Persistence.EFCore.UmbracoDbContext>())|} {}
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            source,
+            VerifyCS.Diagnostic(InternalUsageDiagnosticAnalyzer.Id)
+                .WithLocation(0)
+                .WithSeverity(DiagnosticSeverity.Warning)
+                .WithMessageFormat(InternalUsageDiagnosticAnalyzer.Descriptor.MessageFormat)
+                .WithArguments("Umbraco.Cms.Persistence.EFCore.UmbracoDbContext"),
+            VerifyCS.Diagnostic(InternalUsageDiagnosticAnalyzer.Id)
+                .WithLocation(1)
+                .WithSeverity(DiagnosticSeverity.Warning)
+                .WithMessageFormat(InternalUsageDiagnosticAnalyzer.Descriptor.MessageFormat)
+                .WithArguments("Umbraco.Cms.Persistence.EFCore.UmbracoDbContext"));
+    }
+
+    [Test]
+    public Task Implemented_interface()
+        => VerifySingleInternalUsageAsync(
+"""
+using System;
+using System.Threading.Tasks;
+using Umbraco.Cms.Persistence.EFCore.Migrations;
+            
+class {|#0:MyClass|} : IMigrationProvider
+{
+    public string ProviderName => string.Empty;
+    public Task MigrateAsync(EFCoreMigration migration) => Task.CompletedTask;
+    public Task MigrateAllAsync() => Task.CompletedTask;
+}
+""",
+"Umbraco.Cms.Persistence.EFCore.Migrations.IMigrationProvider");
+
+    [Test]
+    public Task Local_variable_declaration()
+        => VerifySingleInternalUsageAsync(
+"""
+class C
+{
+    void M()
+    {
+        {|#0:Umbraco.Cms.Persistence.EFCore.UmbracoDbContext|} umbracoDbContext = null;
+    }
+}
+""",
+"Umbraco.Cms.Persistence.EFCore.UmbracoDbContext");
+
+    [Test]
+    public Task Generic_type_parameter_in_method_call()
+        => VerifySingleInternalUsageAsync(
+"""
+class C
+{
+    void M()
+    {
+        void SomeGenericMethod<T>() {}
+            
+        {|#0:SomeGenericMethod<Umbraco.Cms.Persistence.EFCore.UmbracoDbContext>()|};
+    }
+}
+""",
+"Umbraco.Cms.Persistence.EFCore.UmbracoDbContext");
+
+    [Test]
+    public Task Typeof()
+        => VerifySingleInternalUsageAsync(
+"""
+class C
+{
+    void M()
+    {
+        var t = typeof({|#0:Umbraco.Cms.Persistence.EFCore.UmbracoDbContext|});
+    }
+}
+""",
+"Umbraco.Cms.Persistence.EFCore.UmbracoDbContext");
+
+    [Test]
+    public Task Field_declaration()
+        => VerifySingleInternalUsageAsync(
+"""
+class MyClass
+{
+    private readonly {|#0:Umbraco.Cms.Persistence.EFCore.UmbracoDbContext|} _stateManager;
+}
+""",
+"Umbraco.Cms.Persistence.EFCore.UmbracoDbContext");
+
+    [Test]
+    public Task Property_declaration()
+        => VerifySingleInternalUsageAsync(
+"""
+class MyClass
+{
+    private {|#0:Umbraco.Cms.Persistence.EFCore.UmbracoDbContext|} StateManager { get; set; }
+}
+""",
+"Umbraco.Cms.Persistence.EFCore.UmbracoDbContext");
+
+    [Test]
+    public Task Method_declaration_return_type()
+        => VerifySingleInternalUsageAsync(
+"""
+class MyClass
+{
+    private {|#0:Umbraco.Cms.Persistence.EFCore.UmbracoDbContext|} Foo() => null;
+}
+""",
+"Umbraco.Cms.Persistence.EFCore.UmbracoDbContext");
+
+    [Test]
+    public Task Method_declaration_parameter()
+        => VerifySingleInternalUsageAsync(
+"""
+class MyClass
+{
+    private void Foo({|#0:Umbraco.Cms.Persistence.EFCore.UmbracoDbContext|} stateManager) {}
+}
+""",
+"Umbraco.Cms.Persistence.EFCore.UmbracoDbContext");
+
+    [Test]
+    public Task No_warning_on_non_internal()
+        => VerifyCS.VerifyAnalyzerAsync("""
+class C
+{
+    void M()
+    {
+        var a = new Umbraco.Cms.Core.GuidUdi(string.Empty, System.Guid.NewGuid());
+        var x = a.Guid;
+    }
+}
+""");
+
+    [Test]
+    public Task No_warning_in_same_assembly()
+        => VerifyCS.VerifyAnalyzerAsync("""
+namespace Umbraco.My.Thing
+{
+    [Umbraco.Cms.Core.Attributes.UmbracoInternal]
+    class MyClass
+    {
+        static internal void Foo() {}
+    }
+}
+
+namespace Bar
+{
+    class Program
+    {
+        public void Main(string[] args) {
+            Umbraco.My.Thing.MyClass.Foo();
+        }
+    }
+}
+""");
+
+    private Task VerifySingleInternalUsageAsync(string source, string internalApi)
+        => VerifyCS.VerifyAnalyzerAsync(
+            source,
+            VerifyCS.Diagnostic(InternalUsageDiagnosticAnalyzer.Id)
+                .WithLocation(0)
+                .WithSeverity(DiagnosticSeverity.Warning)
+                .WithMessageFormat(InternalUsageDiagnosticAnalyzer.Descriptor.MessageFormat)
+                .WithArguments(internalApi));
+}

--- a/tests/Umbraco.Tests.Analyzers/Umbraco.Tests.Analyzers.csproj
+++ b/tests/Umbraco.Tests.Analyzers/Umbraco.Tests.Analyzers.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>Umbraco.Cms.Tests.Analyzers</RootNamespace>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Umbraco.Cms.Analyzers\Umbraco.Cms.Analyzers.csproj" />
+    <ProjectReference Include="..\..\src\Umbraco.Cms\Umbraco.Cms.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Umbraco.Tests.Analyzers/Utilities/CSharpAnalyzerVerifier.cs
+++ b/tests/Umbraco.Tests.Analyzers/Utilities/CSharpAnalyzerVerifier.cs
@@ -1,0 +1,49 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Model;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+namespace Umbraco.Cms.Tests.Analyzers.Utilities;
+
+public static class CSharpAnalyzerVerifier<TAnalyzer>
+    where TAnalyzer : DiagnosticAnalyzer, new()
+{
+    public static DiagnosticResult Diagnostic(string diagnosticId)
+        => CSharpAnalyzerVerifier<TAnalyzer, NUnitVerifier>.Diagnostic(diagnosticId);
+
+    public static Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+    {
+        var test = new Test { TestCode = source };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    public class Test : CSharpAnalyzerTest<TAnalyzer, NUnitVerifier>
+    {
+        protected override CompilationOptions CreateCompilationOptions()
+        {
+            var cSharpOptions = (CSharpCompilationOptions)base.CreateCompilationOptions();
+            return cSharpOptions
+                .WithNullableContextOptions(NullableContextOptions.Enable)
+                .WithSpecificDiagnosticOptions(new Dictionary<string, ReportDiagnostic> { { "CS1701", ReportDiagnostic.Suppress }, { "CS1591", ReportDiagnostic.Suppress } });
+        }
+
+        protected override async Task<Project> CreateProjectImplAsync(EvaluatedProjectState primaryProject, ImmutableArray<EvaluatedProjectState> additionalProjects, CancellationToken cancellationToken)
+        {
+            var metadataReferences
+                = Microsoft.Extensions.DependencyModel.DependencyContext.Load(GetType().Assembly)
+                    .CompileLibraries
+                    .SelectMany(c => c.ResolveReferencePaths())
+                    .Select(path => MetadataReference.CreateFromFile(path))
+                    .Cast<MetadataReference>()
+                    .ToList();
+
+            var project = await base.CreateProjectImplAsync(primaryProject, additionalProjects, cancellationToken).ConfigureAwait(false);
+            return project.WithMetadataReferences(metadataReferences);
+        }
+    }
+}

--- a/umbraco.sln
+++ b/umbraco.sln
@@ -151,11 +151,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Umbraco.Cms.Api.Common", "s
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Umbraco.Cms.Imaging.ImageSharp", "src\Umbraco.Cms.Imaging.ImageSharp\Umbraco.Cms.Imaging.ImageSharp.csproj", "{35E3DA10-5549-41DE-B7ED-CC29355BA9FD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Umbraco.Cms.Persistence.EFCore", "src\Umbraco.Cms.Persistence.EFCore\Umbraco.Cms.Persistence.EFCore.csproj", "{9046F56E-4AC3-4603-A6A3-3ACCF632997E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Umbraco.Cms.Persistence.EFCore", "src\Umbraco.Cms.Persistence.EFCore\Umbraco.Cms.Persistence.EFCore.csproj", "{9046F56E-4AC3-4603-A6A3-3ACCF632997E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Umbraco.Cms.Persistence.EFCore.Sqlite", "src\Umbraco.Cms.Persistence.EFCore.Sqlite\Umbraco.Cms.Persistence.EFCore.Sqlite.csproj", "{8B4771F0-8EC2-4761-BBCE-DDE073DB3B7A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Umbraco.Cms.Persistence.EFCore.Sqlite", "src\Umbraco.Cms.Persistence.EFCore.Sqlite\Umbraco.Cms.Persistence.EFCore.Sqlite.csproj", "{8B4771F0-8EC2-4761-BBCE-DDE073DB3B7A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Umbraco.Cms.Persistence.EFCore.SqlServer", "src\Umbraco.Cms.Persistence.EFCore.SqlServer\Umbraco.Cms.Persistence.EFCore.SqlServer.csproj", "{9276C3F0-0DC9-46C9-BF32-9EE79D92AE02}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Umbraco.Cms.Persistence.EFCore.SqlServer", "src\Umbraco.Cms.Persistence.EFCore.SqlServer\Umbraco.Cms.Persistence.EFCore.SqlServer.csproj", "{9276C3F0-0DC9-46C9-BF32-9EE79D92AE02}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Umbraco.Cms.Analyzers", "src\Umbraco.Cms.Analyzers\Umbraco.Cms.Analyzers.csproj", "{DEE3AD4F-8E51-4C11-B35D-056E84F3BE8C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Umbraco.Tests.Analyzers", "tests\Umbraco.Tests.Analyzers\Umbraco.Tests.Analyzers.csproj", "{2C395DF1-049C-4703-A4AC-7A9B67F4C916}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -303,18 +307,18 @@ Global
 		{D48B5D6B-82FF-4235-986C-CDE646F41DEC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D48B5D6B-82FF-4235-986C-CDE646F41DEC}.SkipTests|Any CPU.ActiveCfg = Debug|Any CPU
 		{D48B5D6B-82FF-4235-986C-CDE646F41DEC}.SkipTests|Any CPU.Build.0 = Debug|Any CPU
-		{9046F56E-4AC3-4603-A6A3-3ACCF632997E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9046F56E-4AC3-4603-A6A3-3ACCF632997E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9046F56E-4AC3-4603-A6A3-3ACCF632997E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9046F56E-4AC3-4603-A6A3-3ACCF632997E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{9046F56E-4AC3-4603-A6A3-3ACCF632997E}.SkipTests|Any CPU.ActiveCfg = Debug|Any CPU
-		{9046F56E-4AC3-4603-A6A3-3ACCF632997E}.SkipTests|Any CPU.Build.0 = Debug|Any CPU
 		{35E3DA10-5549-41DE-B7ED-CC29355BA9FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{35E3DA10-5549-41DE-B7ED-CC29355BA9FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{35E3DA10-5549-41DE-B7ED-CC29355BA9FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{35E3DA10-5549-41DE-B7ED-CC29355BA9FD}.Release|Any CPU.Build.0 = Release|Any CPU
 		{35E3DA10-5549-41DE-B7ED-CC29355BA9FD}.SkipTests|Any CPU.ActiveCfg = Debug|Any CPU
 		{35E3DA10-5549-41DE-B7ED-CC29355BA9FD}.SkipTests|Any CPU.Build.0 = Debug|Any CPU
+		{9046F56E-4AC3-4603-A6A3-3ACCF632997E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9046F56E-4AC3-4603-A6A3-3ACCF632997E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9046F56E-4AC3-4603-A6A3-3ACCF632997E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9046F56E-4AC3-4603-A6A3-3ACCF632997E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9046F56E-4AC3-4603-A6A3-3ACCF632997E}.SkipTests|Any CPU.ActiveCfg = Debug|Any CPU
+		{9046F56E-4AC3-4603-A6A3-3ACCF632997E}.SkipTests|Any CPU.Build.0 = Debug|Any CPU
 		{8B4771F0-8EC2-4761-BBCE-DDE073DB3B7A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8B4771F0-8EC2-4761-BBCE-DDE073DB3B7A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8B4771F0-8EC2-4761-BBCE-DDE073DB3B7A}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -327,6 +331,18 @@ Global
 		{9276C3F0-0DC9-46C9-BF32-9EE79D92AE02}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9276C3F0-0DC9-46C9-BF32-9EE79D92AE02}.SkipTests|Any CPU.ActiveCfg = Debug|Any CPU
 		{9276C3F0-0DC9-46C9-BF32-9EE79D92AE02}.SkipTests|Any CPU.Build.0 = Debug|Any CPU
+		{DEE3AD4F-8E51-4C11-B35D-056E84F3BE8C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DEE3AD4F-8E51-4C11-B35D-056E84F3BE8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DEE3AD4F-8E51-4C11-B35D-056E84F3BE8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DEE3AD4F-8E51-4C11-B35D-056E84F3BE8C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DEE3AD4F-8E51-4C11-B35D-056E84F3BE8C}.SkipTests|Any CPU.ActiveCfg = Debug|Any CPU
+		{DEE3AD4F-8E51-4C11-B35D-056E84F3BE8C}.SkipTests|Any CPU.Build.0 = Debug|Any CPU
+		{2C395DF1-049C-4703-A4AC-7A9B67F4C916}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C395DF1-049C-4703-A4AC-7A9B67F4C916}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C395DF1-049C-4703-A4AC-7A9B67F4C916}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C395DF1-049C-4703-A4AC-7A9B67F4C916}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C395DF1-049C-4703-A4AC-7A9B67F4C916}.SkipTests|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C395DF1-049C-4703-A4AC-7A9B67F4C916}.SkipTests|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -345,6 +361,7 @@ Global
 		{2B47AD9F-FFF1-448A-88F1-D4F568811738} = {F2BF84D9-0A14-40AF-A0F3-B9BBBBC16A44}
 		{25AECCB5-B187-4406-844B-91B8FF0FCB37} = {2B47AD9F-FFF1-448A-88F1-D4F568811738}
 		{EA628ABD-624E-4AF3-B548-6710D4D66531} = {2B47AD9F-FFF1-448A-88F1-D4F568811738}
+		{2C395DF1-049C-4703-A4AC-7A9B67F4C916} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7A0F2E34-D2AF-4DAB-86A0-7D7764B3D0EC}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

This PR adds an analyzer and attribute `UmbracoInternalAttribute` that can be used to mark classes, interfaces and methods as Umbraco internal types that shouldn't be consumed outside the Umbraco repository.

This solves the problem of having public classes, interfaces and methods that needs to be public for a technical requirement like dependency injection but should in reality be internal and not messed with.

The implementation takes heavy inspiration from: https://github.com/dotnet/efcore/tree/main/src/EFCore.Analyzers and this has been included in the cs files.

This PR only adds the attribute to `UmbracoDbContext` and `IMigrationProvider` to create the tests. If these shouldn't be marked internal this can be changed.

I've also marked `EnablePackageValidation` as `false` due to it giving building errors because this would be a new package and isn't on Nuget I hope someone from HQ can help me out with if there needs to be done anything for this to work properly.

Note: The file `_._` is to avoid a build error because the analyzer itself is placed outside `lib/`.

### Test

To test the implementation I've created a simple Unit test project with some tests.

To test manually use `dotnet pack` locally to pack the Nuget packages (Tip: Use output parameter to place the files in a directory `dotnet pack -o testRelease`). Use these local versions and install it any project Console app or Umbraco template. Then reference the `UmbracoDbContext` and a warning should show up:
<img width="644" alt="image" src="https://github.com/umbraco/Umbraco-CMS/assets/24605285/6be84895-c104-4e98-bcc8-31720c61803f">


<!-- Thanks for contributing to Umbraco CMS! -->
