### PR TITLE
Do not allow content type property aliases that conflict with IPublishedElement

### DIFF
--- a/src/Umbraco.Core/Extensions/TypeExtensions.cs
+++ b/src/Umbraco.Core/Extensions/TypeExtensions.cs
@@ -219,96 +219,52 @@ public static class TypeExtensions
     /// <returns></returns>
     public static PropertyInfo[] GetAllProperties(this Type type)
     {
-        if (type.IsInterface)
-        {
-            var propertyInfos = new List<PropertyInfo>();
-
-            var considered = new List<Type>();
-            var queue = new Queue<Type>();
-            considered.Add(type);
-            queue.Enqueue(type);
-            while (queue.Count > 0)
-            {
-                Type subType = queue.Dequeue();
-                foreach (Type subInterface in subType.GetInterfaces())
-                {
-                    if (considered.Contains(subInterface))
-                    {
-                        continue;
-                    }
-
-                    considered.Add(subInterface);
-                    queue.Enqueue(subInterface);
-                }
-
-                PropertyInfo[] typeProperties = subType.GetProperties(
-                    BindingFlags.FlattenHierarchy
-                    | BindingFlags.Public
-                    | BindingFlags.NonPublic
-                    | BindingFlags.Instance);
-
-                IEnumerable<PropertyInfo> newPropertyInfos = typeProperties
-                    .Where(x => !propertyInfos.Contains(x));
-
-                propertyInfos.InsertRange(0, newPropertyInfos);
-            }
-
-            return propertyInfos.ToArray();
-        }
-
-        return type.GetProperties(BindingFlags.FlattenHierarchy
-                                  | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        const BindingFlags bindingFlags = BindingFlags.FlattenHierarchy
+                                          | BindingFlags.Public
+                                          | BindingFlags.NonPublic
+                                          | BindingFlags.Instance;
+        return type.GetAllMemberInfos(t => t.GetProperties(bindingFlags));
     }
 
     /// <summary>
-    ///     Returns all public properties including inherited properties even for interfaces
+    ///     Returns public properties including inherited properties even for interfaces
     /// </summary>
     /// <param name="type"></param>
     /// <returns></returns>
-    /// <remarks>
-    ///     taken from
-    ///     http://stackoverflow.com/questions/358835/getproperties-to-return-all-properties-for-an-interface-inheritance-hierarchy
-    /// </remarks>
     public static PropertyInfo[] GetPublicProperties(this Type type)
     {
-        if (type.IsInterface)
-        {
-            var propertyInfos = new List<PropertyInfo>();
+        const BindingFlags bindingFlags = BindingFlags.FlattenHierarchy
+                                          | BindingFlags.Public
+                                          | BindingFlags.Instance;
+        return type.GetAllMemberInfos(t => t.GetProperties(bindingFlags));
+    }
 
-            var considered = new List<Type>();
-            var queue = new Queue<Type>();
-            considered.Add(type);
-            queue.Enqueue(type);
-            while (queue.Count > 0)
-            {
-                Type subType = queue.Dequeue();
-                foreach (Type subInterface in subType.GetInterfaces())
-                {
-                    if (considered.Contains(subInterface))
-                    {
-                        continue;
-                    }
+    /// <summary>
+    ///     Returns public methods including inherited methods even for interfaces
+    /// </summary>
+    /// <param name="type"></param>
+    /// <returns></returns>
+    public static MethodInfo[] GetPublicMethods(this Type type)
+    {
+        const BindingFlags bindingFlags = BindingFlags.FlattenHierarchy
+                                          | BindingFlags.Public
+                                          | BindingFlags.Instance;
+        return type.GetAllMemberInfos(t => t.GetMethods(bindingFlags));
+    }
 
-                    considered.Add(subInterface);
-                    queue.Enqueue(subInterface);
-                }
-
-                PropertyInfo[] typeProperties = subType.GetProperties(
-                    BindingFlags.FlattenHierarchy
-                    | BindingFlags.Public
-                    | BindingFlags.Instance);
-
-                IEnumerable<PropertyInfo> newPropertyInfos = typeProperties
-                    .Where(x => !propertyInfos.Contains(x));
-
-                propertyInfos.InsertRange(0, newPropertyInfos);
-            }
-
-            return propertyInfos.ToArray();
-        }
-
-        return type.GetProperties(BindingFlags.FlattenHierarchy
-                                  | BindingFlags.Public | BindingFlags.Instance);
+    /// <summary>
+    ///     Returns all methods including inherited methods even for interfaces
+    /// </summary>
+    /// <remarks>Includes both Public and Non-Public methods</remarks>
+    /// <param name="type"></param>
+    /// <returns></returns>
+    public static MethodInfo[] GetAllMethods(this Type type)
+    {
+        const BindingFlags bindingFlags = BindingFlags.FlattenHierarchy
+                                          | BindingFlags.Public
+                                          | BindingFlags.NonPublic
+                                          | BindingFlags.Instance;
+        return type.GetAllMemberInfos(t => t.GetMethods(bindingFlags));
     }
 
     /// <summary>
@@ -511,5 +467,48 @@ public static class TypeExtensions
         }
 
         return attempt;
+    }
+
+    /// <remarks>
+    ///     taken from
+    ///     http://stackoverflow.com/questions/358835/getproperties-to-return-all-properties-for-an-interface-inheritance-hierarchy
+    /// </remarks>
+    private static T[] GetAllMemberInfos<T>(this Type type, Func<Type, T[]> getMemberInfos)
+        where T : MemberInfo
+    {
+        if (type.IsInterface is false)
+        {
+            return getMemberInfos(type);
+        }
+
+        var memberInfos = new List<T>();
+
+        var considered = new List<Type>();
+        var queue = new Queue<Type>();
+        considered.Add(type);
+        queue.Enqueue(type);
+        while (queue.Count > 0)
+        {
+            Type subType = queue.Dequeue();
+            foreach (Type subInterface in subType.GetInterfaces())
+            {
+                if (considered.Contains(subInterface))
+                {
+                    continue;
+                }
+
+                considered.Add(subInterface);
+                queue.Enqueue(subInterface);
+            }
+
+            T[] typeMethodInfos = getMemberInfos(subType);
+
+            IEnumerable<T> newMethodInfos = typeMethodInfos
+                .Where(x => !memberInfos.Contains(x));
+
+            memberInfos.InsertRange(0, newMethodInfos);
+        }
+
+        return memberInfos.ToArray();
     }
 }

--- a/src/Umbraco.Web.BackOffice/ModelsBuilder/ContentTypeModelValidatorBase.cs
+++ b/src/Umbraco.Web.BackOffice/ModelsBuilder/ContentTypeModelValidatorBase.cs
@@ -68,10 +68,10 @@ public abstract class ContentTypeModelValidatorBase<TModel, TProperty> : EditorV
 
     private ValidationResult? ValidateProperty(PropertyTypeBasic property, int groupIndex, int propertyIndex)
     {
-        // don't let them match any properties or methods in IPublishedContent
+        // don't let them match any properties or methods in IPublishedContent (including those defined in any base interfaces like IPublishedElement)
         // TODO: There are probably more!
-        var reservedProperties = typeof(IPublishedContent).GetProperties().Select(x => x.Name).ToArray();
-        var reservedMethods = typeof(IPublishedContent).GetMethods().Select(x => x.Name).ToArray();
+        var reservedProperties = typeof(IPublishedContent).GetPublicProperties().Select(x => x.Name).ToArray();
+        var reservedMethods = typeof(IPublishedContent).GetPublicMethods().Select(x => x.Name).ToArray();
 
         var alias = property.Alias;
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

It is currently possible to define content type properties with aliases that conflict with `IPublishedElement` properties - e.g. `ContentType` and `Properties`. This becomes a problem when ModelsBuilder creates strongly typed models:

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/7b62e75f-144e-4467-a90e-65254ec25d05)

We're already trying to avoid this scenario in the server side validation. However, we're only testing for properties and methods defined on `IPublishedContent`.

With this PR we also test properties from base interfaces like `IPublishedElement`. Now we can no longer create properties with clashing aliases:

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/b4e355c6-123c-46f2-8ca7-b364649884cc)

Note that the `TypeExtensions` changes in this PR have been copied over from similar changes in a V14 PR, thus adding more new extension methods than strictly necessary for this PR. This hopefully will make forward merging easier 😄 