### PR TITLE
V14: Consistently refer to user key

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DataTypeFolderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DataTypeFolderControllerBase.cs
@@ -32,14 +32,14 @@ public abstract class DataTypeFolderControllerBase : FolderManagementControllerB
     protected override async Task<EntityContainer?> GetParentContainerAsync(EntityContainer container)
         => await _dataTypeContainerService.GetParentAsync(container);
 
-    protected override async Task<Attempt<EntityContainer, DataTypeContainerOperationStatus>> CreateContainerAsync(EntityContainer container, Guid? parentId, Guid userId)
-        => await _dataTypeContainerService.CreateAsync(container, parentId, userId);
+    protected override async Task<Attempt<EntityContainer, DataTypeContainerOperationStatus>> CreateContainerAsync(EntityContainer container, Guid? parentId, Guid userKey)
+        => await _dataTypeContainerService.CreateAsync(container, parentId, userKey);
 
-    protected override async Task<Attempt<EntityContainer, DataTypeContainerOperationStatus>> UpdateContainerAsync(EntityContainer container, Guid userId)
-        => await _dataTypeContainerService.UpdateAsync(container, userId);
+    protected override async Task<Attempt<EntityContainer, DataTypeContainerOperationStatus>> UpdateContainerAsync(EntityContainer container, Guid userKey)
+        => await _dataTypeContainerService.UpdateAsync(container, userKey);
 
-    protected override async Task<Attempt<EntityContainer?, DataTypeContainerOperationStatus>> DeleteContainerAsync(Guid id, Guid userId)
-        => await _dataTypeContainerService.DeleteAsync(id, userId);
+    protected override async Task<Attempt<EntityContainer?, DataTypeContainerOperationStatus>> DeleteContainerAsync(Guid id, Guid userKey)
+        => await _dataTypeContainerService.DeleteAsync(id, userKey);
 
     protected override IActionResult OperationStatusResult(DataTypeContainerOperationStatus status)
         => status switch

--- a/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/CreateUserGroupController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/CreateUserGroupController.cs
@@ -49,7 +49,7 @@ public class CreateUserGroupController : UserGroupControllerBase
 
         IUserGroup group = userGroupCreationAttempt.Result;
 
-        Attempt<IUserGroup, UserGroupOperationStatus> result = await _userGroupService.CreateAsync(group, /*currentUser.Id*/ -1);
+        Attempt<IUserGroup, UserGroupOperationStatus> result = await _userGroupService.CreateAsync(group, CurrentUserKey(_backOfficeSecurityAccessor));
         return result.Success
             ? CreatedAtAction<ByKeyUserGroupController>(controller => nameof(controller.ByKey), group.Key)
             : UserGroupOperationStatusResult(result.Status);

--- a/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/UpdateUserGroupController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/UpdateUserGroupController.cs
@@ -5,6 +5,7 @@ using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.UserGroup;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 
@@ -15,13 +16,16 @@ public class UpdateUserGroupController : UserGroupControllerBase
 {
     private readonly IUserGroupService _userGroupService;
     private readonly IUserGroupPresentationFactory _userGroupPresentationFactory;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
 
     public UpdateUserGroupController(
         IUserGroupService userGroupService,
-        IUserGroupPresentationFactory userGroupPresentationFactory)
+        IUserGroupPresentationFactory userGroupPresentationFactory,
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
     {
         _userGroupService = userGroupService;
         _userGroupPresentationFactory = userGroupPresentationFactory;
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
     [HttpPut("{id:guid}")]
@@ -44,7 +48,7 @@ public class UpdateUserGroupController : UserGroupControllerBase
         }
 
         IUserGroup userGroup = userGroupUpdateAttempt.Result;
-        Attempt<IUserGroup, UserGroupOperationStatus> result = await _userGroupService.UpdateAsync(userGroup, -1);
+        Attempt<IUserGroup, UserGroupOperationStatus> result = await _userGroupService.UpdateAsync(userGroup, CurrentUserKey(_backOfficeSecurityAccessor));
 
         return result.Success
             ? Ok()

--- a/src/Umbraco.Core/Services/IPartialViewService.cs
+++ b/src/Umbraco.Core/Services/IPartialViewService.cs
@@ -11,9 +11,9 @@ public interface IPartialViewService : IBasicFileService<IPartialView>
     /// Deletes a partial view.
     /// </summary>
     /// <param name="path">The path of the partial view to delete.</param>
-    /// <param name="performingUserKey">The key of the user performing the operation.</param>
+    /// <param name="userKey">The key of the user performing the operation.</param>
     /// <returns>An operation status.</returns>
-    Task<PartialViewOperationStatus> DeleteAsync(string path, Guid performingUserKey);
+    Task<PartialViewOperationStatus> DeleteAsync(string path, Guid userKey);
 
     /// <summary>
     /// Gets the name of all the available partial view snippets.
@@ -34,15 +34,15 @@ public interface IPartialViewService : IBasicFileService<IPartialView>
     /// Creates a new partial view.
     /// </summary>
     /// <param name="createModel"><see cref="PartialViewCreateModel"/> containing the information about the partial view being created.</param>
-    /// <param name="performingUserKey">The key of the user performing the operation.</param>
+    /// <param name="userKey">The key of the user performing the operation.</param>
     /// <returns>An attempt indicating if the operation was a success as well as a more detailed <see cref="PartialViewOperationStatus"/>.</returns>
-    Task<Attempt<IPartialView?, PartialViewOperationStatus>> CreateAsync(PartialViewCreateModel createModel, Guid performingUserKey);
+    Task<Attempt<IPartialView?, PartialViewOperationStatus>> CreateAsync(PartialViewCreateModel createModel, Guid userKey);
 
     /// <summary>
     /// Updates an existing partial view.
     /// </summary>
     /// <param name="updateModel">A <see cref="PartialViewUpdateModel"/> with the changes.</param>
-    /// <param name="performingUserKey">The key of the user performing the operation.</param>
+    /// <param name="userKey">The key of the user performing the operation.</param>
     /// <returns>An attempt indicating if the operation was a success as well as a more detailed <see cref="PartialViewOperationStatus"/>.</returns>
-    Task<Attempt<IPartialView?, PartialViewOperationStatus>> UpdateAsync(PartialViewUpdateModel updateModel, Guid performingUserKey);
+    Task<Attempt<IPartialView?, PartialViewOperationStatus>> UpdateAsync(PartialViewUpdateModel updateModel, Guid userKey);
 }

--- a/src/Umbraco.Core/Services/IScriptService.cs
+++ b/src/Umbraco.Core/Services/IScriptService.cs
@@ -9,23 +9,23 @@ public interface IScriptService : IBasicFileService<IScript>
     /// Creates a new script.
     /// </summary>
     /// <param name="createModel"><see cref="ScriptCreateModel"/> containing the information about the script being created.</param>
-    /// <param name="performingUserKey">The key of the user performing the operation.</param>
+    /// <param name="userKey">The key of the user performing the operation.</param>
     /// <returns>An attempt indicating if the operation was a success as well as a more detailed <see cref="ScriptOperationStatus"/>.</returns>
-    Task<Attempt<IScript?, ScriptOperationStatus>> CreateAsync(ScriptCreateModel createModel, Guid performingUserKey);
+    Task<Attempt<IScript?, ScriptOperationStatus>> CreateAsync(ScriptCreateModel createModel, Guid userKey);
 
     /// <summary>
     /// Updates an existing script.
     /// </summary>
     /// <param name="updateModel">A <see cref="ScriptUpdateModel"/> with the changes.</param>
-    /// <param name="performingUserKey">The key of the user performing the operation.</param>
+    /// <param name="userKey">The key of the user performing the operation.</param>
     /// <returns>An attempt indicating if the operation was a success as well as a more detailed <see cref="ScriptOperationStatus"/>.</returns>
-    Task<Attempt<IScript?, ScriptOperationStatus>> UpdateAsync(ScriptUpdateModel updateModel, Guid performingUserKey);
+    Task<Attempt<IScript?, ScriptOperationStatus>> UpdateAsync(ScriptUpdateModel updateModel, Guid userKey);
 
     /// <summary>
     /// Deletes a Script.
     /// </summary>
     /// <param name="path">The path of the script to delete.</param>
-    /// <param name="performingUserKey">The key of the user performing the operation.</param>
+    /// <param name="userKey">The key of the user performing the operation.</param>
     /// <returns>An operation status.</returns>
-    Task<ScriptOperationStatus> DeleteAsync(string path, Guid performingUserKey);
+    Task<ScriptOperationStatus> DeleteAsync(string path, Guid userKey);
 }

--- a/src/Umbraco.Core/Services/IStylesheetService.cs
+++ b/src/Umbraco.Core/Services/IStylesheetService.cs
@@ -9,23 +9,23 @@ public interface IStylesheetService : IBasicFileService<IStylesheet>
     /// Creates a new stylesheet.
     /// </summary>
     /// <param name="createModel"><see cref="StylesheetCreateModel"/> containing the information about the stylesheet being created.</param>
-    /// <param name="performingUserKey">The key of the user performing the operation.</param>
+    /// <param name="userKey">The key of the user performing the operation.</param>
     /// <returns>An attempt indicating if the operation was a success as well as a more detailed <see cref="StylesheetOperationStatus"/>.</returns>
-    Task<Attempt<IStylesheet?, StylesheetOperationStatus>> CreateAsync(StylesheetCreateModel createModel, Guid performingUserKey);
+    Task<Attempt<IStylesheet?, StylesheetOperationStatus>> CreateAsync(StylesheetCreateModel createModel, Guid userKey);
 
     /// <summary>
     /// Updates an existing stylesheet.
     /// </summary>
     /// <param name="updateModel">A <see cref="StylesheetUpdateModel"/> with the changes.</param>
-    /// <param name="performingUserKey">The key of the user performing the operation.</param>
+    /// <param name="userKey">The key of the user performing the operation.</param>
     /// <returns>An attempt indicating if the operation was a success as well as a more detailed <see cref="StylesheetOperationStatus"/>.</returns>
-    Task<Attempt<IStylesheet?, StylesheetOperationStatus>> UpdateAsync(StylesheetUpdateModel updateModel, Guid performingUserKey);
+    Task<Attempt<IStylesheet?, StylesheetOperationStatus>> UpdateAsync(StylesheetUpdateModel updateModel, Guid userKey);
 
     /// <summary>
     /// Deletes a stylesheet.
     /// </summary>
     /// <param name="path">The path of the stylesheet to delete.</param>
-    /// <param name="performingUserKey">The key of the user performing the operation.</param>
+    /// <param name="userKey">The key of the user performing the operation.</param>
     /// <returns>An operation status.</returns>
-    Task<StylesheetOperationStatus> DeleteAsync(string path, Guid performingUserKey);
+    Task<StylesheetOperationStatus> DeleteAsync(string path, Guid userKey);
 }

--- a/src/Umbraco.Core/Services/IUserGroupService.cs
+++ b/src/Umbraco.Core/Services/IUserGroupService.cs
@@ -66,18 +66,18 @@ public interface IUserGroupService
     /// Persists a new user group.
     /// </summary>
     /// <param name="userGroup">The user group to create.</param>
-    /// <param name="performingUserId">The ID of the user responsible for creating the group.</param>
-    /// <param name="groupMembersUserIds">The IDs of the users that should be part of the group when created.</param>
+    /// <param name="userKey">The key of the user responsible for creating the group.</param>
+    /// <param name="groupMembersKeys">The keys of the users that should be part of the group when created.</param>
     /// <returns>An attempt indicating if the operation was a success as well as a more detailed <see cref="UserGroupOperationStatus"/>.</returns>
-    Task<Attempt<IUserGroup, UserGroupOperationStatus>> CreateAsync(IUserGroup userGroup, int performingUserId, int[]? groupMembersUserIds = null);
+    Task<Attempt<IUserGroup, UserGroupOperationStatus>> CreateAsync(IUserGroup userGroup, Guid userKey, Guid[]? groupMembersKeys = null);
 
     /// <summary>
     /// Updates an existing user group.
     /// </summary>
     /// <param name="userGroup">The user group to update.</param>
-    /// <param name="performingUserId">The ID of the user responsible for updating the group.</param>
+    /// <param name="userKey">The ID of the user responsible for updating the group.</param>
     /// <returns>An attempt indicating if the operation was a success as well as a more detailed <see cref="UserGroupOperationStatus"/>.</returns>
-    Task<Attempt<IUserGroup, UserGroupOperationStatus>> UpdateAsync(IUserGroup userGroup, int performingUserId);
+    Task<Attempt<IUserGroup, UserGroupOperationStatus>> UpdateAsync(IUserGroup userGroup, Guid userKey);
 
     /// <summary>
     ///     Deletes a UserGroup

--- a/src/Umbraco.Core/Services/IUserService.cs
+++ b/src/Umbraco.Core/Services/IUserService.cs
@@ -51,31 +51,31 @@ public interface IUserService : IMembershipUserService
     /// <remarks>
     /// This creates both the Umbraco user and the identity user.
     /// </remarks>
-    /// <param name="performingUserKey">The key of the user performing the operation.</param>
+    /// <param name="userKey">The key of the user performing the operation.</param>
     /// <param name="model">Model to create the user from.</param>
     /// <param name="approveUser">Specifies if the user should be enabled be default. Defaults to false.</param>
     /// <returns>An attempt indicating if the operation was a success as well as a more detailed <see cref="UserOperationStatus"/>.</returns>
-    Task<Attempt<UserCreationResult, UserOperationStatus>> CreateAsync(Guid performingUserKey, UserCreateModel model, bool approveUser = false);
+    Task<Attempt<UserCreationResult, UserOperationStatus>> CreateAsync(Guid userKey, UserCreateModel model, bool approveUser = false);
 
-    Task<Attempt<UserInvitationResult, UserOperationStatus>> InviteAsync(Guid performingUserKey, UserInviteModel model);
+    Task<Attempt<UserInvitationResult, UserOperationStatus>> InviteAsync(Guid userKey, UserInviteModel model);
 
     Task<Attempt<UserOperationStatus>> VerifyInviteAsync(Guid userKey, string token);
 
     Task<Attempt<PasswordChangedModel, UserOperationStatus>> CreateInitialPasswordAsync(Guid userKey, string token, string password);
-    
-    Task<Attempt<IUser?, UserOperationStatus>> UpdateAsync(Guid performingUserKey, UserUpdateModel model);
+
+    Task<Attempt<IUser?, UserOperationStatus>> UpdateAsync(Guid userKey, UserUpdateModel model);
 
     Task<UserOperationStatus> SetAvatarAsync(Guid userKey, Guid temporaryFileKey);
 
     Task<UserOperationStatus> DeleteAsync(Guid key);
 
-    Task<UserOperationStatus> DisableAsync(Guid performingUserKey, ISet<Guid> keys);
+    Task<UserOperationStatus> DisableAsync(Guid userKey, ISet<Guid> keys);
 
-    Task<UserOperationStatus> EnableAsync(Guid performingUserKey, ISet<Guid> keys);
+    Task<UserOperationStatus> EnableAsync(Guid userKey, ISet<Guid> keys);
 
-    Task<Attempt<UserUnlockResult, UserOperationStatus>> UnlockAsync(Guid performingUserKey, params Guid[] keys);
+    Task<Attempt<UserUnlockResult, UserOperationStatus>> UnlockAsync(Guid userKey, params Guid[] keys);
 
-    Task<Attempt<PasswordChangedModel, UserOperationStatus>> ChangePasswordAsync(Guid performingUserKey, ChangeUserPasswordModel model);
+    Task<Attempt<PasswordChangedModel, UserOperationStatus>> ChangePasswordAsync(Guid userKey, ChangeUserPasswordModel model);
 
     Task<UserOperationStatus> ClearAvatarAsync(Guid userKey);
 
@@ -84,12 +84,14 @@ public interface IUserService : IMembershipUserService
     /// <summary>
     /// Gets all users that the requesting user is allowed to see.
     /// </summary>
-    /// <param name="requestingUserKey">The Key of the user requesting the users.</param>
-    /// <returns></returns>
-    Task<Attempt<PagedModel<IUser>?, UserOperationStatus>> GetAllAsync(Guid requestingUserKey, int skip, int take) => throw new NotImplementedException();
+    /// <param name="userKey">The Key of the user requesting the users.</param>
+    /// <param name="skip">Amount to skip.</param>
+    /// <param name="take">Amount to take.</param>
+    /// <returns>All users that the user is allowed to see.</returns>
+    Task<Attempt<PagedModel<IUser>?, UserOperationStatus>> GetAllAsync(Guid userKey, int skip, int take) => throw new NotImplementedException();
 
     public Task<Attempt<PagedModel<IUser>, UserOperationStatus>> FilterAsync(
-        Guid requestingUserKey,
+        Guid userKey,
         UserFilter filter,
         int skip = 0,
         int take = 100,

--- a/src/Umbraco.Core/Services/PartialViewService.cs
+++ b/src/Umbraco.Core/Services/PartialViewService.cs
@@ -37,7 +37,7 @@ public class PartialViewService : FileServiceBase<IPartialViewRepository, IParti
     }
 
     /// <inheritdoc />
-    public async Task<PartialViewOperationStatus> DeleteAsync(string path, Guid performingUserKey)
+    public async Task<PartialViewOperationStatus> DeleteAsync(string path, Guid userKey)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope();
 
@@ -60,7 +60,7 @@ public class PartialViewService : FileServiceBase<IPartialViewRepository, IParti
         scope.Notifications.Publish(
             new PartialViewDeletedNotification(partialView, eventMessages).WithStateFrom(deletingNotification));
 
-        await AuditAsync(AuditType.Delete, performingUserKey);
+        await AuditAsync(AuditType.Delete, userKey);
         return PartialViewOperationStatus.Success;
     }
 
@@ -99,7 +99,7 @@ public class PartialViewService : FileServiceBase<IPartialViewRepository, IParti
     }
 
     /// <inheritdoc />
-    public async Task<Attempt<IPartialView?, PartialViewOperationStatus>> CreateAsync(PartialViewCreateModel createModel, Guid performingUserKey)
+    public async Task<Attempt<IPartialView?, PartialViewOperationStatus>> CreateAsync(PartialViewCreateModel createModel, Guid userKey)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope();
 
@@ -129,7 +129,7 @@ public class PartialViewService : FileServiceBase<IPartialViewRepository, IParti
 
         Repository.Save(partialView);
         scope.Notifications.Publish(new PartialViewSavedNotification(partialView, eventMessages).WithStateFrom(savingNotification));
-        await AuditAsync(AuditType.Save, performingUserKey);
+        await AuditAsync(AuditType.Save, userKey);
 
         scope.Complete();
         return Attempt.SucceedWithStatus<IPartialView?, PartialViewOperationStatus>(PartialViewOperationStatus.Success, partialView);
@@ -162,7 +162,7 @@ public class PartialViewService : FileServiceBase<IPartialViewRepository, IParti
     }
 
     /// <inheritdoc />
-    public async Task<Attempt<IPartialView?, PartialViewOperationStatus>> UpdateAsync(PartialViewUpdateModel updateModel, Guid performingUserKey)
+    public async Task<Attempt<IPartialView?, PartialViewOperationStatus>> UpdateAsync(PartialViewUpdateModel updateModel, Guid userKey)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope();
         IPartialView? partialView = Repository.Get(updateModel.ExistingPath);
@@ -195,7 +195,7 @@ public class PartialViewService : FileServiceBase<IPartialViewRepository, IParti
         Repository.Save(partialView);
         scope.Notifications.Publish(new PartialViewSavedNotification(partialView, eventMessages).WithStateFrom(savingNotification));
 
-        await AuditAsync(AuditType.Save, performingUserKey);
+        await AuditAsync(AuditType.Save, userKey);
 
         scope.Complete();
         return Attempt.SucceedWithStatus<IPartialView?, PartialViewOperationStatus>(PartialViewOperationStatus.Success, partialView);

--- a/src/Umbraco.Core/Services/PartialViewService.cs
+++ b/src/Umbraco.Core/Services/PartialViewService.cs
@@ -216,9 +216,9 @@ public class PartialViewService : FileServiceBase<IPartialViewRepository, IParti
         return PartialViewOperationStatus.Success;
     }
 
-    private async Task AuditAsync(AuditType type, Guid performingUserKey)
+    private async Task AuditAsync(AuditType type, Guid userKey)
     {
-        int userId = await _userIdKeyResolver.GetAsync(performingUserKey);
+        int userId = await _userIdKeyResolver.GetAsync(userKey);
 
         // We're passing -1 here, because we don't have an entity id to pass in, as files on disc are not entities
         _auditRepository.Save(new AuditItem(-1, type, userId, "PartialView"));

--- a/src/Umbraco.Core/Services/ScriptService.cs
+++ b/src/Umbraco.Core/Services/ScriptService.cs
@@ -32,7 +32,7 @@ public class ScriptService : FileServiceBase<IScriptRepository, IScript>, IScrip
     }
 
     /// <inheritdoc />
-    public async Task<ScriptOperationStatus> DeleteAsync(string path, Guid performingUserKey)
+    public async Task<ScriptOperationStatus> DeleteAsync(string path, Guid userKey)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope();
 
@@ -55,14 +55,14 @@ public class ScriptService : FileServiceBase<IScriptRepository, IScript>, IScrip
         scope.Notifications.Publish(
             new ScriptDeletedNotification(script, eventMessages).WithStateFrom(deletingNotification));
 
-        await AuditAsync(AuditType.Delete, performingUserKey);
+        await AuditAsync(AuditType.Delete, userKey);
 
         scope.Complete();
         return ScriptOperationStatus.Success;
     }
 
     /// <inheritdoc />
-    public async Task<Attempt<IScript?, ScriptOperationStatus>> CreateAsync(ScriptCreateModel createModel, Guid performingUserKey)
+    public async Task<Attempt<IScript?, ScriptOperationStatus>> CreateAsync(ScriptCreateModel createModel, Guid userKey)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope();
 
@@ -92,7 +92,7 @@ public class ScriptService : FileServiceBase<IScriptRepository, IScript>, IScrip
         Repository.Save(script);
 
         scope.Notifications.Publish(new ScriptSavedNotification(script, eventMessages).WithStateFrom(savingNotification));
-        await AuditAsync(AuditType.Save, performingUserKey);
+        await AuditAsync(AuditType.Save, userKey);
 
         scope.Complete();
         return Attempt.SucceedWithStatus<IScript?, ScriptOperationStatus>(ScriptOperationStatus.Success, script);
@@ -125,7 +125,7 @@ public class ScriptService : FileServiceBase<IScriptRepository, IScript>, IScrip
     }
 
     /// <inheritdoc />
-    public async Task<Attempt<IScript?, ScriptOperationStatus>> UpdateAsync(ScriptUpdateModel updateModel, Guid performingUserKey)
+    public async Task<Attempt<IScript?, ScriptOperationStatus>> UpdateAsync(ScriptUpdateModel updateModel, Guid userKey)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope();
         IScript? script = Repository.Get(updateModel.ExistingPath);
@@ -159,7 +159,7 @@ public class ScriptService : FileServiceBase<IScriptRepository, IScript>, IScrip
         Repository.Save(script);
         scope.Notifications.Publish(new ScriptSavedNotification(script, eventMessages).WithStateFrom(savingNotification));
 
-        await AuditAsync(AuditType.Save, performingUserKey);
+        await AuditAsync(AuditType.Save, userKey);
 
         scope.Complete();
         return Attempt.SucceedWithStatus<IScript?, ScriptOperationStatus>(ScriptOperationStatus.Success, script);

--- a/src/Umbraco.Core/Services/ScriptService.cs
+++ b/src/Umbraco.Core/Services/ScriptService.cs
@@ -180,9 +180,9 @@ public class ScriptService : FileServiceBase<IScriptRepository, IScript>, IScrip
         return ScriptOperationStatus.Success;
     }
 
-    private async Task AuditAsync(AuditType type, Guid performingUserKey)
+    private async Task AuditAsync(AuditType type, Guid userKey)
     {
-        int userId = await _userIdKeyResolver.GetAsync(performingUserKey);
+        int userId = await _userIdKeyResolver.GetAsync(userKey);
         _auditRepository.Save(new AuditItem(-1, type, userId, "Script"));
     }
 }

--- a/src/Umbraco.Core/Services/StylesheetService.cs
+++ b/src/Umbraco.Core/Services/StylesheetService.cs
@@ -178,9 +178,9 @@ public class StylesheetService : FileServiceBase<IStylesheetRepository, IStylesh
         return StylesheetOperationStatus.Success;
     }
 
-    private async Task AuditAsync(AuditType type, Guid performingUserKey)
+    private async Task AuditAsync(AuditType type, Guid userKey)
     {
-        var userId = await _userIdKeyResolver.GetAsync(performingUserKey);
+        var userId = await _userIdKeyResolver.GetAsync(userKey);
         _auditRepository.Save(new AuditItem(-1, type, userId, "Stylesheet"));
     }
 }

--- a/src/Umbraco.Core/Services/StylesheetService.cs
+++ b/src/Umbraco.Core/Services/StylesheetService.cs
@@ -32,7 +32,7 @@ public class StylesheetService : FileServiceBase<IStylesheetRepository, IStylesh
     }
 
     /// <inheritdoc />
-    public async Task<StylesheetOperationStatus> DeleteAsync(string path, Guid performingUserKey)
+    public async Task<StylesheetOperationStatus> DeleteAsync(string path, Guid userKey)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope();
 
@@ -52,14 +52,14 @@ public class StylesheetService : FileServiceBase<IStylesheetRepository, IStylesh
         Repository.Delete(stylesheet);
 
         scope.Notifications.Publish(new StylesheetDeletedNotification(stylesheet, eventMessages).WithStateFrom(deletingNotification));
-        await AuditAsync(AuditType.Delete, performingUserKey);
+        await AuditAsync(AuditType.Delete, userKey);
 
         scope.Complete();
         return StylesheetOperationStatus.Success;
     }
 
     /// <inheritdoc />
-    public async Task<Attempt<IStylesheet?, StylesheetOperationStatus>> CreateAsync(StylesheetCreateModel createModel, Guid performingUserKey)
+    public async Task<Attempt<IStylesheet?, StylesheetOperationStatus>> CreateAsync(StylesheetCreateModel createModel, Guid userKey)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope();
 
@@ -89,7 +89,7 @@ public class StylesheetService : FileServiceBase<IStylesheetRepository, IStylesh
         Repository.Save(stylesheet);
 
         scope.Notifications.Publish(new StylesheetSavedNotification(stylesheet, eventMessages).WithStateFrom(savingNotification));
-        await AuditAsync(AuditType.Save, performingUserKey);
+        await AuditAsync(AuditType.Save, userKey);
 
         scope.Complete();
         return Attempt.SucceedWithStatus<IStylesheet?, StylesheetOperationStatus>(StylesheetOperationStatus.Success, stylesheet);
@@ -122,7 +122,7 @@ public class StylesheetService : FileServiceBase<IStylesheetRepository, IStylesh
     }
 
     /// <inheritdoc />
-    public async Task<Attempt<IStylesheet?, StylesheetOperationStatus>> UpdateAsync(StylesheetUpdateModel updateModel, Guid performingUserKey)
+    public async Task<Attempt<IStylesheet?, StylesheetOperationStatus>> UpdateAsync(StylesheetUpdateModel updateModel, Guid userKey)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope();
 
@@ -157,7 +157,7 @@ public class StylesheetService : FileServiceBase<IStylesheetRepository, IStylesh
         Repository.Save(stylesheet);
 
         scope.Notifications.Publish(new StylesheetSavedNotification(stylesheet, eventMessages).WithStateFrom(savingNotification));
-        await AuditAsync(AuditType.Save, performingUserKey);
+        await AuditAsync(AuditType.Save, userKey);
 
         scope.Complete();
         return Attempt.SucceedWithStatus<IStylesheet?, StylesheetOperationStatus>(StylesheetOperationStatus.Success, stylesheet);

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -599,12 +599,12 @@ internal class UserService : RepositoryService, IUserService
     }
 
     /// <inheritdoc/>
-    public async Task<Attempt<UserCreationResult, UserOperationStatus>> CreateAsync(Guid performingUserKey, UserCreateModel model, bool approveUser = false)
+    public async Task<Attempt<UserCreationResult, UserOperationStatus>> CreateAsync(Guid userKey, UserCreateModel model, bool approveUser = false)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope();
         using IServiceScope serviceScope = _serviceScopeFactory.CreateScope();
 
-        IUser? performingUser = await GetAsync(performingUserKey);
+        IUser? performingUser = await GetAsync(userKey);
 
         if (performingUser is null)
         {
@@ -680,12 +680,12 @@ internal class UserService : RepositoryService, IUserService
         return Attempt.SucceedWithStatus(UserOperationStatus.Success, creationResult);
     }
 
-    public async Task<Attempt<UserInvitationResult, UserOperationStatus>> InviteAsync(Guid performingUserKey, UserInviteModel model)
+    public async Task<Attempt<UserInvitationResult, UserOperationStatus>> InviteAsync(Guid userKey, UserInviteModel model)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope();
         using IServiceScope serviceScope = _serviceScopeFactory.CreateScope();
 
-        IUser? performingUser = await GetAsync(performingUserKey);
+        IUser? performingUser = await GetAsync(userKey);
 
         if (performingUser is null)
         {
@@ -803,7 +803,7 @@ internal class UserService : RepositoryService, IUserService
         return UserOperationStatus.Success;
     }
 
-    public async Task<Attempt<IUser?, UserOperationStatus>> UpdateAsync(Guid performingUserKey, UserUpdateModel model)
+    public async Task<Attempt<IUser?, UserOperationStatus>> UpdateAsync(Guid userKey, UserUpdateModel model)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope();
         using IServiceScope serviceScope = _serviceScopeFactory.CreateScope();
@@ -816,7 +816,7 @@ internal class UserService : RepositoryService, IUserService
             return Attempt.FailWithStatus(UserOperationStatus.MissingUser, existingUser);
         }
 
-        IUser? performingUser = await userStore.GetAsync(performingUserKey);
+        IUser? performingUser = await userStore.GetAsync(userKey);
 
         if (performingUser is null)
         {
@@ -1007,7 +1007,7 @@ internal class UserService : RepositoryService, IUserService
         return keys;
     }
 
-    public async Task<Attempt<PasswordChangedModel, UserOperationStatus>> ChangePasswordAsync(Guid performingUserKey, ChangeUserPasswordModel model)
+    public async Task<Attempt<PasswordChangedModel, UserOperationStatus>> ChangePasswordAsync(Guid userKey, ChangeUserPasswordModel model)
     {
         IServiceScope serviceScope = _serviceScopeFactory.CreateScope();
         using ICoreScope scope = ScopeProvider.CreateCoreScope();
@@ -1019,7 +1019,7 @@ internal class UserService : RepositoryService, IUserService
             return Attempt.FailWithStatus(UserOperationStatus.UserNotFound, new PasswordChangedModel());
         }
 
-        IUser? performingUser = await userStore.GetAsync(performingUserKey);
+        IUser? performingUser = await userStore.GetAsync(userKey);
         if (performingUser is null)
         {
             return Attempt.FailWithStatus(UserOperationStatus.MissingUser, new PasswordChangedModel());
@@ -1052,11 +1052,11 @@ internal class UserService : RepositoryService, IUserService
         return Attempt.SucceedWithStatus(UserOperationStatus.Success, result.Result ?? new PasswordChangedModel());
     }
 
-    public async Task<Attempt<PagedModel<IUser>?, UserOperationStatus>> GetAllAsync(Guid requestingUserKey, int skip, int take)
+    public async Task<Attempt<PagedModel<IUser>?, UserOperationStatus>> GetAllAsync(Guid userKey, int skip, int take)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope();
 
-        IUser? requestingUser = await GetAsync(requestingUserKey);
+        IUser? requestingUser = await GetAsync(userKey);
 
         if (requestingUser is null)
         {
@@ -1099,7 +1099,7 @@ internal class UserService : RepositoryService, IUserService
     }
 
     public async Task<Attempt<PagedModel<IUser>, UserOperationStatus>> FilterAsync(
-        Guid requestingUserKey,
+        Guid userKey,
         UserFilter filter,
         int skip = 0,
         int take = 100,
@@ -1108,7 +1108,7 @@ internal class UserService : RepositoryService, IUserService
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope();
 
-        IUser? requestingUser = await GetAsync(requestingUserKey);
+        IUser? requestingUser = await GetAsync(userKey);
 
         if (requestingUser is null)
         {
@@ -1292,7 +1292,7 @@ internal class UserService : RepositoryService, IUserService
         return UserOperationStatus.Success;
     }
 
-    public async Task<UserOperationStatus> DisableAsync(Guid performingUserKey, ISet<Guid> keys)
+    public async Task<UserOperationStatus> DisableAsync(Guid userKey, ISet<Guid> keys)
     {
         if(keys.Any() is false)
         {
@@ -1300,7 +1300,7 @@ internal class UserService : RepositoryService, IUserService
         }
 
         using ICoreScope scope = ScopeProvider.CreateCoreScope();
-        IUser? performingUser = await GetAsync(performingUserKey);
+        IUser? performingUser = await GetAsync(userKey);
 
         if (performingUser is null)
         {
@@ -1338,7 +1338,7 @@ internal class UserService : RepositoryService, IUserService
         return UserOperationStatus.Success;
     }
 
-    public async Task<UserOperationStatus> EnableAsync(Guid performingUserKey, ISet<Guid> keys)
+    public async Task<UserOperationStatus> EnableAsync(Guid userKey, ISet<Guid> keys)
     {
         if(keys.Any() is false)
         {
@@ -1346,7 +1346,7 @@ internal class UserService : RepositoryService, IUserService
         }
 
         using ICoreScope scope = ScopeProvider.CreateCoreScope();
-        IUser? performingUser = await GetAsync(performingUserKey);
+        IUser? performingUser = await GetAsync(userKey);
 
         if (performingUser is null)
         {
@@ -1408,7 +1408,7 @@ internal class UserService : RepositoryService, IUserService
         return UserOperationStatus.Success;
     }
 
-    public async Task<Attempt<UserUnlockResult, UserOperationStatus>> UnlockAsync(Guid performingUserKey, params Guid[] keys)
+    public async Task<Attempt<UserUnlockResult, UserOperationStatus>> UnlockAsync(Guid userKey, params Guid[] keys)
     {
         if (keys.Length == 0)
         {
@@ -1416,7 +1416,7 @@ internal class UserService : RepositoryService, IUserService
         }
 
         using ICoreScope scope = ScopeProvider.CreateCoreScope();
-        IUser? performingUser = await GetAsync(performingUserKey);
+        IUser? performingUser = await GetAsync(userKey);
 
         if (performingUser is null)
         {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserGroupServiceValidationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserGroupServiceValidationTests.cs
@@ -25,7 +25,7 @@ public class UserGroupServiceValidationTests : UmbracoIntegrationTest
             Name = null
         };
 
-        var result = await UserGroupService.CreateAsync(userGroup, Constants.Security.SuperUserId);
+        var result = await UserGroupService.CreateAsync(userGroup, Constants.Security.SuperUserKey);
 
         Assert.IsFalse(result.Success);
         Assert.AreEqual(UserGroupOperationStatus.MissingName, result.Status);
@@ -39,7 +39,7 @@ public class UserGroupServiceValidationTests : UmbracoIntegrationTest
             Name = "Sed porttitor lectus nibh. Vivamus magna justo, lacinia eget consectetur sed, convallis at tellus. Vivamus suscipit tortor eget felis porttitor volutpat. Quisque velit nisi, pretium ut lacinia in, elementum id enim."
         };
 
-        var result = await UserGroupService.CreateAsync(userGroup, Constants.Security.SuperUserId);
+        var result = await UserGroupService.CreateAsync(userGroup, Constants.Security.SuperUserKey);
 
         Assert.IsFalse(result.Success);
         Assert.AreEqual(UserGroupOperationStatus.NameTooLong, result.Status);
@@ -54,7 +54,7 @@ public class UserGroupServiceValidationTests : UmbracoIntegrationTest
             Alias = "Sed porttitor lectus nibh. Vivamus magna justo, lacinia eget consectetur sed, convallis at tellus. Vivamus suscipit tortor eget felis porttitor volutpat. Quisque velit nisi, pretium ut lacinia in, elementum id enim. Vivamus suscipit tortor eget felis porttitor volutpat. Quisque velit nisi, pretium ut lacinia in, elementum id enim."
         };
 
-        var result = await UserGroupService.CreateAsync(userGroup, Constants.Security.SuperUserId);
+        var result = await UserGroupService.CreateAsync(userGroup, Constants.Security.SuperUserKey);
 
         Assert.IsFalse(result.Success);
         Assert.AreEqual(UserGroupOperationStatus.AliasTooLong, result.Status);
@@ -69,7 +69,7 @@ public class UserGroupServiceValidationTests : UmbracoIntegrationTest
             Alias = "someAlias"
         };
 
-        var result = await UserGroupService.UpdateAsync(userGroup, Constants.Security.SuperUserId);
+        var result = await UserGroupService.UpdateAsync(userGroup, Constants.Security.SuperUserKey);
 
         Assert.IsFalse(result.Success);
         Assert.AreEqual(UserGroupOperationStatus.NotFound, result.Status);
@@ -84,11 +84,11 @@ public class UserGroupServiceValidationTests : UmbracoIntegrationTest
             Alias = "someAlias"
         };
 
-        var result = await UserGroupService.CreateAsync(userGroup, Constants.Security.SuperUserId);
+        var result = await UserGroupService.CreateAsync(userGroup, Constants.Security.SuperUserKey);
 
         Assert.IsTrue(result.Success);
 
-        result = await UserGroupService.CreateAsync(userGroup, Constants.Security.SuperUserId);
+        result = await UserGroupService.CreateAsync(userGroup, Constants.Security.SuperUserKey);
 
         Assert.IsFalse(result.Success);
         Assert.AreEqual(UserGroupOperationStatus.AlreadyExists, result.Status);
@@ -104,7 +104,7 @@ public class UserGroupServiceValidationTests : UmbracoIntegrationTest
             Name = "I already exist",
             Alias = alias
         };
-        var setupResult = await UserGroupService.CreateAsync(existingUserGroup, Constants.Security.SuperUserId);
+        var setupResult = await UserGroupService.CreateAsync(existingUserGroup, Constants.Security.SuperUserKey);
         Assert.IsTrue(setupResult.Success);
 
         var newUserGroup = new UserGroup(ShortStringHelper)
@@ -112,7 +112,7 @@ public class UserGroupServiceValidationTests : UmbracoIntegrationTest
             Name = "I have a duplicate alias",
             Alias = alias,
         };
-        var result = await UserGroupService.CreateAsync(newUserGroup, Constants.Security.SuperUserId);
+        var result = await UserGroupService.CreateAsync(newUserGroup, Constants.Security.SuperUserKey);
 
         Assert.IsFalse(result.Success);
         Assert.AreEqual(UserGroupOperationStatus.DuplicateAlias, result.Status);
@@ -128,7 +128,7 @@ public class UserGroupServiceValidationTests : UmbracoIntegrationTest
             Name = "I already exist",
             Alias = alias
         };
-        var setupResult = await UserGroupService.CreateAsync(existingUserGroup, Constants.Security.SuperUserId);
+        var setupResult = await UserGroupService.CreateAsync(existingUserGroup, Constants.Security.SuperUserKey);
         Assert.IsTrue(setupResult.Success);
 
         IUserGroup userGroupToUpdate = new UserGroup(ShortStringHelper)
@@ -136,7 +136,7 @@ public class UserGroupServiceValidationTests : UmbracoIntegrationTest
             Name = "I don't have a duplicate alias",
             Alias = "somAlias",
         };
-        var creationResult = await UserGroupService.CreateAsync(userGroupToUpdate, Constants.Security.SuperUserId);
+        var creationResult = await UserGroupService.CreateAsync(userGroupToUpdate, Constants.Security.SuperUserKey);
         Assert.IsTrue(creationResult.Success);
 
 
@@ -144,7 +144,7 @@ public class UserGroupServiceValidationTests : UmbracoIntegrationTest
         userGroupToUpdate.Name = "Now I have a duplicate alias";
         userGroupToUpdate.Alias = alias;
 
-        var updateResult = await UserGroupService.UpdateAsync(userGroupToUpdate, Constants.Security.SuperUserId);
+        var updateResult = await UserGroupService.UpdateAsync(userGroupToUpdate, Constants.Security.SuperUserKey);
         Assert.IsFalse(updateResult.Success);
         Assert.AreEqual(UserGroupOperationStatus.DuplicateAlias, updateResult.Status);
     }
@@ -157,13 +157,13 @@ public class UserGroupServiceValidationTests : UmbracoIntegrationTest
             Name = "Some Name",
             Alias = "someAlias"
         };
-        var setupResult = await UserGroupService.CreateAsync(userGroup, Constants.Security.SuperUserId);
+        var setupResult = await UserGroupService.CreateAsync(userGroup, Constants.Security.SuperUserKey);
         Assert.IsTrue(setupResult.Success);
 
 
         var updateName = "New Name";
         userGroup.Name = updateName;
-        var updateResult = await UserGroupService.UpdateAsync(userGroup, Constants.Security.SuperUserId);
+        var updateResult = await UserGroupService.UpdateAsync(userGroup, Constants.Security.SuperUserKey);
         Assert.IsTrue(updateResult.Success);
         var updatedGroup = updateResult.Result;
         Assert.AreEqual(updateName, updatedGroup.Name);


### PR DESCRIPTION
Ensures that the key of the performing user is always referred to simply as `userKey` in service method signatures. 

It's worth noting that it still exists some places, like in the audit table schema, but for any new service methods it has been aligned.

## Testing

Ensure tests pass