### PR TITLE
Updated the name of our Acceptance test project in the pipeline

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -368,7 +368,7 @@ stages:
               Umbraco__CMS__Unattended__InstallUnattended: true
               Umbraco__CMS__Global__InstallMissingDatabase: true
               UmbracoDatabaseServer: (LocalDB)\MSSQLLocalDB
-              UmbracoDatabaseName: Playwright
+              UmbracoDatabaseName: AcceptanceTestDB
               ConnectionStrings__umbracoDbDSN: Server=$(UmbracoDatabaseServer);Database=$(UmbracoDatabaseName);Integrated Security=true;
               # Custom Umbraco settings
               Umbraco__CMS__Global__VersionCheckPeriod: 0
@@ -429,7 +429,7 @@ stages:
             workingDirectory: tests/Umbraco.Tests.AcceptanceTest/misc
           - pwsh: |
               dotnet new --install ./nupkg/Umbraco.Templates.*.nupkg
-              dotnet new umbraco --name Playwright --no-restore --output .
+              dotnet new umbraco --name AcceptanceTestProject --no-restore --output .
               dotnet restore --configfile ./nuget.config
               dotnet build --configuration $(buildConfiguration) --no-restore
               dotnet dev-certs https

--- a/tests/Umbraco.Tests.AcceptanceTest/misc/umbraco-linux.docker
+++ b/tests/Umbraco.Tests.AcceptanceTest/misc/umbraco-linux.docker
@@ -46,4 +46,4 @@ ENV Umbraco__CMS__KeepAlive__DisableKeepAliveTask="true"
 # Set application URL
 ENV ASPNETCORE_URLS="http://0.0.0.0:5000;https://0.0.0.0:5001"
 
-CMD dotnet Playwright.dll
+CMD dotnet AcceptanceTestProject.dll

--- a/tests/Umbraco.Tests.AcceptanceTest/misc/umbraco-linux.docker
+++ b/tests/Umbraco.Tests.AcceptanceTest/misc/umbraco-linux.docker
@@ -11,7 +11,7 @@ COPY nupkg .
 
 WORKDIR /build
 RUN dotnet new --install /nupkg/Umbraco.Templates.*.nupkg
-RUN dotnet new umbraco --name Playwright --no-restore --output .
+RUN dotnet new umbraco --name AcceptanceTestProject --no-restore --output .
 RUN dotnet restore --configfile /nuget.config
 RUN dotnet build --configuration Release --no-restore
 RUN dotnet publish --configuration Release --no-build --output /dist


### PR DESCRIPTION
Updated the name of the Acceptance test project. The reason we did this is that we encountered an error on the pipeline which mentioned the former name 'Playwright', we ended up going back and forth since we thought the issue was with playwright itself and not the namespace of the Acceptance test project.

Test: 
- Go into the pipeline.
- Click on the 'E2E Tests'
- Go to step  'E2E Test Linux'
  - Go to Build and run container (Linux only)
    - Check if the command for creating the Umbraco Project looks like this:
    - `dotnet new umbraco --name AcceptanceTestProject --no-restore --output .`
- Go to step 'E2E Test Windows'
  - Go to Build and run container (Windows only)
    - Check if the 'AcceptanceTestProject.csproj ' was restored (Should be on line 32). 