### PR TITLE
Fixes #14649 - Ensure rendering of labels with no angularJS template code

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -644,6 +644,12 @@
                 blockObject.index = 0; 
 
                 if (blockObject.config.label && blockObject.config.label !== "" && blockObject.config.unsupported !== true) {
+
+                    // If the label does not contain any AngularJS template, then the MutationObserver wont give us any updates. To ensure labels without angular JS template code, we will just set the label directly for ones without '{{':
+                    if(blockObject.config.label.indexOf("{{") === -1) {
+                        blockObject.label = blockObject.config.label;
+                    }
+
                     var labelElement = $('<div></div>', { text: blockObject.config.label});
 
                     var observer = new MutationObserver(function(mutations) {
@@ -673,6 +679,7 @@
                         this.__labelScope = Object.assign(this.__labelScope, labelVars);
 
                         $compile(labelElement.contents())(this.__labelScope);
+
                     }.bind(blockObject)
                 } else {
                     blockObject.__renderLabel = function() {};


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/14649

Ensures Labels of Blocks of any Block Editor are rendered though their label does not contain any AngularJS Template code.