### PR TITLE
Backport #14657 to V8

### DIFF
--- a/src/Umbraco.Core/Composing/CompositionExtensions/Services.cs
+++ b/src/Umbraco.Core/Composing/CompositionExtensions/Services.cs
@@ -83,6 +83,7 @@ namespace Umbraco.Core.Composing.CompositionExtensions
 
             composition.RegisterUnique<ITelemetryService, TelemetryService>();
             composition.RegisterUnique<IHtmlSanitizer, NoopHtmlSanitizer>();
+            composition.RegisterUnique<IFileStreamSecurityValidator, FileStreamSecurityValidator>();
 
             return composition;
         }

--- a/src/Umbraco.Core/Security/FileStreamSecurityValidator.cs
+++ b/src/Umbraco.Core/Security/FileStreamSecurityValidator.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using System.IO;
+
+namespace Umbraco.Core.Security
+{
+    public class FileStreamSecurityValidator : IFileStreamSecurityValidator
+    {
+        private readonly IEnumerable<IFileStreamSecurityAnalyzer> _fileAnalyzers;
+
+        public FileStreamSecurityValidator(IEnumerable<IFileStreamSecurityAnalyzer> fileAnalyzers)
+        {
+            _fileAnalyzers = fileAnalyzers;
+        }
+
+        /// <summary>
+        /// Analyzes whether the file content is considered safe with registered IFileStreamSecurityAnalyzers
+        /// </summary>
+        /// <param name="fileStream">Needs to be a Read seekable stream</param>
+        /// <returns>Whether the file is considered safe after running the necessary analyzers</returns>
+        public bool IsConsideredSafe(Stream fileStream)
+        {
+            foreach (var fileAnalyzer in _fileAnalyzers)
+            {
+                fileStream.Seek(0, SeekOrigin.Begin);
+                if (!fileAnalyzer.ShouldHandle(fileStream))
+                {
+                    continue;
+                }
+
+                fileStream.Seek(0, SeekOrigin.Begin);
+                if (fileAnalyzer.IsConsideredSafe(fileStream) == false)
+                {
+                    return false;
+                }
+            }
+            fileStream.Seek(0, SeekOrigin.Begin);
+            // If no analyzer we consider the file to be safe as the implementer has the possibility to add additional analyzers
+            // Or all analyzers deem te file to be safe
+            return true;
+        }
+    }
+}

--- a/src/Umbraco.Core/Security/IFileStreamSecurityAnalyzer.cs
+++ b/src/Umbraco.Core/Security/IFileStreamSecurityAnalyzer.cs
@@ -1,0 +1,23 @@
+﻿using System.IO;
+
+namespace Umbraco.Core.Security
+{
+    public interface IFileStreamSecurityAnalyzer
+    {
+
+        /// <summary>
+        /// Indicates whether the analyzer should process the file
+        /// The implementation should be considerably faster than IsConsideredSafe
+        /// </summary>
+        /// <param name="fileStream"></param>
+        /// <returns></returns>
+        bool ShouldHandle(Stream fileStream);
+
+        /// <summary>
+        /// Analyzes whether the file content is considered safe
+        /// </summary>
+        /// <param name="fileStream">Needs to be a Read/Write seekable stream</param>
+        /// <returns>Whether the file is considered safe</returns>
+        bool IsConsideredSafe(Stream fileStream);
+    }
+}

--- a/src/Umbraco.Core/Security/IFileStreamSecurityValidator.cs
+++ b/src/Umbraco.Core/Security/IFileStreamSecurityValidator.cs
@@ -1,0 +1,15 @@
+﻿using System.IO;
+
+namespace Umbraco.Core.Security
+{
+    public interface IFileStreamSecurityValidator
+    {
+        /// <summary>
+        /// Analyzes whether the file content is considered safe with registered IFileStreamSecurityAnalyzers
+        /// </summary>
+        /// <param name="fileStream">Needs to be a Read seekable stream</param>
+        /// <returns>Whether the file is considered safe after running the necessary analyzers</returns>
+        bool IsConsideredSafe(Stream fileStream);
+    }
+
+}

--- a/src/Umbraco.Core/Umbraco.Core.csproj
+++ b/src/Umbraco.Core/Umbraco.Core.csproj
@@ -197,6 +197,9 @@
     <Compile Include="PropertyEditors\PropertyCacheCompression.cs" />
     <Compile Include="PropertyEditors\IPropertyCacheCompression.cs" />
     <Compile Include="PropertyEditors\UnPublishedContentPropertyCacheCompressionOptions.cs" />
+    <Compile Include="Security\FileStreamSecurityValidator.cs" />
+    <Compile Include="Security\IFileStreamSecurityAnalyzer.cs" />
+    <Compile Include="Security\IFileStreamSecurityValidator.cs" />
     <Compile Include="Security\IHtmlSanitizer.cs" />
     <Compile Include="Security\NoopHtmlSanitizer.cs" />
     <Compile Include="Serialization\AutoInterningStringConverter.cs" />

--- a/src/Umbraco.Tests/PropertyEditors/ImageCropperTest.cs
+++ b/src/Umbraco.Tests/PropertyEditors/ImageCropperTest.cs
@@ -20,6 +20,7 @@ using Umbraco.Web.Models;
 using Umbraco.Web;
 using Umbraco.Web.PropertyEditors;
 using System.Text;
+using Umbraco.Core.Security;
 
 namespace Umbraco.Tests.PropertyEditors
 {
@@ -95,7 +96,16 @@ namespace Umbraco.Tests.PropertyEditors
                     }
                 };
                 var dataTypeService = new TestObjects.TestDataTypeService(
-                    new DataType(new ImageCropperPropertyEditor(Mock.Of<ILogger>(), mediaFileSystem, Mock.Of<IContentSection>(), Mock.Of<IDataTypeService>())) { Id = 1, Configuration = imageCropperConfiguration });
+                    new DataType(new ImageCropperPropertyEditor(
+                        Mock.Of<ILogger>(),
+                        mediaFileSystem,
+                        Mock.Of<IContentSection>(),
+                        Mock.Of<IDataTypeService>(),
+                        Mock.Of<IFileStreamSecurityValidator>()))
+                    {
+                        Id = 1,
+                        Configuration = imageCropperConfiguration
+                    });
 
                 var factory = new PublishedContentTypeFactory(Mock.Of<IPublishedModelFactory>(), new PropertyValueConverterCollection(Array.Empty<IPropertyValueConverter>()), dataTypeService);
 

--- a/src/Umbraco.Tests/Security/FileStreamSecurityValidatorTests.cs
+++ b/src/Umbraco.Tests/Security/FileStreamSecurityValidatorTests.cs
@@ -1,0 +1,129 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Core.Security;
+
+namespace Umbraco.Tests.Security
+{
+    [TestFixture]
+    public class FileStreamSecurityValidatorTests
+    {
+
+        [Test]
+        public void IsConsideredSafe_True_NoAnalyzersPresent()
+        {
+            // Arrange
+            var sut = new FileStreamSecurityValidator(Enumerable.Empty<IFileStreamSecurityAnalyzer>());
+
+            using var memoryStream = new MemoryStream();
+            using var streamWriter = new StreamWriter(memoryStream);
+            streamWriter.Write("TestContent");
+            streamWriter.Flush();
+            memoryStream.Seek(0, SeekOrigin.Begin);
+
+            // Act
+            var validationResult = sut.IsConsideredSafe(memoryStream);
+
+            // Assert
+            Assert.IsTrue(validationResult);
+        }
+
+        [Test]
+        public void IsConsideredSafe_True_NoAnalyzerMatchesType()
+        {
+            // Arrange
+            var analyzerOne = new Mock<IFileStreamSecurityAnalyzer>();
+            analyzerOne.Setup(analyzer => analyzer.ShouldHandle(It.IsAny<Stream>()))
+                .Returns(false);
+            var analyzerTwo = new Mock<IFileStreamSecurityAnalyzer>();
+            analyzerTwo.Setup(analyzer => analyzer.ShouldHandle(It.IsAny<Stream>()))
+                .Returns(false);
+
+            var sut = new FileStreamSecurityValidator(new List<IFileStreamSecurityAnalyzer>{analyzerOne.Object,analyzerTwo.Object});
+
+            using var memoryStream = new MemoryStream();
+            using var streamWriter = new StreamWriter(memoryStream);
+            streamWriter.Write("TestContent");
+            streamWriter.Flush();
+            memoryStream.Seek(0, SeekOrigin.Begin);
+
+            // Act
+            var validationResult = sut.IsConsideredSafe(memoryStream);
+
+            // Assert
+            Assert.IsTrue(validationResult);
+        }
+
+        [Test]
+        public void IsConsideredSafe_True_AllMatchingAnalyzersReturnTrue()
+        {
+            // Arrange
+            var matchingAnalyzerOne = new Mock<IFileStreamSecurityAnalyzer>();
+            matchingAnalyzerOne.Setup(analyzer => analyzer.ShouldHandle(It.IsAny<Stream>()))
+                .Returns(true);
+            matchingAnalyzerOne.Setup(analyzer => analyzer.IsConsideredSafe(It.IsAny<Stream>()))
+                .Returns(true);
+
+            var matchingAnalyzerTwo = new Mock<IFileStreamSecurityAnalyzer>();
+            matchingAnalyzerTwo.Setup(analyzer => analyzer.ShouldHandle(It.IsAny<Stream>()))
+                .Returns(true);
+            matchingAnalyzerTwo.Setup(analyzer => analyzer.IsConsideredSafe(It.IsAny<Stream>()))
+                .Returns(true);
+
+            var unmatchedAnalyzer = new Mock<IFileStreamSecurityAnalyzer>();
+            unmatchedAnalyzer.Setup(analyzer => analyzer.ShouldHandle(It.IsAny<Stream>()))
+                .Returns(false);
+
+            var sut = new FileStreamSecurityValidator(new List<IFileStreamSecurityAnalyzer>{matchingAnalyzerOne.Object,matchingAnalyzerTwo.Object});
+
+            using var memoryStream = new MemoryStream();
+            using var streamWriter = new StreamWriter(memoryStream);
+            streamWriter.Write("TestContent");
+            streamWriter.Flush();
+            memoryStream.Seek(0, SeekOrigin.Begin);
+
+            // Act
+            var validationResult = sut.IsConsideredSafe(memoryStream);
+
+            // Assert
+            Assert.IsTrue(validationResult);
+        }
+
+        [Test]
+        public void IsConsideredSafe_False_AnyMatchingAnalyzersReturnFalse()
+        {
+            // Arrange
+            var saveMatchingAnalyzer = new Mock<IFileStreamSecurityAnalyzer>();
+            saveMatchingAnalyzer.Setup(analyzer => analyzer.ShouldHandle(It.IsAny<Stream>()))
+                .Returns(true);
+            saveMatchingAnalyzer.Setup(analyzer => analyzer.IsConsideredSafe(It.IsAny<Stream>()))
+                .Returns(true);
+
+            var unsafeMatchingAnalyzer = new Mock<IFileStreamSecurityAnalyzer>();
+            unsafeMatchingAnalyzer.Setup(analyzer => analyzer.ShouldHandle(It.IsAny<Stream>()))
+                .Returns(true);
+            unsafeMatchingAnalyzer.Setup(analyzer => analyzer.IsConsideredSafe(It.IsAny<Stream>()))
+                .Returns(false);
+
+            var unmatchedAnalyzer = new Mock<IFileStreamSecurityAnalyzer>();
+            unmatchedAnalyzer.Setup(analyzer => analyzer.ShouldHandle(It.IsAny<Stream>()))
+                .Returns(false);
+
+            var sut = new FileStreamSecurityValidator(new List<IFileStreamSecurityAnalyzer>{saveMatchingAnalyzer.Object,unsafeMatchingAnalyzer.Object});
+
+            using var memoryStream = new MemoryStream();
+            using var streamWriter = new StreamWriter(memoryStream);
+            streamWriter.Write("TestContent");
+            streamWriter.Flush();
+            memoryStream.Seek(0, SeekOrigin.Begin);
+
+            // Act
+            var validationResult = sut.IsConsideredSafe(memoryStream);
+
+            // Assert
+            Assert.IsFalse(validationResult);
+        }
+    }
+}

--- a/src/Umbraco.Tests/Umbraco.Tests.csproj
+++ b/src/Umbraco.Tests/Umbraco.Tests.csproj
@@ -173,6 +173,7 @@
     <Compile Include="Runtimes\StandaloneTests.cs" />
     <Compile Include="Routing\GetContentUrlsTests.cs" />
     <Compile Include="Scheduling\ContentVersionCleanup_Tests_UnitTests.cs" />
+    <Compile Include="Security\FileStreamSecurityValidatorTests.cs" />
     <Compile Include="Serialization\AutoInterningStringConverterTests.cs" />
     <Compile Include="Scoping\ScopeUnitTests.cs" />
     <Compile Include="Services\AmbiguousEventTests.cs" />

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/da.xml
@@ -339,6 +339,7 @@
     <key alias="renameFolderFailed">Omdøbning af mappen med id %0% fejlede</key>
     <key alias="dragAndDropYourFilesIntoTheArea">Træk dine filer ind i dropzonen for, at uploade dem til mediebiblioteket.</key>
     <key alias="uploadNotAllowed">Upload er ikke tiladt på denne lokation</key>
+      <key alias="fileSecurityValidationFailure">En eller flere fil sikkerhedsvalideringer har fejlet</key>
   </area>
   <area alias="member">
     <key alias="createNewMember">Opret et nyt medlem</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en.xml
@@ -338,6 +338,7 @@
     <key alias="createFolderFailed">Failed to create a folder under parent id %0%</key>
     <key alias="renameFolderFailed">Failed to rename the folder with id %0%</key>
     <key alias="dragAndDropYourFilesIntoTheArea">Drag and drop your file(s) into the area</key>
+    <key alias="fileSecurityValidationFailure">One or more file security validations have failed</key>
   </area>
   <area alias="member">
     <key alias="createNewMember">Create a new member</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/en_us.xml
@@ -344,6 +344,7 @@
     <key alias="renameFolderFailed">Failed to rename the folder with id %0%</key>
     <key alias="dragAndDropYourFilesIntoTheArea">Drag and drop your file(s) into the area</key>
     <key alias="uploadNotAllowed">Upload is not allowed in this location.</key>
+    <key alias="fileSecurityValidationFailure">One or more file security validations have failed</key>
   </area>
   <area alias="member">
     <key alias="createNewMember">Create a new member</key>

--- a/src/Umbraco.Web.UI/Umbraco/config/lang/nl.xml
+++ b/src/Umbraco.Web.UI/Umbraco/config/lang/nl.xml
@@ -336,6 +336,7 @@
     <key alias="renameFolderFailed">Kan de map met id %0% niet hernoemen</key>
     <key alias="dragAndDropYourFilesIntoTheArea">Sleep en zet je bestand(en) neer in dit gebied</key>
     <key alias="uploadNotAllowed">Upload is niet toegelaten in deze locatie.</key>
+    <key alias="fileSecurityValidationFailure">Een of meerdere veiligheid validaties zijn gefaald voor het bestand</key>
   </area>
   <area alias="member">
     <key alias="createNewMember">Maak nieuw lid aan</key>

--- a/src/Umbraco.Web/Editors/CurrentUserController.cs
+++ b/src/Umbraco.Web/Editors/CurrentUserController.cs
@@ -12,6 +12,8 @@ using Umbraco.Web.WebApi;
 using System.Linq;
 using Newtonsoft.Json;
 using Umbraco.Core;
+using Umbraco.Core.Security;
+using Umbraco.Web.Composing;
 using Umbraco.Web.Security;
 using Umbraco.Web.WebApi.Filters;
 
@@ -155,7 +157,9 @@ namespace Umbraco.Web.Editors
         public async Task<HttpResponseMessage> PostSetAvatar()
         {
             //borrow the logic from the user controller
-            return await UsersController.PostSetAvatarInternal(Request, Services.UserService, AppCaches.RuntimeCache, Security.GetUserId().ResultOr(0));
+            // This is unbelievable... This controller has no real constructor using DI, instead everything is resolved from the Current service locator.
+            // So I guess we'll just do that again here
+            return await UsersController.PostSetAvatarInternal(Request, Services.UserService, Current.Factory.GetInstance<IFileStreamSecurityValidator>(), AppCaches.RuntimeCache, Security.GetUserId().ResultOr(0));
         }
 
         /// <summary>

--- a/src/Umbraco.Web/Editors/MediaController.cs
+++ b/src/Umbraco.Web/Editors/MediaController.cs
@@ -789,22 +789,6 @@ namespace Umbraco.Web.Editors
                     continue;
                 }
 
-                var fileInfo = new FileInfo(file.LocalFileName);
-                var mediaFileStream = fileInfo.OpenReadWithRetry();
-                if (mediaFileStream == null)
-                {
-                    throw new InvalidOperationException("Could not acquire file stream");
-                }
-
-                if (_fileStreamSecurityValidator != null && _fileStreamSecurityValidator.IsConsideredSafe(mediaFileStream) is false)
-                {
-                    tempFiles.Notifications.Add(new Notification(
-                        localizedTextService.Localize("speechBubbles", "operationFailedHeader"),
-                        localizedTextService.Localize("media", "fileSecurityValidationFailure"),
-                        NotificationStyle.Warning));
-                    continue;
-                }
-
                 if (string.IsNullOrEmpty(mediaTypeAlias))
                 {
                     mediaTypeAlias = Constants.Conventions.MediaTypes.File;
@@ -859,10 +843,24 @@ namespace Umbraco.Web.Editors
                     continue;
                 }
 
+                var fileInfo = new FileInfo(file.LocalFileName);
+                var mediaFileStream = fileInfo.OpenReadWithRetry();
+                if (mediaFileStream == null)
+                {
+                    throw new InvalidOperationException("Could not acquire file stream");
+                }
+
+                if (_fileStreamSecurityValidator != null && _fileStreamSecurityValidator.IsConsideredSafe(mediaFileStream) is false)
+                {
+                    tempFiles.Notifications.Add(new Notification(
+                        localizedTextService.Localize("speechBubbles", "operationFailedHeader"),
+                        localizedTextService.Localize("media", "fileSecurityValidationFailure"),
+                        NotificationStyle.Warning));
+                    continue;
+                }
+
                 var mediaItemName = fileName.ToFriendlyName();
-
                 var createdMediaItem = mediaService.CreateMedia(mediaItemName, parentId, mediaTypeAlias, Security.CurrentUser.Id);
-
                 using (mediaFileStream)
                 {
                     createdMediaItem.SetValue(Services.ContentTypeBaseServices, Constants.Conventions.Media.File, fileName, mediaFileStream);

--- a/src/Umbraco.Web/Editors/MediaController.cs
+++ b/src/Umbraco.Web/Editors/MediaController.cs
@@ -37,6 +37,7 @@ using Umbraco.Web.ContentApps;
 using Umbraco.Web.Editors.Binders;
 using Umbraco.Web.Editors.Filters;
 using Umbraco.Core.Models.Entities;
+using Umbraco.Core.Security;
 
 namespace Umbraco.Web.Editors
 {
@@ -49,10 +50,21 @@ namespace Umbraco.Web.Editors
     [MediaControllerControllerConfiguration]
     public class MediaController : ContentControllerBase
     {
-        public MediaController(PropertyEditorCollection propertyEditors, IGlobalSettings globalSettings, IUmbracoContextAccessor umbracoContextAccessor, ISqlContext sqlContext, ServiceContext services, AppCaches appCaches, IProfilingLogger logger, IRuntimeState runtimeState, UmbracoHelper umbracoHelper)
+        public MediaController(
+            PropertyEditorCollection propertyEditors,
+            IGlobalSettings globalSettings,
+            IUmbracoContextAccessor umbracoContextAccessor,
+            ISqlContext sqlContext,
+            ServiceContext services,
+            AppCaches appCaches,
+            IProfilingLogger logger,
+            IRuntimeState runtimeState,
+            UmbracoHelper umbracoHelper,
+            IFileStreamSecurityValidator fileStreamSecurityValidator)
             : base(globalSettings, umbracoContextAccessor, sqlContext, services, appCaches, logger, runtimeState, umbracoHelper)
         {
             _propertyEditors = propertyEditors ?? throw new ArgumentNullException(nameof(propertyEditors));
+            _fileStreamSecurityValidator = fileStreamSecurityValidator;
         }
 
         /// <summary>
@@ -236,6 +248,7 @@ namespace Umbraco.Web.Editors
 
         private int[] _userStartNodes;
         private readonly PropertyEditorCollection _propertyEditors;
+        private readonly IFileStreamSecurityValidator _fileStreamSecurityValidator;
 
         protected int[] UserStartNodes
         {
@@ -758,6 +771,22 @@ namespace Umbraco.Web.Editors
                     continue;
                 }
 
+                var fileInfo = new FileInfo(file.LocalFileName);
+                var mediaFileStream = fileInfo.OpenReadWithRetry();
+                if (mediaFileStream == null)
+                {
+                    throw new InvalidOperationException("Could not acquire file stream");
+                }
+
+                if (_fileStreamSecurityValidator != null && _fileStreamSecurityValidator.IsConsideredSafe(mediaFileStream) is false)
+                {
+                    tempFiles.Notifications.Add(new Notification(
+                        localizedTextService.Localize("speechBubbles", "operationFailedHeader"),
+                        localizedTextService.Localize("media", "fileSecurityValidationFailure"),
+                        NotificationStyle.Warning));
+                    continue;
+                }
+
                 if (string.IsNullOrEmpty(mediaTypeAlias))
                 {
                     mediaTypeAlias = Constants.Conventions.MediaTypes.File;
@@ -816,12 +845,9 @@ namespace Umbraco.Web.Editors
 
                 var createdMediaItem = mediaService.CreateMedia(mediaItemName, parentId, mediaTypeAlias, Security.CurrentUser.Id);
 
-                var fileInfo = new FileInfo(file.LocalFileName);
-                var fs = fileInfo.OpenReadWithRetry();
-                if (fs == null) throw new InvalidOperationException("Could not acquire file stream");
-                using (fs)
+                using (mediaFileStream)
                 {
-                    createdMediaItem.SetValue(Services.ContentTypeBaseServices, Constants.Conventions.Media.File, fileName, fs);
+                    createdMediaItem.SetValue(Services.ContentTypeBaseServices, Constants.Conventions.Media.File, fileName, mediaFileStream);
                 }
 
                 var saveResult = mediaService.Save(createdMediaItem, Security.CurrentUser.Id);

--- a/src/Umbraco.Web/Editors/MediaController.cs
+++ b/src/Umbraco.Web/Editors/MediaController.cs
@@ -50,6 +50,24 @@ namespace Umbraco.Web.Editors
     [MediaControllerControllerConfiguration]
     public class MediaController : ContentControllerBase
     {
+        [Obsolete("Use the constructor specifying all dependencies instead.")]
+        public MediaController(PropertyEditorCollection propertyEditors, IGlobalSettings globalSettings,
+            IUmbracoContextAccessor umbracoContextAccessor, ISqlContext sqlContext, ServiceContext services,
+            AppCaches appCaches, IProfilingLogger logger, IRuntimeState runtimeState, UmbracoHelper umbracoHelper)
+            : this(propertyEditors,
+                globalSettings,
+                umbracoContextAccessor,
+                sqlContext,
+                services,
+                appCaches,
+                logger,
+                runtimeState,
+                umbracoHelper,
+                Current.Factory.GetInstance<IFileStreamSecurityValidator>())
+        {
+
+        }
+
         public MediaController(
             PropertyEditorCollection propertyEditors,
             IGlobalSettings globalSettings,

--- a/src/Umbraco.Web/Editors/UsersController.cs
+++ b/src/Umbraco.Web/Editors/UsersController.cs
@@ -129,6 +129,15 @@ namespace Umbraco.Web.Editors
 
                 using (var fs = System.IO.File.OpenRead(file.LocalFileName))
                 {
+                    // This is kinda cursed
+                    // BUT having a static method like this is absolutely insane,
+                    // and I'm not sure injecting the validator is gonna make it any less so.
+                    var validator = Current.Factory.GetInstance<IFileStreamSecurityValidator>();
+                    if (validator.IsConsideredSafe(fs) is false)
+                    {
+                        return request.CreateValidationErrorResponse("The uploaded file is not permitted due to security reasons");
+                    }
+
                     Current.MediaFileSystem.AddFile(user.Avatar, fs, true);
                 }
 


### PR DESCRIPTION
See #14657 for details

Registering the testing implementation looks like this in V8:

```C#
    class MyComp : IComposer
    {
        public void Compose(Composition composition)
        {
            composition.Register(typeof(IFileStreamSecurityAnalyzer), typeof(SvgXssSecurityAnalyzer), Lifetime.Transient);
        }
    }
```