### PR TITLE
Add content and media sorting to the Management API

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Content/ContentControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Content/ContentControllerBase.cs
@@ -50,6 +50,10 @@ public class ContentControllerBase : ManagementApiControllerBase
                 .WithTitle("Content is in the recycle bin")
                 .WithDetail("Could not perform the operation because the targeted content was in the recycle bin.")
                 .Build()),
+            ContentEditingOperationStatus.SortingInvalid => BadRequest(new ProblemDetailsBuilder()
+                .WithTitle("Invalid sorting options")
+                .WithDetail("The supplied sorting operations were invalid. Additional details can be found in the log.")
+                .Build()),
             ContentEditingOperationStatus.Unknown => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
                 .WithTitle("Unknown error. Please see the log for more details.")
                 .Build()),

--- a/src/Umbraco.Cms.Api.Management/Content/ContentControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Content/ContentControllerBase.cs
@@ -50,6 +50,10 @@ public class ContentControllerBase : ManagementApiControllerBase
                 .WithTitle("Content is in the recycle bin")
                 .WithDetail("Could not perform the operation because the targeted content was in the recycle bin.")
                 .Build()),
+            ContentEditingOperationStatus.NotInTrash => BadRequest(new ProblemDetailsBuilder()
+                .WithTitle("Content is not in the recycle bin")
+                .WithDetail("The attempted operation requires the targeted content to be in the recycle bin.")
+                .Build()),
             ContentEditingOperationStatus.SortingInvalid => BadRequest(new ProblemDetailsBuilder()
                 .WithTitle("Invalid sorting options")
                 .WithDetail("The supplied sorting operations were invalid. Additional details can be found in the log.")

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/SortDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/SortDocumentController.cs
@@ -21,7 +21,7 @@ public class SortDocumentController : DocumentControllerBase
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
-    [HttpPost("sort")]
+    [HttpPut("sort")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/SortDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/SortDocumentController.cs
@@ -1,0 +1,40 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Sorting;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Document;
+
+[ApiVersion("1.0")]
+public class SortDocumentController : DocumentControllerBase
+{
+    private readonly IContentEditingService _contentEditingService;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+
+    public SortDocumentController(IContentEditingService contentEditingService, IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+    {
+        _contentEditingService = contentEditingService;
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+    }
+
+    [HttpPost("sort")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Sort(SortingRequestModel sortingRequestModel)
+    {
+        ContentEditingOperationStatus result = await _contentEditingService.SortAsync(
+            sortingRequestModel.ParentId,
+            sortingRequestModel.Sorting.Select(m => new SortingModel { Key = m.Id, SortOrder = m.SortOrder }),
+            CurrentUserKey(_backOfficeSecurityAccessor));
+
+        return result == ContentEditingOperationStatus.Success
+            ? Ok()
+            : ContentEditingOperationStatusResult(result);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/SortMediaController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/SortMediaController.cs
@@ -21,7 +21,7 @@ public class SortMediaController : MediaControllerBase
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
-    [HttpPost("sort")]
+    [HttpPut("sort")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/SortMediaController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/SortMediaController.cs
@@ -1,0 +1,40 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Sorting;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Media;
+
+[ApiVersion("1.0")]
+public class SortMediaController : MediaControllerBase
+{
+    private readonly IMediaEditingService _mediaEditingService;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+
+    public SortMediaController(IMediaEditingService mediaEditingService, IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+    {
+        _mediaEditingService = mediaEditingService;
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+    }
+
+    [HttpPost("sort")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Sort(SortingRequestModel sortingRequestModel)
+    {
+        ContentEditingOperationStatus result = await _mediaEditingService.SortAsync(
+            sortingRequestModel.ParentId,
+            sortingRequestModel.Sorting.Select(m => new SortingModel { Key = m.Id, SortOrder = m.SortOrder }),
+            CurrentUserKey(_backOfficeSecurityAccessor));
+
+        return result == ContentEditingOperationStatus.Success
+            ? Ok()
+            : ContentEditingOperationStatusResult(result);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -4678,11 +4678,11 @@
       }
     },
     "/umbraco/management/api/v1/document/sort": {
-      "post": {
+      "put": {
         "tags": [
           "Document"
         ],
-        "operationId": "PostDocumentSort",
+        "operationId": "PutDocumentSort",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8316,11 +8316,11 @@
       }
     },
     "/umbraco/management/api/v1/media/sort": {
-      "post": {
+      "put": {
         "tags": [
           "Media"
         ],
-        "operationId": "PostMediaSort",
+        "operationId": "PutMediaSort",
         "requestBody": {
           "content": {
             "application/json": {

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -4255,6 +4255,95 @@
         ]
       }
     },
+    "/umbraco/management/api/v1/document/sort": {
+      "post": {
+        "tags": [
+          "Document"
+        ],
+        "operationId": "PostDocumentSort",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SortingRequestModel"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SortingRequestModel"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SortingRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
     "/umbraco/management/api/v1/recycle-bin/document/children": {
       "get": {
         "tags": [
@@ -7450,6 +7539,95 @@
                       }
                     ]
                   }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/media/sort": {
+      "post": {
+        "tags": [
+          "Media"
+        ],
+        "operationId": "PostMediaSort",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SortingRequestModel"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SortingRequestModel"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SortingRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -18187,6 +18365,20 @@
         },
         "additionalProperties": false
       },
+      "ItemSortingRequestModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "sortOrder": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
       "LanguageItemResponseModel": {
         "type": "object",
         "properties": {
@@ -20407,6 +20599,27 @@
         "properties": {
           "name": {
             "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SortingRequestModel": {
+        "type": "object",
+        "properties": {
+          "parentId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "sorting": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ItemSortingRequestModel"
+                }
+              ]
+            }
           }
         },
         "additionalProperties": false

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Sorting/ItemSortingRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Sorting/ItemSortingRequestModel.cs
@@ -1,0 +1,8 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Sorting;
+
+public class ItemSortingRequestModel
+{
+    public Guid Id { get; init; }
+
+    public int SortOrder { get; set; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Sorting/SortingRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Sorting/SortingRequestModel.cs
@@ -1,0 +1,8 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Sorting;
+
+public class SortingRequestModel
+{
+    public Guid? ParentId { get; init; }
+
+    public required IEnumerable<ItemSortingRequestModel> Sorting { get; init; }
+}

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -325,6 +325,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
             Services.AddUnique<IMemberTypeService, MemberTypeService>();
             Services.AddUnique<INotificationService, NotificationService>();
             Services.AddUnique<ITrackedReferencesService, TrackedReferencesService>();
+            Services.AddUnique<ITreeEntitySortingService, TreeEntitySortingService>();
             Services.AddUnique<ExternalLoginService>(factory => new ExternalLoginService(
                 factory.GetRequiredService<ICoreScopeProvider>(),
                 factory.GetRequiredService<ILoggerFactory>(),

--- a/src/Umbraco.Core/Models/ContentEditing/SortingModel.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/SortingModel.cs
@@ -1,0 +1,8 @@
+﻿namespace Umbraco.Cms.Core.Models.ContentEditing;
+
+public class SortingModel
+{
+    public required Guid Key { get; init; }
+
+    public required int SortOrder { get; init; }
+}

--- a/src/Umbraco.Core/Services/ContentEditingService.cs
+++ b/src/Umbraco.Core/Services/ContentEditingService.cs
@@ -32,9 +32,9 @@ internal sealed class ContentEditingService
         _userIdKeyResolver = userIdKeyResolver;
     }
 
-    public async Task<IContent?> GetAsync(Guid id)
+    public async Task<IContent?> GetAsync(Guid key)
     {
-        IContent? content = ContentService.GetById(id);
+        IContent? content = ContentService.GetById(key);
         return await Task.FromResult(content);
     }
 
@@ -79,36 +79,36 @@ internal sealed class ContentEditingService
             : Attempt.FailWithStatus(operationStatus, content);
     }
 
-    public async Task<Attempt<IContent?, ContentEditingOperationStatus>> MoveToRecycleBinAsync(Guid id, Guid userKey)
+    public async Task<Attempt<IContent?, ContentEditingOperationStatus>> MoveToRecycleBinAsync(Guid key, Guid userKey)
     {
         var currentUserId = await GetUserIdAsync(userKey);
-        return await HandleDeletionAsync(id, content => ContentService.MoveToRecycleBin(content, currentUserId), false);
+        return await HandleDeletionAsync(key, content => ContentService.MoveToRecycleBin(content, currentUserId), false);
     }
 
-    public async Task<Attempt<IContent?, ContentEditingOperationStatus>> DeleteAsync(Guid id, Guid userKey)
+    public async Task<Attempt<IContent?, ContentEditingOperationStatus>> DeleteAsync(Guid key, Guid userKey)
     {
         var currentUserId = await GetUserIdAsync(userKey);
-        return await HandleDeletionAsync(id, content => ContentService.Delete(content, currentUserId), false);
+        return await HandleDeletionAsync(key, content => ContentService.Delete(content, currentUserId), false);
     }
 
-    public async Task<Attempt<IContent?, ContentEditingOperationStatus>> MoveAsync(Guid id, Guid? parentId, Guid userKey)
+    public async Task<Attempt<IContent?, ContentEditingOperationStatus>> MoveAsync(Guid key, Guid? parentKey, Guid userKey)
     {
         var currentUserId = await GetUserIdAsync(userKey);
-        return await HandleMoveAsync(id, parentId, (content, newParentId) => ContentService.Move(content, newParentId, currentUserId));
+        return await HandleMoveAsync(key, parentKey, (content, newParentId) => ContentService.Move(content, newParentId, currentUserId));
     }
 
-    public async Task<Attempt<IContent?, ContentEditingOperationStatus>> CopyAsync(Guid id, Guid? parentId, bool relateToOriginal, bool includeDescendants, Guid userKey)
+    public async Task<Attempt<IContent?, ContentEditingOperationStatus>> CopyAsync(Guid key, Guid? parentKey, bool relateToOriginal, bool includeDescendants, Guid userKey)
     {
         var currentUserId = await GetUserIdAsync(userKey);
-        return await HandleCopyAsync(id, parentId, (content, newParentId) => ContentService.Copy(content, newParentId, relateToOriginal, includeDescendants, currentUserId));
+        return await HandleCopyAsync(key, parentKey, (content, newParentId) => ContentService.Copy(content, newParentId, relateToOriginal, includeDescendants, currentUserId));
     }
 
 
-    public async Task<ContentEditingOperationStatus> SortAsync(Guid? parentId, IEnumerable<SortingModel> sortingModels, Guid userKey)
+    public async Task<ContentEditingOperationStatus> SortAsync(Guid? parentKey, IEnumerable<SortingModel> sortingModels, Guid userKey)
     {
         var currentUserId = await GetUserIdAsync(userKey);
         return await HandleSortAsync(
-            parentId,
+            parentKey,
             sortingModels,
             (int id, int pageIndex, int pageSize, out long total) => ContentService.GetPagedChildren(id, pageIndex, pageSize, out total),
             items =>

--- a/src/Umbraco.Core/Services/ContentEditingServiceBase.cs
+++ b/src/Umbraco.Core/Services/ContentEditingServiceBase.cs
@@ -97,10 +97,10 @@ public abstract class ContentEditingServiceBase<TContent, TContentType, TContent
     }
 
     // helper method to perform move-to-recycle-bin and delete for content as they are very much handled in the same way
-    protected async Task<Attempt<TContent?, ContentEditingOperationStatus>> HandleDeletionAsync(Guid id, Delete performDelete, bool allowForTrashed)
+    protected async Task<Attempt<TContent?, ContentEditingOperationStatus>> HandleDeletionAsync(Guid key, Delete performDelete, bool allowForTrashed)
     {
         using ICoreScope scope = _scopeProvider.CreateCoreScope();
-        TContent? content = ContentService.GetById(id);
+        TContent? content = ContentService.GetById(key);
         if (content == null)
         {
             return await Task.FromResult(Attempt.FailWithStatus(ContentEditingOperationStatus.NotFound, content));
@@ -118,10 +118,10 @@ public abstract class ContentEditingServiceBase<TContent, TContentType, TContent
         return OperationResultToAttempt(content, deleteResult);
     }
 
-    protected async Task<Attempt<TContent?, ContentEditingOperationStatus>> HandleMoveAsync(Guid id, Guid? parentId, Move performMove)
+    protected async Task<Attempt<TContent?, ContentEditingOperationStatus>> HandleMoveAsync(Guid key, Guid? parentKey, Move performMove)
     {
         using ICoreScope scope = _scopeProvider.CreateCoreScope();
-        TContent? content = ContentService.GetById(id);
+        TContent? content = ContentService.GetById(key);
         if (content is null)
         {
             return await Task.FromResult(Attempt.FailWithStatus(ContentEditingOperationStatus.NotFound, content));
@@ -129,7 +129,7 @@ public abstract class ContentEditingServiceBase<TContent, TContentType, TContent
 
         TContentType contentType = ContentTypeService.Get(content.ContentType.Key)!;
 
-        TContent? parent = TryGetAndValidateParent(parentId, contentType, out ContentEditingOperationStatus operationStatus);
+        TContent? parent = TryGetAndValidateParent(parentKey, contentType, out ContentEditingOperationStatus operationStatus);
         if (operationStatus != ContentEditingOperationStatus.Success)
         {
             return Attempt.FailWithStatus<TContent?, ContentEditingOperationStatus>(operationStatus, content);
@@ -154,10 +154,10 @@ public abstract class ContentEditingServiceBase<TContent, TContentType, TContent
         return OperationResultToAttempt(content, moveResult);
     }
 
-    protected async Task<Attempt<TContent?, ContentEditingOperationStatus>> HandleCopyAsync(Guid id, Guid? parentId, Copy performCopy)
+    protected async Task<Attempt<TContent?, ContentEditingOperationStatus>> HandleCopyAsync(Guid key, Guid? parentKey, Copy performCopy)
     {
         using ICoreScope scope = _scopeProvider.CreateCoreScope();
-        TContent? content = ContentService.GetById(id);
+        TContent? content = ContentService.GetById(key);
         if (content is null)
         {
             return await Task.FromResult(Attempt.FailWithStatus(ContentEditingOperationStatus.NotFound, content));
@@ -165,7 +165,7 @@ public abstract class ContentEditingServiceBase<TContent, TContentType, TContent
 
         TContentType contentType = ContentTypeService.Get(content.ContentType.Key)!;
 
-        TContent? parent = TryGetAndValidateParent(parentId, contentType, out ContentEditingOperationStatus operationStatus);
+        TContent? parent = TryGetAndValidateParent(parentKey, contentType, out ContentEditingOperationStatus operationStatus);
         if (operationStatus != ContentEditingOperationStatus.Success)
         {
             return Attempt.FailWithStatus<TContent?, ContentEditingOperationStatus>(operationStatus, content);
@@ -182,13 +182,13 @@ public abstract class ContentEditingServiceBase<TContent, TContentType, TContent
     }
 
     protected async Task<ContentEditingOperationStatus> HandleSortAsync(
-        Guid? parentId,
+        Guid? parentKey,
         IEnumerable<SortingModel> sortingModels,
         GetPagedChildren getPagedChildren,
         Sort performSort)
     {
-        var contentId = parentId.HasValue
-            ? ContentService.GetById(parentId.Value)?.Id
+        var contentId = parentKey.HasValue
+            ? ContentService.GetById(parentKey.Value)?.Id
             : Constants.System.Root;
 
         if (contentId.HasValue is false)
@@ -302,13 +302,13 @@ public abstract class ContentEditingServiceBase<TContent, TContentType, TContent
         return contentType;
     }
 
-    private TContent? TryGetAndValidateParent(Guid? parentId, TContentType contentType, out ContentEditingOperationStatus operationStatus)
+    private TContent? TryGetAndValidateParent(Guid? parentKey, TContentType contentType, out ContentEditingOperationStatus operationStatus)
     {
-        TContent? parent = parentId.HasValue
-            ? ContentService.GetById(parentId.Value)
+        TContent? parent = parentKey.HasValue
+            ? ContentService.GetById(parentKey.Value)
             : null;
 
-        if (parentId.HasValue && parent == null)
+        if (parentKey.HasValue && parent == null)
         {
             operationStatus = ContentEditingOperationStatus.ParentNotFound;
             return null;

--- a/src/Umbraco.Core/Services/IContentEditingService.cs
+++ b/src/Umbraco.Core/Services/IContentEditingService.cs
@@ -19,4 +19,6 @@ public interface IContentEditingService
     Task<Attempt<IContent?, ContentEditingOperationStatus>> MoveAsync(Guid id, Guid? parentId, Guid userKey);
 
     Task<Attempt<IContent?, ContentEditingOperationStatus>> CopyAsync(Guid id, Guid? parentId, bool relateToOriginal, bool includeDescendants, Guid userKey);
+
+    Task<ContentEditingOperationStatus> SortAsync(Guid? parentId, IEnumerable<SortingModel> sortingModels, Guid userKey);
 }

--- a/src/Umbraco.Core/Services/IContentEditingService.cs
+++ b/src/Umbraco.Core/Services/IContentEditingService.cs
@@ -6,19 +6,19 @@ namespace Umbraco.Cms.Core.Services;
 
 public interface IContentEditingService
 {
-    Task<IContent?> GetAsync(Guid id);
+    Task<IContent?> GetAsync(Guid key);
 
     Task<Attempt<IContent?, ContentEditingOperationStatus>> CreateAsync(ContentCreateModel createModel, Guid userKey);
 
     Task<Attempt<IContent, ContentEditingOperationStatus>> UpdateAsync(IContent content, ContentUpdateModel updateModel, Guid userKey);
 
-    Task<Attempt<IContent?, ContentEditingOperationStatus>> MoveToRecycleBinAsync(Guid id, Guid userKey);
+    Task<Attempt<IContent?, ContentEditingOperationStatus>> MoveToRecycleBinAsync(Guid key, Guid userKey);
 
-    Task<Attempt<IContent?, ContentEditingOperationStatus>> DeleteAsync(Guid id, Guid userKey);
+    Task<Attempt<IContent?, ContentEditingOperationStatus>> DeleteAsync(Guid key, Guid userKey);
 
-    Task<Attempt<IContent?, ContentEditingOperationStatus>> MoveAsync(Guid id, Guid? parentId, Guid userKey);
+    Task<Attempt<IContent?, ContentEditingOperationStatus>> MoveAsync(Guid key, Guid? parentKey, Guid userKey);
 
-    Task<Attempt<IContent?, ContentEditingOperationStatus>> CopyAsync(Guid id, Guid? parentId, bool relateToOriginal, bool includeDescendants, Guid userKey);
+    Task<Attempt<IContent?, ContentEditingOperationStatus>> CopyAsync(Guid key, Guid? parentKey, bool relateToOriginal, bool includeDescendants, Guid userKey);
 
-    Task<ContentEditingOperationStatus> SortAsync(Guid? parentId, IEnumerable<SortingModel> sortingModels, Guid userKey);
+    Task<ContentEditingOperationStatus> SortAsync(Guid? parentKey, IEnumerable<SortingModel> sortingModels, Guid userKey);
 }

--- a/src/Umbraco.Core/Services/IMediaEditingService.cs
+++ b/src/Umbraco.Core/Services/IMediaEditingService.cs
@@ -17,4 +17,6 @@ public interface IMediaEditingService
     Task<Attempt<IMedia?, ContentEditingOperationStatus>> DeleteAsync(Guid id, Guid userKey);
 
     Task<Attempt<IMedia?, ContentEditingOperationStatus>> MoveAsync(Guid id, Guid? parentId, Guid userKey);
+
+    Task<ContentEditingOperationStatus> SortAsync(Guid? parentId, IEnumerable<SortingModel> sortingModels, Guid userKey);
 }

--- a/src/Umbraco.Core/Services/IMediaEditingService.cs
+++ b/src/Umbraco.Core/Services/IMediaEditingService.cs
@@ -6,17 +6,17 @@ namespace Umbraco.Cms.Core.Services;
 
 public interface IMediaEditingService
 {
-    Task<IMedia?> GetAsync(Guid id);
+    Task<IMedia?> GetAsync(Guid key);
 
     Task<Attempt<IMedia?, ContentEditingOperationStatus>> CreateAsync(MediaCreateModel createModel, Guid userKey);
 
     Task<Attempt<IMedia, ContentEditingOperationStatus>> UpdateAsync(IMedia content, MediaUpdateModel updateModel, Guid userKey);
 
-    Task<Attempt<IMedia?, ContentEditingOperationStatus>> MoveToRecycleBinAsync(Guid id, Guid userKey);
+    Task<Attempt<IMedia?, ContentEditingOperationStatus>> MoveToRecycleBinAsync(Guid key, Guid userKey);
 
-    Task<Attempt<IMedia?, ContentEditingOperationStatus>> DeleteAsync(Guid id, Guid userKey);
+    Task<Attempt<IMedia?, ContentEditingOperationStatus>> DeleteAsync(Guid key, Guid userKey);
 
-    Task<Attempt<IMedia?, ContentEditingOperationStatus>> MoveAsync(Guid id, Guid? parentId, Guid userKey);
+    Task<Attempt<IMedia?, ContentEditingOperationStatus>> MoveAsync(Guid key, Guid? parentKey, Guid userKey);
 
-    Task<ContentEditingOperationStatus> SortAsync(Guid? parentId, IEnumerable<SortingModel> sortingModels, Guid userKey);
+    Task<ContentEditingOperationStatus> SortAsync(Guid? parentKey, IEnumerable<SortingModel> sortingModels, Guid userKey);
 }

--- a/src/Umbraco.Core/Services/IMediaEditingService.cs
+++ b/src/Umbraco.Core/Services/IMediaEditingService.cs
@@ -10,7 +10,7 @@ public interface IMediaEditingService
 
     Task<Attempt<IMedia?, ContentEditingOperationStatus>> CreateAsync(MediaCreateModel createModel, Guid userKey);
 
-    Task<Attempt<IMedia, ContentEditingOperationStatus>> UpdateAsync(IMedia content, MediaUpdateModel updateModel, Guid userKey);
+    Task<Attempt<IMedia, ContentEditingOperationStatus>> UpdateAsync(IMedia media, MediaUpdateModel updateModel, Guid userKey);
 
     Task<Attempt<IMedia?, ContentEditingOperationStatus>> MoveToRecycleBinAsync(Guid key, Guid userKey);
 

--- a/src/Umbraco.Core/Services/ITreeEntitySortingService.cs
+++ b/src/Umbraco.Core/Services/ITreeEntitySortingService.cs
@@ -1,0 +1,10 @@
+﻿using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Models.Entities;
+
+namespace Umbraco.Cms.Core.Services;
+
+public interface ITreeEntitySortingService
+{
+    IEnumerable<TTreeEntity> SortEntities<TTreeEntity>(IEnumerable<TTreeEntity> entities, IEnumerable<SortingModel> sortingModels)
+        where TTreeEntity : ITreeEntity;
+}

--- a/src/Umbraco.Core/Services/MediaEditingService.cs
+++ b/src/Umbraco.Core/Services/MediaEditingService.cs
@@ -82,7 +82,7 @@ internal sealed class MediaEditingService
         => ContentService.Move(media, newParentId, userId).Result;
 
     protected override IMedia? Copy(IMedia media, int newParentId, bool relateToOriginal, bool includeDescendants, int userId)
-        => throw new NotImplementedException("Copy is not supported for media");
+        => throw new NotSupportedException("Copy is not supported for media");
 
     protected override OperationResult? MoveToRecycleBin(IMedia media, int userId)
         => ContentService.MoveToRecycleBin(media, userId).Result;

--- a/src/Umbraco.Core/Services/MediaEditingService.cs
+++ b/src/Umbraco.Core/Services/MediaEditingService.cs
@@ -29,9 +29,9 @@ internal sealed class MediaEditingService
         _userIdKeyResolver = userIdKeyResolver;
     }
 
-    public async Task<IMedia?> GetAsync(Guid id)
+    public async Task<IMedia?> GetAsync(Guid key)
     {
-        IMedia? media = ContentService.GetById(id);
+        IMedia? media = ContentService.GetById(key);
         return await Task.FromResult(media);
     }
 
@@ -67,29 +67,29 @@ internal sealed class MediaEditingService
             : Attempt.FailWithStatus(operationStatus, content);
     }
 
-    public async Task<Attempt<IMedia?, ContentEditingOperationStatus>> MoveToRecycleBinAsync(Guid id, Guid userKey)
+    public async Task<Attempt<IMedia?, ContentEditingOperationStatus>> MoveToRecycleBinAsync(Guid key, Guid userKey)
     {
         var currentUserId = await GetUserIdAsync(userKey);
-        return await HandleDeletionAsync(id, media => ContentService.MoveToRecycleBin(media, currentUserId).Result, false);
+        return await HandleDeletionAsync(key, media => ContentService.MoveToRecycleBin(media, currentUserId).Result, false);
     }
 
-    public async Task<Attempt<IMedia?, ContentEditingOperationStatus>> DeleteAsync(Guid id, Guid userKey)
+    public async Task<Attempt<IMedia?, ContentEditingOperationStatus>> DeleteAsync(Guid key, Guid userKey)
     {
         var currentUserId = await GetUserIdAsync(userKey);
-        return await HandleDeletionAsync(id, media => ContentService.Delete(media, currentUserId).Result, true);
+        return await HandleDeletionAsync(key, media => ContentService.Delete(media, currentUserId).Result, true);
     }
 
-    public async Task<Attempt<IMedia?, ContentEditingOperationStatus>> MoveAsync(Guid id, Guid? parentId, Guid userKey)
+    public async Task<Attempt<IMedia?, ContentEditingOperationStatus>> MoveAsync(Guid key, Guid? parentKey, Guid userKey)
     {
         var currentUserId = await GetUserIdAsync(userKey);
-        return await HandleMoveAsync(id, parentId, (content, newParentId) => ContentService.Move(content, newParentId, currentUserId).Result);
+        return await HandleMoveAsync(key, parentKey, (content, newParentId) => ContentService.Move(content, newParentId, currentUserId).Result);
     }
 
-    public async Task<ContentEditingOperationStatus> SortAsync(Guid? parentId, IEnumerable<SortingModel> sortingModels, Guid userKey)
+    public async Task<ContentEditingOperationStatus> SortAsync(Guid? parentKey, IEnumerable<SortingModel> sortingModels, Guid userKey)
     {
         var currentUserId = await GetUserIdAsync(userKey);
         return await HandleSortAsync(
-            parentId,
+            parentKey,
             sortingModels,
             (int id, int pageIndex, int pageSize, out long total) => ContentService.GetPagedChildren(id, pageIndex, pageSize, out total),
             items =>

--- a/src/Umbraco.Core/Services/MediaEditingService.cs
+++ b/src/Umbraco.Core/Services/MediaEditingService.cs
@@ -82,7 +82,7 @@ internal sealed class MediaEditingService
         => ContentService.Move(media, newParentId, userId).Result;
 
     protected override IMedia? Copy(IMedia media, int newParentId, bool relateToOriginal, bool includeDescendants, int userId)
-        => null; // copy is not supported for media
+        => throw new NotImplementedException("Copy is not supported for media");
 
     protected override OperationResult? MoveToRecycleBin(IMedia media, int userId)
         => ContentService.MoveToRecycleBin(media, userId).Result;

--- a/src/Umbraco.Core/Services/OperationStatus/ContentEditingOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/ContentEditingOperationStatus.cs
@@ -14,6 +14,7 @@ public enum ContentEditingOperationStatus
     TemplateNotAllowed,
     PropertyTypeNotFound,
     InTrash,
+    NotInTrash,
     SortingInvalid,
     Unknown
 }

--- a/src/Umbraco.Core/Services/OperationStatus/ContentEditingOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/ContentEditingOperationStatus.cs
@@ -14,5 +14,6 @@ public enum ContentEditingOperationStatus
     TemplateNotAllowed,
     PropertyTypeNotFound,
     InTrash,
+    SortingInvalid,
     Unknown
 }

--- a/src/Umbraco.Core/Services/TreeEntitySortingService.cs
+++ b/src/Umbraco.Core/Services/TreeEntitySortingService.cs
@@ -1,0 +1,58 @@
+﻿using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Models.Entities;
+
+namespace Umbraco.Cms.Core.Services;
+
+public class TreeEntitySortingService : ITreeEntitySortingService
+{
+    public IEnumerable<TTreeEntity> SortEntities<TTreeEntity>(IEnumerable<TTreeEntity> entities, IEnumerable<SortingModel> sortingModels)
+        where TTreeEntity : ITreeEntity
+    {
+        TTreeEntity[] entitiesArray = entities as TTreeEntity[] ?? entities.ToArray();
+        if (entitiesArray.DistinctBy(entity => entity.ParentId).Count() != 1)
+        {
+            throw new ArgumentException("Cannot sort entities under different parents", nameof(entities));
+        }
+
+        var sortedEntityKeys = entitiesArray.OrderBy(entity => entity.SortOrder).Select(entity => entity.Key).ToList();
+
+        SortingModel[] sortingModelsArray = sortingModels as SortingModel[] ?? sortingModels.ToArray();
+
+        if (sortingModelsArray.Any(sort => sort.SortOrder < 0 || sort.SortOrder >= sortedEntityKeys.Count))
+        {
+            throw new ArgumentException("Sort order index out of range - must be within the boundaries of the entities collection", nameof(sortingModels));
+        }
+
+        if (sortingModelsArray.Any(sort => sortedEntityKeys.Contains(sort.Key) is false))
+        {
+            throw new ArgumentException("One or more sort keys was not found in the entities collection", nameof(sortingModels));
+        }
+
+        if (sortingModelsArray.DistinctBy(sort => sort.Key).Count() != sortingModelsArray.Length)
+        {
+            throw new ArgumentException("One or more duplicate sort keys was found in the sorting collection", nameof(sortingModels));
+        }
+
+        if (sortingModelsArray.DistinctBy(sort => sort.SortOrder).Count() != sortingModelsArray.Length)
+        {
+            throw new ArgumentException("One or more duplicate sort orders was found in the sorting collection", nameof(sortingModels));
+        }
+
+        Guid[] keysBeingSorted = sortingModelsArray.Select(sort => sort.Key).ToArray();
+        sortedEntityKeys.RemoveAll(keysBeingSorted.Contains);
+
+        foreach (SortingModel sort in sortingModelsArray.OrderBy(sort => sort.SortOrder))
+        {
+            if (sort.SortOrder < sortedEntityKeys.Count)
+            {
+                sortedEntityKeys.Insert(sort.SortOrder, sort.Key);
+            }
+            else
+            {
+                sortedEntityKeys.Add(sort.Key);
+            }
+        }
+
+        return sortedEntityKeys.Select(key => entitiesArray.Single(i => i.Key == key)).ToArray();
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Sort.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Sort.cs
@@ -1,0 +1,151 @@
+﻿using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Tests.Common.Builders;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
+
+// NOTE: all sorting scenarios are covered by TreeEntitySortingServiceTests; these tests only serve to verify the application of TreeEntitySortingService within ContentEditingService
+public partial class ContentEditingServiceTests
+{
+    [Test]
+    public async Task Can_Sort_Children()
+    {
+        var root = await CreateRootContentWithTenChildren();
+
+        var originalChildren = ContentService.GetPagedChildren(root.Id, 0, 100, out _).ToArray();
+        Assert.AreEqual(10, originalChildren.Length);
+
+        var sortingModels = originalChildren.Reverse().Select((child, index) => new SortingModel { Key = child.Key, SortOrder = index });
+
+        var result = await ContentEditingService.SortAsync(root.Key, sortingModels, Constants.Security.SuperUserKey);
+        Assert.AreEqual(ContentEditingOperationStatus.Success, result);
+
+        var actualChildrenKeys = ContentService
+            .GetPagedChildren(root.Id, 0, 100, out _)
+            .OrderBy(c => c.SortOrder)
+            .Select(c => c.Key)
+            .ToArray();
+        var expectedChildrenKeys = originalChildren
+            .OrderBy(c => c.SortOrder)
+            .Select(c => c.Key)
+            .Reverse()
+            .ToArray();
+        Assert.IsTrue(expectedChildrenKeys.SequenceEqual(actualChildrenKeys));
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Can_Sort_Root_Content(bool useRootKeyForSorting)
+    {
+        var existingRoots = ContentService.GetRootContent();
+        foreach (var existingRoot in existingRoots)
+        {
+            ContentService.Delete(existingRoot);
+        }
+
+        var rootContentType = ContentTypeBuilder.CreateBasicContentType(alias: "rootPage", name: "Root Page");
+        rootContentType.AllowedAsRoot = true;
+        ContentTypeService.Save(rootContentType);
+
+        for (var i = 1; i < 11; i++)
+        {
+            await ContentEditingService.CreateAsync(
+                new ContentCreateModel
+                {
+                    ContentTypeKey = rootContentType.Key, InvariantName = $"Root {i}", ParentKey = Constants.System.RootKey,
+                },
+                Constants.Security.SuperUserKey);
+        }
+
+        var originalRoots = ContentService.GetPagedChildren(Constants.System.Root, 0, 100, out _).ToArray();
+        Assert.AreEqual(10, originalRoots.Length);
+
+        var sortingModels = originalRoots.Reverse().Select((root, index) => new SortingModel { Key = root.Key, SortOrder = index });
+
+        var parentId = useRootKeyForSorting
+            ? Constants.System.RootKey
+            : null;
+
+        var result = await ContentEditingService.SortAsync(parentId, sortingModels, Constants.Security.SuperUserKey);
+        Assert.AreEqual(ContentEditingOperationStatus.Success, result);
+
+        var actualRootKeys = ContentService
+            .GetPagedChildren(Constants.System.Root, 0, 100, out _)
+            .OrderBy(c => c.SortOrder)
+            .Select(c => c.Key)
+            .ToArray();
+        var expectedRootKeys = originalRoots
+            .OrderBy(c => c.SortOrder)
+            .Select(c => c.Key)
+            .Reverse()
+            .ToArray();
+        Assert.IsTrue(expectedRootKeys.SequenceEqual(actualRootKeys));
+    }
+
+    [Test]
+    public async Task Cannot_Sort_Unknown_Children()
+    {
+        var root = await CreateRootContentWithTenChildren();
+
+        var originalChildren = ContentService.GetPagedChildren(root.Id, 0, 100, out _).ToArray();
+        Assert.AreEqual(10, originalChildren.Length);
+
+        var sortingModels = new[]
+        {
+            new SortingModel { Key = Guid.NewGuid(), SortOrder = 0 },
+            new SortingModel { Key = Guid.NewGuid(), SortOrder = 1 },
+        };
+
+        var result = await ContentEditingService.SortAsync(root.Key, sortingModels, Constants.Security.SuperUserKey);
+        Assert.AreEqual(ContentEditingOperationStatus.SortingInvalid, result);
+
+        var actualChildrenKeys = ContentService
+            .GetPagedChildren(root.Id, 0, 100, out _)
+            .OrderBy(c => c.SortOrder)
+            .Select(c => c.Key)
+            .ToArray();
+        var expectedChildrenKeys = originalChildren
+            .OrderBy(c => c.SortOrder)
+            .Select(c => c.Key)
+            .ToArray();
+        Assert.IsTrue(expectedChildrenKeys.SequenceEqual(actualChildrenKeys));
+    }
+
+    private async Task<IContent> CreateRootContentWithTenChildren()
+    {
+        var childContentType = ContentTypeBuilder.CreateBasicContentType(alias: "childPage", name: "Child Page");
+        ContentTypeService.Save(childContentType);
+
+        var rootContentType = ContentTypeBuilder.CreateBasicContentType(alias: "rootPage", name: "Root Page");
+        rootContentType.AllowedAsRoot = true;
+        rootContentType.AllowedContentTypes = new[]
+        {
+            new ContentTypeSort(childContentType.Key, 1, childContentType.Alias)
+        };
+        ContentTypeService.Save(rootContentType);
+
+        var root = (await ContentEditingService.CreateAsync(
+            new ContentCreateModel
+            {
+                ContentTypeKey = rootContentType.Key, InvariantName = "Root", ParentKey = Constants.System.RootKey,
+            },
+            Constants.Security.SuperUserKey)).Result!;
+
+        for (var i = 1; i < 11; i++)
+        {
+            var createModel = new ContentCreateModel
+            {
+                ContentTypeKey = childContentType.Key,
+                ParentKey = root.Key,
+                InvariantName = $"Child {i}",
+            };
+
+            await ContentEditingService.CreateAsync(createModel, Constants.Security.SuperUserKey);
+        }
+
+        return root;
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
@@ -69,6 +69,9 @@
     <Compile Update="Umbraco.Infrastructure\Services\ContentEditingServiceTests.Update.cs">
       <DependentUpon>ContentEditingServiceTests.cs</DependentUpon>
     </Compile>
+    <Compile Update="Umbraco.Infrastructure\Services\ContentEditingServiceTests.Sort.cs">
+      <DependentUpon>ContentEditingServiceTests.cs</DependentUpon>
+    </Compile>
     <Compile Update="Umbraco.Core\Services\UserServiceCrudTests.Create.cs">
       <DependentUpon>UserServiceCrudTests.cs</DependentUpon>
     </Compile>

--- a/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
@@ -66,6 +66,9 @@
     <Compile Update="Umbraco.Infrastructure\Services\ContentEditingServiceTests.Move.cs">
       <DependentUpon>ContentEditingServiceTests.cs</DependentUpon>
     </Compile>
+    <Compile Update="Umbraco.Infrastructure\Services\ContentEditingServiceTests.MoveToRecycleBin.cs">
+      <DependentUpon>ContentEditingServiceTests.cs</DependentUpon>
+    </Compile>
     <Compile Update="Umbraco.Infrastructure\Services\ContentEditingServiceTests.Update.cs">
       <DependentUpon>ContentEditingServiceTests.cs</DependentUpon>
     </Compile>

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/TreeEntitySortingServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/TreeEntitySortingServiceTests.cs
@@ -1,0 +1,340 @@
+﻿using NUnit.Framework;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Models.Entities;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Services;
+
+[TestFixture]
+public class TreeEntitySortingServiceTests
+{
+    private readonly List<ITreeEntity> _treeEntities = new()
+    {
+        new ContentEntitySlim { Id = 01, SortOrder = 00, Key = new Guid("8c927e65-f175-406a-8328-9e5d5bd77689") },
+        new ContentEntitySlim { Id = 02, SortOrder = 01, Key = new Guid("92b27594-882a-4bdc-b238-087851970176") },
+        new ContentEntitySlim { Id = 03, SortOrder = 02, Key = new Guid("30b763bc-2a8b-4e61-859b-d48b3134eaaf") },
+        new ContentEntitySlim { Id = 04, SortOrder = 03, Key = new Guid("aac00e78-a132-4903-9f9e-c7089f17f151") },
+        new ContentEntitySlim { Id = 05, SortOrder = 04, Key = new Guid("263c26b8-9dd6-4bbc-a359-461baf2df191") },
+        new ContentEntitySlim { Id = 06, SortOrder = 05, Key = new Guid("84fa6fef-4b7a-40ea-ad03-c198abaaaea2") },
+        new ContentEntitySlim { Id = 07, SortOrder = 06, Key = new Guid("2db04e7f-2190-4f4b-9a76-55d074a58fa1") },
+        new ContentEntitySlim { Id = 08, SortOrder = 07, Key = new Guid("220a6f46-f5eb-4ab7-80c3-b29f5a927b71") },
+        new ContentEntitySlim { Id = 09, SortOrder = 08, Key = new Guid("f2595836-7133-402c-9f05-3dfeabeb851c") },
+        new ContentEntitySlim { Id = 10, SortOrder = 09, Key = new Guid("143a30ca-8e65-4c94-83da-96cc5088ec2c") },
+        new ContentEntitySlim { Id = 11, SortOrder = 10, Key = new Guid("0c089f9f-f901-4a73-896b-6bd9e8b927a4") },
+        new ContentEntitySlim { Id = 12, SortOrder = 11, Key = new Guid("3f522f7e-f5cc-4f88-90f9-ea7fd52ad868") },
+        new ContentEntitySlim { Id = 13, SortOrder = 12, Key = new Guid("b1cd6692-a073-4992-9905-7e08e91234e5") },
+        new ContentEntitySlim { Id = 14, SortOrder = 13, Key = new Guid("22a7eb2f-1981-4d00-8735-cd87b2a30bda") },
+        new ContentEntitySlim { Id = 15, SortOrder = 14, Key = new Guid("fdb6785c-1f16-4c82-924b-cda37c42839f") },
+        new ContentEntitySlim { Id = 16, SortOrder = 15, Key = new Guid("8ef27112-7224-4066-a628-2ae883b92843") },
+        new ContentEntitySlim { Id = 17, SortOrder = 16, Key = new Guid("df06a384-006e-4d11-bc21-dbdbd864f66f") },
+        new ContentEntitySlim { Id = 18, SortOrder = 17, Key = new Guid("4547c977-97a2-4d08-9ad5-6f65c6cb7aed") },
+        new ContentEntitySlim { Id = 19, SortOrder = 18, Key = new Guid("58f1c5cd-507a-4426-97df-b9e917c10334") },
+        new ContentEntitySlim { Id = 20, SortOrder = 19, Key = new Guid("c3447f0d-f5d2-4301-86fe-0dcfc5f63c6c") },
+    };
+
+    private Guid EntityKey(int id) => _treeEntities.First(i => i.Id == id).Key;
+
+    private SortingModel SortingModel(Guid key, int sortOrder) => new() { Key = key, SortOrder = sortOrder };
+
+    private void AssertContainsAllEntities(ITreeEntity[] result)
+    {
+        Assert.AreEqual(_treeEntities.Count, result.Length);
+        Assert.IsTrue(_treeEntities.All(e => result.SingleOrDefault(r => r.Key == e.Key) is not null));
+    }
+
+    [Test]
+    public void Can_Move_Last_Entity_First()
+    {
+        var treeEntitySortingService = new TreeEntitySortingService();
+        var result = treeEntitySortingService.SortEntities(
+                _treeEntities,
+                new[] { SortingModel(EntityKey(20), 0) })
+            .ToArray();
+
+        AssertContainsAllEntities(result);
+
+        Assert.AreEqual(EntityKey(20), result.First().Key);
+        Assert.AreEqual(EntityKey(1), result[1].Key);
+        Assert.AreEqual(EntityKey(19), result.Last().Key);
+    }
+
+    [Test]
+    public void Can_Move_First_Entity_Last()
+    {
+        var treeEntitySortingService = new TreeEntitySortingService();
+        var result = treeEntitySortingService.SortEntities(
+                _treeEntities,
+                new[] { SortingModel(EntityKey(1), 19) })
+            .ToArray();
+
+        AssertContainsAllEntities(result);
+
+        Assert.AreEqual(EntityKey(2), result.First().Key);
+        Assert.AreEqual(EntityKey(3), result[1].Key);
+        Assert.AreEqual(EntityKey(1), result.Last().Key);
+    }
+
+    [Test]
+    public void Can_Move_Three_Entities_Last()
+    {
+        var treeEntitySortingService = new TreeEntitySortingService();
+        var result = treeEntitySortingService.SortEntities(
+                _treeEntities,
+                new[]
+                {
+                    SortingModel(EntityKey(7), 19),
+                    SortingModel(EntityKey(2), 18),
+                    SortingModel(EntityKey(12), 17)
+                })
+            .ToArray();
+
+        AssertContainsAllEntities(result);
+
+        Assert.AreEqual(EntityKey(1), result.First().Key);
+        Assert.AreEqual(EntityKey(7), result[19].Key);
+        Assert.AreEqual(EntityKey(2), result[18].Key);
+        Assert.AreEqual(EntityKey(12), result[17].Key);
+    }
+
+    [Test]
+    public void Can_Move_Three_Entities_First()
+    {
+        var treeEntitySortingService = new TreeEntitySortingService();
+        var result = treeEntitySortingService.SortEntities(
+                _treeEntities,
+                new[]
+                {
+                    SortingModel(EntityKey(7), 0),
+                    SortingModel(EntityKey(17), 1),
+                    SortingModel(EntityKey(12), 2)
+                })
+            .ToArray();
+
+        AssertContainsAllEntities(result);
+
+        Assert.AreEqual(EntityKey(7), result.First().Key);
+        Assert.AreEqual(EntityKey(17), result[1].Key);
+        Assert.AreEqual(EntityKey(12), result[2].Key);
+        Assert.AreEqual(EntityKey(20), result.Last().Key);
+    }
+
+    [Test]
+    public void Can_Apply_Same_Position_To_Entities()
+    {
+        var treeEntitySortingService = new TreeEntitySortingService();
+        var result = treeEntitySortingService.SortEntities(
+                _treeEntities,
+                new[]
+                {
+                    SortingModel(EntityKey(1), 0),
+                    SortingModel(EntityKey(7), 6),
+                    SortingModel(EntityKey(17), 16),
+                    SortingModel(EntityKey(12), 11)
+                })
+            .ToArray();
+
+        AssertContainsAllEntities(result);
+
+        Assert.IsTrue(result.SequenceEqual(_treeEntities));
+    }
+
+    [Test]
+    public void Can_Move_Multiple_Entities_Forwards()
+    {
+        var treeEntitySortingService = new TreeEntitySortingService();
+        var result = treeEntitySortingService.SortEntities(
+                _treeEntities,
+                new[]
+                {
+                    SortingModel(EntityKey(10), 4),
+                    SortingModel(EntityKey(20), 9)
+                })
+            .ToArray();
+
+        AssertContainsAllEntities(result);
+
+        Assert.AreEqual(EntityKey(10), result[4].Key);
+        Assert.AreEqual(EntityKey(20), result[9].Key);
+    }
+
+    [Test]
+    public void Can_Move_Multiple_Entities_Backwards()
+    {
+        var treeEntitySortingService = new TreeEntitySortingService();
+        var result = treeEntitySortingService.SortEntities(
+                _treeEntities,
+                new[]
+                {
+                    SortingModel(EntityKey(10), 19),
+                    SortingModel(EntityKey(5), 14)
+                })
+            .ToArray();
+
+        AssertContainsAllEntities(result);
+
+        Assert.AreEqual(EntityKey(5), result[14].Key);
+        Assert.AreEqual(EntityKey(10), result[19].Key);
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Sorting_Instruction_Order_Does_Not_Matter_When_Overlapping(bool lastFirst)
+    {
+        var treeEntitySortingService = new TreeEntitySortingService();
+
+        var sortingInstructions = lastFirst
+            ? new[] { SortingModel(EntityKey(10), 19), SortingModel(EntityKey(5), 14) }
+            : new[] { SortingModel(EntityKey(5), 14), SortingModel(EntityKey(10), 19) };
+
+        var result = treeEntitySortingService.SortEntities(_treeEntities, sortingInstructions).ToArray();
+
+        AssertContainsAllEntities(result);
+
+        // the result must not depend on the order in which the instructions are carried out
+        Assert.AreEqual(EntityKey(5), result[14].Key);
+        Assert.AreEqual(EntityKey(10), result[19].Key);
+    }
+
+    [TestCase(false)]
+    [TestCase(false)]
+    public void Sorting_Instruction_Order_Does_Not_Matter_When_Not_Overlapping(bool lastFirst)
+    {
+        var treeEntitySortingService = new TreeEntitySortingService();
+
+        var sortingInstructions = lastFirst
+            ? new[] { SortingModel(EntityKey(5), 8), SortingModel(EntityKey(12), 17) }
+            : new[] { SortingModel(EntityKey(12), 17), SortingModel(EntityKey(5), 8) };
+
+        var result = treeEntitySortingService.SortEntities(_treeEntities, sortingInstructions).ToArray();
+
+        AssertContainsAllEntities(result);
+
+        // the result must not depend on the order in which the instructions are carried out
+        Assert.AreEqual(EntityKey(5), result[8].Key);
+        Assert.AreEqual(EntityKey(12), result[17].Key);
+    }
+
+    [Test]
+    public void Can_Reverse_All_Entities()
+    {
+        var treeEntitySortingService = new TreeEntitySortingService();
+        var result = treeEntitySortingService.SortEntities(
+                _treeEntities,
+                new[]
+                {
+                    SortingModel(EntityKey(1), 19),
+                    SortingModel(EntityKey(2), 18),
+                    SortingModel(EntityKey(3), 17),
+                    SortingModel(EntityKey(4), 16),
+                    SortingModel(EntityKey(5), 15),
+                    SortingModel(EntityKey(6), 14),
+                    SortingModel(EntityKey(7), 13),
+                    SortingModel(EntityKey(8), 12),
+                    SortingModel(EntityKey(9), 11),
+                    SortingModel(EntityKey(10), 10),
+                    SortingModel(EntityKey(11), 9),
+                    SortingModel(EntityKey(12), 8),
+                    SortingModel(EntityKey(13), 7),
+                    SortingModel(EntityKey(14), 6),
+                    SortingModel(EntityKey(15), 5),
+                    SortingModel(EntityKey(16), 4),
+                    SortingModel(EntityKey(17), 3),
+                    SortingModel(EntityKey(18), 2),
+                    SortingModel(EntityKey(19), 1),
+                    SortingModel(EntityKey(20), 0),
+                })
+            .ToArray();
+
+        AssertContainsAllEntities(result);
+
+        Assert.AreEqual(EntityKey(20), result[0].Key);
+        Assert.AreEqual(EntityKey(19), result[1].Key);
+        Assert.AreEqual(EntityKey(18), result[2].Key);
+        Assert.AreEqual(EntityKey(17), result[3].Key);
+        Assert.AreEqual(EntityKey(16), result[4].Key);
+        Assert.AreEqual(EntityKey(15), result[5].Key);
+        Assert.AreEqual(EntityKey(14), result[6].Key);
+        Assert.AreEqual(EntityKey(13), result[7].Key);
+        Assert.AreEqual(EntityKey(12), result[8].Key);
+        Assert.AreEqual(EntityKey(11), result[9].Key);
+        Assert.AreEqual(EntityKey(10), result[10].Key);
+        Assert.AreEqual(EntityKey(9), result[11].Key);
+        Assert.AreEqual(EntityKey(8), result[12].Key);
+        Assert.AreEqual(EntityKey(7), result[13].Key);
+        Assert.AreEqual(EntityKey(6), result[14].Key);
+        Assert.AreEqual(EntityKey(5), result[15].Key);
+        Assert.AreEqual(EntityKey(4), result[16].Key);
+        Assert.AreEqual(EntityKey(3), result[17].Key);
+        Assert.AreEqual(EntityKey(2), result[18].Key);
+        Assert.AreEqual(EntityKey(1), result[19].Key);
+    }
+
+    [TestCase(-1)]
+    [TestCase(-1000)]
+    [TestCase(20)]
+    [TestCase(2000)]
+    public void Cannot_Sort_Outside_Entities_Bounds(int sortOrder)
+    {
+        var treeEntitySortingService = new TreeEntitySortingService();
+        Assert.Throws<ArgumentException>(() => treeEntitySortingService.SortEntities(
+            _treeEntities,
+            new[]
+            {
+                SortingModel(EntityKey(10), sortOrder)
+            }));
+    }
+
+    [Test]
+    public void Cannot_Sort_Entities_Under_Different_Parents()
+    {
+        var treeEntitySortingService = new TreeEntitySortingService();
+        Assert.Throws<ArgumentException>(() => treeEntitySortingService.SortEntities(
+            new []
+            {
+                new ContentEntitySlim { Id = 01, ParentId = 123, SortOrder = 0, Key = new Guid("8c927e65-f175-406a-8328-9e5d5bd77689") },
+                new ContentEntitySlim { Id = 02, ParentId = 456, SortOrder = 1, Key = new Guid("92b27594-882a-4bdc-b238-087851970176") },
+            },
+            new[]
+            {
+                SortingModel(new Guid("8c927e65-f175-406a-8328-9e5d5bd77689"), 1)
+            }));
+    }
+
+    [Test]
+    public void Cannot_Sort_NonExisting_Entity()
+    {
+        var treeEntitySortingService = new TreeEntitySortingService();
+        Assert.Throws<ArgumentException>(() => treeEntitySortingService.SortEntities(
+            _treeEntities,
+            new[]
+            {
+                SortingModel(Guid.NewGuid(), 1)
+            }));
+    }
+
+    [Test]
+    public void Cannot_Supply_Duplicate_Key_Instructions()
+    {
+        var treeEntitySortingService = new TreeEntitySortingService();
+        Assert.Throws<ArgumentException>(() => treeEntitySortingService.SortEntities(
+            _treeEntities,
+            new[]
+            {
+                SortingModel(EntityKey(10), 1),
+                SortingModel(EntityKey(10), 2),
+            }));
+    }
+
+    [Test]
+    public void Cannot_Supply_Duplicate_SortOrder_Instructions()
+    {
+        var treeEntitySortingService = new TreeEntitySortingService();
+        Assert.Throws<ArgumentException>(() => treeEntitySortingService.SortEntities(
+            _treeEntities,
+            new[]
+            {
+                SortingModel(EntityKey(10), 1),
+                SortingModel(EntityKey(11), 1),
+            }));
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR adds content and media sorting to the Management API.

The new endpoints are:

- `/umbraco/management/api/v1.0/document/sort` 
- `/umbraco/management/api/v1.0/media/sort` 

When sorting in the current backoffice, the IDs and updated sort order of all items being sorted are passed to the server as part of the sort update request. This scales really badly, and efficiently makes sorting impossible for large datasets, because all items must be loaded on the client in order to perform the sort.

In the Management API we're going to take a different approach. Here we're _only_ passing the IDs and updated sort order of those items we changed to the server. The server then has to figure out the rest.

Considering this sorting operation:

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/319aab5a-ddd7-4c57-95f3-ac0a74642169)

The sorting request would look like this:

```
POST /umbraco/management/api/v1.0/document/sort
{
    "parentId": "[ID of parent item, or null if sorting at root]",
    "sorting": [
        {
            "id": "[Id of item A]",
            "sortOrder": 2
        },
        {
            "id": "[ID of item H]",
            "sortOrder": 4
        }
    ]
}
```

_NOTE: The sorting algorithm on the server is indifferent to the order of "sorting operations" in the request payload._

Ideally the endpoints would be `/umbraco/management/api/v1.0/document/[parent ID]/sort` and `/umbraco/management/api/v1.0/media/[parent ID]/sort`, so we didn't have to specify `parentId` as part of the request payload.  Unfortunately that would make it impossible (or at least quite counter intuitive) to perform sorting at root level.

### Notable changes

As part of this PR I have fixed up a few things:

- `ContentEditingServiceBase` now consistently uses named delegates instead of anonymous functions to perform actions.
- `IContentEditingService`, `ContentEditingService`, `IMediaEditingService`, `MediaEditingService` and `ContentEditingServiceBase` now use `key` instead of `id` as parameter names for item keys.