### PR TITLE
Added null & whitespace check

### DIFF
--- a/src/Umbraco.Web/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
+++ b/src/Umbraco.Web/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
@@ -32,7 +32,9 @@ namespace Umbraco.Web.PropertyEditors.ValueConverters
 
         public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Snapshot;
 
-        public override bool? IsValue(object value, PropertyValueLevel level) => value?.ToString() != "[]";
+        public override bool? IsValue(object value, PropertyValueLevel level) => value is not null &&
+            !string.IsNullOrWhiteSpace(value.ToString()) &&
+            value.ToString() != "[]";
 
         public override object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview) => source?.ToString();
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #14716 

### Description

As per issue #14716, in Umbraco 8.18 there currently is no null or whitespace check on the MultiUrlPicker's ValueConverter. This means that if an empty MultiUrlPicker is provided, it won't ever use a possible fallback value because Umbraco recognizes a whitespace or null value as being a valid value, which it is not.

