### PR TITLE
Use version range on project references

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -51,4 +51,13 @@
   <PropertyGroup>
     <GitVersionBaseDirectory>$(MSBuildThisFileDirectory)</GitVersionBaseDirectory>
   </PropertyGroup>
+
+  <!-- Use version range on project references (to limit on major version in generated packages) -->
+  <Target Name="_GetProjectReferenceVersionRanges" AfterTargets="_GetProjectReferenceVersions">
+    <ItemGroup>
+      <_ProjectReferencesWithVersions Condition="'%(ProjectVersion)' != ''">
+        <ProjectVersion>[%(ProjectVersion), $([MSBuild]::Add($([System.Text.RegularExpressions.Regex]::Match('%(ProjectVersion)', '^\d+').Value), 1)))</ProjectVersion>
+      </_ProjectReferencesWithVersions>
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
When the current solution gets packaged (using `dotnet pack`), all project references will be converted to package dependencies that only specify the minimum version, for example: `Umbraco.Cms 12.1.1` depends on `Umbraco.Cms.Targets >= 12.1.1`. This allows other dependencies to (accidentally) update any of the transitive Umbraco dependencies to a next major version, which will most likely cause compilation or (worst-case) runtime errors.

This can be prevented by setting the maximum version to the next major version as [version range](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges). Because the version is automatically generated and dependencies are specified in `ProjectReference`s, this version range must be dynamically set as well (better support for this has already been requested on the [NuGet issue tracker](https://github.com/NuGet/Home/issues/5556)). This PR contains an MSBuild target that updates the generated project reference version to use a version range, so when packaging version `12.1.0--rc.preview.96.gfec51a9`, the dependency version is automatically updated to `[12.1.0--rc.preview.96.gfec51a9, 13)`.

Testing can be done by verifying whether the Umbraco dependencies in the NuGet packages contain the version range, either by inspecting the build artifacts or running `dotnet pack -c Release -o build.out` locally.