### PR TITLE
Do not parse short into integer

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Factories/UserGroupFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Factories/UserGroupFactory.cs
@@ -78,7 +78,7 @@ internal static class UserGroupFactory
 
         if (entity.HasIdentity)
         {
-            dto.Id = short.Parse(entity.Id.ToString());
+            dto.Id = entity.Id;
         }
 
         return dto;


### PR DESCRIPTION
Fixes #14690

I think this have been some legacy from sometime in the past where the ids have been a short. Should not be necessary for V10+ at least