### PR TITLE
Update umbBlockGridPropertyEditor.component.js

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbBlockGridPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbBlockGridPropertyEditor.component.js
@@ -493,7 +493,7 @@
             block.showValidation = true;
 
             block.hideContentInOverlay = block.config.forceHideContentEditorInOverlay === true;
-            block.showContent = !block.hideContentInOverlay && block.content?.variants[0].tabs[0]?.properties.length > 0;
+            block.showContent = !block.hideContentInOverlay && block.content?.variants[0].tabs?.some(tab=>tab.properties.length) === true;
             block.showSettings = block.config.settingsElementTypeKey != null;
 
             // If we have content, otherwise it doesn't make sense to copy.


### PR DESCRIPTION
currently checks the first group or tab (index 0) that was added to see if there are properties.

This doesn't work well when the tab has a single group, and the group is created after the tab, as the tab will be empty, even though the group has the properties. 

there is also some interactions when composing tabs from other doc types, but I didn't have a good amount of time to test this.

### Prerequisites

- [x] I have added steps to test this contribution in the description below


### Description
If an element in the block editor has any tab or group with properties and the element does not disable editing then the edit button should be visible. 

Currently the code only checks the first tab, which doesn't always work.

Steps to test:

- Create a page doctype and add a new block list editor. 
- Create a new layout element doctype.
- Add a tab, and then add a group with a text field.
- Add the layout element type as a layout in the grid datatype.
- Create a new content node with this type, and add the layout. The overlay should show for the new block, and you should be able to see you text field.
- Add some text and create the block.
- You should now see that the edit icon is not visible when hovering the new grid content - only copy and delete are there. 
- To confirm you could edit the layout's document type and reorder the text field directly into the tab, then save.
- Go back to the content section, and view the block grid, the edit button will now be present. 