### PR TITLE
Fixed open api enum schema filter not setting type

### DIFF
--- a/src/Umbraco.Cms.Api.Common/OpenApi/EnumSchemaFilter.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/EnumSchemaFilter.cs
@@ -12,6 +12,8 @@ public class EnumSchemaFilter : ISchemaFilter
     {
         if (context.Type.IsEnum)
         {
+            model.Type = "string";
+            model.Format = null;
             model.Enum.Clear();
             foreach (var name in Enum.GetNames(context.Type))
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
By not setting the type and format, it would remain integer is this case, which would result in an invalid specification as the enum members are strings.

Currently I don't think any enums are exposed yet, but I saw this issue as part of some related investigations, checking the feasibility of including the CMS models in the swagger.
