### PR TITLE
Fixed incorrect BlockListPropertyValueConverter delivery api property value type

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockListPropertyValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockListPropertyValueConverter.cs
@@ -113,7 +113,7 @@ public class BlockListPropertyValueConverter : BlockPropertyValueConverterBase<B
 
     /// <inheritdoc />
     public Type GetDeliveryApiPropertyValueType(IPublishedPropertyType propertyType)
-        => typeof(IEnumerable<ApiBlockListModel>);
+        => typeof(ApiBlockListModel);
 
     /// <inheritdoc />
     public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This is currently returning an incorrect type, as you can see in the `ConvertIntermediateToDeliveryApiObject` it returns an `ApiBlockListModel` and not an `IEnumerable`.