### PR TITLE
DeliveryApi: Ensure the ContentType property is serialized first

### DIFF
--- a/src/Umbraco.Core/Models/DeliveryApi/ApiElement.cs
+++ b/src/Umbraco.Core/Models/DeliveryApi/ApiElement.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Umbraco.Cms.Core.Models.DeliveryApi;
 
 public class ApiElement : IApiElement
@@ -11,6 +13,9 @@ public class ApiElement : IApiElement
 
     public Guid Id { get; }
 
+    // Ensure the ContentType property is serialized first
+    // This is needed so it can be used as a discriminator field by System.Text.Json
+    [JsonPropertyOrder(-100)]
     public string ContentType { get; }
 
     public IDictionary<string, object?> Properties { get; }

--- a/src/Umbraco.Core/Models/DeliveryApi/IApiElement.cs
+++ b/src/Umbraco.Core/Models/DeliveryApi/IApiElement.cs
@@ -1,9 +1,14 @@
+using System.Text.Json.Serialization;
+
 namespace Umbraco.Cms.Core.Models.DeliveryApi;
 
 public interface IApiElement
 {
     Guid Id { get; }
 
+    // Ensure the ContentType property is serialized first
+    // This is needed so it can be used as a discriminator field by System.Text.Json
+    [JsonPropertyOrder(-100)]
     string ContentType { get; }
 
     IDictionary<string, object?> Properties { get; }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This is needed so the `ContentType` property can be used as a discriminator field by System.Text.Json.
You can read more about it here: https://github.com/dotnet/runtime/issues/72604

Changed both ApiElement and IApiElement to ensure not only ApiContentResponse, but also ApiBlockItem, which uses the interface directly, are adjusted.