### PR TITLE
Expose composition aliases in SimpleContentType

### DIFF
--- a/src/Umbraco.Core/Models/ISimpleContentType.cs
+++ b/src/Umbraco.Core/Models/ISimpleContentType.cs
@@ -47,6 +47,11 @@ public interface ISimpleContentType
     bool IsElement { get; }
 
     /// <summary>
+    ///     Gets the aliases of the content types that compose this content type.
+    /// </summary>
+    IEnumerable<string> CompositionAliases => Enumerable.Empty<string>();
+
+    /// <summary>
     ///     Validates that a combination of culture and segment is valid for the content type properties.
     /// </summary>
     /// <param name="culture">The culture.</param>

--- a/src/Umbraco.Core/Models/SimpleContentType.cs
+++ b/src/Umbraco.Core/Models/SimpleContentType.cs
@@ -11,14 +11,14 @@ public class SimpleContentType : ISimpleContentType
     ///     Initializes a new instance of the <see cref="SimpleContentType" /> class.
     /// </summary>
     public SimpleContentType(IContentType contentType)
-        : this((IContentTypeBase)contentType) =>
+        : this((IContentTypeComposition)contentType) =>
         DefaultTemplate = contentType.DefaultTemplate;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="SimpleContentType" /> class.
     /// </summary>
     public SimpleContentType(IMediaType mediaType)
-        : this((IContentTypeBase)mediaType)
+        : this((IContentTypeComposition)mediaType)
     {
     }
 
@@ -26,11 +26,11 @@ public class SimpleContentType : ISimpleContentType
     ///     Initializes a new instance of the <see cref="SimpleContentType" /> class.
     /// </summary>
     public SimpleContentType(IMemberType memberType)
-        : this((IContentTypeBase)memberType)
+        : this((IContentTypeComposition)memberType)
     {
     }
 
-    private SimpleContentType(IContentTypeBase contentType)
+    private SimpleContentType(IContentTypeComposition contentType)
     {
         if (contentType == null)
         {
@@ -46,6 +46,7 @@ public class SimpleContentType : ISimpleContentType
         Name = contentType.Name;
         AllowedAsRoot = contentType.AllowedAsRoot;
         IsElement = contentType.IsElement;
+        CompositionAliases = contentType.CompositionAliases().ToList();
     }
 
     public string Alias { get; }
@@ -68,6 +69,8 @@ public class SimpleContentType : ISimpleContentType
     public bool AllowedAsRoot { get; }
 
     public bool IsElement { get; }
+
+    public IEnumerable<string> CompositionAliases { get; }
 
     public bool SupportsPropertyVariation(string? culture, string segment, bool wildcards = false) =>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
The `SimpleContentType` does not expose any information regarding the content type compositions.
This is easily available in the full blow content type model, but not in the simplified version.

I think it makes sense to, while not having the full composition model, at least have the aliases available.

An example implementation of using this would be:
```c#
using Umbraco.Cms.Core.DeliveryApi;
using Umbraco.Cms.Core.Models;

public class HideFromSearchFilter : IFilterHandler, IContentIndexHandler
{
    private const string CustomSearchSpecifier = "hideFromSearch:";
    private const string FieldName = "hideFromSearch";

    public bool CanHandle(string query)
        => query.StartsWith(CustomSearchSpecifier, StringComparison.OrdinalIgnoreCase);

    public FilterOption BuildFilterOption(string filter)
    {
        var fieldValue = filter[CustomSearchSpecifier.Length..];

        return new FilterOption
        {
            FieldName = FieldName,
            Values = new[] { fieldValue.ToLowerInvariant() },
            Operator = FilterOperation.Is
        };
    }

    public IEnumerable<IndexFieldValue> GetFieldValues(IContent content, string? culture)
    {
        bool hideFromSearch = !content.ContentType.CompositionAliases.Contains("basePage");

        return new[]
        {
            new IndexFieldValue
            {
                FieldName = FieldName,
                Values = new object[] { hideFromSearch ? "true" : "false" }
            }
        };
    }

    public IEnumerable<IndexField> GetFields() => new[]
    {
        new IndexField
        {
            FieldName = FieldName,
            FieldType = FieldType.StringRaw,
            VariesByCulture = true
        }
    };
}
```