### PR TITLE
Bulk delete functionality for management api

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/User/BulkDeleteUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/BulkDeleteUsersController.cs
@@ -1,0 +1,35 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.User;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Api.Management.Controllers.User;
+
+[ApiVersion("1.0")]
+public class BulkDeleteUsersController : UserControllerBase
+{
+    private readonly IUserService _userService;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+
+    public BulkDeleteUsersController(IUserService userService, IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+    {
+        _userService = userService;
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+    }
+
+    [HttpDelete()]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> DeleteUsers(DeleteUsersRequestModel model)
+    {
+        UserOperationStatus result = await _userService.DeleteAsync(CurrentUserKey(_backOfficeSecurityAccessor), model.UserIds);
+
+        return result is UserOperationStatus.Success
+            ? Ok()
+            : UserOperationStatusResult(result);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/BulkDeleteUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/BulkDeleteUsersController.cs
@@ -20,7 +20,7 @@ public class BulkDeleteUsersController : UserControllerBase
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
-    [HttpDelete()]
+    [HttpDelete]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/DeleteUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/DeleteUsersController.cs
@@ -1,5 +1,6 @@
 ﻿using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 
@@ -8,15 +9,20 @@ namespace Umbraco.Cms.Api.Management.Controllers.User;
 [ApiVersion("1.0")]
 public class DeleteUserController : UserControllerBase
 {
-    public DeleteUserController(IUserService userService) => _userService = userService;
+    public DeleteUserController(IUserService userService, IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+    {
+        _userService = userService;
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+    }
 
     private readonly IUserService _userService;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
 
     [MapToApiVersion("1.0")]
     [HttpDelete("{id:guid}")]
     public async Task<IActionResult> DeleteUser(Guid id)
     {
-        UserOperationStatus result = await _userService.DeleteAsync(id);
+        UserOperationStatus result = await _userService.DeleteAsync(CurrentUserKey(_backOfficeSecurityAccessor), new HashSet<Guid>(){id});
 
         return result is UserOperationStatus.Success
             ? Ok()

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/DeleteUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/DeleteUsersController.cs
@@ -22,7 +22,7 @@ public class DeleteUserController : UserControllerBase
     [HttpDelete("{id:guid}")]
     public async Task<IActionResult> DeleteUser(Guid id)
     {
-        UserOperationStatus result = await _userService.DeleteAsync(CurrentUserKey(_backOfficeSecurityAccessor), new HashSet<Guid>(){id});
+        UserOperationStatus result = await _userService.DeleteAsync(CurrentUserKey(_backOfficeSecurityAccessor), id);
 
         return result is UserOperationStatus.Success
             ? Ok()

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/UsersControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/UsersControllerBase.cs
@@ -64,6 +64,10 @@ public abstract class UserControllerBase : ManagementApiControllerBase
                 .WithTitle("Cannot disable")
                 .WithDetail("A user cannot disable itself.")
                 .Build()),
+            UserOperationStatus.CannotDeleteSelf => BadRequest(new ProblemDetailsBuilder()
+                .WithTitle("Cannot delete")
+                .WithDetail("A user cannot delete itself.")
+                .Build()),
             UserOperationStatus.OldPasswordRequired => BadRequest(new ProblemDetailsBuilder()
                 .WithTitle("Old password required")
                 .WithDetail("The old password is required to change the password of the specified user.")

--- a/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/BulkDeleteUserGroupsController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/BulkDeleteUserGroupsController.cs
@@ -1,0 +1,33 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.UserGroup;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Api.Management.Controllers.UserGroup;
+
+[ApiVersion("1.0")]
+public class BulkDeleteUserGroupsController : UserGroupControllerBase
+{
+    private readonly IUserGroupService _userGroupService;
+
+    public BulkDeleteUserGroupsController(IUserGroupService userGroupService)
+    {
+        _userGroupService = userGroupService;
+    }
+
+    [HttpDelete("")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> BulkDelete(DeleteUserGroupsRequestModel model)
+    {
+        Attempt<UserGroupOperationStatus> result = await _userGroupService.DeleteAsync(model.UserGroupIds);
+
+        return result.Success
+            ? Ok()
+            : UserGroupOperationStatusResult(result.Result);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/BulkDeleteUserGroupsController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/BulkDeleteUserGroupsController.cs
@@ -18,7 +18,7 @@ public class BulkDeleteUserGroupsController : UserGroupControllerBase
         _userGroupService = userGroupService;
     }
 
-    [HttpDelete("")]
+    [HttpDelete]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/DeleteUsersRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/DeleteUsersRequestModel.cs
@@ -1,0 +1,6 @@
+namespace Umbraco.Cms.Api.Management.ViewModels.User;
+
+public class DeleteUsersRequestModel
+{
+    public HashSet<Guid> UserIds { get; set; } = new();
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/DisableUserRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/DisableUserRequestModel.cs
@@ -3,4 +3,4 @@
 public class DisableUserRequestModel
 {
     public HashSet<Guid> UserIds { get; set; } = new();
- }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/UserGroup/DeleteUserGroupsRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/UserGroup/DeleteUserGroupsRequestModel.cs
@@ -1,0 +1,6 @@
+namespace Umbraco.Cms.Api.Management.ViewModels.UserGroup;
+
+public class DeleteUserGroupsRequestModel
+{
+    public HashSet<Guid> UserGroupIds { get; set; } = new();
+}

--- a/src/Umbraco.Core/Notifications/UserGroupDeletedNotification.cs
+++ b/src/Umbraco.Core/Notifications/UserGroupDeletedNotification.cs
@@ -12,4 +12,9 @@ public sealed class UserGroupDeletedNotification : DeletedNotification<IUserGrou
         : base(target, messages)
     {
     }
+
+    public UserGroupDeletedNotification(IEnumerable<IUserGroup> target, EventMessages messages)
+        : base(target, messages)
+    {
+    }
 }

--- a/src/Umbraco.Core/Services/IUserGroupService.cs
+++ b/src/Umbraco.Core/Services/IUserGroupService.cs
@@ -82,9 +82,10 @@ public interface IUserGroupService
     /// <summary>
     ///     Deletes a UserGroup
     /// </summary>
-    /// <param name="key">The key of the user group to delete.</param>
+    /// <param name="userGroupKeys">The keys of the user groups to delete.</param>
     /// <returns>An attempt indicating if the operation was a success as well as a more detailed <see cref="UserGroupOperationStatus"/>.</returns>
-    Task<Attempt<UserGroupOperationStatus>> DeleteAsync(Guid key);
+    Task<Attempt<UserGroupOperationStatus>> DeleteAsync(ISet<Guid> userGroupKeys);
+    Task<Attempt<UserGroupOperationStatus>> DeleteAsync(Guid userGroupKey) => DeleteAsync(new HashSet<Guid>(){userGroupKey});
 
     /// <summary>
     /// Updates the users to have the groups specified.

--- a/src/Umbraco.Core/Services/IUserService.cs
+++ b/src/Umbraco.Core/Services/IUserService.cs
@@ -67,7 +67,7 @@ public interface IUserService : IMembershipUserService
 
     Task<UserOperationStatus> SetAvatarAsync(Guid userKey, Guid temporaryFileKey);
 
-    Task<UserOperationStatus> DeleteAsync(Guid key);
+    Task<UserOperationStatus> DeleteAsync(Guid userKey, ISet<Guid> keys);
 
     Task<UserOperationStatus> DisableAsync(Guid userKey, ISet<Guid> keys);
 

--- a/src/Umbraco.Core/Services/IUserService.cs
+++ b/src/Umbraco.Core/Services/IUserService.cs
@@ -68,7 +68,8 @@ public interface IUserService : IMembershipUserService
     Task<UserOperationStatus> SetAvatarAsync(Guid userKey, Guid temporaryFileKey);
 
     Task<UserOperationStatus> DeleteAsync(Guid userKey, ISet<Guid> keys);
-    Task<UserOperationStatus> DeleteAsync(Guid userKey, Guid key) => DeleteAsync(userKey, new HashSet<Guid>(){key});
+
+    Task<UserOperationStatus> DeleteAsync(Guid userKey, Guid key) => DeleteAsync(userKey, new HashSet<Guid> { key });
 
     Task<UserOperationStatus> DisableAsync(Guid userKey, ISet<Guid> keys);
 

--- a/src/Umbraco.Core/Services/IUserService.cs
+++ b/src/Umbraco.Core/Services/IUserService.cs
@@ -68,6 +68,7 @@ public interface IUserService : IMembershipUserService
     Task<UserOperationStatus> SetAvatarAsync(Guid userKey, Guid temporaryFileKey);
 
     Task<UserOperationStatus> DeleteAsync(Guid userKey, ISet<Guid> keys);
+    Task<UserOperationStatus> DeleteAsync(Guid userKey, Guid key) => DeleteAsync(userKey, new HashSet<Guid>(){key});
 
     Task<UserOperationStatus> DisableAsync(Guid userKey, ISet<Guid> keys);
 

--- a/src/Umbraco.Core/Services/OperationStatus/UserGroupOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/UserGroupOperationStatus.cs
@@ -18,5 +18,5 @@ public enum UserGroupOperationStatus
     LanguageNotFound,
     NameTooLong,
     AliasTooLong,
-    MissingName,
+    MissingName
 }

--- a/src/Umbraco.Core/Services/OperationStatus/UserOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/UserOperationStatus.cs
@@ -19,6 +19,7 @@ public enum UserOperationStatus
     CannotInvite,
     CannotDelete,
     CannotDisableSelf,
+    CannotDeleteSelf,
     CannotDisableInvitedUser,
     OldPasswordRequired,
     InvalidAvatar,

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserServiceCrudTests.Delete.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserServiceCrudTests.Delete.cs
@@ -12,7 +12,7 @@ public partial class UserServiceCrudTests
     public async Task Delete_Returns_Not_Found_If_Not_Found()
     {
         var userService = CreateUserService();
-        var result = await userService.DeleteAsync(Guid.NewGuid());
+        var result = await userService.DeleteAsync(Constants.Security.SuperUserKey, Guid.NewGuid());
         Assert.AreEqual(UserOperationStatus.UserNotFound, result);
     }
 
@@ -36,7 +36,7 @@ public partial class UserServiceCrudTests
         createdUser!.LastLoginDate = DateTime.Now;
         userService.Save(createdUser);
 
-        var result = await userService.DeleteAsync(createdUser.Key);
+        var result = await userService.DeleteAsync(Constants.Security.SuperUserKey, createdUser.Key);
         Assert.AreEqual(UserOperationStatus.CannotDelete, result);
 
         // Asset that it is in fact not deleted
@@ -61,7 +61,7 @@ public partial class UserServiceCrudTests
         var creationResult = await userService.CreateAsync(Constants.Security.SuperUserKey, userCreateModel, true);
         Assert.IsTrue(creationResult.Success);
 
-        var deletionResult = await userService.DeleteAsync(creationResult.Result.CreatedUser!.Key);
+        var deletionResult = await userService.DeleteAsync(Constants.Security.SuperUserKey, creationResult.Result.CreatedUser!.Key);
         Assert.AreEqual(UserOperationStatus.Success, deletionResult);
         // Make sure it's actually deleted
         var postDeletedUser = await userService.GetAsync(creationResult.Result.CreatedUser.Key);


### PR DESCRIPTION
Added missing bulk delete method on users and user groups.

### Test
- Ensure the original delele single user still works.
- Ensure the original delele single user groups still works.
- Ensure the new endpoint bulk works as expected