### PR TITLE
Add HasTemplate Extension method

### DIFF
--- a/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
@@ -294,6 +294,23 @@ public static class PublishedContentExtensions
         return publishedContentContentType.IsAllowedTemplate(templateId);
     }
 
+    public static bool HasTemplate(this IPublishedContent content, IFileService fileService)
+    {
+        if (!content.TemplateId.HasValue)
+        {
+            return false;
+        }
+
+        if (content.TemplateId <= 0)
+        {
+            return false;
+        }
+
+        ITemplate? template = fileService.GetTemplate(content.TemplateId.Value);
+
+        return template != null;
+    }
+
     public static bool IsAllowedTemplate(this IPublishedContent content, IFileService fileService, IContentTypeService contentTypeService, bool disableAlternativeTemplates, bool validateAlternativeTemplates, string templateAlias)
     {
         ITemplate? template = fileService.GetTemplate(templateAlias);

--- a/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs
@@ -154,6 +154,10 @@ public static class FriendlyPublishedContentExtensions
             validateAlternativeTemplates,
             templateAlias);
 
+    public static bool HasTemplate(
+        this IPublishedContent content)
+        => content.HasTemplate(FileService);
+
     /// <summary>
     ///     Gets a value indicating whether the content has a value for a property identified by its alias.
     /// </summary>


### PR DESCRIPTION
I'm not sure if this PR is indeed seen as a valuable addition, but we often use a similar extension method in our projects.

In our projects, we sometimes have document types with multiple templates, but no default, so a conscious choice must be made. In code, it's very helpful to be able to check if a template is set, for example when displaying a list of pages.

Below is a code example where the extension method is used:

```csharp
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<IPublishedContent>
@using ContentModels = Umbraco.Cms.Web.Common.PublishedModels;
@{
    Layout = null;
}

@foreach (var child in Model.Children.Where(x => x.HasTemplate()))
{
    <a href="@child.Url()">@child.Name</a>
}
```