### PR TITLE
Allow setting id in create endpoints: User, Usergroup, CreatedPackage, Dictionary

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/DictionaryControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/DictionaryControllerBase.cs
@@ -17,6 +17,10 @@ public abstract class DictionaryControllerBase : ManagementApiControllerBase
     protected IActionResult DictionaryItemOperationStatusResult(DictionaryItemOperationStatus status) =>
         status switch
         {
+            DictionaryItemOperationStatus.DuplicateKey => Conflict(new ProblemDetailsBuilder()
+                .WithTitle("Duplicate dictionary item key detected")
+                .WithDetail("Another dictionary item exists with the same key. Dictionary item keys must be unique.")
+                .Build()),
             DictionaryItemOperationStatus.DuplicateItemKey => Conflict(new ProblemDetailsBuilder()
                 .WithTitle("Duplicate dictionary item name detected")
                 .WithDetail("Another dictionary item exists with the same name. Dictionary item names must be unique.")

--- a/src/Umbraco.Cms.Api.Management/Controllers/Package/PackageControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Package/PackageControllerBase.cs
@@ -28,6 +28,18 @@ public abstract class PackageControllerBase : ManagementApiControllerBase
                 .WithTitle("Invalid package name")
                 .WithDetail("The attempted package name does not represent a valid name for a package.")
                 .Build()),
+            PackageOperationStatus.ScriptNotFound => BadRequest(new ProblemDetailsBuilder()
+                .WithTitle("A script was not found")
+                .WithDetail("The script path was not found.")
+                .Build()),
+            PackageOperationStatus.PartialViewNotFound => BadRequest(new ProblemDetailsBuilder()
+                .WithTitle("A partial view was not found")
+                .WithDetail("The partial view path was not found.")
+                .Build()),
+            PackageOperationStatus.StylesheetNotFound => BadRequest(new ProblemDetailsBuilder()
+                .WithTitle("A stylesheet was not found")
+                .WithDetail("The stylesheet path was not found.")
+                .Build()),
             _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
                 .WithTitle("Unknown package operation status.")
                 .Build()),

--- a/src/Umbraco.Cms.Api.Management/Factories/PackageDefinitionFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/PackageDefinitionFactory.cs
@@ -20,6 +20,11 @@ internal class PackageDefinitionFactory : IPackageDefinitionFactory
         packageDefinition.PackageId = Guid.Empty;
         packageDefinition.PackagePath = string.Empty;
 
+        if (createPackageRequestModel.Id.HasValue)
+        {
+            packageDefinition.PackageId = createPackageRequestModel.Id.Value;
+        }
+
         return packageDefinition;
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/UserGroupPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/UserGroupPresentationFactory.cs
@@ -118,6 +118,11 @@ public class UserGroupPresentationFactory : IUserGroupPresentationFactory
             PermissionNames = requestModel.Permissions,
         };
 
+        if (requestModel.Id.HasValue)
+        {
+            group.Key = requestModel.Id.Value;
+        }
+
         Attempt<UserGroupOperationStatus> assignmentAttempt = AssignStartNodesToUserGroup(requestModel, group);
         if (assignmentAttempt.Success is false)
         {

--- a/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
@@ -66,6 +66,7 @@ public class UserPresentationFactory : IUserPresentationFactory
             Name = requestModel.Name,
             UserName = requestModel.UserName,
             UserGroupKeys = requestModel.UserGroupIds,
+            Key = requestModel.Id,
         };
 
         return createModel;

--- a/src/Umbraco.Cms.Api.Management/Mapping/Dictionary/DictionaryMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Dictionary/DictionaryMapDefinition.cs
@@ -40,6 +40,11 @@ public class DictionaryMapDefinition : IMapDefinition
     // Umbraco.Code.MapAll -Id -Key -CreateDate -UpdateDate -Translations
     private void Map(CreateDictionaryItemRequestModel source, IDictionaryItem target, MapperContext context)
     {
+        if (source.Id.HasValue)
+        {
+            target.Key = source.Id.Value;
+        }
+
         target.ItemKey = source.Name;
         target.ParentId = source.ParentId;
         target.DeleteDate = null;

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -15241,6 +15241,73 @@
       }
     },
     "/umbraco/management/api/v1/user-group": {
+      "delete": {
+        "tags": [
+          "User Group"
+        ],
+        "operationId": "DeleteUserGroup",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/DeleteUserGroupsRequestModel"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/DeleteUserGroupsRequestModel"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/DeleteUserGroupsRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      },
       "post": {
         "tags": [
           "User Group"
@@ -15723,6 +15790,73 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "User"
+        ],
+        "operationId": "DeleteUser",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/DeleteUsersRequestModel"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/DeleteUsersRequestModel"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/DeleteUsersRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
           },
           "400": {
             "description": "Bad Request",
@@ -17875,6 +18009,11 @@
           }
         ],
         "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
           "parentId": {
             "type": "string",
             "format": "uuid",
@@ -18049,6 +18188,13 @@
             "$ref": "#/components/schemas/PackageModelBaseModel"
           }
         ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
         "additionalProperties": false
       },
       "CreatePartialViewRequestModel": {
@@ -18140,6 +18286,13 @@
             "$ref": "#/components/schemas/UserGroupBaseModel"
           }
         ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
         "additionalProperties": false
       },
       "CreateUserRequestModel": {
@@ -18149,6 +18302,13 @@
             "$ref": "#/components/schemas/UserPresentationBaseModel"
           }
         ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
         "additionalProperties": false
       },
       "CreateUserResponseModel": {
@@ -18442,6 +18602,34 @@
           },
           "requiresConnectionTest": {
             "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "DeleteUserGroupsRequestModel": {
+        "type": "object",
+        "properties": {
+          "userGroupIds": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "DeleteUsersRequestModel": {
+        "type": "object",
+        "properties": {
+          "userIds": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         },
         "additionalProperties": false

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Dictionary/CreateDictionaryItemRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Dictionary/CreateDictionaryItemRequestModel.cs
@@ -2,5 +2,6 @@
 
 public class CreateDictionaryItemRequestModel : DictionaryItemModelBase
 {
+    public Guid? Id { get; set; }
     public Guid? ParentId { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Package/CreatePackageRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Package/CreatePackageRequestModel.cs
@@ -2,4 +2,5 @@ namespace Umbraco.Cms.Api.Management.ViewModels.Package;
 
 public class CreatePackageRequestModel : PackageModelBase
 {
+    public Guid? Id { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/CreateUserRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/CreateUserRequestModel.cs
@@ -2,5 +2,5 @@
 
 public class CreateUserRequestModel : UserPresentationBase
 {
-
+    public Guid? Id { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/UserGroup/CreateUserGroupRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/UserGroup/CreateUserGroupRequestModel.cs
@@ -2,5 +2,5 @@
 
 public class CreateUserGroupRequestModel : UserGroupBase
 {
-
+    public Guid? Id { get; set; }
 }

--- a/src/Umbraco.Core/Models/UserCreateModel.cs
+++ b/src/Umbraco.Core/Models/UserCreateModel.cs
@@ -11,4 +11,6 @@ public class UserCreateModel
     public string Name { get; set; } = string.Empty;
 
     public ISet<Guid> UserGroupKeys { get; set; } = new HashSet<Guid>();
+
+    public Guid? Key { get; set; }
 }

--- a/src/Umbraco.Core/Services/OperationStatus/PackageOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/PackageOperationStatus.cs
@@ -5,5 +5,8 @@ public enum PackageOperationStatus
     Success,
     NotFound,
     DuplicateItemName,
-    InvalidName
+    InvalidName,
+    ScriptNotFound,
+    PartialViewNotFound,
+    StylesheetNotFound
 }

--- a/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
@@ -142,6 +142,11 @@ public class BackOfficeUserStore :
             IsLockedOut = user.IsLockedOut,
         };
 
+        if (user.Key != Guid.Empty)
+        {
+            userEntity.Key = user.Key;
+        }
+
         // we have to remember whether Logins property is dirty, since the UpdateMemberProperties will reset it.
         var isLoginsPropertyDirty = user.IsPropertyDirty(nameof(BackOfficeIdentityUser.Logins));
         var isTokensPropertyDirty = user.IsPropertyDirty(nameof(BackOfficeIdentityUser.LoginTokens));

--- a/src/Umbraco.Web.Common/Security/BackOfficeUserManager.cs
+++ b/src/Umbraco.Web.Common/Security/BackOfficeUserManager.cs
@@ -299,6 +299,10 @@ public class BackOfficeUserManager : UmbracoUserManager<BackOfficeIdentityUser, 
             _globalSettings.DefaultUILanguage);
 
         identityUser.Name = createModel.Name;
+        if (createModel.Key.HasValue)
+        {
+            identityUser.Key = createModel.Key.Value;
+        }
 
         IdentityResult created = await CreateAsync(identityUser);
 


### PR DESCRIPTION
### Description
Allows setting the ids/keys in the management for user, usergroups, created packages and dictionary keys.

Also added additional validation for created packages, so the endpoint do not return 500.

### Tests
- Ensure the affected endpoints now support both setting and id and ignoring the id (Then a guid will be generated)