### PR TITLE
v12: Fix getting an unpublished start item in preview through Start-Item header

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Services/RequestStartItemProvider.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/RequestStartItemProvider.cs
@@ -11,6 +11,7 @@ internal sealed class RequestStartItemProvider : RequestHeaderHandler, IRequestS
 {
     private readonly IPublishedSnapshotAccessor _publishedSnapshotAccessor;
     private readonly IVariationContextAccessor _variationContextAccessor;
+    private readonly IRequestPreviewService _requestPreviewService;
 
     // this provider lifetime is Scope, so we can cache this as a field
     private IPublishedContent? _requestedStartContent;
@@ -18,11 +19,13 @@ internal sealed class RequestStartItemProvider : RequestHeaderHandler, IRequestS
     public RequestStartItemProvider(
         IHttpContextAccessor httpContextAccessor,
         IPublishedSnapshotAccessor publishedSnapshotAccessor,
-        IVariationContextAccessor variationContextAccessor)
+        IVariationContextAccessor variationContextAccessor,
+        IRequestPreviewService requestPreviewService)
         : base(httpContextAccessor)
     {
         _publishedSnapshotAccessor = publishedSnapshotAccessor;
         _variationContextAccessor = variationContextAccessor;
+        _requestPreviewService = requestPreviewService;
     }
 
     /// <inheritdoc/>
@@ -45,7 +48,7 @@ internal sealed class RequestStartItemProvider : RequestHeaderHandler, IRequestS
             return null;
         }
 
-        IEnumerable<IPublishedContent> rootContent = publishedSnapshot.Content.GetAtRoot();
+        IEnumerable<IPublishedContent> rootContent = publishedSnapshot.Content.GetAtRoot(_requestPreviewService.IsPreview());
 
         _requestedStartContent = Guid.TryParse(headerValue, out Guid key)
             ? rootContent.FirstOrDefault(c => c.Key == key)


### PR DESCRIPTION
## Details
We are now able to pass an unpublished item to the `Start-Item` header and get the correct response depending on whether we are in Preview mode.

## Test
1. Create a Root item and Save and Publish
2. Create a Child item under the Root item and Save and Publish
3. Verify that you can get the child item from any of the `/item` endpoints even when passing the ID or PATH of the start item in the `Start-Item` header
4. Set up Preview
5. Unpublish Root item
6. Try to execute the same API call, this time in Preview
7. Verify that the response hasn't changed
8. Set the Preview header to `false` and verify that you get 404 "The Start-Item could not be found"

- ➕ Test that the Start Item functionality still works in the different endpoints:
  - Limiting the results from the Query endpoint through the `Start-Item` header, getting the right result when specifying a correct or incorrect `Start-Item` header in the different endpoints, etc.