### PR TITLE
Add SetMemberSignInManager builder extension

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/UmbracoApplicationBuilder.Identity.cs
+++ b/src/Umbraco.Web.Common/Extensions/UmbracoApplicationBuilder.Identity.cs
@@ -39,6 +39,17 @@ public static partial class UmbracoApplicationBuilderExtensions
         return builder;
     }
 
+    public static IUmbracoBuilder SetMemberSignInManager<TSignInManager>(this IUmbracoBuilder builder)
+        where TSignInManager : SignInManager<MemberIdentityUser>, IMemberSignInManager
+    {
+        Type customType = typeof(TSignInManager);
+        Type signInManagerType = typeof(SignInManager<MemberIdentityUser>);
+        builder.Services.Replace(ServiceDescriptor.Scoped(typeof(IMemberSignInManager), customType));
+        builder.Services.AddScoped(customType, services => services.GetRequiredService(signInManagerType));
+        builder.Services.Replace(ServiceDescriptor.Scoped(signInManagerType, customType));
+        return builder;
+    }
+
     public static IUmbracoBuilder SetMemberUserStore<TUserStore>(this IUmbracoBuilder builder)
         where TUserStore : MemberUserStore
     {

--- a/src/Umbraco.Web.Common/Extensions/UmbracoApplicationBuilder.Identity.cs
+++ b/src/Umbraco.Web.Common/Extensions/UmbracoApplicationBuilder.Identity.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Web.Common.Security;
 
 namespace Umbraco.Extensions;
 


### PR DESCRIPTION
Been working on an OpenIdConnect integration recently that required the MemberSignInManager is swapped out.

This was achieved by registering an additional scoped service:

```
builder.Services.AddScoped<IMemberSignInManager, CustomMemberSignInManager>();
```

This works because when you inject `IMemberSignInManager` the **last registered** service wins.

It doesn't work if you try to inject `SignInManager<MemberIdentityUser>` as that is still registered to Umbraco's default `MemberSignInManager`.

Similar applies to the user manager, but Umbraco has a helpful extension methods for replacing it – `SetMemberManager<T>()`.

This PR adds an equivalent `SetMemberSignInManager<T>()` for the same purpose.

_(It would have been cool to do this for the `BackOfficeSignInManager` too but that lives in another project, not alongside the `BackOfficeUserManager` though weirdly...)_