### PR TITLE
Revert #13281 and only set `UpgradeUnattended` value to true for new projects

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/UnattendedSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/UnattendedSettings.cs
@@ -13,7 +13,7 @@ namespace Umbraco.Cms.Core.Configuration.Models;
 public class UnattendedSettings
 {
     private const bool StaticInstallUnattended = false;
-    private const bool StaticUpgradeUnattended = true;
+    private const bool StaticUpgradeUnattended = false;
 
     /// <summary>
     ///     Gets or sets a value indicating whether unattended installs are enabled.

--- a/templates/UmbracoProject/appsettings.json
+++ b/templates/UmbracoProject/appsettings.json
@@ -33,6 +33,9 @@
         "ContentVersionCleanupPolicy": {
           "EnableCleanup": true
         }
+      },
+      "Unattended": {
+        "UpgradeUnattended": true
       }
     }
   }


### PR DESCRIPTION
Reverts #13281 and only sets the `UpgradeUnattended` value to true for new projects (when using the updated `dotnet new umbraco` project template in `Umbraco.Templates`).

After a quick internal discussion, we agreed on only changing default setting values in new major versions and otherwise only add the new value in the project template (so it only affects new projects and the updated value is more visible, since it's explicitly set).

This PR should be merged for the 12.2.0 release (to ensure the default value is reverted). After merging everything to `v13/dev`, we can revert this PR again, so only the next major will have unattended upgrades enabled by default.