### PR TITLE
Update MediaController, search by id or key

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/MediaController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MediaController.cs
@@ -1145,10 +1145,13 @@ public class MediaController : ContentControllerBase
             IQuery<IMedia>? queryFilter = null;
             if (filter.IsNullOrWhiteSpace() == false)
             {
+                int.TryParse(filter, out int filterAsIntId);
+                Guid.TryParse(filter, out Guid filterAsGuid);
                 //add the default text filter
                 queryFilter = _sqlContext.Query<IMedia>()
                     .Where(x => x.Name != null)
-                    .Where(x => x.Name!.Contains(filter));
+                    .Where(x => x.Name!.Contains(filter)
+                      || x.Id == filterAsIntId || x.Key == filterAsGuid);
             }
 
             children = _mediaService


### PR DESCRIPTION
In addition to: https://github.com/umbraco/Umbraco-CMS/pull/14514 and as suggested here https://github.com/umbraco/Umbraco-CMS/issues/14468#issuecomment-1658403269 updated the media controller so that media in a listview can be searched by it's id or key.
