### PR TITLE
V10/feature/pipeline test filters

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -32,7 +32,7 @@ parameters:
   - name: integrationReleaseTestFilter
     displayName: TestFilter used for release type builds
     type: string
-    default: null
+    default: ''
   - name: escapedIntegrationNonReleaseTestFilter
     displayName: Escaped TestFilter used for non-release type builds
     type: string
@@ -40,7 +40,7 @@ parameters:
   - name: escapedIntegrationReleaseTestFilter
     displayName: Escaped TestFilter used for release type builds
     type: string
-    default: null
+    default: ''
 
 variables:
   nodeVersion: 14.18.1

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -24,23 +24,23 @@ parameters:
   - name: forceReleaseTestFilter
     displayName: Force to use the release test filters
     type: boolean
-    default: : false
+    default: false
   - name: integrationNonReleaseTestFilter
     displayName: TestFilter used for non-release type builds
     type: string
-    default: : --filter TestCategory!=LongRunning&TestCategory!=NonCritical
+    default: '--filter TestCategory!=LongRunning&TestCategory!=NonCritical'
   - name: integrationReleaseTestFilter
     displayName: TestFilter used for release type builds
     type: string
-    default: : null
+    default: null
   - name: escapedIntegrationNonReleaseTestFilter
     displayName: Escaped TestFilter used for non-release type builds
     type: string
-    default: : --filter TestCategory\!=LongRunning&TestCategory\!=NonCritical
+    default: '--filter TestCategory\!=LongRunning&TestCategory\!=NonCritical'
   - name: escapedIntegrationReleaseTestFilter
     displayName: Escaped TestFilter used for release type builds
     type: string
-    default: : null
+    default: null
 
 variables:
   nodeVersion: 14.18.1
@@ -312,10 +312,10 @@ stages:
               command: test
               projects: '**/*.Tests.Integration.csproj'
               testRunTitle: Integration Tests SQLite - $(Agent.OS)
-              ${{ if or(forceReleaseTestFilter, startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}:
-                arguments: '--configuration $(buildConfiguration) --no-build ${integrationReleaseTestFilter}'
+              ${{ if or( parameters.forceReleaseTestFilter, startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}:
+                arguments: '--configuration $(buildConfiguration) --no-build ${{parameters.integrationReleaseTestFilter}}'
               ${{ else }}:
-                arguments: '--configuration $(buildConfiguration) ${integrationNonReleaseTestFilter}'
+                arguments: '--configuration $(buildConfiguration) ${{parameters.integrationNonReleaseTestFilter}}'
             env:
               Tests__Database__DatabaseType: 'Sqlite'
               Umbraco__CMS__Global__MainDomLock: 'FileSystemMainDomLock'
@@ -326,10 +326,10 @@ stages:
               command: test
               projects: '**/*.Tests.Integration.csproj'
               testRunTitle: Integration Tests SQLite - $(Agent.OS)
-              ${{ if or(forceReleaseTestFilter, startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}:
-                arguments: '--configuration $(buildConfiguration) --no-build ${escapedIntegrationReleaseTestFilter}'
+              ${{ if or( parameters.forceReleaseTestFilter, startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}:
+                arguments: '--configuration $(buildConfiguration) --no-build ${{parameters.escapedIntegrationReleaseTestFilter}}'
               ${{ else }}:
-                arguments: '--configuration $(buildConfiguration) ${escapedIntegrationNonReleaseTestFilter}'
+                arguments: '--configuration $(buildConfiguration) ${{parameters.escapedIntegrationNonReleaseTestFilter}}'
             env:
               Tests__Database__DatabaseType: 'Sqlite'
               Umbraco__CMS__Global__MainDomLock: 'FileSystemMainDomLock'
@@ -372,10 +372,10 @@ stages:
               command: test
               projects: '**/*.Tests.Integration.csproj'
               testRunTitle: Integration Tests SQL Server - $(Agent.OS)
-              ${{ or(forceReleaseTestFilter, if startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}:
-                arguments: '--configuration $(buildConfiguration) --no-build ${integrationReleaseTestFilter}'
+              ${{ if or( parameters.forceReleaseTestFilter, startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}:
+                arguments: '--configuration $(buildConfiguration) --no-build ${{parameters.integrationReleaseTestFilter}}'
               ${{ else }}:
-                arguments: '--configuration $(buildConfiguration) --no-build ${integrationNonReleaseTestFilter}'
+                arguments: '--configuration $(buildConfiguration) --no-build ${{parameters.integrationNonReleaseTestFilter}}'
             env:
               Tests__Database__DatabaseType: $(testDb)
               Tests__Database__SQLServerMasterConnectionString: $(connectionString)
@@ -387,10 +387,10 @@ stages:
               command: test
               projects: '**/*.Tests.Integration.csproj'
               testRunTitle: Integration Tests SQL Server - $(Agent.OS)
-              ${{ or(forceReleaseTestFilter, if startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}:
-                arguments: '--configuration $(buildConfiguration) --no-build ${escapedIntegrationReleaseTestFilter}'
+              ${{ if or( parameters.forceReleaseTestFilter, startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}:
+                arguments: '--configuration $(buildConfiguration) --no-build ${{parameters.escapedIntegrationReleaseTestFilter}}'
               ${{ else }}:
-                arguments: '--configuration $(buildConfiguration) --no-build ${escapedIntegrationNonReleaseTestFilter}'
+                arguments: '--configuration $(buildConfiguration) --no-build ${{parameters.escapedIntegrationNonReleaseTestFilter}}'
             env:
               Tests__Database__DatabaseType: $(testDb)
               Tests__Database__SQLServerMasterConnectionString: $(connectionString)

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -33,12 +33,12 @@ parameters:
     displayName: TestFilter used for release type builds
     type: string
     default: ' '
-  - name: escapedIntegrationNonReleaseTestFilter
-    displayName: Escaped TestFilter used for non-release type builds
+  - name: nonWindowsIntegrationNonReleaseTestFilter
+    displayName: TestFilter used for non-release type builds on non windows agents
     type: string
-    default: '--filter TestCategory\!=LongRunning&TestCategory\!=NonCritical'
-  - name: escapedIntegrationReleaseTestFilter
-    displayName: Escaped TestFilter used for release type builds
+    default: '--filter TestCategory!=LongRunning&TestCategory!=NonCritical'
+  - name: nonWindowsIntegrationReleaseTestFilter
+    displayName: TestFilter used for release type builds on non windows agents
     type: string
     default: ' '
 
@@ -327,9 +327,9 @@ stages:
               projects: '**/*.Tests.Integration.csproj'
               testRunTitle: Integration Tests SQLite - $(Agent.OS)
               ${{ if or( parameters.forceReleaseTestFilter, startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}:
-                arguments: '--configuration $(buildConfiguration) --no-build ${{parameters.escapedIntegrationReleaseTestFilter}}'
+                arguments: '--configuration $(buildConfiguration) --no-build ${{parameters.nonWindowsIntegrationReleaseTestFilter}}'
               ${{ else }}:
-                arguments: '--configuration $(buildConfiguration) ${{parameters.escapedIntegrationNonReleaseTestFilter}}'
+                arguments: '--configuration $(buildConfiguration) ${{parameters.nonWindowsIntegrationNonReleaseTestFilter}}'
             env:
               Tests__Database__DatabaseType: 'Sqlite'
               Umbraco__CMS__Global__MainDomLock: 'FileSystemMainDomLock'
@@ -388,9 +388,9 @@ stages:
               projects: '**/*.Tests.Integration.csproj'
               testRunTitle: Integration Tests SQL Server - $(Agent.OS)
               ${{ if or( parameters.forceReleaseTestFilter, startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}:
-                arguments: '--configuration $(buildConfiguration) --no-build ${{parameters.escapedIntegrationReleaseTestFilter}}'
+                arguments: '--configuration $(buildConfiguration) --no-build ${{parameters.nonWindowsIntegrationReleaseTestFilter}}'
               ${{ else }}:
-                arguments: '--configuration $(buildConfiguration) --no-build ${{parameters.escapedIntegrationNonReleaseTestFilter}}'
+                arguments: '--configuration $(buildConfiguration) --no-build ${{parameters.nonWindowsIntegrationNonReleaseTestFilter}}'
             env:
               Tests__Database__DatabaseType: $(testDb)
               Tests__Database__SQLServerMasterConnectionString: $(connectionString)

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -32,7 +32,7 @@ parameters:
   - name: integrationReleaseTestFilter
     displayName: TestFilter used for release type builds
     type: string
-    default: ''
+    default: ' '
   - name: escapedIntegrationNonReleaseTestFilter
     displayName: Escaped TestFilter used for non-release type builds
     type: string
@@ -40,7 +40,7 @@ parameters:
   - name: escapedIntegrationReleaseTestFilter
     displayName: Escaped TestFilter used for release type builds
     type: string
-    default: ''
+    default: ' '
 
 variables:
   nodeVersion: 14.18.1

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -33,6 +33,8 @@ variables:
   DOTNET_GENERATE_ASPNET_CERTIFICATE: false
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
+  integrationNonReleaseTestFilter: --filter TestCategory\!=LongRunning&TestCategory\!=NonCritical
+  integrationReleaseTestFilter : null
 
 stages:
   ###############################################
@@ -290,8 +292,11 @@ stages:
             inputs:
               command: test
               projects: '**/*.Tests.Integration.csproj'
-              arguments: '--configuration $(buildConfiguration) --no-build'
               testRunTitle: Integration Tests SQLite - $(Agent.OS)
+              ${{if startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')}}:
+                arguments: '--configuration $(buildConfiguration) --no-build ${integrationReleaseTestFilter}'
+              ${{if not startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')}}:
+                arguments: '--configuration $(buildConfiguration) ${integrationNonReleaseTestFilter}'
             env:
               Tests__Database__DatabaseType: 'Sqlite'
               Umbraco__CMS__Global__MainDomLock: 'FileSystemMainDomLock'
@@ -332,8 +337,11 @@ stages:
             inputs:
               command: test
               projects: '**/*.Tests.Integration.csproj'
-              arguments: '--configuration $(buildConfiguration) --no-build'
               testRunTitle: Integration Tests SQL Server - $(Agent.OS)
+              ${{if startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')}}:
+                arguments: '--configuration $(buildConfiguration) --no-build ${integrationReleaseTestFilter}'
+              ${{if not startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')}}:
+                arguments: '--configuration $(buildConfiguration) --no-build ${integrationNonReleaseTestFilter}'
             env:
               Tests__Database__DatabaseType: $(testDb)
               Tests__Database__SQLServerMasterConnectionString: $(connectionString)

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -293,9 +293,9 @@ stages:
               command: test
               projects: '**/*.Tests.Integration.csproj'
               testRunTitle: Integration Tests SQLite - $(Agent.OS)
-              ${{if startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')}}:
+              ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/release/') }}:
                 arguments: '--configuration $(buildConfiguration) --no-build ${integrationReleaseTestFilter}'
-              ${{if not startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')}}:
+              ${{ else }}:
                 arguments: '--configuration $(buildConfiguration) ${integrationNonReleaseTestFilter}'
             env:
               Tests__Database__DatabaseType: 'Sqlite'
@@ -338,9 +338,9 @@ stages:
               command: test
               projects: '**/*.Tests.Integration.csproj'
               testRunTitle: Integration Tests SQL Server - $(Agent.OS)
-              ${{if startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')}}:
+              ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/release/') }}:
                 arguments: '--configuration $(buildConfiguration) --no-build ${integrationReleaseTestFilter}'
-              ${{if not startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')}}:
+              ${{ else }}:
                 arguments: '--configuration $(buildConfiguration) --no-build ${integrationNonReleaseTestFilter}'
             env:
               Tests__Database__DatabaseType: $(testDb)

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -21,6 +21,26 @@ parameters:
     displayName: Upload API docs
     type: boolean
     default: false
+  - name: forceReleaseTestFilter
+    displayName: Force to use the release test filters
+    type: boolean
+    default: : false
+  - name: integrationNonReleaseTestFilter
+    displayName: TestFilter used for non-release type builds
+    type: string
+    default: : --filter TestCategory!=LongRunning&TestCategory!=NonCritical
+  - name: integrationReleaseTestFilter
+    displayName: TestFilter used for release type builds
+    type: string
+    default: : null
+  - name: escapedIntegrationNonReleaseTestFilter
+    displayName: Escaped TestFilter used for non-release type builds
+    type: string
+    default: : --filter TestCategory\!=LongRunning&TestCategory\!=NonCritical
+  - name: escapedIntegrationReleaseTestFilter
+    displayName: Escaped TestFilter used for release type builds
+    type: string
+    default: : null
 
 variables:
   nodeVersion: 14.18.1
@@ -33,8 +53,6 @@ variables:
   DOTNET_GENERATE_ASPNET_CERTIFICATE: false
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
-  integrationNonReleaseTestFilter: --filter TestCategory\!=LongRunning&TestCategory\!=NonCritical
-  integrationReleaseTestFilter : null
 
 stages:
   ###############################################
@@ -288,15 +306,30 @@ stages:
               performMultiLevelLookup: true
               includePreviewVersions: $(dotnetIncludePreviewVersions)
           - task: DotNetCoreCLI@2
-            displayName: Run dotnet test
+            displayName: Run dotnet test Windows
+            condition: eq(variables['Agent.OS'],'Windows_NT')
             inputs:
               command: test
               projects: '**/*.Tests.Integration.csproj'
               testRunTitle: Integration Tests SQLite - $(Agent.OS)
-              ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/release/') }}:
+              ${{ if or(forceReleaseTestFilter, startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}:
                 arguments: '--configuration $(buildConfiguration) --no-build ${integrationReleaseTestFilter}'
               ${{ else }}:
                 arguments: '--configuration $(buildConfiguration) ${integrationNonReleaseTestFilter}'
+            env:
+              Tests__Database__DatabaseType: 'Sqlite'
+              Umbraco__CMS__Global__MainDomLock: 'FileSystemMainDomLock'
+          - task: DotNetCoreCLI@2
+            displayName: Run dotnet test Non Windows
+            condition: ne(variables['Agent.OS'],'Windows_NT')
+            inputs:
+              command: test
+              projects: '**/*.Tests.Integration.csproj'
+              testRunTitle: Integration Tests SQLite - $(Agent.OS)
+              ${{ if or(forceReleaseTestFilter, startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}:
+                arguments: '--configuration $(buildConfiguration) --no-build ${escapedIntegrationReleaseTestFilter}'
+              ${{ else }}:
+                arguments: '--configuration $(buildConfiguration) ${escapedIntegrationNonReleaseTestFilter}'
             env:
               Tests__Database__DatabaseType: 'Sqlite'
               Umbraco__CMS__Global__MainDomLock: 'FileSystemMainDomLock'
@@ -333,15 +366,31 @@ stages:
             displayName: Start SQL Server (Linux only)
             condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
           - task: DotNetCoreCLI@2
-            displayName: Run dotnet test
+            displayName: Run dotnet test Windows
+            condition: eq(variables['Agent.OS'],'Windows_NT')
             inputs:
               command: test
               projects: '**/*.Tests.Integration.csproj'
               testRunTitle: Integration Tests SQL Server - $(Agent.OS)
-              ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/release/') }}:
+              ${{ or(forceReleaseTestFilter, if startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}:
                 arguments: '--configuration $(buildConfiguration) --no-build ${integrationReleaseTestFilter}'
               ${{ else }}:
                 arguments: '--configuration $(buildConfiguration) --no-build ${integrationNonReleaseTestFilter}'
+            env:
+              Tests__Database__DatabaseType: $(testDb)
+              Tests__Database__SQLServerMasterConnectionString: $(connectionString)
+              Umbraco__CMS__Global__MainDomLock: 'SqlMainDomLock'
+          - task: DotNetCoreCLI@2
+            displayName: Run dotnet test NonWindows
+            condition: ne(variables['Agent.OS'],'Windows_NT')
+            inputs:
+              command: test
+              projects: '**/*.Tests.Integration.csproj'
+              testRunTitle: Integration Tests SQL Server - $(Agent.OS)
+              ${{ or(forceReleaseTestFilter, if startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}:
+                arguments: '--configuration $(buildConfiguration) --no-build ${escapedIntegrationReleaseTestFilter}'
+              ${{ else }}:
+                arguments: '--configuration $(buildConfiguration) --no-build ${escapedIntegrationNonReleaseTestFilter}'
             env:
               Tests__Database__DatabaseType: $(testDb)
               Tests__Database__SQLServerMasterConnectionString: $(connectionString)

--- a/build/nightly-build-trigger.yml
+++ b/build/nightly-build-trigger.yml
@@ -21,7 +21,7 @@ steps:
     useSameBranch: true
     waitForQueuedBuildsToFinish: false
     storeInEnvironmentVariable: false
-    buildParameters: 'sqlServerIntegrationTests: true, forceReleaseTestFilter: true'
+    templateParameters: 'sqlServerIntegrationTests: true, forceReleaseTestFilter: true'
     authenticationMethod: 'OAuth Token'
     enableBuildInQueueCondition: false
     dependentOnSuccessfulBuildCondition: false

--- a/build/nightly-build-trigger.yml
+++ b/build/nightly-build-trigger.yml
@@ -1,0 +1,31 @@
+schedules:
+- cron: '0 0 * * *'
+  displayName: Daily midnight build
+  branches:
+    include:
+    - v9/dev
+    - v10/dev
+    - v12/dev
+    - v13/dev
+    - v14/dev
+
+steps:
+- task: TriggerBuild@4
+  inputs:
+    definitionIsInCurrentTeamProject: true
+    buildDefinition: '301'
+    queueBuildForUserThatTriggeredBuild: true
+    ignoreSslCertificateErrors: false
+    useSameSourceVersion: false
+    useCustomSourceVersion: false
+    useSameBranch: true
+    waitForQueuedBuildsToFinish: false
+    storeInEnvironmentVariable: false
+    buildParameters: 'sqlServerIntegrationTests: true, forceReleaseTestFilter: true'
+    authenticationMethod: 'Personal Access Token'
+    password: 'ddf'
+    enableBuildInQueueCondition: false
+    dependentOnSuccessfulBuildCondition: false
+    dependentOnFailedBuildCondition: false
+    checkbuildsoncurrentbranch: false
+    failTaskIfConditionsAreNotFulfilled: false

--- a/build/nightly-build-trigger.yml
+++ b/build/nightly-build-trigger.yml
@@ -22,8 +22,7 @@ steps:
     waitForQueuedBuildsToFinish: false
     storeInEnvironmentVariable: false
     buildParameters: 'sqlServerIntegrationTests: true, forceReleaseTestFilter: true'
-    authenticationMethod: 'Personal Access Token'
-    password: 'ddf'
+    authenticationMethod: 'OAuth Token'
     enableBuildInQueueCondition: false
     dependentOnSuccessfulBuildCondition: false
     dependentOnFailedBuildCondition: false

--- a/build/nightly-build-trigger.yml
+++ b/build/nightly-build-trigger.yml
@@ -1,3 +1,5 @@
+name: Nightly_$(TeamProject)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
+
 schedules:
 - cron: '0 0 * * *'
   displayName: Daily midnight build

--- a/tests/Umbraco.Tests.Common/Attributes/LongRunning.cs
+++ b/tests/Umbraco.Tests.Common/Attributes/LongRunning.cs
@@ -1,0 +1,12 @@
+using NUnit.Framework;
+
+namespace Umbraco.Cms.Tests.Common.Attributes;
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false)]
+public class LongRunning : CategoryAttribute
+{
+    public LongRunning()
+        : base(TestConstants.Categories.LongRunning)
+    {
+    }
+}

--- a/tests/Umbraco.Tests.Common/Attributes/NonCritical.cs
+++ b/tests/Umbraco.Tests.Common/Attributes/NonCritical.cs
@@ -1,0 +1,12 @@
+using NUnit.Framework;
+
+namespace Umbraco.Cms.Tests.Common.Attributes;
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false)]
+public class NonCritical : CategoryAttribute
+{
+    public NonCritical()
+        : base(TestConstants.Categories.NonCritical)
+    {
+    }
+}

--- a/tests/Umbraco.Tests.Common/TestConstants.cs
+++ b/tests/Umbraco.Tests.Common/TestConstants.cs
@@ -1,0 +1,13 @@
+namespace Umbraco.Cms.Tests.Common;
+
+public static class TestConstants
+{
+    /// <summary>
+    /// Used for TestCategories, they are designed to be used in an exclusion filter pattern
+    /// </summary>
+    public static class Categories
+    {
+        public const string LongRunning = "LongRunning";
+        public const string NonCritical = "NonCritical";
+    }
+}

--- a/tests/Umbraco.Tests.Integration/CompatibilitySuppressions.xml
+++ b/tests/Umbraco.Tests.Integration/CompatibilitySuppressions.xml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services.ContentServiceTests</Target>
+    <Left>lib/net6.0/Umbraco.Tests.Integration.dll</Left>
+    <Right>lib/net6.0/Umbraco.Tests.Integration.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence.Repositories.MediaRepositoryTest.QueryMedia_ContentTypeAliasFilter</Target>
+    <Left>lib/net6.0/Umbraco.Tests.Integration.dll</Left>
+    <Right>lib/net6.0/Umbraco.Tests.Integration.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>

--- a/tests/Umbraco.Tests.Integration/ComponentRuntimeTests.cs
+++ b/tests/Umbraco.Tests.Integration/ComponentRuntimeTests.cs
@@ -8,6 +8,7 @@ using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Runtime;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
 
@@ -24,6 +25,7 @@ public class ComponentRuntimeTests : UmbracoIntegrationTest
     ///     This will boot up umbraco with components enabled to show they initialize and shutdown
     /// </summary>
     [Test]
+    [LongRunning]
     public async Task Start_And_Stop_Umbraco_With_Components_Enabled()
     {
         var runtime = Services.GetRequiredService<IRuntime>();

--- a/tests/Umbraco.Tests.Integration/NewBackoffice/OpenAPIContractTest.cs
+++ b/tests/Umbraco.Tests.Integration/NewBackoffice/OpenAPIContractTest.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Integration.TestServerTest;
 using Umbraco.Extensions;
 
@@ -32,6 +33,7 @@ internal sealed class OpenAPIContractTest : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task Validate_OpenApi_Contract_is_implemented()
     {
         string[] keysToIgnore = { "servers", "x-generator" };

--- a/tests/Umbraco.Tests.Integration/TestServerTest/Controllers/EnsureNotAmbiguousActionNameControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/TestServerTest/Controllers/EnsureNotAmbiguousActionNameControllerTests.cs
@@ -5,6 +5,7 @@ using System;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Web.BackOffice.Controllers;
 
 namespace Umbraco.Cms.Tests.Integration.TestServerTest.Controllers;
@@ -13,6 +14,7 @@ namespace Umbraco.Cms.Tests.Integration.TestServerTest.Controllers;
 public class EnsureNotAmbiguousActionNameControllerTests : UmbracoTestServerTestBase
 {
     [Test]
+    [LongRunning]
     public void EnsureNotAmbiguousActionName()
     {
         var intId = 0;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Events/EventAggregatorTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Events/EventAggregatorTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Integration.TestServerTest;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Events;
@@ -20,6 +21,7 @@ public class EventAggregatorTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task Publish_HandlerWithScopedDependency_DoesNotThrow()
     {
         var result = await Client.GetAsync("/test-handler-with-scoped-services");

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/IO/FileSystemsTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/IO/FileSystemsTests.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.IO.MediaPathSchemes;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
 
@@ -33,6 +34,7 @@ public class FileSystemsTests : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void Can_Delete_MediaFiles()
     {
         var mediaFileManager = GetRequiredService<MediaFileManager>();

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/IO/ShadowFileSystemTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/IO/ShadowFileSystemTests.cs
@@ -10,6 +10,7 @@ using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Implementations;
 using Umbraco.Cms.Tests.Integration.Testing;
@@ -573,6 +574,7 @@ public class ShadowFileSystemTests : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void ShadowScopeCompleteWithDirectoryConflict()
     {
         var path = HostingEnvironment.MapPathContentRoot("FileSysTests");

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Mapping/ContentTypeModelMappingTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Mapping/ContentTypeModelMappingTests.cs
@@ -13,6 +13,7 @@ using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
@@ -140,6 +141,7 @@ public class ContentTypeModelMappingTests : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void ContentTypeSave_To_IContentType()
     {
         // Arrange

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Packaging/CreatedPackagesRepositoryTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Packaging/CreatedPackagesRepositoryTests.cs
@@ -16,6 +16,7 @@ using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Packaging;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
@@ -217,6 +218,7 @@ public class CreatedPackagesRepositoryTests : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void Export_Zip()
     {
         var mt = MediaTypeBuilder.CreateImageMediaType("testImage");

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/PublishedContentQueryAccessorTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/PublishedContentQueryAccessorTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Integration.TestServerTest;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Core;
@@ -12,6 +13,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Core;
 public class PublishedContentQueryAccessorTests : UmbracoTestServerTestBase
 {
     [Test]
+    [LongRunning]
     public async Task PublishedContentQueryAccessor_WithRequestScope_WillProvideQuery()
     {
         var result = await Client.GetAsync("/demo-published-content-query-accessor");

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentServiceTests.cs
@@ -1,16 +1,11 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Threading;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
-using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
@@ -20,14 +15,14 @@ using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
 using Umbraco.Cms.Tests.Common.Extensions;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
-using Umbraco.Extensions;
 
-namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Services;
 
 /// <summary>
 ///     Tests covering all methods in the ContentService class.
@@ -160,6 +155,7 @@ public class ContentServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Get_All_Blueprints()
     {
         var template = TemplateBuilder.CreateTextPageTemplate();
@@ -190,6 +186,7 @@ public class ContentServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Perform_Scheduled_Publishing()
     {
         var langUk = new LanguageBuilder()
@@ -334,6 +331,7 @@ public class ContentServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Get_Top_Version_Ids()
     {
         // Arrange
@@ -354,6 +352,7 @@ public class ContentServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Get_By_Ids_Sorted()
     {
         // Arrange
@@ -570,6 +569,7 @@ public class ContentServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Can_Get_All_Versions_Of_Content()
     {
         var parent = ContentService.GetById(Textpage.Id);
@@ -655,6 +655,7 @@ public class ContentServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Can_Get_Content_For_Expiration()
     {
         // Arrange
@@ -753,6 +754,7 @@ public class ContentServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Can_Publish_Culture_After_Last_Culture_Unpublished()
     {
         var content = CreateEnglishAndFrenchDocument(out var langUk, out var langFr,
@@ -1387,6 +1389,7 @@ public class ContentServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Failed_Publish_Should_Not_Update_Edited_State_When_Edited_True()
     {
         // Arrange
@@ -1439,6 +1442,7 @@ public class ContentServiceTests : UmbracoIntegrationTestWithContent
 
     // V9 - Tests.Integration
     [Test]
+    [LongRunning]
     public void Failed_Publish_Should_Not_Update_Edited_State_When_Edited_False()
     {
         // Arrange
@@ -1589,6 +1593,7 @@ public class ContentServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Can_Get_Published_Descendant_Versions()
     {
         // Arrange
@@ -1774,6 +1779,7 @@ public class ContentServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Can_Move_Content_Structure_To_RecycleBin_And_Empty_RecycleBin()
     {
         var contentType = ContentTypeService.Get("umbTextpage");
@@ -1830,6 +1836,7 @@ public class ContentServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Ensures_Permissions_Are_Retained_For_Copied_Descendants_With_Explicit_Permissions()
     {
         // Arrange
@@ -1870,6 +1877,7 @@ public class ContentServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Ensures_Permissions_Are_Inherited_For_Copied_Descendants()
     {
         // Arrange
@@ -1945,6 +1953,7 @@ public class ContentServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Can_Empty_RecycleBin_With_Content_That_Has_All_Related_Data()
     {
         // Arrange
@@ -2317,6 +2326,7 @@ public class ContentServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Can_Rollback_Version_On_Multilingual()
     {
         var langFr = new LanguageBuilder()
@@ -2624,6 +2634,7 @@ public class ContentServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Can_Delete_Previous_Versions_Not_Latest()
     {
         // Arrange
@@ -2639,6 +2650,7 @@ public class ContentServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Can_Get_Paged_Children()
     {
         // Start by cleaning the "db"
@@ -2665,6 +2677,7 @@ public class ContentServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Can_Get_Paged_Children_Dont_Get_Descendants()
     {
         // Start by cleaning the "db"
@@ -2838,6 +2851,7 @@ public class ContentServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Ensure_Invariant_Name()
     {
         var languageService = LocalizationService;
@@ -2921,6 +2935,7 @@ public class ContentServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Can_Get_Paged_Children_WithFilterAndOrder()
     {
         var languageService = LocalizationService;
@@ -3054,6 +3069,7 @@ public class ContentServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Can_SaveRead_Variations()
     {
         var languageService = LocalizationService;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Variants/ContentVariantAllowedActionTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Variants/ContentVariantAllowedActionTests.cs
@@ -6,6 +6,7 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
 using Umbraco.Cms.Tests.Integration.TestServerTest;
@@ -32,6 +33,7 @@ public class ContentVariantAllowedActionTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public void CanCheckIfUserHasAccessToLanguage()
     {
         // setup user groups

--- a/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexTest.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Infrastructure.Examine;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
 using Constants = Umbraco.Cms.Core.Constants;
@@ -19,6 +20,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Examine.Lucene.UmbracoExamine;
 public class IndexTest : ExamineBaseTest
 {
     [Test]
+    [LongRunning]
     public void GivenValidationParentNode_WhenContentIndexedUnderDifferentParent_DocumentIsNotIndexed()
     {
         using (GetSynchronousContentIndex(false, out var index, out _, out _, 999))
@@ -48,6 +50,7 @@ public class IndexTest : ExamineBaseTest
     }
 
     [Test]
+    [LongRunning]
     public void GivenIndexingDocument_WhenRichTextPropertyData_CanStoreImmenseFields()
     {
         using (GetSynchronousContentIndex(false, out var index, out _, out var contentValueSetBuilder))
@@ -85,6 +88,7 @@ public class IndexTest : ExamineBaseTest
     }
 
     [Test]
+    [LongRunning]
     public void GivenIndexingDocument_WhenGridPropertyData_ThenDataIndexedInSegregatedFields()
     {
         using (GetSynchronousContentIndex(false, out var index, out _, out var contentValueSetBuilder))
@@ -170,6 +174,7 @@ public class IndexTest : ExamineBaseTest
     }
 
     [Test]
+    [LongRunning]
     public void GivenEmptyIndex_WhenUsingWithContentAndMediaPopulators_ThenIndexPopulated()
     {
         var mediaRebuilder = IndexInitializer.GetMediaIndexRebuilder(IndexInitializer.GetMockMediaService());
@@ -190,6 +195,7 @@ public class IndexTest : ExamineBaseTest
     ///     Check that the node signalled as protected in the content service is not present in the index.
     /// </summary>
     [Test]
+    [LongRunning]
     public void GivenPublishedContentIndex_WhenProtectedContentIndexed_ThenItIsIgnored()
     {
         using (GetSynchronousContentIndex(true, out var index, out var contentRebuilder, out _))
@@ -209,6 +215,7 @@ public class IndexTest : ExamineBaseTest
     }
 
     [Test]
+    [LongRunning]
     public void GivenMediaUnderNonIndexableParent_WhenMediaMovedUnderIndexableParent_ThenItIsIncludedInTheIndex()
     {
         // create a validator with
@@ -245,6 +252,7 @@ public class IndexTest : ExamineBaseTest
     }
 
     [Test]
+    [LongRunning]
     public void GivenMediaUnderIndexableParent_WhenMediaMovedUnderNonIndexableParent_ThenItIsRemovedFromTheIndex()
     {
         // create a validator with
@@ -288,6 +296,7 @@ public class IndexTest : ExamineBaseTest
     ///     We then call the Examine method to re-index Content and do some comparisons to ensure that it worked correctly.
     /// </summary>
     [Test]
+    [LongRunning]
     public void GivenEmptyIndex_WhenIndexedWithContentPopulator_ThenTheIndexIsPopulated()
     {
         using (GetSynchronousContentIndex(false, out var index, out var contentRebuilder, out _))
@@ -325,6 +334,7 @@ public class IndexTest : ExamineBaseTest
     ///     This will delete an item from the index and ensure that all children of the node are deleted too!
     /// </summary>
     [Test]
+    [LongRunning]
     public void GivenPopulatedIndex_WhenDocumentDeleted_ThenItsHierarchyIsAlsoDeleted()
     {
         using (GetSynchronousContentIndex(false, out var index, out var contentRebuilder, out _))

--- a/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/PublishedContentQueryTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/PublishedContentQueryTests.cs
@@ -9,6 +9,7 @@ using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Infrastructure;
 using Umbraco.Cms.Infrastructure.Examine;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Testing;
 using Directory = Lucene.Net.Store.Directory;
 
@@ -95,6 +96,7 @@ public class PublishedContentQueryTests : ExamineBaseTest
     [TestCase("en-us", ExpectedResult = "1, 2", Description = "Search Culture: en-us. Must return both en-us and invariant results")]
     [TestCase("*", ExpectedResult = "1, 2, 3", Description = "Search Culture: *. Must return all cultures and all invariant results")]
     [TestCase(null, ExpectedResult = "1", Description = "Search Culture: null. Must return only invariant results")]
+    [LongRunning]
     public string Search(string culture)
     {
         using (var luceneDir = new RandomIdRAMDirectory())

--- a/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/SearchTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/SearchTests.cs
@@ -9,6 +9,7 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Querying;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Examine;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Extensions;
 
@@ -19,6 +20,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Examine.Lucene.UmbracoExamine;
 public class SearchTests : ExamineBaseTest
 {
     [Test]
+    [LongRunning]
     public void Test_Sort_Order_Sorting()
     {
         long totalRecs;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Packaging/PackageDataInstallationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Packaging/PackageDataInstallationTests.cs
@@ -14,6 +14,7 @@ using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Packaging;
 using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
 using Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services.Importing;
@@ -81,6 +82,7 @@ public class PackageDataInstallationTests : UmbracoIntegrationTestWithContent
     private IMediaTypeService MediaTypeService => GetRequiredService<IMediaTypeService>();
 
     [Test]
+    [LongRunning]
     public void Can_Import_uBlogsy_ContentTypes_And_Verify_Structure()
     {
         // Arrange
@@ -128,6 +130,7 @@ public class PackageDataInstallationTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Can_Import_Inherited_ContentTypes_And_Verify_PropertyTypes_UniqueIds()
     {
         // Arrange
@@ -154,6 +157,7 @@ public class PackageDataInstallationTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Can_Import_Inherited_ContentTypes_And_Verify_PropertyGroups_And_PropertyTypes()
     {
         // Arrange
@@ -193,6 +197,7 @@ public class PackageDataInstallationTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Can_Import_Template_Package_Xml()
     {
         // Arrange
@@ -262,6 +267,7 @@ public class PackageDataInstallationTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Can_Import_StandardMvc_ContentTypes_Package_Xml()
     {
         // Arrange
@@ -300,6 +306,7 @@ public class PackageDataInstallationTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Can_Import_StandardMvc_ContentTypes_And_Templates_Xml()
     {
         // Arrange
@@ -326,6 +333,7 @@ public class PackageDataInstallationTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Can_Import_Fanoe_Starterkit_ContentTypes_And_Templates_Xml()
     {
         // Arrange
@@ -381,6 +389,7 @@ public class PackageDataInstallationTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Can_Import_Media_Package_Xml()
     {
         // Arrange
@@ -507,6 +516,7 @@ public class PackageDataInstallationTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Can_ReImport_Single_DocType()
     {
         // Arrange
@@ -726,6 +736,7 @@ public class PackageDataInstallationTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Can_Import_Package_With_Compositions()
     {
         // Arrange

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/LocksTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/LocksTests.cs
@@ -12,6 +12,7 @@ using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DistributedLocking.Exceptions;
 using Umbraco.Cms.Infrastructure.Persistence.Dtos;
 using Umbraco.Cms.Persistence.Sqlite.Interceptors;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
 using Umbraco.Extensions;
@@ -155,6 +156,7 @@ public class LocksTests : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void ConcurrentWritersTest()
     {
         const int threadCount = 8;
@@ -429,6 +431,7 @@ public class LocksTests : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void Throws_When_Lock_Timeout_Is_Exceeded_Write()
     {
         var counter = 0;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/ContentTypeRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/ContentTypeRepositoryTest.cs
@@ -20,6 +20,7 @@ using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 using Umbraco.Cms.Infrastructure.Scoping;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Extensions;
 using Umbraco.Cms.Tests.Common.Testing;
@@ -848,6 +849,7 @@ public class ContentTypeRepositoryTest : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void Can_Verify_Addition_Of_PropertyType_After_ContentType_Is_Used()
     {
         // Arrange

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DocumentRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DocumentRepositoryTest.cs
@@ -22,6 +22,7 @@ using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Cms.Persistence.SqlServer.Services;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
@@ -743,6 +744,7 @@ public class DocumentRepositoryTest : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void GetAllContentManyVersions()
     {
         IContent[] result;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/EntityRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/EntityRepositoryTest.cs
@@ -12,6 +12,7 @@ using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 using Umbraco.Cms.Infrastructure.Scoping;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
@@ -23,6 +24,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence.Repos
 public class EntityRepositoryTest : UmbracoIntegrationTest
 {
     [Test]
+    [LongRunning]
     public void Get_Paged_Mixed_Entities_By_Ids()
     {
         // Create content

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MediaRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MediaRepositoryTest.cs
@@ -319,36 +319,6 @@ public class MediaRepositoryTest : UmbracoIntegrationTest
         }
     }
 
-    [Ignore("Unsupported feature.")]
-    [Test]
-    public void QueryMedia_ContentTypeAliasFilter()
-    {
-        // we could support this, but it would require an extra join on the query,
-        // and we don't absolutely need it now, so leaving it out for now
-
-        // Arrange
-        var folderMediaType = MediaTypeService.Get(1031);
-        var provider = ScopeProvider;
-        using (var scope = provider.CreateScope())
-        {
-            var repository = CreateRepository(provider, out var mediaTypeRepository);
-
-            // Act
-            for (var i = 0; i < 10; i++)
-            {
-                var folder = MediaBuilder.CreateMediaFolder(folderMediaType, -1);
-                repository.Save(folder);
-            }
-
-            string[] types = { "Folder" };
-            var query = provider.CreateQuery<IMedia>().Where(x => types.Contains(x.ContentType.Alias));
-            var result = repository.Get(query);
-
-            // Assert
-            Assert.That(result.Count(), Is.GreaterThanOrEqualTo(11));
-        }
-    }
-
     [Test]
     public void GetPagedResultsByQuery_FirstPage()
     {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/PublicAccessRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/PublicAccessRepositoryTest.cs
@@ -11,6 +11,7 @@ using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 using Umbraco.Cms.Infrastructure.Scoping;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
@@ -80,6 +81,7 @@ public class PublicAccessRepositoryTest : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void Can_Add2()
     {
         var content = CreateTestData(3).ToArray();

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Runtime/FileSystemMainDomLockTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Runtime/FileSystemMainDomLockTests.cs
@@ -9,6 +9,7 @@ using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Runtime;
 using Umbraco.Cms.Infrastructure.Runtime;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Integration.Testing;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Runtime;
@@ -76,6 +77,7 @@ internal class FileSystemMainDomLockTests : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public async Task AcquireLockAsync_WhenTimeoutExceeded_ReturnsFalse()
     {
         await using var lockFile = File.Open(LockFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
@@ -88,6 +90,7 @@ internal class FileSystemMainDomLockTests : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public async Task ListenAsync_WhenLockReleaseSignalFileFound_DropsLockFileHandle()
     {
         using var sut = FileSystemMainDomLock;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Scoping/ScopeTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Scoping/ScopeTests.cs
@@ -13,6 +13,7 @@ using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Cms.Tests.Common;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
 using Umbraco.Extensions;
@@ -41,6 +42,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Scoping
         }
 
         [Test]
+        [LongRunning]
         public void GivenUncompletedScopeOnChildThread_WhenTheParentCompletes_TheTransactionIsRolledBack()
         {
             ScopeProvider scopeProvider = ScopeProvider;
@@ -78,6 +80,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Scoping
         }
 
         [Test]
+        [LongRunning]
         public void GivenChildThread_WhenParentDisposedBeforeChild_ParentScopeThrows()
         {
             ScopeProvider scopeProvider = ScopeProvider;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Scoping/ScopedNuCacheTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Scoping/ScopedNuCacheTests.cs
@@ -12,6 +12,7 @@ using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Infrastructure.DependencyInjection;
 using Umbraco.Cms.Tests.Common;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
 using Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Scoping;
@@ -59,6 +60,7 @@ public class ScopedNuCacheTests : UmbracoIntegrationTest
 
     [TestCase(true)]
     [TestCase(false)]
+    [LongRunning]
     public void TestScope(bool complete)
     {
         var umbracoContext = UmbracoContextFactory.EnsureUmbracoContext().UmbracoContext;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEventsTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEventsTests.cs
@@ -18,6 +18,7 @@ using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Infrastructure.Sync;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
@@ -268,6 +269,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         #region Validate Setup
 
         [Test]
+        [LongRunning]
         public void CreatedBranchIsOk()
         {
             IContent content1 = CreateBranch();
@@ -381,6 +383,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         #region Save, Publish & Unpublish single content
 
         [Test]
+        [LongRunning]
         public void SaveUnpublishedContent()
         {
             // rule: when a content is saved,
@@ -403,6 +406,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void SavePublishedContent_ContentProperty1()
         {
             // rule: when a content is saved,
@@ -438,6 +442,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void SavePublishedContent_ContentProperty2()
         {
             // rule: when a content is saved,
@@ -473,6 +478,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void SavePublishedContent_UserProperty()
         {
             // rule: when a content is saved,
@@ -508,6 +514,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void SaveAndPublishUnpublishedContent()
         {
             // rule: when a content is saved&published,
@@ -530,6 +537,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void SaveAndPublishPublishedContent()
         {
             // rule: when a content is saved&published,
@@ -553,6 +561,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void PublishUnpublishedContent()
         {
             // rule: when a content is published,
@@ -578,6 +587,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void UnpublishContent()
         {
             // rule: when a content is unpublished,
@@ -600,6 +610,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void UnpublishContentWithChanges()
         {
             // rule: when a content is unpublished,
@@ -630,6 +641,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         #region Publish & Unpublish branch
 
         [Test]
+        [LongRunning]
         public void UnpublishContentBranch()
         {
             // rule: when a content branch is unpublished,
@@ -656,6 +668,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void PublishContentBranch()
         {
             // rule: when a content branch is published,
@@ -689,6 +702,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void PublishContentBranchWithPublishedChildren()
         {
             // rule?
@@ -726,6 +740,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void PublishContentBranchWithAllChildren()
         {
             // rule?
@@ -775,6 +790,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         #region Sort
 
         [Test]
+        [LongRunning]
         public void SortAll()
         {
             // rule: ?
@@ -811,6 +827,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void SortSome()
         {
             // rule: ?
@@ -850,6 +867,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         // incl. trashing a branch, untrashing a single masked content
         // including emptying the recycle bin
         [Test]
+        [LongRunning]
         public void TrashUnpublishedContent()
         {
             IContent content = CreateContent();
@@ -868,6 +886,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void UntrashUnpublishedContent()
         {
             IContent content = CreateContent();
@@ -888,6 +907,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void TrashPublishedContent()
         {
             // does 1) unpublish and 2) trash
@@ -910,6 +930,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void UntrashPublishedContent()
         {
             // same as unpublished as it's been unpublished
@@ -936,6 +957,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void TrashPublishedContentWithChanges()
         {
             IContent content = CreateContent();
@@ -959,6 +981,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void TrashContentBranch()
         {
             IContent content1 = CreateBranch();
@@ -997,6 +1020,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void EmptyRecycleBinContent()
         {
             ContentService.EmptyRecycleBin();
@@ -1019,6 +1043,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void EmptyRecycleBinContents()
         {
             ContentService.EmptyRecycleBin(Constants.Security.SuperUserId);
@@ -1046,6 +1071,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void EmptyRecycleBinBranch()
         {
             ContentService.EmptyRecycleBin(Constants.Security.SuperUserId);
@@ -1092,6 +1118,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         #region Delete
 
         [Test]
+        [LongRunning]
         public void DeleteUnpublishedContent()
         {
             IContent content = CreateContent();
@@ -1110,6 +1137,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void DeletePublishedContent()
         {
             IContent content = CreateContent();
@@ -1129,6 +1157,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void DeletePublishedContentWithChanges()
         {
             IContent content = CreateContent();
@@ -1150,6 +1179,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void DeleteMaskedPublishedContent()
         {
             IContent content1 = CreateContent();
@@ -1173,6 +1203,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void DeleteBranch()
         {
             IContent content1 = CreateBranch();
@@ -1216,6 +1247,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         #region Move
 
         [Test]
+        [LongRunning]
         public void MoveUnpublishedContentUnderUnpublished()
         {
             IContent content1 = CreateContent();
@@ -1257,6 +1289,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void MovePublishedContentWithChangesUnderUnpublished()
         {
             IContent content1 = CreateContent();
@@ -1280,6 +1313,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void MoveUnpublishedContentUnderPublished()
         {
             IContent content1 = CreateContent();
@@ -1301,6 +1335,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void MoveUnpublishedContentUnderMasked()
         {
             IContent content1 = CreateContent();
@@ -1374,6 +1409,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void MovePublishedContentWithChangesUnderPublished()
         {
             IContent content1 = CreateContent();
@@ -1426,6 +1462,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void MoveMaskedPublishedContentUnderPublished()
         {
             IContent content1 = CreateContent();
@@ -1452,6 +1489,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void MoveMaskedPublishedContentUnderMasked()
         {
             IContent content1 = CreateContent();
@@ -1510,6 +1548,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void MoveMaskedPublishedContentWithChangesUnderMasked()
         {
             IContent content1 = CreateContent();
@@ -1542,6 +1581,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void MoveMaskedPublishedContentUnderUnpublished()
         {
             IContent content1 = CreateContent();
@@ -1594,6 +1634,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void MoveContentBranchUnderUnpublished()
         {
             IContent content1 = CreateBranch();
@@ -1634,6 +1675,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void MoveContentBranchUnderPublished()
         {
             IContent content1 = CreateBranch();
@@ -1675,6 +1717,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void MoveContentBranchUnderMasked()
         {
             IContent content1 = CreateBranch();
@@ -1720,6 +1763,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void MoveContentBranchBackFromPublished()
         {
             IContent content1 = CreateBranch();
@@ -1763,6 +1807,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void MoveContentBranchBackFromUnpublished()
         {
             IContent content1 = CreateBranch();
@@ -1805,6 +1850,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void MoveContentBranchBackFromMasked()
         {
             IContent content1 = CreateBranch();
@@ -1856,6 +1902,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         #region Copy
 
         [Test]
+        [LongRunning]
         public void CopyUnpublishedContent()
         {
             IContent content = CreateContent();
@@ -1874,6 +1921,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void CopyPublishedContent()
         {
             IContent content = CreateContent();
@@ -1893,6 +1941,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void CopyMaskedContent()
         {
             IContent content = CreateContent();
@@ -1915,6 +1964,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void CopyBranch()
         {
             IContent content = CreateBranch();
@@ -1958,6 +2008,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         #region Rollback
 
         [Test]
+        [LongRunning]
         public void Rollback()
         {
             IContent content = CreateContent();
@@ -1996,6 +2047,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         #region Misc
 
         [Test]
+        [LongRunning]
         public void ContentRemembers()
         {
             IContent content = ContentService.GetRootContent().FirstOrDefault();

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceNotificationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceNotificationTests.cs
@@ -11,6 +11,7 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
@@ -338,6 +339,7 @@ public class ContentServiceNotificationTests : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void Unpublishing_Culture()
     {
         LocalizationService.Save(new Language("fr-FR", "French (France)"));

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServicePerformanceTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServicePerformanceTest.cs
@@ -14,6 +14,7 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.TestHelpers.Stubs;
 using Umbraco.Cms.Tests.Common.Testing;
@@ -48,6 +49,7 @@ public class ContentServicePerformanceTest : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void Retrieving_All_Content_In_Site()
     {
         // NOTE: Doing this the old 1 by 1 way and based on the results of the ContentServicePerformanceTest.Retrieving_All_Content_In_Site
@@ -113,6 +115,7 @@ public class ContentServicePerformanceTest : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void Creating_100_Items()
     {
         // Arrange
@@ -132,6 +135,7 @@ public class ContentServicePerformanceTest : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void Creating_1000_Items()
     {
         // Arrange
@@ -151,6 +155,7 @@ public class ContentServicePerformanceTest : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void Getting_100_Uncached_Items()
     {
         // Arrange
@@ -178,6 +183,7 @@ public class ContentServicePerformanceTest : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void Getting_1000_Uncached_Items()
     {
         // Arrange
@@ -204,6 +210,7 @@ public class ContentServicePerformanceTest : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void Getting_100_Cached_Items()
     {
         // Arrange
@@ -233,6 +240,7 @@ public class ContentServicePerformanceTest : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void Getting_1000_Cached_Items()
     {
         // Arrange

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServicePublishBranchTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServicePublishBranchTests.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
 
@@ -28,6 +29,7 @@ public class ContentServicePublishBranchTests : UmbracoIntegrationTest
 
     [TestCase(1)] // use overload w/ culture: "*"
     [TestCase(2)] // use overload w/ cultures: new [] { "*" }
+    [LongRunning]
     public void Can_Publish_Invariant_Branch(int method)
     {
         CreateTypes(out var iContentType, out _);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentTypeServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentTypeServiceTests.cs
@@ -12,6 +12,7 @@ using Umbraco.Cms.Core.Exceptions;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
@@ -75,6 +76,7 @@ public class ContentTypeServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void Deleting_Content_Type_With_Hierarchy_Of_Content_Items_Moves_Orphaned_Content_To_Recycle_Bin()
     {
         var template = TemplateBuilder.CreateTextPageTemplate();
@@ -126,6 +128,7 @@ public class ContentTypeServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void Deleting_Content_Types_With_Hierarchy_Of_Content_Items_Doesnt_Raise_Trashed_Event_For_Deleted_Items_1()
     {
         ContentNotificationHandler.MovedContentToRecycleBin = MovedContentToRecycleBin;
@@ -176,6 +179,7 @@ public class ContentTypeServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void Deleting_Content_Types_With_Hierarchy_Of_Content_Items_Doesnt_Raise_Trashed_Event_For_Deleted_Items_2()
     {
         ContentNotificationHandler.MovedContentToRecycleBin = MovedContentToRecycleBin;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentTypeServiceVariantsTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentTypeServiceVariantsTests.cs
@@ -12,6 +12,7 @@ using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
@@ -82,6 +83,7 @@ public class ContentTypeServiceVariantsTests : UmbracoIntegrationTest
     [TestCase(ContentVariation.CultureAndSegment, ContentVariation.Culture, true)]
     [TestCase(ContentVariation.CultureAndSegment, ContentVariation.Segment, true)]
     [TestCase(ContentVariation.CultureAndSegment, ContentVariation.CultureAndSegment, false)]
+    [LongRunning]
     public void Change_Content_Type_Variation_Clears_Redirects(ContentVariation startingContentTypeVariation,
         ContentVariation changedContentTypeVariation, bool shouldUrlRedirectsBeCleared)
     {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/EntityServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/EntityServiceTests.cs
@@ -10,6 +10,7 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
@@ -191,6 +192,7 @@ public class EntityServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void EntityService_Can_Get_Paged_Content_Descendants_Including_Recycled()
     {
         var contentType = ContentTypeService.Get("umbTextpage");
@@ -232,6 +234,7 @@ public class EntityServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void EntityService_Can_Get_Paged_Content_Descendants_Without_Recycled()
     {
         var contentType = ContentTypeService.Get("umbTextpage");
@@ -274,6 +277,7 @@ public class EntityServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void EntityService_Can_Get_Paged_Trashed_Content_Children()
     {
         var contentType = ContentTypeService.Get("umbTextpage");
@@ -379,6 +383,7 @@ public class EntityServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void EntityService_Can_Get_Paged_Media_Descendants()
     {
         var folderType = MediaTypeService.Get(1031);
@@ -411,6 +416,7 @@ public class EntityServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void EntityService_Can_Get_Paged_Media_Descendants_Including_Recycled()
     {
         var folderType = MediaTypeService.Get(1031);
@@ -453,6 +459,7 @@ public class EntityServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void EntityService_Can_Get_Paged_Media_Descendants_Without_Recycled()
     {
         var folderType = MediaTypeService.Get(1031);
@@ -496,6 +503,7 @@ public class EntityServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void EntityService_Can_Get_Paged_Trashed_Media_Children()
     {
         var folderType = MediaTypeService.Get(1031);
@@ -540,6 +548,7 @@ public class EntityServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void EntityService_Can_Get_Paged_Media_Descendants_With_Search()
     {
         var folderType = MediaTypeService.Get(1031);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaTypeServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaTypeServiceTests.cs
@@ -10,6 +10,7 @@ using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
@@ -94,6 +95,7 @@ public class MediaTypeServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
+    [LongRunning]
     public void Deleting_Media_Types_With_Hierarchy_Of_Media_Items_Doesnt_Raise_Trashed_Event_For_Deleted_Items()
     {
         ContentNotificationHandler.MovedMediaToRecycleBin = MovedMediaToRecycleBin;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/RedirectUrlServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/RedirectUrlServiceTests.cs
@@ -11,6 +11,7 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 using Umbraco.Cms.Infrastructure.Scoping;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
 
@@ -58,6 +59,7 @@ public class RedirectUrlServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Can_Get_Most_Recent_RedirectUrl()
     {
         var redirect = RedirectUrlService.GetMostRecentRedirectUrl(Url);
@@ -65,6 +67,7 @@ public class RedirectUrlServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Can_Get_Most_Recent_RedirectUrl_With_Culture()
     {
         var redirect = RedirectUrlService.GetMostRecentRedirectUrl(Url, CultureEnglish);
@@ -72,6 +75,7 @@ public class RedirectUrlServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Can_Get_Most_Recent_RedirectUrl_With_Culture_When_No_CultureVariant_Exists()
     {
         var redirect = RedirectUrlService.GetMostRecentRedirectUrl(UrlAlt, UnusedCulture);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ThreadSafetyServiceTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ThreadSafetyServiceTest.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
@@ -102,6 +103,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void Ensure_All_Threads_Execute_Successfully_Content_Service()
         {
             if (Environment.GetEnvironmentVariable("UMBRACO_TMP") != null)
@@ -196,6 +198,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services
         }
 
         [Test]
+        [LongRunning]
         public void Ensure_All_Threads_Execute_Successfully_Media_Service()
         {
             if (Environment.GetEnvironmentVariable("UMBRACO_TMP") != null)

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/TrackRelationsTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/TrackRelationsTests.cs
@@ -4,6 +4,7 @@ using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
@@ -31,6 +32,7 @@ public class TrackRelationsTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
+    [LongRunning]
     public void Automatically_Track_Relations()
     {
         var mt = MediaTypeBuilder.CreateSimpleMediaType("testMediaType", "Test Media Type");

--- a/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
@@ -20,7 +20,7 @@
   <Import Project="..\..\src\Umbraco.Cms\buildTransitive\Umbraco.Cms.targets" />
   <ItemGroup>
     <ProjectReference Include="..\..\src\Umbraco.Cms\Umbraco.Cms.csproj" />
-    <ProjectReference Include="..\..\src\Umbraco.Cms.ManagementApi\Umbraco.Cms.ManagementApi.csproj" PrivateAssets="all"/>
+    <ProjectReference Include="..\..\src\Umbraco.Cms.ManagementApi\Umbraco.Cms.ManagementApi.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\Umbraco.Tests.Common\Umbraco.Tests.Common.csproj" />
   </ItemGroup>
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
@@ -6,8 +6,9 @@
     <IsPackable>true</IsPackable>
     <IsTestProject>true</IsTestProject>
     <RootNamespace>Umbraco.Cms.Tests.Integration</RootNamespace>
+    <GenerateCompatibilitySuppressionFile>true</GenerateCompatibilitySuppressionFile>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Bogus" Version="34.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />

--- a/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/Controllers/BackOfficeAssetsControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/Controllers/BackOfficeAssetsControllerTests.cs
@@ -4,6 +4,7 @@
 using System.Net;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Integration.TestServerTest;
 using Umbraco.Cms.Web.BackOffice.Controllers;
 
@@ -13,6 +14,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Web.BackOffice.Controllers;
 public class BackOfficeAssetsControllerTests : UmbracoTestServerTestBase
 {
     [Test]
+    [LongRunning]
     public async Task EnsureSuccessStatusCode()
     {
         // Arrange

--- a/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/Controllers/ContentControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/Controllers/ContentControllerTests.cs
@@ -11,6 +11,7 @@ using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
 using Umbraco.Cms.Tests.Integration.TestServerTest;
@@ -30,6 +31,7 @@ public class ContentControllerTests : UmbracoTestServerTestBase
     ///     Returns 404 if the content wasn't found based on the ID specified
     /// </summary>
     [Test]
+    [LongRunning]
     public async Task PostSave_Validate_Existing_Content()
     {
         var localizationService = GetRequiredService<ILocalizationService>();
@@ -86,6 +88,7 @@ public class ContentControllerTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task PostSave_Validate_At_Least_One_Variant_Flagged_For_Saving()
     {
         var localizationService = GetRequiredService<ILocalizationService>();
@@ -154,6 +157,7 @@ public class ContentControllerTests : UmbracoTestServerTestBase
     ///     Returns 404 if any of the posted properties dont actually exist
     /// </summary>
     [Test]
+    [LongRunning]
     public async Task PostSave_Validate_Properties_Exist()
     {
         var localizationService = GetRequiredService<ILocalizationService>();
@@ -217,6 +221,7 @@ public class ContentControllerTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task PostSave_Simple_Invariant()
     {
         var localizationService = GetRequiredService<ILocalizationService>();
@@ -276,6 +281,7 @@ public class ContentControllerTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task PostSave_Validate_Empty_Name()
     {
         var localizationService = GetRequiredService<ILocalizationService>();
@@ -338,6 +344,7 @@ public class ContentControllerTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task PostSave_Validate_Variants_Empty_Name()
     {
         var localizationService = GetRequiredService<ILocalizationService>();
@@ -400,6 +407,7 @@ public class ContentControllerTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task PostSave_Validates_Domains_Exist()
     {
         var localizationService = GetRequiredService<ILocalizationService>();
@@ -447,6 +455,7 @@ public class ContentControllerTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task PostSave_Validates_All_Ancestor_Cultures_Are_Considered()
     {
         var sweIso = "sv-SE";
@@ -534,6 +543,7 @@ public class ContentControllerTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task PostSave_Validates_All_Cultures_Has_Domains()
     {
         var localizationService = GetRequiredService<ILocalizationService>();
@@ -590,6 +600,7 @@ public class ContentControllerTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task PostSave_Checks_Ancestors_For_Domains()
     {
         var localizationService = GetRequiredService<ILocalizationService>();
@@ -677,6 +688,7 @@ public class ContentControllerTests : UmbracoTestServerTestBase
     [TestCase(
         @"<p><img alt src=""data:image/notallowedextension;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7""></p>",
         true)]
+    [LongRunning]
     public async Task PostSave_Simple_RichText_With_Base64(string html, bool shouldHaveDataUri)
     {
         var url = PrepareApiControllerUrl<ContentController>(x => x.PostSave(null));

--- a/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/Controllers/DataTypeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/Controllers/DataTypeControllerTests.cs
@@ -4,6 +4,7 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
 using Umbraco.Cms.Tests.Integration.TestServerTest;
@@ -19,6 +20,7 @@ public class DataTypeControllerTests : UmbracoTestServerTestBase
     [Test]
     [TestCase(true)]
     [TestCase(false)]
+    [LongRunning]
     public async Task Has_Values_Returns_Correct_Values(bool expectHasValues)
     {
         var dataTypeService = GetRequiredService<IDataTypeService>();

--- a/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/Controllers/EntityControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/Controllers/EntityControllerTests.cs
@@ -9,6 +9,7 @@ using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
 using Umbraco.Cms.Tests.Integration.TestServerTest;
@@ -24,6 +25,7 @@ public class EntityControllerTests : UmbracoTestServerTestBase
     private IScopeProvider ScopeProvider => GetRequiredService<IScopeProvider>();
 
     [Test]
+    [LongRunning]
     public async Task GetUrlsByIds_MediaWithIntegerIds_ReturnsValidMap()
     {
         var mediaTypeService = Services.GetRequiredService<IMediaTypeService>();
@@ -67,6 +69,7 @@ public class EntityControllerTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task GetUrlsByIds_Media_ReturnsEmptyStringsInMapForUnknownItems()
     {
         var queryParameters = new Dictionary<string, object> { ["type"] = Constants.UdiEntityType.Media };
@@ -91,6 +94,7 @@ public class EntityControllerTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task GetUrlsByIds_MediaWithGuidIds_ReturnsValidMap()
     {
         var mediaTypeService = Services.GetRequiredService<IMediaTypeService>();
@@ -177,6 +181,7 @@ public class EntityControllerTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task GetUrlsByIds_Documents_ReturnsHashesInMapForUnknownItems()
     {
         var queryParameters = new Dictionary<string, object> { ["type"] = Constants.UdiEntityType.Document };
@@ -201,6 +206,7 @@ public class EntityControllerTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task GetUrlsByIds_DocumentWithIntIds_ReturnsValidMap()
     {
         var contentTypeService = Services.GetRequiredService<IContentTypeService>();
@@ -250,6 +256,7 @@ public class EntityControllerTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task GetUrlsByIds_DocumentWithGuidIds_ReturnsValidMap()
     {
         var contentTypeService = Services.GetRequiredService<IContentTypeService>();
@@ -299,6 +306,7 @@ public class EntityControllerTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task GetUrlsByIds_DocumentWithUdiIds_ReturnsValidMap()
     {
         var contentTypeService = Services.GetRequiredService<IContentTypeService>();
@@ -348,6 +356,7 @@ public class EntityControllerTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task GetByIds_MultipleCalls_WorksAsExpected()
     {
         var contentTypeService = Services.GetRequiredService<IContentTypeService>();

--- a/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/Controllers/TemplateQueryControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/Controllers/TemplateQueryControllerTests.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Models.TemplateQuery;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
 using Umbraco.Cms.Tests.Integration.TestServerTest;
 using Umbraco.Cms.Web.BackOffice.Controllers;
@@ -19,6 +20,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Web.BackOffice.Controllers;
 public class TemplateQueryControllerTests : UmbracoTestServerTestBase
 {
     [Test]
+    [LongRunning]
     public async Task GetContentTypes__Ensure_camel_case()
     {
         var url = PrepareApiControllerUrl<TemplateQueryController>(x => x.GetContentTypes());

--- a/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/Controllers/UsersControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/Controllers/UsersControllerTests.cs
@@ -11,6 +11,7 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
 using Umbraco.Cms.Tests.Integration.TestServerTest;
@@ -24,6 +25,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Web.BackOffice.Controllers;
 public class UsersControllerTests : UmbracoTestServerTestBase
 {
     [Test]
+    [LongRunning]
     public async Task Save_User()
     {
         var url = PrepareApiControllerUrl<UsersController>(x => x.PostSaveUser(null));
@@ -70,6 +72,7 @@ public class UsersControllerTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task GetPagedUsers_Empty()
     {
         // We get page 2 to force an empty response because there always in the useradmin user
@@ -92,6 +95,7 @@ public class UsersControllerTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task GetPagedUsers_multiple_pages()
     {
         var totalNumberOfUsers = 11;
@@ -130,6 +134,7 @@ public class UsersControllerTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task PostUnlockUsers_When_UserIds_Not_Supplied_Expect_Ok_Response()
     {
         var url = PrepareApiControllerUrl<UsersController>(x => x.PostUnlockUsers(Array.Empty<int>()));
@@ -141,6 +146,7 @@ public class UsersControllerTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task PostUnlockUsers_When_User_Does_Not_Exist_Expect_Zero_Users_Message()
     {
         var userId = 42; // Must not exist
@@ -157,6 +163,7 @@ public class UsersControllerTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task PostUnlockUsers_When_One_UserId_Supplied_Expect_User_Locked_Out_With_Correct_Response_Message()
     {
         var userService = GetRequiredService<IUserService>();
@@ -186,6 +193,7 @@ public class UsersControllerTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task
         PostUnlockUsers_When_Multiple_UserIds_Supplied_Expect_User_Locked_Out_With_Correct_Response_Message()
     {
@@ -228,6 +236,7 @@ public class UsersControllerTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task Cannot_Disable_Invited_User()
     {
         var userService = GetRequiredService<IUserService>();
@@ -258,6 +267,7 @@ public class UsersControllerTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task Can_Disable_Active_User()
     {
         var userService = GetRequiredService<IUserService>();

--- a/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/Filters/OutgoingEditorModelEventFilterTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/Filters/OutgoingEditorModelEventFilterTests.cs
@@ -11,6 +11,7 @@ using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
 using Umbraco.Cms.Tests.Integration.TestServerTest;
@@ -35,6 +36,7 @@ public class OutgoingEditorModelEventFilterTests : UmbracoTestServerTestBase
     public void Reset() => ResetNotifications();
 
     [Test]
+    [LongRunning]
     public async Task Content_Item_With_Schedule_Raises_SendingContentNotification()
     {
         IContentTypeService contentTypeService = GetRequiredService<IContentTypeService>();
@@ -69,6 +71,7 @@ public class OutgoingEditorModelEventFilterTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task Publish_Schedule_Is_Mapped_Correctly()
     {
         const string UsIso = "en-US";

--- a/tests/Umbraco.Tests.Integration/Umbraco.Web.Website/Routing/FrontEndRouteTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Web.Website/Routing/FrontEndRouteTests.cs
@@ -9,6 +9,7 @@ using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Integration.TestServerTest;
 using Umbraco.Cms.Web.Common.Attributes;
 using Umbraco.Cms.Web.Website.Controllers;
@@ -48,6 +49,7 @@ public class SurfaceControllerTests : UmbracoTestServerTestBase
     }
 
     [Test]
+    [LongRunning]
     public async Task Plugin_Controller_Routes_By_Area()
     {
         // Create URL manually, because PrepareSurfaceController URl will prepare whatever the controller is routed as

--- a/tests/Umbraco.Tests.Integration/Umbraco.Web.Website/Security/MemberAuthorizeTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Web.Website/Security/MemberAuthorizeTests.cs
@@ -12,6 +12,7 @@ using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Integration.TestServerTest;
 using Umbraco.Cms.Web.Common.Controllers;
 using Umbraco.Cms.Web.Common.Filters;
@@ -33,6 +34,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Web.Website.Security
         }
 
         [Test]
+        [LongRunning]
         public async Task Secure_SurfaceController_Should_Return_Redirect_WhenNotLoggedIn()
         {
             _memberManagerMock.Setup(x => x.IsLoggedIn()).Returns(false);
@@ -47,6 +49,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Web.Website.Security
         }
 
         [Test]
+        [LongRunning]
         public async Task Secure_SurfaceController_Should_Return_Redirect_WhenNotAuthorized()
         {
             _memberManagerMock.Setup(x => x.IsLoggedIn()).Returns(true);
@@ -67,6 +70,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Web.Website.Security
 
 
         [Test]
+        [LongRunning]
         public async Task Secure_ApiController_Should_Return_Unauthorized_WhenNotLoggedIn()
         {
             _memberManagerMock.Setup(x => x.IsLoggedIn()).Returns(false);
@@ -78,6 +82,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Web.Website.Security
         }
 
         [Test]
+        [LongRunning]
         public async Task Secure_ApiController_Should_Return_Forbidden_WhenNotAuthorized()
         {
             _memberManagerMock.Setup(x => x.IsLoggedIn()).Returns(true);


### PR DESCRIPTION
### Reason
We need a way to reduce the amount of time spend on integration tests for everyday builds. Especially if we are going to increase out test coverage with blackbox testing to guard against ourselves against regression bugs.

### What
A `[LongRunning]` and `[NonCritical]` attribute was added to the codebase that allows us to filter these tests out when running the `dotnet test` command

The pipeline has been update to have 2 filter parameters. One for release builds and one for other builds. These are duplicated for windows and non windows machines as there is a possibility that certain argument constructions will need some for of [character escaping](https://learn.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?pivots=nunit#character-escaping)

Another parameter has been introduced to force the run the release filter.

Lastly, any tests that were taking longer than 200ms on my machine have received the `[LongRunning]` attribute.