### PR TITLE
Feature: Add buttons for additional preview URLs

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -328,7 +328,7 @@
 
             $scope.previewDefaultButton = {
                 alias: 'preview',
-                handler: () => $scope.preview($scope.content, defaultPreviewUrl),
+                handler: () => $scope.preview($scope.content, defaultPreviewUrl, 'umbpreview'),
                 labelKey: "buttons_saveAndPreview"
             };
 
@@ -336,7 +336,8 @@
                 return {
                     alias: 'preview_' + additionalPreviewUrl.name,
                     label: additionalPreviewUrl.name,
-                    handler: () => $scope.preview($scope.content, additionalPreviewUrl.url)
+                    // We use target _blank here. If we open the window in the same tab with a 'umb_preview_name' target, we get a cors js error.
+                    handler: () => $scope.preview($scope.content, additionalPreviewUrl.url, '_blank')
                 }
             });
 
@@ -970,13 +971,13 @@
             }
         };
 
-        $scope.preview = function (content, url) {
+        $scope.preview = function (content, url, urlTarget) {
 
-            const openPreviewWindow = (url) => {
+            const openPreviewWindow = (url, target) => {
                 // Chromes popup blocker will kick in if a window is opened
                 // without the initial scoped request. This trick will fix that.
               
-              const previewWindow = $window.open(url, 'umbpreview');
+              const previewWindow = $window.open(url, target);
 
               previewWindow.addEventListener('load', () => {
                 previewWindow.location.href = previewWindow.document.URL;
@@ -987,7 +988,7 @@
             //The user cannot save if they don't have access to do that, in which case we just want to preview
             //and that's it otherwise they'll get an unauthorized access message
             if (!_.contains(content.allowedActions, "A")) {
-                openPreviewWindow(url);
+                openPreviewWindow(url, urlTarget);
             }
             else {
                 var selectedVariant = $scope.content.variants[0];
@@ -1006,7 +1007,7 @@
                 //ensure the save flag is set for the active variant
                 selectedVariant.save = true;
                 performSave({ saveMethod: $scope.saveMethod(), action: "save" }).then(function (data) {
-                    openPreviewWindow(url);
+                    openPreviewWindow(url, urlTarget);
                 }, function (err) {
                     //validation issues ....
                 });

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -327,12 +327,14 @@
             const defaultPreviewUrl = `preview/?id=${content.id}${$scope.culture ? `&culture=${$scope.culture}` : ''}`;
 
             $scope.previewDefaultButton = {
+                alias: 'preview',
                 handler: () => $scope.preview($scope.content, defaultPreviewUrl),
                 labelKey: "buttons_saveAndPreview"
             };
 
             $scope.previewSubButtons = $scope.content.variants?.[0].additionalPreviewUrls?.map((additionalPreviewUrl) => {
                 return {
+                    alias: 'preview_' + additionalPreviewUrl.name,
                     label: additionalPreviewUrl.name,
                     handler: () => $scope.preview($scope.content, additionalPreviewUrl.url)
                 }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -37,6 +37,11 @@
         //initializes any watches
         function startWatches(content) {
 
+            $scope.$watchGroup(['culture', 'segment'],
+            function (value, oldValue) {
+                createPreviewButton($scope.content, value[0], value[1]);
+            });
+
             //watch for changes to isNew, set the page.isNew accordingly and load the breadcrumb if we can
             $scope.$watch('isNew', function (newVal, oldVal) {
 
@@ -322,9 +327,18 @@
 
             $scope.defaultButton = buttons.defaultButton;
             $scope.subButtons = buttons.subButtons;
+        }
 
-            // Preview buttons
-            const defaultPreviewUrl = `preview/?id=${content.id}${$scope.culture ? `&culture=${$scope.culture}` : ''}`;
+        /**
+         * Create the preview buttons for the active variant
+         * @param {any} content the content node
+         * @param {string} culture the active culture
+         * @param {string} segment the active segment
+         */
+        function createPreviewButton (content, culture, segment) {
+
+            const compositeId = culture + '_' + segment;
+            const defaultPreviewUrl = `preview/?id=${content.id}${culture ? `&culture=${culture}` : ''}`;
 
             $scope.previewDefaultButton = {
                 alias: 'preview',
@@ -332,12 +346,14 @@
                 labelKey: "buttons_saveAndPreview"
             };
 
-            $scope.previewSubButtons = $scope.content.variants?.[0].additionalPreviewUrls?.map((additionalPreviewUrl) => {
+            const activeVariant = content.variants?.find((variant) => variant.compositeId === compositeId);
+
+            $scope.previewSubButtons = activeVariant?.additionalPreviewUrls?.map((additionalPreviewUrl) => {
                 return {
                     alias: 'preview_' + additionalPreviewUrl.name,
                     label: additionalPreviewUrl.name,
                     // We use target _blank here. If we open the window in the same tab with a 'umb_preview_name' target, we get a cors js error.
-                    handler: () => $scope.preview($scope.content, additionalPreviewUrl.url, '_blank')
+                    handler: () => $scope.preview(content, additionalPreviewUrl.url, '_blank')
                 }
             });
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button-group.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button-group.html
@@ -48,7 +48,8 @@
             hotkey="{{subButton.hotKey}}"
             hotkey-when-hidden="{{subButton.hotKeyWhenHidden}}"
             ng-disabled="disabled">
-               <localize key="{{subButton.labelKey}}">{{subButton.labelKey}}</localize>
+               <localize ng-if="subButton.labelKey" key="{{subButton.labelKey}}">{{subButton.labelKey}}</localize>
+               <span ng-if="subButton.label">{{subButton.label}}</span>
                <span ng-if="subButton.addEllipsis === 'true'">...</span>
          </button>
       </umb-dropdown-item>

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/edit.html
@@ -45,7 +45,7 @@
 
                     <umb-button-group
                         ng-if="!page.isNew && content.allowPreview && page.showPreviewButton"
-                        button-style="link"
+                        button-style="info"
                         default-button="previewDefaultButton"
                         sub-buttons="previewSubButtons"
                         state="page.previewButtonState"

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/edit.html
@@ -55,16 +55,6 @@
                     </umb-button-group>
 
                     <umb-button
-                        alias="preview"
-                        ng-if="!page.isNew && content.allowPreview && page.showPreviewButton"
-                        type="button"
-                        button-style="link"
-                        action="preview(content)"
-                        label-key="buttons_saveAndPreview"
-                        disabled="page.uploadsInProgress">
-                    </umb-button>
-
-                    <umb-button
                         ng-if="page.showSaveButton"
                         alias="save"
                         type="button"

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/edit.html
@@ -43,6 +43,17 @@
                         disabled="page.uploadsInProgress">
                     </umb-button>
 
+                    <umb-button-group
+                        ng-if="!page.isNew && content.allowPreview && page.showPreviewButton"
+                        button-style="link"
+                        default-button="previewDefaultButton"
+                        sub-buttons="previewSubButtons"
+                        state="page.previewButtonState"
+                        direction="up"
+                        float="right"
+                        disabled="page.uploadsInProgress">
+                    </umb-button-group>
+
                     <umb-button
                         alias="preview"
                         ng-if="!page.isNew && content.allowPreview && page.showPreviewButton"


### PR DESCRIPTION
This PR replaces the current "Save And Preview" button with a button group that can hold multiple preview URLs. 

The new button group renders additional preview URLs. See https://github.com/umbraco/Umbraco-CMS/pull/14479 for info.

The end result looks like this:
<img width="1301" alt="Screenshot 2023-09-07 at 09 57 57" src="https://github.com/umbraco/Umbraco-CMS/assets/6078361/bedf7eb3-08bf-4a21-b369-573677fdfd77">

**How to test:**
* Follow the steps in PR: https://github.com/umbraco/Umbraco-CMS/pull/14479 to add additional URLs.
* Test that the correct URLs show up on different nodes/variants.
* Test that each button opens the corresponding URL.