### PR TITLE
Limbo models builder changes the content to element when using Compos…

### DIFF
--- a/src/Umbraco.Infrastructure/ModelsBuilder/PublishedModelUtility.cs
+++ b/src/Umbraco.Infrastructure/ModelsBuilder/PublishedModelUtility.cs
@@ -37,6 +37,7 @@ public static class PublishedModelUtility
         switch (itemType)
         {
             case PublishedItemType.Content:
+            case PublishedItemType.Element:
                 return publishedSnapshot.Content?.GetContentType(alias);
             case PublishedItemType.Media:
                 return publishedSnapshot.Media?.GetContentType(alias);


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/14694

### Why:
When using the Limbo Models Builder with Compositions, it uses itemType.Element instead of itemType.Content. Which resulted in an `ArgumentOutOfRangeException`. 


### How to test:

1. Add the package Limbo.Umbraco.ModelsBuilder
2. Create a Composition with a Property(Example: DataProperty: Textstring, name: TesterTitle)
3. Create a Document that uses the created Composition.
4. Create Content with the Document.
5. Generate Models with Limbo ModelsBuilder
6. Create Controller: (Example)
```
public class ProductsController : UmbracoApiController
{
    private readonly IPublishedSnapshotAccessor _publishedSnapshotAccessor;

    public ProductsController(IPublishedSnapshotAccessor publishedSnapshotAccessor)
    {
        _publishedSnapshotAccessor = publishedSnapshotAccessor;
    }

    public string? GetAllProducts()
    {
        var aliasMyProp = YOUR_COMPOSITION_NAME.GetModelPropertyType(_publishedSnapshotAccessor, x => x.PROPERTY_NAME)?.Alias;

        return aliasMyProp;
    }
}
```

7. Call GetAllProducts, (Example: YourLocalHost/Umbraco/Api/Products/GetAllProducts
8. You should receive the content you published.