### PR TITLE
V10 Cherrypicked issuu RTE embed

### DIFF
--- a/src/Umbraco.Core/Media/EmbedProviders/Issuu.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Issuu.cs
@@ -19,6 +19,9 @@ public class Issuu : EmbedProviderBase
 
     public override Dictionary<string, string> RequestParams => new()
     {
+        // ApiUrl/?iframe=true
+        { "iframe", "true" },
+
         // ApiUrl/?format=xml
         { "format", "xml" },
     };

--- a/src/Umbraco.Core/Media/EmbedProviders/OEmbedProviderBase.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/OEmbedProviderBase.cs
@@ -55,11 +55,12 @@ public abstract class OEmbedProviderBase : IEmbedProvider
         if (_httpClient == null)
         {
             _httpClient = new HttpClient();
+            _httpClient.DefaultRequestHeaders.UserAgent.TryParseAdd("Umbraco-CMS");
         }
 
         using (var request = new HttpRequestMessage(HttpMethod.Get, url))
         {
-            HttpResponseMessage response = _httpClient.SendAsync(request).Result;
+            HttpResponseMessage response = _httpClient.SendAsync(request).GetAwaiter().GetResult();
             return response.Content.ReadAsStringAsync().Result;
         }
     }


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/14759
### What was changed:
Added a UserAgent header and changed the request so we are receiving our embed as an iframe

### Test steps:
1. Create a Document with an RTE
2. Create content with the created Document
3. Enter a link for a flip book from Issuu in the RTE as an embed. (Example: https://issuu.com/educationry/docs/educationry-a40529.docx)
4. Retrieve the embed, there should now be an embed of the flipbook.
5. Submit
6. Confirm that the RTE has the embed

(Optional):
Try to render the embed!

