### PR TITLE
add Audit Trail to the media info tab just alike the conten

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/bs.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/bs.xml
@@ -158,6 +158,12 @@
     <key alias="morePublishingOptions">Više opcija za objavljivanje</key>
     <key alias="submitChanges">Pošalji</key>
   </area>
+  <area alias="auditTrailsMedia">
+    <key alias="delete">Mediji je izbrisan</key>
+    <key alias="move">Mediji premješten</key>
+    <key alias="copy">Mediji kopiran</key>
+    <key alias="save">Mediji spremljen</key>
+  </area>
   <area alias="auditTrails">
     <key alias="atViewingFor">Pregled za</key>
     <key alias="delete">Sadržaj je izbrisan</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/cs.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/cs.xml
@@ -151,6 +151,12 @@
     <key alias="confirmActionConfirm">Potvrdit</key>
     <key alias="morePublishingOptions">Další možnosti publikování</key>
   </area>
+  <area alias="auditTrailsMedia">
+    <key alias="delete">Média smazán</key>
+    <key alias="move">Média přesunut</key>
+    <key alias="copy">Média zkopírován</key>
+    <key alias="save">Média uložen</key>
+  </area>
   <area alias="auditTrails">
     <key alias="atViewingFor">Zobrazení pro</key>
     <key alias="delete">Obsah smazán</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/cy.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/cy.xml
@@ -166,6 +166,12 @@
     <key alias="submitChanges">Submit</key>
     <key alias="submitChangesAndClose">Submit and close</key>
   </area>
+  <area alias="auditTrailsMedia">
+    <key alias="delete">Cyfrwng wedi'i dileu</key>
+    <key alias="move">Cyfrwng wedi'i symud</key>
+    <key alias="copy">Cyfrwng wedi'i copïo</key>
+    <key alias="save">Cyfrwng wedi'i achub</key>
+  </area>
   <area alias="auditTrails">
     <key alias="atViewingFor">Dangos am</key>
     <key alias="delete">Cynnwys wedi'i dileu</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
@@ -157,6 +157,12 @@
     <key alias="morePublishingOptions">Flere publiseringsmuligheder</key>
     <key alias="submitChanges">Indsæt</key>
   </area>
+  <area alias="auditTrailsMedia">
+    <key alias="delete">Brugeren har slettet medie</key>
+    <key alias="move">Brugeren har flyttet medie</key>
+    <key alias="copy">Brugeren har kopieret medie</key>
+    <key alias="save">Brugeren har gemt medie</key>
+  </area>
   <area alias="auditTrails">
     <key alias="atViewingFor">For</key>
     <key alias="delete">Brugeren har slettet indholdet</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/de.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/de.xml
@@ -159,6 +159,12 @@
     <key alias="morePublishingOptions">Mehr Veröffentlichungs Optionen</key>
     <key alias="submitChanges">Senden</key>
   </area>
+  <area alias="auditTrailsMedia">
+    <key alias="delete">Medie gelöscht</key>
+    <key alias="move">Medie verschoben</key>
+    <key alias="copy">Medie kopiert</key>
+    <key alias="save">Medie gesichert</key>
+  </area>
   <area alias="auditTrails">
     <key alias="atViewingFor">Anzeigen als</key>
     <key alias="delete">Inhalt gelöscht</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -159,6 +159,12 @@
     <key alias="morePublishingOptions">More publishing options</key>
     <key alias="submitChanges">Submit</key>
   </area>
+  <area alias="auditTrailsMedia">
+    <key alias="delete">Media deleted</key>
+    <key alias="move">Media moved</key>
+    <key alias="copy">Media copied</key>
+    <key alias="save">Media saved</key>
+  </area>
   <area alias="auditTrails">
     <key alias="atViewingFor">Viewing for</key>
     <key alias="delete">Content deleted</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -160,6 +160,12 @@
     <key alias="morePublishingOptions">More publishing options</key>
     <key alias="submitChanges">Submit</key>
   </area>
+  <area alias="auditTrailsMedia">
+    <key alias="delete">Media deleted</key>
+    <key alias="move">Media moved</key>
+    <key alias="copy">Media copied</key>
+    <key alias="save">Media saved</key>
+  </area>
   <area alias="auditTrails">
     <key alias="atViewingFor">Viewing for</key>
     <key alias="delete">Content deleted</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/fr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/fr.xml
@@ -150,6 +150,12 @@
     <key alias="confirmActionConfirm">Confirmer</key>
     <key alias="morePublishingOptions">Options de publication supplémentaires</key>
   </area>
+  <area alias="auditTrailsMedia">
+    <key alias="delete">Media supprimé</key>
+    <key alias="move">Media déplacé</key>
+    <key alias="copy">Media copié</key>
+    <key alias="save">Media sauvegardé</key>
+  </area>
   <area alias="auditTrails">
     <key alias="atViewingFor">Aperçu pour</key>
     <key alias="delete">Contenu supprimé</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/hr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/hr.xml
@@ -158,6 +158,12 @@
     <key alias="morePublishingOptions">Više opcija za objavljivanje</key>
     <key alias="submitChanges">Pošalji</key>
   </area>
+  <area alias="auditTrailsMedia">
+    <key alias="delete">Mediji je obrisan</key>
+    <key alias="move">Mediji premješten</key>
+    <key alias="copy">Mediji kopiran</key>
+    <key alias="save">Mediji spremljen</key>
+  </area>
   <area alias="auditTrails">
     <key alias="atViewingFor">Pregled za</key>
     <key alias="delete">Sadržaj je obrisan</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/it.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/it.xml
@@ -163,6 +163,12 @@
     <key alias="submitChanges">Invia</key>
     <key alias="submitChangesAndClose">Invia e chiudi</key>
   </area>
+  <area alias="auditTrailsMedia">
+    <key alias="delete">Media eliminato</key>
+    <key alias="move">Media spostato</key>
+    <key alias="copy">Media copiato</key>
+    <key alias="save">Media salvato</key>
+  </area>
   <area alias="auditTrails">
     <key alias="atViewingFor">Visualizzazione per</key>
     <key alias="delete">Contenuto eliminato</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
@@ -112,6 +112,12 @@
       zijn op de huidige node, tenzij een domein hieronder ook van toepassing is.]]></key>
     <key alias="setDomains">Domeinen</key>
   </area>
+  <area alias="auditTrailsMedia">
+    <key alias="delete">Media verwijderd</key>
+    <key alias="move">Media verplaatst</key>
+    <key alias="copy">Media gekopieerd</key>
+    <key alias="save">Media bewaard</key>
+  </area>
   <area alias="auditTrails">
     <key alias="atViewingFor">Tonen voor</key>
     <key alias="delete">Inhoud verwijderd</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/sv.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/sv.xml
@@ -67,6 +67,12 @@
     <key alias="setLanguageHelp"><![CDATA[Sätt kulturen för noder under aktuell nod,<br /> eller ärv kulturen från föregående noder. Appliceras även<br />
      på befintlig nod.]]></key>
   </area>
+  <area alias="auditTrailsMedia">
+    <key alias="delete">Media raderat</key>
+    <key alias="move">Media flyttat</key>
+    <key alias="copy">Media kopierat</key>
+    <key alias="save">Media sparat</key>
+  </area>
   <area alias="auditTrails">
     <key alias="atViewingFor">Visar för</key>
     <key alias="delete">Innehållet raderat</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/tr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/tr.xml
@@ -156,6 +156,12 @@
     <key alias="morePublishingOptions">Daha fazla yayınlama seçeneği</key>
     <key alias="submitChanges">Gönder</key>
   </area>
+  <area alias="auditTrailsMedia">
+    <key alias="delete">Medya silindi</key>
+    <key alias="move">Medya taşındı</key>
+    <key alias="copy">Medya kopyalandı</key>
+    <key alias="save">Medya kaydedildi</key>
+  </area>
   <area alias="auditTrails">
     <key alias="atViewingFor">Görüntüleniyor</key>
     <key alias="delete">İçerik silindi</key>

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/media/umbmedianodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/media/umbmedianodeinfo.directive.js
@@ -1,13 +1,74 @@
 (function () {
     'use strict';
 
-    function MediaNodeInfoDirective($timeout, $location, $q, eventsService, userService, dateHelper, editorService, mediaHelper, mediaResource) {
+  function MediaNodeInfoDirective($timeout, logResource, $location, $q, eventsService, userService, dateHelper, editorService, mediaHelper, mediaResource) {
 
         function link(scope, element, attrs, ctrl) {
 
             var evts = [];
+            var isInfoTab = false;
+            var auditTrailLoaded = false;
 
             scope.allowChangeMediaType = false;
+            scope.historyLabelKey = "general_history";
+            scope.auditTrailOptions = {
+              id: scope.node.id
+            };
+
+            scope.auditTrailPageChange = function (pageNumber) {
+              scope.auditTrailOptions.pageNumber = pageNumber;
+              loadAuditTrail(true);
+            };
+
+            function loadAuditTrail(forceReload) {
+
+              //don't load this if it's already done
+              if (auditTrailLoaded && !forceReload) {
+                return;
+              }
+
+              scope.loadingAuditTrail = true;
+
+              logResource.getPagedEntityLog(scope.auditTrailOptions)
+                .then(data => {
+
+                  // get current backoffice user and format dates
+                  userService.getCurrentUser().then(currentUser => {
+                    data.items.forEach(item => {
+                      item.timestampFormatted = dateHelper.getLocalDate(item.timestamp, currentUser.locale, 'LLL');
+                    });
+                  });
+
+                  scope.auditTrail = data.items;
+                  scope.auditTrailOptions.pageNumber = data.pageNumber;
+                  scope.auditTrailOptions.pageSize = data.pageSize;
+                  scope.auditTrailOptions.totalItems = data.totalItems;
+                  scope.auditTrailOptions.totalPages = data.totalPages;
+
+                  setAuditTrailLogTypeColor(scope.auditTrail);
+
+                  scope.loadingAuditTrail = false;
+
+                  auditTrailLoaded = true;
+                });
+
+            }
+
+            function setAuditTrailLogTypeColor(auditTrail) {
+              auditTrail.forEach(item => {
+
+                switch (item.logType) {
+                  case "Save":
+                    item.logTypeColor = "success";
+                    break;
+                  case "Delete":
+                    item.logTypeColor = "danger";
+                    break;
+                  default:
+                    item.logTypeColor = "gray";
+                }
+              });
+            }
 
             function onInit() {
 
@@ -31,6 +92,12 @@
 
                 // set media file extension initially
                 setMediaExtension();
+
+                var activeApp = scope.node.apps.find(a => a.active);
+                if (activeApp.alias === "umbInfo") {
+                  loadAuditTrail();
+                  isInfoTab = true;
+                }
             }
 
             function formatDatesToLocal() {
@@ -92,6 +159,8 @@
 
                 //Update the media file format
                 setMediaExtension();
+
+                loadAuditTrail(true);
             });
 
             //ensure to unregister from all events!
@@ -100,6 +169,18 @@
                     eventsService.unsubscribe(evts[e]);
                 }
             });
+
+            evts.push(eventsService.on("app.tabChange", function (event, args) {
+              $timeout(function () {
+                if (args.alias === "umbInfo") {
+                  isInfoTab = true;
+                  loadAuditTrail();
+                  formatDatesToLocal();
+                } else {
+                  isInfoTab = false;
+                }
+              });
+            }));
 
             onInit();
         }

--- a/src/Umbraco.Web.UI.Client/src/views/components/media/umb-media-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/media/umb-media-node-info.html
@@ -86,7 +86,7 @@
                                     <localize key="auditTrails_small{{ item.logType }}">{{ item.logType }}</localize>
                                 </umb-badge>
                                 <span class="history-item__description">
-                                    <localize key="auditTrails_{{ item.logType | lowercase }}" tokens="[item.parameters]">{{ item.comment }}</localize>
+                                    <localize key="auditTrailsMedia_{{ item.logType | lowercase }}" tokens="[item.parameters]">{{ item.comment }}</localize>
                                 </span>
                             </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/media/umb-media-node-info.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/media/umb-media-node-info.html
@@ -28,6 +28,83 @@
         </umb-box>
 
         <umb-tracked-references id="node.id"></umb-tracked-references>
+
+        <umb-box data-element="node-info-history">
+
+            <umb-box-header title-key="{{historyLabelKey}}" ng-if="historyLabelKey">
+                <umb-button ng-if="node.allowedActions.includes('K')"
+                            ng-hide="node.trashed || node.id === 0"
+                            type="button"
+                            button-style="outline"
+                            action="openRollback()"
+                            label-key="actions_rollback"
+                            size="xs"
+                            add-ellipsis="true">
+                </umb-button>
+            </umb-box-header>
+
+            <umb-box-content class="block-form">
+
+                <div style="position: relative;">
+
+                    <div ng-show="loadingAuditTrail" style="background: rgba(255, 255, 255, 0.8); position: absolute; top: 0; left: 0; right: 0; bottom: 0;"></div>
+                    <umb-load-indicator ng-show="loadingAuditTrail"></umb-load-indicator>
+
+                    <div ng-show="auditTrail.length === 0" style="padding: 10px;">
+                        <umb-empty-state position="center"
+                                         size="small">
+                            <localize key="content_noChanges">No changes have been made</localize>
+                        </umb-empty-state>
+                    </div>
+
+                    <div class="history">
+
+                        <div ng-show="auditTrail.length > 1" class="history-line"></div>
+
+                        <div class="history-item" ng-repeat="item in auditTrail">
+
+                            <div class="history-item__break">
+                                <div class="history-item__avatar">
+                                    <umb-avatar color="secondary"
+                                                size="xs"
+                                                name="{{item.userName}}"
+                                                img-src="{{item.userAvatars[3]}}"
+                                                img-srcset="{{item.userAvatars[4]}} 2x, {{item.userAvatars[4]}} 3x">
+                                    </umb-avatar>
+                                </div>
+
+                                <div>
+                                    <div>{{ item.userName }}</div>
+                                    <div class="history-item__date">{{item.timestampFormatted}}</div>
+                                </div>
+                            </div>
+
+                            <div class="history-item__break">
+                                <umb-badge class="history-item__badge"
+                                           size="xs"
+                                           color="{{item.logTypeColor}}">
+                                    <localize key="auditTrails_small{{ item.logType }}">{{ item.logType }}</localize>
+                                </umb-badge>
+                                <span class="history-item__description">
+                                    <localize key="auditTrails_{{ item.logType | lowercase }}" tokens="[item.parameters]">{{ item.comment }}</localize>
+                                </span>
+                            </div>
+
+                        </div>
+                    </div>
+
+                </div>
+
+                <div class="flex justify-center">
+                    <umb-pagination ng-if="auditTrailOptions.totalPages > 1"
+                                    page-number="auditTrailOptions.pageNumber"
+                                    total-pages="auditTrailOptions.totalPages"
+                                    on-change="auditTrailPageChange(pageNumber)">
+                    </umb-pagination>
+                </div>
+
+            </umb-box-content>
+        </umb-box>
     </div>
 
     <!-- Sidebar -->


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
On the content Info content app page we have a audit trail log over the content, what happende to it thouge out the history.
But on the media info content app, it is missing.

I have in many diffendt times acculy need the audit trail for the media, to see how ex delete this file or folder, when did the last save happens and many more. The data is there, when I have need this data I have just go to the Database and search it out. 
But when take the hard way and always figels inside the database "some day I accedentily maby do something stupid" when we can add the same functionallity the content has to the media.

TEST:
1) Start up a new solution.
2) Upload an image and save.
3) Go the info app and se the first entity is saved marked in green
4) Move it, delete it, or resave it and see the Audit trails get more and more data.

