### PR TITLE
V12 Fixed flaky tests

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@umbraco/json-models-builders": "^1.0.6",
-        "@umbraco/playwright-testhelpers": "^1.0.24",
+        "@umbraco/playwright-testhelpers": "^1.0.25",
         "camelize": "^1.0.0",
         "dotenv": "^16.0.2",
         "faker": "^4.1.0",
@@ -141,9 +141,9 @@
       }
     },
     "node_modules/@umbraco/playwright-testhelpers": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.24.tgz",
-      "integrity": "sha512-xYOgcnyvcEywgC9DT4Q3OhQDTfdtF1zXLQIXdjNtwr6a4j3SUab1RI/tGxlF01fX+8Ttw3edlV4l+HIrY0hM1Q==",
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-1.0.25.tgz",
+      "integrity": "sha512-6H452J6LhP0EHjF4jR7V7i0U8WPTiAbSyhN1J459BbbYEJ4QX1A2ZlCdA6VSBAsK1xYdMXD+yxsVJq7AAwiy9A==",
       "dependencies": {
         "@umbraco/json-models-builders": "^1.0.6",
         "camelize": "^1.0.0",

--- a/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
@@ -17,7 +17,7 @@
         "xhr2": "^0.2.1"
       },
       "devDependencies": {
-        "@playwright/test": "^1.32",
+        "@playwright/test": "^1.37",
         "del": "^6.0.0",
         "ncp": "^2.0.0",
         "prompt": "^1.2.0",
@@ -86,19 +86,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.32.3",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.3.tgz",
-      "integrity": "sha512-BvWNvK0RfBriindxhLVabi8BRe3X0J9EVjKlcmhxjg4giWBD/xleLcg2dz7Tx0agu28rczjNIPQWznwzDwVsZQ==",
+      "version": "1.37.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.37.1.tgz",
+      "integrity": "sha512-bq9zTli3vWJo8S3LwB91U0qDNQDpEXnw7knhxLM0nwDvexQAwx9tO8iKDZSqqneVq+URd/WIoz+BALMqUTgdSg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.32.3"
+        "playwright-core": "1.37.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
@@ -742,15 +742,15 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.32.3",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.3.tgz",
-      "integrity": "sha512-SB+cdrnu74ZIn5Ogh/8278ngEh9NEEV0vR4sJFmK04h2iZpybfbqBY0bX6+BLYWVdV12JLLI+JEFtSnYgR+mWg==",
+      "version": "1.37.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.37.1.tgz",
+      "integrity": "sha512-17EuQxlSIYCmEMwzMqusJ2ztDgJePjrbttaefgdsiqeLWidjYz9BxXaTaZWxH1J95SHGk6tjE+dwgWILJoUZfA==",
       "dev": true,
       "bin": {
-        "playwright": "cli.js"
+        "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/prompt": {

--- a/tests/Umbraco.Tests.AcceptanceTest/package.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@umbraco/json-models-builders": "^1.0.6",
-    "@umbraco/playwright-testhelpers": "^1.0.24",
+    "@umbraco/playwright-testhelpers": "^1.0.25",
     "camelize": "^1.0.0",
     "faker": "^4.1.0",
     "form-data": "^4.0.0",

--- a/tests/Umbraco.Tests.AcceptanceTest/package.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package.json
@@ -10,7 +10,7 @@
     "createTest": "node createTest.js"
   },
   "devDependencies": {
-    "@playwright/test": "^1.32",
+    "@playwright/test": "^1.37",
     "typescript": "^4.8.3",
     "tslib": "^2.4.0",
     "del": "^6.0.0",

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/BlockGridEditor/Content/blockGridEditorContent.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/BlockGridEditor/Content/blockGridEditorContent.spec.ts
@@ -390,7 +390,7 @@ test.describe('BlockGridEditorContent', () => {
       await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.saveAndPublish));
 
       // Assert
-      await umbracoUi.getSuccessNotification();
+      await umbracoUi.isSuccessNotificationVisible();
       // Checks if there are two blocks in the area
       await expect(page.locator('[data-element="property-' + blockGridAlias + '"]').locator('umb-block-grid-entry')).toHaveCount(2);
 
@@ -461,7 +461,7 @@ test.describe('BlockGridEditorContent', () => {
       await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.saveAndPublish));
 
       // Assert
-      await umbracoUi.getSuccessNotification();
+      await umbracoUi.isSuccessNotificationVisible();
       // Checks if there are two blocks in the area
       await expect(page.locator('[data-element="property-' + blockGridAlias + '"]').locator('umb-block-grid-entry')).toHaveCount(2);
     });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/BlockGridEditor/Content/blockGridEditorContent.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/BlockGridEditor/Content/blockGridEditorContent.spec.ts
@@ -346,7 +346,7 @@ test.describe('BlockGridEditorContent', () => {
 
     // Selects the created image for the block
     await page.locator('[data-content-element-type-key="' + element['key'] + '"]').click();
-    await page.locator('[data-element="property-image"]').locator('[key="' + ConstantHelper.buttons.add + '"]').click();
+    await page.getByRole('button', { name: 'Add', exact: true }).click();
     await page.locator('[data-element="media-grid"] >> [title="' + imageName + '"]').click();
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.select));
     await page.locator('[label="Submit"]').click();

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/BlockGridEditor/Content/blockGridEditorContent.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/BlockGridEditor/Content/blockGridEditorContent.spec.ts
@@ -458,7 +458,8 @@ test.describe('BlockGridEditorContent', () => {
       await page.locator('[title="Delete"]').nth(2).click();
       await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey('actions_delete'));
 
-      await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.saveAndPublish));
+      await page.waitForTimeout(2000);
+      await page.getByRole('button', { name: 'Save and publish' }).click();
 
       // Assert
       await umbracoUi.isSuccessNotificationVisible();

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/BlockGridEditor/Datatype/BlockGridEditorDataTypeBlocks.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/BlockGridEditor/Datatype/BlockGridEditorDataTypeBlocks.spec.ts
@@ -43,7 +43,7 @@ test.describe('BlockGridEditorDataTypeBlock', () => {
 
     return blockGridType;
   }
-  
+
   test('can create empty block grid editor', async ({page, umbracoApi, umbracoUi}) => {
     await umbracoUi.goToSection(ConstantHelper.sections.settings);
 
@@ -261,7 +261,7 @@ test.describe('BlockGridEditorDataTypeBlock', () => {
 
   test('can create a block grid datatype with multiple groups and multiple element in each group', async ({page, umbracoApi, umbracoUi},testInfo) => {
     await testInfo.slow();
-    
+
     const GroupOne = 'GroupOne';
     const elementNameFourth = 'FourthElement';
     const elementFourthAlias = AliasHelper.toAlias(elementNameFourth);
@@ -362,7 +362,7 @@ test.describe('BlockGridEditorDataTypeBlock', () => {
     await expect(await umbracoApi.dataTypes.exists(blockGridName)).toBe(true);
     await umbracoUi.doesDataTypeExist(blockGridName);
 
-    // Clean 
+    // Clean
     await umbracoApi.documentTypes.ensureNameNotExists(elementName);
     await umbracoApi.documentTypes.ensureNameNotExists(elementNameTwo);
     await umbracoApi.documentTypes.ensureNameNotExists(elementNameThree);
@@ -552,6 +552,9 @@ test.describe('BlockGridEditorDataTypeBlock', () => {
     await umbracoUi.clickDataElementByElementName(ConstantHelper.actions.delete);
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.delete));
 
+    // We need a wait to make sure the block grid editor is deleted
+    await page.waitForTimeout(1000);
+
     // Assert
     // Checks if the block grid editor still exists
     await umbracoUi.goToSection(ConstantHelper.sections.settings);
@@ -586,7 +589,7 @@ test.describe('BlockGridEditorDataTypeBlock', () => {
     const dragFrom = await page.locator('.umb-block-card-group').nth(0).locator('[data-content-element-type-key="' + element['key'] + '"]');
     const dragTo = await page.locator('[key="blockEditor_addBlockType"]').nth(1);
     await umbracoUi.dragAndDrop(dragFrom, dragTo, 0, 0, 15);
-    
+
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.save));
 
     // Assert
@@ -626,7 +629,7 @@ test.describe('BlockGridEditorDataTypeBlock', () => {
     const dragFrom = await page.locator('.umb-block-card-group >> [icon="icon-navigation"]').nth(0);
     const dragTo = await page.locator('[key="blockEditor_addBlockType"]').nth(2);
     await umbracoUi.dragAndDrop(dragFrom, dragTo, 0, 0, 15);
-    
+
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.save));
 
     // Assert
@@ -642,7 +645,7 @@ test.describe('BlockGridEditorDataTypeBlock', () => {
 
   test('can move a group with elements in a block grid editor', async ({page, umbracoApi, umbracoUi}, testInfo) => {
     await testInfo.slow();
-    
+
     const GroupMove = 'GroupMove';
     const GroupNotMoving = 'GroupNotMoving';
 
@@ -685,9 +688,9 @@ test.describe('BlockGridEditorDataTypeBlock', () => {
     const dragFrom = await page.locator('.umb-block-card-group >> [icon="icon-navigation"]').nth(0);
     const dragTo = await page.locator('[key="blockEditor_addBlockType"]').nth(2);
     await umbracoUi.dragAndDrop(dragFrom, dragTo, 20, 0, 15);
-    
+
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.save));
-    
+
     // Assert
     await umbracoUi.isSuccessNotificationVisible();
     // Checks if the elements were moved with their group

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/BlockListEditor/blockListEditorContent.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/BlockListEditor/blockListEditorContent.spec.ts
@@ -312,7 +312,7 @@ test.describe('BlockListEditorContent', () => {
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.saveAndPublish));
 
     // Assert
-    await umbracoUi.getSuccessNotification();
+    await umbracoUi.isSuccessNotificationVisible();
   });
 
   test('can set a maximum of required blocks in content with a block list editor', async ({page, umbracoApi, umbracoUi}) => {
@@ -375,7 +375,7 @@ test.describe('BlockListEditorContent', () => {
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey('actions_delete'));
 
     // Assert
-    await umbracoUi.getSuccessNotification();
+    await umbracoUi.isSuccessNotificationVisible();
   });
 
   test('can use inline editing mode in content with a block list editor', async ({page, umbracoApi, umbracoUi}) => {

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/BlockListEditor/blockListEditorContent.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/BlockListEditor/blockListEditorContent.spec.ts
@@ -374,6 +374,9 @@ test.describe('BlockListEditorContent', () => {
     // Can't use our constant helper because the action for delete does not contain an s. The correct way is 'action-delete'
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey('actions_delete'));
 
+    // Now that we deleted the block, we should be able to save our content
+    await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.saveAndPublish));
+
     // Assert
     await umbracoUi.isSuccessNotificationVisible();
   });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/routing.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/routing.spec.ts
@@ -164,10 +164,10 @@ test.describe('Routing', () => {
     await page.locator('.btn-success').last().click()
 
     // Assert
-    await expect(await umbracoUi.getSuccessNotification()).toHaveCount(2);
+    await expect(await umbracoUi.getSuccessNotification()).toHaveCount(2, {timeout: 20000});
     await expect(await page.locator('.alert-warning')).toBeVisible();
   });
-  
+
   test('Root node published in language A, Child node published in language A + B, Grandchild published in A + B', async ({page, umbracoApi, umbracoUi}) => {
     const rootDocType = new DocumentTypeBuilder()
       .withName(rootDocTypeName)
@@ -249,6 +249,6 @@ test.describe('Routing', () => {
     await page.locator('.checkbox').last().click();
     await page.locator('.btn-success').last().click()
     // Assert
-    await expect(await umbracoUi.getSuccessNotification()).toHaveCount(2);
+    await expect(await umbracoUi.getSuccessNotification()).toHaveCount(2, {timeout: 20000});
   })
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataTypes/dataTypes.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataTypes/dataTypes.spec.ts
@@ -104,7 +104,7 @@ test.describe('DataTypes', () => {
     // Add char and assert helptext appears - no publish to save time & has been asserted above & below
     await page.locator('input[name="textbox"]').type('9');
     await expect(page.locator('localize[key="textbox_characters_left"]', {hasText: "characters left"}).first()).toBeVisible();
-    await expect(await umbracoUi.getErrorNotification()).not.toBeVisible();
+    await expect(await umbracoUi.getErrorNotification()).not.toBeVisible({timeout: 20000});
 
     // Add char and assert errortext appears and can't save
     await page.locator('input[name="textbox"]').type('10'); // 1 char over max
@@ -154,14 +154,14 @@ test.describe('DataTypes', () => {
     await page.locator('.umb-tree-root').click({button: "right"});
     await page.locator('[data-element="action-create"]').click();
     await page.locator('[data-element="action-create-' + pickerDocTypeAlias + '"] > .umb-action-link').click();
-    
+
     // Fill out content
     await umbracoUi.setEditorHeaderName('UrlPickerContent');
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.saveAndPublish));
     await umbracoUi.isSuccessNotificationVisible();
     await page.locator('span:has-text("×")').click();
     await page.locator('.umb-node-preview-add').click();
-    
+
     await page.locator('[data-element="editor-container"]').locator('[data-element="tree-item-UrlPickerContent"]').click();
     await expect(page.locator('[alias="urlLinkPicker"]').locator('input[id="urlLinkPicker"]')).toHaveValue('/');
     await page.locator('.umb-editor-footer-content__right-side').locator('[label-key="' + ConstantHelper.buttons.submit + '"]').click();
@@ -172,7 +172,7 @@ test.describe('DataTypes', () => {
     await umbracoUi.isSuccessNotificationVisible();
 
     // Assert
-    await expect(await umbracoUi.getErrorNotification()).not.toBeVisible();
+    await expect(await umbracoUi.getErrorNotification()).not.toBeVisible({timeout: 20000});
 
     // Testing if the edits match the expected results
     const expected = '<a href="/">UrlPickerContent</a>';

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataTypes/textBoxVariation.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataTypes/textBoxVariation.spec.ts
@@ -8,7 +8,7 @@ test.describe('Vary by culture for TextBox', () => {
         await umbracoApi.report.report(testInfo);
         await umbracoApi.login();
     });
-    
+
     test('create documentType with vary by culture with UI with a textbox property which also has vary by culture', async ({page, umbracoApi, umbracoUi}) => {
         const documentTypeName = 'Test Document';
         const textBoxPropertyName = 'TestBox';
@@ -37,7 +37,7 @@ test.describe('Vary by culture for TextBox', () => {
         await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.save));
 
         // Assert
-        await expect(page.locator('.umb-notifications__notifications > .alert-success')).toBeVisible();
+        await umbracoUi.isSuccessNotificationVisible();
 
         // Clean
         await umbracoApi.documentTypes.ensureNameNotExists(documentTypeName);
@@ -280,7 +280,7 @@ test.describe('Vary by culture for TextBox', () => {
         await expect(await umbracoApi.content.verifyRenderedContent(daEndpoint, daValue, true)).toBeTruthy();
         await expect(await umbracoApi.content.verifyRenderedContent(enEndpoint, enValue, true)).toBeTruthy();
 
-        // Clean 
+        // Clean
         await umbracoApi.content.deleteAllContent();
         await umbracoApi.documentTypes.ensureNameNotExists(documentName);
         await umbracoApi.languages.ensureCultureNotExists(languageDa);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Media/mediaSection.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Media/mediaSection.spec.ts
@@ -51,7 +51,7 @@ test.describe('Media', () => {
             }
         });
         await page.locator('[label-key="actions_move"]').click();
-        await page.locator('[data-element="editor-container"] >> "' + folderToMoveTooName + '"').click();
+        await page.locator('[data-element="editor-container"]').locator('[data-element="tree-item-MoveHere"]').click();
         await page.locator('[label-key="general_submit"]').click();
 
         // Assert

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/ModelsBuilder/modelsbuilder.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/ModelsBuilder/modelsbuilder.spec.ts
@@ -266,7 +266,7 @@ test.describe('Modelsbuilder tests', () => {
     // We only have to type out the opening tag, the editor adds the closing tag automatically.
     await editor.type("<p>@Model.Bod");
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.save));
-    await umbracoUi.isSuccessNotificationVisible({timeout: 20000});
+    await umbracoUi.isSuccessNotificationVisible();
     await page.locator('span:has-text("×")').click();
 
     // Navigate to the content section and update the content

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/ModelsBuilder/modelsbuilder.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/ModelsBuilder/modelsbuilder.spec.ts
@@ -7,6 +7,9 @@ import {
 test.describe('Modelsbuilder tests', () => {
 
   test.beforeEach(async ({ page, umbracoApi }, testInfo) => {
+    // Added a longer timeout for our tests
+    test.slow();
+
     await umbracoApi.report.report(testInfo);
     await umbracoApi.login();
   });
@@ -49,7 +52,7 @@ test.describe('Modelsbuilder tests', () => {
     // Fortunately for us the input field of a text box has the alias of the property as an id :)
     await page.locator("#title").type("Hello world!");
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.saveAndPublish));
-    await umbracoUi.isSuccessNotificationVisible({timeout:10000});
+    await umbracoUi.isSuccessNotificationVisible({timeout:20000});
     // Ensure that we can render it on the frontend = we can compile the models and views
     await umbracoApi.content.verifyRenderedContent("/", "<h1>Hello world!</h1>", true);
 
@@ -117,7 +120,7 @@ test.describe('Modelsbuilder tests', () => {
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.submit));
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.save));
     // Has a long timeout because it can sometimes take longer than 5 sec to save on the pipeline
-    await umbracoUi.isSuccessNotificationVisible({timeout:10000});
+    await umbracoUi.isSuccessNotificationVisible({timeout:20000});
 
     // Now that the content is updated and the models are rebuilt, ensure that we can still render the frontend.
     await umbracoApi.content.verifyRenderedContent("/", "<h1>" + propertyValue + "</h1>", true)
@@ -184,7 +187,7 @@ test.describe('Modelsbuilder tests', () => {
     await editor.type("<p>Edited");
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.save));
 
-    await umbracoUi.isSuccessNotificationVisible({timeout:10000});
+    await umbracoUi.isSuccessNotificationVisible({timeout:20000});
 
     await umbracoApi.content.verifyRenderedContent("/", "<h1>" + propertyValue + "</h1><p>Edited</p>", true);
 
@@ -194,8 +197,6 @@ test.describe('Modelsbuilder tests', () => {
   });
 
   test('Can update view and document type', async ({page, umbracoApi, umbracoUi},testInfo) => {
-    await testInfo.slow();
-
     const docTypeName = "TestDocument";
     const docTypeAlias = AliasHelper.toAlias(docTypeName);
     const propertyAlias = "title";

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/partialViewMacroFiles.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/partialViewMacroFiles.spec.ts
@@ -5,7 +5,10 @@ import {PartialViewMacroBuilder} from "@umbraco/json-models-builders";
 test.describe('Partial View Macro Files', () => {
 
     test.beforeEach(async ({ page, umbracoApi }, testInfo) => {
-        await umbracoApi.report.report(testInfo);
+      // Added a longer timeout for all our tests
+      test.slow();
+
+      await umbracoApi.report.report(testInfo);
         await umbracoApi.login();
     });
 
@@ -31,18 +34,19 @@ test.describe('Partial View Macro Files', () => {
 
         await page.locator('.menu-label localize[key="create_newPartialViewMacro"]').click();
 
-        //Type name
+        // Type name
         await umbracoUi.setEditorHeaderName(name);
 
-        //Save
+        // Save
         await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.save));
 
-        //Assert
-        await umbracoUi.isSuccessNotificationVisible({timeout:10000});
+        // Assert
+        // It can take quite a long time for a Partial View Macro to be created
+        await umbracoUi.isSuccessNotificationVisible({timeout: 20000});
 
         //Clean up
         await cleanup(umbracoApi, name);
-    });    
+    });
 
     test('Create new partial view macro without macro', async ({page, umbracoApi, umbracoUi}) => {
         const name = "TestPartialMacrolessMacro";
@@ -55,16 +59,17 @@ test.describe('Partial View Macro Files', () => {
 
         // Type name
         await umbracoUi.setEditorHeaderName(name);
-        
+
         // Save
         await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.save));
 
         // Assert
-        await umbracoUi.isSuccessNotificationVisible({timeout:10000});
+        // It can take quite a long time for a Partial View Macro to be created
+        await umbracoUi.isSuccessNotificationVisible({timeout: 20000});
 
         // Clean
         await cleanup(umbracoApi, name);
-    });    
+    });
 
     test('Create new partial view macro from snippet', async ({page, umbracoApi, umbracoUi}) => {
         const name = "TestPartialFromSnippet";
@@ -85,11 +90,12 @@ test.describe('Partial View Macro Files', () => {
         await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.save));
 
         // Assert
-        await umbracoUi.isSuccessNotificationVisible({timeout:10000});
+        // It can take quite a long time for a Partial View Macro to be created
+        await umbracoUi.isSuccessNotificationVisible({timeout: 20000});
 
         // Clean
         await cleanup(umbracoApi, name);
-    });    
+    });
 
     test('Delete partial view macro', async ({page, umbracoApi, umbracoUi}) => {
         const name = "TestDeletePartialViewMacro";
@@ -114,11 +120,11 @@ test.describe('Partial View Macro Files', () => {
         await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.ok));
 
         // Assert
-        await expect(await page.locator("body",{ hasText: fullName})).not.toBeVisible();
+        await expect(page.locator("body",{ hasText: fullName})).not.toBeVisible();
 
         // Clean
         await cleanup(umbracoApi, name);
-    });    
+    });
 
     test('Edit partial view macro', async ({page, umbracoApi, umbracoUi}) => {
         const name = "TestPartialViewMacroEditable";
@@ -140,12 +146,13 @@ test.describe('Partial View Macro Files', () => {
 
         // Type an edit
         await page.locator('.ace_text-input').type(" // test" );
-        
+
         // Save
         await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.save));
 
         // Assert
-        await umbracoUi.isSuccessNotificationVisible({timeout:10000});
+        // It can take quite a long time for a Partial View Macro to be edited
+        await umbracoUi.isSuccessNotificationVisible({timeout: 20000});
 
         await cleanup(umbracoApi, name);
     });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/partialViewMacroFiles.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/partialViewMacroFiles.spec.ts
@@ -42,7 +42,7 @@ test.describe('Partial View Macro Files', () => {
 
         // Assert
         // It can take quite a long time for a Partial View Macro to be created
-        await umbracoUi.isSuccessNotificationVisible({timeout: 20000});
+        await umbracoUi.isSuccessNotificationVisible();
 
         //Clean up
         await cleanup(umbracoApi, name);
@@ -65,7 +65,7 @@ test.describe('Partial View Macro Files', () => {
 
         // Assert
         // It can take quite a long time for a Partial View Macro to be created
-        await umbracoUi.isSuccessNotificationVisible({timeout: 20000});
+        await umbracoUi.isSuccessNotificationVisible();
 
         // Clean
         await cleanup(umbracoApi, name);
@@ -91,7 +91,7 @@ test.describe('Partial View Macro Files', () => {
 
         // Assert
         // It can take quite a long time for a Partial View Macro to be created
-        await umbracoUi.isSuccessNotificationVisible({timeout: 20000});
+        await umbracoUi.isSuccessNotificationVisible();
 
         // Clean
         await cleanup(umbracoApi, name);
@@ -152,7 +152,7 @@ test.describe('Partial View Macro Files', () => {
 
         // Assert
         // It can take quite a long time for a Partial View Macro to be edited
-        await umbracoUi.isSuccessNotificationVisible({timeout: 20000});
+        await umbracoUi.isSuccessNotificationVisible();
 
         await cleanup(umbracoApi, name);
     });


### PR DESCRIPTION
We had multiple flaky tests, they should now be fixed. 
We added more timeouts for tests regarding the modelsBuilder and the partialViewMacroFiles. 
We updated a locator in the blockgridEditorContent tests so we would not find two elements resulting in a failing test.
We updated the media move test because the test could sometimes find two elements.
Also updated the test regarding maximum blocks for the blockGridEditor.