### PR TITLE
Feature: rename context module to app module

### DIFF
--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoBackOffice/Default.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoBackOffice/Default.cshtml
@@ -19,6 +19,7 @@
 
 <!DOCTYPE html>
 <html lang="@CultureInfo.CurrentCulture.Name">
+
 <head>
     <base href="@backOfficePath.EnsureEndsWith('/')" />
     <meta charset="UTF-8" />
@@ -30,6 +31,8 @@
     <script type="importmap">
         {
             "imports": {
+                @Html.Raw(ImportMapValue("@umbraco-cms/backoffice/app", backofficeAssetsPath + "/apps/app/index.js")),
+
                 @Html.Raw(ImportMapValue("@umbraco-cms/backoffice/external/uui", backofficeAssetsPath + "/external/uui/index.js")),
                 @Html.Raw(ImportMapValue("@umbraco-cms/backoffice/external/lit", backofficeAssetsPath + "/external/lit/index.js")),
                 @Html.Raw(ImportMapValue("@umbraco-cms/backoffice/external/openid", backofficeAssetsPath + "/external/openid/index.js")),
@@ -50,7 +53,6 @@
                 @Html.Raw(ImportMapValue("@umbraco-cms/backoffice/observable-api", backofficeAssetsPath + "/libs/observable-api/index.js")),
 
                 @Html.Raw(ImportMapValue("@umbraco-cms/backoffice/auth", backofficeAssetsPath + "/shared/auth/index.js")),
-                @Html.Raw(ImportMapValue("@umbraco-cms/backoffice/context", backofficeAssetsPath + "/shared/context/index.js")),
                 @Html.Raw(ImportMapValue("@umbraco-cms/backoffice/events", backofficeAssetsPath + "/shared/umb-events/index.js")),
                 @Html.Raw(ImportMapValue("@umbraco-cms/backoffice/icon", backofficeAssetsPath + "/shared/icon-registry/index.js")),
                 @Html.Raw(ImportMapValue("@umbraco-cms/backoffice/models", backofficeAssetsPath + "/shared/models/index.js")),
@@ -119,7 +121,9 @@
     </script>
     <script type="module" src="@backofficeAssetsPath/apps/app/app.element.js"></script>
 </head>
+
 <body class="uui-font uui-text" style="margin: 0; padding: 0; overflow: hidden">
     <umb-app culture="@CultureInfo.CurrentCulture.Name"></umb-app>
 </body>
+
 </html>

--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoInstall/Index.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoInstall/Index.cshtml
@@ -19,6 +19,7 @@
 
 <!DOCTYPE html>
 <html lang="@CultureInfo.CurrentCulture.Name">
+
 <head>
     <base href="@backOfficePath.EnsureEndsWith('/')" />
     <meta charset="UTF-8" />
@@ -30,6 +31,8 @@
     <script type="importmap">
             {
                 "imports": {
+                    @Html.Raw(ImportMapValue("@umbraco-cms/backoffice/app", backofficeAssetsPath + "/apps/app/index.js")),
+
                     @Html.Raw(ImportMapValue("@umbraco-cms/backoffice/external/uui", backofficeAssetsPath + "/external/uui/index.js")),
                     @Html.Raw(ImportMapValue("@umbraco-cms/backoffice/external/lit", backofficeAssetsPath + "/external/lit/index.js")),
                     @Html.Raw(ImportMapValue("@umbraco-cms/backoffice/external/openid", backofficeAssetsPath + "/external/openid/index.js")),
@@ -50,7 +53,6 @@
                     @Html.Raw(ImportMapValue("@umbraco-cms/backoffice/observable-api", backofficeAssetsPath + "/libs/observable-api/index.js")),
 
                     @Html.Raw(ImportMapValue("@umbraco-cms/backoffice/auth", backofficeAssetsPath + "/shared/auth/index.js")),
-                    @Html.Raw(ImportMapValue("@umbraco-cms/backoffice/context", backofficeAssetsPath + "/shared/context/index.js")),
                     @Html.Raw(ImportMapValue("@umbraco-cms/backoffice/events", backofficeAssetsPath + "/shared/umb-events/index.js")),
                     @Html.Raw(ImportMapValue("@umbraco-cms/backoffice/icon", backofficeAssetsPath + "/shared/icon-registry/index.js")),
                     @Html.Raw(ImportMapValue("@umbraco-cms/backoffice/models", backofficeAssetsPath + "/shared/models/index.js")),
@@ -119,7 +121,9 @@
         </script>
     <script type="module" src="@backofficeAssetsPath/apps/app/app.element.js"></script>
 </head>
+
 <body class="uui-font uui-text" style="margin: 0; padding: 0; overflow: hidden">
     <umb-app></umb-app>
 </body>
+
 </html>


### PR DESCRIPTION
I have renamed the context module to the app module to remove confusion around context and context-API

See PR https://github.com/umbraco/Umbraco.CMS.Backoffice/pull/875 for more info.