### PR TITLE
a11y improvement for settingsdashboardintro

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/settingsdashboardintro.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/settingsdashboardintro.html
@@ -1,14 +1,14 @@
 <umb-box>
     <umb-box-content>
-        <h3 class="bold">
+        <h1 class="bold h3">
             <localize key="settingsDashboard_start">Start here</localize>
-        </h3>
+        </h1>
         <localize key="settingsDashboard_startDescription">
             <p>This section contains the building blocks for your Umbraco site. Follow the below links to find out more about working with the items in the Settings section:</p>
         </localize>:
-        <h5>
+        <h2 class="h5">
             <localize key="settingsDashboard_more">Find out more</localize>:
-        </h5>
+        </h2>
         <ul>
             <li>
                 <localize key="settingsDashboard_bulletPointOne">Read more about working with the items in Settings <a class="btn-link -underline" href="https://docs.umbraco.com/umbraco-cms/fundamentals/backoffice/sections/" target="_blank" rel="noopener">in the Umbraco Documentation.</a></localize>


### PR DESCRIPTION
In the current situation, Lighthouse is reporting an issue regarding the headings ("Heading elements are not in a sequentially-descending order"):

![image](https://github.com/umbraco/Umbraco-CMS/assets/7831614/b13a846e-885f-47ce-aa63-7bdfe9297919)

I have changed the h3 to an h1 and the h5 to an h2 while maintaining the styling, so that there are no visible differences but the score improves.

