### PR TITLE
Bug fix whre mediapicker dont load before an event fires elsewhere #1…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umbMediaPicker3PropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umbMediaPicker3PropertyEditor.component.js
@@ -80,7 +80,7 @@
             vm.sortableOptions.disabled = vm.readonly || vm.singleMode;
         });
 
-        vm.$onInit = function() {
+      vm.$onInit = function() {
             vm.node = vm.node || editorState.getCurrent();
 
             // If we do not have a node on the scope, then disallow drop media
@@ -179,7 +179,8 @@
                 vm.allowAdd = hasAccessToMedia;
 
                 mediaUploader.init(uploaderOptions).then(() => {
-                    vm.loading = false;
+                  vm.loading = false;
+                  $scope.$apply();
                 });
             });
         };


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->
[Media picker does not load until an event happens](https://github.com/umbraco/Umbraco-CMS/issues/14250)

### Description
After some debugging, I found that the UI didn´t rerender the state of the component. 
When debugging this line https://github.com/umbraco/Umbraco-CMS/blob/1f24b795319681c4b8b34a4018b6f5498d585ee6/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umbMediaPicker3PropertyEditor.component.js#L182 and saw the this line was called imidenly as excptede and startet to go to the DOM and saw this line https://github.com/umbraco/Umbraco-CMS/blob/1f24b795319681c4b8b34a4018b6f5498d585ee6/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umb-media-picker3-property-editor.html#L3 with this command in console in dev tool "angular.element($0).scope().vm.loading" return also false, but the UI still was indikating is was loading.
   
 When i click somewhere in the browser the UI was updatet and the component was repaintet.
 This bug orruce typical when the component is modifed outside of angular apply state.
 
 I have added an method call to apply the current state after loading is set to false and everything works now as excpteded.
 
 1. From settings, create a new document type, and call it image test
 2. Add a group, and name it image
 3. Add a property of type Multi Image Media Picker and name it image
 4. From Permissions, set the Is an Element Type to true and click save
 5. On an existing document type, or a new document type, add a property named image of type Block List where you enable the Inline editing mode, and for the Available Blocks you add the previously created block called image test.
 6. From Content, create a new content of the document type where you added the property in step 5
 7. Click on Add Image test
 8. Add some media (at least one)
 9. Collapse and then expand the Image test block and see the image apperes without need to wait to GetRemainingTimeoutSeconds request is called or a click elsewhere in the browser
