### PR TITLE
Add UsePagedSqlQuery setting to NucacheSettings

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/NuCacheSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/NuCacheSettings.cs
@@ -44,7 +44,4 @@ public class NuCacheSettings
 
     [DefaultValue(StaticUsePagedSqlQuery)]
     public bool UsePagedSqlQuery { get; set; } = true;
-
-
-
 }

--- a/src/Umbraco.Core/Configuration/Models/NuCacheSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/NuCacheSettings.cs
@@ -14,6 +14,7 @@ public class NuCacheSettings
     internal const string StaticNuCacheSerializerType = "MessagePack";
     internal const int StaticSqlPageSize = 1000;
     internal const int StaticKitBatchSize = 1;
+    internal const bool StaticUsePagedSqlQuery = true;
 
     /// <summary>
     ///     Gets or sets a value defining the BTree block size.
@@ -40,4 +41,10 @@ public class NuCacheSettings
     public int KitBatchSize { get; set; } = StaticKitBatchSize;
 
     public bool UnPublishedContentCompression { get; set; } = false;
+
+    [DefaultValue(StaticUsePagedSqlQuery)]
+    public bool UsePagedSqlQuery { get; set; } = true;
+
+
+
 }

--- a/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentRepository.cs
+++ b/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentRepository.cs
@@ -221,19 +221,12 @@ AND cmsContentNu.nodeId IS NULL
             .Append(SqlObjectTypeNotTrashed(SqlContext, Constants.ObjectTypes.Document))
             .Append(SqlOrderByLevelIdSortOrder(SqlContext));
 
-        // Use a more efficient COUNT query
-        Sql<ISqlContext>? sqlCountQuery = SqlContentSourcesCount()
-            .Append(SqlObjectTypeNotTrashed(SqlContext, Constants.ObjectTypes.Document));
-
-        Sql<ISqlContext>? sqlCount =
-            SqlContext.Sql("SELECT COUNT(*) FROM (").Append(sqlCountQuery).Append(") npoco_tbl");
-
         IContentCacheDataSerializer serializer =
             _contentCacheDataSerializerFactory.Create(ContentCacheDataSerializerEntityType.Document);
 
-        // We need to page here. We don't want to iterate over every single row in one connection cuz this can cause an SQL Timeout.
-        // We also want to read with a db reader and not load everything into memory, QueryPaged lets us do that.
-        foreach (ContentSourceDto row in Database.QueryPaged<ContentSourceDto>(_nucacheSettings.Value.SqlPageSize, sql, sqlCount))
+        IEnumerable<ContentSourceDto> dtos = GetContentNodeDtos(sql);
+
+        foreach (ContentSourceDto row in dtos)
         {
             yield return CreateContentNodeKit(row, serializer);
         }
@@ -246,19 +239,12 @@ AND cmsContentNu.nodeId IS NULL
             .Append(SqlWhereNodeIdX(SqlContext, id))
             .Append(SqlOrderByLevelIdSortOrder(SqlContext));
 
-        // Use a more efficient COUNT query
-        Sql<ISqlContext>? sqlCountQuery = SqlContentSourcesCount(SqlContentSourcesSelectUmbracoNodeJoin)
-            .Append(SqlObjectTypeNotTrashed(SqlContext, Constants.ObjectTypes.Document))
-            .Append(SqlWhereNodeIdX(SqlContext, id));
-        Sql<ISqlContext>? sqlCount =
-            SqlContext.Sql("SELECT COUNT(*) FROM (").Append(sqlCountQuery).Append(") npoco_tbl");
-
         IContentCacheDataSerializer serializer =
             _contentCacheDataSerializerFactory.Create(ContentCacheDataSerializerEntityType.Document);
 
-        // We need to page here. We don't want to iterate over every single row in one connection cuz this can cause an SQL Timeout.
-        // We also want to read with a db reader and not load everything into memory, QueryPaged lets us do that.
-        foreach (ContentSourceDto row in Database.QueryPaged<ContentSourceDto>(_nucacheSettings.Value.SqlPageSize, sql, sqlCount))
+        IEnumerable<ContentSourceDto> dtos = GetContentNodeDtos(sql);
+
+        foreach (ContentSourceDto row in dtos)
         {
             yield return CreateContentNodeKit(row, serializer);
         }
@@ -276,19 +262,12 @@ AND cmsContentNu.nodeId IS NULL
             .WhereIn<ContentDto>(x => x.ContentTypeId, ids)
             .Append(SqlOrderByLevelIdSortOrder(SqlContext));
 
-        // Use a more efficient COUNT query
-        Sql<ISqlContext> sqlCountQuery = SqlContentSourcesCount()
-            .Append(SqlObjectTypeNotTrashed(SqlContext, Constants.ObjectTypes.Document))
-            .WhereIn<ContentDto>(x => x.ContentTypeId, ids);
-        Sql<ISqlContext>? sqlCount =
-            SqlContext.Sql("SELECT COUNT(*) FROM (").Append(sqlCountQuery).Append(") npoco_tbl");
-
         IContentCacheDataSerializer serializer =
             _contentCacheDataSerializerFactory.Create(ContentCacheDataSerializerEntityType.Document);
 
-        // We need to page here. We don't want to iterate over every single row in one connection cuz this can cause an SQL Timeout.
-        // We also want to read with a db reader and not load everything into memory, QueryPaged lets us do that.
-        foreach (ContentSourceDto row in Database.QueryPaged<ContentSourceDto>(_nucacheSettings.Value.SqlPageSize, sql, sqlCount))
+        IEnumerable<ContentSourceDto> dtos = GetContentNodeDtos(sql);
+
+        foreach (ContentSourceDto row in dtos)
         {
             yield return CreateContentNodeKit(row, serializer);
         }
@@ -319,18 +298,12 @@ AND cmsContentNu.nodeId IS NULL
             .Append(SqlObjectTypeNotTrashed(SqlContext, Constants.ObjectTypes.Media))
             .Append(SqlOrderByLevelIdSortOrder(SqlContext));
 
-        // Use a more efficient COUNT query
-        Sql<ISqlContext>? sqlCountQuery = SqlMediaSourcesCount()
-            .Append(SqlObjectTypeNotTrashed(SqlContext, Constants.ObjectTypes.Media));
-        Sql<ISqlContext>? sqlCount =
-            SqlContext.Sql("SELECT COUNT(*) FROM (").Append(sqlCountQuery).Append(") npoco_tbl");
-
         IContentCacheDataSerializer serializer =
             _contentCacheDataSerializerFactory.Create(ContentCacheDataSerializerEntityType.Media);
 
-        // We need to page here. We don't want to iterate over every single row in one connection cuz this can cause an SQL Timeout.
-        // We also want to read with a db reader and not load everything into memory, QueryPaged lets us do that.
-        foreach (ContentSourceDto row in Database.QueryPaged<ContentSourceDto>(_nucacheSettings.Value.SqlPageSize, sql, sqlCount))
+        IEnumerable<ContentSourceDto> dtos = GetContentNodeDtos(sql);
+
+        foreach (ContentSourceDto row in dtos)
         {
             yield return CreateMediaNodeKit(row, serializer);
         }
@@ -343,19 +316,12 @@ AND cmsContentNu.nodeId IS NULL
             .Append(SqlWhereNodeIdX(SqlContext, id))
             .Append(SqlOrderByLevelIdSortOrder(SqlContext));
 
-        // Use a more efficient COUNT query
-        Sql<ISqlContext>? sqlCountQuery = SqlMediaSourcesCount(SqlContentSourcesSelectUmbracoNodeJoin)
-            .Append(SqlObjectTypeNotTrashed(SqlContext, Constants.ObjectTypes.Media))
-            .Append(SqlWhereNodeIdX(SqlContext, id));
-        Sql<ISqlContext>? sqlCount =
-            SqlContext.Sql("SELECT COUNT(*) FROM (").Append(sqlCountQuery).Append(") npoco_tbl");
-
         IContentCacheDataSerializer serializer =
             _contentCacheDataSerializerFactory.Create(ContentCacheDataSerializerEntityType.Media);
 
-        // We need to page here. We don't want to iterate over every single row in one connection cuz this can cause an SQL Timeout.
-        // We also want to read with a db reader and not load everything into memory, QueryPaged lets us do that.
-        foreach (ContentSourceDto row in Database.QueryPaged<ContentSourceDto>(_nucacheSettings.Value.SqlPageSize, sql, sqlCount))
+        IEnumerable<ContentSourceDto> dtos = GetContentNodeDtos(sql);
+
+        foreach (ContentSourceDto row in dtos)
         {
             yield return CreateMediaNodeKit(row, serializer);
         }
@@ -373,19 +339,12 @@ AND cmsContentNu.nodeId IS NULL
             .WhereIn<ContentDto>(x => x.ContentTypeId, ids)
             .Append(SqlOrderByLevelIdSortOrder(SqlContext));
 
-        // Use a more efficient COUNT query
-        Sql<ISqlContext> sqlCountQuery = SqlMediaSourcesCount()
-            .Append(SqlObjectTypeNotTrashed(SqlContext, Constants.ObjectTypes.Media))
-            .WhereIn<ContentDto>(x => x.ContentTypeId, ids);
-        Sql<ISqlContext>? sqlCount =
-            SqlContext.Sql("SELECT COUNT(*) FROM (").Append(sqlCountQuery).Append(") npoco_tbl");
-
         IContentCacheDataSerializer serializer =
             _contentCacheDataSerializerFactory.Create(ContentCacheDataSerializerEntityType.Media);
 
-        // We need to page here. We don't want to iterate over every single row in one connection cuz this can cause an SQL Timeout.
-        // We also want to read with a db reader and not load everything into memory, QueryPaged lets us do that.
-        foreach (ContentSourceDto row in Database.QueryPaged<ContentSourceDto>(_nucacheSettings.Value.SqlPageSize, sql, sqlCount))
+        IEnumerable<ContentSourceDto> dtos = GetContentNodeDtos(sql);
+
+        foreach (ContentSourceDto row in dtos)
         {
             yield return CreateMediaNodeKit(row, serializer);
         }
@@ -1029,5 +988,30 @@ WHERE cmsContentNu.nodeId IN (
         var s = new ContentNodeKit(n, dto.ContentTypeId, null, p);
 
         return s;
+    }
+
+    private IEnumerable<ContentSourceDto> GetContentNodeDtos(Sql<ISqlContext> sql)
+    {
+        // We need to page here. We don't want to iterate over every single row in one connection cuz this can cause an SQL Timeout.
+        // We also want to read with a db reader and not load everything into memory, QueryPaged lets us do that.
+        // QueryPaged is very slow on large sites however, so use fetch if UsePagedSqlQuery is disabled.
+        IEnumerable<ContentSourceDto> dtos;
+        if (_nucacheSettings.Value.UsePagedSqlQuery)
+        {
+            // Use a more efficient COUNT query
+            Sql<ISqlContext>? sqlCountQuery = SqlContentSourcesCount()
+                .Append(SqlObjectTypeNotTrashed(SqlContext, Constants.ObjectTypes.Document));
+
+            Sql<ISqlContext>? sqlCount =
+                SqlContext.Sql("SELECT COUNT(*) FROM (").Append(sqlCountQuery).Append(") npoco_tbl");
+
+            dtos = Database.QueryPaged<ContentSourceDto>(_nucacheSettings.Value.SqlPageSize, sql, sqlCount);
+        }
+        else
+        {
+            dtos = Database.Fetch<ContentSourceDto>(sql);
+        }
+
+        return dtos;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/13525

# Notes
- Implements a `UsePagedSqlQuery` in `NuCacheSettings`, that can now be set to `false`, to instead use `Fetch`
- Would love to use an `IOptionsMonitor` instead to track changes, but we cannot refactor this to be non-breaking (even with `ActivatorUtilitiesConstructor`), as the constructors will be ambiguous 😢

# How to test
- Set the `UsePagedSqlQuery` to false: 
```
  "Umbraco": {
    "CMS": {
      "NuCache": {
        "UsePagedSqlQuery" : false      },
```
- Assert that you can still create doc types & content, and it works as expected
- Go to the settings -> Profiling dashboard
- Assert that you can rebuild the memory cache.

You can even test the times by cherry picking this Profiling PR in: https://github.com/umbraco/Umbraco-CMS/pull/13841
and testing with the setting both set to false & true