### PR TITLE
Disabled nighly build branch trigger

### DIFF
--- a/build/nightly-build-trigger.yml
+++ b/build/nightly-build-trigger.yml
@@ -1,5 +1,7 @@
 name: Nightly_$(TeamProject)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 
+trigger: none
+
 schedules:
 - cron: '0 0 * * *'
   displayName: Daily midnight build


### PR DESCRIPTION
Not stating a trigger apparently triggers the pipeline on every commit 🙈 
https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#ci-triggers