### PR TITLE
fix: ensured that allowed user name characters are supported in backo…

### DIFF
--- a/src/Umbraco.Web.BackOffice/Security/ConfigureBackOfficeIdentityOptions.cs
+++ b/src/Umbraco.Web.BackOffice/Security/ConfigureBackOfficeIdentityOptions.cs
@@ -38,6 +38,8 @@ public sealed class ConfigureBackOfficeIdentityOptions : IConfigureOptions<BackO
         options.SignIn.RequireConfirmedPhoneNumber = false; // not implemented
 
         options.User.RequireUniqueEmail = true;
+        // Support validation of users names using Down-Level Logon Name format
+        options.User.AllowedUserNameCharacters = _securitySettings.AllowedUserNameCharacters;
 
         options.ClaimsIdentity.UserIdClaimType = ClaimTypes.NameIdentifier;
         options.ClaimsIdentity.UserNameClaimType = ClaimTypes.Name;


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
Partially fix: https://github.com/umbraco/Umbraco-CMS/issues/14808

Test steps:
1. set UsernameIsEmail to false
2. set AllowedUserNameCharacters to include space
3. create user with name containing a space in login
4. try to change password / unlock / disable user
5. you will get user correctly updated
