### PR TITLE
Fix `JsonNetSerializer` settings leaking into derived implementations

### DIFF
--- a/src/Umbraco.Infrastructure/Serialization/ConfigurationEditorJsonSerializer.cs
+++ b/src/Umbraco.Infrastructure/Serialization/ConfigurationEditorJsonSerializer.cs
@@ -10,10 +10,8 @@ public class ConfigurationEditorJsonSerializer : JsonNetSerializer, IConfigurati
 {
     public ConfigurationEditorJsonSerializer()
     {
-        JsonSerializerSettings.Converters.Add(new FuzzyBooleanConverter());
-        JsonSerializerSettings.ContractResolver = new ConfigurationCustomContractResolver();
-        JsonSerializerSettings.Formatting = Formatting.None;
-        JsonSerializerSettings.NullValueHandling = NullValueHandling.Ignore;
+        Settings.Converters.Add(new FuzzyBooleanConverter());
+        Settings.ContractResolver = new ConfigurationCustomContractResolver();
     }
 
     private class ConfigurationCustomContractResolver : DefaultContractResolver

--- a/src/Umbraco.Infrastructure/Serialization/JsonNetSerializer.cs
+++ b/src/Umbraco.Infrastructure/Serialization/JsonNetSerializer.cs
@@ -7,23 +7,20 @@ namespace Umbraco.Cms.Infrastructure.Serialization;
 
 public class JsonNetSerializer : IJsonSerializer
 {
-    protected JsonSerializerSettings JsonSerializerSettings { get; } = new()
+    protected JsonSerializerSettings Settings { get; } = new()
     {
         Converters = new List<JsonConverter> { new StringEnumConverter() },
         Formatting = Formatting.None,
         NullValueHandling = NullValueHandling.Ignore,
     };
 
-    public string Serialize(object? input) => JsonConvert.SerializeObject(input, JsonSerializerSettings);
+    public string Serialize(object? input) => JsonConvert.SerializeObject(input, Settings);
 
-    public T? Deserialize<T>(string input) => JsonConvert.DeserializeObject<T>(input, JsonSerializerSettings);
+    public T? Deserialize<T>(string input) => JsonConvert.DeserializeObject<T>(input, Settings);
 
     public T? DeserializeSubset<T>(string input, string key)
     {
-        if (key == null)
-        {
-            throw new ArgumentNullException(nameof(key));
-        }
+        ArgumentNullException.ThrowIfNull(key);
 
         JObject? root = Deserialize<JObject>(input);
         JToken? jToken = root?.SelectToken(key);

--- a/src/Umbraco.Infrastructure/Serialization/JsonNetSerializer.cs
+++ b/src/Umbraco.Infrastructure/Serialization/JsonNetSerializer.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Serialization;
 
 public class JsonNetSerializer : IJsonSerializer
 {
-    protected static readonly JsonSerializerSettings JsonSerializerSettings = new()
+    protected JsonSerializerSettings JsonSerializerSettings { get; } = new()
     {
         Converters = new List<JsonConverter> { new StringEnumConverter() },
         Formatting = Formatting.None,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
While working on a Deploy feature involving property/data editor configuration serialization, I noticed `ConfigurationEditorJsonSerializer` adds a converter and sets a custom contract resolver to the `JsonSerializerSettings` field:
https://github.com/umbraco/Umbraco-CMS/blob/f4e333c1782bcb7b614315db42a79702f67d328c/src/Umbraco.Infrastructure/Serialization/ConfigurationEditorJsonSerializer.cs#L9-L17

This class inherits from `JsonNetSerializer`, which defines this field as protected static:
https://github.com/umbraco/Umbraco-CMS/blob/f4e333c1782bcb7b614315db42a79702f67d328c/src/Umbraco.Infrastructure/Serialization/JsonNetSerializer.cs#L8-L15

So both `ConfigurationEditorJsonSerializer` and `JsonNetSerializer` share the same settings instance, resulting in weird side-effects like the `JsonNetSerializer` being able to deserialize/read fuzzy boolean values and reduced performance because of the added overhead of the custom contract resolver.

I've fixed this by changing the static field to an instance property (and renamed it to `Settings`). Because both are a breaking change, I've targeted this PR to v13.

Testing can be done by adding the following composer and setting breakpoints and inspecting the settings and/or commenting out the deserialize calls:
```c#
using Newtonsoft.Json;
using Umbraco.Cms.Core;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Serialization;
using Umbraco.Cms.Infrastructure.Serialization;

namespace Umbraco.Cms.Web.UI;

internal class JsonSerializerComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.AddComponent<JsonSerializerComponent>();
        builder.Services.AddSingleton<CustomJsonSerializer>();
    }

    private class JsonSerializerComponent : IComponent
    {
        private readonly IJsonSerializer _jsonSerializer;
        private readonly IConfigurationEditorJsonSerializer _configurationEditorJsonSerializer;
        private readonly CustomJsonSerializer _customJsonSerializer;

        public JsonSerializerComponent(IJsonSerializer jsonSerializer, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer, CustomJsonSerializer customJsonSerializer)
        {
            _jsonSerializer = jsonSerializer;
            _configurationEditorJsonSerializer = configurationEditorJsonSerializer;
            _customJsonSerializer = customJsonSerializer;
        }

        public void Initialize()
        {
            var enumPayload = """{ "Enum": "Run" }""";
            var fuzzyPayload = """{ "Boolean": "yes" }""";

            // These should all succeed
            _jsonSerializer.Deserialize<TestPoco>(enumPayload);
            _configurationEditorJsonSerializer.Deserialize<TestPoco>(enumPayload);
            _configurationEditorJsonSerializer.Deserialize<TestPoco>(fuzzyPayload);

            // And these should fail
            _jsonSerializer.Deserialize<TestPoco>(fuzzyPayload); // Should not have FuzzyBooleanConverter
            _customJsonSerializer.Deserialize<TestPoco>(enumPayload); // Should not have StringEnumConverter
            _customJsonSerializer.Deserialize<TestPoco>(fuzzyPayload); // Should not have FuzzyBooleanConverter
        }

        public void Terminate()
        { }

        private class TestPoco
        {
            public bool Boolean { get; set; }
            public RuntimeLevel Enum { get; set; }
        }
    }

    private class CustomJsonSerializer : JsonNetSerializer
    {
        public CustomJsonSerializer()
            => Settings.Converters.Clear();
    }
}
```` 