### PR TITLE
Backport fix for `JsonNetSerializer` settings leaking into derived implementations

### DIFF
--- a/src/Umbraco.Infrastructure/Serialization/ConfigurationEditorJsonSerializer.cs
+++ b/src/Umbraco.Infrastructure/Serialization/ConfigurationEditorJsonSerializer.cs
@@ -10,10 +10,8 @@ public class ConfigurationEditorJsonSerializer : JsonNetSerializer, IConfigurati
 {
     public ConfigurationEditorJsonSerializer()
     {
-        JsonSerializerSettings.Converters.Add(new FuzzyBooleanConverter());
-        JsonSerializerSettings.ContractResolver = new ConfigurationCustomContractResolver();
-        JsonSerializerSettings.Formatting = Formatting.None;
-        JsonSerializerSettings.NullValueHandling = NullValueHandling.Ignore;
+        Settings.Converters.Add(new FuzzyBooleanConverter());
+        Settings.ContractResolver = new ConfigurationCustomContractResolver();
     }
 
     private class ConfigurationCustomContractResolver : DefaultContractResolver

--- a/src/Umbraco.Infrastructure/Serialization/JsonNetSerializer.cs
+++ b/src/Umbraco.Infrastructure/Serialization/JsonNetSerializer.cs
@@ -7,23 +7,23 @@ namespace Umbraco.Cms.Infrastructure.Serialization;
 
 public class JsonNetSerializer : IJsonSerializer
 {
-    protected static readonly JsonSerializerSettings JsonSerializerSettings = new()
+    [Obsolete("This is a static field and shared between derived implementations. Use the Settings instance property instead. This field will be removed in v13.")]
+    protected static readonly JsonSerializerSettings JsonSerializerSettings = new();
+
+    protected JsonSerializerSettings Settings { get; } = new()
     {
         Converters = new List<JsonConverter> { new StringEnumConverter() },
         Formatting = Formatting.None,
         NullValueHandling = NullValueHandling.Ignore,
     };
 
-    public string Serialize(object? input) => JsonConvert.SerializeObject(input, JsonSerializerSettings);
+    public string Serialize(object? input) => JsonConvert.SerializeObject(input, Settings);
 
-    public T? Deserialize<T>(string input) => JsonConvert.DeserializeObject<T>(input, JsonSerializerSettings);
+    public T? Deserialize<T>(string input) => JsonConvert.DeserializeObject<T>(input, Settings);
 
     public T? DeserializeSubset<T>(string input, string key)
     {
-        if (key == null)
-        {
-            throw new ArgumentNullException(nameof(key));
-        }
+        ArgumentNullException.ThrowIfNull(key);
 
         JObject? root = Deserialize<JObject>(input);
         JToken? jToken = root?.SelectToken(key);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This is a backport of PR https://github.com/umbraco/Umbraco-CMS/pull/14814, but obsoletes the protected static field to avoid a binary breaking change. This is still a functional breaking change, since derived implementations will need to update their code to change the `Settings` property instead. Updating the `JsonSerializerSettings` field won't have any effect anymore, but since those changes leaked into other implementations and should be avoided anyway.

Since I don't believe a lot of users will create derived implementations, this seems to be a sensible trade-off.

Testing can be done the same way as in the linked PR and if both get merged, we have a workaround/fix for v9-v12 and correct fix/cleanup in v13...