### PR TITLE
Remove duplicate name attribute in 2FA login form

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/login-2fa.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/login-2fa.controller.js
@@ -1,6 +1,7 @@
-﻿angular.module("umbraco").controller("Umbraco.Login2faController",
+angular.module("umbraco").controller("Umbraco.Login2faController",
   function ($scope, userService, authResource) {
-    let vm = this;
+    const vm = this;
+
     vm.code = "";
     vm.provider = "";
     vm.providers = [];

--- a/src/Umbraco.Web.UI.Client/src/views/common/login-2fa.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/login-2fa.html
@@ -1,6 +1,6 @@
-﻿<div ng-controller="Umbraco.Login2faController as cvm" class="umb-login-container">
+<div ng-controller="Umbraco.Login2faController as vm" class="umb-login-container">
   <div id="twoFactorlogin" ng-cloak="">
-    <form name="cvm.authForm" method="POST" name="twoFactorCodeForm" ng-submit="cvm.validate()">
+    <form name="vm.authForm" method="POST" ng-submit="vm.validate()">
       <header class="h4">
         <localize key="login_2fatitle">One last step</localize>
       </header>
@@ -12,21 +12,19 @@
       <br>
 
       <!-- if there's only one provider active, it will skip this step! -->
-      <umb-control-group ng-if="cvm.providers.length > 1" label="@login_2faMultipleText" label-for="provider"
-        alias="2faprovider">
-        <select id="2faprovider" name="provider" ng-model="cvm.provider">
-          <option ng-repeat="provider in cvm.providers" ng-value="provider">{{provider}}</option>
+      <umb-control-group ng-if="vm.providers.length > 1" label="@login_2faMultipleText" label-for="provider" alias="2faprovider">
+        <select id="2faprovider" name="provider" ng-model="vm.provider">
+          <option ng-repeat="provider in vm.providers" ng-value="provider">{{provider}}</option>
         </select>
       </umb-control-group>
 
-      <umb-control-group label-for="token" alias="2facode" label="@login_2faCodeInput"
-        description="@user_2faDisableText" required="true">
+      <umb-control-group label-for="token" alias="2facode" label="@login_2faCodeInput" description="@user_2faDisableText" required="true">
 
-        <input umb-auto-focus id="2facode" class="-full-width-input input-xlarge" type="text" name="token"
-          inputmode="numeric" autocomplete="one-time-code" ng-model="cvm.code" localize="placeholder"
-          placeholder="@login_2faCodeInputHelp" aria-required="true" required no-dirty-check />
+        <input type="text" id="2facode" class="-full-width-input input-xlarge" name="token"
+          inputmode="numeric" autocomplete="one-time-code" ng-model="vm.code" localize="placeholder"
+          placeholder="@login_2faCodeInputHelp" aria-required="true" required umb-auto-focus no-dirty-check />
 
-        <div ng-messages="cvm.authForm.token.$error" role="alert">
+        <div ng-messages="vm.authForm.token.$error" role="alert">
           <span class="umb-validation-label" ng-message="token">
             <localize key="login_2faInvalidCode">Invalid code entered</localize>
           </span>
@@ -34,9 +32,19 @@
       </umb-control-group>
 
       <div class="flex justify-between items-center">
-        <umb-button button-style="success" size="m" label-key="general_validate" state="cvm.stateValidateButton"
-          type="submit" disabled="cvm.code.length === 0"></umb-button>
-        <umb-button size="m" label-key="general_back" type="button" action="cvm.goBack()">
+        <umb-button
+          type="submit"
+          button-style="success"
+          size="m"
+          label-key="general_validate"
+          state="vm.stateValidateButton"
+          disabled="vm.code.length === 0">
+        </umb-button>
+        <umb-button
+          type="button"
+          size="m"
+          label-key="general_back"
+          action="vm.goBack()">
         </umb-button>
       </div>
     </form>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
- Remove duplicate `name` attribute in 2FA login form.
- Use `vm` instead as reference instead of `cvm` to be consistent with other views.
- Define `vm` as `const` instead of `let` as another value isn't assigned - only to it's properties.