### PR TITLE
Updated locator for the acceptance test 'Preview draft'

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/content.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/content.spec.ts
@@ -275,7 +275,7 @@ test.describe('Content tests', () => {
     await umbracoUi.clickElement(umbracoUi.getTreeItem(ConstantHelper.sections.content, [initialNodeName]));
 
     const header = await page.locator('#headerName')
-    // Sadly playwright doesn't have a clear method for inputs :( 
+    // Sadly playwright doesn't have a clear method for inputs :(
     // so we have to triple click to select all, and then hit backspace...
     await header.click({ clickCount: 3 })
     await page.keyboard.press('Backspace');
@@ -381,12 +381,9 @@ test.describe('Content tests', () => {
 
     // Clean up (content is automatically deleted when document types are gone)
     await umbracoApi.documentTypes.ensureNameNotExists(rootDocTypeName);
-  });  
+  });
 
   test('Preview draft', async ({ page, umbracoApi, umbracoUi }) => {
-
-    
-
     await umbracoApi.content.deleteAllContent();
     await umbracoApi.documentTypes.ensureNameNotExists(rootDocTypeName);
 
@@ -415,13 +412,13 @@ test.describe('Content tests', () => {
     await umbracoUi.clickElement(umbracoUi.getTreeItem(ConstantHelper.sections.content, [homeNodeName]));
 
     // Assert
-    await expect(page.locator('[alias="preview"]')).toBeVisible();
-    await page.locator('[alias="preview"]').click();
+    await expect(page.locator('[data-element="button-preview"]')).toBeVisible();
+    await page.locator('[data-element="button-preview"]').click();
     await umbracoUi.isSuccessNotificationVisible();
 
     // Clean up (content is automatically deleted when document types are gone)
     await umbracoApi.documentTypes.ensureNameNotExists(rootDocTypeName);
-  });  
+  });
 
   test('Publish draft', async ({ page, umbracoApi, umbracoUi }) => {
 
@@ -548,7 +545,7 @@ test.describe('Content tests', () => {
     await umbracoUi.clickElement(umbracoUi.getButtonByLabelKey(ConstantHelper.buttons.saveAndPublish));
     // Added additional time because it could fail on pipeline because it's not saving fast enough
     await umbracoUi.isSuccessNotificationVisible({timeout:20000});
-    
+
     // Assert
     const expectedContent = '<p>Acceptance test</p>'
     await expect(await umbracoApi.content.verifyRenderedContent('/contentpickercontent', expectedContent, true)).toBeTruthy();


### PR DESCRIPTION
Updated locator for the acceptance test 'Preview draft'
Moved from using the alias to data-element. 