### PR TITLE
Add support for member type container

### DIFF
--- a/src/Umbraco.Core/Constants-Icons.cs
+++ b/src/Umbraco.Core/Constants-Icons.cs
@@ -5,62 +5,62 @@ public static partial class Constants
     public static class Icons
     {
         /// <summary>
-        ///     System default icon
+        ///     System default icon.
         /// </summary>
         public const string DefaultIcon = Content;
 
         /// <summary>
-        ///     System blueprint icon
+        ///     System blueprint icon.
         /// </summary>
         public const string Blueprint = "icon-blueprint";
 
         /// <summary>
-        ///     System content icon
+        ///     System content icon.
         /// </summary>
         public const string Content = "icon-document";
 
         /// <summary>
-        ///     System content type icon
+        ///     System content type icon.
         /// </summary>
         public const string ContentType = "icon-item-arrangement";
 
         /// <summary>
-        ///     System data type icon
+        ///     System data type icon.
         /// </summary>
         public const string DataType = "icon-autofill";
 
         /// <summary>
-        ///     System dictionary icon
+        ///     System dictionary icon.
         /// </summary>
         public const string Dictionary = "icon-book-alt";
 
         /// <summary>
-        ///     System generic folder icon
+        ///     System generic folder icon.
         /// </summary>
         public const string Folder = "icon-folder";
 
         /// <summary>
-        ///     System language icon
+        ///     System language icon.
         /// </summary>
         public const string Language = "icon-globe";
 
         /// <summary>
-        ///     System logviewer icon
+        ///     System logviewer icon.
         /// </summary>
         public const string LogViewer = "icon-box-alt";
 
         /// <summary>
-        ///     System list view icon
+        ///     System list view icon.
         /// </summary>
         public const string ListView = "icon-thumbnail-list";
 
         /// <summary>
-        ///     System macro icon
+        ///     System macro icon.
         /// </summary>
         public const string Macro = "icon-settings-alt";
 
         /// <summary>
-        ///     System media file icon
+        ///     System media file icon.
         /// </summary>
         public const string MediaFile = "icon-document";
 
@@ -70,92 +70,92 @@ public static partial class Constants
         public const string MediaVideo = "icon-video";
 
         /// <summary>
-        ///     System media audio icon
+        ///     System media audio icon.
         /// </summary>
         public const string MediaAudio = "icon-sound-waves";
 
         /// <summary>
-        ///     System media article icon
+        ///     System media article icon.
         /// </summary>
         public const string MediaArticle = "icon-article";
 
         /// <summary>
-        ///     System media vector icon
+        ///     System media vector icon.
         /// </summary>
         public const string MediaVectorGraphics = "icon-picture";
 
         /// <summary>
-        ///     System media folder icon
+        ///     System media folder icon.
         /// </summary>
         public const string MediaFolder = "icon-folder";
 
         /// <summary>
-        ///     System media image icon
+        ///     System media image icon.
         /// </summary>
         public const string MediaImage = "icon-picture";
 
         /// <summary>
-        ///     System media type icon
+        ///     System media type icon.
         /// </summary>
         public const string MediaType = "icon-thumbnails";
 
         /// <summary>
-        ///     System member icon
+        ///     System member icon.
         /// </summary>
         public const string Member = "icon-user";
 
         /// <summary>
-        ///     System member group icon
+        ///     System member group icon.
         /// </summary>
         public const string MemberGroup = "icon-users-alt";
 
         /// <summary>
-        ///     System member type icon
+        ///     System member type icon.
         /// </summary>
         public const string MemberType = "icon-users";
 
         /// <summary>
-        ///     System packages icon
+        ///     System packages icon.
         /// </summary>
         public const string Packages = "icon-box";
 
         /// <summary>
-        ///     System property editor icon
+        ///     System property editor icon.
         /// </summary>
         public const string PartialView = "icon-article";
 
         /// <summary>
-        ///     System property editor icon
+        ///     System property editor icon.
         /// </summary>
         public const string PropertyEditor = "icon-autofill";
 
         /// <summary>
-        ///     Relation type icon
+        ///     Relation type icon.
         /// </summary>
         public const string RelationType = "icon-trafic";
 
         /// <summary>
-        ///     Script type icon
+        ///     Script type icon.
         /// </summary>
         public const string Script = "icon-script";
 
         /// <summary>
-        ///     Stylesheet type icon
+        ///     Stylesheet type icon.
         /// </summary>
         public const string Stylesheet = "icon-brackets";
 
         /// <summary>
-        ///     System member icon
+        ///     System member icon.
         /// </summary>
         public const string Template = "icon-layout";
 
         /// <summary>
-        ///     System user icon
+        ///     System user icon.
         /// </summary>
         public const string User = "icon-user";
 
         /// <summary>
-        ///     System user group icon
+        ///     System user group icon.
         /// </summary>
         public const string UserGroup = "icon-users";
     }

--- a/src/Umbraco.Core/Constants-ObjectTypes.cs
+++ b/src/Umbraco.Core/Constants-ObjectTypes.cs
@@ -73,6 +73,8 @@ public static partial class Constants
 
             public const string MediaTypeContainer = "42AEF799-B288-4744-9B10-BE144B73CDC4";
 
+            public const string MemberTypeContainer = "59EF5767-7223-4ABC-B229-72821DC711B9";
+
             public const string ContentItem = "10E2B09F-C28B-476D-B77A-AA686435E44A";
 
             public const string ContentItemType = "7A333C54-6F43-40A4-86A2-18688DC7E532";

--- a/src/Umbraco.Core/Constants-ObjectTypes.cs
+++ b/src/Umbraco.Core/Constants-ObjectTypes.cs
@@ -19,6 +19,8 @@ public static partial class Constants
 
         public static readonly Guid MediaTypeContainer = new(Strings.MediaTypeContainer);
 
+        public static readonly Guid MemberTypeContainer = new(Strings.MemberTypeContainer);
+
         public static readonly Guid DataType = new(Strings.DataType);
 
         public static readonly Guid Document = new(Strings.Document);

--- a/src/Umbraco.Core/Constants-UdiEntityType.cs
+++ b/src/Umbraco.Core/Constants-UdiEntityType.cs
@@ -37,11 +37,15 @@ public static partial class Constants
 
         // TODO: What is this? This alias is only used for the blue print tree to render the blueprint's document type, it's not a real udi type
         public const string DocumentTypeBluePrints = "document-type-blueprints";
+
         public const string MediaType = "media-type";
         public const string MediaTypeContainer = "media-type-container";
+
         public const string DataType = "data-type";
         public const string DataTypeContainer = "data-type-container";
+
         public const string MemberType = "member-type";
+        public const string MemberTypeContainer = "member-type-container";
         public const string MemberGroup = "member-group";
 
         public const string RelationType = "relation-type";

--- a/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
@@ -344,6 +344,8 @@
     <key alias="allMembers">Alle medlemmer</key>
     <key alias="memberGroupNoProperties">Medlemgrupper har ingen yderligere egenskaber til redigering.</key>
     <key alias="2fa">Totrinsbekræftelse</key>
+    <key alias="createFolderFailed">Oprettelse af mappen under parent med id %0% fejlede</key>
+    <key alias="renameFolderFailed">Omdøbning af mappen med id %0% fejlede</key>
   </area>
   <area alias="contentType">
     <key alias="copyFailed">Kopiering af indholdstypen fejlede</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -349,6 +349,8 @@
     <key alias="allMembers">All Members</key>
     <key alias="memberGroupNoProperties">Member groups have no additional properties for editing.</key>
     <key alias="2fa">Two-Factor Authentication</key>
+    <key alias="createFolderFailed">Failed to create a folder under parent id %0%</key>
+    <key alias="renameFolderFailed">Failed to rename the folder with id %0%</key>
   </area>
   <area alias="contentType">
     <key alias="copyFailed">Failed to copy content type</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -365,6 +365,8 @@
     <key alias="memberLockoutNotEnabled">Lockout is not enabled for this member</key>
     <key alias="memberNotInGroup">The member is not in group '%0%'</key>
     <key alias="2fa">Two-Factor Authentication</key>
+    <key alias="createFolderFailed">Failed to create a folder under parent id %0%</key>
+    <key alias="renameFolderFailed">Failed to rename the folder with id %0%</key>
   </area>
   <area alias="contentType">
     <key alias="copyFailed">Failed to copy content type</key>

--- a/src/Umbraco.Core/Extensions/UdiGetterExtensions.cs
+++ b/src/Umbraco.Core/Extensions/UdiGetterExtensions.cs
@@ -162,6 +162,10 @@ public static class UdiGetterExtensions
         {
             entityType = Constants.UdiEntityType.MediaTypeContainer;
         }
+        else if (entity.ContainedObjectType == Constants.ObjectTypes.MemberType)
+        {
+            entityType = Constants.UdiEntityType.MemberTypeContainer;
+        }
         else
         {
             throw new NotSupportedException(string.Format(

--- a/src/Umbraco.Core/Models/EntityContainer.cs
+++ b/src/Umbraco.Core/Models/EntityContainer.cs
@@ -12,6 +12,7 @@ public sealed class EntityContainer : TreeEntityBase, IUmbracoEntity
         { Constants.ObjectTypes.DataType, Constants.ObjectTypes.DataTypeContainer },
         { Constants.ObjectTypes.DocumentType, Constants.ObjectTypes.DocumentTypeContainer },
         { Constants.ObjectTypes.MediaType, Constants.ObjectTypes.MediaTypeContainer },
+        { Constants.ObjectTypes.MemberType, Constants.ObjectTypes.MemberTypeContainer },
     };
 
     /// <summary>

--- a/src/Umbraco.Core/Models/UmbracoObjectTypes.cs
+++ b/src/Umbraco.Core/Models/UmbracoObjectTypes.cs
@@ -8,19 +8,19 @@ namespace Umbraco.Cms.Core.Models;
 public enum UmbracoObjectTypes
 {
     /// <summary>
-    ///     Default value
+    ///     Default value.
     /// </summary>
     Unknown,
 
     /// <summary>
-    ///     Root
+    ///     Root.
     /// </summary>
     [UmbracoObjectType(Constants.ObjectTypes.Strings.SystemRoot)]
     [FriendlyName("Root")]
     ROOT,
 
     /// <summary>
-    ///     Document
+    ///     Document.
     /// </summary>
     [UmbracoObjectType(Constants.ObjectTypes.Strings.Document, typeof(IContent))]
     [FriendlyName("Document")]
@@ -28,7 +28,7 @@ public enum UmbracoObjectTypes
     Document,
 
     /// <summary>
-    ///     Media
+    ///     Media.
     /// </summary>
     [UmbracoObjectType(Constants.ObjectTypes.Strings.Media, typeof(IMedia))]
     [FriendlyName("Media")]
@@ -36,7 +36,7 @@ public enum UmbracoObjectTypes
     Media,
 
     /// <summary>
-    ///     Member Type
+    ///     Member Type.
     /// </summary>
     [UmbracoObjectType(Constants.ObjectTypes.Strings.MemberType, typeof(IMemberType))]
     [FriendlyName("Member Type")]
@@ -44,7 +44,7 @@ public enum UmbracoObjectTypes
     MemberType,
 
     /// <summary>
-    ///     Template
+    ///     Template.
     /// </summary>
     [UmbracoObjectType(Constants.ObjectTypes.Strings.Template, typeof(ITemplate))]
     [FriendlyName("Template")]
@@ -52,7 +52,7 @@ public enum UmbracoObjectTypes
     Template,
 
     /// <summary>
-    ///     Member Group
+    ///     Member Group.
     /// </summary>
     [UmbracoObjectType(Constants.ObjectTypes.Strings.MemberGroup, typeof(IMemberGroup))]
     [FriendlyName("Member Group")]
@@ -60,7 +60,7 @@ public enum UmbracoObjectTypes
     MemberGroup,
 
     /// <summary>
-    ///     "Media Type
+    ///     "Media Type.
     /// </summary>
     [UmbracoObjectType(Constants.ObjectTypes.Strings.MediaType, typeof(IMediaType))]
     [FriendlyName("Media Type")]
@@ -68,7 +68,7 @@ public enum UmbracoObjectTypes
     MediaType,
 
     /// <summary>
-    ///     Document Type
+    ///     Document Type.
     /// </summary>
     [UmbracoObjectType(Constants.ObjectTypes.Strings.DocumentType, typeof(IContentType))]
     [FriendlyName("Document Type")]
@@ -76,14 +76,14 @@ public enum UmbracoObjectTypes
     DocumentType,
 
     /// <summary>
-    ///     Recycle Bin
+    ///     Recycle Bin.
     /// </summary>
     [UmbracoObjectType(Constants.ObjectTypes.Strings.ContentRecycleBin)]
     [FriendlyName("Recycle Bin")]
     RecycleBin,
 
     /// <summary>
-    ///     Member
+    ///     Member.
     /// </summary>
     [UmbracoObjectType(Constants.ObjectTypes.Strings.Member, typeof(IMember))]
     [FriendlyName("Member")]
@@ -91,7 +91,7 @@ public enum UmbracoObjectTypes
     Member,
 
     /// <summary>
-    ///     Data Type
+    ///     Data Type.
     /// </summary>
     [UmbracoObjectType(Constants.ObjectTypes.Strings.DataType, typeof(IDataType))]
     [FriendlyName("Data Type")]
@@ -99,7 +99,7 @@ public enum UmbracoObjectTypes
     DataType,
 
     /// <summary>
-    ///     Document type container
+    ///     Document type container.
     /// </summary>
     [UmbracoObjectType(Constants.ObjectTypes.Strings.DocumentTypeContainer)]
     [FriendlyName("Document Type Container")]
@@ -107,7 +107,7 @@ public enum UmbracoObjectTypes
     DocumentTypeContainer,
 
     /// <summary>
-    ///     Media type container
+    ///     Media type container.
     /// </summary>
     [UmbracoObjectType(Constants.ObjectTypes.Strings.MediaTypeContainer)]
     [FriendlyName("Media Type Container")]
@@ -115,7 +115,15 @@ public enum UmbracoObjectTypes
     MediaTypeContainer,
 
     /// <summary>
-    ///     Media type container
+    ///     Member type container.
+    /// </summary>
+    [UmbracoObjectType(Constants.ObjectTypes.Strings.MemberTypeContainer)]
+    [FriendlyName("Member Type Container")]
+    [UmbracoUdiType(Constants.UdiEntityType.MemberTypeContainer)]
+    MemberTypeContainer,
+
+    /// <summary>
+    ///     Media type container.
     /// </summary>
     [UmbracoObjectType(Constants.ObjectTypes.Strings.DataTypeContainer)]
     [FriendlyName("Data Type Container")]
@@ -123,7 +131,7 @@ public enum UmbracoObjectTypes
     DataTypeContainer,
 
     /// <summary>
-    ///     Relation type
+    ///     Relation type.
     /// </summary>
     [UmbracoObjectType(Constants.ObjectTypes.Strings.RelationType)]
     [FriendlyName("Relation Type")]
@@ -131,35 +139,35 @@ public enum UmbracoObjectTypes
     RelationType,
 
     /// <summary>
-    ///     Forms Form
+    ///     Forms Form.
     /// </summary>
     [UmbracoObjectType(Constants.ObjectTypes.Strings.FormsForm)]
     [FriendlyName("Form")]
     FormsForm,
 
     /// <summary>
-    ///     Forms PreValue
+    ///     Forms PreValue.
     /// </summary>
     [UmbracoObjectType(Constants.ObjectTypes.Strings.FormsPreValue)]
     [FriendlyName("PreValue")]
     FormsPreValue,
 
     /// <summary>
-    ///     Forms DataSource
+    ///     Forms DataSource.
     /// </summary>
     [UmbracoObjectType(Constants.ObjectTypes.Strings.FormsDataSource)]
     [FriendlyName("DataSource")]
     FormsDataSource,
 
     /// <summary>
-    ///     Language
+    ///     Language.
     /// </summary>
     [UmbracoObjectType(Constants.ObjectTypes.Strings.Language)]
     [FriendlyName("Language")]
     Language,
 
     /// <summary>
-    ///     Document Blueprint
+    ///     Document Blueprint.
     /// </summary>
     [UmbracoObjectType(Constants.ObjectTypes.Strings.DocumentBlueprint, typeof(IContent))]
     [FriendlyName("DocumentBlueprint")]
@@ -167,7 +175,7 @@ public enum UmbracoObjectTypes
     DocumentBlueprint,
 
     /// <summary>
-    ///     Reserved Identifier
+    ///     Reserved Identifier.
     /// </summary>
     [UmbracoObjectType(Constants.ObjectTypes.Strings.IdReservation)]
     [FriendlyName("Identifier Reservation")]

--- a/src/Umbraco.Core/UdiEntityTypeHelper.cs
+++ b/src/Umbraco.Core/UdiEntityTypeHelper.cs
@@ -32,6 +32,8 @@ public static class UdiEntityTypeHelper
                 return Constants.UdiEntityType.DataTypeContainer;
             case UmbracoObjectTypes.MemberType:
                 return Constants.UdiEntityType.MemberType;
+            case UmbracoObjectTypes.MemberTypeContainer:
+                return Constants.UdiEntityType.MemberTypeContainer;
             case UmbracoObjectTypes.MemberGroup:
                 return Constants.UdiEntityType.MemberGroup;
             case UmbracoObjectTypes.RelationType:
@@ -78,6 +80,8 @@ public static class UdiEntityTypeHelper
                 return UmbracoObjectTypes.DataTypeContainer;
             case Constants.UdiEntityType.MemberType:
                 return UmbracoObjectTypes.MemberType;
+            case Constants.UdiEntityType.MemberTypeContainer:
+                return UmbracoObjectTypes.MemberTypeContainer;
             case Constants.UdiEntityType.MemberGroup:
                 return UmbracoObjectTypes.MemberGroup;
             case Constants.UdiEntityType.RelationType:

--- a/src/Umbraco.Core/UdiParser.cs
+++ b/src/Umbraco.Core/UdiParser.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 
@@ -217,6 +217,7 @@ public sealed class UdiParser
             { Constants.UdiEntityType.DataType, UdiType.GuidUdi },
             { Constants.UdiEntityType.DataTypeContainer, UdiType.GuidUdi },
             { Constants.UdiEntityType.MemberType, UdiType.GuidUdi },
+            { Constants.UdiEntityType.MemberTypeContainer, UdiType.GuidUdi },
             { Constants.UdiEntityType.MemberGroup, UdiType.GuidUdi },
             { Constants.UdiEntityType.RelationType, UdiType.GuidUdi },
             { Constants.UdiEntityType.FormsForm, UdiType.GuidUdi },

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityContainerRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityContainerRepository.cs
@@ -22,10 +22,14 @@ internal class EntityContainerRepository : EntityRepositoryBase<int, EntityConta
     {
         Guid[] allowedContainers =
         {
-            Constants.ObjectTypes.DocumentTypeContainer, Constants.ObjectTypes.MediaTypeContainer,
+            Constants.ObjectTypes.DocumentTypeContainer,
+            Constants.ObjectTypes.MediaTypeContainer,
+            Constants.ObjectTypes.MemberTypeContainer,
             Constants.ObjectTypes.DataTypeContainer,
         };
+
         NodeObjectTypeId = containerObjectType;
+
         if (allowedContainers.Contains(NodeObjectTypeId) == false)
         {
             throw new InvalidOperationException("No container type exists with ID: " + NodeObjectTypeId);

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberTypeContainerRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberTypeContainerRepository.cs
@@ -1,31 +1,16 @@
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Infrastructure.Scoping;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
 {
-    /// <summary>
-    /// A no-op implementation of <see cref="IMemberTypeContainerRepository"/>, as containers aren't supported for members.
-    /// </summary>
-    /// <remarks>
-    /// Introduced to avoid inconsistencies with nullability of dependencies for type repositories for content, media and members.
-    /// </remarks>
-    internal class MemberTypeContainerRepository : IMemberTypeContainerRepository
+    internal class MemberTypeContainerRepository : EntityContainerRepository, IMemberTypeContainerRepository
     {
-        public void Delete(EntityContainer entity)
-        {
-        }
-
-        public bool Exists(int id) => false;
-
-        public EntityContainer? Get(Guid id) => null;
-
-        public IEnumerable<EntityContainer> Get(string name, int level) => Enumerable.Empty<EntityContainer>();
-
-        public EntityContainer? Get(int id) => null;
-
-        public IEnumerable<EntityContainer> GetMany(params int[]? ids) => Enumerable.Empty<EntityContainer>();
-
-        public void Save(EntityContainer entity)
+        public MemberTypeContainerRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<MemberTypeContainerRepository> logger)
+            : base(scopeAccessor, cache, logger, Constants.ObjectTypes.MemberTypeContainer)
         {
         }
     }

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentTypeController.cs
@@ -369,7 +369,7 @@ public class ContentTypeController : ContentTypeControllerBase<IContentType>
     }
 
     /// <summary>
-    ///     Deletes a document type container with a given ID
+    ///     Deletes a document type container with a given ID.
     /// </summary>
     [HttpDelete]
     [HttpPost]

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentTypeController.cs
@@ -458,7 +458,7 @@ public class ContentTypeController : ContentTypeControllerBase<IContentType>
                 }
             });
 
-        if (!(savedCt.Result is null))
+        if (savedCt.Result is not null)
         {
             return savedCt.Result;
         }

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentTypeController.cs
@@ -628,7 +628,7 @@ public class ContentTypeController : ContentTypeControllerBase<IContentType>
     }
 
     /// <summary>
-    ///     Move the content type
+    ///     Move the content type.
     /// </summary>
     /// <param name="move"></param>
     /// <returns></returns>
@@ -640,7 +640,7 @@ public class ContentTypeController : ContentTypeControllerBase<IContentType>
             (type, i) => _contentTypeService.Move(type, i));
 
     /// <summary>
-    ///     Copy the content type
+    ///     Copy the content type.
     /// </summary>
     /// <param name="copy"></param>
     /// <returns></returns>

--- a/src/Umbraco.Web.BackOffice/Controllers/MediaTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MediaTypeController.cs
@@ -272,7 +272,7 @@ public class MediaTypeController : ContentTypeControllerBase<IMediaType>
             .Select(_umbracoMapper.Map<IMediaType, ContentTypeBasic>).WhereNotNull();
 
     /// <summary>
-    ///     Deletes a media type container with a given ID
+    ///     Deletes a media type container with a given ID.
     /// </summary>
     /// <param name="id"></param>
     /// <returns></returns>

--- a/src/Umbraco.Web.BackOffice/Controllers/MediaTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MediaTypeController.cs
@@ -262,9 +262,8 @@ public class MediaTypeController : ContentTypeControllerBase<IMediaType>
         return dto;
     }
 
-
     /// <summary>
-    ///     Returns all media types
+    ///     Returns all media types.
     /// </summary>
     [Authorize(Policy = AuthorizationPolicies.TreeAccessMediaTypes)]
     public IEnumerable<ContentTypeBasic> GetAll() =>

--- a/src/Umbraco.Web.BackOffice/Controllers/MediaTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MediaTypeController.cs
@@ -322,13 +322,12 @@ public class MediaTypeController : ContentTypeControllerBase<IMediaType>
             i => _mediaTypeService.Get(i),
             type => _mediaTypeService.Save(type));
 
-        if (!(savedCt.Result is null))
+        if (savedCt.Result is not null)
         {
             return savedCt.Result;
         }
 
         MediaTypeDisplay? display = _umbracoMapper.Map<MediaTypeDisplay>(savedCt.Value);
-
 
         display?.AddSuccessNotification(
             _localizedTextService.Localize("speechBubbles", "mediaTypeSavedHeader"),

--- a/src/Umbraco.Web.BackOffice/Controllers/MediaTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MediaTypeController.cs
@@ -338,7 +338,7 @@ public class MediaTypeController : ContentTypeControllerBase<IMediaType>
     }
 
     /// <summary>
-    ///     Move the media type
+    ///     Move the media type.
     /// </summary>
     /// <param name="move"></param>
     /// <returns></returns>
@@ -350,7 +350,7 @@ public class MediaTypeController : ContentTypeControllerBase<IMediaType>
             (type, i) => _mediaTypeService.Move(type, i));
 
     /// <summary>
-    ///     Copy the media type
+    ///     Copy the media type.
     /// </summary>
     /// <param name="copy"></param>
     /// <returns></returns>

--- a/src/Umbraco.Web.BackOffice/Controllers/MemberTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MemberTypeController.cs
@@ -313,7 +313,19 @@ public class MemberTypeController : ContentTypeControllerBase<IMemberType>
     }
 
     /// <summary>
-    ///     Copy the member type
+    ///     Move the member type.
+    /// </summary>
+    /// <param name="move"></param>
+    /// <returns></returns>
+    [Authorize(Policy = AuthorizationPolicies.TreeAccessMemberTypes)]
+    public IActionResult PostMove(MoveOrCopy move) =>
+        PerformMove(
+            move,
+            i => _memberTypeService.Get(i),
+            (type, i) => _memberTypeService.Move(type, i));
+
+    /// <summary>
+    ///     Copy the member type.
     /// </summary>
     /// <param name="copy"></param>
     /// <returns></returns>

--- a/src/Umbraco.Web.BackOffice/Controllers/MemberTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MemberTypeController.cs
@@ -200,6 +200,50 @@ public class MemberTypeController : ContentTypeControllerBase<IMemberType>
         return dto;
     }
 
+    /// <summary>
+    ///     Deletes a member type container with a given ID.
+    /// </summary>
+    /// <param name="id"></param>
+    /// <returns></returns>
+    [HttpDelete]
+    [HttpPost]
+    [Authorize(Policy = AuthorizationPolicies.TreeAccessMemberTypes)]
+    public IActionResult DeleteContainer(int id)
+    {
+        _memberTypeService.DeleteContainer(id, _backofficeSecurityAccessor.BackOfficeSecurity?.CurrentUser?.Id ?? -1);
+
+        return Ok();
+    }
+
+    [Authorize(Policy = AuthorizationPolicies.TreeAccessMemberTypes)]
+    public IActionResult PostCreateContainer(int parentId, string name)
+    {
+        Attempt<OperationResult<OperationResultType, EntityContainer>?> result =
+            _memberTypeService.CreateContainer(parentId, Guid.NewGuid(), name, _backofficeSecurityAccessor.BackOfficeSecurity?.CurrentUser?.Id ?? -1);
+
+        if (result.Success)
+        {
+            return Ok(result.Result); //return the id
+        }
+
+        return ValidationProblem(result.Exception?.Message);
+    }
+
+    [Authorize(Policy = AuthorizationPolicies.TreeAccessMemberTypes)]
+    public IActionResult PostRenameContainer(int id, string name)
+    {
+        Attempt<OperationResult<OperationResultType, EntityContainer>?> result =
+            _memberTypeService.RenameContainer(id, name, _backofficeSecurityAccessor.BackOfficeSecurity?.CurrentUser?.Id ?? -1);
+
+        if (result.Success)
+        {
+            return Ok(result.Result); //return the id
+        }
+
+        return ValidationProblem(result.Exception?.Message);
+    }
+
+    [Authorize(Policy = AuthorizationPolicies.TreeAccessMemberTypes)]
     public ActionResult<MemberTypeDisplay?> PostSave(MemberTypeSave contentTypeSave)
     {
         //get the persisted member type

--- a/src/Umbraco.Web.BackOffice/Controllers/MemberTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MemberTypeController.cs
@@ -189,14 +189,36 @@ public class MemberTypeController : ContentTypeControllerBase<IMemberType>
         return Ok(result);
     }
 
-    public MemberTypeDisplay? GetEmpty()
-    {
-        var ct = new MemberType(_shortStringHelper, -1)
-        {
-            Icon = Constants.Icons.Member
-        };
+    //public MemberTypeDisplay? GetEmpty()
+    //{
+    //    var ct = new MemberType(_shortStringHelper, -1)
+    //    {
+    //        Icon = Constants.Icons.Member
+    //    };
 
-        MemberTypeDisplay? dto = _umbracoMapper.Map<IMemberType, MemberTypeDisplay>(ct);
+    //    MemberTypeDisplay? dto = _umbracoMapper.Map<IMemberType, MemberTypeDisplay>(ct);
+    //    return dto;
+    //}
+
+    [Authorize(Policy = AuthorizationPolicies.TreeAccessMemberTypes)]
+    public MemberTypeDisplay? GetEmpty(int parentId)
+    {
+        IMemberType mt;
+        if (parentId != Constants.System.Root)
+        {
+            IMemberType? parent = _memberTypeService.Get(parentId);
+            mt = parent != null
+                ? new MemberType(_shortStringHelper, parent, string.Empty)
+                : new MemberType(_shortStringHelper, parentId);
+        }
+        else
+        {
+            mt = new MemberType(_shortStringHelper, parentId);
+        }
+
+        mt.Icon = Constants.Icons.Member;
+
+        MemberTypeDisplay? dto = _umbracoMapper.Map<IMemberType, MemberTypeDisplay>(mt);
         return dto;
     }
 

--- a/src/Umbraco.Web.BackOffice/Controllers/MemberTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MemberTypeController.cs
@@ -291,11 +291,10 @@ public class MemberTypeController : ContentTypeControllerBase<IMemberType>
             }
         }
 
-        ActionResult<IMemberType?> savedCt =
-            PerformPostSave<MemberTypeDisplay, MemberTypeSave, MemberPropertyTypeBasic>(
-                contentTypeSave,
-                i => ct,
-                type => _memberTypeService.Save(type));
+        ActionResult<IMemberType?> savedCt = PerformPostSave<MemberTypeDisplay, MemberTypeSave, MemberPropertyTypeBasic>(
+            contentTypeSave,
+            i => _memberTypeService.Get(i),
+            type => _memberTypeService.Save(type));
 
         if (savedCt.Result is not null)
         {

--- a/src/Umbraco.Web.BackOffice/Controllers/MemberTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MemberTypeController.cs
@@ -291,14 +291,13 @@ public class MemberTypeController : ContentTypeControllerBase<IMemberType>
             }
         }
 
-
         ActionResult<IMemberType?> savedCt =
             PerformPostSave<MemberTypeDisplay, MemberTypeSave, MemberPropertyTypeBasic>(
                 contentTypeSave,
                 i => ct,
                 type => _memberTypeService.Save(type));
 
-        if (!(savedCt.Result is null))
+        if (savedCt.Result is not null)
         {
             return savedCt.Result;
         }

--- a/src/Umbraco.Web.BackOffice/Trees/ContentTypeTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/ContentTypeTreeController.cs
@@ -154,7 +154,7 @@ public class ContentTypeTreeController : TreeController, ISearchableTree
         IEntitySlim? container = _entityService.Get(int.Parse(id, CultureInfo.InvariantCulture), UmbracoObjectTypes.DocumentTypeContainer);
         if (container != null)
         {
-            //set the default to create
+            // set the default to create
             menu.DefaultMenuAlias = ActionNew.ActionAlias;
 
             menu.Items.Add<ActionNew>(LocalizedTextService, opensDialog: true, useLegacyIcon: false);
@@ -167,7 +167,7 @@ public class ContentTypeTreeController : TreeController, ISearchableTree
 
             if (container.HasChildren == false)
             {
-                //can delete doc type
+                // can delete doc type
                 menu.Items.Add<ActionDelete>(LocalizedTextService, hasSeparator: true, opensDialog: true, useLegacyIcon: false);
             }
 

--- a/src/Umbraco.Web.BackOffice/Trees/ContentTypeTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/ContentTypeTreeController.cs
@@ -54,7 +54,8 @@ public class ContentTypeTreeController : TreeController, ISearchableTree
     protected override ActionResult<TreeNode?> CreateRootNode(FormCollection queryStrings)
     {
         ActionResult<TreeNode?> rootResult = base.CreateRootNode(queryStrings);
-        if (!(rootResult.Result is null))
+
+        if (rootResult.Result is not null)
         {
             return rootResult;
         }
@@ -133,7 +134,7 @@ public class ContentTypeTreeController : TreeController, ISearchableTree
 
         if (id == Constants.System.RootString)
         {
-                //set the default to create
+            // set the default to create
             menu.DefaultMenuAlias = ActionNew.ActionAlias;
 
             // root actions
@@ -167,7 +168,7 @@ public class ContentTypeTreeController : TreeController, ISearchableTree
 
             if (container.HasChildren == false)
             {
-                // can delete doc type
+                // can delete document type
                 menu.Items.Add<ActionDelete>(LocalizedTextService, hasSeparator: true, opensDialog: true, useLegacyIcon: false);
             }
 

--- a/src/Umbraco.Web.BackOffice/Trees/DataTypeTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/DataTypeTreeController.cs
@@ -66,10 +66,10 @@ public class DataTypeTreeController : TreeController, ISearchableTree
                 .OrderBy(entity => entity.Name)
                 .Select(dt =>
                 {
-                    TreeNode node = CreateTreeNode(dt, Constants.ObjectTypes.DataType, id, queryStrings,
-                        Constants.Icons.Folder, dt.HasChildren);
+                    TreeNode node = CreateTreeNode(dt, Constants.ObjectTypes.DataType, id, queryStrings, Constants.Icons.Folder, dt.HasChildren);
                     node.Path = dt.Path;
                     node.NodeType = "container";
+
                     // TODO: This isn't the best way to ensure a no operation process for clicking a node but it works for now.
                     node.AdditionalData["jsClickCallback"] = "javascript:void(0);";
                     return node;
@@ -93,8 +93,7 @@ public class DataTypeTreeController : TreeController, ISearchableTree
                 .Select(dt =>
                 {
                     IDataType dataType = dataTypes[dt.Id];
-                    TreeNode node = CreateTreeNode(dt.Id.ToInvariantString(), id, queryStrings, dt.Name,
-                        dataType.Editor?.Icon, false);
+                    TreeNode node = CreateTreeNode(dt.Id.ToInvariantString(), id, queryStrings, dt.Name, dataType.Editor?.Icon, false);
                     node.Path = dt.Path;
                     return node;
                 })
@@ -140,7 +139,7 @@ public class DataTypeTreeController : TreeController, ISearchableTree
 
         if (id == Constants.System.RootString)
         {
-            //set the default to create
+            // set the default to create
             menu.DefaultMenuAlias = ActionNew.ActionAlias;
 
             // root actions
@@ -153,7 +152,7 @@ public class DataTypeTreeController : TreeController, ISearchableTree
             UmbracoObjectTypes.DataTypeContainer);
         if (container != null)
         {
-                //set the default to create
+            // set the default to create
             menu.DefaultMenuAlias = ActionNew.ActionAlias;
 
             menu.Items.Add<ActionNew>(LocalizedTextService, opensDialog: true, useLegacyIcon: false);

--- a/src/Umbraco.Web.BackOffice/Trees/MediaTypeTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/MediaTypeTreeController.cs
@@ -113,6 +113,7 @@ public class MediaTypeTreeController : TreeController, ISearchableTree
             // root actions
             menu.Items.Add<ActionNew>(LocalizedTextService, opensDialog: true, useLegacyIcon: false);
             menu.Items.Add(new RefreshNode(LocalizedTextService, true));
+
             return menu;
         }
 
@@ -133,7 +134,7 @@ public class MediaTypeTreeController : TreeController, ISearchableTree
 
             if (container.HasChildren == false)
             {
-                // can delete doc type
+                // can delete media type
                     menu.Items.Add<ActionDelete>(LocalizedTextService, opensDialog: true, useLegacyIcon: false);
             }
 

--- a/src/Umbraco.Web.BackOffice/Trees/MediaTypeTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/MediaTypeTreeController.cs
@@ -91,8 +91,7 @@ public class MediaTypeTreeController : TreeController, ISearchableTree
                     // need this check to keep supporting sites where children have already been created.
                     var hasChildren = dt.HasChildren;
                     IMediaType? mt = mediaTypes.FirstOrDefault(x => x.Id == dt.Id);
-                    TreeNode node = CreateTreeNode(dt, Constants.ObjectTypes.MediaType, id, queryStrings,
-                        mt?.Icon ?? Constants.Icons.MediaType, hasChildren);
+                    TreeNode node = CreateTreeNode(dt, Constants.ObjectTypes.MediaType, id, queryStrings, mt?.Icon ?? Constants.Icons.MediaType, hasChildren);
 
                     node.Path = dt.Path;
                     return node;

--- a/src/Umbraco.Web.BackOffice/Trees/MediaTypeTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/MediaTypeTreeController.cs
@@ -119,6 +119,7 @@ public class MediaTypeTreeController : TreeController, ISearchableTree
 
         IEntitySlim? container = _entityService.Get(int.Parse(id, CultureInfo.InvariantCulture),
             UmbracoObjectTypes.MediaTypeContainer);
+
         if (container != null)
         {
             // set the default to create
@@ -147,7 +148,7 @@ public class MediaTypeTreeController : TreeController, ISearchableTree
 
             menu.Items.Add<ActionNew>(LocalizedTextService, opensDialog: true, useLegacyIcon: false);
 
-            // no move action if this is a child doc type
+            // no move action if this is a child media type
             if (parent == null)
             {
                 menu.Items.Add<ActionMove>(LocalizedTextService, hasSeparator: true, opensDialog: true, useLegacyIcon: false);

--- a/src/Umbraco.Web.BackOffice/Trees/MediaTypeTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/MediaTypeTreeController.cs
@@ -136,7 +136,7 @@ public class MediaTypeTreeController : TreeController, ISearchableTree
             if (container.HasChildren == false)
             {
                 // can delete media type
-                    menu.Items.Add<ActionDelete>(LocalizedTextService, opensDialog: true, useLegacyIcon: false);
+                menu.Items.Add<ActionDelete>(LocalizedTextService, opensDialog: true, useLegacyIcon: false);
             }
 
             menu.Items.Add(new RefreshNode(LocalizedTextService, separatorBefore: true));

--- a/src/Umbraco.Web.BackOffice/Trees/MediaTypeTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/MediaTypeTreeController.cs
@@ -64,10 +64,10 @@ public class MediaTypeTreeController : TreeController, ISearchableTree
                 .OrderBy(entity => entity.Name)
                 .Select(dt =>
                 {
-                    TreeNode node = CreateTreeNode(dt.Id.ToString(), id, queryStrings, dt.Name, Constants.Icons.Folder,
-                        dt.HasChildren, "");
+                    TreeNode node = CreateTreeNode(dt.Id.ToString(), id, queryStrings, dt.Name, Constants.Icons.Folder, dt.HasChildren, string.Empty);
                     node.Path = dt.Path;
                     node.NodeType = "container";
+
                     // TODO: This isn't the best way to ensure a no operation process for clicking a node but it works for now.
                     node.AdditionalData["jsClickCallback"] = "javascript:void(0);";
                     return node;

--- a/src/Umbraco.Web.BackOffice/Trees/MemberGroupTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/MemberGroupTreeController.cs
@@ -57,7 +57,8 @@ public class MemberGroupTreeController : MemberTypeAndGroupTreeControllerBase
     protected override ActionResult<TreeNode?> CreateRootNode(FormCollection queryStrings)
     {
         ActionResult<TreeNode?> rootResult = base.CreateRootNode(queryStrings);
-        if (!(rootResult.Result is null))
+
+        if (rootResult.Result is not null)
         {
             return rootResult.Result;
         }

--- a/src/Umbraco.Web.BackOffice/Trees/MemberTypeAndGroupTreeControllerBase.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/MemberTypeAndGroupTreeControllerBase.cs
@@ -148,12 +148,14 @@ public abstract class MemberTypeAndGroupTreeControllerBase : TreeController
                 {
                     menu.Items.Add<ActionMove>(LocalizedTextService, hasSeparator: true, opensDialog: true, useLegacyIcon: false);
                     menu.Items.Add<ActionCopy>(LocalizedTextService, opensDialog: true, useLegacyIcon: false);
+                    menu.Items.Add<ActionDelete>(LocalizedTextService, opensDialog: true, useLegacyIcon: false);
                 }
             }
         }
-
-        // delete member type/group
-        menu.Items.Add<ActionDelete>(LocalizedTextService, opensDialog: true, useLegacyIcon: false);
+        else
+        {
+            menu.Items.Add<ActionDelete>(LocalizedTextService, opensDialog: true, useLegacyIcon: false);
+        }
 
         return menu;
     }

--- a/src/Umbraco.Web.BackOffice/Trees/MemberTypeAndGroupTreeControllerBase.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/MemberTypeAndGroupTreeControllerBase.cs
@@ -114,11 +114,10 @@ public abstract class MemberTypeAndGroupTreeControllerBase : TreeController
             return menu;
         }
 
-        IMemberType? memberType = _memberTypeService.Get(int.Parse(id));
-        if (memberType != null)
+        if (queryStrings["tree"].ToString() == Constants.Trees.MemberTypes)
         {
             IEntitySlim? container = _entityService.Get(int.Parse(id, CultureInfo.InvariantCulture),
-            UmbracoObjectTypes.MemberTypeContainer);
+                UmbracoObjectTypes.MemberTypeContainer);
 
             if (container != null)
             {
@@ -143,7 +142,13 @@ public abstract class MemberTypeAndGroupTreeControllerBase : TreeController
             }
             else
             {
-                menu.Items.Add<ActionCopy>(LocalizedTextService, opensDialog: true, useLegacyIcon: false);
+                IMemberType? ct = _memberTypeService.Get(int.Parse(id));
+
+                if (ct != null)
+                {
+                    menu.Items.Add<ActionMove>(LocalizedTextService, hasSeparator: true, opensDialog: true, useLegacyIcon: false);
+                    menu.Items.Add<ActionCopy>(LocalizedTextService, opensDialog: true, useLegacyIcon: false);
+                }
             }
         }
 

--- a/src/Umbraco.Web.BackOffice/Trees/MemberTypeAndGroupTreeControllerBase.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/MemberTypeAndGroupTreeControllerBase.cs
@@ -68,10 +68,10 @@ public abstract class MemberTypeAndGroupTreeControllerBase : TreeController
                 .OrderBy(entity => entity.Name)
                 .Select(dt =>
                 {
-                    TreeNode node = CreateTreeNode(dt.Id.ToString(), id, queryStrings, dt.Name, Constants.Icons.Folder,
-                        dt.HasChildren, "");
+                    TreeNode node = CreateTreeNode(dt.Id.ToString(), id, queryStrings, dt.Name, Constants.Icons.Folder, dt.HasChildren, string.Empty);
                     node.Path = dt.Path;
                     node.NodeType = "container";
+
                     // TODO: This isn't the best way to ensure a no operation process for clicking a node but it works for now.
                     node.AdditionalData["jsClickCallback"] = "javascript:void(0);";
                     return node;

--- a/src/Umbraco.Web.BackOffice/Trees/MemberTypeAndGroupTreeControllerBase.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/MemberTypeAndGroupTreeControllerBase.cs
@@ -14,6 +14,7 @@ using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Trees;
 using Umbraco.Cms.Web.Common.Attributes;
 using Umbraco.Extensions;
+using static Umbraco.Cms.Core.Constants.Conventions;
 
 namespace Umbraco.Cms.Web.BackOffice.Trees;
 
@@ -85,7 +86,30 @@ public abstract class MemberTypeAndGroupTreeControllerBase : TreeController
             return nodes;
         }
 
-        nodes.AddRange(GetTreeNodesFromService(id, queryStrings));
+        if (queryStrings["tree"].ToString() == Constants.Trees.MemberTypes)
+        {
+            IEnumerable<IMemberType> memberTypes = _memberTypeService.GetAll();
+
+            nodes.AddRange(
+                _entityService.GetChildren(intId, UmbracoObjectTypes.MemberType)
+                    .OrderBy(entity => entity.Name)
+                    .Select(dt =>
+                    {
+                        var hasChildren = dt.HasChildren;
+                        IMemberType? mt = memberTypes.FirstOrDefault(x => x.Id == dt.Id);
+                        TreeNode node = CreateTreeNode(dt, Constants.ObjectTypes.MemberType, id, queryStrings, mt?.Icon ?? Constants.Icons.MemberType, hasChildren);
+
+                        node.Path = dt.Path;
+                        return node;
+                    }));
+
+            //nodes.AddRange(GetTreeNodesFromService(id, queryStrings));
+        }
+        else
+        {
+            nodes.AddRange(GetTreeNodesFromService(id, queryStrings));
+        }
+
         return nodes;
     }
 

--- a/src/Umbraco.Web.BackOffice/Trees/MemberTypeAndGroupTreeControllerBase.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/MemberTypeAndGroupTreeControllerBase.cs
@@ -61,7 +61,9 @@ public abstract class MemberTypeAndGroupTreeControllerBase : TreeController
 
         var nodes = new TreeNodeCollection();
 
-        nodes.AddRange(
+        if (queryStrings["tree"].ToString() == Constants.Trees.MemberTypes)
+        {
+            nodes.AddRange(
             _entityService.GetChildren(intId, UmbracoObjectTypes.MemberTypeContainer)
                 .OrderBy(entity => entity.Name)
                 .Select(dt =>
@@ -74,6 +76,7 @@ public abstract class MemberTypeAndGroupTreeControllerBase : TreeController
                     node.AdditionalData["jsClickCallback"] = "javascript:void(0);";
                     return node;
                 }));
+        }
 
         // if the request is for folders only then just return
         if (queryStrings["foldersonly"].ToString().IsNullOrWhiteSpace() == false &&

--- a/src/Umbraco.Web.BackOffice/Trees/MemberTypeTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/MemberTypeTreeController.cs
@@ -67,6 +67,5 @@ public class MemberTypeTreeController : MemberTypeAndGroupTreeControllerBase, IS
     protected override IEnumerable<TreeNode> GetTreeNodesFromService(string id, FormCollection queryStrings) =>
         _memberTypeService.GetAll()
             .OrderBy(x => x.Name)
-            .Select(dt => CreateTreeNode(dt, Constants.ObjectTypes.MemberType, id, queryStrings,
-                dt?.Icon ?? Constants.Icons.MemberType, false));
+            .Select(dt => CreateTreeNode(dt, Constants.ObjectTypes.MemberType, id, queryStrings, dt?.Icon ?? Constants.Icons.MemberType, false));
 }

--- a/src/Umbraco.Web.UI.Client/src/common/resources/contenttype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/contenttype.resource.js
@@ -323,7 +323,7 @@ function contentTypeResource($q, $http, umbRequestHelper, umbDataFormatter, loca
                         "contentTypeApiBaseUrl",
                         "DeleteContainer",
                         [{ id: id }])),
-                'Failed to delete content type contaier');
+                'Failed to delete content type container');
         },
 
         /**

--- a/src/Umbraco.Web.UI.Client/src/common/resources/mediatype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/mediatype.resource.js
@@ -208,7 +208,7 @@ function mediaTypeResource($q, $http, umbRequestHelper, umbDataFormatter, locali
          *    });
          * </pre>
          * @param {Object} args arguments object
-         * @param {Int} args.idd the ID of the node to move
+         * @param {Int} args.id the ID of the node to move
          * @param {Int} args.parentId the ID of the parent node to move to
          * @returns {Promise} resourcePromise object.
          *

--- a/src/Umbraco.Web.UI.Client/src/common/resources/mediatype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/mediatype.resource.js
@@ -166,7 +166,7 @@ function mediaTypeResource($q, $http, umbRequestHelper, umbDataFormatter, locali
                        "mediaTypeApiBaseUrl",
                        "DeleteContainer",
                        [{ id: id }])),
-               'Failed to delete content type contaier');
+               'Failed to delete media type container');
         },
 
         /**

--- a/src/Umbraco.Web.UI.Client/src/common/resources/membertype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/membertype.resource.js
@@ -90,6 +90,17 @@ function memberTypeResource($q, $http, umbRequestHelper, umbDataFormatter, local
                'Failed to delete member type');
         },
 
+        deleteContainerById: function (id) {
+
+            return umbRequestHelper.resourcePromise(
+               $http.post(
+                   umbRequestHelper.getApiUrl(
+                       "memberTypeApiBaseUrl",
+                       "DeleteContainer",
+                       [{ id: id }])),
+               'Failed to delete member type container');
+        },
+
         getScaffold: function () {
 
             return umbRequestHelper.resourcePromise(
@@ -141,6 +152,32 @@ function memberTypeResource($q, $http, umbRequestHelper, umbDataFormatter, local
                         id: args.id
                     }, { responseType: 'text' }),
                 promise);
+        },
+
+        createContainer: function (parentId, name) {
+
+          var promise = localizationService.localize("member_createFolderFailed", [parentId]);
+
+          return umbRequestHelper.resourcePromise(
+            $http.post(
+              umbRequestHelper.getApiUrl(
+                "memberTypeApiBaseUrl",
+                "PostCreateContainer",
+                { parentId: parentId, name: encodeURIComponent(name) })),
+            promise);
+        },
+
+        renameContainer: function (id, name) {
+
+          var promise = localizationService.localize("member_renameFolderFailed", [id]);
+
+          return umbRequestHelper.resourcePromise(
+            $http.post(umbRequestHelper.getApiUrl("memberTypeApiBaseUrl",
+              "PostRenameContainer",
+              { id: id, name: name })),
+            promise
+          );
+
         }
     };
 }

--- a/src/Umbraco.Web.UI.Client/src/common/resources/membertype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/membertype.resource.js
@@ -103,7 +103,7 @@ function memberTypeResource($q, $http, umbRequestHelper, umbDataFormatter, local
 
         getScaffold: function (parentId) {
 
-            // For backwards compatibility.
+            // For backwards compatibility since parentId parameter has been added.
             parentId = parentId ?? -1;
 
             return umbRequestHelper.resourcePromise(

--- a/src/Umbraco.Web.UI.Client/src/common/resources/membertype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/membertype.resource.js
@@ -153,7 +153,7 @@ function memberTypeResource($q, $http, umbRequestHelper, umbDataFormatter, local
          *    });
          * </pre>
          * @param {Object} args arguments object
-         * @param {Int} args.idd the ID of the node to move
+         * @param {Int} args.id the ID of the node to move
          * @param {Int} args.parentId the ID of the parent node to move to
          * @returns {Promise} resourcePromise object.
          *

--- a/src/Umbraco.Web.UI.Client/src/common/resources/membertype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/membertype.resource.js
@@ -132,6 +132,49 @@ function memberTypeResource($q, $http, umbRequestHelper, umbDataFormatter, local
                 'Failed to save data for member type id ' + contentType.id);
         },
 
+        /**
+         * @ngdoc method
+         * @name umbraco.resources.memberTypeResource#move
+         * @methodOf umbraco.resources.memberTypeResource
+         *
+         * @description
+         * Moves a node underneath a new parentId
+         *
+         * ##usage
+         * <pre>
+         * memberTypeResource.move({ parentId: 1244, id: 123 })
+         *    .then(function() {
+         *        alert("node was moved");
+         *    }, function(err){
+         *      alert("node didnt move:" + err.data.Message);
+         *    });
+         * </pre>
+         * @param {Object} args arguments object
+         * @param {Int} args.idd the ID of the node to move
+         * @param {Int} args.parentId the ID of the parent node to move to
+         * @returns {Promise} resourcePromise object.
+         *
+         */
+        move: function (args) {
+            if (!args) {
+                throw "args cannot be null";
+            }
+            if (!args.parentId) {
+                throw "args.parentId cannot be null";
+            }
+            if (!args.id) {
+                throw "args.id cannot be null";
+            }
+
+            return umbRequestHelper.resourcePromise(
+                $http.post(umbRequestHelper.getApiUrl("memberTypeApiBaseUrl", "PostMove"),
+                    {
+                        parentId: args.parentId,
+                        id: args.id
+                    }, { responseType: 'text' }),
+                'Failed to move member type');
+        },
+
         copy: function (args) {
             if (!args) {
                 throw "args cannot be null";

--- a/src/Umbraco.Web.UI.Client/src/common/resources/membertype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/membertype.resource.js
@@ -103,6 +103,9 @@ function memberTypeResource($q, $http, umbRequestHelper, umbDataFormatter, local
 
         getScaffold: function (parentId) {
 
+            // For backwards compatibility.
+            parentId = parentId ?? -1;
+
             return umbRequestHelper.resourcePromise(
                $http.get(
                    umbRequestHelper.getApiUrl(

--- a/src/Umbraco.Web.UI.Client/src/common/resources/membertype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/membertype.resource.js
@@ -101,13 +101,13 @@ function memberTypeResource($q, $http, umbRequestHelper, umbDataFormatter, local
                'Failed to delete member type container');
         },
 
-        getScaffold: function () {
+        getScaffold: function (parentId) {
 
             return umbRequestHelper.resourcePromise(
                $http.get(
                    umbRequestHelper.getApiUrl(
                        "memberTypeApiBaseUrl",
-                       "GetEmpty")),
+                       "GetEmpty", { parentId: parentId })),
                'Failed to retrieve content type scaffold');
         },
 

--- a/src/Umbraco.Web.UI.Client/src/views/documentTypes/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documentTypes/delete.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for deleting content
  */
-function DocumentTypesDeleteController($scope, dataTypeResource, contentTypeResource, treeService, navigationService, localizationService) {
+function DocumentTypesDeleteController($scope, contentTypeResource, treeService, navigationService, localizationService) {
 
     $scope.performDelete = function() {
 
@@ -51,7 +51,7 @@ function DocumentTypesDeleteController($scope, dataTypeResource, contentTypeReso
     $scope.labels = {};
     localizationService
         .format(["contentTypeEditor_yesDelete", "contentTypeEditor_andAllDocuments"], "%0% " + $scope.currentNode.name + " %1%")
-        .then(function (data) {
+        .then(data => {
             $scope.labels.deleteConfirm = data;
         });
 }

--- a/src/Umbraco.Web.UI.Client/src/views/documentTypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documentTypes/edit.controller.js
@@ -200,11 +200,10 @@
 
                             vm.page.saveButtonState = "busy";
 
-                            localizationService.localize("modelsBuilder_buildingModels").then(function (headerValue) {
-                                localizationService.localize("modelsBuilder_waitingMessage").then(function (msgValue) {
-                                    notificationsService.info(headerValue, msgValue);
-                                });
-                            });
+                            localizationService.localizeMany(["modelsBuilder_buildingModels", "modelsBuilder_waitingMessage"])
+                              .then(values => {
+                                notificationsService.info(values[0], values[1]);
+                              });
 
                             contentTypeHelper.generateModels().then(function (result) {
 

--- a/src/Umbraco.Web.UI.Client/src/views/documentTypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documentTypes/edit.controller.js
@@ -364,10 +364,9 @@
                         editorState.set($scope.content);
                     }
                     else {
-                        localizationService.localize("speechBubbles_validationFailedHeader").then(function (headerValue) {
-                            localizationService.localize("speechBubbles_validationFailedMessage").then(function (msgValue) {
-                                notificationsService.error(headerValue, msgValue);
-                            });
+                      localizationService.localizeMany(["speechBubbles_validationFailedHeader", "speechBubbles_validationFailedMessage"])
+                        .then(values => {
+                            notificationsService.error(values[0], values[1]);
                         });
                     }
                     vm.page.saveButtonState = "error";

--- a/src/Umbraco.Web.UI.Client/src/views/documentTypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documentTypes/edit.controller.js
@@ -404,7 +404,7 @@
             // convert icons for content type
             convertLegacyIcons(contentType);
 
-            //set a shared state
+            // set a shared state
             editorState.set(contentType);
 
             vm.contentType = contentType;

--- a/src/Umbraco.Web.UI.Client/src/views/documentTypes/move.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/documentTypes/move.controller.js
@@ -1,6 +1,6 @@
 angular.module("umbraco")
 .controller("Umbraco.Editors.DocumentTypes.MoveController",
-    function ($scope, contentTypeResource, treeService, navigationService, notificationsService, appState, eventsService) {
+    function ($scope, contentTypeResource, treeService, navigationService, appState, eventsService) {
 
         $scope.dialogTreeApi = {};
         $scope.source = _.clone($scope.currentNode);

--- a/src/Umbraco.Web.UI.Client/src/views/mediaTypes/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediaTypes/create.controller.js
@@ -9,8 +9,9 @@
 function MediaTypesCreateController($scope, $location, navigationService, mediaTypeResource, formHelper, appState) {
 
     $scope.model = {
-        folderName: "",
-        creatingFolder: false
+      allowCreateFolder: $scope.currentNode.parentId === null || $scope.currentNode.nodeType === 'container',
+      folderName: "",
+      creatingFolder: false
     };
 
     var node = $scope.currentNode;

--- a/src/Umbraco.Web.UI.Client/src/views/mediaTypes/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediaTypes/create.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for the media type creation dialog
  */
-function MediaTypesCreateController($scope, $location, navigationService, mediaTypeResource, formHelper, appState, localizationService) {
+function MediaTypesCreateController($scope, $location, navigationService, mediaTypeResource, formHelper, appState) {
 
     $scope.model = {
         folderName: "",
@@ -14,6 +14,7 @@ function MediaTypesCreateController($scope, $location, navigationService, mediaT
     };
 
     var node = $scope.currentNode;
+    var section = appState.getSectionState("currentSection");
 
     $scope.showCreateFolder = function() {
         $scope.model.creatingFolder = true;
@@ -32,9 +33,7 @@ function MediaTypesCreateController($scope, $location, navigationService, mediaT
 
                 formHelper.resetForm({ scope: $scope, formCtrl: $scope.createFolderForm });
 
-                var section = appState.getSectionState("currentSection");
-
-            }, function (err) {
+            }, function(err) {
                 formHelper.resetForm({ scope: $scope, formCtrl: $scope.createFolderForm, hasErrors: true });
                 $scope.error = err;
             });
@@ -43,7 +42,7 @@ function MediaTypesCreateController($scope, $location, navigationService, mediaT
 
     $scope.createMediaType = function() {
         $location.search('create', null);
-        $location.path("/settings/mediaTypes/edit/" + node.id).search("create", "true");
+        $location.path("/" + section + "/mediaTypes/edit/" + node.id).search("create", "true");
         navigationService.hideMenu();
     };
 

--- a/src/Umbraco.Web.UI.Client/src/views/mediaTypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediaTypes/create.html
@@ -22,7 +22,9 @@
           <li data-element="action-folder" class="umb-action" ng-if="model.allowCreateFolder">
             <button type="button" class="umb-action-link umb-outline btn-reset" ng-click="showCreateFolder()">
               <umb-icon class="icon large" icon="icon-folder"></umb-icon>
-              <span class="menu-label"><localize key="general_folder">Folder</localize>...</span>
+              <span class="menu-label">
+                <localize key="general_folder">Folder</localize>
+              </span>
             </button>
           </li>
         </ul>

--- a/src/Umbraco.Web.UI.Client/src/views/mediaTypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediaTypes/create.html
@@ -15,9 +15,9 @@
                     umb-auto-focus>
               <umb-icon class="icon large" icon="icon-item-arrangement"></umb-icon>
               <span class="menu-label">
-                                <localize key="general_new">New</localize>
-                                <localize key="content_mediatype">Media type</localize>
-                            </span>
+                  <localize key="general_new">New</localize>
+                  <localize key="content_mediatype">Media type</localize>
+              </span>
             </button>
           </li>
           <li class="umb-action">

--- a/src/Umbraco.Web.UI.Client/src/views/mediaTypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediaTypes/create.html
@@ -10,9 +10,8 @@
         </h5>
 
         <ul class="umb-actions umb-actions-child">
-          <li class="umb-action">
-            <button class="umb-action-link umb-outline btn-reset" ng-click="createMediaType()" type="button"
-                    umb-auto-focus>
+          <li data-element="action-mediaType" class="umb-action">
+            <button type="button" class="umb-action-link umb-outline btn-reset" ng-click="createMediaType()" umb-auto-focus>
               <umb-icon class="icon large" icon="icon-item-arrangement"></umb-icon>
               <span class="menu-label">
                   <localize key="general_new">New</localize>
@@ -20,8 +19,8 @@
               </span>
             </button>
           </li>
-          <li class="umb-action">
-            <button class="umb-action-link umb-outline btn-reset" ng-click="showCreateFolder()" type="button">
+          <li data-element="action-folder" class="umb-action" ng-if="model.allowCreateFolder">
+            <button type="button" class="umb-action-link umb-outline btn-reset" ng-click="showCreateFolder()">
               <umb-icon class="icon large" icon="icon-folder"></umb-icon>
               <span class="menu-label"><localize key="general_folder">Folder</localize>...</span>
             </button>

--- a/src/Umbraco.Web.UI.Client/src/views/mediaTypes/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediaTypes/delete.controller.js
@@ -49,7 +49,7 @@ function MediaTypesDeleteController($scope, mediaTypeResource, treeService, navi
     $scope.labels = {};
     localizationService
         .format(["contentTypeEditor_yesDelete", "contentTypeEditor_andAllMediaItems"], "%0% " + $scope.currentNode.name + " %1%")
-        .then(function (data) {
+        .then(data => {
             $scope.labels.deleteConfirm = data;
         });
 

--- a/src/Umbraco.Web.UI.Client/src/views/mediaTypes/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediaTypes/delete.html
@@ -31,6 +31,5 @@
             </div>
         </ng-switch>
 
-
     </div>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/mediaTypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediaTypes/edit.controller.js
@@ -347,7 +347,7 @@
             // convert icons for content type
             convertLegacyIcons(contentType);
 
-            //set a shared state
+            // set a shared state
             editorState.set(contentType);
 
             vm.contentType = contentType;

--- a/src/Umbraco.Web.UI.Client/src/views/mediaTypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediaTypes/edit.controller.js
@@ -205,11 +205,10 @@
 
                             vm.page.saveButtonState = "busy";
 
-                            localizationService.localize("modelsBuilder_buildingModels").then(function (headerValue) {
-                                localizationService.localize("modelsBuilder_waitingMessage").then(function(msgValue) {
-                                    notificationsService.info(headerValue, msgValue);
-                                });
-                            });
+                            localizationService.localizeMany(["modelsBuilder_buildingModels", "modelsBuilder_waitingMessage"])
+                              .then(values => {
+                                notificationsService.info(values[0], values[1]);
+                              });
 
                             contentTypeHelper.generateModels().then(function (result) {
 

--- a/src/Umbraco.Web.UI.Client/src/views/mediaTypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediaTypes/edit.controller.js
@@ -327,11 +327,10 @@
                         editorState.set($scope.content);
                     }
                     else {
-                        localizationService.localize("speechBubbles_validationFailedHeader").then(function (headerValue) {
-                            localizationService.localize("speechBubbles_validationFailedMessage").then(function (msgValue) {
-                                notificationsService.error(headerValue, msgValue);
-                            });
-                        });
+                        localizationService.localizeMany(["speechBubbles_validationFailedHeader", "speechBubbles_validationFailedMessage"])
+                          .then(values => {
+                            notificationsService.error(values[0], values[1]);
+                          });
                     }
 
                     vm.page.saveButtonState = "error";

--- a/src/Umbraco.Web.UI.Client/src/views/mediaTypes/move.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediaTypes/move.controller.js
@@ -1,6 +1,6 @@
 angular.module("umbraco")
 .controller("Umbraco.Editors.MediaTypes.MoveController",
-    function ($scope, mediaTypeResource, treeService, navigationService, notificationsService, appState, eventsService) {
+    function ($scope, mediaTypeResource, treeService, navigationService, appState, eventsService) {
 
         $scope.dialogTreeApi = {};
         $scope.source = _.clone($scope.currentNode);

--- a/src/Umbraco.Web.UI.Client/src/views/mediaTypes/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediaTypes/move.html
@@ -4,7 +4,7 @@
         <div class="umb-pane">
 
             <p class="abstract" ng-hide="success">
-                    <localize key="contentTypeEditor_folderToMove">Select the folder to move</localize> <strong>{{source.name}}</strong>&nbsp;<localize key="contentTypeEditor_structureBelow">to in the tree structure below</localize>
+                <localize key="contentTypeEditor_folderToMove">Select the folder to move</localize> <strong>{{source.name}}</strong>&nbsp;<localize key="contentTypeEditor_structureBelow">to in the tree structure below</localize>
             </p>
 
             <umb-loader ng-show="busy"></umb-loader>

--- a/src/Umbraco.Web.UI.Client/src/views/memberTypes/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/memberTypes/create.controller.js
@@ -6,7 +6,7 @@
  * @description
  * The controller for the member type creation dialog
  */
-function MemberTypesCreateController($scope, $location, navigationService, memberTypeResource, formHelper, appState, localizationService) {
+function MemberTypesCreateController($scope, $location, navigationService, memberTypeResource, formHelper, appState) {
 
     $scope.model = {
         folderName: "",
@@ -23,7 +23,7 @@ function MemberTypesCreateController($scope, $location, navigationService, membe
     $scope.createContainer = function () {
         if (formHelper.submitForm({
             scope: $scope,
-            formCtrl: this.createFolderForm
+            formCtrl: $scope.createFolderForm
         })) {
             memberTypeResource.createContainer(node.id, $scope.model.folderName).then(function (folderId) {
 
@@ -31,11 +31,11 @@ function MemberTypesCreateController($scope, $location, navigationService, membe
                 var currPath = node.path ? node.path : "-1";
                 navigationService.syncTree({ tree: "memberTypes", path: currPath + "," + folderId, forceReload: true, activate: true });
 
-                formHelper.resetForm({ scope: $scope, formCtrl: this.createFolderForm });
+                formHelper.resetForm({ scope: $scope, formCtrl: $scope.createFolderForm });
 
             }, function(err) {
-                formHelper.resetForm({ scope: $scope, formCtrl: this.createFolderForm, hasErrors: true });
-               // TODO: Handle errors
+                formHelper.resetForm({ scope: $scope, formCtrl: $scope.createFolderForm, hasErrors: true });
+                $scope.error = err;
             });
         };
     }
@@ -45,6 +45,10 @@ function MemberTypesCreateController($scope, $location, navigationService, membe
         $location.path("/" + section + "/memberTypes/edit/" + node.id).search("create", "true");
         navigationService.hideMenu();
     }
+    $scope.close = function() {
+        const showMenu = true;
+        navigationService.hideDialog(showMenu);
+    };
 }
 
 angular.module('umbraco').controller("Umbraco.Editors.MemberTypes.CreateController", MemberTypesCreateController);

--- a/src/Umbraco.Web.UI.Client/src/views/memberTypes/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/memberTypes/create.controller.js
@@ -9,8 +9,9 @@
 function MemberTypesCreateController($scope, $location, navigationService, memberTypeResource, formHelper, appState) {
 
     $scope.model = {
-        folderName: "",
-        creatingFolder: false
+      allowCreateFolder: $scope.currentNode.parentId === null || $scope.currentNode.nodeType === 'container',
+      folderName: "",
+      creatingFolder: false
     };
 
     var node = $scope.currentNode;

--- a/src/Umbraco.Web.UI.Client/src/views/memberTypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/memberTypes/create.html
@@ -1,50 +1,76 @@
 <div ng-controller="Umbraco.Editors.MemberTypes.CreateController">
+
+  <div ng-cloak ng-show="!model.creatingFolder">
     <div class="umbracoDialog umb-dialog-body with-footer">
-        <div class="umb-pane" ng-if="!model.creatingFolder">
-            <h5>
-                <localize key="create_createUnder">Create a type under</localize> {{currentNode.name}}
-            </h5>
 
-            <ul class="umb-actions umb-actions-child">
-                <li class="umb-action">
-                    <button type="button" class="umb-action-link umb-outline btn-reset" ng-click="showCreateFolder()">
-                        <umb-icon icon="icon-folder" class="icon large"></umb-icon>
-                        <span class="menu-label">
-                            <localize key="general_folder">Folder</localize>
-                        </span>
-                    </button>
-                </li>
-                <li class="umb-action">
-                    <button type="button" class="umb-action-link umb-outline btn-reset" ng-click="createMemberType()">
-                        <umb-icon icon="icon-item-arrangement" class="icon large"></umb-icon>
-                        <span class="menu-label">
-                            <localize key="general_new">New</localize>&nbsp;
-                            <localize key="content_memberType">Member type</localize>
-                        </span>
-                    </button>
-                </li>
-            </ul>
-        </div>
+      <div class="umb-pane">
+        <h5>
+          <localize key="create_createUnder">Create an item under</localize>
+          {{currentNode.name}}
+        </h5>
 
-        <div class="umb-pane" ng-if="model.creatingFolder">
-            <form novalidate name="createFolderForm" ng-submit="createFolder()" val-form-manager>
-
-                <umb-control-group label="Enter a folder name" hide-label="false">
-                    <input type="text" name="folderName" ng-model="model.folderName"
-                        class="umb-textstring textstring input-block-level" required />
-                </umb-control-group>
-
-                <button type="submit" class="btn btn-primary">
-                    <localize key="general_create">Create</localize>
-                </button>
-            </form>
-        </div>
-
+        <ul class="umb-actions umb-actions-child">
+          <li class="umb-action">
+            <button class="umb-action-link umb-outline btn-reset" ng-click="createMemberType()" type="button"
+                    umb-auto-focus>
+              <umb-icon class="icon large" icon="icon-item-arrangement"></umb-icon>
+              <span class="menu-label">
+                  <localize key="general_new">New</localize>
+                  <localize key="content_membertype">Member type</localize>
+              </span>
+            </button>
+          </li>
+          <li class="umb-action">
+            <button class="umb-action-link umb-outline btn-reset" ng-click="showCreateFolder()" type="button">
+              <umb-icon class="icon large" icon="icon-folder"></umb-icon>
+              <span class="menu-label"><localize key="general_folder">Folder</localize>...</span>
+            </button>
+          </li>
+        </ul>
+      </div>
     </div>
 
-    <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-if="!model.creatingFolder">
-        <button type="button" class="btn btn-info" ng-click="nav.hideDialog(true)">
-            <localize key="buttons_somethingElse">Do something else</localize>
-        </button>
+    <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar">
+      <button class="btn btn-info" ng-click="close()" type="button">
+        <localize key="buttons_somethingElse">Do something else</localize>
+      </button>
     </div>
+  </div>
+
+  <div ng-cloak ng-show="model.creatingFolder">
+    <form name="createFolderForm" ng-submit="createContainer()"
+          novalidate
+          val-form-manager>
+      <div class="umbracoDialog umb-dialog-body with-footer">
+        <div class="umb-pane" ng-show="model.creatingFolder">
+          <div ng-show="error">
+            <div class="alert alert-error">
+              <div><strong>{{error.errorMsg}}</strong></div>
+              <div>{{error.data.message}}</div>
+            </div>
+          </div>
+
+          <umb-control-group hide-label="false" label="Enter a folder name">
+            <input class="umb-textstring textstring input-block-level"
+                   focus-when="{{model.creatingFolder}}"
+                   name="folderName"
+                   ng-model="model.folderName"
+                   required
+                   type="text"/>
+          </umb-control-group>
+        </div>
+      </div>
+      <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar">
+        <umb-button action="close()"
+                    button-style="link"
+                    label-key="general_close"
+                    type="button">
+        </umb-button>
+        <umb-button button-style="primary"
+                    label-key="general_create"
+                    type="submit">
+        </umb-button>
+      </div>
+    </form>
+  </div>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/memberTypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/memberTypes/create.html
@@ -22,7 +22,9 @@
           <li data-element="action-folder" class="umb-action" ng-if="model.allowCreateFolder">
             <button type="button" class="umb-action-link umb-outline btn-reset" ng-click="showCreateFolder()">
               <umb-icon class="icon large" icon="icon-folder"></umb-icon>
-              <span class="menu-label"><localize key="general_folder">Folder</localize>...</span>
+              <span class="menu-label">
+                <localize key="general_folder">Folder</localize>
+              </span>
             </button>
           </li>
         </ul>

--- a/src/Umbraco.Web.UI.Client/src/views/memberTypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/memberTypes/create.html
@@ -10,9 +10,8 @@
         </h5>
 
         <ul class="umb-actions umb-actions-child">
-          <li class="umb-action">
-            <button class="umb-action-link umb-outline btn-reset" ng-click="createMemberType()" type="button"
-                    umb-auto-focus>
+          <li data-element="action-memberType" class="umb-action">
+            <button type="button" class="umb-action-link umb-outline btn-reset" ng-click="createMemberType()" umb-auto-focus>
               <umb-icon class="icon large" icon="icon-item-arrangement"></umb-icon>
               <span class="menu-label">
                   <localize key="general_new">New</localize>
@@ -20,8 +19,8 @@
               </span>
             </button>
           </li>
-          <li class="umb-action">
-            <button class="umb-action-link umb-outline btn-reset" ng-click="showCreateFolder()" type="button">
+          <li data-element="action-folder" class="umb-action" ng-if="model.allowCreateFolder">
+            <button type="button" class="umb-action-link umb-outline btn-reset" ng-click="showCreateFolder()">
               <umb-icon class="icon large" icon="icon-folder"></umb-icon>
               <span class="menu-label"><localize key="general_folder">Folder</localize>...</span>
             </button>

--- a/src/Umbraco.Web.UI.Client/src/views/memberTypes/delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/memberTypes/delete.controller.js
@@ -26,6 +26,23 @@ function MemberTypesDeleteController($scope, memberTypeResource, treeService, na
 
     };
 
+  $scope.performContainerDelete = function () {
+
+    //mark it for deletion (used in the UI)
+    $scope.currentNode.loading = true;
+    memberTypeResource.deleteContainerById($scope.currentNode.id).then(function () {
+      $scope.currentNode.loading = false;
+
+      //get the root node before we remove it
+      var rootNode = treeService.getTreeRoot($scope.currentNode);
+
+      // TODO: Need to sync tree, etc...
+      treeService.removeNode($scope.currentNode);
+      navigationService.hideMenu();
+    });
+
+  };
+
     $scope.cancel = function() {
         navigationService.hideDialog();
     };
@@ -33,7 +50,7 @@ function MemberTypesDeleteController($scope, memberTypeResource, treeService, na
     $scope.labels = {};
     localizationService
         .format(["contentTypeEditor_yesDelete", "contentTypeEditor_andAllMembers"], "%0% " + $scope.currentNode.name + " %1%")
-        .then(function (data) {
+        .then(data => {
             $scope.labels.deleteConfirm = data;
         });
 

--- a/src/Umbraco.Web.UI.Client/src/views/memberTypes/delete.html
+++ b/src/Umbraco.Web.UI.Client/src/views/memberTypes/delete.html
@@ -2,22 +2,34 @@
     <div class="umb-dialog-body">
 
         <p class="abstract">
-            <localize key="defaultdialogs_confirmdelete">Are you sure you want to delete</localize> <strong>{{currentNode.name}}</strong>?
+            <localize key="defaultdialogs_confirmdelete">Are you sure you want to delete</localize>&nbsp;<strong>{{currentNode.name}}</strong>?
         </p>
 
-        <p>
-            <umb-icon icon="icon-alert" class="red"></umb-icon>
-            <strong class="red"><localize key="member_allMembers">All members</localize></strong>
-            <localize key="contentTypeEditor_usingThisMember">using this member type will be deleted permanently, please confirm you want to delete these as well.</localize>
-        </p>
+        <ng-switch on="currentNode.nodeType">
+            <div ng-switch-when="container">
+                <umb-confirm
+                    on-confirm="performContainerDelete"
+                    on-cancel="cancel" confirm-button-style="danger">
+                </umb-confirm>
+            </div>
 
-        <hr />
+            <div ng-switch-default>
+                <p>
+                    <umb-icon icon="icon-alert" class="red"></umb-icon>
+                    <strong class="red">
+                        <localize key="member_allMembers">All members</localize>
+                    </strong>
+                    <localize key="contentTypeEditor_usingThisMember">using this member type will be deleted permanently, please confirm you want to delete these as well.</localize>
+                </p>
 
-        <umb-checkbox model="confirmed" text="{{labels.deleteConfirm}}"></umb-checkbox>
+                <hr />
 
-        <umb-confirm confirm-disabled="!confirmed" confirm-label-key="delete" on-confirm="performDelete" on-cancel="cancel" confirm-button-style="danger">
-        </umb-confirm>
+                <umb-checkbox model="confirmed" text="{{labels.deleteConfirm}}"></umb-checkbox>
 
+                <umb-confirm confirm-disabled="!confirmed" confirm-label-key="delete" on-confirm="performDelete" on-cancel="cancel" confirm-button-style="danger">
+                </umb-confirm>
+            </div>
+        </ng-switch>
 
     </div>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/memberTypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/memberTypes/edit.controller.js
@@ -126,11 +126,10 @@
 
                             vm.page.saveButtonState = "busy";
 
-                            localizationService.localize("modelsBuilder_buildingModels").then(function (headerValue) {
-                                localizationService.localize("modelsBuilder_waitingMessage").then(function(msgValue) {
-                                    notificationsService.info(headerValue, msgValue);
-                                });
-                            });
+                            localizationService.localizeMany(["modelsBuilder_buildingModels", "modelsBuilder_waitingMessage"])
+                              .then(values => {
+                                  notificationsService.info(values[0], values[1]);
+                              });
 
                             contentTypeHelper.generateModels().then(function (result) {
 

--- a/src/Umbraco.Web.UI.Client/src/views/memberTypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/memberTypes/edit.controller.js
@@ -268,7 +268,7 @@
             // convert legacy icons
             convertLegacyIcons(contentType);
 
-            //set a shared state
+            // set a shared state
             editorState.set(contentType);
 
             vm.contentType = contentType;

--- a/src/Umbraco.Web.UI.Client/src/views/memberTypes/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/memberTypes/edit.controller.js
@@ -204,7 +204,7 @@
         function save() {
 
             // only save if there is no overlays open
-            if(overlayHelper.getNumberOfOverlays() === 0) {
+            if (overlayHelper.getNumberOfOverlays() === 0) {
 
                 var deferred = $q.defer();
 
@@ -221,7 +221,7 @@
                 }).then(function (data) {
                     //success
 
-                    if(!infiniteMode) {
+                    if (!infiniteMode) {
                         syncTreeNode(vm.contentType, data.path);
                     }
 
@@ -235,7 +235,7 @@
 
                     vm.page.saveButtonState = "success";
 
-                    if(infiniteMode && $scope.model.submit) {
+                    if (infiniteMode && $scope.model.submit) {
                         $scope.model.submit();
                     }
 
@@ -247,10 +247,9 @@
                         editorState.set($scope.content);
                     }
                     else {
-                        localizationService.localize("speechBubbles_validationFailedHeader").then(function (headerValue) {
-                            localizationService.localize("speechBubbles_validationFailedMessage").then(function (msgValue) {
-                                notificationsService.error(headerValue, msgValue);
-                            });
+                      localizationService.localizeMany(["speechBubbles_validationFailedHeader", "speechBubbles_validationFailedMessage"])
+                        .then(values => {
+                          notificationsService.error(values[0], values[1]);
                         });
                     }
 

--- a/src/Umbraco.Web.UI.Client/src/views/memberTypes/move.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/memberTypes/move.controller.js
@@ -1,5 +1,67 @@
 angular.module("umbraco")
 .controller("Umbraco.Editors.MemberTypes.MoveController",
-    function($scope){
+  function ($scope, memberTypeResource, treeService, navigationService, appState, eventsService) {
 
-    });
+    $scope.dialogTreeApi = {};
+    $scope.source = _.clone($scope.currentNode);
+
+    function nodeSelectHandler(args) {
+      args.event.preventDefault();
+      args.event.stopPropagation();
+
+      if ($scope.target) {
+        //un-select if there's a current one selected
+        $scope.target.selected = false;
+      }
+
+      $scope.target = args.node;
+      $scope.target.selected = true;
+    }
+
+    $scope.move = function () {
+
+      $scope.busy = true;
+      $scope.error = false;
+
+      memberTypeResource.move({ parentId: $scope.target.id, id: $scope.source.id })
+        .then(function (path) {
+          $scope.error = false;
+          $scope.success = true;
+          $scope.busy = false;
+
+          //first we need to remove the node that launched the dialog
+          treeService.removeNode($scope.currentNode);
+
+          //get the currently edited node (if any)
+          var activeNode = appState.getTreeState("selectedNode");
+
+          //we need to do a double sync here: first sync to the moved content - but don't activate the node,
+          //then sync to the currenlty edited content (note: this might not be the content that was moved!!)
+
+          navigationService.syncTree({ tree: "memberTypes", path: path, forceReload: true, activate: false }).then(function (args) {
+            if (activeNode) {
+              var activeNodePath = treeService.getPath(activeNode).join();
+              //sync to this node now - depending on what was copied this might already be synced but might not be
+              navigationService.syncTree({ tree: "memberTypes", path: activeNodePath, forceReload: false, activate: true });
+            }
+          });
+
+          eventsService.emit('app.refreshEditor');
+
+        }, function (err) {
+          $scope.success = false;
+          $scope.error = err;
+          $scope.busy = false;
+
+        });
+    };
+
+    $scope.onTreeInit = function () {
+      $scope.dialogTreeApi.callbacks.treeNodeSelect(nodeSelectHandler);
+    };
+
+    $scope.close = function () {
+      navigationService.hideDialog();
+    };
+
+  });

--- a/src/Umbraco.Web.UI.Client/src/views/memberTypes/move.html
+++ b/src/Umbraco.Web.UI.Client/src/views/memberTypes/move.html
@@ -1,11 +1,54 @@
-<div class="umb-dialog umb-pane" ng-controller="Umbraco.Editors.MemberTypes.MoveController">
+<div class="umb-dialog" ng-controller="Umbraco.Editors.MemberTypes.MoveController">
 
     <div class="umb-dialog-body">
+      <div class="umb-pane">
 
-        <p class="umb-abstract">
-        	<localize key="contentTypeEditor_folderToMove">Select the folder to move</localize> {{currentNode.name}} <localize key="general_to">to</localize>.
+        <p class="abstract" ng-hide="success">
+          <localize key="contentTypeEditor_folderToMove">Select the folder to move</localize> <strong>{{source.name}}</strong>&nbsp;<localize key="contentTypeEditor_structureBelow">to in the tree structure below</localize>
         </p>
 
+        <umb-loader ng-show="busy"></umb-loader>
 
+        <div ng-show="error">
+          <div class="alert alert-error">
+            <div><strong>{{error.errorMsg}}</strong></div>
+            <div>{{error.data.message}}</div>
+          </div>
+        </div>
+
+        <div ng-show="success">
+          <div class="alert alert-success">
+            <strong>{{source.name}}</strong> <localize key="contentTypeEditor_movedUnderneath">was moved underneath</localize>&nbsp;<strong>{{target.name}}</strong>
+          </div>
+          <button type="button" class="btn btn-primary" ng-click="close()">Ok</button>
+        </div>
+
+        <div ng-hide="success">
+
+          <div>
+            <umb-tree section="settings"
+                      treealias="memberTypes"
+                      customtreeparams="foldersonly=1"
+                      hideheader="false"
+                      hideoptions="true"
+                      isdialog="true"
+                      api="dialogTreeApi"
+                      on-init="onTreeInit()"
+                      enablecheckboxes="true">
+            </umb-tree>
+          </div>
+
+        </div>
+      </div>
     </div>
+
+    <div class="umb-dialog-footer btn-toolbar umb-btn-toolbar" ng-hide="success">
+        <button type="button" class="btn btn-link" ng-click="close()" ng-show="!busy">
+            <localize key="general_cancel">Cancel</localize>
+        </button>
+        <button class="btn btn-primary" ng-click="move()" ng-disabled="busy || !target">
+            <localize key="actions_move">Move</localize>
+        </button>
+    </div>
+
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/memberTypes/rename.html
+++ b/src/Umbraco.Web.UI.Client/src/views/memberTypes/rename.html
@@ -1,0 +1,23 @@
+<div class="umbracoDialog umb-dialog-body with-footer" ng-controller="Umbraco.Editors.ContentTypeContainers.RenameController" ng-cloak>
+
+    <div class="umb-pane">
+        <form novalidate name="renameFolderForm"
+              ng-submit="renameContainer('memberTypeResource', 'memberTypes')"
+              val-form-manager>
+
+            <div ng-show="error">
+                <div class="alert alert-error">
+                    <div><strong>{{error.errorMsg}}</strong></div>
+                    <div>{{error.data.message}}</div>
+                </div>
+            </div>
+
+            <umb-control-group label="@renamecontainer_enterNewFolderName" hide-label="false">
+                <input type="text" name="folderName" ng-model="model.folderName" class="umb-textstring textstring input-block-level" umb-auto-focus required />
+            </umb-control-group>
+
+            <button type="submit" class="btn btn-primary"><localize key="general_rename">Rename</localize></button>
+        </form>
+    </div>
+
+</div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed we are able to create folders (also called containers) under document types and media types, but not for member types. The codebase did contain part of the logic to support containers for member types.

I think it would be great to make this a bit more consistent between content types.
It working with larger solutions with multiple member types, it may also make a bit more structure.

The `MemberTypeAndGroupTreeControllerBase` is used for both member types tree and member groups tree, so for now it only add this to member types.

I have streamlined the dialogs a bit more for document, media and member types. I also noticed the "create" action for media type allowed to select folder/container as child to an existing media type, which it not supported and document types doesn't allow this. Folder/container are only allowed at root or under other folders/containers.

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/fc9745a8-db92-4405-8772-effaaeff0361)

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/ba539888-e90e-497d-8e93-b6fe6a8f3385)

I have generated a guid, but we can change it to something else if needed.

Notice this also requires Umbraco Deploy to implement changes to support member type container entity.


https://github.com/umbraco/Umbraco-CMS/assets/2919859/e0ea4dae-9dad-41f6-9fd7-5438737bba06

