### PR TITLE
Ensure that value type JSON is translated correctly for Delivery API output

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/JsonValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/JsonValueConverter.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PropertyEditors.DeliveryApi;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
@@ -16,7 +18,7 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 ///     Since this is a default (umbraco) converter it will be ignored if another converter found conflicts with this one.
 /// </remarks>
 [DefaultPropertyValueConverter]
-public class JsonValueConverter : PropertyValueConverterBase
+public class JsonValueConverter : PropertyValueConverterBase, IDeliveryApiPropertyValueConverter
 {
     private readonly ILogger<JsonValueConverter> _logger;
     private readonly PropertyEditorCollection _propertyEditors;
@@ -76,5 +78,14 @@ public class JsonValueConverter : PropertyValueConverterBase
         return sourceString;
     }
 
-    // TODO: Now to convert that to XPath!
+    public PropertyCacheLevel GetDeliveryApiPropertyCacheLevel(IPublishedPropertyType propertyType)
+        => GetPropertyCacheLevel(propertyType);
+
+    public Type GetDeliveryApiPropertyValueType(IPublishedPropertyType propertyType)
+        => typeof(JsonNode);
+
+    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding)
+        => inter is JObject jObject
+            ? JsonNode.Parse(jObject.ToString())
+            : null;
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/JsonValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/JsonValueConverterTests.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.DeliveryApi;
+
+[TestFixture]
+public class JsonValueConverterTests : PropertyValueConverterTests
+{
+    [Test]
+    public void JsonValueConverterTests_ConvertsCustomPropertyWithValueTypeJson()
+    {
+        var valueEditor = Mock.Of<IDataValueEditor>(x => x.ValueType == ValueTypes.Json);
+        var dataEditor = Mock.Of<IDataEditor>(x => x.GetValueEditor() == valueEditor);
+        var propertyEditors = new PropertyEditorCollection(new DataEditorCollection(() => new[] { dataEditor }));
+        var propertyType = Mock.Of<IPublishedPropertyType>(x => x.EditorAlias == "My.Custom.Json");
+
+        var valueConverter = new JsonValueConverter(propertyEditors, Mock.Of<ILogger<JsonValueConverter>>());
+        var inter = valueConverter.ConvertSourceToIntermediate(Mock.Of<IPublishedElement>(), propertyType, "{\"message\": \"Hello, JSON\"}", false);
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), propertyType, PropertyCacheLevel.Element, inter, false, false);
+        Assert.IsTrue(result is JsonNode);
+        JsonNode jsonNode = (JsonNode)result;
+        Assert.AreEqual("Hello, JSON", jsonNode["message"]!.GetValue<string>());
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

A custom property with value type JSON and no custom property value converter will currently convert into a `JObject` for both Razor rendering and Delivery API output. Unfortunately, `JObject` does not play nice with `System.Text.Json` when serializing the Delivery API output. In effect, these kinds of property values are completely useless.

The only current workaround is to implement a custom value converter.

This PR ensures that the built-in handler for these kinds of properties (the `JsonValueConverter`) implements `IDeliveryApiPropertyValueConverter` and converts the stored value into a `JsonNode`, which serializes nicely with `System.Text.Json`.

The resulting Delivery API output is then changed from:

```json
{
  ...
  "properties": {
    "jsonValue": {
      "message": [],
      "length": []
    }
  },
  ...
}
```

...to:

```json
{
  ...
  "properties": {
    "jsonValue": {
      "message": "hello, world",
      "length": 12
    },
  },
  ...
}
```

### Testing this PR

1. Create a content type with a property of type "Pass-through - JSON" from this collection of manifest based property editors: [PassThroughEditors.zip](https://github.com/umbraco/Umbraco-CMS/files/12671129/PassThroughEditors.zip) (unzip them in `App_Plugins`).
2. Create content based on this content type, fill out the editor input field and publish the content.
![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/1804623f-33d8-4439-8c5f-954636e59ff9)
3. Request the content using the Delivery API and verify that the JSON output is rendered correctly.
