### PR TITLE
Don't allow to select folder in create dialog under media type

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/contenttype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/contenttype.resource.js
@@ -323,7 +323,7 @@ function contentTypeResource($q, $http, umbRequestHelper, umbDataFormatter, loca
                         "contentTypeApiBaseUrl",
                         "DeleteContainer",
                         [{ id: id }])),
-                'Failed to delete content type contaier');
+                'Failed to delete content type container');
         },
 
         /**

--- a/src/Umbraco.Web.UI.Client/src/common/resources/mediatype.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/mediatype.resource.js
@@ -166,7 +166,7 @@ function mediaTypeResource($q, $http, umbRequestHelper, umbDataFormatter, locali
                        "mediaTypeApiBaseUrl",
                        "DeleteContainer",
                        [{ id: id }])),
-               'Failed to delete content type contaier');
+               'Failed to delete content type container');
         },
 
         /**

--- a/src/Umbraco.Web.UI.Client/src/views/mediaTypes/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/mediaTypes/create.controller.js
@@ -9,8 +9,9 @@
 function MediaTypesCreateController($scope, $location, navigationService, mediaTypeResource, formHelper, appState, localizationService) {
 
     $scope.model = {
-        folderName: "",
-        creatingFolder: false
+      allowCreateFolder: $scope.currentNode.parentId === null || $scope.currentNode.nodeType === 'container',
+      folderName: "",
+      creatingFolder: false
     };
 
     var node = $scope.currentNode;

--- a/src/Umbraco.Web.UI.Client/src/views/mediaTypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediaTypes/create.html
@@ -14,15 +14,17 @@
             <button type="button" class="umb-action-link umb-outline btn-reset" ng-click="createMediaType()" umb-auto-focus>
               <umb-icon class="icon large" icon="icon-item-arrangement"></umb-icon>
               <span class="menu-label">
-                                <localize key="general_new">New</localize>
-                                <localize key="content_mediatype">Media type</localize>
-                            </span>
+                  <localize key="general_new">New</localize>
+                  <localize key="content_mediatype">Media type</localize>
+              </span>
             </button>
           </li>
           <li data-element="action-folder" class="umb-action" ng-if="model.allowCreateFolder">
             <button type="button" class="umb-action-link umb-outline btn-reset" ng-click="showCreateFolder()">
               <umb-icon class="icon large" icon="icon-folder"></umb-icon>
-              <span class="menu-label"><localize key="general_folder">Folder</localize>...</span>
+              <span class="menu-label">
+                <localize key="general_folder">Folder</localize>
+              </span>
             </button>
           </li>
         </ul>
@@ -34,6 +36,7 @@
         <localize key="buttons_somethingElse">Do something else</localize>
       </button>
     </div>
+
   </div>
 
   <div ng-cloak ng-show="model.creatingFolder">

--- a/src/Umbraco.Web.UI.Client/src/views/mediaTypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/mediaTypes/create.html
@@ -10,9 +10,8 @@
         </h5>
 
         <ul class="umb-actions umb-actions-child">
-          <li class="umb-action">
-            <button class="umb-action-link umb-outline btn-reset" ng-click="createMediaType()" type="button"
-                    umb-auto-focus>
+          <li data-element="action-mediaType" class="umb-action">
+            <button type="button" class="umb-action-link umb-outline btn-reset" ng-click="createMediaType()" umb-auto-focus>
               <umb-icon class="icon large" icon="icon-item-arrangement"></umb-icon>
               <span class="menu-label">
                                 <localize key="general_new">New</localize>
@@ -20,8 +19,8 @@
                             </span>
             </button>
           </li>
-          <li class="umb-action">
-            <button class="umb-action-link umb-outline btn-reset" ng-click="showCreateFolder()" type="button">
+          <li data-element="action-folder" class="umb-action" ng-if="model.allowCreateFolder">
+            <button type="button" class="umb-action-link umb-outline btn-reset" ng-click="showCreateFolder()">
               <umb-icon class="icon large" icon="icon-folder"></umb-icon>
               <span class="menu-label"><localize key="general_folder">Folder</localize>...</span>
             </button>

--- a/src/Umbraco.Web.UI.Client/src/views/memberTypes/create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/memberTypes/create.controller.js
@@ -9,8 +9,9 @@
 function MemberTypesCreateController($scope, $location, navigationService, memberTypeResource, formHelper, appState, localizationService) {
 
     $scope.model = {
-        folderName: "",
-        creatingFolder: false
+      allowCreateFolder: $scope.currentNode.parentId === null || $scope.currentNode.nodeType === 'container',
+      folderName: "",
+      creatingFolder: false
     };
 
     var node = $scope.currentNode;

--- a/src/Umbraco.Web.UI.Client/src/views/memberTypes/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/memberTypes/create.html
@@ -1,4 +1,5 @@
 <div ng-controller="Umbraco.Editors.MemberTypes.CreateController">
+
     <div class="umbracoDialog umb-dialog-body with-footer">
         <div class="umb-pane" ng-if="!model.creatingFolder">
             <h5>
@@ -6,20 +7,20 @@
             </h5>
 
             <ul class="umb-actions umb-actions-child">
-                <li class="umb-action">
+                <li data-element="action-memberType" class="umb-action">
+                  <button type="button" class="umb-action-link umb-outline btn-reset" ng-click="createMemberType()">
+                    <umb-icon icon="icon-item-arrangement" class="icon large"></umb-icon>
+                    <span class="menu-label">
+                      <localize key="general_new">New</localize>
+                      <localize key="content_memberType">Member type</localize>
+                    </span>
+                  </button>
+                </li>
+                <li data-element="action-folder" class="umb-action">
                     <button type="button" class="umb-action-link umb-outline btn-reset" ng-click="showCreateFolder()">
                         <umb-icon icon="icon-folder" class="icon large"></umb-icon>
                         <span class="menu-label">
                             <localize key="general_folder">Folder</localize>
-                        </span>
-                    </button>
-                </li>
-                <li class="umb-action">
-                    <button type="button" class="umb-action-link umb-outline btn-reset" ng-click="createMemberType()">
-                        <umb-icon icon="icon-item-arrangement" class="icon large"></umb-icon>
-                        <span class="menu-label">
-                            <localize key="general_new">New</localize>&nbsp;
-                            <localize key="content_memberType">Member type</localize>
                         </span>
                     </button>
                 </li>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Under a media type it is possible to select folder option, which fails as it isn't supported (only at root or under other folders/containers).
This is also how it works under document types, where folder option is not shown in create dialog under a document/element type.

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/8478c091-5c40-494a-ba2c-3cd25003ff64)


I also cherry picked a few other changes from https://github.com/umbraco/Umbraco-CMS/pull/14833 like some typos.

![chrome_jL2aolXk5W](https://github.com/umbraco/Umbraco-CMS/assets/2919859/2e3ac5de-03e9-40a7-899d-432f5afb38a4)


**Before**

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/dfec6855-f3b6-45d1-974b-134b289d0552)

**After**

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/a2dcc6a0-7a80-4613-939b-5850adcd4ff8)

It is still possible to select "Folder" option in create dialog at root level and under other folders/containers - just like it work with document types.

The create dialog isn't really used for member types are the moment since it route directly to edit view, but I aligned it with media type create dialog and we may enable containers for member types as well later in https://github.com/umbraco/Umbraco-CMS/pull/14833