### PR TITLE
Ensure focus on specific action in block card

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.less
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.less
@@ -129,6 +129,10 @@ umb-block-card {
         transition: opacity 120ms;
         margin-right: 10px;
 
+        > div {
+            position: relative;
+        }
+
         .__action {
             display: inline-flex;
             justify-content: center;
@@ -137,7 +141,7 @@ umb-block-card {
             width: 28px;
             height: 28px;
             background-color: white;
-            color:@ui-action-type;
+            color: @ui-action-type;
 
             &:hover {
                 color: @ui-action-type-hover;

--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.less
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.less
@@ -127,7 +127,8 @@ umb-block-card {
         right: 10px;
         opacity: 0;
         transition: opacity 120ms;
-        margin-right: 10px;
+        display: flex;
+        gap: 5px;
 
         > div {
             position: relative;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/blockgrid.blockconfiguration.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/blockgrid.blockconfiguration.html
@@ -21,16 +21,16 @@
                 data-content-element-type-key="{{block.contentElementTypeKey}}">
                 <div class="__actions" ng-click="$event.stopPropagation()" tabindex="-1">
                     <div ng-if="block.areas.length > 0">
-                      <button type="button" class="btn-reset __action umb-outline" ng-click="vm.openBlockOverlay(block, true); $event.stopPropagation();">
-                          <umb-icon icon="icon-layout" class="icon"></umb-icon>
-                          <localize key="blockEditor_tabAreas" class="sr-only">Areas</localize>
-                      </button>
+                        <button type="button" class="btn-reset __action umb-outline" ng-click="vm.openBlockOverlay(block, true); $event.stopPropagation();">
+                            <umb-icon icon="icon-layout" class="icon"></umb-icon>
+                            <localize key="blockEditor_tabAreas" class="sr-only">Areas</localize>
+                        </button>
                     </div>
                     <div>
-                      <button type="button" class="btn-reset __action umb-outline" ng-click="vm.requestRemoveBlockByIndex($index, $event)">
-                        <umb-icon icon="icon-trash" class="icon"></umb-icon>
-                        <localize key="general_delete" class="sr-only">Delete</localize>
-                      </button>
+                        <button type="button" class="btn-reset __action umb-outline" ng-click="vm.requestRemoveBlockByIndex($index, $event)">
+                            <umb-icon icon="icon-trash" class="icon"></umb-icon>
+                            <localize key="general_delete" class="sr-only">Delete</localize>
+                        </button>
                     </div>
                 </div>
             </umb-block-card>
@@ -83,14 +83,18 @@
                     ng-click="vm.openBlockOverlay(block)"
                     data-content-element-type-key="{{block.contentElementTypeKey}}">
                     <div class="__actions" ng-click="$event.stopPropagation()" tabindex="-1">
-                        <button type="button" ng-if="block.areas.length > 0" class="btn-reset __action umb-outline" ng-click="vm.openBlockOverlay(block, true); $event.stopPropagation();">
-                            <umb-icon icon="icon-layout" class="icon"></umb-icon>
-                            <localize key="blockEditor_tabAreas" class="sr-only">Areas</localize>
-                        </button>
-                        <button type="button" class="btn-reset __action umb-outline" ng-click="vm.requestRemoveBlockByIndex($index, $event)">
-                            <umb-icon icon="icon-trash" class="icon"></umb-icon>
-                            <localize key="general_delete" class="sr-only">Delete</localize>
-                        </button>
+                        <div ng-if="block.areas.length > 0">
+                            <button type="button" class="btn-reset __action umb-outline" ng-click="vm.openBlockOverlay(block, true); $event.stopPropagation();">
+                                <umb-icon icon="icon-layout" class="icon"></umb-icon>
+                                <localize key="blockEditor_tabAreas" class="sr-only">Areas</localize>
+                            </button>
+                        </div>
+                        <div>
+                            <button type="button" class="btn-reset __action umb-outline" ng-click="vm.requestRemoveBlockByIndex($index, $event)">
+                                <umb-icon icon="icon-trash" class="icon"></umb-icon>
+                                <localize key="general_delete" class="sr-only">Delete</localize>
+                            </button>
+                        </div>
                     </div>
                 </umb-block-card>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/blockgrid.blockconfiguration.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/blockgrid.blockconfiguration.html
@@ -20,8 +20,8 @@
                 ng-click="vm.openBlockOverlay(block)"
                 data-content-element-type-key="{{block.contentElementTypeKey}}">
                 <div class="__actions" ng-click="$event.stopPropagation()" tabindex="-1">
-                    <div>
-                      <button type="button" ng-if="block.areas.length > 0" class="btn-reset __action umb-outline" ng-click="vm.openBlockOverlay(block, true); $event.stopPropagation();">
+                    <div ng-if="block.areas.length > 0">
+                      <button type="button" class="btn-reset __action umb-outline" ng-click="vm.openBlockOverlay(block, true); $event.stopPropagation();">
                           <umb-icon icon="icon-layout" class="icon"></umb-icon>
                           <localize key="blockEditor_tabAreas" class="sr-only">Areas</localize>
                       </button>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/blockgrid.blockconfiguration.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/blockgrid.blockconfiguration.html
@@ -20,14 +20,18 @@
                 ng-click="vm.openBlockOverlay(block)"
                 data-content-element-type-key="{{block.contentElementTypeKey}}">
                 <div class="__actions" ng-click="$event.stopPropagation()" tabindex="-1">
-                    <button type="button" ng-if="block.areas.length > 0" class="btn-reset __action umb-outline" ng-click="vm.openBlockOverlay(block, true); $event.stopPropagation();">
-                        <umb-icon icon="icon-layout" class="icon"></umb-icon>
-                        <localize key="blockEditor_tabAreas" class="sr-only">Areas</localize>
-                    </button>
-                    <button type="button" class="btn-reset __action umb-outline" ng-click="vm.requestRemoveBlockByIndex($index, $event)">
+                    <div>
+                      <button type="button" ng-if="block.areas.length > 0" class="btn-reset __action umb-outline" ng-click="vm.openBlockOverlay(block, true); $event.stopPropagation();">
+                          <umb-icon icon="icon-layout" class="icon"></umb-icon>
+                          <localize key="blockEditor_tabAreas" class="sr-only">Areas</localize>
+                      </button>
+                    </div>
+                    <div>
+                      <button type="button" class="btn-reset __action umb-outline" ng-click="vm.requestRemoveBlockByIndex($index, $event)">
                         <umb-icon icon="icon-trash" class="icon"></umb-icon>
                         <localize key="general_delete" class="sr-only">Delete</localize>
-                    </button>
+                      </button>
+                    </div>
                 </div>
             </umb-block-card>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.html
@@ -9,12 +9,12 @@
             ng-class="{'--isOpen':vm.openBlock === block}"
             ng-click="vm.openBlockOverlay(block)">
             <div class="__actions" ng-click="$event.stopPropagation()" tabindex="-1">
-                <button type="button"
-                        class="btn-reset __action umb-outline"
-                        ng-click="vm.requestRemoveBlockByIndex($index, $event)">
-                    <umb-icon icon="icon-trash" class="icon"></umb-icon>
-                    <localize key="general_delete" class="sr-only">Delete</localize>
-                </button>
+                <div>
+                    <button type="button" class="btn-reset __action umb-outline" ng-click="vm.requestRemoveBlockByIndex($index, $event)">
+                        <umb-icon icon="icon-trash" class="icon"></umb-icon>
+                        <localize key="general_delete" class="sr-only">Delete</localize>
+                    </button>
+                </div>
             </div>
         </umb-block-card>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Previous Block List only had a single action (delete) in block card in the configuration of the property editor, but with Block Grid there's also an area action and if (package) developers used `<umb-block-card>` component as well there may be addtional actions.

Since the buttons has `umb-outline` the focus if absolute and therefore on top of each other since the closest relative element is the element with `__actions` class.


https://github.com/umbraco/Umbraco-CMS/assets/2919859/a4e36229-d107-4900-b35e-38303de83f74
