### PR TITLE
Fix spelling mistake, and add details of additional packages

### DIFF
--- a/templates/Umbraco.Templates.csproj
+++ b/templates/Umbraco.Templates.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Title>Umbraco CMS - Templates</Title>
-    <Description>Coontains templates for Umbraco CMS.</Description>
+    <Description>Contains templates for Umbraco CMS, as well as the templates for creating new packages for the Umbraco CMS.</Description>
     <PackageType>Template</PackageType>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>


### PR DESCRIPTION
Noticed this spelling mistake, quick fix to also update details of other templates included, which shows in the nuget page. This shows in the location below

https://www.nuget.org/packages/Umbraco.Templates#readme-body-tab
