### PR TITLE
feat: Make JSON tag value fallback

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tags/umbtagseditor.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tags/umbtagseditor.directive.js
@@ -165,9 +165,23 @@
         function configureViewModel(isInitLoad) {
             if (vm.value) {
                 if (Utilities.isString(vm.value) && vm.value.length > 0) {
-                    if (vm.config.storageType === "Json") {
+
+                    let parsedJson = undefined;
+                    let isValidJson = true;
+                    if (vm.config.storageType === "Json"){
+                        try{
+                            parsedJson = JSON.parse(vm.value);
+                        }
+                        catch(e){
+                            // This can happen if you switch a tag editor from csv to json, and the value is still returned as a csv string.
+                            // The value will be saved as a json string on the next save or publish.
+                            isValidJson = false;
+                        }
+                    }
+
+                    if (vm.config.storageType === "Json" && isValidJson) {
                         //json storage
-                        vm.viewModel = JSON.parse(vm.value);
+                        vm.viewModel = parsedJson;
 
                         //if this is the first load, we are just re-formatting the underlying model to be consistent
                         //we don't want to notify the component parent of any changes, that will occur if the user actually
@@ -177,7 +191,7 @@
                         }
                     }
                     else {
-                        //csv storage
+                        //csv storage / fallback if not valid json
 
                         // split the csv string, and remove any duplicate values
                         let tempArray = vm.value.split(',').map(function (v) {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tags/umbtagseditor.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tags/umbtagseditor.directive.js
@@ -166,22 +166,9 @@
             if (vm.value) {
                 if (Utilities.isString(vm.value) && vm.value.length > 0) {
 
-                    let parsedJson = undefined;
-                    let isValidJson = true;
-                    if (vm.config.storageType === "Json"){
-                        try{
-                            parsedJson = JSON.parse(vm.value);
-                        }
-                        catch(e){
-                            // This can happen if you switch a tag editor from csv to json, and the value is still returned as a csv string.
-                            // The value will be saved as a json string on the next save or publish.
-                            isValidJson = false;
-                        }
-                    }
-
-                    if (vm.config.storageType === "Json" && isValidJson) {
+                    if (vm.config.storageType === "Json" && vm.value.detectIsJson()) {
                         //json storage
-                        vm.viewModel = parsedJson;
+                        vm.viewModel = JSON.parse(vm.value);
 
                         //if this is the first load, we are just re-formatting the underlying model to be consistent
                         //we don't want to notify the component parent of any changes, that will occur if the user actually
@@ -191,7 +178,11 @@
                         }
                     }
                     else {
-                        //csv storage / fallback if not valid json
+                        // csv storage
+                        
+                        // Or fallback if not valid json
+                        // This can happen if you switch a tag editor from csv to json, and the value is still returned as a csv string.
+                        // The value will be saved as a json string on the next save or publish.
 
                         // split the csv string, and remove any duplicate values
                         let tempArray = vm.value.split(',').map(function (v) {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tags/umbtagseditor.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tags/umbtagseditor.directive.js
@@ -167,9 +167,15 @@
                 if (Utilities.isString(vm.value) && vm.value.length > 0) {
 
                     if (vm.config.storageType === "Json" && vm.value.detectIsJson()) {
-                        //json storage
-                        vm.viewModel = JSON.parse(vm.value);
-
+                        try {
+                            //json storage
+                            vm.viewModel = JSON.parse(vm.value);
+                        }
+                        catch (e) {
+                            // Invaild JSON we'll just leave it
+                            console.error("Invalid JSON in tag editor value", vm.value);
+                        }
+                        
                         //if this is the first load, we are just re-formatting the underlying model to be consistent
                         //we don't want to notify the component parent of any changes, that will occur if the user actually
                         //changes a value. If we notify at this point it will signal a form dirty change which we don't want.


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #14519

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

This adds a check to validate that a tag value marked as a JSON type is valid JSON and if not falls back to try and parse as a CSV value.

Steps to reproduce
- Create a document type with a tags property;
- Create some content and add a few tags;
- Change the tags datatype to store data as CSV;
- Add another set of tags, like a,b,c;
- Change the tags storage type back to JSON;

The description in #14519 is great if more information is needed.

<!-- Thanks for contributing to Umbraco CMS! -->
