### PR TITLE
Make sure to sign out external users if an error occurs during sign-in

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
@@ -585,6 +585,11 @@ public class BackOfficeController : UmbracoController
 
         if (errors.Count > 0)
         {
+            // the external user might actually be signed in at this point, but certain errors (i.e. missing claims)
+            // prevents us from applying said user to a back-office session. make sure the sign-in manager does not
+            // report the user as being signed in for subsequent requests.
+            await _signInManager.SignOutAsync();
+
             ViewData.SetExternalSignInProviderErrors(
                 new BackOfficeExternalLoginProviderErrors(
                     loginInfo.LoginProvider,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [#14775](https://github.com/umbraco/Umbraco-CMS/issues/14775)

### Description

When using external auth providers for user login, the authentication process may complete successfully yet be incomplete in respect to the Umbraco backoffice.

An example could be missing claims - most common use-case is if the external user does not have the correct "email" claim.

At this time we do not handle that scenario very well. The user ends up being presented with a blank screen and with no means to retry, nor perform a sign-out. The console will show a 401 error when trying to reach the `GetCurrentUser` endpoint (as described in the linked issue).

This PR ensures that we forcefully perform a sign-out from the external auth provider if any errors are detected. The sign-out in turn ensures that the user state is correct (not signed in) and the login screen re-appears with an error message stating what went wrong:

[14775.webm](https://github.com/umbraco/Umbraco-CMS/assets/7405322/031c8110-fcdf-4ccb-a099-57aa5338d4cc)

### Testing this PR

To test this PR, setup an external auth provider for users. Make sure it does not return the "email" claim and attempt to login using this provider. The flow should go somewhat like the screencast above.

Or, reach out to @kjac for a demo 😄 

