### PR TITLE
#14835 Update link on permissionsreport.html

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/installer/steps/permissionsreport.html
+++ b/src/Umbraco.Web.UI.Client/src/installer/steps/permissionsreport.html
@@ -3,7 +3,7 @@
     <p>
         In order to run Umbraco, you'll need to update your permission settings.
         Detailed information about the correct file and folder permissions for Umbraco can be found
-        <a href="https://docs.umbraco.com/umbraco-cms/fundamentals/setup/server-setup/permissions"><strong>here</strong></a>.
+        <a href="https://docs.umbraco.com/umbraco-cms/v/10.latest-lts/fundamentals/setup/server-setup/permissions"><strong>here</strong></a>.
     </p>
     <p>
         The following report list the permissions that are currently failing. Once the permissions are fixed press the 'Go back' button to restart the installation.


### PR DESCRIPTION
### Updated link to permissions page to point to 10-LTS documentation
Fixes #14835

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description

Steps to test / reproduce (as stated in ticket):
Make sure some folders have no app pool's user Modify nor Full control permissions on the server.
Try to install Umbraco, Permissions page will appear prompting to correct permissions on selected folders.
Now the correct link to 10-LTS version will be displayed:
[https://docs.umbraco.com/umbraco-cms/v/10.latest-lts/fundamentals/setup/server-setup/permissions](https://docs.umbraco.com/umbraco-cms/v/10.latest-lts/fundamentals/setup/server-setup/permissions)