### PR TITLE
Added `[NotNullWhen(true)]` attribute to `IPublishedSnapshotAccessor` and `UmbracoContextPublishedSnapshotAccessor`

### DIFF
--- a/src/Umbraco.Core/PublishedCache/IPublishedSnapshotAccessor.cs
+++ b/src/Umbraco.Core/PublishedCache/IPublishedSnapshotAccessor.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Umbraco.Cms.Core.PublishedCache;
 
 /// <summary>
@@ -6,5 +8,5 @@ namespace Umbraco.Cms.Core.PublishedCache;
 /// </summary>
 public interface IPublishedSnapshotAccessor
 {
-    bool TryGetPublishedSnapshot(out IPublishedSnapshot? publishedSnapshot);
+    bool TryGetPublishedSnapshot([NotNullWhen(true)] out IPublishedSnapshot? publishedSnapshot);
 }

--- a/src/Umbraco.Core/PublishedCache/UmbracoContextPublishedSnapshotAccessor.cs
+++ b/src/Umbraco.Core/PublishedCache/UmbracoContextPublishedSnapshotAccessor.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Umbraco.Cms.Core.Web;
 
 namespace Umbraco.Cms.Core.PublishedCache;
@@ -29,7 +30,7 @@ public class UmbracoContextPublishedSnapshotAccessor : IPublishedSnapshotAccesso
         set => throw new NotSupportedException(); // not ok to set
     }
 
-    public bool TryGetPublishedSnapshot(out IPublishedSnapshot? publishedSnapshot)
+    public bool TryGetPublishedSnapshot([NotNullWhen(true)] out IPublishedSnapshot? publishedSnapshot)
     {
         if (!_umbracoContextAccessor.TryGetUmbracoContext(out IUmbracoContext? umbracoContext))
         {


### PR DESCRIPTION
Since Umbraco 10, the `IPublishedSnapshotAccessor` interface has described a `TryGetPublishedSnapshot` method with a nullable `IPublishedSnapshot` out parameter - using a `?` to indicate that the parameter can possibly be `null`.

Since the parameter has no attributes for code analysis, it should be assumed that it can possibly be null in all situations, regardless of whether the method returns `true` or `false`. Visual Studio and possibly other IDEs will complain about this if you don't do a null check on your own.

But since we know better, we can add the `[NotNullWhen(true)]` attribute to the out parameter. This effectively then tells that if the method returns `true`, the `IPublishedSnapshot` instance in the out parameter is not `null`.

<hr />

I don't think you can test something like this with a unit test, so I've instead set up a small example as shown below. The `Test1` method uses the current `IPublishedSnapshotAccessor` implementation, and therefore Visual Studio complains that I should do a null check when calling `publishedSnapshot.Content` as `publishedSnapshot` could possibly `null`.

The `Test2` method instead uses my `IPublishedSnapshotAccessor2` (which is a copy of `IPublishedSnapshotAccessor`, but with my proses `?` change). Through code analysis, the compiler now knows that if the `TryGetPublishedSnapshot` method returns `true`, the `publishedSnapshot` out parameter is not `null`, and my Visual Studio will be happy that I don't make a null check on my own.

![image](https://github.com/umbraco/Umbraco-CMS/assets/3634580/85f1f6da-646d-427a-ae71-eac0420f90ea)

Here's the code from the screenshot:

```csharp
using System.Diagnostics.CodeAnalysis;
using Umbraco.Cms.Core.PublishedCache;

namespace UmbracoTwelve {

    public interface IPublishedSnapshotAccessor2 {
        bool TryGetPublishedSnapshot([NotNullWhen(true)] out IPublishedSnapshot? publishedSnapshot);
    }

    public class MyClass {

        private readonly IPublishedSnapshotAccessor _publishedSnapshotAccessor;
        private readonly IPublishedSnapshotAccessor2 _publishedSnapshotAccessor2;

        public MyClass(IPublishedSnapshotAccessor publishedSnapshotAccessor, IPublishedSnapshotAccessor2 publishedSnapshotAccessor2) {
            _publishedSnapshotAccessor = publishedSnapshotAccessor;
            _publishedSnapshotAccessor2 = publishedSnapshotAccessor2;
        }

        public void Test1() {

            if (_publishedSnapshotAccessor.TryGetPublishedSnapshot(out IPublishedSnapshot? publishedSnapshot)) {

                // Incorrectly flagged as possibly null
                var contentCache = publishedSnapshot.Content;

            } else {

                // Correctly flagged as possibly null
                var contentCache = publishedSnapshot.Content;

            }

        }

        public void Test2() {

            if (_publishedSnapshotAccessor2.TryGetPublishedSnapshot(out IPublishedSnapshot? publishedSnapshot)) {

                // Correctly flagged as not null due to added [NotNullWhen] attribute
                var contentCache = publishedSnapshot.Content;

            } else {

                // Correctly flagged as possibly null
                var contentCache = publishedSnapshot.Content;

            }

        }

    }

}
```

For reference, the `IUmbracoContextAccessor` interface and it's `TryGetUmbracoContext` method uses a similar *try get* approach, but it instead uses the `[MaybeNullWhen(false)]` attribute.

A major difference is however that the `IUmbracoContext` instance in the out parameter isn't marked with a `?`, hence it shouldn't be considered `null` by default, and the `[MaybeNullWhen(false)]` attribute is used to tell about when it may be `null`.

Since the `IPublishedSnapshot` instance is marked with `?`, it should be considered `null` by default, and we use the `[NotNullWhen(true)]` attribute to indicate when it's not `null`. I believe this approach to be more correct.

https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Core/Web/IUmbracoContextAccessor.cs#L12