### PR TITLE
Replaced `[MaybeNullWhen(false)]` with `[NotNullWhen(true)]` for `UdiParser.TryParse` method

### DIFF
--- a/src/Umbraco.Core/UdiParser.cs
+++ b/src/Umbraco.Core/UdiParser.cs
@@ -70,13 +70,13 @@ public sealed class UdiParser
     /// <param name="s">The string to convert.</param>
     /// <param name="udi">An Udi instance that contains the value that was parsed.</param>
     /// <returns>A boolean value indicating whether the string could be parsed.</returns>
-    public static bool TryParse<T>(string? s, [MaybeNullWhen(false)] out T udi)
-        where T : Udi?
+    public static bool TryParse<T>(string? s, [NotNullWhen(true)] out T? udi)
+        where T : Udi
     {
         var result = ParseInternal(s, true, false, out Udi? parsed);
-        if (result && parsed is T)
+        if (result && parsed is T t)
         {
-            udi = (T)parsed;
+            udi = t;
             return true;
         }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/CoreThings/UdiTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/CoreThings/UdiTests.cs
@@ -205,8 +205,6 @@ public class UdiTests
         Assert.Throws<ArgumentException>(() => new UdiRange(guidUdi, "x"));
     }
 
-
-
     [Test]
     public void TryParseTest()
     {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/CoreThings/UdiTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/CoreThings/UdiTests.cs
@@ -205,6 +205,30 @@ public class UdiTests
         Assert.Throws<ArgumentException>(() => new UdiRange(guidUdi, "x"));
     }
 
+
+
+    [Test]
+    public void TryParseTest()
+    {
+        // try parse to "Udi"
+        var stringUdiString = "umb://document/b9a56165-6c4e-4e79-8277-620430174ad3";
+        Assert.IsTrue(UdiParser.TryParse(stringUdiString, out Udi udi1));
+        Assert.AreEqual("b9a56165-6c4e-4e79-8277-620430174ad3", udi1 is GuidUdi guidUdi1 ? guidUdi1.Guid.ToString() : string.Empty);
+
+        // try parse to "Udi"
+        Assert.IsFalse(UdiParser.TryParse("nope", out Udi udi2));
+        Assert.IsNull(udi2);
+
+        // try parse to "GuidUdi?"
+        Assert.IsTrue(UdiParser.TryParse(stringUdiString, out GuidUdi? guidUdi3));
+        Assert.AreEqual("b9a56165-6c4e-4e79-8277-620430174ad3", guidUdi3.Guid.ToString());
+
+        // try parse to "GuidUdi?"
+        Assert.IsFalse(UdiParser.TryParse("nope", out GuidUdi? guidUdi4));
+        Assert.IsNull(guidUdi4);
+
+    }
+
     [Test]
     public void SerializationTest()
     {


### PR DESCRIPTION
This one has annoyed be for some time, so thought I might as well fix it 😁 

The `UdiParser` class has three `TryParse` methods. Two of them have an out parameter of type `Udi`, and both have been marked with the `[MaybeNullWhen(false)]` attribute. So these two are fine.

The third one also has an out parameter, but the type is `T` where `T : Udi?`. The parameter also has a `[MaybeNullWhen(false)]` attribute to indicate that the parameter may be `null` when the method returns `false`. But as the type is essentially a `Udi?`, the method fails to indicate when the out parameter is *not* `null`. This PR therefore replaces the `[MaybeNullWhen(false)]` attribute with a `[NotNullWhen(true)]` attribute instead.

<hr />

To illustrate the effect of this change, I've set up a quick test class. The `Test1` method shows how my Visual Studio complains as I'm not doing a `null` check before calling the `Guid` property on the `udi` variable.

The `Test2` method uses my `UdiParser2` example class, which is a dummy copy of Umbraco's `UdiParser.TryParse` method, but with the proposed changes. Thanks to the `[NotNullWhen(true)]`, Visual Studio will no longer complain that I need to do a `null` check.

![image](https://github.com/umbraco/Umbraco-CMS/assets/3634580/ac4513ba-9a23-463f-8211-2e75b37c02a3)

```csharp
using System.Diagnostics.CodeAnalysis;
using Umbraco.Cms.Core;

namespace UmbracoTwelve {

    public static class UdiParser2 {

        public static bool TryParse<T>(string? s, [NotNullWhen(true)] out T? udi) where T : Udi {
            throw new NotImplementedException();
        }

    }

    public class TestClass {

        public void Test1() {

            if (UdiParser.TryParse("dummy", out GuidUdi? udi)) {

                // Incorrectly flagged as possibly null
                Guid guid = udi.Guid;

            } else {

                // Correctly flagged as possibly null
                Guid guid = udi.Guid;

            }

        }

        public void Test2() {

            if (UdiParser2.TryParse("dummy", out GuidUdi? udi)) {

                // Correctly flagged as not null due to added [NotNullWhen] attribute
                Guid guid = udi.Guid;

            } else {

                // Correctly flagged as possibly null
                Guid guid = udi.Guid;

            }

        }

    }

}
```

<hr />

I've also changed a few other things about the method:

- Instead of the type of the out parameter being `T` where `T : Udi?`, I've changed it to be `T?` where `T : Udi`. A minor details, but I believe this to be more correct. AFAIK changing this isn't considered a breaking change, since nullable reference types are not part of the method signature.

- The method implementation had `parsed is T` as part of an if statement, and then casted `parsed` to the desired type. With newer versions of C#, we can use pattern matching instead, meaning changing the `parsed is T` to `parsed is T t`, so we can use `t` right away instead of casting `parsed`. Not really related to the rest of the PR, but might as well fix this while I was changing the method.

Since these two changes could theoretically break the implementation, I've added some units tests to test that I didn't. The test cases are not really super advanced, but I think they confirm that I didn't break anything. All the tests in the `UdiTests` test class succeed when I run the tests on my machine. 😎 

![image](https://github.com/umbraco/Umbraco-CMS/assets/3634580/448d83ef-2a54-4d1f-a952-ce67e8a55b05)
