### PR TITLE
Fixed URL tracking not working for invariant pages with culture variant ancestors

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RedirectUrlRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RedirectUrlRepository.cs
@@ -1,5 +1,4 @@
 using System.Security.Cryptography;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NPoco;
 using Umbraco.Cms.Core;
@@ -44,7 +43,7 @@ internal class RedirectUrlRepository : EntityRepositoryBase<Guid, IRedirectUrl>,
         return dto == null ? null : Map(dto);
     }
 
-    public  async Task<IRedirectUrl?> GetMostRecentUrlAsync(string url)
+    public async Task<IRedirectUrl?> GetMostRecentUrlAsync(string url)
     {
         Sql<ISqlContext> sql = GetMostRecentSql(url);
         List<RedirectUrlDto> dtos = await Database.FetchAsync<RedirectUrlDto>(sql);
@@ -71,7 +70,7 @@ internal class RedirectUrlRepository : EntityRepositoryBase<Guid, IRedirectUrl>,
         Sql<ISqlContext> sql = GetMostRecentUrlSql(url, culture);
 
         List<RedirectUrlDto> dtos = Database.Fetch<RedirectUrlDto>(sql);
-        RedirectUrlDto? dto = dtos.FirstOrDefault(f => f.Culture == culture.ToLower());
+        RedirectUrlDto? dto = dtos.FirstOrDefault(f => culture.InvariantEquals(f.Culture));
 
         if (dto == null)
         {
@@ -102,7 +101,7 @@ internal class RedirectUrlRepository : EntityRepositoryBase<Guid, IRedirectUrl>,
         Sql<ISqlContext> sql = GetMostRecentUrlSql(url, culture);
 
         List<RedirectUrlDto> dtos = await Database.FetchAsync<RedirectUrlDto>(sql);
-        RedirectUrlDto? dto = dtos.FirstOrDefault(f => f.Culture == culture.ToLower());
+        RedirectUrlDto? dto = dtos.FirstOrDefault(f => culture.InvariantEquals(f.Culture));
 
         if (dto == null)
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This fixes an issue where URL tracking doesn't work for culture invariant pages that have a culture variant ancestor.
The issue is not present if the whole document hierarchy is either variant or invariant, only when mixing and using cultures that have upper case components (country code), which explains why it wasn't caught earlier.

This change ensure the LINQ culture comparison being done doesn't vary by case.
The actual database SQL query `Where` clauses don't need adjustment because the `culture` column collation is already case insensitive.

### Reproduction Steps
1. Set up 2 languages whose ISO code have upper case characters (e.g `en-US` and `nl-NL`)
2. Create a root document type which varies by culture
3. Create a child document type that doesn't vary by culture
4. Create some example content, and rename the child document
5. Confirm that although the URL tracking entry for the renamed document exists in the Redirect URL Management dashboard, navigating to the old URL results in a 404

(Steps 1-4 can be skipped by using the attached [Umbraco.sqlite.db.zip](https://github.com/umbraco/Umbraco-CMS/files/12777024/Umbraco.sqlite.db.zip) database file and creating an `Empty.cshtml` view file)

<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
