### PR TITLE
made link to umbraco learning base youtube visible with underline sty…

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/bs.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/bs.xml
@@ -2653,7 +2653,7 @@ Da upravljate svojom web lokacijom, jednostavno otvorite Umbraco backoffice i po
     </key>
     <key alias="learningBaseDescription">
       <![CDATA[
-        <p>Želite savladati Umbraco? Provedite nekoliko minuta učeći neke najbolje prakse gledajući jedan od ovih videozapisa o korištenju Umbraco-a <a href="https://www.youtube.com/c/UmbracoLearningBase" target="_blank" rel="noopener"> Umbraco Learning Base Youtube kanal</a>. Ovdje možete pronaći gomilu video materijala koji pokriva mnoge aspekte Umbraco-a.</p>
+        <p>Želite savladati Umbraco? Provedite nekoliko minuta učeći neke najbolje prakse gledajući jedan od ovih videozapisa o korištenju Umbraco-a <a class="btn-link -underline" href="https://www.youtube.com/c/UmbracoLearningBase" target="_blank" rel="noopener"> Umbraco Learning Base Youtube kanal</a>. Ovdje možete pronaći gomilu video materijala koji pokriva mnoge aspekte Umbraco-a.</p>
       ]]>
     </key>
     <key alias="getStarted">Za početak</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -2674,7 +2674,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     </key>
     <key alias="learningBaseDescription">
       <![CDATA[
-        <p>Want to master Umbraco? Spend a few minutes learning some best practices by visiting <a href="https://www.youtube.com/c/UmbracoLearningBase" target="_blank" rel="noopener">the Umbraco Learning Base Youtube channel</a>. Here you can find a bunch of video material covering many aspects of Umbraco.</p>
+        <p>Want to master Umbraco? Spend a few minutes learning some best practices by visiting <a class="btn-link -underline" href="https://www.youtube.com/c/UmbracoLearningBase" target="_blank" rel="noopener">the Umbraco Learning Base Youtube channel</a>. Here you can find a bunch of video material covering many aspects of Umbraco.</p>
       ]]>
     </key>
     <key alias="getStarted">To get you started</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/hr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/hr.xml
@@ -2610,7 +2610,7 @@ Da bi upravljali svojom web lokacijom, jednostavno otvorite Umbraco backoffice i
     </key>
     <key alias="learningBaseDescription">
       <![CDATA[
-        <p>Želite savladati Umbraco? Provedite nekoliko minuta učeći najbolje prakse gledajući jedan od ovih videozapisa o korištenju Umbraco-a <a href="https://www.youtube.com/c/UmbracoLearningBase" target="_blank" rel="noopener"> Umbraco Learning Base Youtube kanal</a>. Ovdje možete pronaći gomilu video materijala koji pokriva mnoge aspekte Umbraco-a.</p>
+        <p>Želite savladati Umbraco? Provedite nekoliko minuta učeći najbolje prakse gledajući jedan od ovih videozapisa o korištenju Umbraco-a <a class="btn-link -underline" href="https://www.youtube.com/c/UmbracoLearningBase" target="_blank" rel="noopener"> Umbraco Learning Base Youtube kanal</a>. Ovdje možete pronaći gomilu video materijala koji pokriva mnoge aspekte Umbraco-a.</p>
       ]]>
     </key>
     <key alias="getStarted">Za početak</key>

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/members/membersdashboardvideos.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/members/membersdashboardvideos.html
@@ -6,7 +6,7 @@
 		<umb-box-content>
 			<h3 class="bold"><localize key="settingsDashboardVideos_trainingHeadline">Hours of Umbraco training videos are only a click away</localize></h3>
 			<localize key="settingsDashboardVideos_learningBaseDescription">
-        <p>Want to master Umbraco? Spend a few minutes learning some best practices by visiting <a href="https://www.youtube.com/c/UmbracoLearningBase" target="_blank" rel="noopener">the Umbraco Learning Base Youtube channel</a>. Here you can find a bunch of video material coverings many aspects of Umbraco.</p>
+        <p>Want to master Umbraco? Spend a few minutes learning some best practices by visiting <a class="btn-link -underline" href="https://www.youtube.com/c/UmbracoLearningBase" target="_blank" rel="noopener">the Umbraco Learning Base Youtube channel</a>. Here you can find a bunch of video material coverings many aspects of Umbraco.</p>
       </localize>
 		</umb-box-content>
 	</umb-box>


### PR DESCRIPTION
made link to umbraco learning base youtube visible with underline style as per the other links on other dashboards.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
On the members dashboard there is a link to the Umbraco Learning Base YouTube channel. But it is not visible. All other links on dashboards link this are underlined using a class. 

I have added the class to this link so it is visible as being a link and not just plain text.

**Before**

![before](https://github.com/umbraco/Umbraco-CMS/assets/9142936/572c60db-8b6c-425d-8258-fe2d3377cdf8)

**After**

![after](https://github.com/umbraco/Umbraco-CMS/assets/9142936/45e36c23-eabf-49a7-8dd5-fbf3b1dd4f42)
