### PR TITLE
Refactor to improve code legibility and performance

### DIFF
--- a/src/Umbraco.Examine.Lucene/LuceneIndexDiagnosticsFactory.cs
+++ b/src/Umbraco.Examine.Lucene/LuceneIndexDiagnosticsFactory.cs
@@ -28,7 +28,7 @@ public class LuceneIndexDiagnosticsFactory : IndexDiagnosticsFactory
 
     public override IIndexDiagnostics Create(IIndex index)
     {
-        if (!(index is IIndexDiagnostics indexDiag))
+        if (index is not IIndexDiagnostics indexDiag)
         {
             if (index is LuceneIndex luceneIndex)
             {

--- a/src/Umbraco.Examine.Lucene/NoPrefixSimpleFsLockFactory.cs
+++ b/src/Umbraco.Examine.Lucene/NoPrefixSimpleFsLockFactory.cs
@@ -21,6 +21,6 @@ public class NoPrefixSimpleFsLockFactory : SimpleFSLockFactory
     public override string LockPrefix
     {
         get => base.LockPrefix;
-        set => base.LockPrefix = null; //always set to null
+        set => base.LockPrefix = null; // always set to null
     }
 }

--- a/src/Umbraco.Examine.Lucene/UmbracoContentIndex.cs
+++ b/src/Umbraco.Examine.Lucene/UmbracoContentIndex.cs
@@ -63,7 +63,7 @@ public class UmbracoContentIndex : UmbracoExamineIndex, IUmbracoContentIndex
         // We don't want to re-enumerate this list, but we need to split it into 2x enumerables: invalid and valid items.
         // The Invalid items will be deleted, these are items that have invalid paths (i.e. moved to the recycle bin, etc...)
         // Then we'll index the Value group all together.
-        var invalidOrValid = values.GroupBy(v =>
+        IGrouping<ValueSetValidationStatus, ValueSet>[] invalidOrValid = values.GroupBy(v =>
         {
             if (!v.Values.TryGetValue("path", out IReadOnlyList<object>? paths) || paths.Count <= 0 || paths[0] == null)
             {


### PR DESCRIPTION
Modified UmbracoContentIndex.cs, LuceneIndexDiagnosticsFactory.cs and BackOfficeExamineSearcher.cs to make the code more readable and efficient. The changes include half explicit type declarations and the usage of the 'is not' operator for clearer legibility. more manageable parts. This will help improve overall code legibility, debuggability, maintainability and performance. Lastly, added spaces in certain comments for uniformity.
