### PR TITLE
Fix permissions for assign hostname

### DIFF
--- a/src/Umbraco.Core/Services/UserServiceExtensions.cs
+++ b/src/Umbraco.Core/Services/UserServiceExtensions.cs
@@ -26,6 +26,25 @@ public static class UserServiceExtensions
         return userService.GetPermissions(user, ids[^1]).FirstOrDefault();
     }
 
+    public static EntityPermissionCollection GetAllPermissions(this IUserService userService, IUser? user, string path)
+    {
+        var ids = path.Split(Constants.CharArrays.Comma, StringSplitOptions.RemoveEmptyEntries)
+            .Select(x =>
+                int.TryParse(x, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
+                    ? Attempt<int>.Succeed(value)
+                    : Attempt<int>.Fail())
+            .Where(x => x.Success)
+            .Select(x => x.Result)
+            .ToArray();
+        if (ids.Length == 0)
+        {
+            throw new InvalidOperationException("The path: " + path +
+                                                " could not be parsed into an array of integers or the path was empty");
+        }
+
+        return userService.GetPermissions(user, ids[^1]);
+    }
+
     /// <summary>
     ///     Get explicitly assigned permissions for a group and optional node Ids
     /// </summary>

--- a/src/Umbraco.Core/Services/UserServiceExtensions.cs
+++ b/src/Umbraco.Core/Services/UserServiceExtensions.cs
@@ -9,21 +9,7 @@ public static class UserServiceExtensions
 {
     public static EntityPermission? GetPermissions(this IUserService userService, IUser? user, string path)
     {
-        var ids = path.Split(Constants.CharArrays.Comma, StringSplitOptions.RemoveEmptyEntries)
-            .Select(x =>
-                int.TryParse(x, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
-                    ? Attempt<int>.Succeed(value)
-                    : Attempt<int>.Fail())
-            .Where(x => x.Success)
-            .Select(x => x.Result)
-            .ToArray();
-        if (ids.Length == 0)
-        {
-            throw new InvalidOperationException("The path: " + path +
-                                                " could not be parsed into an array of integers or the path was empty");
-        }
-
-        return userService.GetPermissions(user, ids[^1]).FirstOrDefault();
+       return userService.GetAllPermissions(user, path).FirstOrDefault();
     }
 
     public static EntityPermissionCollection GetAllPermissions(this IUserService userService, IUser? user, string path)

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
@@ -2400,8 +2400,10 @@ public class ContentController : ContentControllerBase
         }
 
         // Validate permissions on node
-        EntityPermission? permission = _userService.GetPermissions(_backofficeSecurityAccessor.BackOfficeSecurity?.CurrentUser, node.Path);
-        if (permission?.AssignedPermissions.Contains(ActionAssignDomain.ActionLetter.ToString(), StringComparer.Ordinal) == false)
+        var permissions = _userService.GetAllPermissions(_backofficeSecurityAccessor.BackOfficeSecurity?.CurrentUser, node.Path);
+
+        if (permissions.Any(x =>
+                x.AssignedPermissions.Contains(ActionAssignDomain.ActionLetter.ToString(), StringComparer.Ordinal) && x.EntityId == node.Id) == false)
         {
             HttpContext.SetReasonPhrase("Permission Denied.");
             return BadRequest("You do not have permission to assign domains on that node.");


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

We have a project with a lot of user groups. Some groups define startnodes. Others will add permissions like for example Assigning cultures and hostnames.

To reproduce create a user group and call it for example "Domain admin" and assign it only the permission "Culture and hostnames".

Then create a new user and assign the user to the roles Editors, Translators and the Domain Admin group.

Login to the backoffice with this new user and try to assign Culture and hostnames. You will see a error happening because of denied permissions.

We discovered this on 10.6.1, but also on the latest version of the contrib branch.

The problem occurred in a the extension method UserServiceExtensions.GetPermissions. This will retrieve all permissions but only return the first one. If that doesn't have the Culture & Hostnames permission the error will occur.

I fixed this by adding another extensions method (to be backwards compatible) that will get all permissions. And then check if the permissions is assigned on one of the groups for the content node.

With these changes the problem will not occur anymore.

<!-- Thanks for contributing to Umbraco CMS! -->
