### PR TITLE
Dispatch TreeChanged event after saving/deleting blueprints

### DIFF
--- a/src/Umbraco.Core/Services/Implement/ContentService.cs
+++ b/src/Umbraco.Core/Services/Implement/ContentService.cs
@@ -3046,6 +3046,7 @@ namespace Umbraco.Core.Services.Implement
                 Audit(AuditType.Save, Constants.Security.SuperUserId, content.Id, $"Saved content template: {content.Name}");
 
                 scope.Events.Dispatch(SavedBlueprint, this, new SaveEventArgs<IContent>(content), "SavedBlueprint");
+                scope.Events.Dispatch(TreeChanged, this, new TreeChange<IContent>(content, TreeChangeTypes.RefreshNode).ToEventArgs());
 
                 scope.Complete();
             }
@@ -3058,6 +3059,7 @@ namespace Umbraco.Core.Services.Implement
                 scope.WriteLock(Constants.Locks.ContentTree);
                 _documentBlueprintRepository.Delete(content);
                 scope.Events.Dispatch(DeletedBlueprint, this, new DeleteEventArgs<IContent>(content), nameof(DeletedBlueprint));
+                scope.Events.Dispatch(TreeChanged, this, new TreeChange<IContent>(content, TreeChangeTypes.Remove).ToEventArgs());
                 scope.Complete();
             }
         }
@@ -3148,6 +3150,7 @@ namespace Umbraco.Core.Services.Implement
                 }
 
                 scope.Events.Dispatch(DeletedBlueprint, this, new DeleteEventArgs<IContent>(blueprints), nameof(DeletedBlueprint));
+                scope.Events.Dispatch(TreeChanged, this, blueprints.Select(x => new TreeChange<IContent>(x, TreeChangeTypes.Remove)).ToEventArgs());
                 scope.Complete();
             }
         }

--- a/src/Umbraco.Web/Cache/DistributedCacheBinder_Handlers.cs
+++ b/src/Umbraco.Web/Cache/DistributedCacheBinder_Handlers.cs
@@ -135,12 +135,6 @@ namespace Umbraco.Web.Cache
             Bind(() => ContentService.EmptiedRecycleBin += ContentService_EmptiedRecycleBin,
                 () => ContentService.EmptiedRecycleBin -= ContentService_EmptiedRecycleBin);
 
-            // TreeChanged should also deal with this
-            //Bind(() => ContentService.SavedBlueprint += ContentService_SavedBlueprint,
-            //    () => ContentService.SavedBlueprint -= ContentService_SavedBlueprint);
-            //Bind(() => ContentService.DeletedBlueprint += ContentService_DeletedBlueprint,
-            //    () => ContentService.DeletedBlueprint -= ContentService_DeletedBlueprint);
-
             // bind to public access events
             Bind(() => PublicAccessService.Saved += PublicAccessService_Saved,
                 () => PublicAccessService.Saved -= PublicAccessService_Saved);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
While @AndyButland was fixing a [Deploy issue regarding content templates/blueprints](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/182), during testing he noticed the caches weren't cleared (because outdated property values were shown until restarting the web application).

After some investigation, I found the following comment:
https://github.com/umbraco/Umbraco-CMS/blob/2534f99cdba1fe7a34c675783652a97b89ee271f/src/Umbraco.Web/Cache/DistributedCacheBinder_Handlers.cs#L138-L142

But saving or deleting blueprints currently doesn't trigger this event and consequently doesn't refresh the caches. This PR adds the `TreeChanged` event dispatches, ensuring this now does happen correctly.

To test, install a fresh v8 site using The Starter Kit, add a breakpoint to `ContentCacheRefresher.Refresh(JsonPayload[] payloads)` and create/update a content template: you'll see this breakpoint doesn't get hit. Now apply the PR and see that it does.