### PR TITLE
Publish ContentTreeChangeNotification after saving/deleting blueprints

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -3585,6 +3585,7 @@ public class ContentService : RepositoryService, IContentService
             Audit(AuditType.Save, Constants.Security.SuperUserId, content.Id, $"Saved content template: {content.Name}");
 
             scope.Notifications.Publish(new ContentSavedBlueprintNotification(content, evtMsgs));
+            scope.Notifications.Publish(new ContentTreeChangeNotification(content, TreeChangeTypes.RefreshNode, evtMsgs));
 
             scope.Complete();
         }
@@ -3599,6 +3600,7 @@ public class ContentService : RepositoryService, IContentService
             scope.WriteLock(Constants.Locks.ContentTree);
             _documentBlueprintRepository.Delete(content);
             scope.Notifications.Publish(new ContentDeletedBlueprintNotification(content, evtMsgs));
+            scope.Notifications.Publish(new ContentTreeChangeNotification(content, TreeChangeTypes.Remove, evtMsgs));
             scope.Complete();
         }
     }
@@ -3699,6 +3701,7 @@ public class ContentService : RepositoryService, IContentService
                 }
 
                 scope.Notifications.Publish(new ContentDeletedBlueprintNotification(blueprints, evtMsgs));
+                scope.Notifications.Publish(new ContentTreeChangeNotification(blueprints, TreeChangeTypes.Remove, evtMsgs));
                 scope.Complete();
             }
         }

--- a/src/Umbraco.Infrastructure/Cache/DistributedCacheBinder_Handlers.cs
+++ b/src/Umbraco.Infrastructure/Cache/DistributedCacheBinder_Handlers.cs
@@ -67,15 +67,6 @@ public class DistributedCacheBinder :
         _distributedCache.RefreshContentCache(notification.Changes.ToArray());
     }
 
-    // private void ContentService_SavedBlueprint(IContentService sender, SaveEventArgs<IContent> e)
-    // {
-    //    _distributedCache.RefreshUnpublishedPageCache(e.SavedEntities.ToArray());
-    // }
-
-    // private void ContentService_DeletedBlueprint(IContentService sender, DeleteEventArgs<IContent> e)
-    // {
-    //    _distributedCache.RemoveUnpublishedPageCache(e.DeletedEntities.ToArray());
-    // }
     #endregion
 
     #region LocalizationService / Dictionary


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This is the v10+ version of PR https://github.com/umbraco/Umbraco-CMS/pull/14897 and can be tested in the same way... After merging, this should be easily merged up to the latest versions as well.