### PR TITLE
Add IExceptionHandlerFeature check to dynamic route check

### DIFF
--- a/src/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformer.cs
+++ b/src/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformer.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Routing;
@@ -170,7 +171,11 @@ public class UmbracoRouteValueTransformer : DynamicRouteValueTransformer
         // This can occur if someone else is dynamically routing and in which case we don't want to overwrite
         // the routing work being done there.
         UmbracoRouteValues? umbracoRouteValues = httpContext.Features.Get<UmbracoRouteValues>();
-        if (umbracoRouteValues != null)
+
+        // Check whether an exception occured in the current request.
+        // If this is the case we do want dynamic routing since it might be an Umbraco content page which is used as an error page.
+        IExceptionHandlerFeature? exceptionHandlerFeature = httpContext.Features.Get<IExceptionHandlerFeature>();
+        if (umbracoRouteValues != null && exceptionHandlerFeature == null)
         {
             return null!;
         }

--- a/src/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformer.cs
+++ b/src/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformer.cs
@@ -167,15 +167,7 @@ public class UmbracoRouteValueTransformer : DynamicRouteValueTransformer
             return null!;
         }
 
-        // Don't execute if there are already UmbracoRouteValues assigned.
-        // This can occur if someone else is dynamically routing and in which case we don't want to overwrite
-        // the routing work being done there.
-        UmbracoRouteValues? umbracoRouteValues = httpContext.Features.Get<UmbracoRouteValues>();
-
-        // Check whether an exception occured in the current request.
-        // If this is the case we do want dynamic routing since it might be an Umbraco content page which is used as an error page.
-        IExceptionHandlerFeature? exceptionHandlerFeature = httpContext.Features.Get<IExceptionHandlerFeature>();
-        if (umbracoRouteValues != null && exceptionHandlerFeature == null)
+        if (CheckActiveDynamicRoutingAndNoException(httpContext))
         {
             return null!;
         }
@@ -203,7 +195,7 @@ public class UmbracoRouteValueTransformer : DynamicRouteValueTransformer
 
         IPublishedRequest publishedRequest = await RouteRequestAsync(umbracoContext);
 
-        umbracoRouteValues = await _routeValuesFactory.CreateAsync(httpContext, publishedRequest);
+        UmbracoRouteValues? umbracoRouteValues = await _routeValuesFactory.CreateAsync(httpContext, publishedRequest);
 
         // now we need to do some public access checks
         umbracoRouteValues =
@@ -246,6 +238,30 @@ public class UmbracoRouteValueTransformer : DynamicRouteValueTransformer
         }
 
         return newValues;
+    }
+
+    /// <summary>
+    ///     Check whether dynamic routing is currently active in an request where no exception has occured.
+    /// </summary>
+    /// <returns>[true] if dynamic routing is active, [false] if inactive or an exception has occured.</returns>
+    private static bool CheckActiveDynamicRoutingAndNoException(HttpContext httpContext)
+    {
+        // Don't execute if there are already UmbracoRouteValues assigned.
+        // This can occur if someone else is dynamically routing and in which case we don't want to overwrite
+        // the routing work being done there.
+        UmbracoRouteValues? umbracoRouteValues = httpContext.Features.Get<UmbracoRouteValues>();
+
+        // No dynamic routing is active currently.
+        if (umbracoRouteValues == null)
+        {
+            return false;
+        }
+
+        // There is dynamic routing active so we have to check whether an exception occured in the current request.
+        // If this is the case we do want dynamic routing since it might be an Umbraco content page which is used as an error page.
+        IExceptionHandlerFeature? exceptionHandlerFeature = httpContext.Features.Get<IExceptionHandlerFeature>();
+
+        return exceptionHandlerFeature == null;
     }
 
     private async Task<IPublishedRequest> RouteRequestAsync(IUmbracoContext umbracoContext)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #13052 

### Steps to reproduce

1. Create a new Umbraco 10 web app, e.g. using the auto-generated scripts created by [psw.codeshare.co.uk](https://psw.codeshare.co.uk/) as the starting point.
2. Add a home page, a test page, and an error page using the back office.
3. In the view template for the test page add a "throw new Exception(...)" statement which will trigger the exception handling process when you navigate to the page.
4. In Startup.Configure() remove any if (env.IsDevelopment()) clause and the app.UseDeveloperExceptionPage(); call. Instead add a call to app.UseExceptionHandler("/error"); and replace "/error" with your error page's url.
5. Run the app, navigate explicitly to the error page to verify that it's reachable, and then navigate to the test page to trigger the exception.

### Description
This fix solves the problem described in the issue linked above.
This allows for `app.UseExceptionHandler("/error");` being used in the `Startup.Configure(IApplicationBuilder app, IWebHostEnvironment env)` method where `/error` is an Umbraco page. 

Whenever the a static page is used like `app.UseExceptionHandler("/error.html");` this will be handled by the `StaticFileMiddleware` which will run before `UmbracoRouteValueTransformer` is ever called.

I wondered whether it would be a good idea to add a `app.UseUmbracoExceptionHandler("/error");` to replace `app.UseExceptionHandler("/error");` and have it add a `UmbracoExceptionFeature` to the current request. That way we can specifically check for that feature in the `TransformAsync` method. But since `TransformAsync` in this case feels like a last resort I thought it wouldn't hurt to have it check for the `IExceptionHandlerFeature` there.

**Edit:**
Also running a `Clean and Format` from within Rider results in a few changes, but I cannot validate whether they are valid or not so I have not included them (yet).