### PR TITLE
Now properly checks the lockedoutdate

### DIFF
--- a/src/Umbraco.Infrastructure/Security/IdentityMapDefinition.cs
+++ b/src/Umbraco.Infrastructure/Security/IdentityMapDefinition.cs
@@ -34,9 +34,26 @@ public class IdentityMapDefinition : IMapDefinition
         _textService = textService;
         _entityService = entityService;
         _globalSettings = globalSettings.Value;
+        _securitySettings = securitySettings.Value;
         _appCaches = appCaches;
         _twoFactorLoginService = twoFactorLoginService;
-        _securitySettings = securitySettings.Value;
+    }
+
+    [Obsolete("Use constructor that also takes an IOptions<SecuritySettings>. Scheduled for removal in V14")]
+    public IdentityMapDefinition(
+        ILocalizedTextService textService,
+        IEntityService entityService,
+        IOptions<GlobalSettings> globalSettings,
+        AppCaches appCaches,
+        ITwoFactorLoginService twoFactorLoginService)
+        : this(
+            textService,
+            entityService,
+            globalSettings,
+            StaticServiceProvider.Instance.GetRequiredService<IOptions<SecuritySettings>>(),
+            appCaches,
+            twoFactorLoginService)
+    {
     }
 
     [Obsolete("Use constructor that also takes an ITwoFactorLoginService. Scheduled for removal in V12")]
@@ -44,13 +61,12 @@ public class IdentityMapDefinition : IMapDefinition
         ILocalizedTextService textService,
         IEntityService entityService,
         IOptions<GlobalSettings> globalSettings,
-        IOptions<SecuritySettings> securitySettings,
         AppCaches appCaches)
         : this(
             textService,
             entityService,
             globalSettings,
-            securitySettings,
+            StaticServiceProvider.Instance.GetRequiredService<IOptions<SecuritySettings>>(),
             appCaches,
             StaticServiceProvider.Instance.GetRequiredService<ITwoFactorLoginService>())
     {

--- a/src/Umbraco.Infrastructure/Security/IdentityMapDefinition.cs
+++ b/src/Umbraco.Infrastructure/Security/IdentityMapDefinition.cs
@@ -113,7 +113,7 @@ public class IdentityMapDefinition : IMapDefinition
         target.IsApproved = source.IsApproved;
         target.SecurityStamp = source.SecurityStamp;
         DateTime? lockedOutUntil = source.LastLockoutDate?.AddMinutes(_securitySettings.UserDefaultLockoutTimeInMinutes);
-        target.LockoutEnd = source.IsLockedOut ? source.LastLockoutDate.HasValue ? lockedOutUntil?.ToUniversalTime() : DateTime.MaxValue.ToUniversalTime() : null;
+        target.LockoutEnd = source.IsLockedOut ? (lockedOutUntil ?? DateTime.MaxValue).ToUniversalTime() : null;
     }
 
     // Umbraco.Code.MapAll -Id -LockoutEnabled -PhoneNumber -PhoneNumberConfirmed -ConcurrencyStamp -NormalizedEmail -NormalizedUserName -Roles
@@ -131,7 +131,7 @@ public class IdentityMapDefinition : IMapDefinition
         target.IsApproved = source.IsApproved;
         target.SecurityStamp = source.SecurityStamp;
         DateTime? lockedOutUntil = source.LastLockoutDate?.AddMinutes(_securitySettings.UserDefaultLockoutTimeInMinutes);
-        target.LockoutEnd = source.IsLockedOut ? source.LastLockoutDate.HasValue ? lockedOutUntil?.ToUniversalTime() : DateTime.MaxValue.ToUniversalTime() : null;
+        target.LockoutEnd = source.IsLockedOut ? (lockedOutUntil ?? DateTime.MaxValue).ToUniversalTime() : null;
         target.Comments = source.Comments;
         target.LastLockoutDateUtc = source.LastLockoutDate == DateTime.MinValue
             ? null

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberManagerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberManagerTests.cs
@@ -42,6 +42,7 @@ public class MemberManagerTests
                 Mock.Of<ILocalizedTextService>(),
                 Mock.Of<IEntityService>(),
                 new TestOptionsSnapshot<GlobalSettings>(new GlobalSettings()),
+                new TestOptionsSnapshot<SecuritySettings>(new SecuritySettings()),
                 AppCaches.Disabled,
                 Mock.Of<ITwoFactorLoginService>())
         };


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Decription/reproduction can be found in the original issue: 

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/14561

### Description
The line:
`target.LockoutEnd = source.IsLockedOut ? DateTime.MaxValue.ToUniversalTime() : (DateTime?)null;`
only would set the LockedOut value to the maxvalue (so basically, infinite) so I've changed the following to fix this:

- Injected the `_securitySettings` (not entirely sure if it's considers as breaking, also because of the interaction with the obsolete method) 
- Added the configured minutes to the configured value (default 43200minutes / 30 days)

This will set the lockedout date correclty.

**However**
I feel like this is an issue, but mostly in `Microsoft.AspNetCore.Identity` as it seems to have no check for this.

When a user is locked out, and the locked out period is expired, they can keep logging in indefinitely, a new lock is NOT set at all on a new fail.

Perhaps I'm overlooking something, and would love some thoughts on this, perhaps I can make a PR to Core after this if I'm correct :)
