### PR TITLE
Setting SavedDictionaryItem EventState to the one from SavingDictionaryItem

### DIFF
--- a/src/Umbraco.Core/Services/Implement/LocalizationService.cs
+++ b/src/Umbraco.Core/Services/Implement/LocalizationService.cs
@@ -231,7 +231,8 @@ namespace Umbraco.Core.Services.Implement
         {
             using (var scope = ScopeProvider.CreateScope())
             {
-                if (scope.Events.DispatchCancelable(SavingDictionaryItem, this, new SaveEventArgs<IDictionaryItem>(dictionaryItem)))
+                var saveEventArgs = new SaveEventArgs<IDictionaryItem>(dictionaryItem);
+                if (scope.Events.DispatchCancelable(SavingDictionaryItem, this, saveEventArgs))
                 {
                     scope.Complete();
                     return;
@@ -243,7 +244,10 @@ namespace Umbraco.Core.Services.Implement
                 // ensure the lazy Language callback is assigned
 
                 EnsureDictionaryItemLanguageCallback(dictionaryItem);
-                scope.Events.Dispatch(SavedDictionaryItem, this, new SaveEventArgs<IDictionaryItem>(dictionaryItem, false));
+                scope.Events.Dispatch(SavedDictionaryItem, this, new SaveEventArgs<IDictionaryItem>(dictionaryItem, false)
+                {
+                    EventState = saveEventArgs.EventState
+                });
 
                 Audit(AuditType.Save, "Save DictionaryItem", userId, dictionaryItem.Id, "DictionaryItem");
                 scope.Complete();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [#14907](https://github.com/umbraco/Umbraco-CMS/issues/14907)
Instructions on how to test can be found in the issue.

### Description
When setting the `EventArgs` for the `SavedDictionaryItem` event, a new instance was always being created (unlike when creating a new item, which re-used the one from the `SavingDictionaryItem`).
I now set the `EventState` of the Saved to the same as the Saving.