### PR TITLE
Allow dashboard content to grow and fit height

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/application/umb-dashboard.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/application/umb-dashboard.less
@@ -19,6 +19,7 @@
 }
 
 .umb-dashboard__content {
+    flex: 1;
     padding: 20px;
     overflow: auto;
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
While installing `Skybrud.Redirects` package  in dashboard section, I noticed the content area doesn't fill full height, and thus a dropdown may be hidden because of `overflow: auto`.
https://github.com/skybrud/Skybrud.Umbraco.Redirects/issues/186

It does make sense to keep overflow auto if content exceeds the height of dashboard content area.

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/a6d774b1-e49f-468c-a7e3-801ba9796cd9)

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/0e07c09e-1dc7-485d-a566-cb05a6f8e0f7)

More content in content area.

https://github.com/umbraco/Umbraco-CMS/assets/2919859/b70f72ee-46ec-41dd-90cb-48c70103e08b
