### PR TITLE
Add notification state to "final" published notification when publishing with descendants

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1950,7 +1950,7 @@ public class ContentService : RepositoryService, IContentService
                 cultures = new HashSet<string>(); // empty means 'already published'
             }
 
-            if (isRoot || edited)
+            if (edited)
             {
                 cultures.Add(c); // <culture> means 'republish this culture'
             }
@@ -2105,13 +2105,11 @@ public class ContentService : RepositoryService, IContentService
             }
 
             // deal with the branch root - if it fails, abort
-            var rootPublishNotificationState = new Dictionary<string, object?>();
-            PublishResult? rootResult = SaveAndPublishBranchItem(scope, document, shouldPublish, publishCultures, true,
-                publishedDocuments, eventMessages, userId, allLangs, rootPublishNotificationState);
-            if (rootResult != null)
+            PublishResult? result = SaveAndPublishBranchItem(scope, document, shouldPublish, publishCultures, true, publishedDocuments, eventMessages, userId, allLangs);
+            if (result != null)
             {
-                results.Add(rootResult);
-                if (!rootResult.Success)
+                results.Add(result);
+                if (!result.Success)
                 {
                     return results;
                 }
@@ -2124,7 +2122,6 @@ public class ContentService : RepositoryService, IContentService
             int count;
             var page = 0;
             const int pageSize = 100;
-            PublishResult? result = null;
             do
             {
                 count = 0;
@@ -2143,8 +2140,7 @@ public class ContentService : RepositoryService, IContentService
                     }
 
                     // no need to check path here, parent has to be published here
-                    result = SaveAndPublishBranchItem(scope, d, shouldPublish, publishCultures, false,
-                        publishedDocuments, eventMessages, userId, allLangs,null);
+                    result = SaveAndPublishBranchItem(scope, d, shouldPublish, publishCultures, false, publishedDocuments, eventMessages, userId, allLangs);
                     if (result != null)
                     {
                         results.Add(result);
@@ -2168,12 +2164,7 @@ public class ContentService : RepositoryService, IContentService
             // (SaveAndPublishBranchOne does *not* do it)
             scope.Notifications.Publish(
                 new ContentTreeChangeNotification(document, TreeChangeTypes.RefreshBranch, eventMessages));
-            if (rootResult?.Success is true)
-            {
-                scope.Notifications.Publish(
-                    new ContentPublishedNotification(rootResult!.Content!, eventMessages)
-                        .WithState(rootPublishNotificationState));
-            }
+            scope.Notifications.Publish(new ContentPublishedNotification(publishedDocuments, eventMessages));
 
             scope.Complete();
         }
@@ -2184,9 +2175,6 @@ public class ContentService : RepositoryService, IContentService
     // shouldPublish: a function determining whether the document has changes that need to be published
     //  note - 'force' is handled by 'editing'
     // publishValues: a function publishing values (using the appropriate PublishCulture calls)
-    /// <param name="rootPublishingNotificationState">Only set this when processing a the root of the branch
-    /// Published notification will not be send when this property is set</param>
-    /// <returns></returns>
     private PublishResult? SaveAndPublishBranchItem(
         ICoreScope scope,
         IContent document,
@@ -2197,8 +2185,7 @@ public class ContentService : RepositoryService, IContentService
         ICollection<IContent> publishedDocuments,
         EventMessages evtMsgs,
         int userId,
-        IReadOnlyCollection<ILanguage> allLangs,
-        IDictionary<string, object?>? rootPublishingNotificationState)
+        IReadOnlyCollection<ILanguage> allLangs)
     {
         HashSet<string>? culturesToPublish = shouldPublish(document);
 
@@ -2227,17 +2214,10 @@ public class ContentService : RepositoryService, IContentService
             return new PublishResult(PublishResultType.FailedPublishContentInvalid, evtMsgs, document);
         }
 
-        var notificationState = rootPublishingNotificationState ?? new Dictionary<string, object?>();
-        PublishResult result = CommitDocumentChangesInternal(scope, document, evtMsgs, allLangs, notificationState, userId, true, isRoot);
-        if (!result.Success)
+        PublishResult result = CommitDocumentChangesInternal(scope, document, evtMsgs, allLangs, savingNotification.State, userId, true, isRoot);
+        if (result.Success)
         {
-            return result;
-        }
-
-        publishedDocuments.Add(document);
-        if (rootPublishingNotificationState == null)
-        {
-            scope.Notifications.Publish(new ContentPublishedNotification(result.Content!, evtMsgs).WithState(notificationState));
+            publishedDocuments.Add(document);
         }
 
         return result;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServicePublishBranchTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServicePublishBranchTests.cs
@@ -93,7 +93,7 @@ public class ContentServicePublishBranchTests : UmbracoIntegrationTest
         AssertPublishResults(
             r,
             x => x.Result,
-            PublishResultType.SuccessPublish, // During branch publishing, the change detection of the root branch runs AFTER the check to process the branchItem => root is always saved&Published as the intent requires it.
+            PublishResultType.SuccessPublishAlready,
             PublishResultType.SuccessPublishAlready,
             PublishResultType.SuccessPublishAlready);
 
@@ -140,7 +140,7 @@ public class ContentServicePublishBranchTests : UmbracoIntegrationTest
         AssertPublishResults(
             r,
             x => x.Result,
-            PublishResultType.SuccessPublish, // During branch publishing, the change detection of the root branch runs AFTER the check to process the branchItem => root is always saved&Published as the intent requires it.
+            PublishResultType.SuccessPublishAlready,
             PublishResultType.SuccessPublishAlready,
             PublishResultType.SuccessPublishAlready,
             PublishResultType.SuccessPublish,
@@ -185,7 +185,7 @@ public class ContentServicePublishBranchTests : UmbracoIntegrationTest
 
         var r = ContentService.SaveAndPublishBranch(vRoot, false)
             .ToArray(); // no culture specified so "*" is used, so all cultures
-        Assert.AreEqual(PublishResultType.SuccessPublishCulture, r[0].Result); // During branch publishing, the change detection of the root branch runs AFTER the check to process the branchItem => root is always saved&Published as the intent requires it.
+        Assert.AreEqual(PublishResultType.SuccessPublishAlready, r[0].Result);
         Assert.AreEqual(PublishResultType.SuccessPublishCulture, r[1].Result);
     }
 
@@ -221,7 +221,7 @@ public class ContentServicePublishBranchTests : UmbracoIntegrationTest
         var saveResult = ContentService.Save(iv1);
 
         var r = ContentService.SaveAndPublishBranch(vRoot, false, "de").ToArray();
-        Assert.AreEqual(PublishResultType.SuccessPublishCulture, r[0].Result); // During branch publishing, the change detection of the root branch runs AFTER the check to process the branchItem => root is always saved&Published as the intent requires it.
+        Assert.AreEqual(PublishResultType.SuccessPublishAlready, r[0].Result);
         Assert.AreEqual(PublishResultType.SuccessPublishCulture, r[1].Result);
     }
 
@@ -381,7 +381,7 @@ public class ContentServicePublishBranchTests : UmbracoIntegrationTest
         AssertPublishResults(
             r,
             x => x.Result,
-            PublishResultType.SuccessPublish, // During branch publishing, the change detection of the root branch runs AFTER the check to process the branchItem => root is always saved&Published as the intent requires it.
+            PublishResultType.SuccessPublishAlready,
             PublishResultType.SuccessPublish,
             PublishResultType.SuccessPublishCulture);
 
@@ -407,7 +407,7 @@ public class ContentServicePublishBranchTests : UmbracoIntegrationTest
         AssertPublishResults(
             r,
             x => x.Result,
-            PublishResultType.SuccessPublish, // During branch publishing, the change detection of the root branch runs AFTER the check to process the branchItem => root is always saved&Published as the intent requires it.
+            PublishResultType.SuccessPublishAlready,
             PublishResultType.SuccessPublish,
             PublishResultType.SuccessPublishCulture);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #14543

### Description

This PR rolls back the functional breakage introduced by #14763 and fixes the original issue (#14543) in a non-breaking way.

### Testing this PR

Create a notification handler that logs all "saving", "saved", "publishing" and "published" notifications for content.

Perform "save and publish" on an unpublished structure of content (including all unpublished descendants). Verify that:

1. The same amount of notifications are fired before and after applying this PR, and in the same order.
2. The "published" notification contains state from both the "saving" and the "publishing" notification of the root content being published.