### PR TITLE
Add strict contextual escaping on the $scope for grid controller

### DIFF
--- a/src/Umbraco.Cms.StaticAssets/wwwroot/App_Plugins/Umbraco.BlockGridEditor.DefaultCustomViews/umbBlockGridDemoRichTextBlock.html
+++ b/src/Umbraco.Cms.StaticAssets/wwwroot/App_Plugins/Umbraco.BlockGridEditor.DefaultCustomViews/umbBlockGridDemoRichTextBlock.html
@@ -21,5 +21,5 @@
 
 </style>
 
-<div class="text" ng-click="block.edit()" ng-focus="block.focus" ng-bind-html="sce.trustAsHtml(block.data.richText)" style="margin: 0 20px;">
+<div class="text" ng-click="block.edit()" ng-focus="block.focus" ng-bind-html="block.data.richText | safe_html" style="margin: 0 20px;">
 </div>

--- a/src/Umbraco.Cms.StaticAssets/wwwroot/App_Plugins/Umbraco.BlockGridEditor.DefaultCustomViews/umbBlockGridDemoRichTextBlock.html
+++ b/src/Umbraco.Cms.StaticAssets/wwwroot/App_Plugins/Umbraco.BlockGridEditor.DefaultCustomViews/umbBlockGridDemoRichTextBlock.html
@@ -21,5 +21,5 @@
 
 </style>
 
-<div class="text" ng-click="block.edit()" ng-focus="block.focus" ng-bind-html="block.data.richText" style="margin: 0 20px;">
+<div class="text" ng-click="block.edit()" ng-focus="block.focus" ng-bind-html="sce.trustAsHtml(block.data.richText)" style="margin: 0 20px;">
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbblockgridblock.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbblockgridblock.component.js
@@ -29,7 +29,7 @@
         }
     );
 
-    function BlockGridBlockController($scope, $compile, $element, $sce) {
+    function BlockGridBlockController($scope, $compile, $element) {
         var model = this;
 
         model.$onInit = function () {
@@ -45,7 +45,6 @@
             $scope.index = model.index;
             $scope.parentForm = model.parentForm;
             $scope.valFormManager = model.valFormManager;
-            $scope.sce = $sce;
 
             var shadowRoot = $element[0].attachShadow({ mode: 'open' });
             shadowRoot.innerHTML = 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbblockgridblock.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbblockgridblock.component.js
@@ -29,7 +29,7 @@
         }
     );
 
-    function BlockGridBlockController($scope, $compile, $element) {
+    function BlockGridBlockController($scope, $compile, $element, $sce) {
         var model = this;
 
         model.$onInit = function () {
@@ -45,6 +45,7 @@
             $scope.index = model.index;
             $scope.parentForm = model.parentForm;
             $scope.valFormManager = model.valFormManager;
+            $scope.sce = $sce;
 
             var shadowRoot = $element[0].attachShadow({ mode: 'open' });
             shadowRoot.innerHTML = 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes !-- link to the issue here! -->
https://github.com/umbraco/Umbraco-CMS/issues/14403

### Description
Angular's ng-html-bind strips away style tags from the inserted html, rendering most styling in the rich text editor moot when viewed in backoffice through the umbBlockGridDemoRichTextBlock.html. I have updated the BlockGridBlockController to include $sce on the $scope so it's available to use in the custom views for the grid blocks, and updated the custom view to use $sce.trustAsHtml to insert the HTML.

This way it's still the developers choice whether to use potential unsafe html or not, but it's available when you, like in this case, is in control of the content the entire way.

**To test it:**

1. Install the demo blockgrid and create a document type that uses it
2. Create page with the new document type and insert a Rich Text Block
3. Write text or insert image and center - or - insert html directly in the rich text editor that uses a style tag
4. Observe the style tag isn't removed in the view in backoffice and now closer reflects what will be rendered out in the frontend.


<!-- Thanks for contributing to Umbraco CMS! -->
