### PR TITLE
wrapped vm.loading in a $timeout to help angular pick up the change

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umbMediaPicker3PropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umbMediaPicker3PropertyEditor.component.js
@@ -29,7 +29,7 @@
             }
         });
 
-    function MediaPicker3Controller($scope, $element, editorService, clipboardService, localizationService, overlayService, userService, entityResource, $attrs, umbRequestHelper, $injector, uploadTracker, editorState) {
+    function MediaPicker3Controller($scope, $element, $timeout, editorService, clipboardService, localizationService, overlayService, userService, entityResource, $attrs, umbRequestHelper, $injector, uploadTracker, editorState) {
 
         const mediaUploader = $injector.instantiate(Utilities.MediaUploader);
         let uploadInProgress = false;
@@ -179,8 +179,10 @@
                 vm.allowAdd = hasAccessToMedia;
 
                 mediaUploader.init(uploaderOptions).then(() => {
-                    vm.loading = false;
-                });
+                    $timeout(function () {
+                      vm.loading = false;
+                    });
+                 });
             });
         };
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->
https://github.com/umbraco/Umbraco-CMS/issues/13916

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
The issue seems to be Angular not picking up the change from vm.loading being set to false, and then registering it on an event, like a mouse click/redraw etc.
Wrapping the update of vm.loading = false in a $timeout seems to fix the issue and have the images load immediately after clicking to open the blocklist

**How to test:**

1. Create blocklist that has an element type that contains an Image Picker 3
2. Create a few entries with images in the lists and save
3. Refresh page 
4. Click to open a list entry without performing any other actions
5. Observe image loads immediately

Included video that can be used to compare with videos in bug issue
https://github.com/umbraco/Umbraco-CMS/assets/137318845/37c60175-0bb6-4d8c-9c95-c38ade1e14dd


<!-- Thanks for contributing to Umbraco CMS! -->
