### PR TITLE
Fix button styling in block list & block grid overlay

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/blockgrid.blockconfiguration.overlay.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/blockgrid.blockconfiguration.overlay.less
@@ -69,7 +69,7 @@
             border-radius: @baseBorderRadius;
             transition: color 120ms;
             &.--hideText {
-                color: white;
+                color: @ui-action-discreet-type;
             }
             &:hover, &:focus {
                 color: @ui-action-discreet-type-hover;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.less
@@ -67,7 +67,7 @@
         &.--noValue {
             text-align: center;
             border-radius: @baseBorderRadius;
-            color: white;
+            color: @ui-action-discreet-type;
             transition: color 120ms;
             &:hover, &:focus {
                 color: @ui-action-discreet-type-hover;


### PR DESCRIPTION
### Description
Update `blockgrid.blockconfiguration.overlay.less` & `blocklist.blockconfiguration.overlay.less` so that the text in the button is visible. Use variables for color in the buttons instead of hardcoded value. 

Before: 
![image](https://github.com/umbraco/Umbraco-CMS/assets/7831614/674537d1-7fee-491c-9295-d82ca4267b52)

After: 
![image](https://github.com/umbraco/Umbraco-CMS/assets/7831614/ec87dc7a-d481-4855-98fb-a287593c41a8)
