### PR TITLE
Fix build logging of warnings/errors during packaging step

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,8 +38,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" IsImplicitlyDefined="true" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.113" PrivateAssets="all" IsImplicitlyDefined="true" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406" PrivateAssets="all" IsImplicitlyDefined="true" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" PrivateAssets="all" IsImplicitlyDefined="true" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507" PrivateAssets="all" IsImplicitlyDefined="true" />
     <PackageReference Include="Umbraco.Code" Version="2.0.0" PrivateAssets="all" IsImplicitlyDefined="true" />
     <PackageReference Include="Umbraco.GitVersioning.Extensions" Version="0.2.0" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -79,33 +79,18 @@ stages:
               command: restore
               projects: $(solution)
           - task: DotNetCoreCLI@2
+            name: build
             displayName: Run dotnet build
             inputs:
               command: build
               projects: $(solution)
               arguments: '--configuration $(buildConfiguration) --no-restore --property:ContinuousIntegrationBuild=true'
-          - script: |
-              version="$(Build.BuildNumber)"
-              echo "Version: $version"
-
-              major="$(echo $version | cut -d '.' -f 1)"
-              echo "Major version: $major"
-
-              echo "##vso[task.setvariable variable=majorVersion;isOutput=true]$major"
-            displayName: Set major version
-            name: determineMajorVersion
           - task: DotNetCoreCLI@2
             displayName: Run dotnet pack
             inputs:
               command: pack
               projects: $(solution)
               arguments: '--configuration $(buildConfiguration) --no-build --property:PackageOutputPath=$(Build.ArtifactStagingDirectory)/nupkg'
-          - script: |
-              sha="$(Build.SourceVersion)"
-              sha=${sha:0:7}
-              buildnumber="$(Build.BuildNumber)_$(Build.BuildId)_$sha"
-              echo "##vso[build.updatebuildnumber]$buildnumber"
-            displayName: Update build number
           - task: PublishPipelineArtifact@1
             displayName: Publish nupkg
             inputs:
@@ -122,7 +107,7 @@ stages:
     displayName: Prepare API Documentation
     dependsOn: Build
     variables:
-      umbracoMajorVersion: $[ stageDependencies.Build.A.outputs['determineMajorVersion.majorVersion'] ]
+      umbracoMajorVersion: $[ stageDependencies.Build.A.outputs['build.NBGV_VersionMajor'] ]
     jobs:
       # C# API Reference
       - job:
@@ -527,7 +512,7 @@ stages:
     pool:
       vmImage: 'windows-latest' # Apparently AzureFileCopy is windows only :(
     variables:
-      umbracoMajorVersion:  $[ stageDependencies.Build.A.outputs['determineMajorVersion.majorVersion'] ]
+      umbracoMajorVersion:  $[ stageDependencies.Build.A.outputs['build.NBGV_VersionMajor'] ]
     displayName: Upload API Documention
     dependsOn:
       - Build

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -103,7 +103,7 @@ stages:
               artifactName: build_output
 
   - stage: Build_Docs
-    condition: and(succeeded(), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), ${{parameters.buildApiDocs}}))
+    condition: and(succeeded(), or(eq(stageDependencies.Build.A.outputs['build.NBGV_PublicRelease'], 'True'), ${{parameters.buildApiDocs}}))
     displayName: Prepare API Documentation
     dependsOn: Build
     variables:
@@ -270,7 +270,7 @@ stages:
       # Integration Tests (SQL Server)
       - job:
         timeoutInMinutes: 120
-        condition: or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), ${{parameters.sqlServerIntegrationTests}})
+        condition: or(eq(stageDependencies.Build.A.outputs['build.NBGV_PublicRelease'], 'True'), ${{parameters.sqlServerIntegrationTests}})
         displayName: Integration Tests (SQL Server)
         strategy:
           matrix:
@@ -466,7 +466,7 @@ stages:
       - Unit
       - Integration
       # - E2E # TODO: Enable when stable.
-    condition: and(succeeded(), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), ${{parameters.myGetDeploy}}))
+    condition: and(succeeded(), or(eq(stageDependencies.Build.A.outputs['build.NBGV_PublicRelease'], 'True'), ${{parameters.myGetDeploy}}))
     jobs:
       - job:
         displayName: Push to pre-release feed
@@ -489,7 +489,7 @@ stages:
     dependsOn:
       - Deploy_MyGet
       - Build_Docs
-    condition: and(succeeded(), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), ${{parameters.nuGetDeploy}}))
+    condition: and(succeeded(), or(eq(stageDependencies.Build.A.outputs['build.NBGV_PublicRelease'], 'True'), ${{parameters.nuGetDeploy}}))
     jobs:
       - job:
         displayName: Push to NuGet
@@ -517,7 +517,7 @@ stages:
     dependsOn:
       - Build
       - Deploy_NuGet
-    condition: and(succeeded(), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), ${{parameters.uploadApiDocs}}))
+    condition: and(succeeded(), or(eq(stageDependencies.Build.A.outputs['build.NBGV_PublicRelease'], 'True'), ${{parameters.uploadApiDocs}}))
     jobs:
       - job:
         displayName: Upload C# Docs

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -83,7 +83,7 @@ stages:
             inputs:
               command: build
               projects: $(solution)
-              arguments: '--configuration $(buildConfiguration) --no-restore -p:ContinuousIntegrationBuild=true'
+              arguments: '--configuration $(buildConfiguration) --no-restore --property:ContinuousIntegrationBuild=true'
           - script: |
               version="$(Build.BuildNumber)"
               echo "Version: $version"
@@ -94,8 +94,12 @@ stages:
               echo "##vso[task.setvariable variable=majorVersion;isOutput=true]$major"
             displayName: Set major version
             name: determineMajorVersion
-          - script: dotnet pack $(solution) --configuration $(buildConfiguration) --no-build --property:PackageOutputPath=$(Build.ArtifactStagingDirectory)/nupkg
+          - task: DotNetCoreCLI@2
             displayName: Run dotnet pack
+            inputs:
+              command: pack
+              projects: $(solution)
+              arguments: '--configuration $(buildConfiguration) --no-build --property:PackageOutputPath=$(Build.ArtifactStagingDirectory)/nupkg'
           - script: |
               sha="$(Build.SourceVersion)"
               sha=${sha:0:7}

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
   "version": "12.2.0-rc",
   "assemblyVersion": {
     "precision": "build"
@@ -12,7 +12,12 @@
     "^refs/heads/main$",
     "^refs/heads/release/"
   ],
+  "release": {
+    "branchName": "release/{version}",
+    "tagName": "release-{version}"
+  },
   "cloudBuild": {
+    "setAllVariables": true,
     "buildNumber": {
       "enabled": true
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
The `dotnet build` step uses the `DotNetCoreCLI@2` task, which configures a custom logger for Azure Pipelines that uses the correct [logging commands](https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash) to ensure any warnings or errors are reported on the Azure Pipelines build summary. The `dotnet pack` commands was using a regular CLI command, so any package validation errors weren't easily visible...

As a first try I've updated the CLI command to the `DotNetCoreCLI` task. If that doesn't add the custom logger, I'll update this PR to generate the NuGet packages during the build command...

Besides that, I've also removed the `Set major version` and `Update build number` steps, since the latest Nerdbank.GitVersioning already sets output variables that can be used instead and sets the build number automatically.