### PR TITLE
Fix custom dbcontexts extention methods

### DIFF
--- a/src/Umbraco.Cms.Persistence.EFCore.SqlServer/SqlServerMigrationProvider.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore.SqlServer/SqlServerMigrationProvider.cs
@@ -10,7 +10,7 @@ public class SqlServerMigrationProvider : IMigrationProvider
 
     public SqlServerMigrationProvider(IDbContextFactory<UmbracoDbContext> dbContextFactory) => _dbContextFactory = dbContextFactory;
 
-    public string ProviderName => "Microsoft.Data.SqlClient";
+    public string ProviderName => Constants.ProviderNames.SQLServer;
 
     public async Task MigrateAsync(EFCoreMigration migration)
     {

--- a/src/Umbraco.Cms.Persistence.EFCore.SqlServer/SqlServerMigrationProviderSetup.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore.SqlServer/SqlServerMigrationProviderSetup.cs
@@ -5,7 +5,7 @@ namespace Umbraco.Cms.Persistence.EFCore.SqlServer;
 
 public class SqlServerMigrationProviderSetup : IMigrationProviderSetup
 {
-    public string ProviderName => "Microsoft.Data.SqlClient";
+    public string ProviderName => Constants.ProviderNames.SQLServer;
 
     public void Setup(DbContextOptionsBuilder builder, string? connectionString)
     {

--- a/src/Umbraco.Cms.Persistence.EFCore.Sqlite/SqliteMigrationProvider.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore.Sqlite/SqliteMigrationProvider.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Umbraco.Cms.Persistence.EFCore.Migrations;
 using Umbraco.Extensions;
+using Umbraco.Cms.Persistence.EFCore;
 
 namespace Umbraco.Cms.Persistence.EFCore.Sqlite;
 
@@ -11,7 +12,7 @@ public class SqliteMigrationProvider : IMigrationProvider
     public SqliteMigrationProvider(IDbContextFactory<UmbracoDbContext> dbContextFactory)
         => _dbContextFactory = dbContextFactory;
 
-    public string ProviderName => "Microsoft.Data.Sqlite";
+    public string ProviderName => Constants.ProviderNames.SQLLite;
 
     public async Task MigrateAsync(EFCoreMigration migration)
     {

--- a/src/Umbraco.Cms.Persistence.EFCore.Sqlite/SqliteMigrationProviderSetup.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore.Sqlite/SqliteMigrationProviderSetup.cs
@@ -5,7 +5,7 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite;
 
 public class SqliteMigrationProviderSetup : IMigrationProviderSetup
 {
-    public string ProviderName => "Microsoft.Data.Sqlite";
+    public string ProviderName => Constants.ProviderNames.SQLLite;
 
     public void Setup(DbContextOptionsBuilder builder, string? connectionString)
     {

--- a/src/Umbraco.Cms.Persistence.EFCore/Composition/UmbracoEFCoreComposer.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/Composition/UmbracoEFCoreComposer.cs
@@ -20,7 +20,7 @@ public class UmbracoEFCoreComposer : IComposer
         builder.AddNotificationAsyncHandler<DatabaseSchemaAndDataCreatedNotification, EFCoreCreateTablesNotificationHandler>();
         builder.AddNotificationAsyncHandler<UnattendedInstallNotification, EFCoreCreateTablesNotificationHandler>();
 
-        builder.Services.AddUmbracoEFCoreContext<UmbracoDbContext>((options, connectionString, providerName) =>
+        builder.Services.AddUmbracoDbContext<UmbracoDbContext>((options) =>
         {
             // Register the entity sets needed by OpenIddict.
             options.UseOpenIddict();

--- a/src/Umbraco.Cms.Persistence.EFCore/Constants-ProviderNames.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/Constants-ProviderNames.cs
@@ -1,0 +1,11 @@
+namespace Umbraco.Cms.Persistence.EFCore;
+
+public static partial class Constants
+{
+    public static class ProviderNames
+    {
+        public const string SQLLite = "Microsoft.Data.Sqlite";
+
+        public const string SQLServer = "Microsoft.Data.SqlClient";
+    }
+}

--- a/src/Umbraco.Cms.Persistence.EFCore/Extensions/UmbracoEFCoreServiceCollectionExtensions.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/Extensions/UmbracoEFCoreServiceCollectionExtensions.cs
@@ -1,7 +1,9 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
+using Serilog;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DistributedLocking;
@@ -16,6 +18,7 @@ public static class UmbracoEFCoreServiceCollectionExtensions
 {
     public delegate void DefaultEFCoreOptionsAction(DbContextOptionsBuilder options, string? providerName, string? connectionString);
 
+    [Obsolete("Use AddUmbracoDbContext<T>(this IServiceCollection services, Action<DbContextOptionsBuilder>? optionsAction = null) instead.")]
     public static IServiceCollection AddUmbracoEFCoreContext<T>(this IServiceCollection services, DefaultEFCoreOptionsAction? defaultEFCoreOptionsAction = null)
         where T : DbContext
     {
@@ -24,7 +27,7 @@ public static class UmbracoEFCoreServiceCollectionExtensions
             sp =>
             {
                 SetupDbContext(defaultEFCoreOptionsAction, sp, optionsBuilder);
-                return new UmbracoPooledDbContextFactory<T>(sp.GetRequiredService<IRuntimeState>(),optionsBuilder.Options);
+                return new UmbracoPooledDbContextFactory<T>(sp.GetRequiredService<IRuntimeState>(), optionsBuilder.Options);
             });
         services.AddPooledDbContextFactory<T>((provider, builder) => SetupDbContext(defaultEFCoreOptionsAction, provider, builder));
         services.AddTransient(services => services.GetRequiredService<IDbContextFactory<T>>().CreateDbContext());
@@ -38,6 +41,7 @@ public static class UmbracoEFCoreServiceCollectionExtensions
         return services;
     }
 
+    [Obsolete("Use AddUmbracoDbContext<T>(this IServiceCollection services, Action<DbContextOptionsBuilder>? optionsAction = null) instead.")]
     public static IServiceCollection AddUmbracoEFCoreContext<T>(this IServiceCollection services, string connectionString, string providerName, DefaultEFCoreOptionsAction? defaultEFCoreOptionsAction = null)
         where T : DbContext
     {
@@ -52,8 +56,8 @@ public static class UmbracoEFCoreServiceCollectionExtensions
         services.TryAddSingleton<IDbContextFactory<T>>(
             sp =>
             {
-                SetupDbContext(defaultEFCoreOptionsAction, sp, optionsBuilder);
-                return new UmbracoPooledDbContextFactory<T>(sp.GetRequiredService<IRuntimeState>(),optionsBuilder.Options);
+                defaultEFCoreOptionsAction?.Invoke(optionsBuilder, providerName, connectionString);
+                return new UmbracoPooledDbContextFactory<T>(sp.GetRequiredService<IRuntimeState>(), optionsBuilder.Options);
             });
         services.AddPooledDbContextFactory<T>(options => defaultEFCoreOptionsAction?.Invoke(options, providerName, connectionString));
         services.AddTransient(services => services.GetRequiredService<IDbContextFactory<T>>().CreateDbContext());
@@ -67,12 +71,117 @@ public static class UmbracoEFCoreServiceCollectionExtensions
         return services;
     }
 
+    /// <summary>
+    /// Adds a EFCore DbContext with all the services needed to integrate with Umbraco scopes.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="services"></param>
+    /// <param name="optionsAction"></param>
+    /// <returns></returns>
+    public static IServiceCollection AddUmbracoDbContext<T>(this IServiceCollection services, Action<DbContextOptionsBuilder>? optionsAction = null)
+        where T : DbContext
+    {
+        return AddUmbracoDbContext<T>(services, (IServiceProvider _, DbContextOptionsBuilder options) =>
+        {
+            optionsAction?.Invoke(options);
+        });
+    }
+
+    /// <summary>
+    /// Adds a EFCore DbContext with all the services needed to integrate with Umbraco scopes.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="services"></param>
+    /// <param name="optionsAction"></param>
+    /// <returns></returns>
+    public static IServiceCollection AddUmbracoDbContext<T>(this IServiceCollection services, Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction = null)
+        where T : DbContext
+    {
+        optionsAction ??= (sp, options) => { };
+
+        var optionsBuilder = new DbContextOptionsBuilder<T>();
+
+        services.TryAddSingleton<IDbContextFactory<T>>(sp =>
+        {
+            optionsAction.Invoke(sp, optionsBuilder);
+            return new UmbracoPooledDbContextFactory<T>(sp.GetRequiredService<IRuntimeState>(), optionsBuilder.Options);
+        });
+        services.AddPooledDbContextFactory<T>(optionsAction);
+        services.AddTransient(services => services.GetRequiredService<IDbContextFactory<T>>().CreateDbContext());
+
+        services.AddUnique<IAmbientEFCoreScopeStack<T>, AmbientEFCoreScopeStack<T>>();
+        services.AddUnique<IEFCoreScopeAccessor<T>, EFCoreScopeAccessor<T>>();
+        services.AddUnique<IEFCoreScopeProvider<T>, EFCoreScopeProvider<T>>();
+        services.AddSingleton<IDistributedLockingMechanism, SqliteEFCoreDistributedLockingMechanism<T>>();
+        services.AddSingleton<IDistributedLockingMechanism, SqlServerEFCoreDistributedLockingMechanism<T>>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Sets the database provider. I.E UseSqlite or UseSqlServer based on the provider name.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <param name="providerName"></param>
+    /// <param name="connectionString"></param>
+    /// <exception cref="InvalidDataException"></exception>
+    /// <remarks>
+    /// Only supports the databases normally supported in Umbraco.
+    /// </remarks>
+    public static void UseDatabaseProvider(this DbContextOptionsBuilder builder, string providerName, string connectionString)
+    {
+        switch (providerName)
+        {
+            case Cms.Persistence.EFCore.Constants.ProviderNames.SQLServer:
+                builder.UseSqlServer(connectionString);
+                break;
+            case Cms.Persistence.EFCore.Constants.ProviderNames.SQLLite:
+                builder.UseSqlite(connectionString);
+                break;
+            default:
+                throw new InvalidDataException($"The provider {providerName} is not supported. Manually add the add the UseXXX statement to the options. I.E UseNpgsql()");
+        }
+    }
+
+    /// <summary>
+    /// Sets the database provider to use based on the Umbraco connection string.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <param name="serviceProvider"></param>
+    public static void UseUmbracoDatabaseProvider(this DbContextOptionsBuilder builder, IServiceProvider serviceProvider)
+    {
+        ConnectionStrings connectionStrings = serviceProvider.GetRequiredService<IOptionsMonitor<ConnectionStrings>>().CurrentValue;
+
+        // Replace data directory
+        string? dataDirectory = AppDomain.CurrentDomain.GetData(Constants.System.DataDirectoryName)?.ToString();
+        if (string.IsNullOrEmpty(dataDirectory) is false)
+        {
+            connectionStrings.ConnectionString = connectionStrings.ConnectionString?.Replace(Constants.System.DataDirectoryPlaceholder, dataDirectory);
+        }
+
+        if (string.IsNullOrEmpty(connectionStrings.ProviderName))
+        {
+            Log.Warning("No database provider was set. ProviderName is null");
+            return;
+        }
+
+        if (string.IsNullOrEmpty(connectionStrings.ConnectionString))
+        {
+            Log.Warning("No database provider was set. Connection string is null");
+            return;
+        }
+
+        builder.UseDatabaseProvider(connectionStrings.ProviderName, connectionStrings.ConnectionString);
+    }
+
+    [Obsolete]
     private static void SetupDbContext(DefaultEFCoreOptionsAction? defaultEFCoreOptionsAction, IServiceProvider provider, DbContextOptionsBuilder builder)
     {
         ConnectionStrings connectionStrings = GetConnectionStringAndProviderName(provider);
         defaultEFCoreOptionsAction?.Invoke(builder, connectionStrings.ConnectionString, connectionStrings.ProviderName);
     }
 
+    [Obsolete]
     private static ConnectionStrings GetConnectionStringAndProviderName(IServiceProvider serviceProvider)
     {
         ConnectionStrings connectionStrings = serviceProvider.GetRequiredService<IOptionsMonitor<ConnectionStrings>>().CurrentValue;

--- a/src/Umbraco.Cms.Persistence.EFCore/UmbracoDbContext.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/UmbracoDbContext.cs
@@ -3,7 +3,6 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Persistence.EFCore.Migrations;
@@ -77,7 +76,7 @@ public class UmbracoDbContext : DbContext
 
         foreach (IMutableEntityType entity in modelBuilder.Model.GetEntityTypes())
         {
-            entity.SetTableName(Constants.DatabaseSchema.TableNamePrefix + entity.GetTableName());
+            entity.SetTableName(Core.Constants.DatabaseSchema.TableNamePrefix + entity.GetTableName());
         }
     }
 }

--- a/tests/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTest.cs
+++ b/tests/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTest.cs
@@ -155,8 +155,6 @@ public abstract class UmbracoIntegrationTest : UmbracoIntegrationTestBase
             .AddUmbracoSqliteSupport()
             .AddTestServices(TestHelper);
 
-        ConfigureUmbracoTestServices(builder);
-
         if (TestOptions.Mapper)
         {
             // TODO: Should these just be called from within AddUmbracoCore/AddWebComponents?
@@ -187,13 +185,6 @@ public abstract class UmbracoIntegrationTest : UmbracoIntegrationTestBase
     ///     Hook for registering test doubles.
     /// </summary>
     protected virtual void ConfigureTestServices(IServiceCollection services)
-    {
-    }
-
-    /// <summary>
-    ///     Hook for registering umbraco test doubles.
-    /// </summary>
-    protected virtual void ConfigureUmbracoTestServices(IUmbracoBuilder builder)
     {
     }
 

--- a/tests/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTest.cs
+++ b/tests/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTest.cs
@@ -155,6 +155,8 @@ public abstract class UmbracoIntegrationTest : UmbracoIntegrationTestBase
             .AddUmbracoSqliteSupport()
             .AddTestServices(TestHelper);
 
+        ConfigureUmbracoTestServices(builder);
+
         if (TestOptions.Mapper)
         {
             // TODO: Should these just be called from within AddUmbracoCore/AddWebComponents?
@@ -185,6 +187,13 @@ public abstract class UmbracoIntegrationTest : UmbracoIntegrationTestBase
     ///     Hook for registering test doubles.
     /// </summary>
     protected virtual void ConfigureTestServices(IServiceCollection services)
+    {
+    }
+
+    /// <summary>
+    ///     Hook for registering umbraco test doubles.
+    /// </summary>
+    protected virtual void ConfigureUmbracoTestServices(IUmbracoBuilder builder)
     {
     }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Persistence.EFCore/DbContext/CustomDbContextTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Persistence.EFCore/DbContext/CustomDbContextTests.cs
@@ -1,19 +1,13 @@
-using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Options;
 using NUnit.Framework;
-using Umbraco.Cms.Core.Configuration.Models;
-using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Persistence.EFCore.DbContext;
 
 [TestFixture]
-[Timeout(60000)]
 [UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest, Logger = UmbracoTestOptions.Logger.Console)]
 public class CustomDbContextUmbracoProviderTests : UmbracoIntegrationTest
 {
@@ -26,7 +20,7 @@ public class CustomDbContextUmbracoProviderTests : UmbracoIntegrationTest
         Assert.IsNotEmpty(dbContext.Database.GetConnectionString());
     }
 
-    protected override void ConfigureUmbracoTestServices(IUmbracoBuilder builder)
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
     {
         builder.Services.AddUmbracoDbContext<CustomDbContext>((serviceProvider, options) =>
         {
@@ -45,7 +39,6 @@ public class CustomDbContextUmbracoProviderTests : UmbracoIntegrationTest
 
 
 [TestFixture]
-[Timeout(60000)]
 [UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest, Logger = UmbracoTestOptions.Logger.Console)]
 public class CustomDbContextCustomSqliteProviderTests : UmbracoIntegrationTest
 {
@@ -58,7 +51,7 @@ public class CustomDbContextCustomSqliteProviderTests : UmbracoIntegrationTest
         Assert.IsNotEmpty(dbContext.Database.GetConnectionString());
     }
 
-    protected override void ConfigureUmbracoTestServices(IUmbracoBuilder builder)
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
     {
         builder.Services.AddUmbracoDbContext<CustomDbContext>((serviceProvider, options) =>
         {
@@ -77,7 +70,6 @@ public class CustomDbContextCustomSqliteProviderTests : UmbracoIntegrationTest
 
 [Obsolete]
 [TestFixture]
-[Timeout(60000)]
 [UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest, Logger = UmbracoTestOptions.Logger.Console)]
 public class CustomDbContextLegacyExtensionProviderTests : UmbracoIntegrationTest
 {
@@ -90,7 +82,7 @@ public class CustomDbContextLegacyExtensionProviderTests : UmbracoIntegrationTes
         Assert.IsNotEmpty(dbContext.Database.GetConnectionString());
     }
 
-    protected override void ConfigureUmbracoTestServices(IUmbracoBuilder builder)
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
     {
         builder.Services.AddUmbracoEFCoreContext<CustomDbContext>("Data Source=:memory:;Version=3;New=True;", "Microsoft.Data.Sqlite", (options, connectionString, providerName) =>
         {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Persistence.EFCore/DbContext/CustomDbContextTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Persistence.EFCore/DbContext/CustomDbContextTests.cs
@@ -1,0 +1,41 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Persistence.EFCore.DbContext;
+
+[TestFixture]
+[Timeout(60000)]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest, Logger = UmbracoTestOptions.Logger.Console)]
+public class CustomDbContextTests : UmbracoIntegrationTest
+{
+    [Test]
+    public void Can_Register_Custom_DbContext_And_Resolve()
+    {
+        var dbContext = Services.GetRequiredService<CustomDbContext>();
+
+        Assert.IsNotNull(dbContext);
+        Assert.IsNotEmpty(dbContext.Database.GetConnectionString());
+    }
+
+    protected override void ConfigureUmbracoTestServices(IUmbracoBuilder builder)
+    {
+        builder.Services.AddUmbracoEFCoreContext<CustomDbContext>("Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True", "Microsoft.Data.Sqlite");
+    }
+
+    internal class CustomDbContext : Microsoft.EntityFrameworkCore.DbContext
+    {
+        public CustomDbContext(DbContextOptions<CustomDbContext> options)
+            : base(options)
+        {
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #14893

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

#### Why

This problem described in #14893 stems from the database provider not being registered when adding a custom DbContext. The reason the problem was introduced in #14674 was because it was unclear what the extension methods usage was. I.E you couldn't easily see that you were supposed to use one method internally (In Umbraco source code) and one from a consuming application.

Therefore, I think that the extension methods needs to be unified and follow the same basic behavioral patterns as the original `AddDbContext()` methods from EF Core. In this way I also think it would be easier for experienced EF Core developers to start using it in an Umbraco context.

To solve this problem this PR adds two new extensions:

```csharp
AddUmbracoDbContext<T>(this IServiceCollection services, Action<DbContextOptionsBuilder>? optionsAction = null)
```

Umbraco equivalent to EF Cores `AddDbContext(this IServiceCollection, Action<DbContextOptionsBuilder>? optionsAction = null, ServiceLifetime contextLifetime = ServiceLifetime.Scoped, ServiceLifetime optionsLifetime = ServiceLifetime.Scoped)`

```csharp
AddUmbracoDbContext<T>(this IServiceCollection services, Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction = null)
```

Umbraco equivalent to EF Cores `AddDbContext(this IServiceCollection, Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction = null, ServiceLifetime contextLifetime = ServiceLifetime.Scoped, ServiceLifetime optionsLifetime = ServiceLifetime.Scoped)`

**Note:**
- Service lifetimes isn't relevant when using `AddUmbracoDbContext` because we use pooled DbContexts after `RuntimeLevel.Run` and transient for every DI request before that.
- `AddUmbracoDbcontext` better matches the EF Core naming of the extension methods.
- Because we don't use a custom `Action` it's easier to tell what parameters do what. And if you have used EF Core before you will be able to use similar setup in the options.

#### What is the behavior of `AddUmbracoDbcontext()`?

Similarly to the normal `AddDbContext` from EF Core this shouldn't magically add the database provider but you should specify what provider to use. To make this behavior similar to what we had in 12.1 I've added two extension methods that can be used in the `optionsAction`.

**Examples:**

```csharp
builder.Services.AddUmbracoDbContext<CustomDbContext>((serviceProvider, options) =>
{
    options.UseUmbracoDatabaseProvider(serviceProvider);
});
```

Uses the Umbraco database connection string

```csharp
builder.Services.AddUmbracoDbContext<CustomDbContext>((options) =>
{
    options.UseDatabaseProvider("My provider name", "Connection string");
});
```

Uses the provider name and connection string provided and automatically adds the correct provider based on the provider name.

```csharp
builder.Services.AddUmbracoDbContext<CustomDbContext>((serviceProvider, options) =>
{
    options.UseSqlite("Data Source=:memory:;Version=3;New=True;");
});
```

Uses the custom provided provider like `AddDbContext` would. This would also make it possible to add options database specific options to the provider.

#### What changed

- This PR includes commit `170ed3a` by Bjarke Berg (The first one) which is cherry picked from `v12/dev`. (This adds the UmbracoPooledDbContextFactory)
- Obsolete the old extension methods
- Added some integration tests to test the registration
- Added new Extension methods to replace the old ones
  - `ÀddUmbracoDbcontext`
  - `UseDatabaseProvider`
  - `UseUmbracoDatabaseProvider`
- Added constant values for the database providers. 


#### What doesn't the PR solve

Right now this PR doesn't auto register the database provider on the extension methods on the old `AddUmbracoEFCoreContext` as this would actually be a breaking change from v12.2 to a version with this change.

But it is quite easy to add we just need to call `UseDatabaseProvider` on the options in the `AddUmbracoEFCoreContext` extension methods.

I'm a bit unsure what the best approach is here.

/CC @Zeegaan

#### Final notes

I think streamlining these extension methods will make it easier to work with EF Core in Umbraco and make a better fit for Umbraco.

Principles of the extension methods:
- A developer should manually specify their database provider like when normally using EF Core but we can provide short hands for using the Umbraco connection string and auto selecting a provider.
- We should support the DbContext itself setting the provider like on the `UmbracoDbContext`.
- We should allow the developer to specify their own database provider so they can parse what ever options they need and they can use the right database for the them.
- The naming should match EF Core so developers don't need to learn new naming
  - And Options should be set in a similarly to EF Core.

I hope it makes sense

#### Test

To test this PR I've added some Unit tests. We could also test other combinations of setting the options in similarly.

<!-- Thanks for contributing to Umbraco CMS! -->
