### PR TITLE
fixed #14832 user without  HasAccessToSensitiveData change sensitive data:  IsApproved IsApproved IsTwoFactorEnabled

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/MemberController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MemberController.cs
@@ -376,7 +376,10 @@ public class MemberController : ContentControllerBase
             }
 
             // map the custom properties - this will already be set for new entities in our member binder
-            contentItem.PersistedContent.IsApproved = contentItem.IsApproved;
+            if (_backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser?.HasAccessToSensitiveData() ?? false)
+            {
+                contentItem.PersistedContent.IsApproved = contentItem.IsApproved;
+            }
             contentItem.PersistedContent.Email = contentItem.Email.Trim();
             contentItem.PersistedContent.Username = contentItem.Username;
         }
@@ -548,6 +551,13 @@ public class MemberController : ContentControllerBase
                     }
                 }
             }
+            //thoese properties defaulting to sensitive, change the value of the contentItem model to the persisted value
+            if (contentItem.PersistedContent is not null)
+            {
+                contentItem.IsApproved = contentItem.PersistedContent.IsApproved;
+                contentItem.IsLockedOut = contentItem.PersistedContent.IsLockedOut;
+            }
+            contentItem.IsTwoFactorEnabled = await _twoFactorLoginService.IsTwoFactorEnabledAsync(contentItem.Key);
         }
 
         if (contentItem.PersistedContent is not null)


### PR DESCRIPTION

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #14832 

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

change persisted IsApprove with user data if user HasAccessToSensitiveData
restore user data  IsApprove  IsLockedOut  IsTwoFactorEnabled  with persisted data

<!-- Thanks for contributing to Umbraco CMS! -->
