### PR TITLE
Fixed potential NuCache file lock causing unusable website

### DIFF
--- a/src/Umbraco.PublishedCache.NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.PublishedCache.NuCache/PublishedSnapshotService.cs
@@ -58,8 +58,9 @@ internal class PublishedSnapshotService : IPublishedSnapshotService
     private long _domainGen;
     private SnapDictionary<int, Domain> _domainStore = null!;
     private IAppCache? _elementsCache;
-    private bool _isReadSet;
 
+    private bool _mainDomRegistered;
+    private bool _isReadSet;
     private bool _isReady;
     private object? _isReadyLock;
 
@@ -490,9 +491,20 @@ internal class PublishedSnapshotService : IPublishedSnapshotService
             // it will not be able to close the stores until we are done populating (if the store is empty)
             lock (_storesLock)
             {
+                SyncBootState bootState = _syncBootStateAccessor.GetSyncBootState();
+
                 if (!_options.IgnoreLocalDb)
                 {
-                    _mainDom.Register(MainDomRegister, MainDomRelease);
+                    if (Volatile.Read(ref _mainDomRegistered) == false)
+                    {
+                        _mainDom.Register(MainDomRegister, MainDomRelease);
+                    }
+                    else
+                    {
+                        // MainDom is already registered, so we must be retrying to load cache data
+                        // We can't trust the localdb state, so always perform a cold boot
+                        bootState = SyncBootState.ColdBoot;
+                    }
 
                     // stores are created with a db so they can write to it, but they do not read from it,
                     // stores need to be populated, happens in OnResolutionFrozen which uses _localDbExists to
@@ -540,8 +552,6 @@ internal class PublishedSnapshotService : IPublishedSnapshotService
 
                 var okContent = false;
                 var okMedia = false;
-
-                SyncBootState bootState = _syncBootStateAccessor.GetSyncBootState();
 
                 try
                 {
@@ -613,6 +623,8 @@ internal class PublishedSnapshotService : IPublishedSnapshotService
         // if both local databases exist then GetTree will open them, else new databases will be created
         _localContentDb = BTree.GetTree(localContentDbPath, _localContentDbExists, _config, _contentDataSerializer);
         _localMediaDb = BTree.GetTree(localMediaDbPath, _localMediaDbExists, _config, _contentDataSerializer);
+
+        _mainDomRegistered = true;
 
         _logger.LogInformation(
             "Registered with MainDom, localContentDbExists? {LocalContentDbExists}, localMediaDbExists? {LocalMediaDbExists}",
@@ -699,21 +711,10 @@ internal class PublishedSnapshotService : IPublishedSnapshotService
             _localContentDb?.Clear();
 
             // IMPORTANT GetAllContentSources sorts kits by level + parentId + sortOrder
-            try
-            {
-                IEnumerable<ContentNodeKit> kits = _publishedContentService.GetAllContentSources();
-                return onStartup
-                    ? _contentStore.SetAllFastSortedLocked(kits, _config.KitBatchSize, true)
-                    : _contentStore.SetAllLocked(kits, _config.KitBatchSize, true);
-            }
-            catch (ThreadAbortException tae)
-            {
-                // Caught a ThreadAbortException, most likely from a database timeout.
-                // If we don't catch it here, the whole local cache can remain locked causing widespread panic (see above comment).
-                _logger.LogWarning(tae, tae.Message);
-            }
-
-            return false;
+            IEnumerable<ContentNodeKit> kits = _publishedContentService.GetAllContentSources();
+            return onStartup
+                ? _contentStore.SetAllFastSortedLocked(kits, _config.KitBatchSize, true)
+                : _contentStore.SetAllLocked(kits, _config.KitBatchSize, true);
         }
     }
 
@@ -762,21 +763,10 @@ internal class PublishedSnapshotService : IPublishedSnapshotService
             }
 
             // IMPORTANT GetAllMediaSources sorts kits by level + parentId + sortOrder
-            try
-            {
-                IEnumerable<ContentNodeKit> kits = _publishedContentService.GetAllMediaSources();
-                return onStartup
-                    ? _mediaStore.SetAllFastSortedLocked(kits, _config.KitBatchSize, true)
-                    : _mediaStore.SetAllLocked(kits, _config.KitBatchSize, true);
-            }
-            catch (ThreadAbortException tae)
-            {
-                // Caught a ThreadAbortException, most likely from a database timeout.
-                // If we don't catch it here, the whole local cache can remain locked causing widespread panic (see above comment).
-                _logger.LogWarning(tae, tae.Message);
-            }
-
-            return false;
+            IEnumerable<ContentNodeKit> kits = _publishedContentService.GetAllMediaSources();
+            return onStartup
+                ? _mediaStore.SetAllFastSortedLocked(kits, _config.KitBatchSize, true)
+                : _mediaStore.SetAllLocked(kits, _config.KitBatchSize, true);
         }
     }
 

--- a/src/Umbraco.PublishedCache.NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.PublishedCache.NuCache/PublishedSnapshotService.cs
@@ -59,10 +59,11 @@ internal class PublishedSnapshotService : IPublishedSnapshotService
     private SnapDictionary<int, Domain> _domainStore = null!;
     private IAppCache? _elementsCache;
 
-    private bool _mainDomRegistered;
     private bool _isReadSet;
     private bool _isReady;
     private object? _isReadyLock;
+
+    private bool _mainDomRegistered;
 
     private BPlusTree<int, ContentNodeKit>? _localContentDb;
     private bool _localContentDbExists;
@@ -495,7 +496,7 @@ internal class PublishedSnapshotService : IPublishedSnapshotService
 
                 if (!_options.IgnoreLocalDb)
                 {
-                    if (Volatile.Read(ref _mainDomRegistered) == false)
+                    if (!_mainDomRegistered)
                     {
                         _mainDom.Register(MainDomRegister, MainDomRelease);
                     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
If during startup any error occurs while generating the nuCache file, the file will be permanently locked and all non backoffice CMS requests will fail with a nuCache locked error.

This is because it will constantly try to run the  `MainDomRegister` method, which in turn tries to open the already opened nuCache files.
A previous attempt to address this issue was done in #12149, but it simply ignores a specific exception which both doesn't cover all the cases, and even when the correct exception is caught, will simply cause the website to load without any content in it's cache, causing 404s for all pages.

### Reproduction steps
We were observing this with uSync configured to import content types and content on first boot, as that would throw a SQL deadlock exception, but it can also be caused by any connection issues during startup. such as a simple timeout.

A reliable way of reproducing the issue is to:
 - Configure a MSSQL/LocalDB connection string and unnatend install
 (As the migration below only runs once, clean the database between runs)
 - Add the following file to the project:
```c#
using Umbraco.Cms.Core;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Migrations;
using Umbraco.Cms.Core.Notifications;
using Umbraco.Cms.Core.Scoping;
using Umbraco.Cms.Core.Services;
using Umbraco.Cms.Core.Web;
using Umbraco.Cms.Infrastructure.Migrations;
using Umbraco.Cms.Infrastructure.Migrations.Upgrade;

namespace Umbraco.Cms.Web.UI;

public class FirstBootMigration : MigrationBase
{
    private readonly IUmbracoContextFactory _umbracoContextFactory;
    private readonly IContentTypeService _contentTypeService;

    public FirstBootMigration(
        IMigrationContext context,
        IUmbracoContextFactory umbracoContextFactory,
        IContentTypeService contentTypeService
    )
        : base(context)
    {
        _umbracoContextFactory = umbracoContextFactory;
        _contentTypeService = contentTypeService;
    }

    protected override void Migrate()
    {
        using (_ = _umbracoContextFactory.EnsureUmbracoContext())
        {
            for (var i = 0; i < 5000; i++)
            {
                _contentTypeService.CreateContainer(-1, Guid.NewGuid(), $"Folder #{i}");
            }
        }
    }
}

internal class FirstBootMigrationPlan : MigrationPlan
{
    public FirstBootMigrationPlan()
        : base("test_FirstBoot")
    {
        From(string.Empty)
            .To<FirstBootMigration>("FirstBootMigration");
    }
}

internal class FirstBootAppStartingHandler
    : INotificationHandler<UmbracoApplicationStartedNotification>
{

    private readonly ICoreScopeProvider _scopeProvider;
    private readonly IKeyValueService _keyValueService;
    private readonly IMigrationPlanExecutor _migrationPlanExecutor;
    private readonly IRuntimeState _runtimeState;

    public FirstBootAppStartingHandler(
        ICoreScopeProvider scopeProvider,
        IKeyValueService keyValueService,
        IMigrationPlanExecutor migrationPlanExecutor,
        IRuntimeState runtimeState)
    {
        _scopeProvider = scopeProvider;
        _keyValueService = keyValueService;
        _migrationPlanExecutor = migrationPlanExecutor;
        _runtimeState = runtimeState;
    }

    public void Handle(UmbracoApplicationStartedNotification notification)
    {
        if (_runtimeState.Level == RuntimeLevel.Run)
        {
            var firstBootMigration = new FirstBootMigrationPlan();
            var upgrader = new Upgrader(firstBootMigration);

            upgrader.Execute(_migrationPlanExecutor, _scopeProvider, _keyValueService);
        }
    }
}

public class FirstBootMigrationComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder) => builder.AddNotificationHandler<UmbracoApplicationStartedNotification, FirstBootAppStartingHandler>();
}

```
- Verify that although on startup an exception does occur, after reloading the page, it will properly retry to load the cache and succeed.

<!-- Thanks for contributing to Umbraco CMS! -->
