### PR TITLE
Fix potential NullReferenceException

### DIFF
--- a/src/Umbraco.Web.Common/AspNetCore/AspNetCoreSessionManager.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/AspNetCoreSessionManager.cs
@@ -27,7 +27,7 @@ internal class AspNetCoreSessionManager : ISessionIdResolver, ISessionManager
     /// <summary>
     ///     If session isn't enabled this will throw an exception so we check
     /// </summary>
-    private bool IsSessionsAvailable => !(_httpContextAccessor.HttpContext?.Features.Get<ISessionFeature>() is null);
+    private bool IsSessionsAvailable => !(_httpContextAccessor.HttpContext?.Features.Get<ISessionFeature>()?.Session is null);
 
     public string? GetSessionValue(string key)
     {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
While troubleshooting another issue I ran into a NRE being triggered by the `HttpSessionIdEnricher`, when trying to retrieve the `SessionId`.

I couldn't reliably reproduce this by itself, and it can't be seen in the logs either, as serilog swallows any exception that occur in enrichers, but it can be fairly easily forced to happen by adding the following, before `app.UseUmbraco`:
```c#
app.Use(async (context, func) =>
{
    // This is to make the issue reproducible
    // The issue does occur without this line, for the log lines in PublishedSnapshotService, but I can't reliably reproduce it
    context.Session = null!;

    ILogger<Startup> logger = context.RequestServices.GetRequiredService<ILogger<Startup>>();
    logger.LogInformation("Test 1");

    await func();
});
```

The issue got introduced when cleaning up nullable reference types warnings, as the session is marked as not nullable, but it does appear that somehow it does get set to null.
Also, for reference, as it is a publicly settable field, the `SessionMiddleware` itself also checks for null: https://github.com/dotnet/aspnetcore/blob/main/src/Middleware/Session/src/SessionMiddleware.cs#L96

<!-- Thanks for contributing to Umbraco CMS! -->
