### PR TITLE
Fix update to update foreach Group

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddGuidsToUserGroups.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddGuidsToUserGroups.cs
@@ -46,9 +46,13 @@ public class AddGuidsToUserGroups : UnscopedMigrationBase
         AddColumnIfNotExists<UserGroupDto>(columns, NewColumnName);
 
         // We want specific keys for the default user groups, so we need to fetch the user groups again to set their keys.
-        IEnumerable<Guid> updatedUserGroups = Database.Fetch<UserGroupDto>()
-            .Select(x => x.Key = ResolveAliasToGuid(x.Alias));
-        Database.Update(updatedUserGroups);
+        List<UserGroupDto>? userGroups = Database.Fetch<UserGroupDto>();
+
+        foreach (UserGroupDto userGroup in userGroups)
+        {
+            userGroup.Key = ResolveAliasToGuid(userGroup.Alias);
+            Database.Update(userGroup);
+        }
 
         scope.Complete();
     }


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/14860 & https://github.com/umbraco/Umbraco-CMS/issues/14861

This fixes the SqlServer migration, the update before selected only guids and tried to update them.

This now updates the user groups instead :) 

# How to test
- Install umbraco ON V12 (use the `v12/dev` branch
- Switch to this branch 
- Run the migrations
- This should now run without errors

Alternatively, you can just duplicate the migration in `UmbracoPlan` and give it a new key, to re-trigger the migration