### PR TITLE
Condition on the userState instead of the dates.

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
@@ -532,7 +532,7 @@ public class UsersController : BackOfficeNotificationsController
         {
             // first validate the username if we're showing it
             ActionResult<IUser?> userResult = CheckUniqueUsername(userSave.Username,
-                u => u.LastLoginDate != default || u.EmailConfirmedDate.HasValue);
+                u => u.UserState != UserState.Invited);
             if (userResult.Result is not null)
             {
                 return userResult.Result;
@@ -540,7 +540,7 @@ public class UsersController : BackOfficeNotificationsController
         }
 
         IUser? user = CheckUniqueEmail(userSave.Email,
-            u => u.LastLoginDate != default || u.EmailConfirmedDate.HasValue);
+            u => u.UserState != UserState.Invited);
 
         if (ModelState.IsValid == false)
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/14949

### Description
When the user is invited, your are able to resend an invitation, from the User page.

But as soon the the VerifyInvite flow has been requested, the `EmailConfirmedDate` has value and therefore the `CheckUniqueUsername` method always return true. But this user witch was invited, only click on the link and left the VerifyInvite  flow undone. 

If the administrator need to request a new invitation they are stuck, now due to the system always sayes true, due to the fact that the email has been confirmed, but the UserState is still Inviteded.

I have change the condition from checking `EmailConfirmedDate` to check the `UserState` as the frontend also do, to show the resend invitation box https://github.com/umbraco/Umbraco-CMS/blob/6e154e0a0f63bb0f8c742f15c4f2c718b9515b16/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html#L316

The state only change, if the user complete the invitation flow to end.

This change is also test with the appSetting `UsernameIsEmail` valued true and false.