### PR TITLE
Added BlockEditorDataConverter method to BlockListPropertyEditorBase …

### DIFF
--- a/src/Umbraco.Infrastructure/Models/Blocks/BlockListEditorDataConverter.cs
+++ b/src/Umbraco.Infrastructure/Models/Blocks/BlockListEditorDataConverter.cs
@@ -6,15 +6,32 @@ using Newtonsoft.Json.Linq;
 namespace Umbraco.Cms.Core.Models.Blocks;
 
 /// <summary>
-///     Data converter for the block list property editor
+/// Handles the conversion of data for the block list property editor.
 /// </summary>
 public class BlockListEditorDataConverter : BlockEditorDataConverter
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BlockListEditorDataConverter"/> class with a default alias.
+    /// </summary>
     public BlockListEditorDataConverter()
         : base(Constants.PropertyEditors.Aliases.BlockList)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BlockListEditorDataConverter"/> class with a provided alias.
+    /// </summary>
+    /// <param name="propertyEditorAlias">The alias of the property editor.</param>
+    public BlockListEditorDataConverter(string propertyEditorAlias)
+        : base(propertyEditorAlias)
+    {
+    }
+
+    /// <summary>
+    /// Extracts block references from the provided JSON layout.
+    /// </summary>
+    /// <param name="jsonLayout">The JSON layout containing the block references.</param>
+    /// <returns>A collection of <see cref="ContentAndSettingsReference"/> objects extracted from the JSON layout.</returns>
     protected override IEnumerable<ContentAndSettingsReference>? GetBlockReferences(JToken jsonLayout)
     {
         IEnumerable<BlockListLayoutItem>? blockListLayout = jsonLayout.ToObject<IEnumerable<BlockListLayoutItem>>();

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditorBase.cs
@@ -35,6 +35,11 @@ public abstract class BlockListPropertyEditorBase : DataEditor
 
     public override IPropertyIndexValueFactory PropertyIndexValueFactory => _blockValuePropertyIndexValueFactory;
 
+    /// <summary>
+    /// Creates a new instance of the BlockEditorDataConverter.
+    /// </summary>
+    /// <returns>An instance of BlockListEditorDataConverter.</returns>
+    protected virtual BlockEditorDataConverter CreateBlockEditorDataConverter() => new BlockListEditorDataConverter();
 
     #region Value Editor
 
@@ -45,6 +50,7 @@ public abstract class BlockListPropertyEditorBase : DataEditor
     {
         public BlockListEditorPropertyValueEditor(
             DataEditorAttribute attribute,
+            BlockEditorDataConverter blockEditorDataConverter,
             PropertyEditorCollection propertyEditors,
             IDataTypeService dataTypeService,
             IContentTypeService contentTypeService,
@@ -56,7 +62,7 @@ public abstract class BlockListPropertyEditorBase : DataEditor
             IPropertyValidationService propertyValidationService) :
             base(attribute, propertyEditors, dataTypeService, textService, logger, shortStringHelper, jsonSerializer, ioHelper)
         {
-            BlockEditorValues = new BlockEditorValues(new BlockListEditorDataConverter(), contentTypeService, logger);
+            BlockEditorValues = new BlockEditorValues(blockEditorDataConverter, contentTypeService, logger);
             Validators.Add(new BlockEditorValidator(propertyValidationService, BlockEditorValues, contentTypeService));
             Validators.Add(new MinMaxValidator(BlockEditorValues, textService));
         }

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditorBase.cs
@@ -44,7 +44,7 @@ public abstract class BlockListPropertyEditorBase : DataEditor
     #region Value Editor
 
     protected override IDataValueEditor CreateValueEditor() =>
-        DataValueEditorFactory.Create<BlockListEditorPropertyValueEditor>(Attribute!);
+        DataValueEditorFactory.Create<BlockListEditorPropertyValueEditor>(Attribute!, CreateBlockEditorDataConverter());
 
     internal class BlockListEditorPropertyValueEditor : BlockEditorPropertyValueEditor
     {

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditorBase.cs
@@ -35,13 +35,13 @@ public abstract class BlockListPropertyEditorBase : DataEditor
 
     public override IPropertyIndexValueFactory PropertyIndexValueFactory => _blockValuePropertyIndexValueFactory;
 
-    /// <summary>
-    /// Creates a new instance of the BlockEditorDataConverter.
-    /// </summary>
-    /// <returns>An instance of BlockListEditorDataConverter.</returns>
-    protected virtual BlockEditorDataConverter CreateBlockEditorDataConverter() => new BlockListEditorDataConverter();
-
     #region Value Editor
+
+    /// <summary>
+    /// Instantiates a new <see cref="BlockEditorDataConverter"/> for use with the block list editor property value editor.
+    /// </summary>
+    /// <returns>A new instance of <see cref="BlockListEditorDataConverter"/>.</returns>
+    protected virtual BlockEditorDataConverter CreateBlockEditorDataConverter() => new BlockListEditorDataConverter();
 
     protected override IDataValueEditor CreateValueEditor() =>
         DataValueEditorFactory.Create<BlockListEditorPropertyValueEditor>(Attribute!, CreateBlockEditorDataConverter());

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueEditorReuseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueEditorReuseTests.cs
@@ -1,8 +1,9 @@
-﻿using System.Linq;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
@@ -34,9 +35,10 @@ public class DataValueEditorReuseTests
 
         _dataValueEditorFactoryMock
             .Setup(m =>
-                m.Create<BlockListPropertyEditorBase.BlockListEditorPropertyValueEditor>(It.IsAny<DataEditorAttribute>()))
+                m.Create<BlockListPropertyEditorBase.BlockListEditorPropertyValueEditor>(It.IsAny<DataEditorAttribute>(), It.IsAny<BlockEditorDataConverter>()))
             .Returns(() => new BlockListPropertyEditorBase.BlockListEditorPropertyValueEditor(
                 new DataEditorAttribute("a", "b", "c"),
+                new BlockListEditorDataConverter(),
                 _propertyEditorCollection,
                 Mock.Of<IDataTypeService>(),
                 Mock.Of<IContentTypeService>(),

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueEditorReuseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueEditorReuseTests.cs
@@ -107,7 +107,7 @@ public class DataValueEditorReuseTests
         Assert.NotNull(dataValueEditor2);
         Assert.AreNotSame(dataValueEditor1, dataValueEditor2);
         _dataValueEditorFactoryMock.Verify(
-            m => m.Create<BlockListPropertyEditorBase.BlockListEditorPropertyValueEditor>(It.IsAny<DataEditorAttribute>()),
+            m => m.Create<BlockListPropertyEditorBase.BlockListEditorPropertyValueEditor>(It.IsAny<DataEditorAttribute>(), It.IsAny<BlockEditorDataConverter>()),
             Times.Exactly(2));
     }
 
@@ -130,7 +130,7 @@ public class DataValueEditorReuseTests
         Assert.AreEqual("config", ((DataValueEditor)dataValueEditor2).Configuration);
         Assert.AreNotSame(dataValueEditor1, dataValueEditor2);
         _dataValueEditorFactoryMock.Verify(
-            m => m.Create<BlockListPropertyEditorBase.BlockListEditorPropertyValueEditor>(It.IsAny<DataEditorAttribute>()),
+            m => m.Create<BlockListPropertyEditorBase.BlockListEditorPropertyValueEditor>(It.IsAny<DataEditorAttribute>(), It.IsAny<BlockEditorDataConverter>()),
             Times.Exactly(2));
     }
 }


### PR DESCRIPTION
…and updated BlockListEditorPropertyValueEditor to utilize it.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #14959 

### Description

The pull request aims to make it so that the BlockEditorDataConverter used by BlockListPropertyEditorBase can be customised to handle custom property editors.

1. Created new inline method CreateBlockEditorDataConverter with a return type of BlockEditorDataConverter that defaults to a new instance of the previously hard coded BlockListEditorDataConverter
2. Method is protected virtual
3. Updated CreateValueEditor to pass the result of CreateBlockEditorDataConverter to the BlockListEditorPropertyValueEditor
4. Updated BlockListEditorPropertyValueEditor constructor to accept BlockListEditorDataConverter as a ctor arg
5. Updated setting of BlockEditorValues to use passed argument
6. Added additional constructor to BlockListEditorPropertyValueEditor allowing it to be used with a custom property editor
7. Added xmldocs in areas worked on.
8. Updated unit tests

Steps for manual testing:
1. Create a new custom property editor that extends BlockListPropertyEditorBase
2. Install / configure in umbraco as per usual
3. Add Content, Click Save
4. Validate content saved
5. Smoke test block list editor: Check that still saves as expected

<!-- Thanks for contributing to Umbraco CMS! -->

