### PR TITLE
Out-of-date models status flag is created when using SourceCodeManual and Development Runtime

### DIFF
--- a/src/Umbraco.Web.Common/ModelsBuilder/DependencyInjection/UmbracoBuilderDependencyInjectionExtensions.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/DependencyInjection/UmbracoBuilderDependencyInjectionExtensions.cs
@@ -114,8 +114,6 @@ public static class UmbracoBuilderDependencyInjectionExtensions
             builder.AddInMemoryModelsRazorEngine();
 
             builder.AddNotificationHandler<ModelBindingErrorNotification, ModelsBuilderNotificationHandler>();
-            builder.AddNotificationHandler<ContentTypeCacheRefresherNotification, OutOfDateModelsStatus>();
-            builder.AddNotificationHandler<DataTypeCacheRefresherNotification, OutOfDateModelsStatus>();
         }
 
         if (builder.Config.GetRuntimeMode() != RuntimeMode.Production)
@@ -137,6 +135,7 @@ public static class UmbracoBuilderDependencyInjectionExtensions
 
         // Register required services for ModelsBuilderDashboardController
         builder.Services.AddSingleton<IModelsGenerator, ModelsGenerator>();
+        
         // TODO: Remove in v13 - this is only here in case someone is already using this generator directly
         builder.Services.AddSingleton<ModelsGenerator>();
         builder.Services.AddSingleton<OutOfDateModelsStatus>();
@@ -166,6 +165,7 @@ public static class UmbracoBuilderDependencyInjectionExtensions
 
         // This is what the community MB would replace, all of the above services are fine to be registered
         builder.Services.AddSingleton<IPublishedModelFactory>(factory => factory.CreateDefaultPublishedModelFactory());
+        
         return builder;
     }
 }

--- a/src/Umbraco.Web.Common/ModelsBuilder/DependencyInjection/UmbracoBuilderDependencyInjectionExtensions.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/DependencyInjection/UmbracoBuilderDependencyInjectionExtensions.cs
@@ -128,6 +128,9 @@ public static class UmbracoBuilderDependencyInjectionExtensions
             builder.AddNotificationHandler<UmbracoRequestEndNotification, AutoModelsNotificationHandler>();
             builder.AddNotificationHandler<ContentTypeCacheRefresherNotification, AutoModelsNotificationHandler>();
             builder.AddNotificationHandler<DataTypeCacheRefresherNotification, AutoModelsNotificationHandler>();
+            
+            builder.AddNotificationHandler<ContentTypeCacheRefresherNotification, OutOfDateModelsStatus>();
+            builder.AddNotificationHandler<DataTypeCacheRefresherNotification, OutOfDateModelsStatus>();
         }
 
         builder.Services.TryAddSingleton<IModelsBuilderDashboardProvider, NoopModelsBuilderDashboardProvider>();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
This PR is in draft as I 1) need verification that this is a code bug and not a documentation bug, and 2) need to test a bit more before finalizing.

Should fix #14965 by implementing the change proposed in that same issue.

Test by following the steps to reproduce and verify that the ood.flag file is created upon changing a document type.
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
