### PR TITLE
Add config to limit concurrent logins

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/SecuritySettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/SecuritySettings.cs
@@ -17,6 +17,7 @@ public class SecuritySettings
     internal const bool StaticHideDisabledUsersInBackOffice = false;
     internal const bool StaticAllowPasswordReset = true;
     internal const bool StaticAllowEditInvariantFromNonDefault = false;
+    internal const bool StaticAllowConcurrentLogins = true;
     internal const string StaticAuthCookieName = "UMB_UCONTEXT";
 
     internal const string StaticAllowedUserNameCharacters =
@@ -109,4 +110,10 @@ public class SecuritySettings
     [Obsolete("Use ContentSettings.AllowEditFromInvariant instead")]
     [DefaultValue(StaticAllowEditInvariantFromNonDefault)]
     public bool AllowEditInvariantFromNonDefault { get; set; } = StaticAllowEditInvariantFromNonDefault;
+
+    /// <summary>
+    ///     Gets or sets a value indicating whether to allow concurrent logins.
+    /// </summary>
+    [DefaultValue(StaticAllowConcurrentLogins)]
+    public bool AllowConcurrentLogins { get; set; } = StaticAllowConcurrentLogins;
 }

--- a/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs
+++ b/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs
@@ -58,9 +58,19 @@ public class BackOfficeSignInManager : UmbracoSignInManager<BackOfficeIdentityUs
         IAuthenticationSchemeProvider schemes,
         IUserConfirmation<BackOfficeIdentityUser> confirmation,
         IEventAggregator eventAggregator)
-        : this(userManager, contextAccessor, externalLogins, claimsFactory, optionsAccessor, globalSettings, logger, schemes, confirmation, eventAggregator,StaticServiceProvider.Instance.GetRequiredService<IOptions<SecuritySettings>>())
+        : this(
+            userManager,
+            contextAccessor,
+            externalLogins,
+            claimsFactory,
+            optionsAccessor,
+            globalSettings,
+            logger,
+            schemes,
+            confirmation,
+            eventAggregator,
+            StaticServiceProvider.Instance.GetRequiredService<IOptions<SecuritySettings>>())
     {
-
     }
 
     [Obsolete("Use non-obsolete constructor. This is scheduled for removal in V14.")]
@@ -74,7 +84,18 @@ public class BackOfficeSignInManager : UmbracoSignInManager<BackOfficeIdentityUs
         ILogger<SignInManager<BackOfficeIdentityUser>> logger,
         IAuthenticationSchemeProvider schemes,
         IUserConfirmation<BackOfficeIdentityUser> confirmation)
-        : this(userManager, contextAccessor, externalLogins, claimsFactory, optionsAccessor, globalSettings, logger, schemes, confirmation, StaticServiceProvider.Instance.GetRequiredService<IEventAggregator>(),StaticServiceProvider.Instance.GetRequiredService<IOptions<SecuritySettings>>())
+        : this(
+            userManager,
+            contextAccessor,
+            externalLogins,
+            claimsFactory,
+            optionsAccessor,
+            globalSettings,
+            logger,
+            schemes,
+            confirmation,
+            StaticServiceProvider.Instance.GetRequiredService<IEventAggregator>(),
+            StaticServiceProvider.Instance.GetRequiredService<IOptions<SecuritySettings>>())
     {
     }
 

--- a/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs
+++ b/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs
@@ -36,8 +36,9 @@ public class BackOfficeSignInManager : UmbracoSignInManager<BackOfficeIdentityUs
         ILogger<SignInManager<BackOfficeIdentityUser>> logger,
         IAuthenticationSchemeProvider schemes,
         IUserConfirmation<BackOfficeIdentityUser> confirmation,
-        IEventAggregator eventAggregator)
-        : base(userManager, contextAccessor, claimsFactory, optionsAccessor, logger, schemes, confirmation)
+        IEventAggregator eventAggregator,
+        IOptions<SecuritySettings> securitySettings)
+        : base(userManager, contextAccessor, claimsFactory, optionsAccessor, logger, schemes, confirmation, securitySettings)
     {
         _userManager = userManager;
         _externalLogins = externalLogins;
@@ -45,7 +46,24 @@ public class BackOfficeSignInManager : UmbracoSignInManager<BackOfficeIdentityUs
         _globalSettings = globalSettings.Value;
     }
 
-    [Obsolete("Use ctor with all params")]
+    [Obsolete("Use non-obsolete constructor. This is scheduled for removal in V14.")]
+    public BackOfficeSignInManager(
+        BackOfficeUserManager userManager,
+        IHttpContextAccessor contextAccessor,
+        IBackOfficeExternalLoginProviders externalLogins,
+        IUserClaimsPrincipalFactory<BackOfficeIdentityUser> claimsFactory,
+        IOptions<IdentityOptions> optionsAccessor,
+        IOptions<GlobalSettings> globalSettings,
+        ILogger<SignInManager<BackOfficeIdentityUser>> logger,
+        IAuthenticationSchemeProvider schemes,
+        IUserConfirmation<BackOfficeIdentityUser> confirmation,
+        IEventAggregator eventAggregator)
+        : this(userManager, contextAccessor, externalLogins, claimsFactory, optionsAccessor, globalSettings, logger, schemes, confirmation, eventAggregator,StaticServiceProvider.Instance.GetRequiredService<IOptions<SecuritySettings>>())
+    {
+
+    }
+
+    [Obsolete("Use non-obsolete constructor. This is scheduled for removal in V14.")]
     public BackOfficeSignInManager(
         BackOfficeUserManager userManager,
         IHttpContextAccessor contextAccessor,
@@ -56,7 +74,7 @@ public class BackOfficeSignInManager : UmbracoSignInManager<BackOfficeIdentityUs
         ILogger<SignInManager<BackOfficeIdentityUser>> logger,
         IAuthenticationSchemeProvider schemes,
         IUserConfirmation<BackOfficeIdentityUser> confirmation)
-        : this(userManager, contextAccessor, externalLogins, claimsFactory, optionsAccessor, globalSettings, logger, schemes, confirmation, StaticServiceProvider.Instance.GetRequiredService<IEventAggregator>())
+        : this(userManager, contextAccessor, externalLogins, claimsFactory, optionsAccessor, globalSettings, logger, schemes, confirmation, StaticServiceProvider.Instance.GetRequiredService<IEventAggregator>(),StaticServiceProvider.Instance.GetRequiredService<IOptions<SecuritySettings>>())
     {
     }
 

--- a/src/Umbraco.Web.BackOffice/Security/ConfigureBackOfficeCookieOptions.cs
+++ b/src/Umbraco.Web.BackOffice/Security/ConfigureBackOfficeCookieOptions.cs
@@ -11,9 +11,11 @@ using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Net;
 using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Web.BackOffice.Controllers;
+using Umbraco.Cms.Web.Common.Security;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Web.BackOffice.Security;
@@ -221,6 +223,20 @@ public class ConfigureBackOfficeCookieOptions : IConfigureNamedOptions<CookieAut
                         Constants.Security.BackOfficeAuthenticationType,
                         Constants.Security.BackOfficeAuthenticationType,
                         backOfficeIdentity));
+
+                    // Update the security stamp when sign-in is successful
+                    var userManager = ctx.HttpContext.RequestServices.GetRequiredService<BackOfficeUserManager>();
+
+                    // TODO: check if securitySettings.AllowConcurrentLogins is not allowed
+                    if (ctx.Principal != null)
+                    {
+                        BackOfficeIdentityUser? user = userManager.GetUserAsync(ctx.Principal).GetAwaiter().GetResult();
+
+                        if (user is not null)
+                        {
+                            userManager.UpdateSecurityStampAsync(user).GetAwaiter().GetResult();
+                        }
+                    }
                 }
 
                 return Task.CompletedTask;

--- a/src/Umbraco.Web.BackOffice/Security/ConfigureBackOfficeCookieOptions.cs
+++ b/src/Umbraco.Web.BackOffice/Security/ConfigureBackOfficeCookieOptions.cs
@@ -11,11 +11,9 @@ using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Net;
 using Umbraco.Cms.Core.Routing;
-using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Web.BackOffice.Controllers;
-using Umbraco.Cms.Web.Common.Security;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Web.BackOffice.Security;
@@ -223,20 +221,6 @@ public class ConfigureBackOfficeCookieOptions : IConfigureNamedOptions<CookieAut
                         Constants.Security.BackOfficeAuthenticationType,
                         Constants.Security.BackOfficeAuthenticationType,
                         backOfficeIdentity));
-
-                    // Update the security stamp when sign-in is successful
-                    var userManager = ctx.HttpContext.RequestServices.GetRequiredService<BackOfficeUserManager>();
-
-                    // TODO: check if securitySettings.AllowConcurrentLogins is not allowed
-                    if (ctx.Principal != null)
-                    {
-                        BackOfficeIdentityUser? user = userManager.GetUserAsync(ctx.Principal).GetAwaiter().GetResult();
-
-                        if (user is not null)
-                        {
-                            userManager.UpdateSecurityStampAsync(user).GetAwaiter().GetResult();
-                        }
-                    }
                 }
 
                 return Task.CompletedTask;

--- a/src/Umbraco.Web.BackOffice/Security/ConfigureBackOfficeSecurityStampValidatorOptions.cs
+++ b/src/Umbraco.Web.BackOffice/Security/ConfigureBackOfficeSecurityStampValidatorOptions.cs
@@ -11,9 +11,10 @@ public class ConfigureBackOfficeSecurityStampValidatorOptions : IConfigureOption
 {
     private readonly SecuritySettings _securitySettings;
 
-    public ConfigureBackOfficeSecurityStampValidatorOptions(IOptionsMonitor<SecuritySettings> securitySettings)
-        => _securitySettings = securitySettings.CurrentValue;
+    public ConfigureBackOfficeSecurityStampValidatorOptions(IOptions<SecuritySettings> securitySettings)
+        => _securitySettings = securitySettings.Value;
 
+    /// <inheritdoc />
     public void Configure(BackOfficeSecurityStampValidatorOptions options)
         => ConfigureSecurityStampOptions.ConfigureOptions(options, _securitySettings);
 }

--- a/src/Umbraco.Web.BackOffice/Security/ConfigureBackOfficeSecurityStampValidatorOptions.cs
+++ b/src/Umbraco.Web.BackOffice/Security/ConfigureBackOfficeSecurityStampValidatorOptions.cs
@@ -1,5 +1,7 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Web.Common.Security;
 
 namespace Umbraco.Cms.Web.BackOffice.Security;
@@ -10,6 +12,11 @@ namespace Umbraco.Cms.Web.BackOffice.Security;
 public class ConfigureBackOfficeSecurityStampValidatorOptions : IConfigureOptions<BackOfficeSecurityStampValidatorOptions>
 {
     private readonly SecuritySettings _securitySettings;
+
+    public ConfigureBackOfficeSecurityStampValidatorOptions()
+        : this(StaticServiceProvider.Instance.GetRequiredService<IOptions<SecuritySettings>>())
+    {
+    }
 
     public ConfigureBackOfficeSecurityStampValidatorOptions(IOptions<SecuritySettings> securitySettings)
         => _securitySettings = securitySettings.Value;

--- a/src/Umbraco.Web.BackOffice/Security/ConfigureBackOfficeSecurityStampValidatorOptions.cs
+++ b/src/Umbraco.Web.BackOffice/Security/ConfigureBackOfficeSecurityStampValidatorOptions.cs
@@ -1,14 +1,19 @@
 using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Web.Common.Security;
 
 namespace Umbraco.Cms.Web.BackOffice.Security;
 
 /// <summary>
-///     Configures the back office security stamp options
+///     Configures the back office security stamp options.
 /// </summary>
-public class
-    ConfigureBackOfficeSecurityStampValidatorOptions : IConfigureOptions<BackOfficeSecurityStampValidatorOptions>
+public class ConfigureBackOfficeSecurityStampValidatorOptions : IConfigureOptions<BackOfficeSecurityStampValidatorOptions>
 {
+    private readonly SecuritySettings _securitySettings;
+
+    public ConfigureBackOfficeSecurityStampValidatorOptions(IOptionsMonitor<SecuritySettings> securitySettings)
+        => _securitySettings = securitySettings.CurrentValue;
+
     public void Configure(BackOfficeSecurityStampValidatorOptions options)
-        => ConfigureSecurityStampOptions.ConfigureOptions(options);
+        => ConfigureSecurityStampOptions.ConfigureOptions(options, _securitySettings);
 }

--- a/src/Umbraco.Web.Common/Security/ConfigureSecurityStampOptions.cs
+++ b/src/Umbraco.Web.Common/Security/ConfigureSecurityStampOptions.cs
@@ -12,8 +12,8 @@ public class ConfigureSecurityStampOptions : IConfigureOptions<SecurityStampVali
 {
     private readonly SecuritySettings _securitySettings;
 
-    public ConfigureSecurityStampOptions(IOptionsMonitor<SecuritySettings> securitySettings)
-        => _securitySettings = securitySettings.CurrentValue;
+    public ConfigureSecurityStampOptions(IOptions<SecuritySettings> securitySettings)
+        => _securitySettings = securitySettings.Value;
 
     [Obsolete("Use the overload accepting SecuritySettings instead. Scheduled for removal in v14.")]
     public static void ConfigureOptions(SecurityStampValidatorOptions options)
@@ -30,9 +30,9 @@ public class ConfigureSecurityStampOptions : IConfigureOptions<SecurityStampVali
         // Adjust the security stamp validation interval to a shorter duration
         // when concurrent logins are not allowed and the duration has the default interval value
         // (currently defaults to 30 minutes), ensuring quicker re-validation.
-        if (!securitySettings.AllowConcurrentLogins && options.ValidationInterval == TimeSpan.FromMinutes(30))
+        if (securitySettings.AllowConcurrentLogins is false && options.ValidationInterval == TimeSpan.FromMinutes(30))
         {
-            options.ValidationInterval = TimeSpan.FromSeconds(5);
+            options.ValidationInterval = TimeSpan.FromSeconds(30);
         }
 
         // When refreshing the principal, ensure custom claims that
@@ -53,6 +53,7 @@ public class ConfigureSecurityStampOptions : IConfigureOptions<SecurityStampVali
         };
     }
 
+    /// <inheritdoc />
     public void Configure(SecurityStampValidatorOptions options)
         => ConfigureOptions(options, _securitySettings);
 }

--- a/src/Umbraco.Web.Common/Security/ConfigureSecurityStampOptions.cs
+++ b/src/Umbraco.Web.Common/Security/ConfigureSecurityStampOptions.cs
@@ -1,20 +1,39 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Web.Common.Security;
 
 public class ConfigureSecurityStampOptions : IConfigureOptions<SecurityStampValidatorOptions>
 {
+    private readonly SecuritySettings _securitySettings;
+
+    public ConfigureSecurityStampOptions(IOptionsMonitor<SecuritySettings> securitySettings)
+        => _securitySettings = securitySettings.CurrentValue;
+
+    [Obsolete("Use the overload accepting SecuritySettings instead. Scheduled for removal in v14.")]
+    public static void ConfigureOptions(SecurityStampValidatorOptions options)
+        => ConfigureOptions(options, StaticServiceProvider.Instance.GetRequiredService<SecuritySettings>());
+
     /// <summary>
     ///     Configures security stamp options and ensures any custom claims
     ///     set on the identity are persisted to the new identity when it's refreshed.
     /// </summary>
-    /// <param name="options"></param>
-    public static void ConfigureOptions(SecurityStampValidatorOptions options)
+    /// <param name="options">Options for <see cref="ISecurityStampValidator"/>.</param>
+    /// <param name="securitySettings">The <see cref="SecuritySettings" /> options.</param>
+    public static void ConfigureOptions(SecurityStampValidatorOptions options, SecuritySettings securitySettings)
     {
-        options.ValidationInterval = TimeSpan.FromMinutes(30);
+        // Adjust the security stamp validation interval to a shorter duration
+        // when concurrent logins are not allowed and the duration has the default interval value
+        // (currently defaults to 30 minutes), ensuring quicker re-validation.
+        if (!securitySettings.AllowConcurrentLogins && options.ValidationInterval == TimeSpan.FromMinutes(30))
+        {
+            options.ValidationInterval = TimeSpan.FromSeconds(5);
+        }
 
         // When refreshing the principal, ensure custom claims that
         // might have been set with an external identity continue
@@ -35,5 +54,5 @@ public class ConfigureSecurityStampOptions : IConfigureOptions<SecurityStampVali
     }
 
     public void Configure(SecurityStampValidatorOptions options)
-        => ConfigureOptions(options);
+        => ConfigureOptions(options, _securitySettings);
 }

--- a/src/Umbraco.Web.Common/Security/ConfigureSecurityStampOptions.cs
+++ b/src/Umbraco.Web.Common/Security/ConfigureSecurityStampOptions.cs
@@ -12,6 +12,11 @@ public class ConfigureSecurityStampOptions : IConfigureOptions<SecurityStampVali
 {
     private readonly SecuritySettings _securitySettings;
 
+    public ConfigureSecurityStampOptions()
+        : this(StaticServiceProvider.Instance.GetRequiredService<IOptions<SecuritySettings>>())
+    {
+    }
+
     public ConfigureSecurityStampOptions(IOptions<SecuritySettings> securitySettings)
         => _securitySettings = securitySettings.Value;
 

--- a/src/Umbraco.Web.Common/Security/MemberSignInManager.cs
+++ b/src/Umbraco.Web.Common/Security/MemberSignInManager.cs
@@ -60,10 +60,8 @@ public class MemberSignInManager : UmbracoSignInManager<MemberIdentityUser>, IMe
             confirmation,
             StaticServiceProvider.Instance.GetRequiredService<IMemberExternalLoginProviders>(),
             StaticServiceProvider.Instance.GetRequiredService<IEventAggregator>(),
-            StaticServiceProvider.Instance.GetRequiredService<IOptions<SecuritySettings>>()
-            )
+            StaticServiceProvider.Instance.GetRequiredService<IOptions<SecuritySettings>>())
     {
-
     }
 
     [Obsolete("Use non-obsolete constructor. This is scheduled for removal in V14.")]

--- a/src/Umbraco.Web.Common/Security/MemberSignInManager.cs
+++ b/src/Umbraco.Web.Common/Security/MemberSignInManager.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Notifications;
@@ -30,14 +31,42 @@ public class MemberSignInManager : UmbracoSignInManager<MemberIdentityUser>, IMe
         IAuthenticationSchemeProvider schemes,
         IUserConfirmation<MemberIdentityUser> confirmation,
         IMemberExternalLoginProviders memberExternalLoginProviders,
-        IEventAggregator eventAggregator)
-        : base(memberManager, contextAccessor, claimsFactory, optionsAccessor, logger, schemes, confirmation)
+        IEventAggregator eventAggregator,
+        IOptions<SecuritySettings> securitySettings)
+        : base(memberManager, contextAccessor, claimsFactory, optionsAccessor, logger, schemes, confirmation, securitySettings)
     {
         _memberExternalLoginProviders = memberExternalLoginProviders;
         _eventAggregator = eventAggregator;
     }
 
-    [Obsolete("Use ctor with all params")]
+    [Obsolete("Use non-obsolete constructor. This is scheduled for removal in V14.")]
+    public MemberSignInManager(
+        UserManager<MemberIdentityUser> memberManager,
+        IHttpContextAccessor contextAccessor,
+        IUserClaimsPrincipalFactory<MemberIdentityUser> claimsFactory,
+        IOptions<IdentityOptions> optionsAccessor,
+        ILogger<SignInManager<MemberIdentityUser>> logger,
+        IAuthenticationSchemeProvider schemes,
+        IUserConfirmation<MemberIdentityUser> confirmation,
+        IMemberExternalLoginProviders memberExternalLoginProviders,
+        IEventAggregator eventAggregator)
+        : this(
+            memberManager,
+            contextAccessor,
+            claimsFactory,
+            optionsAccessor,
+            logger,
+            schemes,
+            confirmation,
+            StaticServiceProvider.Instance.GetRequiredService<IMemberExternalLoginProviders>(),
+            StaticServiceProvider.Instance.GetRequiredService<IEventAggregator>(),
+            StaticServiceProvider.Instance.GetRequiredService<IOptions<SecuritySettings>>()
+            )
+    {
+
+    }
+
+    [Obsolete("Use non-obsolete constructor. This is scheduled for removal in V14.")]
     public MemberSignInManager(
         UserManager<MemberIdentityUser> memberManager,
         IHttpContextAccessor contextAccessor,

--- a/src/Umbraco.Web.Common/Security/UmbracoSignInManager.cs
+++ b/src/Umbraco.Web.Common/Security/UmbracoSignInManager.cs
@@ -36,7 +36,15 @@ public abstract class UmbracoSignInManager<TUser> : SignInManager<TUser>
         ILogger<SignInManager<TUser>> logger,
         IAuthenticationSchemeProvider schemes,
         IUserConfirmation<TUser> confirmation)
-        : this(userManager, contextAccessor, claimsFactory, optionsAccessor, logger, schemes, confirmation, StaticServiceProvider.Instance.GetRequiredService<IOptions<SecuritySettings>>())
+        : this(
+            userManager,
+            contextAccessor,
+            claimsFactory,
+            optionsAccessor,
+            logger,
+            schemes,
+            confirmation,
+            StaticServiceProvider.Instance.GetRequiredService<IOptions<SecuritySettings>>())
     {
     }
 
@@ -357,7 +365,6 @@ public abstract class UmbracoSignInManager<TUser> : SignInManager<TUser>
                 // we have successfully logged in, reset the AccessFailedCount
                 user.AccessFailedCount = 0;
             }
-
 
             await UserManager.UpdateAsync(user);
 

--- a/src/Umbraco.Web.Common/Security/UmbracoSignInManager.cs
+++ b/src/Umbraco.Web.Common/Security/UmbracoSignInManager.cs
@@ -10,7 +10,7 @@ using Umbraco.Extensions;
 namespace Umbraco.Cms.Web.Common.Security;
 
 /// <summary>
-///     Abstract sign in manager implementation allowing modifying all defeault authentication schemes
+///     Abstract sign in manager implementation allowing modifying all default authentication schemes.
 /// </summary>
 /// <typeparam name="TUser"></typeparam>
 public abstract class UmbracoSignInManager<TUser> : SignInManager<TUser>

--- a/templates/UmbracoProject/appsettings.json
+++ b/templates/UmbracoProject/appsettings.json
@@ -36,6 +36,9 @@
       },
       "Unattended": {
         "UpgradeUnattended": true
+      },
+      "Security": {
+        "AllowConcurrentLogins": false
       }
     }
   }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/MemberSignInManagerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/MemberSignInManagerTests.cs
@@ -71,8 +71,7 @@ public class MemberSignInManagerTests
             Mock.Of<IUserConfirmation<MemberIdentityUser>>(),
             Mock.Of<IMemberExternalLoginProviders>(),
             Mock.Of<IEventAggregator>(),
-            Mock.Of<IOptions<SecuritySettings>>(x=>x.Value == new SecuritySettings())
-            );
+            Mock.Of<IOptions<SecuritySettings>>(x => x.Value == new SecuritySettings()));
     }
 
     private static Mock<MemberManager> MockMemberManager()

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/MemberSignInManagerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/MemberSignInManagerTests.cs
@@ -70,7 +70,9 @@ public class MemberSignInManagerTests
             Mock.Of<IAuthenticationSchemeProvider>(),
             Mock.Of<IUserConfirmation<MemberIdentityUser>>(),
             Mock.Of<IMemberExternalLoginProviders>(),
-            Mock.Of<IEventAggregator>());
+            Mock.Of<IEventAggregator>(),
+            Mock.Of<IOptions<SecuritySettings>>(x=>x.Value == new SecuritySettings())
+            );
     }
 
     private static Mock<MemberManager> MockMemberManager()


### PR DESCRIPTION
### Description
This adds new configuration that limits concurrent logins.
- `Umbraco:CMS:Security:AllowConcurrentLogins`

The value will be true for existing projects but false on new projects. We expect to change this so it defaults to false for v13, because this is breaking

### Tests
- `AllowConcurrentLogins == true`
  - Ensure you still concurrently can sign in from two different browsers
  
- `AllowConcurrentLogins == false`
  - Ensure you are signed out from the old browser, when signing in on a new (at most 30 sec wait)