### PR TITLE
Added logging around adding a property value during examine indexing

### DIFF
--- a/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexInitializer.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexInitializer.cs
@@ -83,7 +83,8 @@ public class IndexInitializer
             _shortStringHelper,
             _scopeProvider,
             publishedValuesOnly,
-            _localizationService);
+            _localizationService,
+             _loggerFactory.CreateLogger<ContentValueSetBuilder>());
 
         return contentValueSetBuilder;
     }


### PR DESCRIPTION
### Prerequisites

Whilst working on a migration I ran into this error, on rebuilding the index, however the log wasn't really helpful in me finding the problem node.

``` 
Newtonsoft.Json.JsonSerializationException: Cannot deserialize the current JSON array (e.g. [1,2,3]) into type 'Umbraco.Cms.Core.Models.Blocks.BlockValue' because the type requires a JSON object (e.g. {"name":"value"}) to deserialize correctly.
To fix this error either change the JSON to a JSON object (e.g. {"name":"value"}) or change the deserialized type to an array or a type that implements a collection interface (e.g. ICollection, IList) like List<T> that can be deserialized from a JSON array. JsonArrayAttribute can also be added to the type to force it to deserialize from a JSON array.
Path '', line 1, position 1.
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.EnsureArrayContract(JsonReader reader, Type objectType, JsonContract contract)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateList(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, Object existingValue, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonConvert.DeserializeObject(String value, Type type, JsonSerializerSettings settings)
   at Newtonsoft.Json.JsonConvert.DeserializeObject[T](String value, JsonSerializerSettings settings)
   at Umbraco.Cms.Core.PropertyEditors.JsonPropertyIndexValueFactoryBase`1.GetIndexValues(IProperty property, String culture, String segment, Boolean published, IEnumerable`1 availableCultures)
   at Umbraco.Cms.Infrastructure.Examine.BaseValueSetBuilder`1.AddPropertyValue(IProperty property, String culture, String segment, IDictionary`2 values, IEnumerable`1 availableCultures)
   at Umbraco.Cms.Infrastructure.Examine.ContentValueSetBuilder.GetValueSetsEnumerable(IContent[] content, Dictionary`2 creatorIds, Dictionary`2 writerIds)+MoveNext()
   at System.Collections.Generic.LargeArrayBuilder`1.AddRange(IEnumerable`1 items)
   at System.Collections.Generic.EnumerableHelpers.ToArray[T](IEnumerable`1 source)
   at Umbraco.Cms.Infrastructure.Examine.ContentIndexPopulator.IndexPublishedContent(Int32 contentParentId, Int32 pageIndex, Int32 pageSize, IReadOnlyList`1 indexes)
```


### Description
Adds context for this error to help with debugging the issues. Avoided a generic exception but wonder if this should be a wider catch?
