### PR TITLE
help links tests + clean up of system info

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/HelpPanel/helpLinks.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/HelpPanel/helpLinks.spec.ts
@@ -1,0 +1,41 @@
+import { test } from '@umbraco/playwright-testhelpers';
+import { expect } from '@playwright/test';
+
+test.describe("Help panel links", () => {
+    const enCulture = "en-US";
+  
+    test.beforeEach(async ({ umbracoApi }, testInfo) => {
+      await umbracoApi.report.report(testInfo);
+      await umbracoApi.login();
+      await umbracoApi.users.setCurrentLanguage(enCulture);
+    });
+  
+    test.afterEach(async ({ umbracoApi }) => {
+      await umbracoApi.users.setCurrentLanguage(enCulture);
+    });
+
+test("Check the youtube link works as expected", async ({ page, umbracoUi }) => {
+    // Action
+    await umbracoUi.clickElement(umbracoUi.getGlobalHelp());
+    let watchVideoLink = await page.locator('[key="help_umbracoLearningBase"]');
+    await watchVideoLink.click();
+
+    // Wait for a popup event
+    const youtubeConsent = page.waitForEvent("popup");
+    const youtubePopup = await youtubeConsent;
+
+    if (youtubePopup) {
+      // If the YouTube consent popup is displayed, interact with it
+      const rejectAllButton = await youtubePopup.locator('[aria-label="Reject all"]').first();
+      await rejectAllButton.waitFor({ state: "visible" });
+      await rejectAllButton.click();
+
+      // Assert the URL of the popup
+      await expect(youtubePopup).toHaveURL(/.*UmbracoLearningBase/);
+      await youtubePopup.close();
+
+    } else {
+      await expect(page).toHaveURL(/.*UmbracoLearningBase/);
+    }
+  });
+});

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/HelpPanel/systemInformation.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/HelpPanel/systemInformation.spec.ts
@@ -1,36 +1,38 @@
-import {ConstantHelper, test, UiHelpers} from '@umbraco/playwright-testhelpers';
-import {expect, Page} from "@playwright/test";
+import { ConstantHelper, test, UiHelpers } from '@umbraco/playwright-testhelpers';
+import { expect, Page } from '@playwright/test';
 
-test.describe('System Information', () => {
+test.describe("System Information", () => {
   const enCulture = "en-US";
   const dkCulture = "da-DK";
 
-  test.beforeEach(async ({ page, umbracoApi }, testInfo) => {
+  test.beforeEach(async ({ umbracoApi }, testInfo) => {
     await umbracoApi.report.report(testInfo);
     await umbracoApi.login();
     await umbracoApi.users.setCurrentLanguage(enCulture);
   });
 
-  test.afterEach(async ({page, umbracoApi}) => {
+  test.afterEach(async ({ umbracoApi }) => {
     await umbracoApi.users.setCurrentLanguage(enCulture);
   });
 
   async function openSystemInformation(page: Page, umbracoUi: UiHelpers) {
     //We have to wait for page to load, if the site is slow
     await umbracoUi.clickElement(umbracoUi.getGlobalHelp());
-    await expect(page.locator('.umb-help-list-item').last()).toBeVisible();
-    await umbracoUi.clickElement(page.locator('.umb-help-list-item').last());
-    await page.locator('.umb-drawer-content').scrollIntoViewIfNeeded();
+    await expect(page.locator(".umb-help-list-item").last()).toBeVisible();
+    await umbracoUi.clickElement(
+      Promise.resolve(page.locator(".umb-help-list-item").last())
+    );
+    await page.locator(".umb-drawer-content").scrollIntoViewIfNeeded();
   }
 
-  test('Check System Info Displays', async ({page, umbracoApi, umbracoUi}) => {
+  test('Check System Info Displays', async ({page, umbracoUi}) => {
     await openSystemInformation(page, umbracoUi);
     await expect(page.locator('.table').locator('tr')).toHaveCount(15);
     await expect(await page.locator("tr", {hasText: "Current Culture"})).toContainText(enCulture);
     await expect(await page.locator("tr", {hasText: "Current UI Culture"})).toContainText(enCulture);
   });
 
-  test('Checks language displays correctly after switching', async ({page, umbracoApi, umbracoUi}) => {
+  test("Checks language displays correctly after switching", async ({ page, umbracoUi }) => {
     //Navigate to edit user and change language
     await umbracoUi.clickElement(umbracoUi.getGlobalUser());
     await page.locator('[alias="editUser"]').click();
@@ -39,7 +41,6 @@ test.describe('System Information', () => {
     await umbracoUi.isSuccessNotificationVisible();
 
     await openSystemInformation(page, umbracoUi);
-    
     //Assert
     await expect(await page.locator("tr", {hasText: "Current Culture"})).toContainText(dkCulture);
     await expect(await page.locator("tr", {hasText: "Current UI Culture"})).toContainText(dkCulture);


### PR DESCRIPTION
### Prerequisites

[/ ] I have added steps to test this contribution in the description below

**Description**
This PR contains a new Playwright test to check that the youtube link in the help panel opens to the correct youtube URL. 

I also had to include a check to reject (felt like this would be preferred) the cookies in youtube, if the consent popup displays.

The reason for the System Information clean up is because I originally had my test in here until I felt it would be better suited in its own file. Whilst in there there was an error which I fixed (line 22) and a bit on unused code which I removed. 

**To test:**

1. Make sure to `run npm ci `&` npx playwright install`
2. I would suggest adding test.only to the start of the test so you don't have to watch 20+ tests run.
3. run `npm run ui`
4. check to see if the test passes


<!-- Thanks for contributing to Umbraco CMS! -->
