### PR TITLE
[v14] Create Umbraco/Bellissima Package RCL Template

### DIFF
--- a/templates/UmbracoPackageRcl/UmbracoPackage.csproj
+++ b/templates/UmbracoPackageRcl/UmbracoPackage.csproj
@@ -24,4 +24,21 @@
     <PackageReference Include="Umbraco.Cms.Web.Website" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
     <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Content Update="package.json" Pack="False" />
+    <Content Update="package-lock.json" Pack="False" />
+    <Content Update="tsconfig.json" Pack="False" />
+  </ItemGroup>
+
+  <Target Name="NpmInstall" AfterTargets="Restore;Build" Inputs="package-lock.json" Outputs="node_modules\.package-lock.json">
+    <Message Text="Installing NPM packages" Importance="High" />
+    <Exec Command="npm ci --no-fund --no-audit --prefer-offline" />
+  </Target>
+
+  <Target Name="NpmBuild" AfterTargets="Build;NpmInstall">
+    <Message Text="Executing NPM build script" Importance="High" />
+    <Exec Command="npm run build" />
+  </Target>
+
 </Project>

--- a/templates/UmbracoPackageRcl/package-lock.json
+++ b/templates/UmbracoPackageRcl/package-lock.json
@@ -1,0 +1,1705 @@
+{
+  "name": "umbraco-create-package-template",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "umbraco-create-package-template",
+      "version": "0.0.0",
+      "dependencies": {
+        "lit": "^2.8.0"
+      },
+      "devDependencies": {
+        "@umbraco-cms/backoffice": "^14.0.0--preview003",
+        "typescript": "^5.2.2",
+        "vite": "^4.4.9"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.1.tgz",
+      "integrity": "sha512-kXOeFbfCm4fFf2A3WwVEeQj55tMZa8c8/f9AKHMobQMkzNUfUj+antR3fRPaZJawsa1aZiP/Da3ndpZrwEe4rQ=="
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
+    "node_modules/@openid/appauth": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@openid/appauth/-/appauth-1.3.1.tgz",
+      "integrity": "sha512-e54kpi219wES2ijPzeHe1kMnT8VKH8YeTd1GAn9BzVBmutz3tBgcG1y8a4pziNr4vNjFnuD4W446Ua7ELnNDiA==",
+      "dev": true,
+      "dependencies": {
+        "@types/base64-js": "^1.3.0",
+        "@types/jquery": "^3.5.5",
+        "base64-js": "^1.5.1",
+        "follow-redirects": "^1.13.3",
+        "form-data": "^4.0.0",
+        "opener": "^1.5.2"
+      }
+    },
+    "node_modules/@types/base64-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@types/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ZmI0sZGAUNXUfMWboWwi4LcfpoVUYldyN6Oe0oJ5cCsHDU/LlRq8nQKPXhYLOx36QYSW9bNIb1vvRrD6K7Llgw==",
+      "dev": true
+    },
+    "node_modules/@types/jquery": {
+      "version": "3.5.19",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.19.tgz",
+      "integrity": "sha512-KFbmk+dXfphHGuVCmlopgcNRCegN/21mkeoD4BzuJhVH0SJW3Uo2mLuAwb6oqTNV79EsRp6J7yC1BbKymjpx/g==",
+      "dev": true,
+      "dependencies": {
+        "@types/sizzle": "*"
+      }
+    },
+    "node_modules/@types/sizzle": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
+      "dev": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.4.tgz",
+      "integrity": "sha512-IDaobHimLQhjwsQ/NMwRVfa/yL7L/wriQPMhw1ZJall0KX6E1oxk29XMDeilW5qTIg5aoiqf5Udy8U/51aNoQQ=="
+    },
+    "node_modules/@umbraco-cms/backoffice": {
+      "version": "14.0.0--preview003",
+      "resolved": "https://www.myget.org/F/umbracoprereleases/npm/@umbraco-cms/backoffice/-/@umbraco-cms/backoffice-14.0.0--preview003.tgz",
+      "integrity": "sha1-9dKp9yP9w1NkwhoAa32uXh2tEd8=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@openid/appauth": "^1.3.1",
+        "@umbraco-ui/uui": "1.4.0-rc.2",
+        "@umbraco-ui/uui-css": "1.4.0-rc.2",
+        "element-internals-polyfill": "^1.3.7",
+        "lit": "^2.8.0",
+        "lodash-es": "4.17.21",
+        "monaco-editor": "^0.41.0",
+        "rxjs": "^7.8.1",
+        "tinymce": "^6.6.1",
+        "tinymce-i18n": "^23.8.7",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18.14 <19",
+        "npm": ">=9.5 < 10"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui/-/uui-1.4.0-rc.2.tgz",
+      "integrity": "sha512-MmIB4GKhH+KUYOVm1p1RH8pumr6Jn9S46BWeDIRpK0JldszXR6EggLNl7ZxtVf43tEIBN7i+36079+7lHpA04Q==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-action-bar": "1.4.0-rc.2",
+        "@umbraco-ui/uui-avatar": "1.4.0-rc.2",
+        "@umbraco-ui/uui-avatar-group": "1.4.0-rc.2",
+        "@umbraco-ui/uui-badge": "1.4.0-rc.2",
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-boolean-input": "1.4.0-rc.2",
+        "@umbraco-ui/uui-box": "1.4.0-rc.2",
+        "@umbraco-ui/uui-breadcrumbs": "1.4.0-rc.2",
+        "@umbraco-ui/uui-button": "1.4.0-rc.2",
+        "@umbraco-ui/uui-button-group": "1.4.0-rc.2",
+        "@umbraco-ui/uui-button-inline-create": "1.4.0-rc.2",
+        "@umbraco-ui/uui-card": "1.4.0-rc.2",
+        "@umbraco-ui/uui-card-content-node": "1.4.0-rc.2",
+        "@umbraco-ui/uui-card-media": "1.4.0-rc.2",
+        "@umbraco-ui/uui-card-user": "1.4.0-rc.2",
+        "@umbraco-ui/uui-caret": "1.4.0-rc.2",
+        "@umbraco-ui/uui-checkbox": "1.4.0-rc.2",
+        "@umbraco-ui/uui-color-area": "1.4.0-rc.2",
+        "@umbraco-ui/uui-color-picker": "1.4.0-rc.2",
+        "@umbraco-ui/uui-color-slider": "1.4.0-rc.2",
+        "@umbraco-ui/uui-color-swatch": "1.4.0-rc.2",
+        "@umbraco-ui/uui-color-swatches": "1.4.0-rc.2",
+        "@umbraco-ui/uui-combobox": "1.4.0-rc.2",
+        "@umbraco-ui/uui-combobox-list": "1.4.0-rc.2",
+        "@umbraco-ui/uui-css": "1.4.0-rc.2",
+        "@umbraco-ui/uui-dialog": "1.4.0-rc.2",
+        "@umbraco-ui/uui-dialog-layout": "1.4.0-rc.2",
+        "@umbraco-ui/uui-file-dropzone": "1.4.0-rc.2",
+        "@umbraco-ui/uui-file-preview": "1.4.0-rc.2",
+        "@umbraco-ui/uui-form": "1.4.0-rc.2",
+        "@umbraco-ui/uui-form-layout-item": "1.4.0-rc.2",
+        "@umbraco-ui/uui-form-validation-message": "1.4.0-rc.2",
+        "@umbraco-ui/uui-icon": "1.4.0-rc.2",
+        "@umbraco-ui/uui-icon-registry": "1.4.0-rc.2",
+        "@umbraco-ui/uui-icon-registry-essential": "1.4.0-rc.2",
+        "@umbraco-ui/uui-input": "1.4.0-rc.2",
+        "@umbraco-ui/uui-input-file": "1.4.0-rc.2",
+        "@umbraco-ui/uui-input-lock": "1.4.0-rc.2",
+        "@umbraco-ui/uui-input-password": "1.4.0-rc.2",
+        "@umbraco-ui/uui-keyboard-shortcut": "1.4.0-rc.2",
+        "@umbraco-ui/uui-label": "1.4.0-rc.2",
+        "@umbraco-ui/uui-loader": "1.4.0-rc.2",
+        "@umbraco-ui/uui-loader-bar": "1.4.0-rc.2",
+        "@umbraco-ui/uui-loader-circle": "1.4.0-rc.2",
+        "@umbraco-ui/uui-menu-item": "1.4.0-rc.2",
+        "@umbraco-ui/uui-modal": "1.4.0-rc.2",
+        "@umbraco-ui/uui-pagination": "1.4.0-rc.2",
+        "@umbraco-ui/uui-popover": "1.4.0-rc.2",
+        "@umbraco-ui/uui-progress-bar": "1.4.0-rc.2",
+        "@umbraco-ui/uui-radio": "1.4.0-rc.2",
+        "@umbraco-ui/uui-range-slider": "1.4.0-rc.2",
+        "@umbraco-ui/uui-ref": "1.4.0-rc.2",
+        "@umbraco-ui/uui-ref-list": "1.4.0-rc.2",
+        "@umbraco-ui/uui-ref-node": "1.4.0-rc.2",
+        "@umbraco-ui/uui-ref-node-data-type": "1.4.0-rc.2",
+        "@umbraco-ui/uui-ref-node-document-type": "1.4.0-rc.2",
+        "@umbraco-ui/uui-ref-node-form": "1.4.0-rc.2",
+        "@umbraco-ui/uui-ref-node-member": "1.4.0-rc.2",
+        "@umbraco-ui/uui-ref-node-package": "1.4.0-rc.2",
+        "@umbraco-ui/uui-ref-node-user": "1.4.0-rc.2",
+        "@umbraco-ui/uui-scroll-container": "1.4.0-rc.2",
+        "@umbraco-ui/uui-select": "1.4.0-rc.2",
+        "@umbraco-ui/uui-slider": "1.4.0-rc.2",
+        "@umbraco-ui/uui-symbol-expand": "1.4.0-rc.2",
+        "@umbraco-ui/uui-symbol-file": "1.4.0-rc.2",
+        "@umbraco-ui/uui-symbol-file-dropzone": "1.4.0-rc.2",
+        "@umbraco-ui/uui-symbol-file-thumbnail": "1.4.0-rc.2",
+        "@umbraco-ui/uui-symbol-folder": "1.4.0-rc.2",
+        "@umbraco-ui/uui-symbol-lock": "1.4.0-rc.2",
+        "@umbraco-ui/uui-symbol-more": "1.4.0-rc.2",
+        "@umbraco-ui/uui-symbol-sort": "1.4.0-rc.2",
+        "@umbraco-ui/uui-table": "1.4.0-rc.2",
+        "@umbraco-ui/uui-tabs": "1.4.0-rc.2",
+        "@umbraco-ui/uui-tag": "1.4.0-rc.2",
+        "@umbraco-ui/uui-textarea": "1.4.0-rc.2",
+        "@umbraco-ui/uui-toast-notification": "1.4.0-rc.2",
+        "@umbraco-ui/uui-toast-notification-container": "1.4.0-rc.2",
+        "@umbraco-ui/uui-toast-notification-layout": "1.4.0-rc.2",
+        "@umbraco-ui/uui-toggle": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-action-bar": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-action-bar/-/uui-action-bar-1.4.0-rc.2.tgz",
+      "integrity": "sha512-bxbRzcvE+q8pqtKykV+CrtQCqcYd/YBGWMekMhnbmOjK/oILzCjvcqXUA0uY1QEFXpGfCfidEOxU2cXvEUZ/zg==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-button-group": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-avatar": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar/-/uui-avatar-1.4.0-rc.2.tgz",
+      "integrity": "sha512-J+pXoik+BXOItTBiMMTEYDSKCVZ362zALXvasgnA5uJh2yOxKYOuP0BA6u9kfQYTBE6gPrwQrGEMYb21L1X9aw==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-avatar-group": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar-group/-/uui-avatar-group-1.4.0-rc.2.tgz",
+      "integrity": "sha512-ieHln2EgmSzldn9W/HT9J3cA2zefuFpTinqtccsqgVQFCyrUSaWKGlj4T7gbTK81Vsla1FRPcwdM18pVmMPr2Q==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-avatar": "1.4.0-rc.2",
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-badge": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-badge/-/uui-badge-1.4.0-rc.2.tgz",
+      "integrity": "sha512-/Fvkz+NuaFnvulY++OV1cEqDtriyQy3+smL0K5tNWzUz2sjZZ+LKVdNRJV1HCDk5oc1wcGOKemnAcpBmqFED7A==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-base": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-base/-/uui-base-1.4.0-rc.2.tgz",
+      "integrity": "sha512-L5dc2J/PrA4oXyhgUly9tFo+UxAMHSdLTksGujOiiOloOrtklPzJXIu18V3fziivd/WHv+C2ix7415FJok6cOA==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.3.1"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-boolean-input": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-boolean-input/-/uui-boolean-input-1.4.0-rc.2.tgz",
+      "integrity": "sha512-+uOjBvvZ5GM0oj8JUIht1F3HjQOKmDi/0Kll2Ph1b3Q5326e4Jlt+JEh/MsZZ/CZNnY8nuFw+SRryxcvI5uVfA==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-box": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-box/-/uui-box-1.4.0-rc.2.tgz",
+      "integrity": "sha512-mmhsXTsBojqeD2cVuYu6+aUtt1ouRBza1hSKZ5b4Zjd/3xgT/xHSj/v/Q+xYLnr7nAG7MGVSCoBK3jSbsa+cMg==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-css": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-breadcrumbs": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-breadcrumbs/-/uui-breadcrumbs-1.4.0-rc.2.tgz",
+      "integrity": "sha512-vT3ANz1c7yTRrmLvqLReil5h8aLKV8C9GWjw5Phxxu061KRelaWy82+zk9FRwM+2NgdnPbSqCmMoQrsVD3fzcA==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-button": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button/-/uui-button-1.4.0-rc.2.tgz",
+      "integrity": "sha512-G3pOW37jH6bmDBfc0DiQ3BEFgJ8N6qn3wqSwg9mL5FD0oecayk/pZuzFYYoSwls898j/WPq2nAwIkUxVq5evmg==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-icon-registry-essential": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-button-group": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-group/-/uui-button-group-1.4.0-rc.2.tgz",
+      "integrity": "sha512-wk9JsVpkSRP9jqSWpVp/97Omhvl3fo+F/zlcp39rCN+li8gad2ezhKkXEsF4zKPmjS8T/CuA9Kd9evEQSd3uPA==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-button-inline-create": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-inline-create/-/uui-button-inline-create-1.4.0-rc.2.tgz",
+      "integrity": "sha512-tU3fVMWO8ZjDxnQvRJI0wHiISC30cfW61YjRCSf+n7z2oMQ4/4fVbVMbKHznlFe7phjAAitqCbjzSIIiweNfPA==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-card": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card/-/uui-card-1.4.0-rc.2.tgz",
+      "integrity": "sha512-+rC6kfUug3TQkkm+92KsDWPs1COPzEd0jAPccjThvEZuAf1WlENNOkiS6AzlsjhnOBRGf0WJe/lItDZK5mSe1Q==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-card-content-node": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-content-node/-/uui-card-content-node-1.4.0-rc.2.tgz",
+      "integrity": "sha512-/Ht8m1iUo/9QInPOqB3nN6hsdL8xrP8j8Duvh+egruUVzcu5wjUrUvzmgA6X/ZxZNmzKd8mAgSQoE2jqcGO0Wg==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-card": "1.4.0-rc.2",
+        "@umbraco-ui/uui-icon": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-card-media": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-media/-/uui-card-media-1.4.0-rc.2.tgz",
+      "integrity": "sha512-CzzLKLMQ4j1C3PY4K3lo3qLqsegSOLX7oYsVUQMLk75ct2xIgNn/e+cuHBDfXR31+mkwzaOzhAAeDnrkDYe6YA==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-card": "1.4.0-rc.2",
+        "@umbraco-ui/uui-symbol-file": "1.4.0-rc.2",
+        "@umbraco-ui/uui-symbol-folder": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-card-user": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-user/-/uui-card-user-1.4.0-rc.2.tgz",
+      "integrity": "sha512-/pY8QAw8P601Zdg0HGH4/V3R/TKEaj8k53sOvKfXyfouJ74VHIA95EU1cMIgKzZzOv/+Zq/gHt0Goql29gEaCg==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-avatar": "1.4.0-rc.2",
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-card": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-caret": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-caret/-/uui-caret-1.4.0-rc.2.tgz",
+      "integrity": "sha512-hb9Nk/Gqih9S19fjUIYTZJ8+q0xXFJfMY7RlS8l8TmPVJAr77U6/lZYLDDG/wLgYkYszqeEeS5Z6GyQXYK+hEQ==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-checkbox": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-checkbox/-/uui-checkbox-1.4.0-rc.2.tgz",
+      "integrity": "sha512-fvwFeflja04PhViXRMo+f3swdnAb3HjfVtLFeFus+F928hkJnWgvSF8jJX19OfItu/5vSBVgvCOVgiGZ8KTn4w==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-boolean-input": "1.4.0-rc.2",
+        "@umbraco-ui/uui-icon-registry-essential": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-color-area": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-area/-/uui-color-area-1.4.0-rc.2.tgz",
+      "integrity": "sha512-f2icfmIguNOJ7BqottgwRhuiSrPcyb7/WXt1MT9WYeXWjn5aXMFGf6rzU3QSqnF+S8CqdB+BdtZErWEg6oCBtA==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "colord": "^2.9.3"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-color-picker": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-picker/-/uui-color-picker-1.4.0-rc.2.tgz",
+      "integrity": "sha512-SEeOXY+q1pRzFJMgv/RC/zQdZyP9ULLn5AvIUkJ31loMaAiNPP72RKg9PVhiuIhyHMMUKigJm9B+IBUuJ6Wf4w==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "colord": "^2.9.3"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-color-slider": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-slider/-/uui-color-slider-1.4.0-rc.2.tgz",
+      "integrity": "sha512-z43+sDRsRTbB9XDLozXcjm4mKSrks3GanO+wf7KU4/IyRR1934LQGDDwkNf90CHf7wl1uIIp4+0ICr1JpIdwng==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-color-swatch": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatch/-/uui-color-swatch-1.4.0-rc.2.tgz",
+      "integrity": "sha512-xmjmcI2+sC8q/tT+hyvL2gKHB6ceWw5Tjo1HbwkBtqSUJvpSc26VkX/GuP1zyyHcNUGuvBJnUYoGJ10pQAUdsw==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-icon-registry-essential": "1.4.0-rc.2",
+        "colord": "^2.9.3"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-color-swatches": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatches/-/uui-color-swatches-1.4.0-rc.2.tgz",
+      "integrity": "sha512-lI94yrS6RHtVdkFKEkJXlPwrUtmOcCMp4xsUlNDHvY8LFVqKtXeKHx8xH7hT/Mu6RlAmXvrjq2SZS0YJD8t/1A==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-color-swatch": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-combobox": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox/-/uui-combobox-1.4.0-rc.2.tgz",
+      "integrity": "sha512-BmhZ9ppYU3gmoo1YreLE2JYRsgNe8gSHb0EJTeviCAXWCT3o1Ta9Jnx0pQiV3rmGKjR45QyIR3FUttXlDOCOEw==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-button": "1.4.0-rc.2",
+        "@umbraco-ui/uui-combobox-list": "1.4.0-rc.2",
+        "@umbraco-ui/uui-icon": "1.4.0-rc.2",
+        "@umbraco-ui/uui-scroll-container": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-combobox-list": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox-list/-/uui-combobox-list-1.4.0-rc.2.tgz",
+      "integrity": "sha512-yFU2/UuWDr/Xshaf68cIpC+smvf/hNa2Gm4FLu/3qpDGYNe8KEy2wKpGD0rvBtuveS3Tn0ZxY+AvrOucomRCxw==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-css": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-css/-/uui-css-1.4.0-rc.2.tgz",
+      "integrity": "sha512-6vXzFjDl4Etxvc+YHUV3hcjh+K+cNOOkdVhNBupHZLwLbEq9xznlJqmjgj2pdn5gXrHM5hY5mzBuX03iK0dpaw==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.2.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-dialog": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog/-/uui-dialog-1.4.0-rc.2.tgz",
+      "integrity": "sha512-MbgeFbbCoBGQbN8mbXsR2tP4Pi2mA+4rRTd0cnu2EfmfzcEcJ10l72aKpLPwB5+wIbKNVocQhyZMZT1tdAkcng==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-css": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-dialog-layout": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog-layout/-/uui-dialog-layout-1.4.0-rc.2.tgz",
+      "integrity": "sha512-veuSmSRI0tq5GHF6T3ifyhx3zM1zANMNV+EpKcgi2OhiV4I806y6pgNr3HQQxhyi54f51nY/IKEw2Y0ZZ5y4oQ==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-file-dropzone": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-dropzone/-/uui-file-dropzone-1.4.0-rc.2.tgz",
+      "integrity": "sha512-cOGqcxxSSlEyeFDPVfRQA7ItefrPu/Iw0A2NqvtvMF/igklm1htrMWAJY0ur7UXGhr+EQCvUICna2Ox0lpXg6Q==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-symbol-file-dropzone": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-file-preview": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-preview/-/uui-file-preview-1.4.0-rc.2.tgz",
+      "integrity": "sha512-0qBcfl8oL7vraE8XeLMM+DkfT2/Ej7dV4BPkEqWjZenEusRvd5KFWitNNR41NN7lLGdL7ATk7mjzX70oFgyzPQ==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-symbol-file": "1.4.0-rc.2",
+        "@umbraco-ui/uui-symbol-file-thumbnail": "1.4.0-rc.2",
+        "@umbraco-ui/uui-symbol-folder": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-form": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form/-/uui-form-1.4.0-rc.2.tgz",
+      "integrity": "sha512-GBFGOjdJ7+LmrKN0//DoxkXqTWhLfV7HMg8FALyceX51/WwnNYxiHon1VyetIHiRlxa/n1NqUBKz4KC94D73ug==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-form-layout-item": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-layout-item/-/uui-form-layout-item-1.4.0-rc.2.tgz",
+      "integrity": "sha512-IAYsu5pmtGRi+/WQ3Dos7oAYkOKfp/IMeItupCpzUgXJOETjXOnSqe0yaW3FVqRiZtjHzPOnyZE4IX9vCiNXpg==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-form-validation-message": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-form-validation-message": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-validation-message/-/uui-form-validation-message-1.4.0-rc.2.tgz",
+      "integrity": "sha512-LfhYTgAN+7s8ce8NtmI1Os+V9YLUKTJgdtHmchzEazmwycClXpasoSbvTNaMlbIlLXpv1lRk/MDTtlS9UvZC/g==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-icon": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon/-/uui-icon-1.4.0-rc.2.tgz",
+      "integrity": "sha512-hKZ5RSPT/Iw1CwV75v09aHf6nZe5vc6wv0XaTdXvYFMf73GK+DANYG1q+vEuiDbu8dmnz4v95YY3h2J6rDFmXw==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-icon-registry": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry/-/uui-icon-registry-1.4.0-rc.2.tgz",
+      "integrity": "sha512-Yd16qscWN3zlScm7anrn2EjcmWHrld+M++U32IULQaw7Fs81nekZ03lyLXeTbsU7vQIWYrg+UfTGnumCbe2Esw==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-icon": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-icon-registry-essential": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry-essential/-/uui-icon-registry-essential-1.4.0-rc.2.tgz",
+      "integrity": "sha512-XiwbdoVt9z4/bzU8RtlIcITDcQQeVFw7dXY2saBtSWuLTh7qTMHOeRRRw1CIX1zyFQkaMGMoZu3eaH/7pEna8A==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-icon-registry": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-input": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input/-/uui-input-1.4.0-rc.2.tgz",
+      "integrity": "sha512-hPkb4z4L6vbWTiBZHQuOJULyYMvSPib3ZxQYBb5goNpogaoidZIkqsHHcZPazSf+976UyYM6yZWQt5WziJiXVQ==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-input-file": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-file/-/uui-input-file-1.4.0-rc.2.tgz",
+      "integrity": "sha512-BDbpr5ncidoSmn6GM1NAlCPkMRqcucKQFMo5hmlEv55ktNvZ8miD0BaQWi4TXDgQeuEJOXRqKGCng4W9AH5wPA==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-action-bar": "1.4.0-rc.2",
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-button": "1.4.0-rc.2",
+        "@umbraco-ui/uui-file-dropzone": "1.4.0-rc.2",
+        "@umbraco-ui/uui-icon": "1.4.0-rc.2",
+        "@umbraco-ui/uui-icon-registry-essential": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-input-lock": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-lock/-/uui-input-lock-1.4.0-rc.2.tgz",
+      "integrity": "sha512-TMLPzS3SwOgQKqDpH/RX7sYvtsYgW8gG2tullhNn+J8d63gSGWhYk1fLoT87a3fs9ClOWL1xEnXxq7CqveLjlg==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-button": "1.4.0-rc.2",
+        "@umbraco-ui/uui-icon": "1.4.0-rc.2",
+        "@umbraco-ui/uui-input": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-input-password": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-password/-/uui-input-password-1.4.0-rc.2.tgz",
+      "integrity": "sha512-wSoejiCDsXKbUG5wj3PuU2NjUFp+Fab58yRwaZDkqDcJ8yhKP3/vYYPGaRBw28Hz6RNSt4uut/lKkczCDAPalg==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-icon-registry-essential": "1.4.0-rc.2",
+        "@umbraco-ui/uui-input": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-keyboard-shortcut": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-keyboard-shortcut/-/uui-keyboard-shortcut-1.4.0-rc.2.tgz",
+      "integrity": "sha512-obEctCv+zKBFHrZeKo8OSTI9BQnKIt15zuLmG3xnPqu33bzjP2ubPGJnnCdKeoglX7LALR8D6RpqEFZvp08hTQ==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-label": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-label/-/uui-label-1.4.0-rc.2.tgz",
+      "integrity": "sha512-1YZi66DRRkuo9p2dwKNut35UCi3v32UIsQ6Mrx5/D9rlnuy/4sk36NZ3twbtKWAoQl8DII0TsjwnkQJOppEBzA==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-loader": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader/-/uui-loader-1.4.0-rc.2.tgz",
+      "integrity": "sha512-4NX5PoRSwcEEvukWf9v1TlWU5kyvigLL7HNsaOKyq7AYe6JHWTej/xMwWOFPuRt8poFnIZZzDAvE/P1GEAg16w==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-loader-bar": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-bar/-/uui-loader-bar-1.4.0-rc.2.tgz",
+      "integrity": "sha512-ffSrpofNpj6jjI/wTmoG0guDIgub1NpOCTil1JO8cPnsBFL9HFLFK4xblnBbU/lZ6C33aoRfu4IDfH0ux2y0Ww==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-loader-circle": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-circle/-/uui-loader-circle-1.4.0-rc.2.tgz",
+      "integrity": "sha512-Kqb9k8JHS5qORqa4mZSzpaPh1He2rEEeEOD72DkLtBW01EhpRjMO3cRVxOmHY90AvWAMJkywRKXB7b7PFYV7nA==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-menu-item": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-menu-item/-/uui-menu-item-1.4.0-rc.2.tgz",
+      "integrity": "sha512-GtxDbYcH1WJgY36kODThaLOwvePH1CYZCmFaN6Mv85n8gVbmCogI6NVgjp3eYZX5aBBqnw+NC5l7/UpETJn9dA==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-loader-bar": "1.4.0-rc.2",
+        "@umbraco-ui/uui-symbol-expand": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-modal": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-modal/-/uui-modal-1.4.0-rc.2.tgz",
+      "integrity": "sha512-RNGEkHeqcM8dVqG5Fjzjo+ir4iREe8Wb0xTAkSyL1+paCOq9pNyYKptln4eFWsfop5L9Ia8DHKyV4AS3JBNE8w==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-pagination": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-pagination/-/uui-pagination-1.4.0-rc.2.tgz",
+      "integrity": "sha512-1u6PEnAM5MMYPdEGgoyHxXihL/Mx+TE667tsAcKE7hGaMuUfd2rbvJcCYmdJSn8v4VuvHiDOyL70nUME97+jEQ==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-button": "1.4.0-rc.2",
+        "@umbraco-ui/uui-button-group": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-popover": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover/-/uui-popover-1.4.0-rc.2.tgz",
+      "integrity": "sha512-QiZlK8Idk8ygSrO5SH9sl6dVjGwB7uP2VLPiOA5kCMGTiJU1JpvIFtw1flmNkQPxcV/r96xrUxePtXqhQLN4pw==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-progress-bar": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-progress-bar/-/uui-progress-bar-1.4.0-rc.2.tgz",
+      "integrity": "sha512-Uepscoo9nMaWJ7XCei0Q7O93R01Po6J5DuGhsWZP/BBEzhanGqtt6XXQzoppM9U8Bpmvs6Q/bmJ37my7E5whOg==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-radio": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-radio/-/uui-radio-1.4.0-rc.2.tgz",
+      "integrity": "sha512-EfUd4/OETuyrr6Y6wBQ2Muan05ZR+XfmYIg99FI6vocT4hlSGQp9Nu+J8EhQobjPcA2K630Q2aIQddydMKjKUA==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-range-slider": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-range-slider/-/uui-range-slider-1.4.0-rc.2.tgz",
+      "integrity": "sha512-eV2k7bUAMvJ+wUYSm8fFf28OicM590GL2+1Em9An5UMvnnN0bq+Y0H0nP038P3+/38Ea92Tm+iIY7/EeaZC/Ug==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-ref": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref/-/uui-ref-1.4.0-rc.2.tgz",
+      "integrity": "sha512-BzU8U/pXWAyaBtsndnhNgYLEuZC5mnoOv+CouxmcUpi9Onb5XTS6lOgO2Onoee0gzmjtH72fv2PeJPJPnXTV1g==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-ref-list": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-list/-/uui-ref-list-1.4.0-rc.2.tgz",
+      "integrity": "sha512-BlTelLG7V1tCRsrPo7lf6V3Dp2L++9hFCZu8a26hirvEsczcWkUxclFrZnZw7I0+DyVvWli9yd89yJH8XL3bfw==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-ref-node": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node/-/uui-ref-node-1.4.0-rc.2.tgz",
+      "integrity": "sha512-NjxTgQA5AmS1CpcJLyUKiebDz3J1iy+rAWWWzpfY1QaJdi2GtSYS57HzawFsb6GJEoxxMNWGomNz3KhD1Pm7dQ==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-icon": "1.4.0-rc.2",
+        "@umbraco-ui/uui-ref": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-ref-node-data-type": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-data-type/-/uui-ref-node-data-type-1.4.0-rc.2.tgz",
+      "integrity": "sha512-mSLVI3uA4lI9PQvK6TCOjm5ek/JClZk3RXJgitXYcJFwpGeQsXyq9F3whjs3E90kSAfaLhaNfo/6375QxTCUjw==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-ref-node": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-ref-node-document-type": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-document-type/-/uui-ref-node-document-type-1.4.0-rc.2.tgz",
+      "integrity": "sha512-sMsXYkLyHtSXMol4pWsnYkqbGg0rY4Yc4glRUaWj4IAEfSJi3jPex6Ti+qzNy3we/rQ+8h2QIISigHiREX6yYg==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-ref-node": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-ref-node-form": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-form/-/uui-ref-node-form-1.4.0-rc.2.tgz",
+      "integrity": "sha512-OzK68p0op0tKC1EHRIQ8wGb8v59KubZPy2k7GHmfKdpWcgQzYRiAscif1ACRUNXYaZ27+M0dRc+fJbCP5w/HRg==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-ref-node": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-ref-node-member": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-member/-/uui-ref-node-member-1.4.0-rc.2.tgz",
+      "integrity": "sha512-jE7R4h5n0dlMzciTHjmK3C+CQDpCHOx0gPxB/xA+vCmrinGrE1DXfqALk5TTZqrcfRZ53L6KspkXv8ozVMLQdg==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-ref-node": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-ref-node-package": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-package/-/uui-ref-node-package-1.4.0-rc.2.tgz",
+      "integrity": "sha512-2R8/HL4pitnSiTTtGYv+iqOW2/dQDq32zVxSuvm6EUkQuKZeDEiQ+zAVsnjAViIMRRrkEiCiANPFkAXu5tEp3A==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-ref-node": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-ref-node-user": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-user/-/uui-ref-node-user-1.4.0-rc.2.tgz",
+      "integrity": "sha512-bJrNXJ0GCQG7GLhCsxEExc9wAOptg9rYevTkNLs1MuvRM7TFn7Nj8weAxxVewAM0ZocWwu1oNDD/Rri+eV713g==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-ref-node": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-scroll-container": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-scroll-container/-/uui-scroll-container-1.4.0-rc.2.tgz",
+      "integrity": "sha512-clwL4+7QcNVFEHKtF4Tp1H7tj4Ed0mGct/eApGGCfv1vpXD1uir05TZ57AaAt9DORIUdKAnYzjPGBB6QvZKihA==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-select": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-select/-/uui-select-1.4.0-rc.2.tgz",
+      "integrity": "sha512-8afwgw8WZ93uWeE/WPtvMKyZy/Ey4gVrkh8rF3ZD+czCxYvoZ+gnF25IcpARTkfc3Dy9Cte1c0uoXlJUu8cCVg==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-slider": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-slider/-/uui-slider-1.4.0-rc.2.tgz",
+      "integrity": "sha512-ze9bKW/HuMnb5kun74tATPjYOUUcwZH+0oadAJBtw5CGJ4uTlwl9caEe32NYBgc731V3BrHHoy0FNFb5RxyCJg==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-symbol-expand": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-expand/-/uui-symbol-expand-1.4.0-rc.2.tgz",
+      "integrity": "sha512-hflDXOAKyIfsWVpaTnBi6s1XiCcuvR+2E836Jeh7txdDzz1MHbdh0Aze6XhhtBQUPtKXFSHXPp7v1YZRJVp4vg==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-symbol-file": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file/-/uui-symbol-file-1.4.0-rc.2.tgz",
+      "integrity": "sha512-raHWXxPD1bTlB0q/CUMJblBPSQTRfJF9tMTTFocYVj9/7cf1N8yxayKqmsb+cEfZR76D1NkhwxMODkVyGIee2Q==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-symbol-file-dropzone": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-dropzone/-/uui-symbol-file-dropzone-1.4.0-rc.2.tgz",
+      "integrity": "sha512-wNXlISiShZkqtX4+4OSznI+RfwEg1N8nJTFraehREv1atQ7rmfiKBcb63+j/s2hOmBtYCsPsE6x/YRRlsm4myg==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-symbol-file-thumbnail": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-thumbnail/-/uui-symbol-file-thumbnail-1.4.0-rc.2.tgz",
+      "integrity": "sha512-SgBJJmUB+S8Bitpq9UCueLb5JKPxkWo0W08EKbnmKqNsmhLfNihYsjz83EZFr6vfKJQL9lJRn/TO0skZziq0Xw==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-symbol-folder": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-folder/-/uui-symbol-folder-1.4.0-rc.2.tgz",
+      "integrity": "sha512-s4rMNMpRe72PJZ92RZHLeDdMrRWu+oLWqm2cEUJC55Xx/ssz2p/4zu8UmqNoS38BylrA9C381Jqnv95Cp0pqVA==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-symbol-lock": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-lock/-/uui-symbol-lock-1.4.0-rc.2.tgz",
+      "integrity": "sha512-4+Yo8icGlt+1S7iZWVoID0V0igsU48WxDTVqWLzuaAJ8jtGnyEAICPhWD+/tpQKkhR0ZSRSg06kq3gClJkxyIw==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-symbol-more": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-more/-/uui-symbol-more-1.4.0-rc.2.tgz",
+      "integrity": "sha512-1APpGHIowaZxDM1K68W9u+D7S11t2bcBxs53uNhj1QOaeaHX5R7LYEKYu6mb1DQsQ/dfFXXSw9Sg4sabOEJSAQ==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-symbol-sort": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-sort/-/uui-symbol-sort-1.4.0-rc.2.tgz",
+      "integrity": "sha512-0IgGAX046wD5Qc1UM3rSGlYNw5fD8RA9EHPGxm3TgiVmNlTgLsSQEk0Syv4lhZZZl0SEWppwwTupJUm+2/PeTg==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-table": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-table/-/uui-table-1.4.0-rc.2.tgz",
+      "integrity": "sha512-CYzCHOr98WUjBHJooZCsiT8wX7felNHiX4WBOoRE3qheuXUjmBEQryoiHLe+ceYTjngINZN7IrWetcR0QSelqg==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-tabs": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tabs/-/uui-tabs-1.4.0-rc.2.tgz",
+      "integrity": "sha512-g/2O7pDyF0k6HHzsBcnTDstylXwmW8DyfNlyp7/HcUZjaxcs5hN55OIlJohzOsPhyBiGscHHOzVBU32yIlAR7g==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-tag": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tag/-/uui-tag-1.4.0-rc.2.tgz",
+      "integrity": "sha512-A9tj3ITwcfdsJqkDQvG10fNz8hz1PJikuFN2CqGM+A1h1KXXYZ9zg/jnHq7LBJL+uBwfRlTgxbH97dYPGxou3A==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-textarea": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-textarea/-/uui-textarea-1.4.0-rc.2.tgz",
+      "integrity": "sha512-Z2NKAu52KragOQOf89kiFoHq5wKA+w9A5Is6L21hDycbnKH7lxsfddqAhmlc4axMTSo/rBjGa/KVoAmyzGblfw==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-toast-notification": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification/-/uui-toast-notification-1.4.0-rc.2.tgz",
+      "integrity": "sha512-rxVAoncACM1SotUhBD0fNiwgiVb7Lj/2PPxO50YFFP1p9+DbnG7PYfzxXwSxqisQ8d+DyO0nVQa4YE6XscjRMA==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-button": "1.4.0-rc.2",
+        "@umbraco-ui/uui-css": "1.4.0-rc.2",
+        "@umbraco-ui/uui-icon": "1.4.0-rc.2",
+        "@umbraco-ui/uui-icon-registry-essential": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-toast-notification-container": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-container/-/uui-toast-notification-container-1.4.0-rc.2.tgz",
+      "integrity": "sha512-cS65Cl8dSpZcj1fEXODQ0Jj/j+pCQwuWIyAKsWFpuaIDv2cW7K4SxTuqlFdiIMvHPnyKRvlsdulwle3UVFTBHA==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-toast-notification": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-toast-notification-layout": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-layout/-/uui-toast-notification-layout-1.4.0-rc.2.tgz",
+      "integrity": "sha512-9iK3uX1pe1UdJi/uF9yttbJvzEcwADhd187CLZdVYaZgM0Qj9cir2r5mqigak7iAqw9/t45QfME4e+B7mAmwLg==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-css": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/@umbraco-cms/backoffice/node_modules/@umbraco-ui/uui-toggle": {
+      "version": "1.4.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toggle/-/uui-toggle-1.4.0-rc.2.tgz",
+      "integrity": "sha512-qXKImYh+WG0Vau73U7eCizO8sUHguzC2EEqC4BmoDEs5rXDg8ny4gTPLKqln8YPlGMvmir0Xu4/XcNMstfN+hw==",
+      "dev": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.4.0-rc.2",
+        "@umbraco-ui/uui-boolean-input": "1.4.0-rc.2"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/colord": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "dev": true
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/element-internals-polyfill": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/element-internals-polyfill/-/element-internals-polyfill-1.3.8.tgz",
+      "integrity": "sha512-nymTA/NftVOlS6UjLCL8lKUm8MEgt6TXntQqGGKt+er4dzS9eU88zaGUHLTYVgdfifQ8JQFGbQERMvxse5GMrA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lit": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.8.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.8.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.41.0.tgz",
+      "integrity": "sha512-1o4olnZJsiLmv5pwLEAmzHTE/5geLKQ07BrGxlF4Ri/AXAc2yyDGZwHjiTqD8D/ROKUZmwMA28A+yEowLNOEcA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
+    "node_modules/postcss": {
+      "version": "8.4.30",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.30.tgz",
+      "integrity": "sha512-7ZEao1g4kd68l97aWG/etQKPKq07us0ieSZ2TnFDk11i0ZfDW2AwKHYU8qv4MZKqN2fdBfg+7q0ES06UA73C1g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.2.tgz",
+      "integrity": "sha512-CJouHoZ27v6siztc21eEQGo0kIcE5D1gVPA571ez0mMYb25LGYGKnVNXpEj5MGlepmDWGXNjDB5q7uNiPHC11A==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinymce": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.6.1.tgz",
+      "integrity": "sha512-n1ub/Jq6c5o2mju6A1HPFoR5/X7eH8720yDzLchg4MbKKJg6tthTGr+lBPHzQyrImwbfo7LVgx28mN5InzVMmw==",
+      "dev": true
+    },
+    "node_modules/tinymce-i18n": {
+      "version": "23.8.7",
+      "resolved": "https://registry.npmjs.org/tinymce-i18n/-/tinymce-i18n-23.8.7.tgz",
+      "integrity": "sha512-VIWuHdwzWFJzHxOLd5Ao7Fj/W2fKajQxI5dzJc2M2k6l0LCTtfnGQkK47ADlU7Yttqbd1QlcJt1yfi957/EAtw==",
+      "dev": true
+    },
+    "node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
+    "node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vite": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
+      "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.18.10",
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 14",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/templates/UmbracoPackageRcl/package.json
+++ b/templates/UmbracoPackageRcl/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "UmbracoPackage",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "tsc && vite build --watch",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "lit": "^2.8.0"
+  },
+  "devDependencies": {
+    "@umbraco-cms/backoffice": "^14.0.0--preview003",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.9"
+  }
+}

--- a/templates/UmbracoPackageRcl/src/dashboard/my-welcome-dashboard.ts
+++ b/templates/UmbracoPackageRcl/src/dashboard/my-welcome-dashboard.ts
@@ -1,0 +1,61 @@
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
+import { UMB_NOTIFICATION_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/notification';
+
+@customElement('my-welcome-dashboard')
+export default class MyWelcomeDashboard extends UmbElementMixin(LitElement) {
+  #notificationContext?: typeof UMB_NOTIFICATION_CONTEXT_TOKEN.TYPE;
+
+  @property() private hitCount: number = 0;
+  @property() private buttonColor: string = 'positive';
+  @property() private icon: string = 'umb:handtool';
+  @property() private disabled: boolean = false
+
+  constructor() {
+    super();
+    this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (_instance) => {
+      this.#notificationContext = _instance;
+    });
+  }
+
+  #onClick = () => {
+    if (this.hitCount > 11) {
+      this.disabled = true;
+    } else if (this.hitCount > 8) {
+      this.#notificationContext?.peek('danger', { data: { message: 'Please stop' } });
+      this.buttonColor = 'danger';
+      this.icon = 'umb:alert';
+    } else if (this.hitCount > 4) {
+      this.#notificationContext?.peek('warning', { data: { message: 'Okay, that\'s enough' } });
+      this.buttonColor = 'warning';
+    } else {
+      this.#notificationContext?.peek('positive', { data: { message: '#h5yr' } });
+    }
+    this.hitCount++;
+  }
+
+  render() {
+    return html`
+			<uui-box headline="Welcome">
+				<p>A TypeScript Lit Dashboard</p>
+				<uui-button ?disabled=${this.disabled} style="font-size:2rem;" look="primary" color=${this.buttonColor} label="Click me" @click=${this.#onClick} compact><uui-icon name=${this.icon}></uui-icon></uui-button>
+			</uui-box>
+		`;
+  }
+
+  static styles = [
+      css`
+        :host {
+            display: block;
+            padding: var(--uui-size-layout-1);
+        }
+      `
+  ]
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'my-welcome-dashboard': MyWelcomeDashboard;
+  }
+}

--- a/templates/UmbracoPackageRcl/src/property-editor/my-card.element.ts
+++ b/templates/UmbracoPackageRcl/src/property-editor/my-card.element.ts
@@ -1,0 +1,25 @@
+import {UUICardElement} from "@umbraco-cms/backoffice/external/uui";
+import {css} from "lit";
+import {customElement, property} from "lit/decorators.js";
+
+@customElement("my-card")
+export class MyCardElement extends UUICardElement {
+
+    @property()
+    value!: string;
+
+    constructor() {
+        super();
+        this.selectable = true;
+    }
+
+    static styles = [
+        ...UUICardElement.styles,
+        css`
+          :host {
+            padding: 1rem;
+            width: 200px;
+          }
+        `
+    ]
+}

--- a/templates/UmbracoPackageRcl/src/property-editor/my-property-editor-ui.ts
+++ b/templates/UmbracoPackageRcl/src/property-editor/my-property-editor-ui.ts
@@ -1,0 +1,52 @@
+import {LitElement, html, css} from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { UmbPropertyEditorExtensionElement } from "@umbraco-cms/backoffice/extension-registry";
+
+import type {MyCardElement} from "./my-card.element.ts";
+import './my-card.element.js';
+
+@customElement("my-property-editor-ui")
+export class MyPropertyEditorUiElement
+  extends LitElement
+  implements UmbPropertyEditorExtensionElement
+{
+  @property({ type: String })
+  public value = "";
+
+  #onCardSelected(evt: Event) {
+    const card = evt.target as MyCardElement;
+    this.value = card.value ?? "";
+    this.dispatchEvent(new CustomEvent("property-value-change"));
+  }
+
+  render() {
+    return html`
+      <div class="cards">
+        <my-card value="VISA" ?selected=${this.value === 'VISA'} @selected=${this.#onCardSelected}>VISA</my-card>
+        <my-card value="MasterCard" ?selected=${this.value === 'MasterCard'} @selected=${this.#onCardSelected}>MasterCard</my-card>
+      </div>
+    `;
+  }
+
+  static styles = [
+    css`
+      :host {
+        display: block;
+      }
+
+      .cards {
+        display: flex;
+        flex-direction: row;
+        gap: 1rem;
+      }
+    `
+  ]
+}
+
+export default MyPropertyEditorUiElement;
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "my-property-editor-ui": MyPropertyEditorUiElement;
+  }
+}

--- a/templates/UmbracoPackageRcl/tsconfig.json
+++ b/templates/UmbracoPackageRcl/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/templates/UmbracoPackageRcl/vite.config.ts
+++ b/templates/UmbracoPackageRcl/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: ["src/property-editor/my-property-editor-ui.ts", "src/dashboard/my-welcome-dashboard.ts"], // your web component source file
+      formats: ["es"],
+    },
+    outDir: "wwwroot/dist", // your web component will be saved in this location
+    sourcemap: true,
+    emptyOutDir: true,
+    rollupOptions: {
+      external: [/^@umbraco/],
+    },
+  },
+});

--- a/templates/UmbracoPackageRcl/wwwroot/umbraco-package.json
+++ b/templates/UmbracoPackageRcl/wwwroot/umbraco-package.json
@@ -1,6 +1,31 @@
 {
+  "$schema": "../../umbraco-package-schema.json",
   "id": "UmbracoPackage",
   "name": "UmbracoPackage",
+  "version": "0.1.0",
   "allowPackageTelemetry": true,
-  "extensions": []
+  "extensions": [
+    {
+      "type": "dashboard",
+      "alias": "My.Dashboard.MyExtension",
+      "name": "My Dashboard",
+      "js": "/App_Plugins/UmbracoPackage/dist/my-welcome-dashboard.js",
+      "meta": {
+        "label": "My Dashboard",
+        "pathname": "my-dashboard"
+      }
+    },
+    {
+      "type": "propertyEditorUi",
+      "alias": "My.PropertyEditorUi",
+      "name": "My Property Editor UI",
+      "js": "/App_Plugins/UmbracoPackage/dist/my-property-editor-ui.js",
+      "meta": {
+        "label": "My Property Editor UI",
+        "icon": "umb:list",
+        "group": "common",
+        "propertyEditorSchemaAlias": "Umbraco.TextBox"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
### Prerequisites

- [x] FYI @iOvergaard 👋 

### Description

During the Umbraco Community Teams days (2023), the Backoffice Team undertook the task to update the Umbraco Package template to work with the latest v14 preview release.

The updated template would be opinionated and install the following npm packages:

- `@umbraco-cms/backoffice`
- TypeScript
- Vite

The template would have an example **Dashboard** and a **Property Editor**.

Currently, this pull request is only for the RCL version of the template.  Going forwards, it is preferable to share the source files between both the RCL and non-RCL versions of the template, _(although that is currently beyond my knowledge of how do to that with `dotnet new` templates - any help appreciated)._ 🙏

