### PR TITLE
Fix for 14946 12.2.0 - Issue with getting Content URL, when in the th-TH culture

### DIFF
--- a/src/Umbraco.Core/UriUtilityCore.cs
+++ b/src/Umbraco.Core/UriUtilityCore.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Extensions;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core;
 
@@ -6,7 +6,7 @@ public static class UriUtilityCore
 {
     #region Uri string utilities
 
-    public static bool HasScheme(string uri) => uri.IndexOf("://") > 0;
+    public static bool HasScheme(string uri) => uri.IndexOf("://", StringComparison.InvariantCulture) > 0;
 
     public static string StartWithScheme(string uri) => StartWithScheme(uri, null);
 


### PR DESCRIPTION
### Prerequisites

Steps to reproduce are within this ticket -  #14946 

### Description
String comparison for the schema was returning 0 when in using in the Thai culture.

![image](https://github.com/umbraco/Umbraco-CMS/assets/6782865/cbfc59c6-954f-42fe-97e3-8d9ca6f83473)

