### PR TITLE
Bugfix: #14742 - Tabs not coded according to best practice

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/tabs/umbtabsnav.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/tabs/umbtabsnav.directive.js
@@ -95,6 +95,8 @@ Use this directive to render a tabs navigation.
         function link(scope, element, attrs, ctrl) {
 
             var tabNavItemsWidths = [];
+            var tabItems = [];
+            var firstTab, lastTab;
             // the parent is the component itself so we need to go one level higher
             var container = element.parent().parent();
 
@@ -107,6 +109,32 @@ Use this directive to render a tabs navigation.
             $timeout(function(){
                 element.find("li:not(umb-tab--expand)").each(function() {
                     tabNavItemsWidths.push($(this).outerWidth());
+                });
+
+                tabItems = Array.from(element.find(".umb-tab > button"));
+                firstTab = tabItems[0];
+                lastTab = tabItems[tabItems.length - 1];
+
+                tabItems.forEach(tab => {
+                    tab.addEventListener("keydown", event => {
+                        var currentTarget = event.currentTarget;
+                        switch (event.key) {
+                            case "ArrowLeft":
+                                moveFocusToPreviousTab(currentTarget);
+                                break;
+                            case "ArrowRight":
+                                moveFocusToNextTab(currentTarget);
+                                break;
+                            case "Home":
+                                firstTab.focus();
+                                break;
+                            case "End":
+                                lastTab.focus();
+                                break;
+                            default:
+                                break;
+                        }
+                    });
                 });
             });
 
@@ -121,7 +149,7 @@ Use this directive to render a tabs navigation.
 
                     // detect how many tabs we can show on the screen
                     for (var i = 0; i <= tabNavItemsWidths.length; i++) {
-                        
+
                         var tabWidth = tabNavItemsWidths[i];
                         tabsWidth += tabWidth;
 
@@ -132,8 +160,29 @@ Use this directive to render a tabs navigation.
                             break;
                         }
                     }
-                    
+
                 });
+            }
+
+            function moveFocusToNextTab(currentTab) {
+                var index = tabItems.indexOf(currentTab);
+
+                if (currentTab === lastTab) {
+                    firstTab.focus();
+                }
+                else {
+                    tabItems[index + 1].focus();
+                }
+            }
+
+            function moveFocusToPreviousTab(currentTab) {
+                var index = tabItems.indexOf(currentTab);
+                if(currentTab === firstTab) {
+                    lastTab.focus();
+                }
+                else {
+                    tabItems[index - 1].focus();
+                }
             }
 
             scope.$on('$destroy', function() {
@@ -152,7 +201,7 @@ Use this directive to render a tabs navigation.
             vm.clickTab = clickTab;
             vm.toggleTray = toggleTray;
             vm.hideTray = hideTray;
-    
+
             function clickTab($event, tab) {
                 if (vm.onTabChange) {
                     hideTray();
@@ -169,7 +218,6 @@ Use this directive to render a tabs navigation.
             function hideTray() {
                 vm.showTray = false;
             }
-
         }
 
         var directive = {

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-tabbed-content.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-tabbed-content.html
@@ -1,12 +1,14 @@
 <div>
     <ng-form name="tabbedContentForm">
 
+        <!-- TABS GO HERE -->
         <umb-editor-tab-bar ng-if="tabs.length > 0">
             <umb-tabs-nav tabs="tabs" on-tab-change="setActiveTab(tab)"></umb-tabs-nav>
         </umb-editor-tab-bar>
 
+        <!-- TABS CONTENT GO HERE -->
         <umb-box ng-repeat="tab in tabs track by tab.key" ng-show="tab.alias === activeTabAlias && tab.properties.length > 0">
-            <umb-box-content data-element="tab-content-{{tab.alias}}">
+            <umb-box-content role="tabpanel" id="tabpanel-{{tab.alias}}" aria-labelledby="tab-{{tab.alias}}" data-element="tab-content-{{tab.alias}}">
                 <umb-property
                     data-element="property-{{property.alias}}"
                     ng-repeat="property in tab.properties track by property.alias"

--- a/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
@@ -1,7 +1,7 @@
 
 <ul role="tablist" class="umb-tabs-nav" aria-label="Content Fields">
     <li class="umb-tab" ng-repeat="tab in vm.tabs |  limitTo: vm.maxTabs" data-element="tab-{{tab.alias}}" ng-class="{'umb-tab--active': tab.active, 'umb-tab--error': valTab_tabHasError}" val-tab>
-        <button role="tab" aria-selected="{{tab.active}}" aria-controls="tabpanel-{{tab.alias}}" tabindex="{{!tab.active ? '-1' : null}}" class="btn-reset umb-tab-button" ng-click="vm.clickTab($event, tab)" type="button">
+        <button role="tab" aria-selected="{{tab.active}}" aria-controls="tabpanel-{{tab.alias}}" tabindex="{{!tab.active ? '-1' : null}}" class="btn-reset umb-tab-button" ng-click="vm.clickTab($event, tab)" ng-disabled="tab.disabled" type="button">
             {{ tab.label }}
             <div ng-show="valTab_tabHasError && !tab.active" class="badge">!</div>
         </button>

--- a/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
@@ -1,6 +1,6 @@
-<ul role="tablist" class="umb-tabs-nav"> 
-    <li role="tab" aria-selected="{{tab.active}}" class="umb-tab" ng-repeat="tab in vm.tabs |  limitTo: vm.maxTabs" data-element="tab-{{tab.alias}}" ng-class="{'umb-tab--active': tab.active, 'umb-tab--error': valTab_tabHasError}" val-tab>
-        <button class="btn-reset umb-tab-button" ng-click="vm.clickTab($event, tab)" ng-disabled="tab.disabled" type="button">
+<ul role="tablist" class="umb-tabs-nav">
+    <li class="umb-tab" ng-repeat="tab in vm.tabs |  limitTo: vm.maxTabs" data-element="tab-{{tab.alias}}" ng-class="{'umb-tab--active': tab.active, 'umb-tab--error': valTab_tabHasError}" val-tab>
+        <button role="tab" aria-selected="{{tab.active}}" aria-controls="tabpanel-{{tab.alias}}" tabindex="{{!tab.active ? '-1' : null}}" class="btn-reset umb-tab-button" ng-click="vm.clickTab($event, tab)" type="button">
             {{ tab.label }}
             <div ng-show="valTab_tabHasError && !tab.active" class="badge">!</div>
         </button>

--- a/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/tabs/umb-tabs-nav.html
@@ -1,4 +1,5 @@
-<ul role="tablist" class="umb-tabs-nav">
+
+<ul role="tablist" class="umb-tabs-nav" aria-label="Content Fields">
     <li class="umb-tab" ng-repeat="tab in vm.tabs |  limitTo: vm.maxTabs" data-element="tab-{{tab.alias}}" ng-class="{'umb-tab--active': tab.active, 'umb-tab--error': valTab_tabHasError}" val-tab>
         <button role="tab" aria-selected="{{tab.active}}" aria-controls="tabpanel-{{tab.alias}}" tabindex="{{!tab.active ? '-1' : null}}" class="btn-reset umb-tab-button" ng-click="vm.clickTab($event, tab)" type="button">
             {{ tab.label }}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #14742 

### Description
I have implemented the missing aria attributes and keyboard behavior as provided in the guidelines here https://www.w3.org/WAI/ARIA/apg/patterns/tabs/examples/tabs-manual/ - See a demo here https://codepen.io/pen

Changes
- Removed the "ng-disabled" attribute since the `tab` object did not contain a `disabled` property. Even if it did, it should have been removed anyway since using the disabled attribute comes with a bunch of accessibility issues too.
- Added the a bunch of attributes to connect the tabs with the content (tabpanel) they actually refer to.
- Added a keydown event handler to check for whether arrow left, arrow right, home or end keys are being pushed
- Added an aria-label on the `tablist` - I have not created a dictionary item for this yet, since I'm uncertain about what a good label for this would actually be - My suggestion is "Content Fields", but I'm not sure if it's providing enough context... So I would love some ideas/feedback around this

This also changes the tabbing behavior, so when you tab through the UI you no longer need to tab past all your content tabs but tab straight to the content area unless you move tab using the arrow keys and hit space or enter to activate the next tab.

All in all this should improve accessibility for screen readers as well for keyboard users.

**Before**
![tabs-before](https://github.com/umbraco/Umbraco-CMS/assets/1932158/9fb00293-a0e3-4003-a980-e942a4d5af2a)


**After**
![tabs-after](https://github.com/umbraco/Umbraco-CMS/assets/1932158/302a9f4d-4a38-4af7-9261-e7708c62b9de)

**Edit**: Oh in the "After" GIF I forget to actually click enter, showing how the tab would change and how it would then be possible to tab into the conent fields of the selected tabs - Hope it still makes sense :)

**Edit - 15/10/2023** - Ok, so after som discussion with @bjarnef and @abjerner I have a suspicion that my initial **after** GIF might have caused some confusion about how this is actually going to be working, so here is an updated version with a little explanation about what I'm doing - I hope this clears things up a bit 😅

**After - UPDATED VERSION**
![tabs-after-updated](https://github.com/umbraco/Umbraco-CMS/assets/1932158/34e24d84-d31c-474b-bdee-cb29a1d026cb)

Ok, so in this GIF I now first go to the input field, where the "Name" of the page is added and then I start tabbing through the UI using the `tab` key. I'm tabbing forwards and backwards and I'm only hitting the actively selected "tab" and not the other tabs from the tablist. So I can freely tab from the "tab" directly into it's content instead of first having to tab past the other tabs in the list.

Now if I tab to "Content" and actually want to go to the next Tab, which in this case is named "SEO" I can do so using the "Next" arrow key, once "SEO" has focus I can click on either `space` or `enter` to make the tab active and then I can switch to using my `tab` key again tabbing directly into the content fields of the active tab and if I tab backwards I go from the content fields, to the "SEO" tab to the "Actions" tab further up.

In the ending of the GIF I display how it's also possible to use the "Home" and "End" keys to jump to the beginning or end of the list, making it possible for the user to decide the shortest travel to the tab they wish to see the content for.

I hope this clarifies what the updates to this PR is doing - I will also re-enable the `tab.disabled` option so this change will not be breaking but hopefully package creators can safely remove the disabled option in their future releases :-)