### PR TITLE
Add support for [Route] when generating API base urls

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/LinkGeneratorExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/LinkGeneratorExtensions.cs
@@ -68,7 +68,20 @@ public static class LinkGeneratorExtensions
                                              " or the result ");
         }
 
-        return linkGenerator.GetUmbracoApiService<T>(method.Name)?.TrimEnd(method.Name);
+        var url = linkGenerator.GetUmbracoApiService<T>(method.Name)?.TrimEnd(method.Name);
+
+        // if there's a Route attribute on the action method, strip its value too
+        var routeAttr = method
+            .GetCustomAttributes(typeof(RouteAttribute), false)
+            .OfType<RouteAttribute>()
+            .FirstOrDefault();
+
+        if (routeAttr != null)
+        {
+            url = url?.TrimEnd(routeAttr.Template);
+        }
+
+        return url;
     }
 
     /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
The `LinkGeneratorExtensions.GetUmbracoApiServiceBaseUrl<T>` takes a controller method and generates the URL to it and strips the method name from the end, leaving the "base url".

If there's a `[Route("custom-name")]` on the method, it doesn't strip it. This adds that feature.

Consider the following controller as an example:

```
[Route("api/foobar")]
public class FoobarApiController : UmbracoApiController
{
    [HttpGet]
    [Route("bar")]
    public IActionResult SomeActionName()
    {
        return Ok();
    }
}
```

This changes the route to the controller to `/api/foobar` and the endpoint to `/api/foobar/bar` instead of the default `/umbraco/api/FoobarApi/SomeActionName` (which is a feature of standard WebApi and quite useful in Umbraco too).

For this example controller the default implementation of `LinkGeneratorExtensions.GetUmbracoApiServiceBaseUrl<T>` gives you:
```
var url = _linkGenerator.GetUmbracoApiServiceBaseUrl<FoobarApiController>(
                                controller => controller.SomeActionName());
// url == "/umbraco/api/foobar/bar"
```

The new implementation gives you the expected value:
```
var url = _linkGenerator.GetUmbracoApiServiceBaseUrl<FoobarApiController>(
                                controller => controller.SomeActionName());
// url == "/umbraco/api/foobar"
```

It leaves other cases intact, i.e. controllers without the `[Route]` attribute.