### PR TITLE
V14/feature/resend user invite endpoint

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/User/ResendInviteUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/ResendInviteUsersController.cs
@@ -1,5 +1,4 @@
 ﻿using Asp.Versioning;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
@@ -33,7 +32,7 @@ public class ResendInviteUserController : UserControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> ResendInvite(ResendInviteUserRequestModel model)
     {
-        UserResendInviteModel resendInviteModel = await _userPresentationFactory.CreateResendInviteModel(model);
+        UserResendInviteModel resendInviteModel = await _userPresentationFactory.CreateResendInviteModelAsync(model);
 
         Attempt<UserInvitationResult, UserOperationStatus> result =
             await _userService.ResendInvitationAsync(CurrentUserKey(_backOfficeSecurityAccessor), resendInviteModel);

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/ResendInviteUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/ResendInviteUsersController.cs
@@ -27,14 +27,13 @@ public class ResendInviteUserController : UserControllerBase
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
-    [AllowAnonymous]
     [HttpPost("invite/resend")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> ResendInvite(ResendInviteUserRequestModel model)
     {
-        UserResendInviteModel resendInviteModel = _userPresentationFactory.CreateResendInviteModel(model);
+        UserResendInviteModel resendInviteModel = await _userPresentationFactory.CreateResendInviteModel(model);
 
         Attempt<UserInvitationResult, UserOperationStatus> result =
             await _userService.ResendInvitationAsync(CurrentUserKey(_backOfficeSecurityAccessor), resendInviteModel);

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/ResendInviteUsersController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/ResendInviteUsersController.cs
@@ -1,0 +1,46 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.ViewModels.User;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Api.Management.Controllers.User;
+
+[ApiVersion("1.0")]
+public class ResendInviteUserController : UserControllerBase
+{
+    private readonly IUserService _userService;
+    private readonly IUserPresentationFactory _userPresentationFactory;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+
+    public ResendInviteUserController(IUserService userService, IUserPresentationFactory userPresentationFactory, IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+    {
+        _userService = userService;
+        _userPresentationFactory = userPresentationFactory;
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+    }
+
+    [AllowAnonymous]
+    [HttpPost("invite/resend")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> ResendInvite(ResendInviteUserRequestModel model)
+    {
+        UserResendInviteModel resendInviteModel = _userPresentationFactory.CreateResendInviteModel(model);
+
+        Attempt<UserInvitationResult, UserOperationStatus> result =
+            await _userService.ResendInvitationAsync(CurrentUserKey(_backOfficeSecurityAccessor), resendInviteModel);
+
+        return result.Success
+            ? Ok()
+            : UserOperationStatusResult(result.Status, result.Result);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/UsersControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/UsersControllerBase.cs
@@ -120,6 +120,10 @@ public abstract class UserControllerBase : ManagementApiControllerBase
                 .WithTitle("Content node not found")
                 .WithDetail("The specified content node was not found.")
                 .Build()),
+            UserOperationStatus.InvalidState => BadRequest(new ProblemDetailsBuilder()
+                .WithTitle("Invalid user state")
+                .WithDetail("The user is in an invalid state to perform the requested action.")
+                .Build()),
             UserOperationStatus.Forbidden => Forbid(),
             _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
                     .WithTitle("Unknown user operation status.")

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/UsersControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/UsersControllerBase.cs
@@ -120,9 +120,9 @@ public abstract class UserControllerBase : ManagementApiControllerBase
                 .WithTitle("Content node not found")
                 .WithDetail("The specified content node was not found.")
                 .Build()),
-            UserOperationStatus.InvalidState => BadRequest(new ProblemDetailsBuilder()
+            UserOperationStatus.NotInInviteState => BadRequest(new ProblemDetailsBuilder()
                 .WithTitle("Invalid user state")
-                .WithDetail("The user is in an invalid state to perform the requested action.")
+                .WithDetail("The target user is not in the invite state.")
                 .Build()),
             UserOperationStatus.Forbidden => Forbid(),
             _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()

--- a/src/Umbraco.Cms.Api.Management/Factories/IUserPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IUserPresentationFactory.cs
@@ -16,4 +16,5 @@ public interface IUserPresentationFactory
     Task<UserUpdateModel> CreateUpdateModelAsync(Guid existingUserKey, UpdateUserRequestModel updateModel);
 
     Task<CurrentUserResponseModel> CreateCurrentUserResponseModelAsync(IUser user);
+    Task<UserResendInviteModel> CreateResendInviteModel(ResendInviteUserRequestModel requestModel);
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/IUserPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IUserPresentationFactory.cs
@@ -16,5 +16,6 @@ public interface IUserPresentationFactory
     Task<UserUpdateModel> CreateUpdateModelAsync(Guid existingUserKey, UpdateUserRequestModel updateModel);
 
     Task<CurrentUserResponseModel> CreateCurrentUserResponseModelAsync(IUser user);
-    Task<UserResendInviteModel> CreateResendInviteModel(ResendInviteUserRequestModel requestModel);
+
+    Task<UserResendInviteModel> CreateResendInviteModelAsync(ResendInviteUserRequestModel requestModel);
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
@@ -85,6 +85,17 @@ public class UserPresentationFactory : IUserPresentationFactory
         return inviteModel;
     }
 
+    public async Task<UserResendInviteModel> CreateResendInviteModel(ResendInviteUserRequestModel requestModel)
+    {
+        var inviteModel = new UserResendInviteModel
+        {
+            InvitedUserKey = requestModel.UserId,
+            Message = requestModel.Message,
+        };
+
+        return await Task.FromResult(inviteModel);
+    }
+
     public async Task<UserUpdateModel> CreateUpdateModelAsync(Guid existingUserKey, UpdateUserRequestModel updateModel)
     {
         var model = new UserUpdateModel

--- a/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
@@ -84,7 +84,7 @@ public class UserPresentationFactory : IUserPresentationFactory
         return await Task.FromResult(inviteModel);
     }
 
-    public async Task<UserResendInviteModel> CreateResendInviteModel(ResendInviteUserRequestModel requestModel)
+    public async Task<UserResendInviteModel> CreateResendInviteModelAsync(ResendInviteUserRequestModel requestModel)
     {
         var inviteModel = new UserResendInviteModel
         {

--- a/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
@@ -1,6 +1,5 @@
 ﻿using Umbraco.Cms.Api.Management.ViewModels.User;
 using Umbraco.Cms.Api.Management.ViewModels.User.Current;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Media;
@@ -68,7 +67,7 @@ public class UserPresentationFactory : IUserPresentationFactory
             UserGroupKeys = requestModel.UserGroupIds,
         };
 
-        return createModel;
+        return await Task.FromResult(createModel);
     }
 
     public async Task<UserInviteModel> CreateInviteModelAsync(InviteUserRequestModel requestModel)
@@ -82,7 +81,7 @@ public class UserPresentationFactory : IUserPresentationFactory
             Message = requestModel.Message,
         };
 
-        return inviteModel;
+        return await Task.FromResult(inviteModel);
     }
 
     public async Task<UserResendInviteModel> CreateResendInviteModel(ResendInviteUserRequestModel requestModel)
@@ -111,7 +110,7 @@ public class UserPresentationFactory : IUserPresentationFactory
 
         model.UserGroupKeys = updateModel.UserGroupIds;
 
-        return model;
+        return await Task.FromResult(model);
     }
 
     public async Task<CurrentUserResponseModel> CreateCurrentUserResponseModelAsync(IUser user)

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/ResendInviteUserRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/ResendInviteUserRequestModel.cs
@@ -1,0 +1,7 @@
+namespace Umbraco.Cms.Api.Management.ViewModels.User;
+
+public class ResendInviteUserRequestModel
+{
+    public Guid UserId { get; set; } = Guid.Empty;
+    public string? Message { get; set; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/ResendInviteUserRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/ResendInviteUserRequestModel.cs
@@ -3,5 +3,6 @@ namespace Umbraco.Cms.Api.Management.ViewModels.User;
 public class ResendInviteUserRequestModel
 {
     public Guid UserId { get; set; } = Guid.Empty;
+
     public string? Message { get; set; }
 }

--- a/src/Umbraco.Core/Models/UserReInviteModel.cs
+++ b/src/Umbraco.Core/Models/UserReInviteModel.cs
@@ -1,0 +1,7 @@
+﻿namespace Umbraco.Cms.Core.Models;
+
+public class UserResendInviteModel
+{
+    public string? Message { get; set; }
+    public Guid InvitedUserKey { get; set; }
+}

--- a/src/Umbraco.Core/Services/IUserService.cs
+++ b/src/Umbraco.Core/Services/IUserService.cs
@@ -404,4 +404,6 @@ public interface IUserService : IMembershipUserService
     /// </summary>
     /// <param name="userEmail">The email address of the user.</param>
     Task<Attempt<UserOperationStatus>> SendResetPasswordEmailAsync(string userEmail);
+
+    Task<Attempt<UserInvitationResult, UserOperationStatus>> ResendInvitationAsync(Guid performingUserKey, UserResendInviteModel model);
 }

--- a/src/Umbraco.Core/Services/OperationStatus/UserOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/UserOperationStatus.cs
@@ -1,5 +1,8 @@
 ﻿namespace Umbraco.Cms.Core.Services.OperationStatus;
 
+/// <summary>
+/// Used to signal a user operation succeeded or an atomic failure reason
+/// </summary>
 public enum UserOperationStatus
 {
     Success,
@@ -32,5 +35,5 @@ public enum UserOperationStatus
     MediaNodeNotFound,
     UnknownFailure,
     CannotPasswordReset,
-    InvalidState
+    NotInInviteState
 }

--- a/src/Umbraco.Core/Services/OperationStatus/UserOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/UserOperationStatus.cs
@@ -31,5 +31,6 @@ public enum UserOperationStatus
     ContentNodeNotFound,
     MediaNodeNotFound,
     UnknownFailure,
-    CannotPasswordReset
+    CannotPasswordReset,
+    InvalidState
 }

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -797,6 +797,43 @@ internal class UserService : RepositoryService, IUserService
 
         await userStore.SaveAsync(invitedUser);
 
+        Attempt<UserInvitationResult, UserOperationStatus> invitationAttempt = await SendInvitationAsync(performingUser, serviceScope, invitedUser, model.Message);
+
+        scope.Complete();
+
+        return invitationAttempt;
+    }
+
+    public async Task<Attempt<UserInvitationResult, UserOperationStatus>> ResendInvitationAsync(Guid performingUserKey, UserResendInviteModel model)
+    {
+        using ICoreScope scope = ScopeProvider.CreateCoreScope();
+        using IServiceScope serviceScope = _serviceScopeFactory.CreateScope();
+
+        IUser? performingUser = await GetAsync(performingUserKey);
+        if (performingUser == null)
+        {
+            return Attempt.FailWithStatus(UserOperationStatus.MissingUser, new UserInvitationResult());
+        }
+
+        IUser? invitedUser = await GetAsync(model.InvitedUserKey);
+        if (invitedUser == null)
+        {
+            return Attempt.FailWithStatus(UserOperationStatus.MissingUser, new UserInvitationResult());
+        }
+
+        if (invitedUser.UserState != UserState.Invited)
+        {
+            return Attempt.FailWithStatus(UserOperationStatus.InvalidState, new UserInvitationResult());
+        }
+
+        Attempt<UserInvitationResult, UserOperationStatus> invitationAttempt = await SendInvitationAsync(performingUser, serviceScope, invitedUser, model.Message);
+        scope.Complete();
+
+        return invitationAttempt;
+    }
+
+    private async Task<Attempt<UserInvitationResult, UserOperationStatus>> SendInvitationAsync(IUser performingUser, IServiceScope serviceScope, IUser invitedUser, string? message)
+    {
         IInviteUriProvider inviteUriProvider = serviceScope.ServiceProvider.GetRequiredService<IInviteUriProvider>();
         Attempt<Uri, UserOperationStatus> inviteUriAttempt = await inviteUriProvider.CreateInviteUriAsync(invitedUser);
         if (inviteUriAttempt.Success is false)
@@ -807,15 +844,13 @@ internal class UserService : RepositoryService, IUserService
         var invitation = new UserInvitationMessage
         {
             InviteUri = inviteUriAttempt.Result,
-            Message = model.Message ?? string.Empty,
+            Message = message ?? string.Empty,
             Recipient = invitedUser,
             Sender = performingUser,
         };
         await _inviteSender.InviteUser(invitation);
 
-        scope.Complete();
-
-        return Attempt.SucceedWithStatus(UserOperationStatus.Success, new UserInvitationResult { InvitedUser =  invitedUser });
+        return Attempt.SucceedWithStatus(UserOperationStatus.Success, new UserInvitationResult { InvitedUser = invitedUser });
     }
 
     private UserOperationStatus ValidateUserCreateModel(UserCreateModel model)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
- Added a new endpoint to resend an invitation for an invited user
- [x] Used similar mapping/endpoint signatures as existing management api endpoints
- Added new userService method to resend the invite
- [x] New method only works for existing users that have the Invited state. 
- Cleaned up some code in UserPresentationFactory
- [x] Checked existing permissions (v13) and matched them
- Clarified UserOperationStatus enum

### Reproduction
- [Configure smtp](https://docs.umbraco.com/umbraco-cms/extending/health-check/guides/smtp) and have a way to capture the emails (smtp4dev, papercut smtp,...)
- Invite a user trough the ui or endpoint
- Get user userid from the users endpoint or the response header from the previous endpoint
- hit the umbraco/management/api/v1/user/invite/resend endpoint with a payload like
```
{
    "userId" : "9542756b-fe07-4e87-929a-76e34a2306c0",
    "message" : "newMessage"
}
```
- You should get a new email with the "newMessage"
- Click on the link and set a password
- resend the same payload to umbraco/management/api/v1/user/invite/resend
- You should get a 400 error because the user is past the invite state

