### PR TITLE
Create matcher policy to pick the correct item endpoint

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Delivery/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Api.Common.DependencyInjection;
 using Umbraco.Cms.Api.Delivery.Accessors;
@@ -7,6 +8,7 @@ using Umbraco.Cms.Api.Delivery.Configuration;
 using Umbraco.Cms.Api.Delivery.Handlers;
 using Umbraco.Cms.Api.Delivery.Json;
 using Umbraco.Cms.Api.Delivery.Rendering;
+using Umbraco.Cms.Api.Delivery.Routing;
 using Umbraco.Cms.Api.Delivery.Security;
 using Umbraco.Cms.Api.Delivery.Services;
 using Umbraco.Cms.Core;
@@ -57,6 +59,9 @@ public static class UmbracoBuilderExtensions
         builder.AddNotificationAsyncHandler<MemberDeletedNotification, RevokeMemberAuthenticationTokensNotificationHandler>();
         builder.AddNotificationAsyncHandler<AssignedMemberRolesNotification, RevokeMemberAuthenticationTokensNotificationHandler>();
         builder.AddNotificationAsyncHandler<RemovedMemberRolesNotification, RevokeMemberAuthenticationTokensNotificationHandler>();
+
+        // FIXME: remove this when Delivery API V1 is removed
+        builder.Services.AddSingleton<MatcherPolicy, DeliveryApiItemsEndpointsMatcherPolicy>();
         return builder;
     }
 }

--- a/src/Umbraco.Cms.Api.Delivery/Routing/DeliveryApiItemsEndpointsMatcherPolicy.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Routing/DeliveryApiItemsEndpointsMatcherPolicy.cs
@@ -1,0 +1,55 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Matching;
+using Umbraco.Cms.Api.Delivery.Controllers;
+
+namespace Umbraco.Cms.Api.Delivery.Routing;
+
+// FIXME: remove this when Delivery API V1 is removed
+internal sealed class DeliveryApiItemsEndpointsMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy
+{
+    public override int Order => 100;
+
+    public bool AppliesToEndpoints(IReadOnlyList<Endpoint> endpoints)
+    {
+        for (var i = 0; i < endpoints.Count; i++)
+        {
+            ControllerActionDescriptor? controllerActionDescriptor = endpoints[i].Metadata.GetMetadata<ControllerActionDescriptor>();
+            if (IsByIdsController(controllerActionDescriptor) || IsByRouteController(controllerActionDescriptor))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public Task ApplyAsync(HttpContext httpContext, CandidateSet candidates)
+    {
+        var hasIdQueryParameter = httpContext.Request.Query.ContainsKey("id");
+        for (var i = 0; i < candidates.Count; i++)
+        {
+            ControllerActionDescriptor? controllerActionDescriptor = candidates[i].Endpoint?.Metadata.GetMetadata<ControllerActionDescriptor>();
+            if (IsByIdsController(controllerActionDescriptor))
+            {
+                candidates.SetValidity(i, hasIdQueryParameter);
+            }
+            else if (IsByRouteController(controllerActionDescriptor))
+            {
+                candidates.SetValidity(i, hasIdQueryParameter is false);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static bool IsByIdsController(ControllerActionDescriptor? controllerActionDescriptor)
+        => IsControllerType<ByIdsContentApiController>(controllerActionDescriptor) || IsControllerType<ByIdsMediaApiController>(controllerActionDescriptor);
+
+    private static bool IsByRouteController(ControllerActionDescriptor? controllerActionDescriptor)
+        => IsControllerType<ByRouteContentApiController>(controllerActionDescriptor) || IsControllerType<ByPathMediaApiController>(controllerActionDescriptor);
+
+    private static bool IsControllerType<T>(ControllerActionDescriptor? controllerActionDescriptor)
+        => controllerActionDescriptor?.MethodInfo.DeclaringType == typeof(T);
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #14875

### Description

This PR ensures that we pick the correct endpoint when querying the Delivery API for items - either by route/path or by (multiple) IDs.

The code is a temporary workaround; we will (likely) change the by-IDs endpoint route to be "/items" instead (plural) in V2 of the Delivery API.

See #14875 for steps to test. Note that the issue is also present for media items, albeit less critical as the by-path endpoint does not work with a "/" parameter (but should still be invoked all the same to show the error).
