### PR TITLE
14523: Return focus to trigger element when close event occurs

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -134,7 +134,7 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
                 leftColumn.classList.remove(aboveClass);
             }
 
-            returnFocusToTriggerElement()
+            returnFocusToTriggerElement();
         }
     }
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/navigation.service.js
@@ -14,8 +14,8 @@
  *
  */
 function navigationService($routeParams, $location, $q, $injector, eventsService, umbModelMapper, treeService, appState, backdropService) {
-
     //the promise that will be resolved when the navigation is ready
+    var activeElement = undefined;
     var navReadyPromise = $q.defer();
 
     //the main tree's API reference, this is acquired when the tree has initialized
@@ -82,7 +82,6 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
                 if (appState.getGlobalState("isTablet") === true) {
                     appState.setGlobalState("showNavigation", false);
                 }
-
                 break;
         }
     }
@@ -134,7 +133,18 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
                 backdropService.close();
                 leftColumn.classList.remove(aboveClass);
             }
+
+            returnFocusToTriggerElement()
         }
+    }
+
+    function returnFocusToTriggerElement() {
+        if(!activeElement) return;
+
+        const elementToFocus = activeElement.querySelector(".umb-tree-item__inner .umb-button-ellipsis");
+        document.body.classList.add("tabbing-active");
+        elementToFocus.style.backgroundColor = "hsla(0,0%,100%,.8)";
+        elementToFocus.focus();
     }
 
     function showBackdrop() {
@@ -680,9 +690,12 @@ function navigationService($routeParams, $location, $q, $injector, eventsService
             if (appState.getMenuState("allowHideMenuDialog") === false) {
                 return;
             }
+
             if (showMenu) {
                 this.showMenu({ skipDefault: true, node: appState.getMenuState("currentNode") });
             } else {
+                activeElement = document.querySelector("#tree .active");
+
                 closeBackdrop();
                 setMode("default");
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #14523 

### Description
I have added a function, which returns the focus to the trigger element, whenever the "close" event happens in the "Context/Ellipsis" menu.

I might have missed some scenarios - One I can think of is when a node is deleted then the focus currently is not added to anything. I guess that is a challenge for a separate PR. Nevertheless this PR should improve what we already have. It happens whenever the dialog is closed and not just for the "Sort" scenario mentioned in the issue.

**Before**
![context-menu-before](https://github.com/umbraco/Umbraco-CMS/assets/1932158/af22e405-d2b0-4129-918d-586902cc96ec)

**After**
![context-menu-after](https://github.com/umbraco/Umbraco-CMS/assets/1932158/07374343-4912-42cd-9c6a-9927925b3dc4)
