### PR TITLE
12752: Adds configuration to set first day of week as monday in datepickers

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/DateTimeConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/DateTimeConfiguration.cs
@@ -19,4 +19,11 @@ public class DateTimeConfiguration
         "boolean",
         Description = "When enabled the time displayed will be offset with the server's timezone, this is useful for scenarios like scheduled publishing when an editor is in a different timezone than the hosted server")]
     public bool OffsetTime { get; set; }
+
+    [ConfigurationField(
+        "firstDayOfWeekIsMonday",
+        "Use Monday as first day of the week",
+        "boolean",
+        Description = "When enabled the first day of week in the calendar will be Monday")]
+    public bool FirstDayOfWeekIsMonday { get; set; }
 }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbdatetimepicker.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbdatetimepicker.directive.js
@@ -140,6 +140,17 @@ Use this directive to render a date time picker
                 ctrl.options.locale = userLocale;
             }
 
+            if (ctrl.options.firstDayOfWeek) {
+              // convert locale to object, if its a string
+              if (typeof ctrl.options.locale === "string") {
+                ctrl.options.locale = {
+                  locale: ctrl.options.locale
+                }
+              }
+
+              ctrl.options.locale.firstDayOfWeek = ctrl.options.firstDayOfWeek;
+            }
+
             // handle special keydown events
             ctrl.options.onKeyDown = function (selectedDates, dateStr, instance, event) {
                 var code = event.keyCode || event.which;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
@@ -54,6 +54,10 @@ function dateTimePickerController($scope, angularHelper, dateHelper, validationM
       clickOpens: !$scope.readonly
     };
 
+    if (Object.toBoolean($scope.model.config.firstDayOfWeekIsMonday)) {
+      $scope.datePickerConfig.firstDayOfWeek = 1;
+    }
+
     // Don't show calendar if date format has been set to only time
     const timeFormat = $scope.model.config.format.toLowerCase();
     const timeFormatPattern = /^h{1,2}:m{1,2}(:s{1,2})?\s?a?$/gmi;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #12752 

### Description
As proposed, this change adds a configuration setting for the datepicker, where you can set if the first day of the week in the calendar should be Monday.

To test:

Add a date picker to a content type, check "Use Monday as first day of week" in the settings.
Verify that the datepicker displays Monday as the first day of the week.

Uncheck "Use Monday as first day of week" in settings, and verify that the datepicker now displays Sunday as the first day of the week.


![Skærmbillede 2023-10-18 110421](https://github.com/umbraco/Umbraco-CMS/assets/3726467/3238521b-73d1-4788-a6ef-8284d733c1ac)
![Skærmbillede 2023-10-18 110429](https://github.com/umbraco/Umbraco-CMS/assets/3726467/c037c13f-a321-4555-8d2a-7ca6c2f17c38)
![Skærmbillede 2023-10-18 110454](https://github.com/umbraco/Umbraco-CMS/assets/3726467/ed7e06fb-6d3f-414d-a7ef-bffa4547ec03)

<!-- Thanks for contributing to Umbraco CMS! -->
