### PR TITLE
fix for umbraco.jsonschema umbraco.core error nu1104 error

### DIFF
--- a/tools/Umbraco.JsonSchema/Umbraco.JsonSchema.csproj
+++ b/tools/Umbraco.JsonSchema/Umbraco.JsonSchema.csproj
@@ -12,6 +12,5 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Umbraco.Core\Umbraco.Core.csproj" />
-    <ProjectReference Include="..\Umbraco.Core\Umbraco.Core.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
…roject, check that the project ref is valid

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
After cloning the latest Umbraco CMS contrib branch code and building it, I saw the following error. When I investigated it, I realised that the Umbraco.Core project wasn't referenced correctly in Umbraco.JsonSchema.

After removing the reference and adding it again has fixed the problem. 

Error NU1104  Unable to find project 'D:\git\repos\Umbraco-CMS\tools\Umbraco.Core\Umbraco.Core.csproj'. Check that the project reference is valid and that the project file exists. Umbraco.JsonSchema    D:\git\repos\Umbraco-CMS\tools\Umbraco.JsonSchema\Umbraco.JsonSchema.csproj


<!-- Thanks for contributing to Umbraco CMS! -->
