### PR TITLE
Prevent RTE in fullscreen being partially covered by the left menu column (should fix #14890)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/application/grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/application/grid.less
@@ -76,7 +76,7 @@ body.umb-drawer-is-visible #mainwrapper{
 
 #leftcolumn {
   height: 100%;
-  z-index: 1100;
+  z-index: 0;
   float: left;
   position: absolute;
   top: 0;

--- a/src/Umbraco.Web.UI.Client/src/less/application/grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/application/grid.less
@@ -76,7 +76,7 @@ body.umb-drawer-is-visible #mainwrapper{
 
 #leftcolumn {
   height: 100%;
-  z-index: 0;
+  z-index: 1100;
   float: left;
   position: absolute;
   top: 0;
@@ -84,6 +84,12 @@ body.umb-drawer-is-visible #mainwrapper{
   &.above-backdrop{
       z-index: 7501;
   }
+
+  // force behind TinyMCE when it's in fullscreen mode
+  .tox-fullscreen & {
+    z-index: 0;
+  }
+
 }
 
 #navigation {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #14890 <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
This should fix a problem (#14890) where an RTE in fullscreen mode would be partly covered by the left "menu" column due to a very high z-index.

To test this specific error, add the "fullscreen" plugin and command to RichTextEditor settings in appsettings.json, enable it on any RTE datatype and verify that clicking the Fullscreen button does in fact show the editor in full, without the left side menu obstructing it.

Test that right clicking in different contexts/sections still works (as in, there's no difference in how a right click context menu is shown, and everything is still clickable).

<!-- Thanks for contributing to Umbraco CMS! -->
