### PR TITLE
Link Picker Title UI Quirk

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.controller.js
@@ -33,6 +33,8 @@ angular.module("umbraco").controller("Umbraco.Editors.LinkPickerController",
             selectedSearchResults: []
         };
 
+      $scope.userLinkNameInput = '';
+
         $scope.showTarget = $scope.model.hideTarget !== true;
         $scope.showAnchor = $scope.model.hideAnchor !== true;
 
@@ -143,7 +145,9 @@ angular.module("umbraco").controller("Umbraco.Editors.LinkPickerController",
             $scope.currentNode.selected = true;
             $scope.model.target.id = args.node.id;
             $scope.model.target.udi = args.node.udi;
-            $scope.model.target.name = args.node.name;
+            if ($scope.oKToUpdateLinkTargetName()) {
+              $scope.model.target.name = args.node.name;
+            }
 
             if (args.node.id < 0) {
                 $scope.model.target.url = "/";
@@ -167,7 +171,18 @@ angular.module("umbraco").controller("Umbraco.Editors.LinkPickerController",
                 openMiniListView(args.node);
             }
         }
+      $scope.trackUserInput = function (userInput) {
+        $scope.userLinkNameInput = userInput;
 
+      }
+      $scope.oKToUpdateLinkTargetName = function () {
+        if (!$scope.userLinkNameInput || !$scope.model.target.name) {
+          return true;
+        }
+        else {
+          return false;
+        }
+      }
         $scope.switchToMediaPicker = function () {
             userService.getCurrentUser().then(function (userData) {
 
@@ -190,8 +205,10 @@ angular.module("umbraco").controller("Umbraco.Editors.LinkPickerController",
 
                         $scope.model.target.id = media.id;
                         $scope.model.target.udi = media.udi;
-                        $scope.model.target.isMedia = true;
+                      $scope.model.target.isMedia = true;
+                      if ($scope.oKToUpdateLinkTargetName()) {
                         $scope.model.target.name = media.name;
+                      }
                         $scope.model.target.url = media.image;
 
                         editorService.close();

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.html
@@ -49,6 +49,7 @@
                                 placeholder="@placeholders_entername"
                                 class="umb-property-editor umb-textstring"
                                 ng-model="model.target.name"
+                                ng-change="trackUserInput(model.target.name)"
                                 id="nodeNameLinkPicker"/>
                     </umb-control-group>
 


### PR DESCRIPTION
### Prerequisites

- [ x] I have added steps to test this contribution in the description below

There is an existing issue that describes this quirk, back in the day, from V8 - here it is: https://github.com/umbraco/Umbraco-CMS/issues/8450

When that issue was raised the discussion led into lots of exciting thoughts about the Url Picker UX/UI and the conclusion was kind of  ooh there are lots of ui/ux challenges with the UX/UI of the picker but we are not actively working on this... and I totally expect this is still the case... but what was welcomed was proposals that might incrementally improve things through a PR...

... so this PR is along those lines, and It's October, and it's a tiny thing, but completely ok if you want to close this PR in exchange for the proper thinking about the UX/UI later down the line...

I've only revived it here because I made this change on a V8 site to appease an editor AND I recently read this post in the forum:

https://our.umbraco.com/forum/using-umbraco-and-getting-started/112848-when-using-the-multi-url-picker-is-there-a-way-to-stop-it-from-auto-filling-the-link-title-field

which made me think, this is still an annoying thing for editors in their link picking exploits.

### Description

There is a description of the problem in the issue BUT essentially when an editor picks a link they are presented with the overlay in the order

Link
Link Title
Content/Media Picker

A: soooo a good proportion of editors are linking to a specific thing, and want to word the Link Title accordingly, so they type in their Link Title, and THEN pick the Content / Media item, and this action of picking overwrites what they put in the Link Title box... and as they immediately click submit, they don't notice it has been ovewritten.

Or 

B: An editor won't fill in a Link Title at all, and just pick a content or media item, and in which case it's super useful that the Link Title is automatically filled in for them - also if they pick the wrong thing and pick again, it's great the link title is updated to the new thing.

So for some editors this isn't a problem - for some editors this is intensely annoying time sink that catches them out over and over...

There is something wrong with the UX/UI here BUT that is a much bigger thing to sort out gracefully.

What this PR does is use ng-change on the LinkTitle textbox, which is ONLY fired when an editor manually interacts with the LinkTitle textbox, eg Scenario A, to store what they entered in a variable, and then this 'flag' is checked whenever a Media Item or Content Item is picked, and if the flag has text in it, the LinkTitle isn't updated by the picking, it stays as what the Editor has just entered.... but in Scenario B, it makes no difference, the LinkTitle text is filled in by the first picking of the content / media item, and if you pick an alternative one, it still updates the LinkTitle.

This is only catering for the specific annoyance of the journey of creating a new link and the editor carefully crafting their Link Title FIRST and then losing it when they pick, it isn't addressing what happens if somebody opens an excitingly picked link to edit it, picks something new and loses their Link Text - that is a different journey / issue, and is less frustrating than the one that occurs when you have 'just this moment' entered it...

... what do we think? lots of unintended consequences? or a tiny change that might help a proportion of editors in the short term.... ? 

Stop creating PRs with long descriptions like this it's a pain to have to read them all?

### How to test

#### Before the fix:
Create a  Doc Type with a Multi Url Picker
Create a Content Item based on this Doc Type
Add a link, write 'My lovely information about flowers' as the Link Title
Pick another Content Item or Media Item for the Link Url
Submit the overlay

You should find your LinkTitle is now set to whatever name is of the Media Item or Content Item you picked.

#### After the fix:
Add a link, write 'My lovely information about flowers' as the Link Title
Pick another Content Item or Media Item for the Link Url
Submit the overlay

Your LinkTitle should stay as 'My lovely information about flowers'

Should also verify, if you don't specify a Link TItle, and pick a content and media item, the name of these items are used as the LinkText, and picking something else, will update the LinkTitle

Also verify, if you add some text for the LinkTitle, and then pick a content or media item, and the link title doesn't change, that if you then go into the LinkTitle and delete the contents, and pick another Media or Content item that the text does update to be the name of the item picked....

 Thanks for considering this contribution to Umbraco CMS! 

(also appreciate the variables are named a bit silly, but it's more to explain the change...)