### PR TITLE
Added word-wrap so block item doesn't extend over the whole line

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.less
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card.less
@@ -104,6 +104,7 @@ umb-block-card {
             font-size: 14px;
             color: @ui-action-type;
             margin: 0 16px -1px;
+            word-wrap: break-word;
         }
         .__subname {
             color: @gray-4;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: fixes one of the issues in #15011

### Description

Stops long names extending across the whole line in block items. 

Steps to replicate:

1. Create a block list editor
2. Add a block with a long name such as "Rich Text Editor with a VERYLONGNAMEVERYLONGNAMEVERYLONGNAMEVERYLONGNAMEVERYLONGNAMEVERYLONGNAMEVERYLONGNAMEVERYLONGNAMEVERYLONGNAMEVERYLONGNAMEVERYLONGNAMEVERYLONGNAMEVERYLONGNAMEVERYLONGNAMEVERYLONGNAME"
3. Save and observe the effect of the long non-breaking line of text

Before:

![image](https://github.com/umbraco/Umbraco-CMS/assets/1649855/2816d7f9-d3ed-4c0b-bae7-1fed6d5be99e)

After:


![image](https://github.com/umbraco/Umbraco-CMS/assets/1649855/cd029006-7ab5-458f-ae15-209fe37b2dec)


<!-- Thanks for contributing to Umbraco CMS! -->
