### PR TITLE
Fixed warning SA1116 for Umbraco.Cms.Api.Delivery project

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Querying/QueryOptionBase.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Querying/QueryOptionBase.cs
@@ -10,7 +10,8 @@ public abstract class QueryOptionBase
     private readonly IPublishedSnapshotAccessor _publishedSnapshotAccessor;
     private readonly IRequestRoutingService _requestRoutingService;
 
-    public QueryOptionBase(IPublishedSnapshotAccessor publishedSnapshotAccessor,
+    public QueryOptionBase(
+        IPublishedSnapshotAccessor publishedSnapshotAccessor,
         IRequestRoutingService requestRoutingService)
     {
         _publishedSnapshotAccessor = publishedSnapshotAccessor;


### PR DESCRIPTION
Fixed StyleCop warning [SA1116](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1116.md) (_The parameters should begin on the line after the declaration..._) for `Umbraco.Cms.Api.Delivery` project, and no warnings show up in that project now.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: part of my issue #15015

### Description

Start of removal of warnings per project