### PR TITLE
Bug fix for compistion on member and media give 404

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -518,8 +518,18 @@
                         editorService.close();
                     }
                 };
-                editorService.documentTypeEditor(editor);
 
+                switch (scope.contentType) {
+                    case "documentType":
+                        editorService.documentTypeEditor(editor);
+                        break;
+                    case "mediaType":
+                        editorService.mediaTypeEditor(editor);
+                        break;
+                    case "memberType":
+                        editorService.memberTypeEditor(editor);
+                        break;
+                }
             };
 
             /* ---------- TABS ---------- */


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->
https://github.com/umbraco/Umbraco-CMS/issues/15009

### Description
1) add a new media type or member type
2) go to exiting media type or member type
3) Add the created media type og member from step 1 as a compisition
4) save the type
5) Click on the inhrite link, and see the composition media type or member type open as expteced instead of throw 404

The solution is simple and work without any compromise made, the code is taken from what is allerede done, in the code here:
https://github.com/umbraco/Umbraco-CMS/blob/f8b66aaf507ae575bce0fb85ee55dbab38fb15f8/src/Umbraco.Web.UI.Client/src/views/dataTypes/views/datatype.info.controller.js#L74
