### PR TITLE
Fixed warning SA1119 for Umbraco.Web.UI project

### DIFF
--- a/src/Umbraco.Web.UI/Startup.cs
+++ b/src/Umbraco.Web.UI/Startup.cs
@@ -48,7 +48,7 @@ namespace Umbraco.Cms.Web.UI
             {
                 app.UseDeveloperExceptionPage();
             }
-#if (UseHttpsRedirect)
+#if UseHttpsRedirect
 
             app.UseHttpsRedirection();
 #endif


### PR DESCRIPTION
Fixed warning SA1119 for Umbraco.Web.UI project

Fixed StyleCop warning [SA1119](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md) (_unnecessary parenthesis_) for `Umbraco.Web.UI` project, and no warnings show up in that project now.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: part of my issue #15015

### Description

Continuation of removal of warnings per project.

I have tested that setting `UseHttps:true` means I cannot access the Umbraco backoffice over http (vs being allowed on https).

### Question

As an aside, where does this `UseHttpsRedirect` come from in the code? I know it lets us call `app.UseHttpsRedirection();` but I can't find a reference to it in the solution.