### PR TITLE
Cleaned up V14 TODOs from ContentApiItemControllerBase

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Controllers/Content/ContentApiItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/Content/ContentApiItemControllerBase.cs
@@ -1,35 +1,18 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.DeliveryApi;
-using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Security;
-using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Delivery.Controllers.Content;
 
 public abstract class ContentApiItemControllerBase : ContentApiControllerBase
 {
-    // TODO: Remove this in V14 when the obsolete constructors have been removed
-    private readonly IPublicAccessService _publicAccessService;
-
-    [Obsolete($"Please use the constructor that does not accept {nameof(IPublicAccessService)}. Will be removed in V14.")]
-    protected ContentApiItemControllerBase(
-        IApiPublishedContentCache apiPublishedContentCache,
-        IApiContentResponseBuilder apiContentResponseBuilder,
-        IPublicAccessService publicAccessService)
-        : this(apiPublishedContentCache, apiContentResponseBuilder)
-    {
-    }
-
     protected ContentApiItemControllerBase(
         IApiPublishedContentCache apiPublishedContentCache,
         IApiContentResponseBuilder apiContentResponseBuilder)
         : base(apiPublishedContentCache, apiContentResponseBuilder)
-        => _publicAccessService = StaticServiceProvider.Instance.GetRequiredService<IPublicAccessService>();
-
-    [Obsolete($"Please use {nameof(IPublicAccessService)} to test for content protection. Will be removed in V14.")]
-    protected bool IsProtected(IPublishedContent content) => _publicAccessService.IsProtected(content.Path);
+    {
+    }
 
     protected async Task<IActionResult?> HandleMemberAccessAsync(IPublishedContent contentItem, IRequestMemberAccessService requestMemberAccessService)
     {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When implementing member auth in the V14 branch, a few things were marked for V14 obsoletion in `ContentApiItemControllerBase`, but they were not removed from the source. This was in order to make the backport and subsequent forward merge less conflicting. 

Now that the backport and forward merge is done, this PR removes the obsoleted parts of `ContentApiItemControllerBase`.