### PR TITLE
Dont explicitly index nested property by default

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/IndexingSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/IndexingSettings.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Core.Configuration.Models;
 [UmbracoOptions(Constants.Configuration.ConfigIndexing)]
 public class IndexingSettings
 {
-    private const bool StaticExplicitlyIndexEachNestedProperty = true;
+    private const bool StaticExplicitlyIndexEachNestedProperty = false;
 
     /// <summary>
     /// Gets or sets a value for whether each nested property should have it's own indexed value. Requires a rebuild of indexes when changed.


### PR DESCRIPTION
# Notes
- Inverts the default setting of `ExplicitlyIndexEachNestedProperty`

# How to test
- Create an element, with a textstring property "Title", and textarea property named "Body"
- Create a documenttype, with a blocklist using the element you just created
- Create some content (including creating 1 or more blocks)
- Navigate to Examine Management dashboard (Settings -> Examine management)
- Go to the external index, and search the name of the content you just created
- It should no longer index the individual blocks
- Here is a screenshot of how it looks when it indexes the individual blocks:
![image](https://github.com/umbraco/Umbraco-CMS/assets/70372949/91ed3428-6f21-4c98-b041-6a9bea77a33d)
