### PR TITLE
V14: Add CORS in DEBUG mode

### DIFF
--- a/src/Umbraco.Web.BackOffice/Extensions/UmbracoApplicationBuilder.BackOffice.cs
+++ b/src/Umbraco.Web.BackOffice/Extensions/UmbracoApplicationBuilder.BackOffice.cs
@@ -53,4 +53,35 @@ public static partial class UmbracoApplicationBuilderExtensions
 
         return app;
     }
+
+    /// <summary>
+    ///     Adds CORS middleware to the pipeline for the BackOffice.
+    ///     This is useful if you are running the BackOffice on a different port than the backend server.
+    /// </summary>
+    /// <param name="app"></param>
+    /// <param name="origins">
+    ///     A list of allowed fully-qualified hostnames that should be whitelisted.
+    ///     If this is omitted, all origins will be allowed, which will not work with credentials.
+    /// </param>
+    /// <returns></returns>
+    public static IApplicationBuilder UseBackOfficeCors(
+        this IApplicationBuilder app, params string[] origins)
+    {
+        app.UseCors(u =>
+        {
+            u.AllowCredentials();
+            u.AllowAnyMethod();
+            u.AllowAnyHeader();
+            u.WithExposedHeaders("Location");
+            if (origins.Length > 0)
+            {
+                u.WithOrigins(origins);
+            }
+            else
+            {
+                u.AllowAnyOrigin();
+            }
+        });
+        return app;
+    }
 }

--- a/src/Umbraco.Web.UI.New/Program.cs
+++ b/src/Umbraco.Web.UI.New/Program.cs
@@ -11,6 +11,14 @@ WebApplication app = builder.Build();
 
 await app.BootUmbracoAsync();
 
+#if DEBUG
+if (app.Environment.IsDevelopment())
+{
+    Console.WriteLine(@"Enabling CORS in development mode");
+    app.UseBackOfficeCors("http://127.0.0.1:5173", "http://localhost:5173", "https://127.0.0.1:5173", "https://localhost:5173");
+}
+#endif
+
 #if (UseHttpsRedirect)
 app.UseHttpsRedirection();
 #endif


### PR DESCRIPTION
This adds an IApplicationBuilder extension which can be used to add relevant CORS headers to connect a Backoffice client from another server. We also want to add certain hosts used locally for Vite's dev-server only in DEBUG mode in Program.cs of the new Backoffice executable.

This was initially introduced in the old Startup.cs file and later removed in commit 463068c07b3ef7c14302d5eaa09c298b4fac8ca6. This PR essentially reintroduces the concept as it was but allows external developers to use it with their own hostnames as well.