### PR TITLE
Bugfix: UI for preview bug related to single language & non variant content

### DIFF
--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -39,7 +39,7 @@
         "ng-file-upload": "12.2.13",
         "nouislider": "15.7.1",
         "spectrum-colorpicker2": "2.0.10",
-        "tinymce": "6.7.0",
+        "tinymce": "6.7.1",
         "typeahead.js": "0.11.1",
         "underscore": "1.13.6",
         "wicg-inert": "3.1.2"
@@ -16518,9 +16518,9 @@
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "node_modules/tinymce": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.7.0.tgz",
-      "integrity": "sha512-Wf2RSobIXQ7XNw3/v4z1lPGiH3Pjsmc/6/7fG28aIS6uVWj/7IhvOPuwfJJDeOx0o0D3nSnoLHgR2KU8JAdE+w=="
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.7.1.tgz",
+      "integrity": "sha512-SIGJgWk2d/X59VbO+i81QfNx2EP1P5t+sza2/1So3OLGtmMBhEJMag7sN/Mo8sq4s0niwb65Z51yLju32jP11g=="
     },
     "node_modules/to-absolute-glob": {
       "version": "2.0.2",

--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -51,7 +51,7 @@
     "ng-file-upload": "12.2.13",
     "nouislider": "15.7.1",
     "spectrum-colorpicker2": "2.0.10",
-    "tinymce": "6.7.0",
+    "tinymce": "6.7.1",
     "typeahead.js": "0.11.1",
     "underscore": "1.13.6",
     "wicg-inert": "3.1.2"

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -35,15 +35,18 @@
         $scope.activeApp = null;
 
         //initializes any watches
-        function startWatches(content) {
+        var watchers = [];
 
-            $scope.$watchGroup(['culture', 'segment'],
+        function startWatches(content) {
+            clearWatchers();
+
+            watchers.push($scope.$watchGroup(['culture', 'segment'],
             function (value, oldValue) {
                 createPreviewButton($scope.content, value[0], value[1]);
-            });
+            }));
 
             //watch for changes to isNew, set the page.isNew accordingly and load the breadcrumb if we can
-            $scope.$watch('isNew', function (newVal, oldVal) {
+            watchers.push($scope.$watch('isNew', function (newVal, oldVal) {
 
                 $scope.page.isNew = Object.toBoolean(newVal);
 
@@ -59,8 +62,12 @@
                             });
                     }
                 }
-            });
+            }));
+        }
 
+        function clearWatchers () {
+            watchers.forEach(w => w());
+            watchers = [];
         }
 
         //this initializes the editor with the data which will be called more than once if the data is re-loaded
@@ -109,6 +116,7 @@
             bindEvents();
 
             resetVariantFlags();
+            startWatches($scope.content);
         }
 
         function loadBreadcrumb() {
@@ -241,7 +249,6 @@
 
                     appendRuntimeData();
                     init();
-                    startWatches($scope.content);
 
                     syncTreeNode($scope.content, $scope.content.path, true);
 
@@ -265,7 +272,6 @@
 
                     appendRuntimeData();
                     init();
-                    startWatches($scope.content);
 
                     resetLastListPageNumber($scope.content);
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -352,7 +352,10 @@
                 labelKey: "buttons_saveAndPreview"
             };
 
-            const activeVariant = content.variants?.find((variant) => content.documentType?.variations === "Nothing" || variant.compositeId === compositeId);
+            let activeVariant = content.variants?.find((variant) => content.documentType?.variations === "Nothing" || variant.compositeId === compositeId);
+            /* if we can't find the active variant and there is only one variant available, we will use that.
+            this happens if we have a node that can vary by culture but there is only one language available. */
+            activeVariant = !activeVariant && content.variants.length === 1 ? content.variants[0] : activeVariant;
 
             $scope.previewSubButtons = activeVariant?.additionalPreviewUrls?.map((additionalPreviewUrl) => {
                 return {

--- a/templates/Umbraco.Templates.csproj
+++ b/templates/Umbraco.Templates.csproj
@@ -52,7 +52,7 @@
   <ItemGroup>
     <Content Update="**\.template.config\template.json" Pack="false" />
   </ItemGroup>
-  <Target Name="GetUpdatedTemplateJsonPackageFiles" BeforeTargets="GenerateNuspec" AfterTargets="GetBuildVersion;GetUmbracoBuildVersion">
+  <Target Name="GetUpdatedTemplateJsonPackageFiles" BeforeTargets="GenerateNuspec" AfterTargets="GetUmbracoBuildVersion">
     <ItemGroup>
       <_TemplateJsonFiles Include="**\.template.config\template.json" Exclude="bin\**;obj\**" />
       <_TemplateJsonFiles>


### PR DESCRIPTION
**How to reproduce:**

- Enable the delivery API - set `Umbraco:CMS:DeliveryApi:Enabled` to `true` in appsettings.json
- Use the code from a new PR with a partial UI fix https://github.com/umbraco/Umbraco-CMS/pull/14995 or use the examples from the docs: https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/additional-preview-environments-support#configuring-custom-preview-urls
- Have a single language & non-variant content
- Make the content type vary by culture
- Visit the content node & you will see that the button group for previewing additional Preview URLs is not there. We just have the regular "Save and preview" button.
Another issue related to this (continue from the preview steps...):
- Add a new language
- In the Content section - try to create a new content node in the new language
- Without inputting any info, the default buttons we get are "Save and preview", "Save" and "Save and publish" - we are missing the button group here as well


**What to test:**
* Make sure that the additional preview URLs are shown when a document is published.

