### PR TITLE
Add contentTypeEditor to editorService

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -509,6 +509,7 @@
             scope.openContentType = (contentTypeId) => {
                 const editor = {
                     id: contentTypeId,
+                    entityType: scope.contentType,
                     submit: () => {
                         const args = { node: scope.model };
                         eventsService.emit("editors.documentType.reload", args);
@@ -519,7 +520,7 @@
                     }
                 };
 
-                editorService.contentTypeEditor(editor, scope.contentType);
+                editorService.contentTypeEditor(editor);
             };
 
             /* ---------- TABS ---------- */

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js
@@ -519,17 +519,7 @@
                     }
                 };
 
-                switch (scope.contentType) {
-                    case "documentType":
-                        editorService.documentTypeEditor(editor);
-                        break;
-                    case "mediaType":
-                        editorService.mediaTypeEditor(editor);
-                        break;
-                    case "memberType":
-                        editorService.memberTypeEditor(editor);
-                        break;
-                }
+                editorService.contentTypeEditor(editor, scope.contentType);
             };
 
             /* ---------- TABS ---------- */

--- a/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
@@ -637,6 +637,35 @@ When building a custom infinite editor view you can use the same components as a
 
     /**
      * @ngdoc method
+     * @name umbraco.services.editorService#contentTypeEditor
+     * @methodOf umbraco.services.editorService
+     *
+     * @description
+     * Opens the content type editor in infinite editing, the submit callback returns the alias of the saved content type.
+     *
+     * @param {object} editor rendering options.
+     * @param {number} editor.id Indicates the ID of the content type to be edited. Alternatively the ID may be set to `-1` in combination with `create` being set to `true` to open the content type editor for creating a new content type.
+     * @param {boolean} editor.create Set to `true` to open the content type editor for creating a new content type.
+     * @param {function} editor.submit Callback function when the submit button is clicked. Returns the editor model object.
+     * @param {function} editor.close Callback function when the close button is clicked.
+     * @returns {object} editor object.
+     */
+    function contentTypeEditor(editor, type) {
+      switch (type) {
+        case "documentType":
+          documentTypeEditor(editor);
+          break;
+        case "mediaType":
+          mediaTypeEditor(editor);
+          break;
+        case "memberType":
+          memberTypeEditor(editor);
+          break;
+      }
+    }
+
+    /**
+     * @ngdoc method
      * @name umbraco.services.editorService#documentTypeEditor
      * @methodOf umbraco.services.editorService
      *
@@ -1158,6 +1187,7 @@ When building a custom infinite editor view you can use the same components as a
       linkPicker: linkPicker,
       mediaPicker: mediaPicker,
       iconPicker: iconPicker,
+      contentTypeEditor: contentTypeEditor,
       documentTypeEditor: documentTypeEditor,
       mediaTypeEditor: mediaTypeEditor,
       memberTypeEditor: memberTypeEditor,

--- a/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
@@ -644,14 +644,18 @@ When building a custom infinite editor view you can use the same components as a
      * Opens the content type editor in infinite editing, the submit callback returns the alias of the saved content type.
      *
      * @param {object} editor rendering options.
+     * @param {string} editor.entityType Entity type to open - default document type.
      * @param {number} editor.id Indicates the ID of the content type to be edited. Alternatively the ID may be set to `-1` in combination with `create` being set to `true` to open the content type editor for creating a new content type.
      * @param {boolean} editor.create Set to `true` to open the content type editor for creating a new content type.
      * @param {function} editor.submit Callback function when the submit button is clicked. Returns the editor model object.
      * @param {function} editor.close Callback function when the close button is clicked.
      * @returns {object} editor object.
      */
-    function contentTypeEditor(editor, type) {
-      switch (type) {
+    function contentTypeEditor(editor) {
+
+      if (!editor.entityType) editor.entityType = "documentType";
+
+      switch (editor.entityType) {
         case "documentType":
           documentTypeEditor(editor);
           break;

--- a/src/Umbraco.Web.UI.Client/src/views/dataTypes/views/datatype.info.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dataTypes/views/datatype.info.controller.js
@@ -71,17 +71,7 @@ function DataTypeInfoController($scope, $routeParams, dataTypeResource, $timeout
             }
         };
 
-        switch (type) {
-            case "documentType":
-                editorService.documentTypeEditor(editor);
-                break;
-            case "mediaType":
-                editorService.mediaTypeEditor(editor);
-                break;
-            case "memberType":
-                editorService.memberTypeEditor(editor);
-                break;
-        }
+        editorService.contentTypeEditor(editor, type);
     }
 
     loadRelations();

--- a/src/Umbraco.Web.UI.Client/src/views/dataTypes/views/datatype.info.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dataTypes/views/datatype.info.controller.js
@@ -60,6 +60,7 @@ function DataTypeInfoController($scope, $routeParams, dataTypeResource, $timeout
 
         const editor = {
             id: id,
+            entityType: type,
             submit: function (model) {
                 editorService.close();
                 vm.view.loading = true;
@@ -71,7 +72,7 @@ function DataTypeInfoController($scope, $routeParams, dataTypeResource, $timeout
             }
         };
 
-        editorService.contentTypeEditor(editor, type);
+        editorService.contentTypeEditor(editor);
     }
 
     loadRelations();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below


### Description
Follow-up on https://github.com/umbraco/Umbraco-CMS/pull/15017 to make it a bit simple to open content type editor and reduce some of the same logic based on content type.

I think it could also be useful to (package) developers.

Relates to https://github.com/umbraco/Umbraco-CMS/pull/15080