### PR TITLE
Check content permissions before performing action

### DIFF
--- a/src/Umbraco.Core/Security/ContentPermissions.cs
+++ b/src/Umbraco.Core/Security/ContentPermissions.cs
@@ -201,7 +201,8 @@ public class ContentPermissions
         }
 
         // get the implicit/inherited permissions for the user for this path
-        return CheckPermissionsPath(entity?.Path, user, permissionsToCheck)
+        // if there is no entity for this id, than just use the id as the path (i.e. -1 or -20)
+        return CheckPermissionsPath(entity?.Path ?? nodeId.ToString(), user, permissionsToCheck)
             ? ContentAccess.Granted
             : ContentAccess.Denied;
     }
@@ -262,7 +263,8 @@ public class ContentPermissions
         }
 
         // get the implicit/inherited permissions for the user for this path
-        return CheckPermissionsPath(contentItem?.Path, user, permissionsToCheck)
+        // if there is no content item for this id, than just use the id as the path (i.e. -1 or -20)
+        return CheckPermissionsPath(contentItem?.Path ?? nodeId.ToString(), user, permissionsToCheck)
             ? ContentAccess.Granted
             : ContentAccess.Denied;
     }
@@ -274,8 +276,7 @@ public class ContentPermissions
             permissionsToCheck = Array.Empty<char>();
         }
 
-        // get the implicit/inherited permissions for the user for this path,
-        // if there is no content item for this id, than just use the id as the path (i.e. -1 or -20)
+        // get the implicit/inherited permissions for the user for this path
         EntityPermissionSet permission = _userService.GetPermissionsForPath(user, path);
 
         var allowed = true;

--- a/src/Umbraco.Core/Security/ContentPermissions.cs
+++ b/src/Umbraco.Core/Security/ContentPermissions.cs
@@ -167,12 +167,7 @@ public class ContentPermissions
             throw new ArgumentNullException(nameof(user));
         }
 
-        if (permissionsToCheck == null)
-        {
-            permissionsToCheck = Array.Empty<char>();
-        }
-
-        bool? hasPathAccess = null;
+        bool hasPathAccess;
         entity = null;
 
         if (nodeId == Constants.System.Root)
@@ -183,19 +178,17 @@ public class ContentPermissions
         {
             hasPathAccess = user.HasContentBinAccess(_entityService, _appCaches);
         }
-
-        if (hasPathAccess.HasValue)
+        else
         {
-            return hasPathAccess.Value ? ContentAccess.Granted : ContentAccess.Denied;
-        }
+            entity = _entityService.Get(nodeId, UmbracoObjectTypes.Document);
 
-        entity = _entityService.Get(nodeId, UmbracoObjectTypes.Document);
-        if (entity == null)
-        {
-            return ContentAccess.NotFound;
-        }
+            if (entity == null)
+            {
+                return ContentAccess.NotFound;
+            }
 
-        hasPathAccess = user.HasContentPathAccess(entity, _entityService, _appCaches);
+            hasPathAccess = user.HasContentPathAccess(entity, _entityService, _appCaches);
+        }
 
         if (hasPathAccess == false)
         {
@@ -208,7 +201,7 @@ public class ContentPermissions
         }
 
         // get the implicit/inherited permissions for the user for this path
-        return CheckPermissionsPath(entity.Path, user, permissionsToCheck)
+        return CheckPermissionsPath(entity?.Path, user, permissionsToCheck)
             ? ContentAccess.Granted
             : ContentAccess.Denied;
     }
@@ -235,12 +228,7 @@ public class ContentPermissions
             throw new ArgumentNullException(nameof(user));
         }
 
-        if (permissionsToCheck == null)
-        {
-            permissionsToCheck = Array.Empty<char>();
-        }
-
-        bool? hasPathAccess = null;
+        bool hasPathAccess;
         contentItem = null;
 
         if (nodeId == Constants.System.Root)
@@ -251,19 +239,17 @@ public class ContentPermissions
         {
             hasPathAccess = user.HasContentBinAccess(_entityService, _appCaches);
         }
-
-        if (hasPathAccess.HasValue)
+        else
         {
-            return hasPathAccess.Value ? ContentAccess.Granted : ContentAccess.Denied;
-        }
+            contentItem = _contentService.GetById(nodeId);
 
-        contentItem = _contentService.GetById(nodeId);
-        if (contentItem == null)
-        {
-            return ContentAccess.NotFound;
-        }
+            if (contentItem == null)
+            {
+                return ContentAccess.NotFound;
+            }
 
-        hasPathAccess = user.HasPathAccess(contentItem, _entityService, _appCaches);
+            hasPathAccess = user.HasPathAccess(contentItem, _entityService, _appCaches);
+        }
 
         if (hasPathAccess == false)
         {
@@ -276,7 +262,7 @@ public class ContentPermissions
         }
 
         // get the implicit/inherited permissions for the user for this path
-        return CheckPermissionsPath(contentItem.Path, user, permissionsToCheck)
+        return CheckPermissionsPath(contentItem?.Path, user, permissionsToCheck)
             ? ContentAccess.Granted
             : ContentAccess.Denied;
     }

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
@@ -759,6 +759,7 @@ public class ContentController : ContentControllerBase
 
         return pagedResult;
     }
+
     /// <summary>
     ///     Creates a blueprint from a content item
     /// </summary>
@@ -1057,7 +1058,7 @@ public class ContentController : ContentControllerBase
                 AddDomainWarnings(publishStatus.Content, successfulCultures, globalNotifications);
                 AddPublishStatusNotifications(new[] { publishStatus }, globalNotifications, notifications, successfulCultures);
             }
-            break;
+                break;
             case ContentSaveAction.PublishWithDescendants:
             case ContentSaveAction.PublishWithDescendantsNew:
             {
@@ -1074,7 +1075,7 @@ public class ContentController : ContentControllerBase
                 AddDomainWarnings(publishStatus, successfulCultures, globalNotifications);
                 AddPublishStatusNotifications(publishStatus, globalNotifications, notifications, successfulCultures);
             }
-            break;
+                break;
             case ContentSaveAction.PublishWithDescendantsForce:
             case ContentSaveAction.PublishWithDescendantsForceNew:
             {
@@ -1090,7 +1091,7 @@ public class ContentController : ContentControllerBase
                 var publishStatus = PublishBranchInternal(contentItem, true, cultureForInvariantErrors, out wasCancelled, out var successfulCultures).ToList();
                 AddPublishStatusNotifications(publishStatus, globalNotifications, notifications, successfulCultures);
             }
-            break;
+                break;
             default:
                 throw new ArgumentOutOfRangeException();
         }
@@ -2745,7 +2746,7 @@ public class ContentController : ContentControllerBase
                         }
                     }
                 }
-                break;
+                    break;
                 case PublishResultType.SuccessPublish:
                 {
                     // TODO: Here we should have messaging for when there are release dates specified like https://github.com/umbraco/Umbraco-CMS/pull/3507
@@ -2773,7 +2774,7 @@ public class ContentController : ContentControllerBase
                         }
                     }
                 }
-                break;
+                    break;
                 case PublishResultType.FailedPublishPathNotPublished:
                 {
                     //TODO: This doesn't take into account variations with the successfulCultures param
@@ -2782,14 +2783,14 @@ public class ContentController : ContentControllerBase
                         _localizedTextService.Localize(null, "publish"),
                         _localizedTextService.Localize("publish", "contentPublishedFailedByParent", new[] { names }).Trim());
                 }
-                break;
+                    break;
                 case PublishResultType.FailedPublishCancelledByEvent:
                 {
                     //TODO: This doesn't take into account variations with the successfulCultures param
                     var names = string.Join(", ", status.Select(x => $"'{x.Content?.Name}'"));
                     AddCancelMessage(display, "publish", "contentPublishedFailedByEvent", new[] { names });
                 }
-                break;
+                    break;
                 case PublishResultType.FailedPublishAwaitingRelease:
                 {
                     //TODO: This doesn't take into account variations with the successfulCultures param
@@ -2798,7 +2799,7 @@ public class ContentController : ContentControllerBase
                         _localizedTextService.Localize(null, "publish"),
                         _localizedTextService.Localize("publish", "contentPublishedFailedAwaitingRelease", new[] { names }).Trim());
                 }
-                break;
+                    break;
                 case PublishResultType.FailedPublishHasExpired:
                 {
                     //TODO: This doesn't take into account variations with the successfulCultures param
@@ -2807,7 +2808,7 @@ public class ContentController : ContentControllerBase
                         _localizedTextService.Localize(null, "publish"),
                         _localizedTextService.Localize("publish", "contentPublishedFailedExpired", new[] { names }).Trim());
                 }
-                break;
+                    break;
                 case PublishResultType.FailedPublishIsTrashed:
                 {
                     //TODO: This doesn't take into account variations with the successfulCultures param
@@ -2816,7 +2817,7 @@ public class ContentController : ContentControllerBase
                         _localizedTextService.Localize(null, "publish"),
                         _localizedTextService.Localize("publish", "contentPublishedFailedIsTrashed", new[] { names }).Trim());
                 }
-                break;
+                    break;
                 case PublishResultType.FailedPublishContentInvalid:
                 {
                     if (successfulCultures == null)
@@ -2840,7 +2841,7 @@ public class ContentController : ContentControllerBase
                         }
                     }
                 }
-                break;
+                    break;
                 case PublishResultType.FailedPublishMandatoryCultureMissing:
                     display.AddWarningNotification(
                         _localizedTextService.Localize(null, "publish"),

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentControllerBase.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentControllerBase.cs
@@ -79,7 +79,6 @@ public abstract class ContentControllerBase : BackOfficeNotificationsController
         ModelState.AddModelError("id", $"content with id: {id} was not found");
         NotFoundObjectResult errorResponse = NotFound(ModelState);
 
-
         return errorResponse;
     }
 

--- a/src/Umbraco.Web.BackOffice/Filters/ContentSaveValidationAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/ContentSaveValidationAttribute.cs
@@ -278,6 +278,7 @@ internal sealed class ContentSaveValidationAttribute : TypeFilterAttribute
 
             if (!authorizationResult.Succeeded)
             {
+                actionContext.Result = new ForbidResult();
                 return false;
             }
 


### PR DESCRIPTION
## Details
- When `[ContentSaveValidation]` attribute was applied and the authorization wasn't successful - we were not setting the action result which led to executing the next action even though the user doesn't have the necessary permissions;
- When checking the content permissions of a **newly created** content node, we were not taking into account the permissions to check;
- Both are fixed in this PR.

## Test
- Make a document type with a property like the RTE or similar. Allow it to be created as a root node;
- Make some test content using the document type you just created and publish it;
- Invite a user and give them either the "Writer" group or any other group without permission to publish nodes;
- Open the Network tab and check the following POST request:
  - Have the new user make some changes to your content node and "Send for approval".
- Copy the Request Body and construct the following Request in Postman:
```http
POST https://localhost:44331/umbraco/backoffice/umbracoapi/content/PostSave
X-UMB-XSRF-TOKEN: <value>
```
  - Make sure that you add `UMB_UCONTEXT` and `UMB-XSRF-V` as **cookies** with their values to your request;
  - Paste the Request Body that you've copied and apply it to the request in a `form-data` format, like:
    - Key: `contentItem`;
    - Value: `<copied JSON here>`;
      - Ex:
```JSON
{
   "id":1064,
   "contentTypeAlias":"contentPage",
   "parentId":1057,
   "action":"sendPublish",
   "variants":[
      {
         "name":"Pretty nice page hehe",
         "properties":[
            {
               "id":10,
               "alias":"mainContent",
               "value":"<p>Let's try with an already published page</p>"
            }
         ],
         "culture":null,
         "segment":null,
         "publish":false,
         "save":true,
         "releaseDate":null,
         "expireDate":null
      }
   ],
   "expireDate":null,
   "releaseDate":null,
   "templateAlias":"ContentPage"
}
``` 
  - Test the request by modifying the text in the RTE property in the Request payload & verifying the changes in the BO (_you can also check the History in Info tab if it registered another "Send to Publish" action_)
  - Modify the request body's `"action"` property from `"sendPublish"` to `"publish"` and execute the POST request again;
    - You will get 200 OK without the changes taking effect:
      - Check RTE content and content node's History.
  - In the BO, try creating a new node and copy the Request Body and test it in Postman in the same way:
    - Try with `"publishNew"` as the `"action"` value;
    - You will get 200 OK without the changes taking effect:
      - Check RTE content and content node's History.
 - Try to click around in the Content section - creating/deleting/modifying nodes as different users (from different user groups);
   - Functionality should be as before. 

