### PR TITLE
Updated project template.json to check for required unattended user details 

### DIFF
--- a/templates/UmbracoProject/.template.config/template.json
+++ b/templates/UmbracoProject/.template.config/template.json
@@ -114,7 +114,7 @@
     },
     "DevelopmentDatabaseType": {
       "displayName": "Development database type",
-      "description": "Database type used by Umbraco for development.",
+      "description": "Database type used by Umbraco for development. If a development database type is configured, a unattended user name, email and password is required.",
       "type": "parameter",
       "datatype": "choice",
       "choices": [
@@ -143,12 +143,16 @@
       "parameters": {
         "cases": [
           {
-            "condition": "(DevelopmentDatabaseType == 'SQLite')",
+            "condition": "(DevelopmentDatabaseType == 'SQLite' && UnattendedUserName != '' && UnattendedUserEmail != '' && UnattendedUserPassword != '')",
             "value": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True"
           },
           {
-            "condition": "(DevelopmentDatabaseType == 'LocalDB')",
+            "condition": "(DevelopmentDatabaseType == 'LocalDB' && UnattendedUserName != '' && UnattendedUserEmail != '' && UnattendedUserPassword != '')",
             "value": "Data Source=(localdb)\\\\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\\\\Umbraco.mdf;Integrated Security=True"
+          },
+          {
+            "condition": "(DevelopmentDatabaseType != 'None' && (UnattendedUserName == '' || UnattendedUserEmail == '' || UnattendedUserPassword == ''))",
+            "value": ""
           }
         ]
       },
@@ -179,6 +183,7 @@
     "UnattendedUserName": {
       "displayName": "Unattended user name",
       "description": "Used to specify the name of the default admin user when using unattended install on development (stored as plain text).",
+      "isRequired": "DevelopmentDatabaseType != 'None'",
       "type": "parameter",
       "datatype": "string",
       "defaultValue": "",
@@ -192,6 +197,7 @@
     "UnattendedUserEmail": {
       "displayName": "Unattended user email",
       "description": "Used to specify the email of the default admin user when using unattended install on development (stored as plain text).",
+      "isRequired": "DevelopmentDatabaseType != 'None'",
       "type": "parameter",
       "datatype": "string",
       "defaultValue": "",
@@ -205,6 +211,7 @@
     "UnattendedUserPassword": {
       "displayName": "Unattended user password",
       "description": "Used to specify the password of the default admin user when using unattended install on development (stored as plain text).",
+      "isRequired": "DevelopmentDatabaseType != 'None'",
       "type": "parameter",
       "datatype": "string",
       "defaultValue": "",


### PR DESCRIPTION
Fixes this issue  #14956

Updated our project template file to check if unattended user details are defined when configuring a development database type. If not, the development database type is gonna be ignored.

### Test cases: 
You will need to install the local template for this PR to be able to test this. Follow these steps:
1. Run this command at the root of your project `dotnet pack -o {FULL_PATH_TO_FOLDER}\nupkg`
2. Open a terminal and change the location to `{FULL_PATH_TO_FOLDER}\nupkg`
3. In your `{FULL_PATH_TO_FOLDER}\nupkg` folder, you should have a file called `Umbraco.Templates.{SOME_VERSION}.nupkg`  Copy the whole filename
4. In your terminal write the command `dotnet new install Umbraco.Templates.{SOME_VERSION}.nupkg`

The local template should now be installed and be ready to test!

Time to test:
- Use a terminal to install Umbraco with a name and a development database Type configured
  - You should get a message about missing mandatory options in the console. 
-  Use a terminal to install Umbraco with a name, development database Type, UnattendedUserName, UnattenderEmail, and an 
    UnattendedPassword configured
   - Umbraco should be successfully installed with unattended install
- Try different install scenarios to see if anything isn't working as intended, you can try installing through Visual Studio.