### PR TITLE
Added new IsEnumerableEmpty() extension method and updated IsCollectionEmpty()

### DIFF
--- a/src/Umbraco.Core/Extensions/EnumerableExtensions.cs
+++ b/src/Umbraco.Core/Extensions/EnumerableExtensions.cs
@@ -10,7 +10,15 @@ namespace Umbraco.Extensions;
 /// </summary>
 public static class EnumerableExtensions
 {
-    public static bool IsCollectionEmpty<T>(this IReadOnlyCollection<T>? list) => list == null || list.Count == 0;
+    /// <summary>
+    /// Determines whether the specified IReadOnlyCollection is null or empty.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the collection.</typeparam>
+    /// <param name="collection">The IReadOnlyCollection to check.</param>
+    /// <returns>
+    ///   <c>true</c> if the specified collection is null or empty; otherwise, <c>false</c>.
+    /// </returns>
+    public static bool IsCollectionEmpty<T>(this IReadOnlyCollection<T>? collection) => collection == null || collection.Count == 0;
 
     /// <summary>
     ///     Wraps this object instance into an IEnumerable{T} consisting of a single item.

--- a/src/Umbraco.Core/Extensions/EnumerableExtensions.cs
+++ b/src/Umbraco.Core/Extensions/EnumerableExtensions.cs
@@ -21,6 +21,16 @@ public static class EnumerableExtensions
     public static bool IsCollectionEmpty<T>(this IReadOnlyCollection<T>? collection) => collection == null || collection.Count == 0;
 
     /// <summary>
+    /// Determines whether the specified IEnumerable is null or has no elements.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the enumerable.</typeparam>
+    /// <param name="enumerable">The IEnumerable to check.</param>
+    /// <returns>
+    ///   <c>true</c> if the specified enumerable is null or has no elements; otherwise, <c>false</c>.
+    /// </returns>
+    public static bool IsEnumerableEmpty<T>(this IEnumerable<T>? enumerable) => enumerable == null || !enumerable.Any();
+
+    /// <summary>
     ///     Wraps this object instance into an IEnumerable{T} consisting of a single item.
     /// </summary>
     /// <typeparam name="T"> Type of the object. </typeparam>

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/EnumerableExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/EnumerableExtensionsTests.cs
@@ -166,4 +166,41 @@ public class EnumerableExtensionsTests
         iteratorSource = list.DistinctBy(x => x.Item2).ToArray();
         Assert.AreEqual(iteratorSource.Length, iteratorSource.ToList().Count);
     }
+
+    #region IsCollectionEmpty()
+    private static IEnumerable<IEnumerable<object>> IsCollectionEmptyTestCases()
+    {
+        yield return new object[] { null, true };
+        yield return new object[] { new List<int>(), true };
+        yield return new object[] { new List<int>() { 1, 2, 3, 4, 5, 6 }, false };
+    }
+
+    [TestCaseSource(nameof(IsCollectionEmptyTestCases))]
+    public void IsCollectionEmptyTests(IReadOnlyCollection<int>? collection, bool expectedResult)
+    {
+        bool result = collection.IsEnumerableEmpty();
+        Assert.AreEqual(expectedResult, result);
+    }
+    #endregion
+
+    #region IsEnumerableEmpty()
+    private static IEnumerable<IEnumerable<object>> IsEnumerableEmptyTestCases()
+    {
+        List<int> listOfIntegers = new List<int>() { 1, 2, 3, 4, 5, 6 };
+
+        IEnumerable<int> queryAbove6 = listOfIntegers.Where(x => x > 6);
+        IEnumerable<int> queryBelow4 = listOfIntegers.Where(x => x < 4);
+
+        yield return new object[] { null, true };
+        yield return new object[] { queryAbove6, true };
+        yield return new object[] { queryBelow4, false };
+    }
+
+    [TestCaseSource(nameof(IsEnumerableEmptyTestCases))]
+    public void IsEnumerableEmptyTests(IEnumerable<int>? enumerable, bool expectedResult)
+    {
+        bool result = enumerable.IsEnumerableEmpty();
+        Assert.AreEqual(expectedResult, result);
+    }
+    #endregion
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

`Umbraco.Extensions.EnumerableExtensions` changes.

#### `IsCollectionEmpty<T>()` Updates:

- Added summary, param and returns XML documentation to describe the purpose of the method.
- Renamed the parameter from list to collection for consistency and clarity.

#### `IsEnumerableEmpty<T>()` Addition:

- Introduced a new method, IsEnumerableEmpty, to check whether the specified IEnumerable is null or has no elements.
- Can be used to check if an enumerable is empty without having to convert to a collection first (i.e. ToList()). Useful within LINQ queries.

### Testing

Added unit tests at `Umbraco.Cms.Tests.UnitTests.Umbraco.Core.EnumerableExtensionsTests`. Each extension method includes 3 tests each to test null, empty and non-empty values.