### PR TITLE
Make clearer where to go to see build documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -27,7 +27,7 @@ The following steps are a quick-start guide:
 
 4. **Build**
 
-    Build your fork of Umbraco locally as described in the build documentation, you can [build with any IDE that support dotnet or the command line](BUILD.md).
+    Build your fork of Umbraco locally [as described in the build documentation](BUILD.md), (you can build with any IDE that supports dotnet or the command line.
 
 5. **Branch**
 


### PR DESCRIPTION
When I setup locally again after a long long while and read through the contributing page with freshish eyes, if my eyes can ever be described as fresh, god it's so hard to read cooking instructions on food packets these days...

... anyway when I read the sentence

Build your fork of Umbraco locally as described in the build documentation, you can [build with any IDE that support dotnet or the command line](https://github.com/umbraco/Umbraco-CMS/blob/634afc4b18d2b1bfd5fbe6de290c9790b2218074/.github/BUILD.md).

I immediately was like, yeah, but where on Earth IS this 'build documentation' why not link to it FFS... and then I saw BUILD.MD in the repo, and thought ahh, I bet that's it...

So this is me coming back to add the link to the build documentation for when the text says 'as described in the build documentation' as that is what I was expecting to be a link...

only now do I realise that there is a link to the build documentation in the same sentence, but around the text 'you can build with any IDE that support dot net or the command line' - now in my noobish unfresh fresh eyes that sent a signal to my head of go there if you want to do this for some Linux MoonShadow IDE on a Mac... 

... anyway I'm here now, the PR is open, I think it's clearer if there is just one link around 'as described in the build documentation' and the text about IDE is just there for encouragement rather than the main link text...

... but I could of course be wrong, and you might be tutting and saying, bloody hacktoberfest, brings all these pointless grammar things... 

... in which case I say perhaps wait til November to review this.

Thanks for considering this contributing to Umbraco CMS!
