### PR TITLE
Don't overwrite default values in the block list editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -31,7 +31,8 @@
                 for (var p = 0; p < tab.properties.length; p++) {
                     var prop = tab.properties[p];
 
-                    prop.value = dataModel[prop.alias];
+                    if (typeof (dataModel[prop.alias]) !== 'undefined')
+                        prop.value = dataModel[prop.alias];
                 }
             }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes #14914 

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
When the model is being created from the scaffolding to push into the infinite editor it overwrites the default value with `undefined` if the property doesn't exist in the `dataModel` object. This causes an issue when a default value is injected via a notification. The original issue only mentions an issue with this in the content, but this is also an issue with the settings tab. As the code in the fix is ran through by both the content and settings app of the block list, it fixes it in settings too.

This won't impact subsequent saves/loads as all data has a default value, whether that be a 0 or an empty string/array/object etc.

In addition to the recordings below I also tested the copying of block list items, deleting and nested block lists.

Here it is pre-fix, the doc type is composed of the same element as the block list to show it working directly on the doc:
![broken](https://github.com/umbraco/Umbraco-CMS/assets/5808078/d7f2cc56-0bcd-463f-883b-2ec66a4688ed)

And post-fix:
![fixed](https://github.com/umbraco/Umbraco-CMS/assets/5808078/e8589402-2881-4ce5-82e7-58538fe6bdb6)


In order to test you can drop the below CS file into your Umbraco site somewhere:

```
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Models.ContentEditing;
using Umbraco.Cms.Core.Notifications;

namespace Umbraco.Cms.Web.UI
{
    public class NotificationHandlerComposer : IComposer
    {
        public void Compose(IUmbracoBuilder builder)
        {
            builder.AddNotificationHandler<SendingContentNotification, EditorSendingContentNotificationHandler>();
        }
    }

    public class EditorSendingContentNotificationHandler : INotificationHandler<SendingContentNotification>
    {
        public void Handle(SendingContentNotification notification)
        {
            if (notification.Content.ContentTypeAlias.Equals("ele") || notification.Content.ContentTypeAlias.Equals("home"))
            {
                foreach (var variant in notification.Content.Variants)
                {
                    if (variant.State == ContentSavedState.NotCreated)
                    {
#pragma warning disable CS8603 // Possible null reference return.
                        var headingTypeProperty = variant.Tabs.SelectMany(f => f.Properties)
                            .FirstOrDefault(f => f.Alias.InvariantEquals("singleDropdown"));
                        var simpleTextProperty = variant.Tabs.SelectMany(f => f.Properties)
                            .FirstOrDefault(f => f.Alias.InvariantEquals("simpleText"));
#pragma warning restore CS8603 // Possible null reference return.

                        if (headingTypeProperty is not null)
                        {
                            // set default value of the heading type property to 'Heading 2'
                            headingTypeProperty.Value = new[] { "Heading 2" };

                            // change the description of the heading type property to verify the handler is being executed
                            headingTypeProperty.Description = "Description set from notification";
                        }
                        if (simpleTextProperty is not null)
                        {
                            // set default value of the heading type property to 'Heading 2'
                            simpleTextProperty.Value = "Test";
                        }
                    }
                }
            }
        }
    }
}
```

And have the following doc type / data type setup, allowing `Home` to be added as root.
![image](https://github.com/umbraco/Umbraco-CMS/assets/5808078/7f3a089c-95e7-4cec-8f43-b2f053215217)
![image](https://github.com/umbraco/Umbraco-CMS/assets/5808078/48248248-2521-4d37-8da8-3fa8f1ee5728)
![image](https://github.com/umbraco/Umbraco-CMS/assets/5808078/cab1309e-09bd-42b9-bb31-df53b2487f19)
![image](https://github.com/umbraco/Umbraco-CMS/assets/5808078/70e18182-91ca-43cd-877d-2d95d2a6d39d)

Once setup, create a node within the content section and see the default values. Then add a new `Ele` to the `Block` property and see the default values there.


<!-- Thanks for contributing to Umbraco CMS! -->
