### PR TITLE
UI Update: Added object key (GUID) for doc type, data type, etc. to context menus (+ bug fix)

### DIFF
--- a/src/Umbraco.Web.BackOffice/Trees/ContentTypeTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/ContentTypeTreeController.cs
@@ -120,6 +120,7 @@ public class ContentTypeTreeController : TreeController, ISearchableTree
                     // now we can enrich the result with content type data that's not available in the entity service output
                     node.Alias = contentType?.Alias ?? string.Empty;
                     node.AdditionalData["isElement"] = contentType?.IsElement;
+                    node.Key = contentType?.Key ?? Guid.Empty;
 
                     return node;
                 }));

--- a/src/Umbraco.Web.BackOffice/Trees/DataTypeTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/DataTypeTreeController.cs
@@ -96,6 +96,7 @@ public class DataTypeTreeController : TreeController, ISearchableTree
                     TreeNode node = CreateTreeNode(dt.Id.ToInvariantString(), id, queryStrings, dt.Name,
                         dataType.Editor?.Icon, false);
                     node.Path = dt.Path;
+                    node.Key = dataType?.Key ?? Guid.Empty;
                     return node;
                 })
         );

--- a/src/Umbraco.Web.BackOffice/Trees/MediaTypeTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/MediaTypeTreeController.cs
@@ -95,6 +95,7 @@ public class MediaTypeTreeController : TreeController, ISearchableTree
                         mt?.Icon ?? Constants.Icons.MediaType, hasChildren);
 
                     node.Path = dt.Path;
+                    node.Key = mt?.Key ?? Guid.Empty;
                     return node;
                 }));
 

--- a/src/Umbraco.Web.BackOffice/Trees/MemberTypeTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/MemberTypeTreeController.cs
@@ -10,6 +10,7 @@ using Umbraco.Cms.Core.Trees;
 using Umbraco.Cms.Infrastructure.Search;
 using Umbraco.Cms.Web.Common.Attributes;
 using Umbraco.Cms.Web.Common.Authorization;
+using static Umbraco.Cms.Core.Collections.TopoGraph;
 
 namespace Umbraco.Cms.Web.BackOffice.Trees;
 
@@ -67,6 +68,11 @@ public class MemberTypeTreeController : MemberTypeAndGroupTreeControllerBase, IS
     protected override IEnumerable<TreeNode> GetTreeNodesFromService(string id, FormCollection queryStrings) =>
         _memberTypeService.GetAll()
             .OrderBy(x => x.Name)
-            .Select(dt => CreateTreeNode(dt, Constants.ObjectTypes.MemberType, id, queryStrings,
-                dt?.Icon ?? Constants.Icons.MemberType, false));
+            .Select(dt =>
+            {
+                var tn = CreateTreeNode(dt, Constants.ObjectTypes.MemberType, id, queryStrings,
+                dt?.Icon ?? Constants.Icons.MemberType, false);
+                tn.Key = dt?.Key ?? Guid.Empty;
+                return tn;
+            });
 }

--- a/src/Umbraco.Web.BackOffice/Trees/TemplatesTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/TemplatesTreeController.cs
@@ -92,17 +92,23 @@ public class TemplatesTreeController : TreeController, ISearchableTree
 
         if (found is not null)
         {
-            nodes.AddRange(found.Select(template => CreateTreeNode(
-                template.Id.ToString(CultureInfo.InvariantCulture),
-                // TODO: Fix parent ID stuff for templates
-                "-1",
-                queryStrings,
-                template.Name,
-                template.IsMasterTemplate ? "icon-newspaper" : "icon-newspaper-alt",
-                template.IsMasterTemplate,
-                null,
-                Udi.Create(ObjectTypes.GetUdiType(Constants.ObjectTypes.TemplateType), template.Key)
-            )));
+            nodes.AddRange(found.Select(template =>
+            {
+                var tn = CreateTreeNode(
+                    template.Id.ToString(CultureInfo.InvariantCulture),
+                    // TODO: Fix parent ID stuff for templates
+                    "-1",
+                    queryStrings,
+                    template.Name,
+                    template.IsMasterTemplate ? "icon-newspaper" : "icon-newspaper-alt",
+                    template.IsMasterTemplate,
+                    null,
+                    Udi.Create(ObjectTypes.GetUdiType(Constants.ObjectTypes.TemplateType), template.Key)
+                );
+                tn.Key = template.Key;
+
+                return tn;
+            }));
         }
 
         return nodes;

--- a/src/Umbraco.Web.UI.Client/src/less/modals.less
+++ b/src/Umbraco.Web.UI.Client/src/less/modals.less
@@ -12,8 +12,11 @@
   box-sizing: border-box;
   padding: 0 20px;
   display: flex;
-  align-items: center;
-  white-space: nowrap
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 10px;
+  white-space: nowrap;
 }
 
 .umb-modalcolumn-header h1,
@@ -21,7 +24,19 @@
   margin: 0;
   white-space: nowrap;
   font-size: @fontSizeMedium;
+  line-height: 1;
   font-weight: 400;
+}
+
+.umb-modalcolumn-header #contextmenu-key {
+  font-size: @fontSizeSmall;
+  line-height: 1;
+  font-weight: 400;
+  color: @gray-5;
+}
+
+.umb-modalcolumn-header p {
+  margin-bottom: 0;
 }
 
 .umb-modalcolumn-body {

--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-contextmenu.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-contextmenu.html
@@ -3,6 +3,7 @@
     <div>
         <div class="umb-modalcolumn-header">
             <h1 id="contextmenu-title">{{menuDialogTitle}}</h1>
+            <p id="contextmenu-key" ng-show="currentNode.key !== '00000000-0000-0000-0000-000000000000'">{{currentNode.key}}</p>
             <p id="contextmenu-description" class="sr-only">
                 <localize key="visuallyHiddenTexts_contextMenuDescription">Select one of the options to edit the node.</localize>
             </p>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Overview
This pull request comes after a recent Cloud Developer Umbraco Training and some work on Umbraco Deploy on Umbraco Cloud. It was clear that finding the `key` (GUID) of items like a doc type or template in the backoffice UI was hard. This key info is helpful when looking at Umbraco Deploy conflicts with UDA files that have the same `key` in their names (without the hyphens).

### Solution
I saw that we needed to fix this and took on the task. I found the easiest way to add the `key` to the backoffice UI was to put it close to the tree item. The best way seemed to be adding it in the context menu below the item's name.

### Implementation
This PR adds this feature to the UI and fixes a bug. The `key` property of the `TreeNode` object used for the `currentNode` property of the angular scope was missing its value before. It used to default to an empty GUID of `00000000-0000-0000-0000-000000000000`. I fixed this in each of the `TreeController`s.

### Testing
For testing, start with a new installation, create a new doc type with a template, and check the context menu of doc types, data types, member types, media types, and templates. This will show that now it's easier to find the `key` info in the backoffice UI, which helps with sorting out Umbraco Deploy conflicts (as well as anything else). For all other items, business as usual.

### Screenshots
![image](https://github.com/umbraco/Umbraco-CMS/assets/82056925/ab0aa298-9730-49a1-92fe-62e019f486a6)
![image](https://github.com/umbraco/Umbraco-CMS/assets/82056925/652a4d2d-57a1-4e79-90ea-8244146e0b69)
![image](https://github.com/umbraco/Umbraco-CMS/assets/82056925/356ffe88-02b5-4785-bb96-06edd20e5c72)
![image](https://github.com/umbraco/Umbraco-CMS/assets/82056925/758a51a7-c07e-4e1b-9433-d6faaa5dd49c)
![image](https://github.com/umbraco/Umbraco-CMS/assets/82056925/557cc167-3bd0-4a19-981d-6bb5eeb761b4)





