### PR TITLE
All users can access nodes in the content recycle bin

### DIFF
--- a/src/Umbraco.Core/Security/ContentPermissions.cs
+++ b/src/Umbraco.Core/Security/ContentPermissions.cs
@@ -58,11 +58,10 @@ public class ContentPermissions
 
         var formattedPath = string.Concat(",", path, ",");
 
-        // only users with root access have access to the recycle bin,
-        // if the above check didn't pass then access is denied
+        // all users have access to the recycle bin
         if (formattedPath.Contains(string.Concat(",", recycleBinId.ToString(CultureInfo.InvariantCulture), ",")))
         {
-            return false;
+            return true;
         }
 
         // check for a start node in the path

--- a/src/Umbraco.Web.BackOffice/Trees/ContentTreeControllerBase.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/ContentTreeControllerBase.cs
@@ -159,7 +159,21 @@ public abstract class ContentTreeControllerBase : TreeController, ITreeNodeContr
     {
         var entityIsAncestorOfStartNodes =
             ContentPermissions.IsInBranchOfStartNode(e.Path, startNodeIds, startNodePaths, out var hasPathAccess);
-        var ignoreUserStartNodes = IgnoreUserStartNodes(queryStrings);
+
+        bool ignoreUserStartNodes;
+
+        // if the user is accessing a node in the recycle bin ignore the user's start nodes
+        // they will always have access to nodes in the recycle bin
+        if (parentId == Constants.System.RecycleBinContentString)
+        {
+            ignoreUserStartNodes = true;
+        }
+        else
+        {
+            ignoreUserStartNodes = IgnoreUserStartNodes(queryStrings);
+        }
+
+
         if (ignoreUserStartNodes == false && entityIsAncestorOfStartNodes == false)
         {
             return null;


### PR DESCRIPTION
These changes will allow all users with access to the content section, to access items in the recycle bin.  This addresses the comment here https://github.com/umbraco/Umbraco-CMS/pull/14977#issuecomment-1776759545.

- To test this create at least two nodes and then delete one of them so it's in the recycle bin.
- Create a user whose content start node is the node that isn't in the recycle bin
- Login with the newly created user and check that they can access the node in the recycle bin and restore it
- Perform the same tests with a user account whose content start node is the content root
