### PR TITLE
Block editors - replaces hardcoded -20 with current node ID

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -13,7 +13,7 @@
 (function () {
     'use strict';
 
-    function blockEditorModelObjectFactory($interpolate, $q, udiService, contentResource, localizationService, umbRequestHelper, clipboardService, notificationsService, $compile) {
+    function blockEditorModelObjectFactory($interpolate, $q, udiService, contentResource, localizationService, umbRequestHelper, clipboardService, notificationsService, $compile, editorState) {
 
         /**
          * Simple mapping from property model content entry to editing model,
@@ -396,7 +396,11 @@
                 // removing duplicates.
                 scaffoldKeys = scaffoldKeys.filter((value, index, self) => self.indexOf(value) === index);
 
-                tasks.push(contentResource.getScaffoldByKeys(-20, scaffoldKeys).then(scaffolds => {
+                // get current node (for page context)
+                var currentPage = editorState.getCurrent();
+                var currentPageId = currentPage ? (currentPage.id > 0 ? currentPage.id : currentPage.parentId) : null || -20;
+
+                tasks.push(contentResource.getScaffoldByKeys(currentPageId, scaffoldKeys).then(scaffolds => {
                     Object.values(scaffolds).forEach(scaffold => {
                         // self.scaffolds might not exists anymore, this happens if this instance has been destroyed before the load is complete.
                         if (self.scaffolds) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When a Block editor makes a call to `contentResource.getScaffoldByKeys()` (to get the element type schemas), it currently passed through a hardcoded ID of `-20`.  This patch replaces the hardcoded ID with the current page/node's ID, with a fallback on parent page/node, (and a final fallback on the previous hardcoded ID `-20`.

The motivation behind this pull request is that with my Contentment package's Data List editor has a feature to make use of the current page/node, but it can only do this when the `id` or `parentId` parameters are available in the `GetEmptyByKeys()` content API request.  This works fine within page-level property-editors, but it doesn't work with the BlockList/BlockGrid editors, _(this issue also applies to NestedContent, but since that is deprecated, I didn't look to patch that too)._
I regularly have support requests for Contentment to support Block editors better.

**Steps to test**
View a content page/node with either the BlockList or BlockGrid editors configured, and verify that it still works as expected.

In theory, this shouldn't be a breaking-change, but in reality, there may be a scenario where a developer is relying on the `-20` ID being present, and would break their implementation.  Personally, I can't see why someone would do this, but I submit to  much wiser developers than me. 🤗 