### PR TITLE
Set max height of media item in grid

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbmediagrid.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbmediagrid.directive.js
@@ -282,6 +282,7 @@ Use this directive to generate a thumbnail grid of media items.
                     var flexStyle = {
                         "flex": flex + " 1 " + imageMinFlexWidth + "px",
                         "max-width": mediaItem.width + "px",
+                        "max-height": itemMaxHeight + "px",
                         "min-width": itemMinWidth + "px",
                         "min-height": itemMinHeight + "px"
                     };

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -837,7 +837,6 @@
     border: 1px solid @inputBorder;
     box-sizing: border-box;
     width: 100%;
-    max-height: 80vh;
     .umb-property-editor--limit-width();
 }
 

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -837,6 +837,7 @@
     border: 1px solid @inputBorder;
     box-sizing: border-box;
     width: 100%;
+    max-height: 80vh;
     .umb-property-editor--limit-width();
 }
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/media/umbimagepreview/umb-image-preview.less
+++ b/src/Umbraco.Web.UI.Client/src/views/components/media/umbimagepreview/umb-image-preview.less
@@ -5,6 +5,6 @@
 
     img {
         width: 100%;
-        aspect-ratio: 1/1;
+        max-height: 50vh;
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/views/components/media/umbimagepreview/umb-image-preview.less
+++ b/src/Umbraco.Web.UI.Client/src/views/components/media/umbimagepreview/umb-image-preview.less
@@ -5,5 +5,6 @@
 
     img {
         width: 100%;
+        aspect-ratio: 1/1;
     }
 }


### PR DESCRIPTION
…  to avoid portrait images of take up much of height.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/14917

### Description
Adjusted media grid to set `max-height` to avoid slim portrait images to take up a lot of height.
[Test images](https://github.com/umbraco/Umbraco-CMS/files/13206364/test.zip) to upload.


**Before**

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/a7404718-04d6-4441-88be-9ff43cf4930f)


**After**

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/af764542-5a51-4b4a-b75b-4a0556d1b6a9)

