### PR TITLE
Fix warning CS0618: 'IHostingEnvironment.MapPathContentRoot(string)' is obsolete in Umbraco.TestData.

### DIFF
--- a/tests/Umbraco.TestData/LoadTestController.cs
+++ b/tests/Umbraco.TestData/LoadTestController.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Hosting;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Extensions;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
@@ -99,7 +100,7 @@ public class LoadTestController : Controller
     private readonly IDataTypeService _dataTypeService;
     private readonly IFileService _fileService;
     private readonly IHostApplicationLifetime _hostApplicationLifetime;
-    private readonly IHostingEnvironment _hostingEnvironment;
+    private readonly IHostEnvironment _hostEnvironment;
     private readonly IShortStringHelper _shortStringHelper;
 
     public LoadTestController(
@@ -108,7 +109,7 @@ public class LoadTestController : Controller
         IDataTypeService dataTypeService,
         IFileService fileService,
         IShortStringHelper shortStringHelper,
-        IHostingEnvironment hostingEnvironment,
+        IHostEnvironment hostEnvironment,
         IHostApplicationLifetime hostApplicationLifetime)
     {
         _contentTypeService = contentTypeService;
@@ -116,7 +117,7 @@ public class LoadTestController : Controller
         _dataTypeService = dataTypeService;
         _fileService = fileService;
         _shortStringHelper = shortStringHelper;
-        _hostingEnvironment = hostingEnvironment;
+        _hostEnvironment = hostEnvironment;
         _hostApplicationLifetime = hostApplicationLifetime;
     }
 
@@ -321,7 +322,7 @@ public class LoadTestController : Controller
     public IActionResult ColdBootRestart()
     {
         Directory.Delete(
-            _hostingEnvironment.MapPathContentRoot(Path.Combine(Constants.SystemDirectories.TempData, "DistCache")),
+            _hostEnvironment.MapPathContentRoot(Path.Combine(Constants.SystemDirectories.TempData, "DistCache")),
             true);
 
         DoRestart();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Issue: https://github.com/umbraco/Umbraco-CMS/issues/15015

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
This PR fixes the following task:
> Remove warnings from Tests/Umbraco.TestData project

This PR can be tested by building the Umbraco source code and checking that this warning is gone:

`LoadTestController.cs(324,13,324,116): warning CS0618: 'IHostingEnvironment.MapPathContentRoot(string)' is obsolete: 'Please use the MapPathContentRoot extension method on an instance of IHostEnvironment (or IWebHostEnvironment) instead'`




<!-- Thanks for contributing to Umbraco CMS! -->
