### PR TITLE
Adjust content type picker to support different content types

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
@@ -391,12 +391,44 @@ When building a custom infinite editor view you can use the same components as a
      * Opens a content type picker in infinite editing, the submit callback returns an array of selected items
      *
      * @param {object} editor rendering options.
+     * @param {string} editor.entityType Entity type to open - default document type.
      * @param {boolean} editor.multiPicker Pick one or multiple items.
      * @param {function} editor.submit Callback function when the submit button is clicked. Returns the editor model object.
      * @param {function} editor.close Callback function when the close button is clicked.
      * @returns {object} editor object
      */
     function contentTypePicker(editor) {
+      
+      if (!editor.entityType) editor.entityType = "documentType";
+      
+      switch (editor.entityType) {
+        case "documentType":
+          documentTypePicker(editor);
+          break;
+        case "mediaType":
+          mediaTypePicker(editor);
+          break;
+        case "memberType":
+          memberTypePicker(editor);
+          break;
+      }
+    }
+
+    /**
+     * @ngdoc method
+     * @name umbraco.services.editorService#documentTypePicker
+     * @methodOf umbraco.services.editorService
+     *
+     * @description
+     * Opens a document type picker in infinite editing, the submit callback returns an array of selected items
+     *
+     * @param {object} editor rendering options.
+     * @param {boolean} editor.multiPicker Pick one or multiple items.
+     * @param {function} editor.submit Callback function when the submit button is clicked. Returns the editor model object.
+     * @param {function} editor.close Callback function when the close button is clicked.
+     * @returns {object} editor object
+     */
+    function documentTypePicker(editor) {
       editor.view = "views/common/infiniteeditors/treepicker/treepicker.html";
       if (!editor.size) editor.size = "small";
       editor.section = "settings";
@@ -1143,10 +1175,12 @@ When building a custom infinite editor view you can use the same components as a
       open: open,
       close: close,
       closeAll: closeAll,
-      mediaEditor: mediaEditor,
       contentEditor: contentEditor,
+      mediaEditor: mediaEditor,
+      memberEditor: memberEditor,
       contentPicker: contentPicker,
       contentTypePicker: contentTypePicker,
+      documentTypePicker: documentTypePicker,
       mediaTypePicker: mediaTypePicker,
       memberTypePicker: memberTypePicker,
       copy: copy,
@@ -1178,7 +1212,6 @@ When building a custom infinite editor view you can use the same components as a
       macroPicker: macroPicker,
       memberGroupPicker: memberGroupPicker,
       memberPicker: memberPicker,
-      memberEditor: memberEditor,
       mediaCropDetails
     };
 

--- a/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js
@@ -391,7 +391,7 @@ When building a custom infinite editor view you can use the same components as a
      * Opens a content type picker in infinite editing, the submit callback returns an array of selected items
      *
      * @param {object} editor rendering options.
-     * @param {string} editor.entityType Entity type to open - default document type.
+     * @param {string} editor.entityType Entity type to open - default is document type.
      * @param {boolean} editor.multiPicker Pick one or multiple items.
      * @param {function} editor.submit Callback function when the submit button is clicked. Returns the editor model object.
      * @param {function} editor.close Callback function when the close button is clicked.

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/blockgrid.blockconfiguration.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/blockgrid.blockconfiguration.controller.js
@@ -199,12 +199,9 @@
 
             localizationService.localize("blockEditor_headlineCreateBlock").then(function(localizedTitle) {
 
-                const contentTypePicker = {
+                const dialog = {
                     title: localizedTitle,
-                    section: "settings",
-                    treeAlias: "documentTypes",
                     entityType: "documentType",
-                    isDialog: true,
                     filter: function (node) {
                         if (node.metaData.isElement === true) {
                             var key = udiService.getKey(node.udi);
@@ -238,8 +235,8 @@
                         }
                     ]
                 };
-                editorService.treePicker(contentTypePicker);
 
+                editorService.contentTypePicker(dialog);
             });
         };
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.controller.js
@@ -103,12 +103,9 @@
 
             localizationService.localize("blockEditor_headlineCreateBlock").then(localizedTitle => {
 
-                const contentTypePicker = {
+                const dialog = {
                     title: localizedTitle,
-                    section: "settings",
-                    treeAlias: "documentTypes",
                     entityType: "documentType",
-                    isDialog: true,
                     filter: function (node) {
                         if (node.metaData.isElement === true) {
                             var key = udiService.getKey(node.udi);
@@ -142,7 +139,7 @@
                     ]
                 };
                 
-                editorService.treePicker(contentTypePicker);
+                editorService.contentTypePicker(dialog);
             });
         };
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Adjust `editorService` to have a dedicated `documentTypePicker`, while the current allow specifying entity type, but fallback to `documentType` which is current behaviour and to avoid a breaking change.

This also streamline the concept that content type is both content, media and member type, while document type is more specific.

Related to https://github.com/umbraco/Umbraco-CMS/pull/15034