### PR TITLE
Ensure that missing access rules do not break the site

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Dtos/AccessDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/AccessDto.cs
@@ -37,5 +37,5 @@ internal class AccessDto
 
     [ResultColumn]
     [Reference(ReferenceType.Many, ReferenceMemberName = "AccessId")]
-    public List<AccessRuleDto> Rules { get; set; } = null!;
+    public List<AccessRuleDto> Rules { get; set; } = new();
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/15024

### Description

As outlined in the linked issue, the entire site frontend goes down if an access rule is accidentally deleted. At the time of writing we can't reproduce this in any other way than to delete the access rule from the database, but somehow this has happened in the wild.

Fortunately the fix is straightforward 😄 and has no implications apart from a little bit more allocation when reading the public access rules. 

### Testing this PR

1. Restrict public access on a content item.
2. Delete the resulting entry in the `umbracoAccessRule` table and restart the site.
3. Without this PR the site will be entirely broken. With this PR, the site still works.
4. It should be possible to re-configure the deleted access rule.

When re-configuring the missing rule, the UI gets a little confused about the whole thing, but all in all it is perfectly possible to re-configure. Given that this is extremely unlikely to happen I would say it's not worth the time to make the UI handle things in a better way.