### PR TITLE
Move localdb file management of PublishedSnapshotService into itself.

### DIFF
--- a/src/Umbraco.Core/PublishedCache/IPublishedSnapshotService.cs
+++ b/src/Umbraco.Core/PublishedCache/IPublishedSnapshotService.cs
@@ -126,5 +126,7 @@ public interface IPublishedSnapshotService : IDisposable
     /// </summary>
     Task CollectAsync();
 
-    void ResetLocalDb();
+    void ResetLocalDb()
+    {
+    }
 }

--- a/src/Umbraco.Core/PublishedCache/IPublishedSnapshotService.cs
+++ b/src/Umbraco.Core/PublishedCache/IPublishedSnapshotService.cs
@@ -125,4 +125,6 @@ public interface IPublishedSnapshotService : IDisposable
     ///     Cleans up unused snapshots
     /// </summary>
     Task CollectAsync();
+
+    void ResetLocalDb();
 }

--- a/src/Umbraco.Core/PublishedCache/Internal/InternalPublishedSnapshotService.cs
+++ b/src/Umbraco.Core/PublishedCache/Internal/InternalPublishedSnapshotService.cs
@@ -52,4 +52,8 @@ public class InternalPublishedSnapshotService : IPublishedSnapshotService
     public void Rebuild(IReadOnlyCollection<int>? contentTypeIds = null, IReadOnlyCollection<int>? mediaTypeIds = null, IReadOnlyCollection<int>? memberTypeIds = null)
     {
     }
+
+    public void ResetLocalDb()
+    {
+    }
 }

--- a/src/Umbraco.Core/PublishedCache/Internal/InternalPublishedSnapshotService.cs
+++ b/src/Umbraco.Core/PublishedCache/Internal/InternalPublishedSnapshotService.cs
@@ -52,8 +52,4 @@ public class InternalPublishedSnapshotService : IPublishedSnapshotService
     public void Rebuild(IReadOnlyCollection<int>? contentTypeIds = null, IReadOnlyCollection<int>? mediaTypeIds = null, IReadOnlyCollection<int>? memberTypeIds = null)
     {
     }
-
-    public void ResetLocalDb()
-    {
-    }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_12_0_0/ResetCache.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_12_0_0/ResetCache.cs
@@ -1,22 +1,26 @@
-﻿using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
+﻿using Umbraco.Cms.Core.PublishedCache;
+using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
 
 namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_12_0_0;
 
 public class ResetCache : MigrationBase
 {
     private readonly IHostingEnvironment _hostingEnvironment;
+    private readonly IPublishedSnapshotService _publishedSnapshotService;
 
-    public ResetCache(IMigrationContext context, IHostingEnvironment hostingEnvironment)
-        : base(context) =>
+    public ResetCache(IMigrationContext context, IHostingEnvironment hostingEnvironment, IPublishedSnapshotService publishedSnapshotService)
+        : base(context)
+    {
         _hostingEnvironment = hostingEnvironment;
+        _publishedSnapshotService = publishedSnapshotService;
+    }
 
     protected override void Migrate()
     {
         RebuildCache = true;
         var distCacheFolderAbsolutePath = Path.Combine(_hostingEnvironment.LocalTempPath, "DistCache");
-        var nuCacheFolderAbsolutePath = Path.Combine(_hostingEnvironment.LocalTempPath, "NuCache");
         DeleteAllFilesInFolder(distCacheFolderAbsolutePath);
-        DeleteAllFilesInFolder(nuCacheFolderAbsolutePath);
+        _publishedSnapshotService.ResetLocalDb();
     }
 
     private void DeleteAllFilesInFolder(string path)

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_12_0_0/ResetCache.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_12_0_0/ResetCache.cs
@@ -1,4 +1,6 @@
-﻿using Umbraco.Cms.Core.PublishedCache;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.PublishedCache;
 using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
 
 namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_12_0_0;
@@ -7,6 +9,12 @@ public class ResetCache : MigrationBase
 {
     private readonly IHostingEnvironment _hostingEnvironment;
     private readonly IPublishedSnapshotService _publishedSnapshotService;
+
+    [Obsolete("Use ctor with all params - This will be removed in Umbraco 14.")]
+    public ResetCache(IMigrationContext context, IHostingEnvironment hostingEnvironment)
+        : this(context, hostingEnvironment, StaticServiceProvider.Instance.GetRequiredService<IPublishedSnapshotService>())
+    {
+    }
 
     public ResetCache(IMigrationContext context, IHostingEnvironment hostingEnvironment, IPublishedSnapshotService publishedSnapshotService)
         : base(context)

--- a/src/Umbraco.PublishedCache.NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.PublishedCache.NuCache/PublishedSnapshotService.cs
@@ -70,6 +70,8 @@ internal class PublishedSnapshotService : IPublishedSnapshotService
     private long _mediaGen;
     private ContentStore _mediaStore = null!;
 
+    private string LocalFilePath => Path.Combine(_hostingEnvironment.LocalTempPath, "NuCache");
+
     public PublishedSnapshotService(
         PublishedSnapshotServiceOptions options,
         ISyncBootStateAccessor syncBootStateAccessor,
@@ -475,6 +477,22 @@ internal class PublishedSnapshotService : IPublishedSnapshotService
         return GetUid(_mediaStore, id);
     }
 
+
+    public void ResetLocalDb()
+    {
+        _logger.LogInformation(
+            "Resetting NuCache local db");
+        var path = LocalFilePath;
+        if (Directory.Exists(path) is false)
+        {
+            return;
+        }
+
+        MainDomRelease();
+        Directory.Delete(path, true);
+        MainDomRegister();
+    }
+
     /// <summary>
     ///     Lazily populates the stores only when they are first requested
     /// </summary>
@@ -654,7 +672,7 @@ internal class PublishedSnapshotService : IPublishedSnapshotService
 
     private string GetLocalFilesPath()
     {
-        var path = Path.Combine(_hostingEnvironment.LocalTempPath, "NuCache");
+        var path = LocalFilePath;
 
         if (!Directory.Exists(path))
         {

--- a/src/Umbraco.PublishedCache.NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.PublishedCache.NuCache/PublishedSnapshotService.cs
@@ -621,7 +621,7 @@ internal class PublishedSnapshotService : IPublishedSnapshotService
     /// </remarks>
     private void MainDomRegister()
     {
-        var path = GetLocalFilesPath();
+        var path = GetAndEnsureLocalFilesPathExists();
         var localContentDbPath = Path.Combine(path, "NuCache.Content.db");
         var localMediaDbPath = Path.Combine(path, "NuCache.Media.db");
 
@@ -670,7 +670,7 @@ internal class PublishedSnapshotService : IPublishedSnapshotService
         }
     }
 
-    private string GetLocalFilesPath()
+    private string GetAndEnsureLocalFilesPathExists()
     {
         var path = LocalFilePath;
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

[Link to the issue](https://github.com/umbraco/Umbraco-CMS/issues/14863)

### Description
Added a way for the PublishedSnapshot service to clean up it's local files so (for example) Upgrade migrations have a reliable way of removing known invalid cache files without running into locking issues

### Reproduction/testing
- Create an 11.x installation, add a doctype, add a document, browse the document on the frontend
- Upgrade Umbraco package to 12
- Make sure `ShowMaintenancePageWhenInUpgradeState` is set to false and no unattended install is configured (see issue for details)
- Boot the site, browse to the backoffice and go trough to the installer

- [ ] There should be no file lock issues.
