### PR TITLE
Make Block List configuration consistent with Block Grid

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/views/components/blockcard/umb-block-card-grid.less
@@ -1,7 +1,7 @@
 .umb-block-card-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    grid-auto-rows: minmax(30px, auto);
+    grid-auto-rows: minmax(150px, auto);
     gap: 20px;
     margin-bottom: 20px;
 }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/blockgrid.blockconfiguration.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/blockgrid.blockconfiguration.less
@@ -1,32 +1,29 @@
 .umb-block-grid-block-configuration {
+  margin-bottom: 20px;
 
-    margin-bottom: 20px;
+  uui-button {
+    --uui-button-border-radius: 6px;
+    font-weight: 700;
+    min-height: 80px;
+  }
 
-    uui-button {
-        font-weight: 700;
-        --uui-button-border-radius: 6px;
-        min-height: 80px;
+  .__get-sample-box {
+    position: relative;
+    border: 1px solid @gray-10;
+    border-radius: 6px;
+    box-shadow: 3px 3px 6px rgba(0, 0, 0, .07);
+    padding-left: 40px;
+    padding-right: 40px;
+    padding-top: 15px;
+    padding-bottom: 20px;
+    margin-bottom: 40px;
+    max-width: 480px;
+
+    umb-button {
+      margin-left: auto;
+      margin-right: 0;
+      display: block;
+      width: fit-content;
     }
-
-    .__get-sample-box {
-        position:relative;
-        border: 1px solid @gray-10;
-        border-radius: 6px;
-        box-shadow: 3px 3px 6px rgba(0, 0, 0, .07);
-
-        padding-left: 40px;
-        padding-right: 40px;
-        padding-top: 15px;
-        padding-bottom: 20px;
-        margin-bottom: 40px;
-        max-width: 480px;
-
-        umb-button {
-            margin-left: auto;
-            margin-right: 0;
-            display: block;
-            width: fit-content;
-        }
-    }
-
+  }
 }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.html
@@ -18,8 +18,9 @@
             </div>
         </umb-block-card>
 
-        <button type="button" id="{{model.alias}}" class="btn-reset __add-button" ng-click="vm.openAddDialog($event)">
-            <localize key="general_add">Add</localize>
-        </button>
+        <uui-button id="{{model.alias}}" look="{{model.value.length === 0 ? 'primary' : 'placeholder'}}" color="primary" ng-click="vm.openAddDialog($event)">
+          <localize key="blockEditor_addBlockType">Add Block</localize>
+        </uui-button>
+
     </div>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.less
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.less
@@ -1,5 +1,11 @@
 .umb-block-list-block-configuration {
 
+    uui-button {
+      --uui-button-border-radius: 6px;
+      font-weight: 700;
+      min-height: 80px;
+    }
+
     .__add-button {
         position: relative;
         display: inline-flex;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR makes add block in Block List consistent with Block Grid configuration.

**Block List**

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/40edc480-bf50-407b-af4c-85570d1b46ae)

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/77e218c6-c3ec-422b-a880-d82552f39a34)


**Block Grid**

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/502ce6c9-4292-4bec-8def-9ae647260781)

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/7fdc358f-2fe9-437f-902f-cd42fd2dfbc4)
