### PR TITLE
Update webhook log table using constant

### DIFF
--- a/src/Umbraco.Core/Persistence/Constants-DatabaseSchema.cs
+++ b/src/Umbraco.Core/Persistence/Constants-DatabaseSchema.cs
@@ -90,7 +90,7 @@ public static partial class Constants
             public const string Webhook2ContentTypeKeys = Webhook + "2ContentTypeKeys";
             public const string Webhook2Events = Webhook + "2Events";
             public const string Webhook2Headers = Webhook + "2Headers";
-            public const string WebhookLog = TableNamePrefix + "WebhookLog";
+            public const string WebhookLog = Webhook + "Log";
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below


### Description
Just a minor update in database constant to use exisitng `Webhook` constant, which is `TableNamePrefix + "Webhook"`.
The table name on webhook log table is unchanged, so full table name is `umbracoWebhookLog`.