### PR TITLE
v13: Add NVARCHARMAX to WebhookLogDto columns

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Dtos/WebhookLogDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/WebhookLogDto.cs
@@ -42,18 +42,22 @@ internal class WebhookLogDto
     public int RetryCount { get; set; }
 
     [Column(Name = "requestHeaders")]
+    [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
     [NullSetting(NullSetting = NullSettings.NotNull)]
     public string RequestHeaders { get; set; } = string.Empty;
 
     [Column(Name = "requestBody")]
+    [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
     [NullSetting(NullSetting = NullSettings.NotNull)]
     public string RequestBody { get; set; } = string.Empty;
 
     [Column(Name = "responseHeaders")]
+    [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
     [NullSetting(NullSetting = NullSettings.NotNull)]
     public string ResponseHeaders { get; set; } = string.Empty;
 
     [Column(Name = "responseBody")]
+    [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
     [NullSetting(NullSetting = NullSettings.NotNull)]
     public string ResponseBody { get; set; } = string.Empty;
 }


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/15092

# Notes
This worked on SQLite, but not on SqlServer, as the text columns are not the same
This PR sets the column types to NVARCHARMAX, to alleviate this issue 🚀 

# How to test
- Follow steps in original issue 🙌 