### PR TITLE
Dynamic root feature translations (Dutch)

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -1465,7 +1465,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="addQueryStep">Add query step</key>
     <key alias="queryStepTypes">That matches types: </key>
     <key alias="noValidStartNodeTitle">No matching content</key>
-    <key alias="noValidStartNodeDesc">The configuration of this property does not match any content. Create the missing content or contact your adminnistrator to adjust the Dynamic Root settings for this property.</key>
+    <key alias="noValidStartNodeDesc">The configuration of this property does not match any content. Create the missing content or contact your administrator to adjust the Dynamic Root settings for this property.</key>
   </area>
   <area alias="mediaPicker">
     <key alias="deletedItem">Deleted item</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -1505,7 +1505,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="addQueryStep">Add query step</key>
     <key alias="queryStepTypes">That matches types: </key>
     <key alias="noValidStartNodeTitle">No matching content</key>
-    <key alias="noValidStartNodeDesc">The configuration of this property does not match any content. Create the missing content or contact your adminnistrator to adjust the Dynamic Root settings for this property.</key>
+    <key alias="noValidStartNodeDesc">The configuration of this property does not match any content. Create the missing content or contact your administrator to adjust the Dynamic Root settings for this property.</key>
   </area>
   <area alias="mediaPicker">
     <key alias="deletedItem">Deleted item</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
@@ -1235,6 +1235,10 @@ Echter, Runway biedt een gemakkelijke basis om je snel op weg te helpen. Als je 
       prullenbak zijn
     </key>
   </area>
+  <area alias="dynamicRoot">
+    <key alias="noValidStartNodeTitle">Geen overeenkomende inhoud</key>
+    <key alias="noValidStartNodeDesc">De configuratie van deze eigenschap komt met geen enkele inhoud overeen. Maak de ontbrekende inhoud aan of neem contact op met uw beheerder om de dynamische root-instellingen voor deze eigenschap aan te passen.</key>
+  </area>
   <area alias="mediaPicker">
     <key alias="deletedItem">Verwijderd item</key>
     <key alias="pickedTrashedItem">Je hebt een media-item geselecteerd dat op dit ogenblik verwijderd of in the


### PR DESCRIPTION
- [x] Fix typo: 'adminnistrator' --> 'administrator'
- [x] Translate 'noValidStartNodeTitle' and 'noValidStartNodeDesc'

For now, I have chosen to only add translations for the message displayed in the content section because the rest of the multi-node tree picker does not have translations, and it's also difficult to translate this to Dutch.