### PR TITLE
Umbraco.Web.UI: Removed parenthesis from compiler directive

### DIFF
--- a/src/Umbraco.Web.UI/Startup.cs
+++ b/src/Umbraco.Web.UI/Startup.cs
@@ -48,7 +48,7 @@ namespace Umbraco.Cms.Web.UI
             {
                 app.UseDeveloperExceptionPage();
             }
-#if (UseHttpsRedirect)
+#if UseHttpsRedirect
 
             app.UseHttpsRedirection();
 #endif


### PR DESCRIPTION
### Prerequisites

N/A

### Description

Removed parenthesis from compiler directive as generates warning from Umbraco.Web.UI as part of #15015 