### PR TITLE
V13 RC: Avoid duplicate id's on the login screen

### DIFF
--- a/src/Umbraco.Web.UI.Login/src/auth.element.ts
+++ b/src/Umbraco.Web.UI.Login/src/auth.element.ts
@@ -50,6 +50,7 @@ const createForm = (elements: HTMLElement[]) => {
   const form = document.createElement('form');
   form.id = 'umb-login-form';
   form.name = 'login-form';
+  form.noValidate = true;
 
   elements.push(styles);
   elements.forEach((element) => form.appendChild(element));

--- a/src/Umbraco.Web.UI.Login/src/components/login-input.element.ts
+++ b/src/Umbraco.Web.UI.Login/src/components/login-input.element.ts
@@ -1,13 +1,53 @@
-// make new lit element that extends UUIInputElement
-
 import { UUIInputElement } from '@umbraco-ui/uui';
 import { customElement } from 'lit/decorators.js';
 
+/**
+ * This is a custom element based on UUIInputElement that is used in the login page.
+ * It differs from UUIInputElement in that it does not render a Shadow DOM.
+ *
+ * @element umb-login-input
+ * @inheritDoc UUIInputElement
+ */
 @customElement('umb-login-input')
 export class UmbLoginInputElement extends UUIInputElement {
+
+  /**
+   * Remove the id attribute from the inner input element to avoid duplicate ids.
+   *
+   * @override
+   * @protected
+   */
+  protected firstUpdated() {
+    const innerInput = this.querySelector('input')
+    innerInput?.removeAttribute('id');
+  }
+
+  /**
+   * Since this element does not render a Shadow DOM nor does it have a unique ID,
+   * we need to override this method to get the form element.
+   *
+   * @override
+   * @protected
+   */
+  protected getFormElement(): HTMLElement {
+    const formElement = this.querySelector('input');
+
+    if (!formElement) {
+      throw new Error('Form element not found');
+    }
+
+    return formElement;
+  }
+
+  /**
+   * Instruct Lit to not render a Shadow DOM.
+   *
+   * @protected
+   */
   protected createRenderRoot() {
     return this;
   }
+
   static styles = [...UUIInputElement.styles];
 }
 


### PR DESCRIPTION
Fixes #15089

This removes the `id` attribute from the inner input element of the `umb-login-input` component to avoid having duplicate id's on the login screen.