### PR TITLE
Fix FurthestAncestorOrSelfDynamicRootQueryStep and FurthestDescendantOrSelfDynamicRootQueryStep

### DIFF
--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
@@ -90,7 +90,7 @@ public static partial class UmbracoBuilderExtensions
 
         builder.DynamicRootSteps()
             .Append<NearestAncestorOrSelfDynamicRootQueryStep>()
-            .Append<FarthestAncestorOrSelfDynamicRootQueryStep>()
+            .Append<FurthestAncestorOrSelfDynamicRootQueryStep>()
             .Append<NearestDescendantOrSelfDynamicRootQueryStep>()
             .Append<FurthestDescendantOrSelfDynamicRootQueryStep>();
 

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
@@ -92,7 +92,7 @@ public static partial class UmbracoBuilderExtensions
             .Append<NearestAncestorOrSelfDynamicRootQueryStep>()
             .Append<FarthestAncestorOrSelfDynamicRootQueryStep>()
             .Append<NearestDescendantOrSelfDynamicRootQueryStep>()
-            .Append<FarthestDescendantOrSelfDynamicRootQueryStep>();
+            .Append<FurthestDescendantOrSelfDynamicRootQueryStep>();
 
         builder.Components();
         // register core CMS dashboards and 3rd party types - will be ordered by weight attribute & merged with package.manifest dashboards

--- a/src/Umbraco.Core/DynamicRoot/QuerySteps/FurthestAncestorOrSelfDynamicRootQueryStep.cs
+++ b/src/Umbraco.Core/DynamicRoot/QuerySteps/FurthestAncestorOrSelfDynamicRootQueryStep.cs
@@ -30,7 +30,7 @@ public class FurthestAncestorOrSelfDynamicRootQueryStep : IDynamicRootQueryStep
         }
 
         using ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true);
-        var result = (await _nodeFilterRepository.FarthestAncestorOrSelfAsync(origins, filter))?.ToSingleItemCollection() ?? Array.Empty<Guid>();
+        var result = (await _nodeFilterRepository.FurthestAncestorOrSelfAsync(origins, filter))?.ToSingleItemCollection() ?? Array.Empty<Guid>();
 
         return Attempt<ICollection<Guid>>.Succeed(result);
     }

--- a/src/Umbraco.Core/DynamicRoot/QuerySteps/FurthestAncestorOrSelfDynamicRootQueryStep.cs
+++ b/src/Umbraco.Core/DynamicRoot/QuerySteps/FurthestAncestorOrSelfDynamicRootQueryStep.cs
@@ -4,18 +4,18 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.DynamicRoot.QuerySteps;
 
-public class FarthestAncestorOrSelfDynamicRootQueryStep : IDynamicRootQueryStep
+public class FurthestAncestorOrSelfDynamicRootQueryStep : IDynamicRootQueryStep
 {
     private readonly ICoreScopeProvider _scopeProvider;
     private readonly IDynamicRootRepository _nodeFilterRepository;
 
-    public FarthestAncestorOrSelfDynamicRootQueryStep(ICoreScopeProvider scopeProvider, IDynamicRootRepository nodeFilterRepository)
+    public FurthestAncestorOrSelfDynamicRootQueryStep(ICoreScopeProvider scopeProvider, IDynamicRootRepository nodeFilterRepository)
     {
         _scopeProvider = scopeProvider;
         _nodeFilterRepository = nodeFilterRepository;
     }
 
-    protected virtual string SupportedDirectionAlias { get; set; } = "FarthestAncestorOrSelf";
+    protected virtual string SupportedDirectionAlias { get; set; } = "FurthestAncestorOrSelf";
 
     public async Task<Attempt<ICollection<Guid>>> ExecuteAsync(ICollection<Guid> origins, DynamicRootQueryStep filter)
     {

--- a/src/Umbraco.Core/DynamicRoot/QuerySteps/FurthestDescendantOrSelfDynamicRootQueryStep.cs
+++ b/src/Umbraco.Core/DynamicRoot/QuerySteps/FurthestDescendantOrSelfDynamicRootQueryStep.cs
@@ -28,7 +28,7 @@ public class FurthestDescendantOrSelfDynamicRootQueryStep : IDynamicRootQuerySte
         }
 
         using ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true);
-        var result = await _nodeFilterRepository.FarthestDescendantOrSelfAsync(origins, filter);
+        var result = await _nodeFilterRepository.FurthestDescendantOrSelfAsync(origins, filter);
 
         return Attempt<ICollection<Guid>>.Succeed(result);
     }

--- a/src/Umbraco.Core/DynamicRoot/QuerySteps/FurthestDescendantOrSelfDynamicRootQueryStep.cs
+++ b/src/Umbraco.Core/DynamicRoot/QuerySteps/FurthestDescendantOrSelfDynamicRootQueryStep.cs
@@ -2,18 +2,18 @@ using Umbraco.Cms.Core.Scoping;
 
 namespace Umbraco.Cms.Core.DynamicRoot.QuerySteps;
 
-public class FarthestDescendantOrSelfDynamicRootQueryStep : IDynamicRootQueryStep
+public class FurthestDescendantOrSelfDynamicRootQueryStep : IDynamicRootQueryStep
 {
     private readonly ICoreScopeProvider _scopeProvider;
     private readonly IDynamicRootRepository _nodeFilterRepository;
 
-    public FarthestDescendantOrSelfDynamicRootQueryStep(ICoreScopeProvider scopeProvider, IDynamicRootRepository nodeFilterRepository)
+    public FurthestDescendantOrSelfDynamicRootQueryStep(ICoreScopeProvider scopeProvider, IDynamicRootRepository nodeFilterRepository)
     {
         _scopeProvider = scopeProvider;
         _nodeFilterRepository = nodeFilterRepository;
     }
 
-    protected virtual string SupportedDirectionAlias { get; set; } = "FarthestDescendantOrSelf";
+    protected virtual string SupportedDirectionAlias { get; set; } = "FurthestDescendantOrSelf";
 
     public async Task<Attempt<ICollection<Guid>>> ExecuteAsync(ICollection<Guid> origins, DynamicRootQueryStep filter)
     {

--- a/src/Umbraco.Core/DynamicRoot/QuerySteps/IDynamicRootRepository.cs
+++ b/src/Umbraco.Core/DynamicRoot/QuerySteps/IDynamicRootRepository.cs
@@ -4,9 +4,9 @@ public interface IDynamicRootRepository
 {
     Task<Guid?> NearestAncestorOrSelfAsync(IEnumerable<Guid> origins, DynamicRootQueryStep queryStep);
 
-    Task<Guid?> FarthestAncestorOrSelfAsync(IEnumerable<Guid> origins, DynamicRootQueryStep queryStep);
+    Task<Guid?> FurthestAncestorOrSelfAsync(IEnumerable<Guid> origins, DynamicRootQueryStep queryStep);
 
     Task<ICollection<Guid>> NearestDescendantOrSelfAsync(ICollection<Guid> origins, DynamicRootQueryStep queryStep);
 
-    Task<ICollection<Guid>> FarthestDescendantOrSelfAsync(ICollection<Guid> origins, DynamicRootQueryStep queryStep);
+    Task<ICollection<Guid>> FurthestDescendantOrSelfAsync(ICollection<Guid> origins, DynamicRootQueryStep queryStep);
 }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DynamicRootRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DynamicRootRepository.cs
@@ -35,7 +35,7 @@ public class DynamicRootRepository: IDynamicRootRepository
         return await Database.SingleOrDefaultAsync<Guid?>(query);
     }
 
-    public async Task<Guid?> FarthestAncestorOrSelfAsync(IEnumerable<Guid> origins, DynamicRootQueryStep filter) {
+    public async Task<Guid?> FurthestAncestorOrSelfAsync(IEnumerable<Guid> origins, DynamicRootQueryStep filter) {
         Sql<ISqlContext> query = Database.SqlContext.SqlSyntax.SelectTop(
             GetAncestorOrSelfBaseQuery(origins, filter)
                 .Append($"ORDER BY n.level ASC"),
@@ -83,7 +83,7 @@ public class DynamicRootRepository: IDynamicRootRepository
         return await Database.FetchAsync<Guid>(query);
     }
 
-    public async Task<ICollection<Guid>> FarthestDescendantOrSelfAsync(ICollection<Guid> origins, DynamicRootQueryStep filter)
+    public async Task<ICollection<Guid>> FurthestDescendantOrSelfAsync(ICollection<Guid> origins, DynamicRootQueryStep filter)
     {
         var level = Database.Single<int>(Database.SqlContext.Sql()
             .Select("COALESCE(MAX(n.level), 0)")

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DynamicRootServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DynamicRootServiceTests.cs
@@ -34,7 +34,7 @@ public class DynamicRootServiceTests : UmbracoIntegrationTest
     {
         NearestAncestorOrSelf,
         NearestDescendantOrSelf,
-        FarthestDescendantOrSelf,
+        FurthestDescendantOrSelf,
     }
 
     protected IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
@@ -240,7 +240,7 @@ public class DynamicRootServiceTests : UmbracoIntegrationTest
 
     [Test]
     [TestCase(DynamicRootStepAlias.NearestDescendantOrSelf)]
-    [TestCase(DynamicRootStepAlias.FarthestDescendantOrSelf)]
+    [TestCase(DynamicRootStepAlias.FurthestDescendantOrSelf)]
     public async Task
         GetDynamicRoots__DescendantOrSelf_must_handle_when_there_is_not_found_any_and_level_becomes_impossible_to_get(
             DynamicRootStepAlias dynamicRootAlias)
@@ -323,7 +323,7 @@ public class DynamicRootServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
-    public async Task GetDynamicRoots__FarthestDescendantOrSelf__has_to_find_only_the_farthest()
+    public async Task GetDynamicRoots__FurthestDescendantOrSelf__has_to_find_only_the_furthest()
     {
         // Arrange
 
@@ -351,7 +351,7 @@ public class DynamicRootServiceTests : UmbracoIntegrationTest
             {
                 new DynamicRootQueryStep()
                 {
-                    Alias = DynamicRootStepAlias.FarthestDescendantOrSelf.ToString(),
+                    Alias = DynamicRootStepAlias.FurthestDescendantOrSelf.ToString(),
                     AnyOfDocTypeKeys = new[] { ContentTypeActs.Key },
                 },
             },


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/15112 

The aliases of `FarthestAncestorOrSelfDynamicRootQueryStep` and `FarthestDescendantOrSelfDynamicRootQueryStep` were incorrect. Changed the aliases and also updated the class names to be consistent. 