### PR TITLE
Fixed one warning for Umbraco.Infrastructure . 'AesCryptoServiceProvi…

### DIFF
--- a/src/Umbraco.Infrastructure/Security/MemberPasswordHasher.cs
+++ b/src/Umbraco.Infrastructure/Security/MemberPasswordHasher.cs
@@ -131,7 +131,9 @@ public class MemberPasswordHasher : UmbracoPasswordHasher<MemberIdentityUser>
         switch (algorithmName)
         {
             case "AES":
-                algorithm = new AesCryptoServiceProvider { Key = StringToByteArray(decryptionKey), IV = new byte[16] };
+                algorithm = Aes.Create();
+                algorithm.Key = StringToByteArray(decryptionKey);
+                algorithm.IV = new byte[16];
                 break;
             default:
                 throw new NotSupportedException($"The algorithm ({algorithmName}) is not supported");


### PR DESCRIPTION
…der' is obsolete.

### Prerequisites


If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/15015

### Description
Removes the warning:
Severity	Code	Description	Project	File	Line	Suppression State
Warning	SYSLIB0021	'AesCryptoServiceProvider' is obsolete: 'Derived cryptographic types are obsolete. Use the Create method on the base type instead.'	Umbraco.Infrastructure	\Umbraco-CMS-ZebSadiq\src\Umbraco.Infrastructure\Security\MemberPasswordHasher.cs	134	Active

<!-- Thanks for contributing to Umbraco CMS! -->
