### PR TITLE
Accessibility Issue 15071 - add select all sr-only text to umb table select all button

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -844,6 +844,7 @@
     <key alias="search">Search</key>
     <key alias="searchNoResult">Sorry, we can not find what you are looking for.</key>
     <key alias="noItemsInList">No items have been added</key>
+    <key alias="selectAll">Select all</key>
     <key alias="server">Server</key>
     <key alias="settings">Settings</key>
     <key alias="shared">Shared</key>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-table.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-table.html
@@ -6,7 +6,8 @@
                 <div class="umb-table-cell">
 
                     <button type="button" class="umb-table__action" ng-show="vm.allowSelectAll" ng-click="vm.selectAll()">
-                        <umb-checkmark checked="vm.isSelectedAll()" size="xs"></umb-checkmark>
+                      <span class="sr-only"><localize key="general_selectAll">Select all</localize></span>
+                      <umb-checkmark checked="vm.isSelectedAll()" size="xs"></umb-checkmark>
                     </button>
 
                 </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes - [15071](https://github.com/umbraco/Umbraco-CMS/issues/15071)

### Description
This PR adds a little bit of screen reader only text to the `select all` button found in the umb table view. It's a little generic at the moment and could probably do with being a little more contextual, but it's an improvement on the nothing that was there

Proof that lighthouse no longer errors for it
![image](https://github.com/umbraco/Umbraco-CMS/assets/6573613/25a1b02e-99cb-48f2-a970-e33c7b319055)

![image](https://github.com/umbraco/Umbraco-CMS/assets/6573613/5b20f56d-6b59-4215-a898-99120cc7410c)
