### PR TITLE
Accessibility Issue Fix  15068 -  media - Watermark image on page has no alt text

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-file-dropzone.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/upload/umb-file-dropzone.html
@@ -20,7 +20,7 @@
         </p>
 
         <!-- Drag and drop illustration -->
-        <img class="illustration" src="assets/img/uploader/upload-illustration.svg" alt="" draggable="false" />
+        <img class="illustration" src="assets/img/uploader/upload-illustration.svg" alt=" " draggable="false" />
 
         <!-- Select files -->
         <button type="button"


### PR DESCRIPTION
There seems to be an odd bug where on build, the alt tag is removed is it is alt="". Simply adding a space fixes this.

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [15068](https://github.com/umbraco/Umbraco-CMS/issues/15068)

### Description
There appears to be an odd bug where on build, even though the image has an `alt=""` tag, it was being removed. Adding a space, e.g. `alt=" "` ensures the alt tag remains, and behaves correctly for assistive technologies, e.i. it ignore it.

![image](https://github.com/umbraco/Umbraco-CMS/assets/6573613/e9ffe43a-97c5-4800-af60-9af8e7c181b2)

How the accessibility tree views the image after the fix
![image](https://github.com/umbraco/Umbraco-CMS/assets/6573613/658b1034-0790-4f7c-80f1-ec0f594d8084)

P.S. enjoy the dog tax