### PR TITLE
Fixes issue https://github.com/umbraco/Umbraco-CMS/issues/12834

### DIFF
--- a/src/Umbraco.Core/Routing/PublishedRouter.cs
+++ b/src/Umbraco.Core/Routing/PublishedRouter.cs
@@ -274,7 +274,7 @@ public class PublishedRouter : IPublishedRouter
     ///     Finds the site root (if any) matching the http request, and updates the PublishedRequest accordingly.
     /// </summary>
     /// <returns>A value indicating whether a domain was found.</returns>
-    internal bool FindDomain(IPublishedRequestBuilder request)
+    public bool FindDomain(IPublishedRequestBuilder request)
     {
         const string tracePrefix = "FindDomain: ";
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/12834

### Description

This fixes an issue with the IUmbracoContextAccessor.PublishedRequest.PublishedContent not being set when a page is requested via an IVirtualPageController.

The issue (https://github.com/umbraco/Umbraco-CMS/issues/12834) has a comment from Kenn Jacobsen (https://github.com/umbraco/Umbraco-CMS/issues/12834#issuecomment-1350503166) which recreates the issue and you can see the PublishedContent via the UmbracoContext is null.  With this fix the PublishedRequest is set from the content returned from IVirtualPageController FindContent method.  Use Ken's code from the issue to test this.

I have also followed the tests outlined in https://github.com/umbraco/Umbraco-CMS/pull/13103 to ensure that existing functionality regarding virtual page controllers works as expected (as there are some comprehensive test scenarios in that PR).

All tests have been run and passed.
