### PR TITLE
Ensure inline editing works although a custom view has been selected

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/BlockListConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/BlockListConfiguration.cs
@@ -16,9 +16,7 @@ public class BlockListConfiguration
     [ConfigurationField("validationLimit", "Amount", "numberrange", Description = "Set a required range of blocks")]
     public NumberRange ValidationLimit { get; set; } = new();
 
-    [ConfigurationField("useSingleBlockMode", "Single block mode", "boolean",
-        Description = @"When in Single block mode, the output will be BlockListItem<>, instead of BlockListModel.
-
+    [ConfigurationField("useSingleBlockMode", "Single block mode", "boolean", Description = @"When in Single block mode, the output will be BlockListItem<>, instead of BlockListModel.
 **NOTE:**
 Single block mode requires a maximum of one available block, and an amount set to minimum 1 and maximum 1 blocks.")]
     public bool UseSingleBlockMode { get; set; }
@@ -26,7 +24,7 @@ Single block mode requires a maximum of one available block, and an amount set t
     [ConfigurationField("useLiveEditing", "Live editing mode", "boolean", Description = "Live editing in editor overlays for live updated custom views or labels using custom expression.")]
     public bool UseLiveEditing { get; set; }
 
-    [ConfigurationField("useInlineEditingAsDefault", "Inline editing mode", "boolean", Description = "Use the inline editor as the default block view.")]
+    [ConfigurationField("useInlineEditingAsDefault", "Inline editing mode", "boolean", Description = "Use the inline editor as the default block view. **NOTE:** Custom view is currently not supported in inline editing.")]
     public bool UseInlineEditingAsDefault { get; set; }
 
     [ConfigurationField("maxPropertyWidth", "Property editor width", "textstring", Description = "Optional CSS override, example: 800px or 100%")]

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -334,7 +334,7 @@
 
             if (block === null) return null;
 
-            block.view = (block.config.view ? block.config.view : getDefaultViewForBlock(block));
+            block.view = block.config.view && inlineEditing === false ? block.config.view : getDefaultViewForBlock(block);
             block.showValidation = block.config.view ? true : false;
 
             block.hideContentInOverlay = block.config.forceHideContentEditorInOverlay === true || inlineEditing === true;


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/15104

### Description
Currently if custom view has been selected on a block in Block List and inline editing has been enabled, the `block.edit()` does nothing, because it stops here:
https://github.com/umbraco/Umbraco-CMS/issues/15104#issuecomment-1790933280

It require some hacky workaround or inherit `Umbraco.PropertyEditors.BlockEditor.InlineBlockEditor` to make the custom view work in inline editing.
https://github.com/umbraco/Umbraco-CMS/issues/15104#issuecomment-1790976658

For now I think it a better to make a note about this and ensure inline editing works and the custom view is ignored. Maybe in future or in the new backoffice we can make it possible to customize the view for inline editing.