### PR TITLE
Aligned parameters on sync and async methods on IFileSource.

### DIFF
--- a/src/Umbraco.Core/Deploy/IFileSource.cs
+++ b/src/Umbraco.Core/Deploy/IFileSource.cs
@@ -61,19 +61,31 @@ public interface IFileSource
     /// <returns>The length of the file, or -1 if the file does not exist.</returns>
     Task<long> GetFileLengthAsync(StringUdi udi, CancellationToken token);
 
+    // TODO (V14): Remove obsolete methods and default implementations for GetFiles and GetFilesAsync overloads.
+
     /// <summary>
     ///     Gets files and store them using a file store.
     /// </summary>
-    /// <param name="udis">The udis of the files to get.</param>
+    /// <param name="udis">The UDIs of the files to get.</param>
     /// <param name="fileTypes">A collection of file types which can store the files.</param>
+    [Obsolete("Please use the method overload taking all parameters. This method overload will be removed in Umbraco 14.")]
     void GetFiles(IEnumerable<StringUdi> udis, IFileTypeCollection fileTypes);
 
-    // TODO (V14): Remove obsolete method and default implementation for GetFilesAsync overloads.
+    /// <summary>
+    ///     Gets files and store them using a file store.
+    /// </summary>
+    /// <param name="udis">The UDIs of the files to get.</param>
+    /// <param name="fileTypes">A collection of file types which can store the files.</param>
+    /// <param name="continueOnFileNotFound">A flag indicating whether to continue if a file isn't found or to stop and throw a FileNotFoundException.</param>
+    void GetFiles(IEnumerable<StringUdi> udis, bool continueOnFileNotFound, IFileTypeCollection fileTypes)
+#pragma warning disable CS0618 // Type or member is obsolete
+        => GetFiles(udis, fileTypes);
+#pragma warning restore CS0618 // Type or member is obsolete
 
     /// <summary>
     ///     Gets files and store them using a file store.
     /// </summary>
-    /// <param name="udis">The udis of the files to get.</param>
+    /// <param name="udis">The UDIs of the files to get.</param>
     /// <param name="fileTypes">A collection of file types which can store the files.</param>
     /// <param name="token">A cancellation token.</param>
     [Obsolete("Please use the method overload taking all parameters. This method overload will be removed in Umbraco 14.")]
@@ -82,10 +94,12 @@ public interface IFileSource
     /// <summary>
     ///     Gets files and store them using a file store.
     /// </summary>
-    /// <param name="udis">The udis of the files to get.</param>
+    /// <param name="udis">The UDIs of the files to get.</param>
     /// <param name="fileTypes">A collection of file types which can store the files.</param>
     /// <param name="continueOnFileNotFound">A flag indicating whether to continue if a file isn't found or to stop and throw a FileNotFoundException.</param>
     /// <param name="token">A cancellation token.</param>
     Task GetFilesAsync(IEnumerable<StringUdi> udis, IFileTypeCollection fileTypes, bool continueOnFileNotFound, CancellationToken token)
+#pragma warning disable CS0618 // Type or member is obsolete
         => GetFilesAsync(udis, fileTypes, token);
+#pragma warning restore CS0618 // Type or member is obsolete
 }


### PR DESCRIPTION
This is a small adendum to the work in [this PR](https://github.com/umbraco/Umbraco-CMS/pull/14990), where I added a parameter to a method in `IFileSource`, but omitted to do so for the "sync" equivalent.

This PR adds this to align the signatures on these methods.