### PR TITLE
New WebhookEventBase class

### DIFF
--- a/src/Umbraco.Core/Webhooks/Events/ContentDeleteWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/ContentDeleteWebhookEvent.cs
@@ -7,7 +7,7 @@ using Umbraco.Cms.Core.Sync;
 
 namespace Umbraco.Cms.Core.Webhooks.Events;
 
-public class ContentDeleteWebhookEvent : WebhookEventBase<ContentDeletedNotification, IContent>
+public class ContentDeleteWebhookEvent : WebhookEventContentBase<ContentDeletedNotification, IContent>
 {
     public ContentDeleteWebhookEvent(
         IWebhookFiringService webhookFiringService,

--- a/src/Umbraco.Core/Webhooks/Events/ContentPublishWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/ContentPublishWebhookEvent.cs
@@ -10,7 +10,7 @@ using Umbraco.Cms.Core.Sync;
 
 namespace Umbraco.Cms.Core.Webhooks.Events;
 
-public class ContentPublishWebhookEvent : WebhookEventBase<ContentPublishedNotification, IContent>
+public class ContentPublishWebhookEvent : WebhookEventContentBase<ContentPublishedNotification, IContent>
 {
     private readonly IPublishedSnapshotAccessor _publishedSnapshotAccessor;
     private readonly IApiContentBuilder _apiContentBuilder;

--- a/src/Umbraco.Core/Webhooks/Events/ContentUnpublishWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/ContentUnpublishWebhookEvent.cs
@@ -7,7 +7,7 @@ using Umbraco.Cms.Core.Sync;
 
 namespace Umbraco.Cms.Core.Webhooks.Events;
 
-public class ContentUnpublishWebhookEvent : WebhookEventBase<ContentUnpublishedNotification, IContent>
+public class ContentUnpublishWebhookEvent : WebhookEventContentBase<ContentUnpublishedNotification, IContent>
 {
     public ContentUnpublishWebhookEvent(
         IWebhookFiringService webhookFiringService,

--- a/src/Umbraco.Core/Webhooks/Events/MediaDeleteWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/MediaDeleteWebhookEvent.cs
@@ -7,7 +7,7 @@ using Umbraco.Cms.Core.Sync;
 
 namespace Umbraco.Cms.Core.Webhooks.Events;
 
-public class MediaDeleteWebhookEvent : WebhookEventBase<MediaDeletedNotification, IMedia>
+public class MediaDeleteWebhookEvent : WebhookEventContentBase<MediaDeletedNotification, IMedia>
 {
     public MediaDeleteWebhookEvent(
         IWebhookFiringService webhookFiringService,

--- a/src/Umbraco.Core/Webhooks/Events/MediaSaveWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/MediaSaveWebhookEvent.cs
@@ -10,7 +10,7 @@ using Umbraco.Cms.Core.Sync;
 
 namespace Umbraco.Cms.Core.Webhooks.Events;
 
-public class MediaSaveWebhookEvent : WebhookEventBase<MediaSavedNotification, IMedia>
+public class MediaSaveWebhookEvent : WebhookEventContentBase<MediaSavedNotification, IMedia>
 {
     private readonly IPublishedSnapshotAccessor _publishedSnapshotAccessor;
     private readonly IApiMediaBuilder _apiMediaBuilder;

--- a/src/Umbraco.Core/Webhooks/WebhookEventContentBase.cs
+++ b/src/Umbraco.Core/Webhooks/WebhookEventContentBase.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.Options;
+
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Sync;
+
+namespace Umbraco.Cms.Core.Webhooks;
+
+public abstract class WebhookEventContentBase<TNotification, TEntity> : WebhookEventBase<TNotification>
+    where TNotification : INotification
+    where TEntity : IContentBase
+{
+    protected WebhookEventContentBase(
+        IWebhookFiringService webhookFiringService,
+        IWebHookService webHookService,
+        IOptionsMonitor<WebhookSettings> webhookSettings,
+        IServerRoleAccessor serverRoleAccessor,
+        string eventName)
+        : base(webhookFiringService, webHookService, webhookSettings, serverRoleAccessor, eventName)
+    {
+    }
+
+    public override async Task ProcessWebhooks(TNotification notification, IEnumerable<Webhook> webhooks, CancellationToken cancellationToken)
+    {
+        foreach (Webhook webhook in webhooks)
+        {
+            if (!webhook.Enabled)
+            {
+                continue;
+            }
+
+            foreach (TEntity entity in GetEntitiesFromNotification(notification))
+            {
+                if (webhook.ContentTypeKeys.Any() && !webhook.ContentTypeKeys.Contains(entity.ContentType.Key))
+                {
+                    continue;
+                }
+
+                await WebhookFiringService.FireAsync(webhook, EventName, ConvertEntityToRequestPayload(entity), cancellationToken);
+            }
+        }
+    }
+
+    protected abstract IEnumerable<TEntity> GetEntitiesFromNotification(TNotification notification);
+
+    protected abstract object? ConvertEntityToRequestPayload(TEntity entity);
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes : #15093

### Description

Creates a new `WebhookEventBase` class that doesn't depend on `IContentBase` or any other `IEntity` object.
Means the `WebhookEventBase` class can then be used for any Notification Inheriting `INotification`

Removes the need for other people to do the checks for enabled/server roll etc in their webhooks. 

Renames existing `WebhookEventBase` to `WebhookEventContentBase`. 


```cs
public class CustomWebhookEvent : WebhookEventBase<LanguageSavedNotification>
{
    public CustomWebhookEvent(
        IWebhookFiringService webhookFiringService,
        IWebHookService webHookService,
        IOptionsMonitor<WebhookSettings> webhookSettings,
        IServerRoleAccessor serverRoleAccessor)
        : base(webhookFiringService, webHookService, webhookSettings, serverRoleAccessor, "Language Saved")
    { }
}
```

If you want to override how the webhook is fired - the `ProcessWebhooks` Method can be overridden

```cs
    public override async Task ProcessWebhooks(
        LanguageSavedNotificationnotification,
        IEnumerable<Webhook> webhooks,
        CancellationToken cancellationToken)
    {
        foreach(var webhook in webhooks)
        {
            WebhookFiringService.FireAsync(webhook, EventName, new object[] {"hello", notification}, cancellationToken);
        }
    }
```



