### PR TITLE
 Remove parameter value/return nullability in `IImageSourceParser`, `ILocalLinkParser` and `IMacroParser`

### DIFF
--- a/src/Umbraco.Core/Deploy/IImageSourceParser.cs
+++ b/src/Umbraco.Core/Deploy/IImageSourceParser.cs
@@ -12,7 +12,7 @@ public interface IImageSourceParser
     /// <param name="dependencies">A list of dependencies.</param>
     /// <returns>The parsed value.</returns>
     /// <remarks>Turns src="/media/..." into src="umb://media/..." and adds the corresponding udi to the dependencies.</remarks>
-    string? ToArtifact(string? value, ICollection<Udi> dependencies);
+    string ToArtifact(string value, ICollection<Udi> dependencies);
 
     /// <summary>
     ///     Parses an artifact property value and produces an Umbraco property value.
@@ -20,5 +20,5 @@ public interface IImageSourceParser
     /// <param name="value">The artifact property value.</param>
     /// <returns>The parsed value.</returns>
     /// <remarks>Turns umb://media/... into /media/....</remarks>
-    string? FromArtifact(string? value);
+    string FromArtifact(string value);
 }

--- a/src/Umbraco.Core/Deploy/ILocalLinkParser.cs
+++ b/src/Umbraco.Core/Deploy/ILocalLinkParser.cs
@@ -15,7 +15,7 @@ public interface ILocalLinkParser
     ///     Turns {{localLink:1234}} into {{localLink:umb://{type}/{id}}} and adds the corresponding udi to the
     ///     dependencies.
     /// </remarks>
-    string? ToArtifact(string? value, ICollection<Udi> dependencies);
+    string ToArtifact(string value, ICollection<Udi> dependencies);
 
     /// <summary>
     ///     Parses an artifact property value and produces an Umbraco property value.
@@ -23,5 +23,5 @@ public interface ILocalLinkParser
     /// <param name="value">The artifact property value.</param>
     /// <returns>The parsed value.</returns>
     /// <remarks>Turns {{localLink:umb://{type}/{id}}} into {{localLink:1234}}.</remarks>
-    string? FromArtifact(string? value);
+    string FromArtifact(string value);
 }

--- a/src/Umbraco.Core/Deploy/ILocalLinkParser.cs
+++ b/src/Umbraco.Core/Deploy/ILocalLinkParser.cs
@@ -15,7 +15,7 @@ public interface ILocalLinkParser
     ///     Turns {{localLink:1234}} into {{localLink:umb://{type}/{id}}} and adds the corresponding udi to the
     ///     dependencies.
     /// </remarks>
-    string ToArtifact(string value, ICollection<Udi> dependencies);
+    string? ToArtifact(string? value, ICollection<Udi> dependencies);
 
     /// <summary>
     ///     Parses an artifact property value and produces an Umbraco property value.
@@ -23,5 +23,5 @@ public interface ILocalLinkParser
     /// <param name="value">The artifact property value.</param>
     /// <returns>The parsed value.</returns>
     /// <remarks>Turns {{localLink:umb://{type}/{id}}} into {{localLink:1234}}.</remarks>
-    string FromArtifact(string value);
+    string? FromArtifact(string? value);
 }

--- a/src/Umbraco.Core/Deploy/IMacroParser.cs
+++ b/src/Umbraco.Core/Deploy/IMacroParser.cs
@@ -8,14 +8,14 @@ public interface IMacroParser
     /// <param name="value">Property value.</param>
     /// <param name="dependencies">A list of dependencies.</param>
     /// <returns>Parsed value.</returns>
-    string? ToArtifact(string? value, ICollection<Udi> dependencies);
+    string ToArtifact(string value, ICollection<Udi> dependencies);
 
     /// <summary>
     ///     Parses an artifact property value and produces an Umbraco property value.
     /// </summary>
     /// <param name="value">Artifact property value.</param>
     /// <returns>Parsed value.</returns>
-    string? FromArtifact(string? value);
+    string FromArtifact(string value);
 
     /// <summary>
     ///     Tries to replace the value of the attribute/parameter with a value containing a converted identifier.


### PR DESCRIPTION
This update just aligns the nullability of the parameter and return value of the three interfaces that define parsers for rich text content.  It's not essential, but nice to tidy up.

Implemented in response to [this comment](https://github.com/umbraco/Umbraco-Deploy/pull/800/files#r1381910981).

There is no implementation of this class in the CMS itself.