### PR TITLE
Add a translation api controller to the Delivery API

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Configuration/ConfigureUmbracoDeliveryApiSwaggerGenOptions.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Configuration/ConfigureUmbracoDeliveryApiSwaggerGenOptions.cs
@@ -23,6 +23,7 @@ public class ConfigureUmbracoDeliveryApiSwaggerGenOptions: IConfigureOptions<Swa
         swaggerGenOptions.DocumentFilter<MimeTypeDocumentFilter>(DeliveryApiConfiguration.ApiName);
 
         swaggerGenOptions.OperationFilter<SwaggerContentDocumentationFilter>();
+        swaggerGenOptions.OperationFilter<SwaggerTranslationApiDocumentationFilter>();
         swaggerGenOptions.OperationFilter<SwaggerMediaDocumentationFilter>();
         swaggerGenOptions.ParameterFilter<SwaggerContentDocumentationFilter>();
         swaggerGenOptions.ParameterFilter<SwaggerMediaDocumentationFilter>();

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/GetListTranslationApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/GetListTranslationApiController.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Delivery.Controllers;
+
+[ApiVersion("1.0")]
+public class GetListTranslationApiController : TranslationApiControllerBase
+{
+    private readonly ILocalizationService _localizationService;
+    private readonly IRequestCultureService _requestCultureService;
+
+    public GetListTranslationApiController(ILocalizationService localizationService, IRequestCultureService requestCultureService) : base(localizationService, requestCultureService)
+    {
+        _localizationService = localizationService;
+        _requestCultureService = requestCultureService;
+    }
+
+    /// <summary>
+    ///     Gets a json translation object based on your requested culture
+    /// </summary>
+    /// <param name="startItem">Optional start item guid</param>
+    /// <returns>The translations.</returns>
+    [HttpGet("list")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(ApiTranslationResponse), StatusCodes.Status200OK)]
+    public async Task<ActionResult> GetList(Guid? startItem = null)
+    {
+        IDictionaryItem[] dictionaryItems = _localizationService.GetDictionaryItemDescendants(startItem).ToArray();
+
+        object BuildJson(IDictionaryItem[] items, Guid? parentId)
+        {
+            var result = new Dictionary<string, object>();
+
+            foreach (IDictionaryItem item in items.Where(t => t.ParentId == parentId))
+            {
+                var culture = _requestCultureService.GetRequestedCulture()?.ToLower();
+                var translation = item.Translations.FirstOrDefault(x => x.LanguageIsoCode.ToLower() == culture);
+                if (translation is not null)
+                {
+                    // Check if the item has children to determine if it should be a nested structure
+                    IDictionaryItem[] children = items.Where(t => t.ParentId == item.Key).ToArray();
+                    if (children.Any())
+                    {
+                        result[item.ItemKey] = BuildJson(items, item.Key);
+                    }
+                    else
+                    {
+                        result[item.ItemKey] = translation.Value;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        var jsonStructure = BuildJson(dictionaryItems, null);
+
+        return await Task.FromResult(Json(jsonStructure));
+    }
+
+
+}

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/TranslationApiControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/TranslationApiControllerBase.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Common.Attributes;
+using Umbraco.Cms.Api.Delivery.Configuration;
+using Umbraco.Cms.Api.Delivery.Filters;
+using Umbraco.Cms.Api.Delivery.Routing;
+using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Delivery.Controllers;
+
+[DeliveryApiAccess]
+[VersionedDeliveryApiRoute("translation")]
+[ApiExplorerSettings(GroupName = "Translation")]
+[LocalizeFromAcceptLanguageHeader]
+public abstract class TranslationApiControllerBase : DeliveryApiControllerBase
+{
+    public ILocalizationService LocalizationService { get; }
+    public IRequestCultureService RequestCultureService { get; }
+
+    protected TranslationApiControllerBase(ILocalizationService localizationService, IRequestCultureService requestCultureService)
+    {
+        LocalizationService = localizationService;
+        RequestCultureService = requestCultureService;
+    }
+
+}

--- a/src/Umbraco.Cms.Api.Delivery/Filters/SwaggerTranslationApiDocumentationFilter.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Filters/SwaggerTranslationApiDocumentationFilter.cs
@@ -1,0 +1,36 @@
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using Umbraco.Cms.Api.Delivery.Configuration;
+using Umbraco.Cms.Api.Delivery.Controllers;
+
+namespace Umbraco.Cms.Api.Delivery.Filters;
+
+internal sealed class SwaggerTranslationApiDocumentationFilter : SwaggerDocumentationFilterBase<TranslationApiControllerBase>
+{
+    protected override string DocumentationLink => DeliveryApiConfiguration.ApiDocumentationContentArticleLink;
+
+    protected override void ApplyOperation(OpenApiOperation operation, OperationFilterContext context)
+    {
+        operation.Parameters ??= new List<OpenApiParameter>();
+
+        operation.Parameters.Add(new OpenApiParameter
+        {
+            Name = "Accept-Language",
+            In = ParameterLocation.Header,
+            Required = false,
+            Description = "Defines the language to return. Use this when querying language variant content items.",
+            Schema = new OpenApiSchema { Type = "string" },
+            Examples = new Dictionary<string, OpenApiExample>
+            {
+                { "Default", new OpenApiExample { Value = new OpenApiString(string.Empty) } },
+                { "English culture", new OpenApiExample { Value = new OpenApiString("en-us") } }
+            }
+        });
+    }
+
+    protected override void ApplyParameter(OpenApiParameter parameter, ParameterFilterContext context)
+    {
+        return;
+    }
+}

--- a/src/Umbraco.Core/DeliveryApi/ApiTranslationResponse.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiTranslationResponse.cs
@@ -1,0 +1,6 @@
+namespace Umbraco.Cms.Core.DeliveryApi;
+
+public class ApiTranslationResponse : Dictionary<string, object>
+{
+
+}


### PR DESCRIPTION
Internationalization is important, so I would like a way to fetch Umbraco dictionary items. Preferably it would be using the request language, and return a json format similar to https://www.i18next.com/misc/json-format as a good standard in the field.

### Prerequisites

Add a few translation items and test the API in `/umbraco/swagger/`

### Description
I added a `TranslationApiControllerBase `that creates a new route and section in the API Explorer "translation".
Then I added a new controller endpoint `GetListTranslationApiController `with an optional startItem param that fetches dictionary values from `LocalizationService `and writes them to a json format.

I'm not sure you need to be able to fetch a single item, but you can with `startItem`.
The idea is to fetch your translations for a given language and cache it on the client side.

Here's where I'm a bit unsure of the Umbraco internals, do we need to index the dictionary items from `LocalizationService`? Do we need a cache or is the service fetching cached items already?

This is a work in progress, and I'm not sure what your thoughts are on adding new controllers to the Delivery API, but I feel like it'd be a good addition. It's also my first time looking into the Umbraco Core, so I might be totally wrong on best practices and such.

I'm not sure what you want the Delivery API to be going forwards, but I would consider dictionary to be part of the content.