### PR TITLE
V13 RC: Fix issue with 2FA login

### DIFF
--- a/src/Umbraco.Web.UI.Login/src/components/pages/mfa.page.element.ts
+++ b/src/Umbraco.Web.UI.Login/src/components/pages/mfa.page.element.ts
@@ -7,7 +7,8 @@ import { umbLocalizationContext } from '../../external/localization/localization
 import { loadCustomView, renderCustomView } from '../../utils/load-custom-view.function.js';
 
 type MfaCustomViewElement = HTMLElement & {
-	providers: string[];
+	providers?: string[];
+  returnPath?: string;
 };
 
 @customElement('umb-mfa-page')
@@ -200,6 +201,7 @@ export default class UmbMfaPageElement extends LitElement {
 			const customView = await loadCustomView<MfaCustomViewElement>(view);
 			if (typeof customView === 'object') {
 				customView.providers = this.providers.map((provider) => provider.value);
+        customView.returnPath = umbAuthContext.returnPath;
 			}
 			return renderCustomView(customView);
 		} catch (e) {

--- a/src/Umbraco.Web.UI.Login/src/components/pages/mfa.page.element.ts
+++ b/src/Umbraco.Web.UI.Login/src/components/pages/mfa.page.element.ts
@@ -108,7 +108,7 @@ export default class UmbMfaPageElement extends LitElement {
 				location.href = returnPath;
 			}
 
-			this.dispatchEvent(new CustomEvent('umb-login-success', { bubbles: true, composed: true }));
+			this.dispatchEvent(new CustomEvent('umb-login-success', { bubbles: true, composed: true, detail: response.data }));
 		} catch (e) {
 			if (e instanceof Error) {
 				this.error = e.message ?? 'Unknown error';

--- a/src/Umbraco.Web.UI.Login/src/context/auth.repository.ts
+++ b/src/Umbraco.Web.UI.Login/src/context/auth.repository.ts
@@ -1,9 +1,9 @@
 import type {
-	LoginRequestModel,
-	LoginResponse,
-	MfaProvidersResponse,
-	ResetPasswordResponse,
-	ValidatePasswordResetCodeResponse,
+  LoginRequestModel,
+  LoginResponse,
+  MfaProvidersResponse,
+  ResetPasswordResponse,
+  ValidatePasswordResetCodeResponse,
 } from '../types.js';
 import { umbLocalizationContext } from '../external/localization/localization-context.js';
 
@@ -215,16 +215,17 @@ export class UmbAuthRepository {
 
 		const response = await fetch(request);
 
+    let text = await response.text();
+    text = this.#removeAngularJSResponseData(text);
+
+    const data = JSON.parse(text);
+
 		if (response.ok) {
 			return {
+        data,
 				status: response.status,
 			};
 		}
-
-		let text = await response.text();
-		text = this.#removeAngularJSResponseData(text);
-
-		const data = JSON.parse(text);
 
 		return {
 			status: response.status,


### PR DESCRIPTION
When a login happens inside the umb-overlay in the backoffice, we emit an event to indicate the success of that to close the overlay. That event needs to hold the user details to let the AngularJS application refresh itself with updated user details. This already happened on the regular login form but not on 2fa, so this PR fixes that.

The other change is that custom 2fa views can benefit to know the returnPath, so that is now also forwarded to them as a property.