### PR TITLE
Include automatic relation type aliases from factory and fix SQL parameter overflow

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollection.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollection.cs
@@ -8,61 +8,50 @@ public class DataValueReferenceFactoryCollection : BuilderCollectionBase<IDataVa
 {
     public DataValueReferenceFactoryCollection(Func<IEnumerable<IDataValueReferenceFactory>> items)
         : base(items)
-    {
-    }
+    { }
 
     // TODO: We could further reduce circular dependencies with PropertyEditorCollection by not having IDataValueReference implemented
     // by property editors and instead just use the already built in IDataValueReferenceFactory and/or refactor that into a more normal collection
-    public IEnumerable<UmbracoEntityReference> GetAllReferences(
-        IPropertyCollection properties,
-        PropertyEditorCollection propertyEditors)
+    public ISet<UmbracoEntityReference> GetAllReferences(IPropertyCollection properties, PropertyEditorCollection propertyEditors)
     {
-        var trackedRelations = new HashSet<UmbracoEntityReference>();
+        var references = new HashSet<UmbracoEntityReference>();
 
-        foreach (IProperty p in properties)
+        foreach (IProperty property in properties)
         {
-            if (!propertyEditors.TryGet(p.PropertyType.PropertyEditorAlias, out IDataEditor? editor))
+            if (!propertyEditors.TryGet(property.PropertyType.PropertyEditorAlias, out IDataEditor? dataEditor))
             {
                 continue;
             }
 
             // TODO: We will need to change this once we support tracking via variants/segments
             // for now, we are tracking values from ALL variants
-            foreach (IPropertyValue propertyVal in p.Values)
+            foreach (IPropertyValue propertyValue in property.Values)
             {
-                var val = propertyVal.EditedValue;
+                object? value = propertyValue.EditedValue;
 
-                IDataValueEditor? valueEditor = editor?.GetValueEditor();
-                if (valueEditor is IDataValueReference reference)
+                if (dataEditor.GetValueEditor() is IDataValueReference dataValueReference)
                 {
-                    IEnumerable<UmbracoEntityReference> refs = reference.GetReferences(val);
-                    foreach (UmbracoEntityReference r in refs)
-                    {
-                        trackedRelations.Add(r);
-                    }
+                    references.UnionWith(dataValueReference.GetReferences(value));
                 }
 
                 // Loop over collection that may be add to existing property editors
                 // implementation of GetReferences in IDataValueReference.
                 // Allows developers to add support for references by a
                 // package /property editor that did not implement IDataValueReference themselves
-                foreach (IDataValueReferenceFactory item in this)
+                foreach (IDataValueReferenceFactory dataValueReferenceFactory in this)
                 {
                     // Check if this value reference is for this datatype/editor
                     // Then call it's GetReferences method - to see if the value stored
                     // in the dataeditor/property has references to media/content items
-                    if (item.IsForEditor(editor))
+                    if (dataValueReferenceFactory.IsForEditor(dataEditor))
                     {
-                        foreach (UmbracoEntityReference r in item.GetDataValueReference().GetReferences(val))
-                        {
-                            trackedRelations.Add(r);
-                        }
+                        references.UnionWith(dataValueReferenceFactory.GetDataValueReference().GetReferences(value));
                     }
                 }
             }
         }
 
-        return trackedRelations;
+        return references;
     }
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -1087,9 +1087,8 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
             var trackedRelations = new List<UmbracoEntityReference>();
             trackedRelations.AddRange(_dataValueReferenceFactories.GetAllReferences(entity.Properties, PropertyEditors));
 
-            var relationTypeAliases = GetAutomaticRelationTypesAliases(entity.Properties, PropertyEditors).ToArray();
-
             // First delete all auto-relations for this entity
+            var relationTypeAliases = _dataValueReferenceFactories.GetAutomaticRelationTypesAliases(entity.Properties, PropertyEditors).ToArray();
             RelationRepository.DeleteByParent(entity.Id, relationTypeAliases);
 
             if (trackedRelations.Count == 0)
@@ -1133,31 +1132,6 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
 
             // Save bulk relations
             RelationRepository.SaveBulk(toSave);
-        }
-
-        private IEnumerable<string> GetAutomaticRelationTypesAliases(
-            IPropertyCollection properties,
-            PropertyEditorCollection propertyEditors)
-        {
-            var automaticRelationTypesAliases = new HashSet<string>(Constants.Conventions.RelationTypes.AutomaticRelationTypes);
-
-            foreach (IProperty property in properties)
-            {
-                if (propertyEditors.TryGet(property.PropertyType.PropertyEditorAlias, out IDataEditor? editor) is false )
-                {
-                    continue;
-                }
-
-                if (editor.GetValueEditor() is IDataValueReference reference)
-                {
-                    foreach (var alias in reference.GetAutomaticRelationTypesAliases())
-                    {
-                        automaticRelationTypesAliases.Add(alias);
-                    }
-                }
-            }
-
-            return automaticRelationTypesAliases;
         }
 
         /// <summary>

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -1083,9 +1083,8 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
         protected void PersistRelations(TEntity entity)
         {
             // Get all references from our core built in DataEditors/Property Editors
-            // Along with seeing if deverlopers want to collect additional references from the DataValueReferenceFactories collection
-            var trackedRelations = new List<UmbracoEntityReference>();
-            trackedRelations.AddRange(_dataValueReferenceFactories.GetAllReferences(entity.Properties, PropertyEditors));
+            // Along with seeing if developers want to collect additional references from the DataValueReferenceFactories collection
+            var trackedRelations = _dataValueReferenceFactories.GetAllReferences(entity.Properties, PropertyEditors);
 
             // First delete all auto-relations for this entity
             var relationTypeAliases = _dataValueReferenceFactories.GetAutomaticRelationTypesAliases(entity.Properties, PropertyEditors).ToArray();
@@ -1096,23 +1095,20 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
                 return;
             }
 
-            trackedRelations = trackedRelations.Distinct().ToList();
-            var udiToGuids = trackedRelations.Select(x => x.Udi as GuidUdi)
-                .ToDictionary(x => (Udi)x!, x => x!.Guid);
+            var udiToGuids = trackedRelations.Select(x => x.Udi as GuidUdi).WhereNotNull().ToDictionary(x => (Udi)x, x => x.Guid);
 
             // lookup in the DB all INT ids for the GUIDs and chuck into a dictionary
-            var keyToIds = Database.Fetch<NodeIdKey>(Sql()
+            var keyToIds = Database.FetchByGroups<NodeIdKey, Guid>(udiToGuids.Values, Constants.Sql.MaxParameterCount, guids => Sql()
                 .Select<NodeDto>(x => x.NodeId, x => x.UniqueId)
                 .From<NodeDto>()
-                .WhereIn<NodeDto>(x => x.UniqueId, udiToGuids.Values))
+                .WhereIn<NodeDto>(x => x.UniqueId, guids))
                 .ToDictionary(x => x.UniqueId, x => x.NodeId);
 
-            var allRelationTypes = RelationTypeRepository.GetMany(Array.Empty<int>())?
-                .ToDictionary(x => x.Alias, x => x);
+            var allRelationTypes = RelationTypeRepository.GetMany(Array.Empty<int>()).ToDictionary(x => x.Alias, x => x);
 
             IEnumerable<ReadOnlyRelation> toSave = trackedRelations.Select(rel =>
                 {
-                    if (allRelationTypes is null || !allRelationTypes.TryGetValue(rel.RelationTypeAlias, out IRelationType? relationType))
+                    if (!allRelationTypes.TryGetValue(rel.RelationTypeAlias, out IRelationType? relationType))
                     {
                         throw new InvalidOperationException($"The relation type {rel.RelationTypeAlias} does not exist");
                     }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollectionTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollectionTests.cs
@@ -181,19 +181,9 @@ public class DataValueReferenceFactoryCollectionTests
         var resultA = collection.GetAutomaticRelationTypesAliases(propertyEditors).ToArray();
         var resultB = collection.GetAutomaticRelationTypesAliases(properties, propertyEditors).ToArray();
 
-        Assert.Multiple(() =>
-        {
-            foreach (var alias in Constants.Conventions.RelationTypes.AutomaticRelationTypes)
-            {
-                Assert.Contains(alias, resultA, "Result A does not contain one of the default automatic relation types.");
-                Assert.Contains(alias, resultB, "Result B does not contain one of the default automatic relation types.");
-            }
-        });
-
-        // Ensure we don't have more than just the default
-        int expectedCount = Constants.Conventions.RelationTypes.AutomaticRelationTypes.Length;
-        Assert.AreEqual(expectedCount, resultA.Length, "Result A should only contain the default automatic relation types.");
-        Assert.AreEqual(expectedCount, resultB.Length, "Result B should only contain the default automatic relation types.");
+        var expected = Constants.Conventions.RelationTypes.AutomaticRelationTypes;
+        CollectionAssert.AreEquivalent(expected, resultA, "Result A does not contain the expected relation type aliases.");
+        CollectionAssert.AreEquivalent(expected, resultB, "Result B does not contain the expected relation type aliases.");
     }
 
     [Test]
@@ -210,16 +200,9 @@ public class DataValueReferenceFactoryCollectionTests
         var resultA = collection.GetAutomaticRelationTypesAliases(propertyEditors).ToArray();
         var resultB = collection.GetAutomaticRelationTypesAliases(properties, propertyEditors).ToArray();
 
-        Assert.Multiple(() =>
-        {
-            Assert.Contains("umbTest", resultA, "Result A does not contain the custom automatic relation type.");
-            Assert.Contains("umbTest", resultB, "Result B does not contain the custom automatic relation type.");
-        });
-
-        // Ensure we don't have more than just the default and single custom
-        int expectedCount = Constants.Conventions.RelationTypes.AutomaticRelationTypes.Length + 1;
-        Assert.AreEqual(expectedCount, resultA.Length, "Result A should only contain the default and a single custom automatic relation type.");
-        Assert.AreEqual(expectedCount, resultB.Length, "Result B should only contain the default and a single custom automatic relation type.");
+        var expected = Constants.Conventions.RelationTypes.AutomaticRelationTypes.Append("umbTest");
+        CollectionAssert.AreEquivalent(expected, resultA, "Result A does not contain the expected relation type aliases.");
+        CollectionAssert.AreEquivalent(expected, resultB, "Result B does not contain the expected relation type aliases.");
     }
 
     private class TestDataValueReferenceFactory : IDataValueReferenceFactory

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollectionTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollectionTests.cs
@@ -173,6 +173,44 @@ public class DataValueReferenceFactoryCollectionTests
         Assert.AreEqual(trackedUdi4, result.ElementAt(1).Udi.ToString());
     }
 
+    [Test]
+    public void GetAutomaticRelationTypesAliases_ContainsDefault()
+    {
+        var collection = new DataValueReferenceFactoryCollection(Enumerable.Empty<IDataValueReferenceFactory>);
+        var propertyEditors = new PropertyEditorCollection(new DataEditorCollection(Enumerable.Empty<IDataEditor>));
+        var properties = new PropertyCollection();
+
+        var resultA = collection.GetAutomaticRelationTypesAliases(propertyEditors).ToArray();
+        var resultB = collection.GetAutomaticRelationTypesAliases(properties, propertyEditors).ToArray();
+
+        Assert.AreEqual(resultA.Length, Constants.Conventions.RelationTypes.AutomaticRelationTypes.Length);
+        Assert.AreEqual(resultA.Length, Constants.Conventions.RelationTypes.AutomaticRelationTypes.Length);
+
+        foreach (var alias in Constants.Conventions.RelationTypes.AutomaticRelationTypes)
+        {
+            Assert.Contains(alias, resultA);
+            Assert.Contains(alias, resultB);
+        }
+    }
+
+    [Test]
+    public void GetAutomaticRelationTypesAliases_ContainsCustom()
+    {
+        var collection = new DataValueReferenceFactoryCollection(() => new TestDataValueReferenceFactory().Yield());
+
+        var labelPropertyEditor = new LabelPropertyEditor(DataValueEditorFactory, IOHelper, EditorConfigurationParser);
+        var propertyEditors = new PropertyEditorCollection(new DataEditorCollection(() => labelPropertyEditor.Yield()));
+        var serializer = new ConfigurationEditorJsonSerializer();
+        var property = new Property(new PropertyType(ShortStringHelper, new DataType(labelPropertyEditor, serializer)));
+        var properties = new PropertyCollection { property };
+
+        var resultA = collection.GetAutomaticRelationTypesAliases(propertyEditors).ToArray();
+        var resultB = collection.GetAutomaticRelationTypesAliases(properties, propertyEditors).ToArray();
+
+        Assert.Contains("umbTest", resultA);
+        Assert.Contains("umbTest", resultB);
+    }
+
     private class TestDataValueReferenceFactory : IDataValueReferenceFactory
     {
         public IDataValueReference GetDataValueReference() => new TestMediaDataValueReference();
@@ -196,6 +234,8 @@ public class DataValueReferenceFactoryCollectionTests
                     yield return new UmbracoEntityReference(udi);
                 }
             }
+
+            public IEnumerable<string> GetAutomaticRelationTypesAliases() => new[] { "umbTest" };
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Deploy automatically excludes the automatic relation types that are used for reference tracking (because they are always updated in the base content repository during save). However, the CMS doesn't have a built-in helper method to get all of them, so this PR creates a new `GetAutomaticRelationTypesAliases()` method on the `DataValueReferenceFactoryCollection` to get these from:
- The default ones from `Constants.Conventions.RelationTypes.AutomaticRelationTypes` (`umbMedia` and `umbDocument`);
- From any `IDataValueEditor` that also implements `IDataValueReference`;
- From any `IDataValueReferenceFactory` that is registered.

The code in `ContentRepositoryBase` also didn't get the relation types from the factory, so this PR also fixes a bug that would cause any custom relation type alias provided via the factory to not be automatically cleaned up. And finally, to avoid passing too many parameters into a SQL WHERE IN query, the GUID to ID lookup is now done in groups.