### PR TITLE
Update correct action permission for schedule publishing

### DIFF
--- a/src/Umbraco.Web.BackOffice/Filters/ContentSaveValidationAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/ContentSaveValidationAttribute.cs
@@ -189,7 +189,7 @@ internal sealed class ContentSaveValidationAttribute : TypeFilterAttribute
                     break;
                 case ContentSaveAction.Schedule:
                     permissionToCheck.Add(ActionUpdate.ActionLetter);
-                    permissionToCheck.Add(ActionToPublish.ActionLetter);
+                    permissionToCheck.Add(ActionPublish.ActionLetter);
                     contentToCheck = contentItem.PersistedContent;
                     contentIdToCheck = contentToCheck?.Id ?? default;
                     break;


### PR DESCRIPTION
## Details
- Fixes: #15131
- Instead of "Send to Publish" action/permission (`H`), we need the "Publish" (`U`) one.
  - This bug surfaced because of a recent fix but has been there for a while.

## Test
- Schedule publish both an already Saved/Published node and a newly created one

