### PR TITLE
Fix WithCollectionBuilder helper methods nullability

### DIFF
--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
@@ -36,9 +36,9 @@ public static partial class UmbracoBuilderExtensions
     /// </summary>
     internal static void AddAllCoreCollectionBuilders(this IUmbracoBuilder builder)
     {
-        builder.CacheRefreshers().Add(() => builder.TypeLoader.GetCacheRefreshers());
-        builder.DataEditors().Add(() => builder.TypeLoader.GetDataEditors());
-        builder.Actions().Add(() => builder .TypeLoader.GetActions());
+        builder.CacheRefreshers().Add(builder.TypeLoader.GetCacheRefreshers);
+        builder.DataEditors().Add(builder.TypeLoader.GetDataEditors);
+        builder.Actions().Add(builder.TypeLoader.GetActions);
 
         // register known content apps
         builder.ContentApps()

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
@@ -242,14 +242,14 @@ public static partial class UmbracoBuilderExtensions
     /// Gets the partial view snippets collection builder.
     /// </summary>
     /// <param name="builder">The builder.</param>
-    public static PartialViewSnippetCollectionBuilder? PartialViewSnippets(this IUmbracoBuilder builder)
+    public static PartialViewSnippetCollectionBuilder PartialViewSnippets(this IUmbracoBuilder builder)
         => builder.WithCollectionBuilder<PartialViewSnippetCollectionBuilder>();
 
     /// <summary>
     /// Gets the partial view macro snippets collection builder.
     /// </summary>
     /// <param name="builder">The builder.</param>
-    public static PartialViewMacroSnippetCollectionBuilder? PartialViewMacroSnippets(this IUmbracoBuilder builder)
+    public static PartialViewMacroSnippetCollectionBuilder PartialViewMacroSnippets(this IUmbracoBuilder builder)
         => builder.WithCollectionBuilder<PartialViewMacroSnippetCollectionBuilder>();
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Collections.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Collections.cs
@@ -15,21 +15,21 @@ public static partial class UmbracoBuilderExtensions
     ///     Gets the mappers collection builder.
     /// </summary>
     /// <param name="builder">The builder.</param>
-    public static MapperCollectionBuilder? Mappers(this IUmbracoBuilder builder)
+    public static MapperCollectionBuilder Mappers(this IUmbracoBuilder builder)
         => builder.WithCollectionBuilder<MapperCollectionBuilder>();
 
     /// <summary>
     ///     Gets the NPoco mappers collection builder.
     /// </summary>
     /// <param name="builder">The builder.</param>
-    public static NPocoMapperCollectionBuilder? NPocoMappers(this IUmbracoBuilder builder)
+    public static NPocoMapperCollectionBuilder NPocoMappers(this IUmbracoBuilder builder)
         => builder.WithCollectionBuilder<NPocoMapperCollectionBuilder>();
 
     /// <summary>
     ///     Gets the package migration plans collection builder.
     /// </summary>
     /// <param name="builder">The builder.</param>
-    public static PackageMigrationPlanCollectionBuilder? PackageMigrationPlans(this IUmbracoBuilder builder)
+    public static PackageMigrationPlanCollectionBuilder PackageMigrationPlans(this IUmbracoBuilder builder)
         => builder.WithCollectionBuilder<PackageMigrationPlanCollectionBuilder>();
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -78,8 +78,8 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddSingleton<IDistributedLockingMechanismFactory, DefaultDistributedLockingMechanismFactory>();
         builder.Services.AddSingleton<IUmbracoDatabaseFactory, UmbracoDatabaseFactory>();
         builder.Services.AddSingleton(factory => factory.GetRequiredService<IUmbracoDatabaseFactory>().SqlContext);
-        builder.NPocoMappers()?.Add<NullableDateMapper>();
-        builder.PackageMigrationPlans()?.Add(() => builder.TypeLoader.GetPackageMigrationPlans());
+        builder.NPocoMappers().Add<NullableDateMapper>();
+        builder.PackageMigrationPlans().Add(builder.TypeLoader.GetPackageMigrationPlans);
 
         builder.Services.AddSingleton<IRuntimeState, RuntimeState>();
         builder.Services.AddSingleton<IRuntime, CoreRuntime>();
@@ -107,7 +107,7 @@ public static partial class UmbracoBuilderExtensions
         // register persistence mappers - required by database factory so needs to be done here
         // means the only place the collection can be modified is in a runtime - afterwards it
         // has been frozen and it is too late
-        builder.Mappers()?.AddCoreMappers();
+        builder.Mappers().AddCoreMappers();
 
         // register the scope provider
         builder.Services.AddSingleton<ScopeProvider>(sp => ActivatorUtilities.CreateInstance<ScopeProvider>(sp, sp.GetRequiredService<IAmbientScopeStack>())); // implements IScopeProvider, IScopeAccessor


### PR DESCRIPTION
While looking at https://github.com/umbraco/Umbraco-CMS/pull/15138, I noticed the nullability of the `PackageMigrationPlans()` helper method was incorrect (`WithCollectionBuilder()` doesn't return a nullable type anymore). This PR fixes the following helper methods:
- `PartialViewSnippets()`
- `PartialViewMacroSnippets()`
- `Mappers()`
- `NPocoMappers()`
- `PackageMigrationPlans()`

