### PR TITLE
Added support for user supplied filter query to search

### DIFF
--- a/src/Umbraco.Infrastructure/Examine/UmbracoExamineExtensions.cs
+++ b/src/Umbraco.Infrastructure/Examine/UmbracoExamineExtensions.cs
@@ -5,17 +5,17 @@ using Umbraco.Cms.Infrastructure.Examine;
 
 namespace Umbraco.Extensions;
 
-public static class UmbracoExamineExtensions
+public static partial class UmbracoExamineExtensions
 {
     /// <summary>
     ///     Matches a culture iso name suffix
     /// </summary>
     /// <remarks>
     ///     myFieldName_en-us will match the "en-us"
+    ///     myBlockListField.items[0].myFieldName_en-us will match the "en-us"
     /// </remarks>
-    internal static readonly Regex _cultureIsoCodeFieldNameMatchExpression = new(
-        "^(?<FieldName>[_\\w]+)_(?<CultureName>[a-z]{2,3}(-[a-z0-9]{2,4})?)$",
-        RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+    [GeneratedRegex(@"^(?<FieldName>.+)_(?<CultureName>[a-z]{2,3}(-[a-z0-9]{2,4})?)$", RegexOptions.ExplicitCapture)]
+    internal static partial Regex CultureIsoCodeFieldNameMatchExpression();
 
     // TODO: We need a public method here to just match a field name against CultureIsoCodeFieldNameMatchExpression
 
@@ -32,7 +32,7 @@ public static class UmbracoExamineExtensions
         var results = new List<string>();
         foreach (var field in allFields)
         {
-            Match match = _cultureIsoCodeFieldNameMatchExpression.Match(field);
+            Match match = CultureIsoCodeFieldNameMatchExpression().Match(field);
             if (match.Success && culture.InvariantEquals(match.Groups["CultureName"].Value))
             {
                 results.Add(field);
@@ -54,7 +54,7 @@ public static class UmbracoExamineExtensions
 
         foreach (var field in allFields)
         {
-            Match match = _cultureIsoCodeFieldNameMatchExpression.Match(field);
+            Match match = CultureIsoCodeFieldNameMatchExpression().Match(field);
             if (match.Success && culture.InvariantEquals(match.Groups["CultureName"].Value))
             {
                 yield return field; // matches this culture field

--- a/src/Umbraco.Infrastructure/Examine/UmbracoFieldDefinitionCollection.cs
+++ b/src/Umbraco.Infrastructure/Examine/UmbracoFieldDefinitionCollection.cs
@@ -70,7 +70,7 @@ public class UmbracoFieldDefinitionCollection : FieldDefinitionCollection
             return false;
         }
 
-        Match match = UmbracoExamineExtensions._cultureIsoCodeFieldNameMatchExpression.Match(fieldName);
+        Match match = UmbracoExamineExtensions.CultureIsoCodeFieldNameMatchExpression().Match(fieldName);
         if (match.Success)
         {
             var nonCultureFieldName = match.Groups["FieldName"].Value;

--- a/src/Umbraco.Infrastructure/IPublishedContentQuery.cs
+++ b/src/Umbraco.Infrastructure/IPublishedContentQuery.cs
@@ -131,4 +131,20 @@ public interface IPublishedContentQuery
     ///     The search results.
     /// </returns>
     IEnumerable<PublishedSearchResult> Search(IQueryExecutor query, int skip, int take, out long totalRecords);
+
+    /// <summary>
+    ///     Executes the query and converts the results to <see cref="PublishedSearchResult" />.
+    /// </summary>
+    /// <param name="query">The query.</param>
+    /// <param name="skip">The amount of results to skip.</param>
+    /// <param name="take">The amount of results to take/return.</param>
+    /// <param name="totalRecords">The total amount of records.</param>
+    /// <param name="culture">The culture (defaults to a culture insensitive search).</param>
+    /// <returns>
+    ///     The search results.
+    /// </returns>
+    /// <remarks>
+    ///     While enumerating results, the ambient culture is changed to be the searched culture.
+    /// </remarks>
+    IEnumerable<PublishedSearchResult> Search(IQueryExecutor query, int skip, int take, out long totalRecords, string? culture);
 }

--- a/src/Umbraco.Infrastructure/IPublishedContentQuery.cs
+++ b/src/Umbraco.Infrastructure/IPublishedContentQuery.cs
@@ -63,10 +63,7 @@ public interface IPublishedContentQuery
     ///     The name of the index to search (defaults to
     ///     <see cref="Constants.UmbracoIndexes.ExternalIndexName" />).
     /// </param>
-    /// <param name="loadedFields">
-    ///     This parameter is no longer used, because the results are loaded from the published snapshot
-    ///     using the single item ID field.
-    /// </param>
+    /// <param name="filterQuery">Additional filter query to be applied.</param>
     /// <returns>
     ///     The search results.
     /// </returns>
@@ -86,7 +83,7 @@ public interface IPublishedContentQuery
         out long totalRecords,
         string culture = "*",
         string indexName = Constants.UmbracoIndexes.ExternalIndexName,
-        ISet<string>? loadedFields = null);
+        Func<IBooleanOperation, IOrdering>? filterQuery = null);
 
     /// <summary>
     ///     Searches content.


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
Currently any consumer of the `IPublishedContentQuery` can use either:
- Simple search method, where a single query string parameter is supplied, and where Umbraco does all the heavy lifting
- Supply its own search query, but lose all out of the box functionality of the simple method.

It would be nice to have the option of using the simple search method, but still be able to further refine the search, by passing additional query filters.
This is strictly a QoL improvement, as everything can already be achieved by copying Umbraco code.

Also, not sure if this can be implemented in a backwards compatible way.

Dependent on changes in #15148


<!-- Thanks for contributing to Umbraco CMS! -->
