### PR TITLE
Expose the Delivery API CLR type

### DIFF
--- a/src/Umbraco.Core/Models/PublishedContent/IPublishedPropertyType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/IPublishedPropertyType.cs
@@ -66,6 +66,14 @@ public interface IPublishedPropertyType
     Type ModelClrType { get; }
 
     /// <summary>
+    ///     Gets the property model Delivery Api CLR type.
+    /// </summary>
+    /// <remarks>
+    ///     <para>The model CLR type may be a <see cref="ModelType" /> type, or may contain <see cref="ModelType" /> types.</para>
+    /// </remarks>
+    Type DeliveryApiModelClrType { get; }
+
+    /// <summary>
     ///     Gets the property CLR type.
     /// </summary>
     /// <remarks>

--- a/src/Umbraco.Core/Models/PublishedContent/IPublishedPropertyType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/IPublishedPropertyType.cs
@@ -71,7 +71,7 @@ public interface IPublishedPropertyType
     /// <remarks>
     ///     <para>The model CLR type may be a <see cref="ModelType" /> type, or may contain <see cref="ModelType" /> types.</para>
     /// </remarks>
-    Type DeliveryApiModelClrType { get; }
+    Type DeliveryApiModelClrType => ModelClrType;
 
     /// <summary>
     ///     Gets the property CLR type.

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedPropertyType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedPropertyType.cs
@@ -23,7 +23,7 @@ namespace Umbraco.Cms.Core.Models.PublishedContent
         private PropertyCacheLevel _deliveryApiCacheLevel;
 
         private Type? _modelClrType;
-        private Type? _modelDeliveryApiClrType;
+        private Type? _deliveryApiModelClrType;
         private Type? _clrType;
 
         #region Constructors
@@ -192,12 +192,12 @@ namespace Umbraco.Cms.Core.Models.PublishedContent
                 }
             }
 
-            IDeliveryApiPropertyValueConverter? deliveryApiPropertyValueConverter = _converter as IDeliveryApiPropertyValueConverter;
+            var deliveryApiPropertyValueConverter = _converter as IDeliveryApiPropertyValueConverter;
 
             _cacheLevel = _converter?.GetPropertyCacheLevel(this) ?? PropertyCacheLevel.Snapshot;
             _deliveryApiCacheLevel = deliveryApiPropertyValueConverter?.GetDeliveryApiPropertyCacheLevel(this) ?? _cacheLevel;
             _modelClrType = _converter?.GetPropertyValueType(this) ?? typeof(object);
-            _modelDeliveryApiClrType = deliveryApiPropertyValueConverter?.GetDeliveryApiPropertyValueType(this) ?? _modelClrType;
+            _deliveryApiModelClrType = deliveryApiPropertyValueConverter?.GetDeliveryApiPropertyValueType(this) ?? _modelClrType;
         }
 
         /// <inheritdoc />
@@ -343,7 +343,7 @@ namespace Umbraco.Cms.Core.Models.PublishedContent
                     Initialize();
                 }
 
-                return _modelDeliveryApiClrType!;
+                return _deliveryApiModelClrType!;
             }
         }
 

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedPropertyType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedPropertyType.cs
@@ -23,6 +23,7 @@ namespace Umbraco.Cms.Core.Models.PublishedContent
         private PropertyCacheLevel _deliveryApiCacheLevel;
 
         private Type? _modelClrType;
+        private Type? _modelDeliveryApiClrType;
         private Type? _clrType;
 
         #region Constructors
@@ -191,11 +192,12 @@ namespace Umbraco.Cms.Core.Models.PublishedContent
                 }
             }
 
+            IDeliveryApiPropertyValueConverter? deliveryApiPropertyValueConverter = _converter as IDeliveryApiPropertyValueConverter;
+
             _cacheLevel = _converter?.GetPropertyCacheLevel(this) ?? PropertyCacheLevel.Snapshot;
-            _deliveryApiCacheLevel = _converter is IDeliveryApiPropertyValueConverter deliveryApiPropertyValueConverter
-                ? deliveryApiPropertyValueConverter.GetDeliveryApiPropertyCacheLevel(this)
-                : _cacheLevel;
+            _deliveryApiCacheLevel = deliveryApiPropertyValueConverter?.GetDeliveryApiPropertyCacheLevel(this) ?? _cacheLevel;
             _modelClrType = _converter?.GetPropertyValueType(this) ?? typeof(object);
+            _modelDeliveryApiClrType = deliveryApiPropertyValueConverter?.GetDeliveryApiPropertyValueType(this) ?? _modelClrType;
         }
 
         /// <inheritdoc />
@@ -328,6 +330,20 @@ namespace Umbraco.Cms.Core.Models.PublishedContent
                 }
 
                 return _modelClrType!;
+            }
+        }
+
+        /// <inheritdoc />
+        public Type DeliveryApiModelClrType
+        {
+            get
+            {
+                if (!_initialized)
+                {
+                    Initialize();
+                }
+
+                return _modelDeliveryApiClrType!;
             }
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Currently it's not possible to determine the delivery API type of a property without the use of reflection.
The use case for such a feature is to transform the swagger so it returns the proper document types response models, similar to Umbraco's models builder.
(You can check it here: [https://github.com/ByteCrumb/Umbraco.Community.DeliveryApiExtensions](https://github.com/ByteCrumb/Umbraco.Community.DeliveryApiExtensions/blob/main/src/UmbracoDeliveryApiExtensions/Services/ContentTypeInfoService.cs#L77C15))

Example of the code that is currently necessary:
```c#
private static readonly FieldInfo? ConverterField = typeof(PublishedPropertyType).GetField("_converter", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance);
private static Type GetPropertyType(IPublishedPropertyType publishedPropertyType)
{
    // This needs to be done first to ensure the converter field is actually loaded
    Type modelClrType = publishedPropertyType.ModelClrType;

    return ConverterField?.GetValue(publishedPropertyType) switch
    {
        IDeliveryApiPropertyValueConverter propertyValueConverter => propertyValueConverter.GetDeliveryApiPropertyValueType(publishedPropertyType),
        _ => modelClrType
    };
}
```

This PR exposes the necessary properties.
It's technically a breaking change as a property was added to `IPublishedPropertyType`.