### PR TITLE
Add comments to methods in `IWebHookService`

### DIFF
--- a/src/Umbraco.Core/Services/IWebHookService.cs
+++ b/src/Umbraco.Core/Services/IWebHookService.cs
@@ -1,18 +1,40 @@
-﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Core.Services;
 
 public interface IWebHookService
 {
+    /// <summary>
+    ///     Creates a webhook.
+    /// </summary>
+    /// <param name="webhook"><see cref="Webhook" /> to create.</param>
     Task<Webhook> CreateAsync(Webhook webhook);
 
+    /// <summary>
+    ///     Updates a webhook.
+    /// </summary>
+    /// <param name="webhook"><see cref="Webhook" /> to update.</param>
     Task UpdateAsync(Webhook webhook);
 
+    /// <summary>
+    ///     Deletes a webhook.
+    /// </summary>
+    /// <param name="key">The unique key of the webhook.</param>
     Task DeleteAsync(Guid key);
 
+    /// <summary>
+    ///     Gets a webhook by its key.
+    /// </summary>
+    /// <param name="key">The unique key of the webhook.</param>
     Task<Webhook?> GetAsync(Guid key);
 
+    /// <summary>
+    ///     Gets all webhooks.
+    /// </summary>
     Task<PagedModel<Webhook>> GetAllAsync(int skip, int take);
 
+    /// <summary>
+    ///     Gets webhooks by event name.
+    /// </summary>
     Task<IEnumerable<Webhook>> GetByEventNameAsync(string eventName);
 }

--- a/src/Umbraco.Core/Services/WebhookService.cs
+++ b/src/Umbraco.Core/Services/WebhookService.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Scoping;
 
@@ -15,6 +15,7 @@ public class WebhookService : IWebHookService
         _webhookRepository = webhookRepository;
     }
 
+    /// <inheritdoc />
     public async Task<Webhook> CreateAsync(Webhook webhook)
     {
         using ICoreScope scope = _provider.CreateCoreScope();
@@ -24,6 +25,7 @@ public class WebhookService : IWebHookService
         return created;
     }
 
+    /// <inheritdoc />
     public async Task UpdateAsync(Webhook webhook)
     {
         using ICoreScope scope = _provider.CreateCoreScope();
@@ -45,6 +47,7 @@ public class WebhookService : IWebHookService
         scope.Complete();
     }
 
+    /// <inheritdoc />
     public async Task DeleteAsync(Guid key)
     {
         using ICoreScope scope = _provider.CreateCoreScope();
@@ -57,6 +60,7 @@ public class WebhookService : IWebHookService
         scope.Complete();
     }
 
+    /// <inheritdoc />
     public async Task<Webhook?> GetAsync(Guid key)
     {
         using ICoreScope scope = _provider.CreateCoreScope();
@@ -65,6 +69,7 @@ public class WebhookService : IWebHookService
         return webhook;
     }
 
+    /// <inheritdoc />
     public async Task<PagedModel<Webhook>> GetAllAsync(int skip, int take)
     {
         using ICoreScope scope = _provider.CreateCoreScope();
@@ -74,6 +79,7 @@ public class WebhookService : IWebHookService
         return webhooks;
     }
 
+    /// <inheritdoc />
     public async Task<IEnumerable<Webhook>> GetByEventNameAsync(string eventName)
     {
         using ICoreScope scope = _provider.CreateCoreScope();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Added comments to methods in new `IWebHookService`.

Not sure if create, update and delete should have `int userId = Constants.Security.SuperUserId` param like many others services, e.g. `IDataTypeService`:
https://github.com/umbraco/Umbraco-CMS/blob/a2a2680defd40ed0ef72fb85bf6d7a9bf1db33bc/src/Umbraco.Core/Services/IDataTypeService.cs#L75

which is used for `Audit()`:
https://github.com/umbraco/Umbraco-CMS/blob/a2a2680defd40ed0ef72fb85bf6d7a9bf1db33bc/src/Umbraco.Core/Services/DataTypeService.cs#L515

while looking into supporting Webhooks in management API, I noticed other services pass in `CurrentUserKey(_backOfficeSecurityAccessor)`, so maybe we need this later anyway?
https://github.com/umbraco/Umbraco-CMS/pull/15147/files#diff-33a00493a31cf8daad754645a3ba59e063c24b6aa7d9a89fc24a3226237f6a6eR35