### PR TITLE
Data type icons should not be served from the Management API

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Tree/DataTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Tree/DataTypeTreeControllerBase.cs
@@ -38,7 +38,7 @@ public class DataTypeTreeControllerBase : FolderTreeControllerBase<DataTypeTreeI
             DataTypeTreeItemResponseModel responseModel = MapTreeItemViewModel(parentId, entity);
             if (dataTypes.TryGetValue(entity.Id, out IDataType? dataType))
             {
-                responseModel.Icon = dataType.Editor?.Icon ?? responseModel.Icon;
+                responseModel.EditorUiAlias = dataType.EditorUiAlias;
             }
 
             return responseModel;

--- a/src/Umbraco.Cms.Api.Management/Mapping/Items/ItemTypeMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Items/ItemTypeMapDefinition.cs
@@ -49,7 +49,7 @@ public class ItemTypeMapDefinition : IMapDefinition
     {
         target.Name = source.Name ?? string.Empty;
         target.Id = source.Key;
-        target.Icon = source.Editor?.Icon;
+        target.EditorUiAlias = source.EditorUiAlias;
     }
 
     // Umbraco.Code.MapAll

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -16973,6 +16973,75 @@
         }
       }
     },
+    "/umbraco/management/api/v1/user/invite/resend": {
+      "post": {
+        "tags": [
+          "User"
+        ],
+        "operationId": "PostUserInviteResend",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ResendInviteUserRequestModel"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ResendInviteUserRequestModel"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ResendInviteUserRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
     "/umbraco/management/api/v1/user/invite/verify": {
       "post": {
         "tags": [
@@ -18301,7 +18370,7 @@
           }
         ],
         "properties": {
-          "icon": {
+          "editorUiAlias": {
             "type": "string",
             "nullable": true
           }
@@ -18409,7 +18478,7 @@
           }
         ],
         "properties": {
-          "icon": {
+          "editorUiAlias": {
             "type": "string",
             "nullable": true
           }
@@ -18677,6 +18746,9 @@
           "contentTypeId": {
             "type": "string",
             "format": "uuid"
+          },
+          "isTrashed": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false
@@ -18715,6 +18787,9 @@
             "type": "string",
             "format": "uuid",
             "nullable": true
+          },
+          "isTrashed": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false
@@ -19633,6 +19708,9 @@
           "icon": {
             "type": "string",
             "nullable": true
+          },
+          "isTrashed": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false
@@ -21464,6 +21542,20 @@
             "nullable": true
           },
           "childObjectTypeName": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ResendInviteUserRequestModel": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "message": {
             "type": "string",
             "nullable": true
           }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DataType/Item/DataTypeItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DataType/Item/DataTypeItemResponseModel.cs
@@ -4,5 +4,5 @@ namespace Umbraco.Cms.Api.Management.ViewModels.DataType.Item;
 
 public class DataTypeItemResponseModel : ItemResponseModelBase
 {
-    public string? Icon { get; set; }
+    public string? EditorUiAlias { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DataType/Item/DataTypeTreeItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DataType/Item/DataTypeTreeItemResponseModel.cs
@@ -4,5 +4,5 @@ namespace Umbraco.Cms.Api.Management.ViewModels.DataType.Item;
 
 public class DataTypeTreeItemResponseModel : FolderTreeItemResponseModel
 {
-    public string? Icon { get; set; }
+    public string? EditorUiAlias { get; set; }
 }

--- a/src/Umbraco.Core/PropertyEditors/IDataEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/IDataEditor.cs
@@ -31,12 +31,14 @@ public interface IDataEditor : IDiscoverable
     ///     Gets the icon of the editor.
     /// </summary>
     /// <remarks>Can be used to display editors when presenting them.</remarks>
+    // FIXME: remove this when we are rid of the old backoffice - the server should not know about data editor icons
     string Icon { get; }
 
     /// <summary>
     ///     Gets the group of the editor.
     /// </summary>
     /// <remarks>Can be used to organize editors when presenting them.</remarks>
+    // FIXME: remove this when we are rid of the old backoffice - the server should not know about data editor groups
     string Group { get; }
 
     /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The server should not know about data type icons in V14, so the Management API should not be serving them 😄 instead, the client needs the editor UI alias to handle data type icons, groups etc. etc.

### Testing this PR

1. Verify that the data type tree endpoints return editor UI alias instead of icon for the data type tree items returned.
2. Verify that the data type item endpoints return editor UI alias instead of icon for the data type items returned.