### PR TITLE
Fix rendering and parsing new RTE markup object in backoffice

### DIFF
--- a/src/Umbraco.Cms.StaticAssets/wwwroot/App_Plugins/Umbraco.BlockGridEditor.DefaultCustomViews/umbBlockGridDemoRichTextBlock.html
+++ b/src/Umbraco.Cms.StaticAssets/wwwroot/App_Plugins/Umbraco.BlockGridEditor.DefaultCustomViews/umbBlockGridDemoRichTextBlock.html
@@ -21,5 +21,5 @@
 
 </style>
 
-<div class="text" ng-click="block.edit()" ng-focus="block.focus" ng-bind-html="block.data.richText" style="margin: 0 20px;">
+<div class="text" ng-click="block.edit()" ng-focus="block.focus" ng-bind-html="block.data.richText.markup" style="margin: 0 20px;">
 </div>

--- a/src/Umbraco.Web.UI.Client/src/common/filters/nestedcontent.filter.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/nestedcontent.filter.js
@@ -1,4 +1,4 @@
-﻿// Filter to take a node id and grab it's name instead
+// Filter to take a node id and grab it's name instead
 // Usage: {{ pickerAlias | ncNodeName }}
 
 // Cache for node names so we don't make a ton of requests
@@ -78,6 +78,9 @@ angular.module("umbraco.filters").filter("ncNodeName", function (editorState, en
 
 }).filter("ncRichText", function () {
   return function (input) {
-    return $("<div/>").html(input).text();
+    // Get markup from RTE object or assume HTML
+    var html = input && Object.hasOwn(input, 'markup') ? input.markup : input;
+
+    return $("<div/>").html(html).text();
   };
 });


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This fixes 2 cases where the HTML markup of the RTE wasn't correctly rendered in the backoffice, because the editor now returns an object that stores both the HTML and used blocks (see PR https://github.com/umbraco/Umbraco-CMS/pull/15029 that adds the 'Blocks in RTE' feature).

The default custom view we provide for the RTE in the Block Grid didn't render the actual HTML and if a label used the `ncRichText` filter, it couldn't parse the HTML to text, resulting in:

![Broken RTE display](https://github.com/umbraco/Umbraco-CMS/assets/1051287/c270a75c-32c1-453f-996b-89aeb1c235d2)

This fixes both the custom view and `ncRichText` filter, so the HTML markup is correctly rendered/parsed to text:
![Fixed RTE display](https://github.com/umbraco/Umbraco-CMS/assets/1051287/e1f0ae20-209c-4f37-a4cd-ceeeb2e5c026)

Testing can be done by installing `Umbraco.TheStarterKit` 12.0.0 and viewing the Home page in the backoffice: applying this PR and rebuilding the front-end assets should fix it.