### PR TITLE
Use header value instead if present to set culture on request

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/HttpRequestExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/HttpRequestExtensions.cs
@@ -45,6 +45,9 @@ public static class HttpRequestExtensions
     public static string? ClientCulture(this HttpRequest request)
         => request.Headers.TryGetValue("X-UMB-CULTURE", out StringValues values) ? values[0] : null;
 
+    public static string? ClientSegment(this HttpRequest request)
+        => request.Headers.TryGetValue("X-UMB-SEGMENT", out StringValues values) ? values[0] : null;
+
     /// <summary>
     ///     Determines if a request is local.
     /// </summary>

--- a/src/Umbraco.Web.Common/Middleware/UmbracoRequestMiddleware.cs
+++ b/src/Umbraco.Web.Common/Middleware/UmbracoRequestMiddleware.cs
@@ -104,7 +104,7 @@ public class UmbracoRequestMiddleware : IMiddleware
         // Also MiniProfiler.Current becomes null if it is handled by the event aggregator due to async/await
         _profiler?.UmbracoApplicationBeginRequest(context, _runtimeState.Level);
 
-        _variationContextAccessor.VariationContext ??= new VariationContext(_defaultCultureAccessor.DefaultCulture);
+        _variationContextAccessor.VariationContext ??= new VariationContext(context.Request.ClientCulture() ?? _defaultCultureAccessor.DefaultCulture, context.Request.ClientSegment());
         UmbracoContextReference umbracoContextReference = _umbracoContextFactory.EnsureUmbracoContext();
 
         Uri? currentApplicationUrl = GetApplicationUrlFromCurrentRequest(context.Request);


### PR DESCRIPTION
### Description
This pr uses the header value to set culture and segment, if present on the request.

This means the `IVariantionContextAccessor` is usable from backoffice requests


### Test

- Try to get the value from the `IVariantionContextAccessor` e.g. on the EntityController.GetDynamicRoot endpoint
- Ensure delivery api etc still works as expected
- Ensure regular razor calls still work as expected