### PR TITLE
Fix alt attribute of logo image on login page

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/application/umb-login.html
@@ -5,7 +5,7 @@
         <div class="login-overlay__background-image" ng-style="{'background-image': 'url('+vm.backgroundImage+')'}"></div>
 
         <div class="login-overlay__logo">
-            <img ng-src="{{vm.logoImage}}" alt=""/>
+            <img ng-src="{{vm.logoImage}}" alt="Umbraco"/>
         </div>
 
         <div ng-if="!vm.denyLocalLogin" ng-show="vm.invitedUser != null" class="umb-login-container">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below
To test it: 
- Visit the login page: /umbraco#/login/false, then the lighthouse accessibility tool should not show "missing alt attribute"
- Visit the Login page, right-click on the page and press Inspect on the menu then search for _assets/img/application/umbraco_logo_white.svg_ to find the logo img tag. It should contain **alt="Umbraco"**

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->
Related issue: https://github.com/umbraco/Umbraco-CMS/issues/15069
### Description
I just added alt="Umbraco" to the logo on the login page