### PR TITLE
Performance optimisations related to blocks (and multi url picker)

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/DefaultPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Core/PropertyEditors/DefaultPropertyIndexValueFactory.cs
@@ -9,15 +9,22 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 /// </summary>
 public class DefaultPropertyIndexValueFactory : IPropertyIndexValueFactory
 {
-    /// <inheritdoc />
-    public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published, IEnumerable<string> availableCultures)
+    public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published,
+        IEnumerable<string> availableCultures, IDictionary<Guid, IContentType> contentTypeDictionary)
     {
         yield return new KeyValuePair<string, IEnumerable<object?>>(
             property.Alias,
             property.GetValue(culture, segment, published).Yield());
     }
 
-    [Obsolete("Use the overload with the availableCultures parameter instead, scheduled for removal in v14")]
+    /// <inheritdoc />
+    [Obsolete("Use the non-obsolete overload, scheduled for removal in v14")]
+    public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture,
+        string? segment, bool published, IEnumerable<string> availableCultures)
+        => GetIndexValues(property, culture, segment, published, availableCultures,
+            new Dictionary<Guid, IContentType>());
+
+    [Obsolete("Use the non-obsolete overload, scheduled for removal in v14")]
     public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published)
-        => GetIndexValues(property, culture, segment, published, Enumerable.Empty<string>());
+        => GetIndexValues(property, culture, segment, published, Enumerable.Empty<string>(), new Dictionary<Guid, IContentType>());
 }

--- a/src/Umbraco.Core/PropertyEditors/IPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Core/PropertyEditors/IPropertyIndexValueFactory.cs
@@ -22,9 +22,14 @@ public interface IPropertyIndexValueFactory
     ///         more than one value for a given field.
     ///     </para>
     /// </remarks>
+    IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture,
+        string? segment, bool published, IEnumerable<string> availableCultures,
+        IDictionary<Guid, IContentType> contentTypeDictionary) => GetIndexValues(property, culture, segment, published);
+
+    [Obsolete("Use non-obsolete overload, scheduled for removal in v14")]
     IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published, IEnumerable<string> availableCultures)
         => GetIndexValues(property, culture, segment, published);
 
-    [Obsolete("Use the overload with the availableCultures parameter instead, scheduled for removal in v14")]
+    [Obsolete("Use non-obsolete overload, scheduled for removal in v14")]
     IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published);
 }

--- a/src/Umbraco.Core/PropertyEditors/NoopPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Core/PropertyEditors/NoopPropertyIndexValueFactory.cs
@@ -8,6 +8,12 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 public class NoopPropertyIndexValueFactory : IPropertyIndexValueFactory
 {
     /// <inheritdoc />
+    public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published,
+        IEnumerable<string> availableCultures, IDictionary<Guid, IContentType> contentTypeDictionary)
+    => Array.Empty<KeyValuePair<string, IEnumerable<object?>>>();
+
+
+    [Obsolete("Use the overload with the availableCultures parameter instead, scheduled for removal in v14")]
     public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published, IEnumerable<string> availableCultures) => Array.Empty<KeyValuePair<string, IEnumerable<object?>>>();
 
     [Obsolete("Use the overload with the availableCultures parameter instead, scheduled for removal in v14")]

--- a/src/Umbraco.Infrastructure/Examine/MediaValueSetBuilder.cs
+++ b/src/Umbraco.Infrastructure/Examine/MediaValueSetBuilder.cs
@@ -1,10 +1,12 @@
 using Examine;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Examine;
@@ -14,8 +16,11 @@ public class MediaValueSetBuilder : BaseValueSetBuilder<IMedia>
     private readonly ContentSettings _contentSettings;
     private readonly MediaUrlGeneratorCollection _mediaUrlGenerators;
     private readonly IShortStringHelper _shortStringHelper;
+    private readonly IContentTypeService _contentTypeService;
     private readonly UrlSegmentProviderCollection _urlSegmentProviders;
     private readonly IUserService _userService;
+
+
 
     public MediaValueSetBuilder(
         PropertyEditorCollection propertyEditors,
@@ -23,19 +28,41 @@ public class MediaValueSetBuilder : BaseValueSetBuilder<IMedia>
         MediaUrlGeneratorCollection mediaUrlGenerators,
         IUserService userService,
         IShortStringHelper shortStringHelper,
-        IOptions<ContentSettings> contentSettings)
+        IOptions<ContentSettings> contentSettings,
+        IContentTypeService contentTypeService)
         : base(propertyEditors, false)
     {
         _urlSegmentProviders = urlSegmentProviders;
         _mediaUrlGenerators = mediaUrlGenerators;
         _userService = userService;
         _shortStringHelper = shortStringHelper;
+        _contentTypeService = contentTypeService;
         _contentSettings = contentSettings.Value;
     }
 
+    [Obsolete("Use non-obsolete ctor, scheduled for removal in v14")]
+    public MediaValueSetBuilder(
+        PropertyEditorCollection propertyEditors,
+        UrlSegmentProviderCollection urlSegmentProviders,
+        MediaUrlGeneratorCollection mediaUrlGenerators,
+        IUserService userService,
+        IShortStringHelper shortStringHelper,
+        IOptions<ContentSettings> contentSettings)
+        : this(propertyEditors,
+            urlSegmentProviders,
+            mediaUrlGenerators,
+            userService,
+            shortStringHelper,
+            contentSettings,
+            StaticServiceProvider.Instance.GetRequiredService<IContentTypeService>())
+    {
+
+    }
     /// <inheritdoc />
     public override IEnumerable<ValueSet> GetValueSets(params IMedia[] media)
     {
+        IDictionary<Guid, IContentType> contentTypeDictionary = _contentTypeService.GetAll().ToDictionary(x => x.Key);
+
         foreach (IMedia m in media)
         {
             var urlValue = m.GetUrlSegment(_shortStringHelper, _urlSegmentProviders);
@@ -65,7 +92,7 @@ public class MediaValueSetBuilder : BaseValueSetBuilder<IMedia>
 
             foreach (IProperty property in m.Properties)
             {
-                AddPropertyValue(property, null, null, values, m.AvailableCultures);
+                AddPropertyValue(property, null, null, values, m.AvailableCultures, contentTypeDictionary);
             }
 
             var vs = new ValueSet(m.Id.ToInvariantString(), IndexTypes.Media, m.ContentType.Alias, values);

--- a/src/Umbraco.Infrastructure/Examine/MediaValueSetBuilder.cs
+++ b/src/Umbraco.Infrastructure/Examine/MediaValueSetBuilder.cs
@@ -20,8 +20,6 @@ public class MediaValueSetBuilder : BaseValueSetBuilder<IMedia>
     private readonly UrlSegmentProviderCollection _urlSegmentProviders;
     private readonly IUserService _userService;
 
-
-
     public MediaValueSetBuilder(
         PropertyEditorCollection propertyEditors,
         UrlSegmentProviderCollection urlSegmentProviders,

--- a/src/Umbraco.Infrastructure/Examine/MemberValueSetBuilder.cs
+++ b/src/Umbraco.Infrastructure/Examine/MemberValueSetBuilder.cs
@@ -1,20 +1,34 @@
 using Examine;
+using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Examine;
 
 public class MemberValueSetBuilder : BaseValueSetBuilder<IMember>
 {
-    public MemberValueSetBuilder(PropertyEditorCollection propertyEditors)
+    private readonly IContentTypeService _contentTypeService;
+
+    public MemberValueSetBuilder(PropertyEditorCollection propertyEditors, IContentTypeService contentTypeService)
         : base(propertyEditors, false)
+    {
+        _contentTypeService = contentTypeService;
+    }
+
+    [Obsolete("Use non-obsolete ctor, scheduled for removal in v14")]
+    public MemberValueSetBuilder(PropertyEditorCollection propertyEditors)
+        : this(propertyEditors, StaticServiceProvider.Instance.GetRequiredService<IContentTypeService>())
     {
     }
 
     /// <inheritdoc />
     public override IEnumerable<ValueSet> GetValueSets(params IMember[] members)
     {
+        IDictionary<Guid, IContentType> contentTypeDictionary = _contentTypeService.GetAll().ToDictionary(x => x.Key);
+
         foreach (IMember m in members)
         {
             var values = new Dictionary<string, IEnumerable<object?>>
@@ -37,7 +51,7 @@ public class MemberValueSetBuilder : BaseValueSetBuilder<IMember>
 
             foreach (IProperty property in m.Properties)
             {
-                AddPropertyValue(property, null, null, values, m.AvailableCultures);
+                AddPropertyValue(property, null, null, values, m.AvailableCultures, contentTypeDictionary);
             }
 
             var vs = new ValueSet(m.Id.ToInvariantString(), IndexTypes.Member, m.ContentType.Alias, values);

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyIndexValueFactory.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyIndexValueFactory.cs
@@ -39,8 +39,12 @@ internal sealed class BlockValuePropertyIndexValueFactory :
     }
 
 
+    [Obsolete]
     protected override IContentType? GetContentTypeOfNestedItem(BlockItemData input) =>
         _contentTypeService.Get(input.ContentTypeKey);
+
+    protected override IContentType? GetContentTypeOfNestedItem(BlockItemData input, IDictionary<Guid, IContentType> contentTypeDictionary)
+        => contentTypeDictionary.TryGetValue(input.ContentTypeKey, out var result) ? result : null;
 
     protected override IDictionary<string, object?> GetRawProperty(BlockItemData blockItemData) =>
         blockItemData.RawPropertyValues;

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyIndexValueFactory.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyIndexValueFactory.cs
@@ -38,8 +38,7 @@ internal sealed class BlockValuePropertyIndexValueFactory :
         _contentTypeService = contentTypeService;
     }
 
-
-    [Obsolete]
+    [Obsolete("Use non-obsolete overload, scheduled for removal in v14")]
     protected override IContentType? GetContentTypeOfNestedItem(BlockItemData input) =>
         _contentTypeService.Get(input.ContentTypeKey);
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/NestedContentPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/NestedContentPropertyIndexValueFactory.cs
@@ -40,6 +40,12 @@ internal sealed class NestedContentPropertyIndexValueFactory
     }
 
     protected override IContentType? GetContentTypeOfNestedItem(
+        NestedContentPropertyEditor.NestedContentValues.NestedContentRowValue input, IDictionary<Guid, IContentType> contentTypeDictionary)
+        => _contentTypeService.Get(input.ContentTypeAlias);
+
+    [Obsolete("Use non-obsolete overload, scheduled for removal in v14")]
+
+    protected override IContentType? GetContentTypeOfNestedItem(
         NestedContentPropertyEditor.NestedContentValues.NestedContentRowValue input)
         => _contentTypeService.Get(input.ContentTypeAlias);
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/NestedContentPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/NestedContentPropertyIndexValueFactory.cs
@@ -41,10 +41,9 @@ internal sealed class NestedContentPropertyIndexValueFactory
 
     protected override IContentType? GetContentTypeOfNestedItem(
         NestedContentPropertyEditor.NestedContentValues.NestedContentRowValue input, IDictionary<Guid, IContentType> contentTypeDictionary)
-        => _contentTypeService.Get(input.ContentTypeAlias);
+        => contentTypeDictionary.Values.FirstOrDefault(x=>x.Alias.Equals(input.ContentTypeAlias));
 
     [Obsolete("Use non-obsolete overload, scheduled for removal in v14")]
-
     protected override IContentType? GetContentTypeOfNestedItem(
         NestedContentPropertyEditor.NestedContentValues.NestedContentRowValue input)
         => _contentTypeService.Get(input.ContentTypeAlias);

--- a/src/Umbraco.Infrastructure/PropertyEditors/NestedPropertyIndexValueFactoryBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/NestedPropertyIndexValueFactoryBase.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Examine;
 using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Extensions;
@@ -42,20 +43,39 @@ internal abstract class NestedPropertyIndexValueFactoryBase<TSerialized, TItem> 
         bool published) =>
         Handle(deserializedPropertyValue, property, culture, segment, published, Enumerable.Empty<string>());
 
+    [Obsolete("Use the overload that specifies availableCultures, scheduled for removal in v14")]
     protected override IEnumerable<KeyValuePair<string, IEnumerable<object?>>> Handle(
         TSerialized deserializedPropertyValue,
         IProperty property,
         string? culture,
         string? segment,
         bool published,
-        IEnumerable<string> availableCultures)
+        IEnumerable<string> availableCultures) =>
+        Handle(
+            deserializedPropertyValue,
+            property,
+            culture,
+            segment,
+            published,
+            Enumerable.Empty<string>(),
+            StaticServiceProvider.Instance.GetRequiredService<IContentTypeService>().GetAll().ToDictionary(x=>x.Key));
+
+
+    protected override IEnumerable<KeyValuePair<string, IEnumerable<object?>>> Handle(
+        TSerialized deserializedPropertyValue,
+        IProperty property,
+        string? culture,
+        string? segment,
+        bool published,
+        IEnumerable<string> availableCultures,
+        IDictionary<Guid, IContentType> contentTypeDictionary)
     {
         var result = new List<KeyValuePair<string, IEnumerable<object?>>>();
 
         var index = 0;
         foreach (TItem nestedContentRowValue in GetDataItems(deserializedPropertyValue))
         {
-            IContentType? contentType = GetContentTypeOfNestedItem(nestedContentRowValue);
+            IContentType? contentType = GetContentTypeOfNestedItem(nestedContentRowValue, contentTypeDictionary);
 
             if (contentType is null)
             {
@@ -125,6 +145,9 @@ internal abstract class NestedPropertyIndexValueFactoryBase<TSerialized, TItem> 
     /// <summary>
     /// Gets the content type using the nested item.
     /// </summary>
+    protected abstract IContentType? GetContentTypeOfNestedItem(TItem nestedItem, IDictionary<Guid, IContentType> contentTypeDictionary);
+
+    [Obsolete("Use non-obsolete overload. Scheduled for removal in Umbraco 14.")]
     protected abstract IContentType? GetContentTypeOfNestedItem(TItem nestedItem);
 
     /// <summary>


### PR DESCRIPTION
### Description
This optimised a few things related to blocks.
Related issues, that is maybe fixed by this is #15056 and #14936.

When indexing, it get all content types once. Even that it is cached by the repository, the deep cloning is too slow, when done a lot (like when indexing)

Also updated MultiUrlPicker.ToEditor. This is called a lot (e.g. when used in blocks). It used to use the entity service, but this do not cache, so each MultiUrlPicker would go to the database up to two times (If it contains both referenced media and content), when editing content.

![image](https://github.com/umbraco/Umbraco-CMS/assets/1561480/30aff332-18c5-4176-9a73-423255db4bb9)



### Tests
In general, performance testing is easiest when not using a local database, and when the db have a lot of content.
Ensure:
- Indexing should work like before. 
- Content editing should work like before.

