### PR TITLE
Add check for ContentVariation.Nothing when copying documents.

### DIFF
--- a/src/Umbraco.Core/Models/ContentRepositoryExtensions.cs
+++ b/src/Umbraco.Core/Models/ContentRepositoryExtensions.cs
@@ -174,15 +174,17 @@ public static class ContentRepositoryExtensions
         foreach (IProperty property in content.Properties)
         {
             // each property type may or may not support the variation
-            if (!property.PropertyType?.SupportsVariation(culture, "*", true) ?? false)
+            if ((!property.PropertyType?.SupportsVariation(culture, "*", true) ?? false) &&
+                    !(property.PropertyType?.Variations == ContentVariation.Nothing))
             {
                 continue;
             }
 
             foreach (IPropertyValue pvalue in property.Values)
             {
-                if ((property.PropertyType?.SupportsVariation(pvalue.Culture, pvalue.Segment, true) ?? false) &&
-                    (culture == "*" || (pvalue.Culture?.InvariantEquals(culture) ?? false)))
+                if (((property.PropertyType?.SupportsVariation(pvalue.Culture, pvalue.Segment, true) ?? false) &&
+                    (culture == "*" || (pvalue.Culture?.InvariantEquals(culture) ?? false))) ||
+                    property.PropertyType?.Variations == ContentVariation.Nothing)
                 {
                     property.SetValue(null, pvalue.Culture, pvalue.Segment);
                 }
@@ -193,7 +195,8 @@ public static class ContentRepositoryExtensions
         IPropertyCollection otherProperties = other.Properties;
         foreach (IProperty otherProperty in otherProperties)
         {
-            if (!otherProperty?.PropertyType?.SupportsVariation(culture, "*", true) ?? true)
+            if ((!otherProperty?.PropertyType?.SupportsVariation(culture, "*", true) ?? true) &&
+                    !(otherProperty?.PropertyType?.Variations == ContentVariation.Nothing))
             {
                 continue;
             }
@@ -203,8 +206,9 @@ public static class ContentRepositoryExtensions
             {
                 foreach (IPropertyValue pvalue in otherProperty.Values)
                 {
-                    if (otherProperty.PropertyType.SupportsVariation(pvalue.Culture, pvalue.Segment, true) &&
-                        (culture == "*" || (pvalue.Culture?.InvariantEquals(culture) ?? false)))
+                    if (((otherProperty?.PropertyType.SupportsVariation(pvalue.Culture, pvalue.Segment, true) ?? false) &&
+                        (culture == "*" ||(pvalue.Culture?.InvariantEquals(culture) ?? false))) ||
+                         otherProperty?.PropertyType?.Variations == ContentVariation.Nothing)
                     {
                         var value = published ? pvalue.PublishedValue : pvalue.EditedValue;
                         content.SetValue(alias, value, pvalue.Culture, pvalue.Segment);


### PR DESCRIPTION
A new check for ContentVariation.Nothing is necessary when copying from documents to ensure that if there is no content variation as defined by the Nothing property, values are still copied even if variation is not supported since the content itself will not vary.

### Prerequisites

- [X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [14687](https://github.com/umbraco/Umbraco-CMS/issues/14687)

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

**Changes made:**

- Added additional check when copying. If the ContentVariation for a property is "Nothing" then regardless of whether variation is supported or not, the content of the property will not vary by culture so copying can continue.

**Steps to Test**

1. Create document type "Home"
2. Add a text field "Title". 
3. Enable "Allow as root" 
4. Enable "Allow vary by culture". Ensure Title is still not varied by culture. 
5. Save and close 
6. In settings, configure a second language. Keep the default (en-us). This step is important. If I later delete the second language, rollbacks work as expected.
7. Create a page using the Home document type.
8. Save and publish once with the Title as "test1"
9. Save and publish again with the Title as "test2"
10. Rollback to the test1 version
11. Notice that the title says "test1" as expected.

(copied from original issue 14687)

Additionally, the following can be tested to ensure that the rollback behaves as expected.

1. Repeat steps 7-9 with "Allow vary by culture" enabled for both the document type and text field.
2. Repeat steps 7-9 with "Allow vary by culture" disabled for the document type.

<!-- Thanks for contributing to Umbraco CMS! -->
