### PR TITLE
Allow ID for a new dictionary-item to be specified

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Mapping/Dictionary/DictionaryMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Dictionary/DictionaryMapDefinition.cs
@@ -37,9 +37,14 @@ public class DictionaryMapDefinition : IMapDefinition
         target.DeleteDate = null;
     }
 
-    // Umbraco.Code.MapAll -Id -Key -CreateDate -UpdateDate -Translations
+    // Umbraco.Code.MapAll -Id -CreateDate -UpdateDate -Translations
     private void Map(CreateDictionaryItemRequestModel source, IDictionaryItem target, MapperContext context)
     {
+        if (source.Id != null)
+        {
+            target.Key = source.Id.Value;
+        }
+
         target.ItemKey = source.Name;
         target.ParentId = source.ParentId;
         target.DeleteDate = null;

--- a/src/Umbraco.Cms.Api.Management/Mapping/Dictionary/DictionaryMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Dictionary/DictionaryMapDefinition.cs
@@ -40,7 +40,7 @@ public class DictionaryMapDefinition : IMapDefinition
     // Umbraco.Code.MapAll -Id -CreateDate -UpdateDate -Translations
     private void Map(CreateDictionaryItemRequestModel source, IDictionaryItem target, MapperContext context)
     {
-        if (source.Id != null)
+        if (source.Id is not null)
         {
             target.Key = source.Id.Value;
         }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Dictionary/CreateDictionaryItemRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Dictionary/CreateDictionaryItemRequestModel.cs
@@ -2,5 +2,6 @@
 
 public class CreateDictionaryItemRequestModel : DictionaryItemModelBase
 {
+    public Guid? Id { get; set; }
     public Guid? ParentId { get; set; }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Frontend needs to specify the Id of a new dictionary items to easily swap between views

### Testing
Using the managment api
- Create a new dictionary item without specifying the id => return header should give you a new id
- Create a new dictionary item and specify its id, fetching on that ID should return this item

