### PR TITLE
V12 Bugfix, Added compare provider name extension for Sqlite

### DIFF
--- a/src/Umbraco.Cms.Persistence.EFCore/EfCoreMigrationExecutor.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/EfCoreMigrationExecutor.cs
@@ -21,7 +21,7 @@ public class EfCoreMigrationExecutor : IEFCoreMigrationExecutor
 
     public async Task ExecuteSingleMigrationAsync(EFCoreMigration migration)
     {
-        IMigrationProvider? provider = _migrationProviders.FirstOrDefault(x => x.ProviderName == _options.Value.ProviderName);
+        IMigrationProvider? provider = _migrationProviders.FirstOrDefault(x => x.ProviderName.CompareProviderNames(_options.Value.ProviderName));
 
         if (provider is not null)
         {
@@ -31,8 +31,7 @@ public class EfCoreMigrationExecutor : IEFCoreMigrationExecutor
 
     public async Task ExecuteAllMigrationsAsync()
     {
-        IMigrationProvider? provider = _migrationProviders.FirstOrDefault(x => x.ProviderName == _options.Value.ProviderName);
-
+        IMigrationProvider? provider = _migrationProviders.FirstOrDefault(x => x.ProviderName.CompareProviderNames(_options.Value.ProviderName));
         if (provider is not null)
         {
             await provider.MigrateAllAsync();

--- a/src/Umbraco.Cms.Persistence.EFCore/Extensions/UmbracoEFCoreServiceCollectionExtensions.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/Extensions/UmbracoEFCoreServiceCollectionExtensions.cs
@@ -138,6 +138,9 @@ public static class UmbracoEFCoreServiceCollectionExtensions
             case Constants.ProviderNames.SQLLite:
                 builder.UseSqlite(connectionString);
                 break;
+            case "Microsoft.Data.SQLite":
+                builder.UseSqlite(connectionString);
+                break;
             default:
                 throw new InvalidDataException($"The provider {providerName} is not supported. Manually add the add the UseXXX statement to the options. I.E UseNpgsql()");
         }

--- a/src/Umbraco.Cms.Persistence.EFCore/StringExtensions.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/StringExtensions.cs
@@ -1,0 +1,21 @@
+﻿using Umbraco.Cms.Core;
+
+namespace Umbraco.Cms.Persistence.EFCore;
+
+internal static class StringExtensions
+{
+    internal static bool CompareProviderNames(this string connectionProvider, string? compareString)
+    {
+        if (compareString is null)
+        {
+            return false;
+        }
+
+        if (connectionProvider == compareString)
+        {
+            return true;
+        }
+
+        return connectionProvider is "Microsoft.Data.SQLite" or Constants.ProviderNames.SQLLite && compareString is "Microsoft.Data.SQLite" or Constants.ProviderNames.SQLLite;
+    }
+}

--- a/src/Umbraco.Cms.Persistence.EFCore/UmbracoDbContext.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/UmbracoDbContext.cs
@@ -58,7 +58,7 @@ public class UmbracoDbContext : DbContext
         }
 
         IEnumerable<IMigrationProviderSetup> migrationProviders = StaticServiceProvider.Instance.GetServices<IMigrationProviderSetup>();
-        IMigrationProviderSetup? migrationProvider = migrationProviders.FirstOrDefault(x => x.ProviderName == connectionStrings.ProviderName);
+        IMigrationProviderSetup? migrationProvider = migrationProviders.FirstOrDefault(x => x.ProviderName.CompareProviderNames(connectionStrings.ProviderName));
 
         if (migrationProvider == null && connectionStrings.ProviderName != null)
         {


### PR DESCRIPTION
Fixes this issue: #15164
A change was added from v12.2.0 to 12.3.1. Which changed the provider name usage from "Microsoft.Data.SQLite" to "Microsoft.Data.Sqlite". 

This PR enables the user to install with both "Microsoft.Data.SQLite" and "Microsoft.Data.Sqlite"

Test if you are able to unattended install with different connection ProviderNames. 
Also, test if you are able to use the outdated ProviderName for Sqlite. "Microsoft.Data.SQLite"