### PR TITLE
Click row in dictionary list

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/dictionary/list.html
+++ b/src/Umbraco.Web.UI.Client/src/views/dictionary/list.html
@@ -50,12 +50,12 @@
               </tr>
             </thead>
             <tbody>
-              <tr ng-repeat="item in vm.filtered = (vm.items | filter: { 'name': vm.filter.searchTerm })" class="cursor-pointer">
+              <tr ng-repeat="item in vm.filtered = (vm.items | filter: { 'name': vm.filter.searchTerm })" ng-click="vm.clickItem(item.id)" class="cursor-pointer">
                 <th>
-                  <button type="button" ng-style="item.style" class="btn-reset bold" ng-click="vm.clickItem(item.id)">{{item.name}}</button>
+                  <span ng-style="item.style" class="bold">{{item.name}}</span>
                 </th>
                 <td ng-repeat="column in item.translations | orderBy:'displayName'">
-                  <button type="button" class="btn-reset" ng-click="vm.clickItem(item.id)">
+                  <div>
                     <umb-icon icon="{{ column.hasTranslation ? 'icon-check' : 'icon-alert' }}"
                               class="{{ column.hasTranslation ? 'color-green' : 'color-red' }}">
                     </umb-icon>
@@ -63,7 +63,7 @@
                       <localize ng-if="column.hasTranslation" key="visuallyHiddenTexts_hasTranslation">Has translation</localize>
                       <localize ng-if="!column.hasTranslation" key="visuallyHiddenTexts_noTranslation">Missing translation</localize>
                     </span>
-                  </button>
+                  </div>
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/15188

### Description
Allow to browse the dictionary items from list, by clicking the entire table row, which is consistent with languages.