### PR TITLE
V13: Webhook logging cleanup

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/WebhookSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/WebhookSettings.cs
@@ -7,6 +7,9 @@ public class WebhookSettings
 {
     private const bool StaticEnabled = true;
     private const int StaticMaximumRetries = 5;
+    private const bool StaticEnableLoggingCleanup = true;
+    private const int StaticKeepLogsForDays = 30;
+
 
     /// <summary>
     ///     Gets or sets a value indicating whether webhooks are enabled.
@@ -31,4 +34,26 @@ public class WebhookSettings
     /// </remarks>
     [DefaultValue(StaticMaximumRetries)]
     public int MaximumRetries { get; set; } = StaticMaximumRetries;
+
+    /// <summary>
+    ///     Gets or sets a value indicating whether cleanup of webhook logs are enabled.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         By default, cleanup is enabled.
+    ///     </para>
+    /// </remarks>
+    [DefaultValue(StaticEnableLoggingCleanup)]
+    public bool EnableLoggingCleanup { get; set; } = StaticEnableLoggingCleanup;
+
+    /// <summary>
+    ///     Gets or sets a value indicating number of days to keep logs for.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         By default, logs are kept for 30 days.
+    ///     </para>
+    /// </remarks>
+    [DefaultValue(StaticKeepLogsForDays)]
+    public int KeepLogsForDays { get; set; } = StaticKeepLogsForDays;
 }

--- a/src/Umbraco.Core/Persistence/Constants-Locks.cs
+++ b/src/Umbraco.Core/Persistence/Constants-Locks.cs
@@ -72,8 +72,13 @@ public static partial class Constants
         public const int ScheduledPublishing = -341;
 
         /// <summary>
-        ///     ScheduledPublishing job.
+        ///    All Webhook requests.
         /// </summary>
         public const int WebhookRequest = -342;
+
+        /// <summary>
+        ///     All webhook logs.
+        /// </summary>
+        public const int WebhookLogs = -342;
     }
 }

--- a/src/Umbraco.Core/Persistence/Constants-Locks.cs
+++ b/src/Umbraco.Core/Persistence/Constants-Locks.cs
@@ -79,6 +79,6 @@ public static partial class Constants
         /// <summary>
         ///     All webhook logs.
         /// </summary>
-        public const int WebhookLogs = -342;
+        public const int WebhookLogs = -343;
     }
 }

--- a/src/Umbraco.Core/Persistence/Repositories/IWebhookLogRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IWebhookLogRepository.cs
@@ -1,5 +1,4 @@
 ﻿using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Webhooks;
 
 namespace Umbraco.Cms.Core.Persistence.Repositories;
 
@@ -8,4 +7,8 @@ public interface IWebhookLogRepository
     Task CreateAsync(WebhookLog log);
 
     Task<PagedModel<WebhookLog>> GetPagedAsync(int skip, int take);
+
+    Task<IEnumerable<WebhookLog>> GetOlderThanDate(DateTime date);
+
+    Task DeleteByIds(int[] ids);
 }

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookLoggingCleanup.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookLoggingCleanup.cs
@@ -9,6 +9,9 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.BackgroundJobs.Jobs;
 
+/// <summary>
+/// Daily background job that removes all webhook log data older than x days as defined by <see cref="WebhookSettings.KeepLogsForDays"/>
+/// </summary>
 public class WebhookLoggingCleanup : IRecurringBackgroundJob
 {
     private readonly ILogger<WebhookLoggingCleanup> _logger;
@@ -24,13 +27,20 @@ public class WebhookLoggingCleanup : IRecurringBackgroundJob
         _coreScopeProvider = coreScopeProvider;
     }
 
+    /// <inheritdoc />
+    // No-op event as the period never changes on this job
+    public event EventHandler PeriodChanged
+    {
+        add { } remove { }
+    }
+
+    /// <inheritdoc />
     public TimeSpan Period => TimeSpan.FromDays(1);
 
+    /// <inheritdoc />
     public TimeSpan Delay { get; } = TimeSpan.FromSeconds(20);
 
-    // No-op event as the period never changes on this job
-    public event EventHandler PeriodChanged { add { } remove { } }
-
+    /// <inheritdoc />
     public async Task RunJobAsync()
     {
         if (_webhookSettings.EnableLoggingCleanup is false)

--- a/src/Umbraco.Infrastructure/HostedServices/WebhookLoggingCleanup.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/WebhookLoggingCleanup.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Runtime;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Infrastructure.BackgroundJobs;
+
+namespace Umbraco.Cms.Infrastructure.HostedServices;
+
+public class WebhookLoggingCleanup : IRecurringBackgroundJob
+{
+    private readonly ILogger<WebhookLoggingCleanup> _logger;
+    private readonly IOptionsMonitor<WebhookSettings> _webhookSettings;
+
+    public WebhookLoggingCleanup(ILogger<WebhookLoggingCleanup> logger, IOptionsMonitor<WebhookSettings> webhookSettings)
+    {
+        _logger = logger;
+        _webhookSettings = webhookSettings;
+    }
+
+    public TimeSpan Period => TimeSpan.FromDays(1);
+
+    public TimeSpan Delay { get; } = TimeSpan.FromSeconds(20);
+
+    // No-op event as the period never changes on this job
+    public event EventHandler PeriodChanged { add { } remove { } }
+
+    public Task RunJobAsync()
+    {
+        if (!_webhookSettings.CurrentValue.Enabled)
+        {
+            _logger.LogInformation("WebhookLoggingCleanup task will not run as it has been globally disabled via configuration");
+            return Task.CompletedTask;
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Umbraco.Infrastructure/HostedServices/WebhookLoggingCleanup.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/WebhookLoggingCleanup.cs
@@ -2,22 +2,27 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
-using Umbraco.Cms.Core.Runtime;
-using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Infrastructure.BackgroundJobs;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.HostedServices;
 
 public class WebhookLoggingCleanup : IRecurringBackgroundJob
 {
     private readonly ILogger<WebhookLoggingCleanup> _logger;
-    private readonly IOptionsMonitor<WebhookSettings> _webhookSettings;
+    private readonly WebhookSettings _webhookSettings;
+    private readonly IWebhookLogRepository _webhookLogRepository;
+    private readonly ICoreScopeProvider _coreScopeProvider;
 
-    public WebhookLoggingCleanup(ILogger<WebhookLoggingCleanup> logger, IOptionsMonitor<WebhookSettings> webhookSettings)
+    public WebhookLoggingCleanup(ILogger<WebhookLoggingCleanup> logger, IOptionsMonitor<WebhookSettings> webhookSettings, IWebhookLogRepository webhookLogRepository, ICoreScopeProvider coreScopeProvider)
     {
         _logger = logger;
-        _webhookSettings = webhookSettings;
+        _webhookSettings = webhookSettings.CurrentValue;
+        _webhookLogRepository = webhookLogRepository;
+        _coreScopeProvider = coreScopeProvider;
     }
 
     public TimeSpan Period => TimeSpan.FromDays(1);
@@ -27,14 +32,23 @@ public class WebhookLoggingCleanup : IRecurringBackgroundJob
     // No-op event as the period never changes on this job
     public event EventHandler PeriodChanged { add { } remove { } }
 
-    public Task RunJobAsync()
+    public async Task RunJobAsync()
     {
-        if (!_webhookSettings.CurrentValue.Enabled)
+        if (!_webhookSettings.Enabled)
         {
             _logger.LogInformation("WebhookLoggingCleanup task will not run as it has been globally disabled via configuration");
-            return Task.CompletedTask;
+            return;
         }
 
-        return Task.CompletedTask;
+        IEnumerable<WebhookLog> webhookLogs = await _webhookLogRepository.GetOlderThanDate(DateTime.Now - _webhookSettings.Period);
+
+        foreach (IEnumerable<WebhookLog> group in webhookLogs.InGroupsOf(Constants.Sql.MaxParameterCount))
+        {
+            using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
+            scope.WriteLock(Constants.Locks.WebhookLogs);
+            await _webhookLogRepository.DeleteByIds(group.Select(x => x.Id).ToArray());
+
+            scope.Complete();
+        }
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
@@ -1006,6 +1006,7 @@ internal class DatabaseDataCreator
         _database.Insert(Constants.DatabaseSchema.Tables.Lock, "id", false, new LockDto { Id = Constants.Locks.ScheduledPublishing, Name = "ScheduledPublishing" });
         _database.Insert(Constants.DatabaseSchema.Tables.Lock, "id", false, new LockDto { Id = Constants.Locks.MainDom, Name = "MainDom" });
         _database.Insert(Constants.DatabaseSchema.Tables.Lock, "id", false, new LockDto { Id = Constants.Locks.WebhookRequest, Name = "WebhookRequest" });
+        _database.Insert(Constants.DatabaseSchema.Tables.Lock, "id", false, new LockDto { Id = Constants.Locks.WebhookLogs, Name = "WebhookLogs" });
     }
 
     private void CreateContentTypeData()

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -100,5 +100,6 @@ public class UmbracoPlan : MigrationPlan
         To<V_13_0_0.RenameEventNameColumn>("{D5139400-E507-4259-A542-C67358F7E329}");
         To<V_13_0_0.AddWebhookRequest>("{4E652F18-9A29-4656-A899-E3F39069C47E}");
         To<V_13_0_0.RenameWebhookIdToKey>("{148714C8-FE0D-4553-B034-439D91468761}");
+        To<V_13_0_0.AddWebhookDatabaseLock>("{23BA95A4-FCCE-49B0-8AA1-45312B103A9B}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_0_0/AddWebhookDatabaseLock.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_0_0/AddWebhookDatabaseLock.cs
@@ -8,7 +8,8 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_13_0_0;
 
 public class AddWebhookDatabaseLock : MigrationBase
 {
-    public AddWebhookDatabaseLock(IMigrationContext context) : base(context)
+    public AddWebhookDatabaseLock(IMigrationContext context)
+        : base(context)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_0_0/AddWebhookDatabaseLock.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_0_0/AddWebhookDatabaseLock.cs
@@ -1,0 +1,29 @@
+﻿using NPoco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_13_0_0;
+
+public class AddWebhookDatabaseLock : MigrationBase
+{
+    public AddWebhookDatabaseLock(IMigrationContext context) : base(context)
+    {
+    }
+
+    protected override void Migrate()
+    {
+        Sql<ISqlContext> sql = Database.SqlContext.Sql()
+            .Select<LockDto>()
+            .From<LockDto>()
+            .Where<LockDto>(x => x.Id == Constants.Locks.WebhookLogs);
+
+        LockDto? webhookRequestLock = Database.FirstOrDefault<LockDto>(sql);
+
+        if (webhookRequestLock is null)
+        {
+            Database.Insert(Constants.DatabaseSchema.Tables.Lock, "id", false, new LockDto { Id = Constants.Locks.WebhookRequest, Name = "WebhookRequest" });
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/WebhookLogRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/WebhookLogRepository.cs
@@ -59,7 +59,7 @@ public class WebhookLogRepository : IWebhookLogRepository
         Sql<ISqlContext> sql = Database.SqlContext.Sql()
             .Select<WebhookLogDto>()
             .From<WebhookLogDto>()
-            .Where<WebhookLogDto>(log => log.Date > date);
+            .Where<WebhookLogDto>(log => log.Date < date);
 
         List<WebhookLogDto>? logs = await Database.FetchAsync<WebhookLogDto>(sql);
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/WebhookLogRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/WebhookLogRepository.cs
@@ -2,7 +2,6 @@
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
-using Umbraco.Cms.Core.Webhooks;
 using Umbraco.Cms.Infrastructure.Persistence.Dtos;
 using Umbraco.Cms.Infrastructure.Persistence.Factories;
 using Umbraco.Cms.Infrastructure.Scoping;
@@ -14,31 +13,65 @@ public class WebhookLogRepository : IWebhookLogRepository
 {
     private readonly IScopeAccessor _scopeAccessor;
 
+    private IUmbracoDatabase Database
+    {
+        get
+        {
+            if (_scopeAccessor.AmbientScope is null)
+            {
+                throw new NotSupportedException("Need to be executed in a scope");
+            }
+
+            return _scopeAccessor.AmbientScope.Database;
+        }
+    }
+
     public WebhookLogRepository(IScopeAccessor scopeAccessor) => _scopeAccessor = scopeAccessor;
 
     public async Task CreateAsync(WebhookLog log)
     {
         WebhookLogDto dto = WebhookLogFactory.CreateDto(log);
-        var result = await _scopeAccessor.AmbientScope?.Database.InsertAsync(dto)!;
+        var result = await Database.InsertAsync(dto)!;
         var id = Convert.ToInt32(result);
         log.Id = id;
     }
 
     public async Task<PagedModel<WebhookLog>> GetPagedAsync(int skip, int take)
     {
-        Sql<ISqlContext>? sql = _scopeAccessor.AmbientScope?.Database.SqlContext.Sql()
+        Sql<ISqlContext> sql = Database.SqlContext.Sql()
             .Select<WebhookLogDto>()
             .From<WebhookLogDto>()
             .OrderByDescending<WebhookLogDto>(x => x.Date);
 
         PaginationHelper.ConvertSkipTakeToPaging(skip, take, out var pageNumber, out var pageSize);
 
-        Page<WebhookLogDto>? page = await _scopeAccessor.AmbientScope?.Database.PageAsync<WebhookLogDto>(pageNumber + 1, pageSize, sql)!;
+        Page<WebhookLogDto>? page = await Database.PageAsync<WebhookLogDto>(pageNumber + 1, pageSize, sql)!;
 
         return new PagedModel<WebhookLog>
         {
             Total = page.TotalItems,
             Items = page.Items.Select(WebhookLogFactory.DtoToEntity),
         };
+    }
+
+    public async Task<IEnumerable<WebhookLog>> GetOlderThanDate(DateTime date)
+    {
+        Sql<ISqlContext> sql = Database.SqlContext.Sql()
+            .Select<WebhookLogDto>()
+            .From<WebhookLogDto>()
+            .Where<WebhookLogDto>(log => log.Date > date);
+
+        List<WebhookLogDto>? logs = await Database.FetchAsync<WebhookLogDto>(sql);
+
+        return logs.Select(WebhookLogFactory.DtoToEntity);
+    }
+
+    public async Task DeleteByIds(int[] ids)
+    {
+        Sql<ISqlContext> query = Database.SqlContext.Sql()
+            .Delete<WebhookLogDto>()
+            .WhereIn<WebhookLogDto>(x => x.Id, ids);
+
+        await Database.ExecuteAsync(query);
     }
 }

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -216,6 +216,7 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddRecurringBackgroundJob<InstructionProcessJob>();
         builder.Services.AddRecurringBackgroundJob<TouchServerJob>();
         builder.Services.AddRecurringBackgroundJob<WebhookFiring>();
+        builder.Services.AddRecurringBackgroundJob<WebhookLoggingCleanup>();
         builder.Services.AddRecurringBackgroundJob(provider =>
             new ReportSiteJob(
                 provider.GetRequiredService<ILogger<ReportSiteJob>>(),

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/WebhookRequestServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/WebhookRequestServiceTests.cs
@@ -19,7 +19,7 @@ public class WebhookRequestServiceTests : UmbracoIntegrationTest
     public async Task Can_Create_And_Get()
     {
         var createdWebhook = await WebhookService.CreateAsync(new Webhook("https://example.com", true, new[] { Guid.NewGuid() }, new[] { Constants.WebhookEvents.Aliases.ContentPublish }));
-        var created = await WebhookRequestService.CreateAsync(createdWebhook.Key, Constants.WebhookEvents.Aliases.ContentPublish, null);
+        var created = await WebhookRequestService.CreateAsync(createdWebhook.Result.Key, Constants.WebhookEvents.Aliases.ContentPublish, null);
         var webhooks = await WebhookRequestService.GetAllAsync();
         var webhook = webhooks.First(x => x.Id == created.Id);
 
@@ -38,7 +38,7 @@ public class WebhookRequestServiceTests : UmbracoIntegrationTest
     {
         var newRetryCount = 4;
         var createdWebhook = await WebhookService.CreateAsync(new Webhook("https://example.com", true, new[] { Guid.NewGuid() }, new[] { Constants.WebhookEvents.Aliases.ContentPublish }));
-        var created = await WebhookRequestService.CreateAsync(createdWebhook.Key, Constants.WebhookEvents.Aliases.ContentPublish, null);
+        var created = await WebhookRequestService.CreateAsync(createdWebhook.Result.Key, Constants.WebhookEvents.Aliases.ContentPublish, null);
         created.RetryCount = newRetryCount;
         await WebhookRequestService.UpdateAsync(created);
         var webhooks = await WebhookRequestService.GetAllAsync();
@@ -54,7 +54,7 @@ public class WebhookRequestServiceTests : UmbracoIntegrationTest
     public async Task Can_Delete()
     {
         var createdWebhook = await WebhookService.CreateAsync(new Webhook("https://example.com", true, new[] { Guid.NewGuid() }, new[] { Constants.WebhookEvents.Aliases.ContentPublish }));
-        var created = await WebhookRequestService.CreateAsync(createdWebhook.Key, Constants.WebhookEvents.Aliases.ContentPublish, null);
+        var created = await WebhookRequestService.CreateAsync(createdWebhook.Result.Key, Constants.WebhookEvents.Aliases.ContentPublish, null);
         await WebhookRequestService.DeleteAsync(created);
         var webhooks = await WebhookRequestService.GetAllAsync();
         var webhook = webhooks.FirstOrDefault(x => x.Id == created.Id);


### PR DESCRIPTION
# Notes
- Adds functionality much like `ContentVersionCleanup`, that will clean up webhook logs when they are X days old. This is in form of a `IRecurringBackgroundJob`, which will run every day.
- Adds settings to Enable/Disable this functionality
- Adds settings to configure how many days to keeps logs for

# How to test
- Create a document type with allow as root set to true
- Create a webhook with the `Content was published` event
- Publish some content with the doc type you created in step 1.
- Go to Settings -> Webhooks -> Logs to assert that you now have logs in there.
- You can change the `webhookLogs = await _webhookLogRepository.GetOlderThanDate(DateTime.Now - TimeSpan.FromDays(_webhookSettings.KeepLogsForDays));` into 
webhookLogs = await _webhookLogRepository.GetOlderThanDate(DateTime.Now + TimeSpan.FromDays(_webhookSettings.KeepLogsForDays));
- Or you can set the `Umbraco:CMS:Webhook:KeepLogsForDays` to 0
- Rerun your umbraco application and wait a bit for the Cleanup task to run
- you should now no longer have any logs