### PR TITLE
Change background job notification timing

### DIFF
--- a/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedService.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedService.cs
@@ -38,6 +38,7 @@ public class RecurringBackgroundJobHostedService<TJob> : RecurringHostedServiceB
     private readonly IServerRoleAccessor _serverRoleAccessor;
     private readonly IEventAggregator _eventAggregator;
     private readonly IRecurringBackgroundJob _job;
+    private readonly string _jobName;
 
     public RecurringBackgroundJobHostedService(
         IRuntimeState runtimeState,
@@ -54,16 +55,21 @@ public class RecurringBackgroundJobHostedService<TJob> : RecurringHostedServiceB
         _serverRoleAccessor = serverRoleAccessor;
         _eventAggregator = eventAggregator;
         _job = job;
+        _jobName = job.GetType().Name;
 
         _job.PeriodChanged += (sender, e) => ChangePeriod(_job.Period);
     }
 
+    public string JobName { get { return _jobName; } }
+
     /// <inheritdoc />
     public override async Task PerformExecuteAsync(object? state)
     {
+        _logger.LogDebug($"Job {_jobName} checking");
+
         if (_runtimeState.Level != RuntimeLevel.Run)
         {
-            _logger.LogDebug("Job not running as runlevel not yet ready");
+            _logger.LogDebug($"Job {_jobName} not running as runlevel not yet ready");
             await _eventAggregator.PublishAsync(new Notifications.RecurringBackgroundJobIgnoredNotification(_job, new EventMessages()));
             return;
         }
@@ -71,7 +77,7 @@ public class RecurringBackgroundJobHostedService<TJob> : RecurringHostedServiceB
         // Don't run on replicas nor unknown role servers
         if (!_job.ServerRoles.Contains(_serverRoleAccessor.CurrentServerRole))
         {
-            _logger.LogDebug("Job not running on this server role");
+            _logger.LogDebug($"Job {_jobName} not running on this server role");
             await _eventAggregator.PublishAsync(new Notifications.RecurringBackgroundJobIgnoredNotification(_job, new EventMessages()));
             return;
         }
@@ -79,7 +85,7 @@ public class RecurringBackgroundJobHostedService<TJob> : RecurringHostedServiceB
         // Ensure we do not run if not main domain, but do NOT lock it
         if (!_mainDom.IsMainDom)
         {
-            _logger.LogDebug("Job not running as not MainDom");
+            _logger.LogDebug($"Job {_jobName} not running as not MainDom");
             await _eventAggregator.PublishAsync(new Notifications.RecurringBackgroundJobIgnoredNotification(_job, new EventMessages()));
             return;
         }
@@ -89,16 +95,16 @@ public class RecurringBackgroundJobHostedService<TJob> : RecurringHostedServiceB
         try
         {
 
-            await _eventAggregator.PublishAsync(executingNotification);
+            _logger.LogDebug($"Job {_jobName} executing");
             await _job.RunJobAsync();
             await _eventAggregator.PublishAsync(new Notifications.RecurringBackgroundJobExecutedNotification(_job, new EventMessages()).WithStateFrom(executingNotification));
-
+            _logger.LogDebug($"Job {_jobName} Completed");
 
         }
         catch (Exception ex)
         {
             await _eventAggregator.PublishAsync(new Notifications.RecurringBackgroundJobFailedNotification(_job, new EventMessages()).WithStateFrom(executingNotification));
-            _logger.LogError(ex, "Unhandled exception in recurring background job.");
+            _logger.LogError(ex, $"Unhandled exception in {_jobName} recurring background job.");
         }
 
     }

--- a/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedService.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedService.cs
@@ -62,7 +62,6 @@ public class RecurringBackgroundJobHostedService<TJob> : RecurringHostedServiceB
     public override async Task PerformExecuteAsync(object? state)
     {
         var executingNotification = new Notifications.RecurringBackgroundJobExecutingNotification(_job, new EventMessages());
-        await _eventAggregator.PublishAsync(executingNotification);
 
         try
         {
@@ -90,7 +89,7 @@ public class RecurringBackgroundJobHostedService<TJob> : RecurringHostedServiceB
                 return;
             }
 
-
+            await _eventAggregator.PublishAsync(executingNotification);
             await _job.RunJobAsync();
             await _eventAggregator.PublishAsync(new Notifications.RecurringBackgroundJobExecutedNotification(_job, new EventMessages()).WithStateFrom(executingNotification));
 

--- a/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedServiceRunner.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedServiceRunner.cs
@@ -31,6 +31,19 @@ public class RecurringBackgroundJobHostedServiceRunner : IHostedService
         _jobFactory = jobFactory;
     }
 
+    private static string PrettyName(Type type)
+    {
+        if (type.GetGenericArguments().Length == 0)
+        {
+            return type.Name;
+        }
+        var genericArguments = type.GetGenericArguments();
+        var typeDefinition = type.Name;
+        var unmangledName = typeDefinition.Substring(0, typeDefinition.IndexOf("`"));
+        return unmangledName + "<" + String.Join(",", genericArguments.Select(PrettyName)) + ">";
+    }
+    
+
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         _logger.LogInformation("Creating recurring background jobs hosted services");
@@ -44,12 +57,12 @@ public class RecurringBackgroundJobHostedServiceRunner : IHostedService
         {
             try
             {
-                _logger.LogInformation($"Starting background hosted service for {hostedService.GetType().Name}");
+                _logger.LogInformation($"Starting background hosted service for {PrettyName(hostedService.GetType())}");
                 await hostedService.StartAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (Exception exception)
             {
-                _logger.LogError(exception, $"Failed to start background hosted service for {hostedService.GetType().Name}");
+                _logger.LogError(exception, $"Failed to start background hosted service for {PrettyName(hostedService.GetType())}");
             }
         }
 
@@ -66,12 +79,12 @@ public class RecurringBackgroundJobHostedServiceRunner : IHostedService
         {
             try
             {
-                _logger.LogInformation($"Stopping background hosted service for {hostedService.GetType().Name}");
+                _logger.LogInformation($"Stopping background hosted service for {PrettyName(hostedService.GetType())}");
                 await hostedService.StopAsync(stoppingToken).ConfigureAwait(false);
             }
             catch (Exception exception)
             {
-                _logger.LogError(exception, $"Failed to stop background hosted service for {hostedService.GetType().Name}");
+                _logger.LogError(exception, $"Failed to stop background hosted service for {PrettyName(hostedService.GetType())}");
             }
         }
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description
This PR changes the timing of the "Executing" notification for recurring background jobs.

The sequence of notifications for successful and failed jobs does not change. Only the sequence for ignored jobs changes.

Sequence for **SUCCESSFUL** jobs:

1. Executing
2. Executed

Sequence for **FAILED** jobs:

1. Executing
2. Failed

New sequence for **IGNORED** jobs:

1. Ignored

By comparison, the old sequence is:

1. Executing
2. Ignored

### Reasoning

By moving the notification directly in front of the actual call to the underlying job it removes a number of "false positive" **executing** notifications for jobs which would be stopped due to one of the check conditions (runState, serverRole, mainDom). 

If the job is being ignored due to one of the check conditions it should not be considered executing.

Additionally, if the **executing** notification were being hooked to update a database or other external system, the notification handler would need to check that the runState, mainDom, etc were valid. During testing this proved troublesome as the jobs often started BEFORE the database setup was complete and resulted in a number of attempts to access databases that were not present.





<!-- Thanks for contributing to Umbraco CMS! -->
