### PR TITLE
Bugfix: Count existing media correct

### DIFF
--- a/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentRepository.cs
+++ b/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentRepository.cs
@@ -1025,7 +1025,7 @@ WHERE cmsContentNu.nodeId IN (
         {
             // Use a more efficient COUNT query
             Sql<ISqlContext>? sqlCountQuery = SqlContentSourcesCount()
-                .Append(SqlObjectTypeNotTrashed(SqlContext, Constants.ObjectTypes.ContentItem));
+                .Append(SqlObjectTypeNotTrashed(SqlContext, Constants.ObjectTypes.Document));
 
             Sql<ISqlContext>? sqlCount =
                 SqlContext.Sql("SELECT COUNT(*) FROM (").Append(sqlCountQuery).Append(") npoco_tbl");

--- a/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentRepository.cs
+++ b/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentRepository.cs
@@ -224,7 +224,7 @@ AND cmsContentNu.nodeId IS NULL
         IContentCacheDataSerializer serializer =
             _contentCacheDataSerializerFactory.Create(ContentCacheDataSerializerEntityType.Document);
 
-        IEnumerable<ContentSourceDto> dtos = GetContentNodeDtos(sql, Constants.ObjectTypes.Document);
+        IEnumerable<ContentSourceDto> dtos = GetContentNodeDtos(sql);
 
         foreach (ContentSourceDto row in dtos)
         {
@@ -242,7 +242,7 @@ AND cmsContentNu.nodeId IS NULL
         IContentCacheDataSerializer serializer =
             _contentCacheDataSerializerFactory.Create(ContentCacheDataSerializerEntityType.Document);
 
-        IEnumerable<ContentSourceDto> dtos = GetContentNodeDtos(sql, Constants.ObjectTypes.Document);
+        IEnumerable<ContentSourceDto> dtos = GetContentNodeDtos(sql);
 
         foreach (ContentSourceDto row in dtos)
         {
@@ -265,7 +265,7 @@ AND cmsContentNu.nodeId IS NULL
         IContentCacheDataSerializer serializer =
             _contentCacheDataSerializerFactory.Create(ContentCacheDataSerializerEntityType.Document);
 
-        IEnumerable<ContentSourceDto> dtos = GetContentNodeDtos(sql, Constants.ObjectTypes.Document);
+        IEnumerable<ContentSourceDto> dtos = GetContentNodeDtos(sql);
 
         foreach (ContentSourceDto row in dtos)
         {
@@ -301,7 +301,7 @@ AND cmsContentNu.nodeId IS NULL
         IContentCacheDataSerializer serializer =
             _contentCacheDataSerializerFactory.Create(ContentCacheDataSerializerEntityType.Media);
 
-        IEnumerable<ContentSourceDto> dtos = GetContentNodeDtos(sql, Constants.ObjectTypes.Media);
+        IEnumerable<ContentSourceDto> dtos = GetMediaNodeDtos(sql);
 
         foreach (ContentSourceDto row in dtos)
         {
@@ -319,7 +319,7 @@ AND cmsContentNu.nodeId IS NULL
         IContentCacheDataSerializer serializer =
             _contentCacheDataSerializerFactory.Create(ContentCacheDataSerializerEntityType.Media);
 
-        IEnumerable<ContentSourceDto> dtos = GetContentNodeDtos(sql, Constants.ObjectTypes.Media);
+        IEnumerable<ContentSourceDto> dtos = GetMediaNodeDtos(sql);
 
         foreach (ContentSourceDto row in dtos)
         {
@@ -342,7 +342,7 @@ AND cmsContentNu.nodeId IS NULL
         IContentCacheDataSerializer serializer =
             _contentCacheDataSerializerFactory.Create(ContentCacheDataSerializerEntityType.Media);
 
-        IEnumerable<ContentSourceDto> dtos = GetContentNodeDtos(sql, Constants.ObjectTypes.Media);
+        IEnumerable<ContentSourceDto> dtos = GetMediaNodeDtos(sql);
 
         foreach (ContentSourceDto row in dtos)
         {
@@ -990,7 +990,32 @@ WHERE cmsContentNu.nodeId IN (
         return s;
     }
 
-    private IEnumerable<ContentSourceDto> GetContentNodeDtos(Sql<ISqlContext> sql, Guid nodeObjectType)
+    private IEnumerable<ContentSourceDto> GetMediaNodeDtos(Sql<ISqlContext> sql)
+    {
+        // We need to page here. We don't want to iterate over every single row in one connection cuz this can cause an SQL Timeout.
+        // We also want to read with a db reader and not load everything into memory, QueryPaged lets us do that.
+        // QueryPaged is very slow on large sites however, so use fetch if UsePagedSqlQuery is disabled.
+        IEnumerable<ContentSourceDto> dtos;
+        if (_nucacheSettings.Value.UsePagedSqlQuery)
+        {
+            // Use a more efficient COUNT query
+            Sql<ISqlContext>? sqlCountQuery = SqlMediaSourcesCount()
+                .Append(SqlObjectTypeNotTrashed(SqlContext, Constants.ObjectTypes.Media));
+
+            Sql<ISqlContext>? sqlCount =
+                SqlContext.Sql("SELECT COUNT(*) FROM (").Append(sqlCountQuery).Append(") npoco_tbl");
+
+            dtos = Database.QueryPaged<ContentSourceDto>(_nucacheSettings.Value.SqlPageSize, sql, sqlCount);
+        }
+        else
+        {
+            dtos = Database.Fetch<ContentSourceDto>(sql);
+        }
+
+        return dtos;
+    }
+
+    private IEnumerable<ContentSourceDto> GetContentNodeDtos(Sql<ISqlContext> sql)
     {
         // We need to page here. We don't want to iterate over every single row in one connection cuz this can cause an SQL Timeout.
         // We also want to read with a db reader and not load everything into memory, QueryPaged lets us do that.
@@ -1000,7 +1025,7 @@ WHERE cmsContentNu.nodeId IN (
         {
             // Use a more efficient COUNT query
             Sql<ISqlContext>? sqlCountQuery = SqlContentSourcesCount()
-                .Append(SqlObjectTypeNotTrashed(SqlContext, nodeObjectType));
+                .Append(SqlObjectTypeNotTrashed(SqlContext, Constants.ObjectTypes.ContentItem));
 
             Sql<ISqlContext>? sqlCount =
                 SqlContext.Sql("SELECT COUNT(*) FROM (").Append(sqlCountQuery).Append(") npoco_tbl");


### PR DESCRIPTION
Fixes #15205

Use explicit query to count media, instead of using content query.