### PR TITLE
Added missing scope.Complete in some edge cases.

### DIFF
--- a/src/Umbraco.Core/Services/ContentVersionService.cs
+++ b/src/Umbraco.Core/Services/ContentVersionService.cs
@@ -77,6 +77,7 @@ internal class ContentVersionService : IContentVersionService
 
             if (version is null)
             {
+                scope.Complete();
                 return;
             }
 
@@ -128,6 +129,7 @@ internal class ContentVersionService : IContentVersionService
 
             if (allHistoricVersions is null)
             {
+                scope.Complete();
                 return Array.Empty<ContentVersionMeta>();
             }
             if (_logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))

--- a/src/Umbraco.Web.Website/Controllers/UmbProfileController.cs
+++ b/src/Umbraco.Web.Website/Controllers/UmbProfileController.cs
@@ -112,6 +112,7 @@ public class UmbProfileController : SurfaceController
         IdentityResult saveResult = await _memberManager.UpdateAsync(currentMember);
         if (!saveResult.Succeeded)
         {
+            scope.Complete();
             return saveResult;
         }
 


### PR DESCRIPTION
### Description
Added scope complete in a few edge cases after https://github.com/umbraco/Umbraco-CMS/pull/14947.

The two in `ContentVersionService.cs` can't really be tested, as it should only ever be null, when the repository is used outside of a scope.
