### PR TITLE
Updated rich text parser interfaces to support context cache.

### DIFF
--- a/src/Umbraco.Core/Deploy/IImageSourceParser.cs
+++ b/src/Umbraco.Core/Deploy/IImageSourceParser.cs
@@ -12,7 +12,20 @@ public interface IImageSourceParser
     /// <param name="dependencies">A list of dependencies.</param>
     /// <returns>The parsed value.</returns>
     /// <remarks>Turns src="/media/..." into src="umb://media/..." and adds the corresponding udi to the dependencies.</remarks>
+    [Obsolete("Please use the overload taking all parameters. This method will be removed in Umbraco 14.")]
     string ToArtifact(string value, ICollection<Udi> dependencies);
+
+    /// <summary>
+    ///     Parses an Umbraco property value and produces an artifact property value.
+    /// </summary>
+    /// <param name="value">The property value.</param>
+    /// <param name="dependencies">A list of dependencies.</param>
+    /// <param name="contextCache">The context cache.</param>
+    /// <returns>The parsed value.</returns>
+    /// <remarks>Turns src="/media/..." into src="umb://media/..." and adds the corresponding udi to the dependencies.</remarks>
+#pragma warning disable CS0618 // Type or member is obsolete
+    string ToArtifact(string value, ICollection<Udi> dependencies, IContextCache contextCache) => ToArtifact(value, dependencies);
+#pragma warning restore CS0618 // Type or member is obsolete
 
     /// <summary>
     ///     Parses an artifact property value and produces an Umbraco property value.
@@ -20,5 +33,17 @@ public interface IImageSourceParser
     /// <param name="value">The artifact property value.</param>
     /// <returns>The parsed value.</returns>
     /// <remarks>Turns umb://media/... into /media/....</remarks>
+    [Obsolete("Please use the overload taking all parameters. This method will be removed in Umbraco 14.")]
     string FromArtifact(string value);
+
+    /// <summary>
+    ///     Parses an artifact property value and produces an Umbraco property value.
+    /// </summary>
+    /// <param name="value">The artifact property value.</param>
+    /// <param name="contextCache">The context cache.</param>
+    /// <returns>The parsed value.</returns>
+    /// <remarks>Turns umb://media/... into /media/....</remarks>
+#pragma warning disable CS0618 // Type or member is obsolete
+    string FromArtifact(string value, IContextCache contextCache) => FromArtifact(value);
+#pragma warning restore CS0618 // Type or member is obsolete
 }

--- a/src/Umbraco.Core/Deploy/ILocalLinkParser.cs
+++ b/src/Umbraco.Core/Deploy/ILocalLinkParser.cs
@@ -15,7 +15,23 @@ public interface ILocalLinkParser
     ///     Turns {{localLink:1234}} into {{localLink:umb://{type}/{id}}} and adds the corresponding udi to the
     ///     dependencies.
     /// </remarks>
+    [Obsolete("Please use the overload taking all parameters. This method will be removed in Umbraco 14.")]
     string ToArtifact(string value, ICollection<Udi> dependencies);
+
+    /// <summary>
+    ///     Parses an Umbraco property value and produces an artifact property value.
+    /// </summary>
+    /// <param name="value">The property value.</param>
+    /// <param name="dependencies">A list of dependencies.</param>
+    /// <param name="contextCache">The context cache.</param>
+    /// <returns>The parsed value.</returns>
+    /// <remarks>
+    ///     Turns {{localLink:1234}} into {{localLink:umb://{type}/{id}}} and adds the corresponding udi to the
+    ///     dependencies.
+    /// </remarks>
+#pragma warning disable CS0618 // Type or member is obsolete
+    string ToArtifact(string value, ICollection<Udi> dependencies, IContextCache contextCache) => ToArtifact(value, dependencies);
+#pragma warning restore CS0618 // Type or member is obsolete
 
     /// <summary>
     ///     Parses an artifact property value and produces an Umbraco property value.
@@ -23,5 +39,17 @@ public interface ILocalLinkParser
     /// <param name="value">The artifact property value.</param>
     /// <returns>The parsed value.</returns>
     /// <remarks>Turns {{localLink:umb://{type}/{id}}} into {{localLink:1234}}.</remarks>
+    [Obsolete("Please use the overload taking all parameters. This method will be removed in Umbraco 14.")]
     string FromArtifact(string value);
+
+    /// <summary>
+    ///     Parses an artifact property value and produces an Umbraco property value.
+    /// </summary>
+    /// <param name="value">The artifact property value.</param>
+    /// <param name="contextCache">The context cache.</param>
+    /// <returns>The parsed value.</returns>
+    /// <remarks>Turns {{localLink:umb://{type}/{id}}} into {{localLink:1234}}.</remarks>
+#pragma warning disable CS0618 // Type or member is obsolete
+    string FromArtifact(string value, IContextCache contextCache) => FromArtifact(value);
+#pragma warning restore CS0618 // Type or member is obsolete
 }

--- a/src/Umbraco.Core/Deploy/IMacroParser.cs
+++ b/src/Umbraco.Core/Deploy/IMacroParser.cs
@@ -8,14 +8,37 @@ public interface IMacroParser
     /// <param name="value">Property value.</param>
     /// <param name="dependencies">A list of dependencies.</param>
     /// <returns>Parsed value.</returns>
+    [Obsolete("Please use the overload taking all parameters. This method will be removed in Umbraco 14.")]
     string ToArtifact(string value, ICollection<Udi> dependencies);
+
+    /// <summary>
+    ///     Parses an Umbraco property value and produces an artifact property value.
+    /// </summary>
+    /// <param name="value">Property value.</param>
+    /// <param name="dependencies">A list of dependencies.</param>
+    /// <param name="contextCache">The context cache.</param>
+    /// <returns>Parsed value.</returns>
+#pragma warning disable CS0618 // Type or member is obsolete
+    string ToArtifact(string value, ICollection<Udi> dependencies, IContextCache contextCache) => ToArtifact(value, dependencies);
+#pragma warning restore CS0618 // Type or member is obsolete
 
     /// <summary>
     ///     Parses an artifact property value and produces an Umbraco property value.
     /// </summary>
     /// <param name="value">Artifact property value.</param>
     /// <returns>Parsed value.</returns>
+    [Obsolete("Please use the overload taking all parameters. This method will be removed in Umbraco 14.")]
     string FromArtifact(string value);
+
+    /// <summary>
+    ///     Parses an artifact property value and produces an Umbraco property value.
+    /// </summary>
+    /// <param name="value">Artifact property value.</param>
+    /// <param name="contextCache">The context cache.</param>
+    /// <returns>Parsed value.</returns>
+#pragma warning disable CS0618 // Type or member is obsolete
+    string FromArtifact(string value, IContextCache contextCache) => FromArtifact(value);
+#pragma warning restore CS0618 // Type or member is obsolete
 
     /// <summary>
     ///     Tries to replace the value of the attribute/parameter with a value containing a converted identifier.
@@ -25,5 +48,20 @@ public interface IMacroParser
     /// <param name="dependencies">Collection to add dependencies to when performing ToArtifact</param>
     /// <param name="direction">Indicates which action is being performed (to or from artifact)</param>
     /// <returns>Value with converted identifiers</returns>
+    [Obsolete("Please use the overload taking all parameters. This method will be removed in Umbraco 14.")]
     string ReplaceAttributeValue(string value, string editorAlias, ICollection<Udi> dependencies, Direction direction);
+
+    /// <summary>
+    ///     Tries to replace the value of the attribute/parameter with a value containing a converted identifier.
+    /// </summary>
+    /// <param name="value">Value to attempt to convert</param>
+    /// <param name="editorAlias">Alias of the editor used for the parameter</param>
+    /// <param name="dependencies">Collection to add dependencies to when performing ToArtifact</param>
+    /// <param name="direction">Indicates which action is being performed (to or from artifact)</param>
+    /// <param name="contextCache">The context cache.</param>
+    /// <returns>Value with converted identifiers</returns>
+    string ReplaceAttributeValue(string value, string editorAlias, ICollection<Udi> dependencies, Direction direction, IContextCache contextCache)
+#pragma warning disable CS0618 // Type or member is obsolete
+        => ReplaceAttributeValue(value, editorAlias, dependencies, direction);
+#pragma warning restore CS0618 // Type or member is obsolete
 }


### PR DESCRIPTION
### Description

This PR updates three interfaces used only in Umbraco Deploy to add a "context cache" parameter.  Currently we have interfaces in Deploy - e.g. `IMacroParser2` - that include this parameter, and moving this to core means we can clean this up.

Just to note I'm getting a compiler error...

```
Could not load type 'Enumerator' from assembly 'Microsoft.CodeAnalysis, Version=4.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
```

...since the upgrade to .NET 8 locally, so haven't been able to verify - so I'll have to rely on the build server to check the changes compile.