### PR TITLE
Don't change format in convertToLocalMomentTime

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/util.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/util.service.js
@@ -108,7 +108,7 @@ function dateHelper() {
                 const localOffset = new Date().getTimezoneOffset();
                 const serverTimeNeedsOffsetting = -serverOffset !== localOffset;
                 if (serverTimeNeedsOffsetting) {
-                    dateVal = this.convertToLocalMomentTime(date, serverOffset, format);
+                    dateVal = this.convertToLocalMomentTime(date, serverOffset);
                 } else {
                     dateVal = moment(date, parsingFormat);
                 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/15202

### Description
In https://github.com/umbraco/Umbraco-CMS/pull/13500 it adjusted a few functions to allow specifying a known parsing format instead of just default parsing format `YYYY-MM-DD HH:mm:ss`.

However it also passed in `format` to `convertToLocalMomentTime()` here: https://github.com/umbraco/Umbraco-CMS/pull/13500/files#diff-277b13396c90722385a98d599dbfea84855ff088949d00d4b5d14259208ed034R111

which before always used `YYYY-MM-DDTHH:mm:ss` format. Now it passed in format from where `getLocalDate()` is called, e.g. `LLL` or `MMM Do YYYY, HH:mm`.
https://github.com/search?q=repo%3Aumbraco%2FUmbraco-CMS%20getLocalDate&type=code
