### PR TITLE
Update WebhookFiring.cs with fix for serialization issue (#15232)

### DIFF
--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookFiring.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookFiring.cs
@@ -91,9 +91,8 @@ public class WebhookFiring : IRecurringBackgroundJob
     {
         using var httpClient = new HttpClient();
 
-        var serializedObject = _jsonSerializer.Serialize(payload);
-        var stringContent = new StringContent(serializedObject, Encoding.UTF8, "application/json");
-        stringContent.Headers.TryAddWithoutValidation("Umb-Webhook-Event", eventName);
+        var jsonContent = JsonContent.Create(payload);
+        jsonContent.Headers.TryAddWithoutValidation("Umb-Webhook-Event", eventName);
 
         foreach (KeyValuePair<string, string> header in webhook.Headers)
         {
@@ -103,7 +102,7 @@ public class WebhookFiring : IRecurringBackgroundJob
         HttpResponseMessage? response = null;
         try
         {
-            response = await httpClient.PostAsync(webhook.Url, stringContent, cancellationToken);
+            response = await httpClient.PostAsync(webhook.Url, jsonContent, cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookFiring.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookFiring.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
@@ -96,7 +96,7 @@ public class WebhookFiring : IRecurringBackgroundJob
 
         foreach (KeyValuePair<string, string> header in webhook.Headers)
         {
-            stringContent.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            jsonContent.Headers.TryAddWithoutValidation(header.Key, header.Value);
         }
 
         HttpResponseMessage? response = null;


### PR DESCRIPTION
Replaces the posted StringContent with JsonContent so the POST-ed body is no longer a JSON object wrapped in a string (#15232).
