### PR TITLE
Ensure content types are updated in ContentStore when a data type changes

### DIFF
--- a/src/Umbraco.PublishedCache.NuCache/ContentStore.cs
+++ b/src/Umbraco.PublishedCache.NuCache/ContentStore.cs
@@ -736,16 +736,22 @@ public class ContentStore
     {
         EnsureLocked();
 
-        IPublishedContentType?[] contentTypes = _contentTypesById
+        IPublishedContentType[] contentTypes = _contentTypesById
             .Where(kvp =>
                 kvp.Value.Value != null &&
                 kvp.Value.Value.PropertyTypes.Any(p => dataTypeIds.Contains(p.DataType.Id)))
             .Select(kvp => kvp.Value.Value)
             .Select(x => getContentType(x!.Id))
-            .Where(x => x != null) // poof, gone, very unlikely and probably an anomaly
+            .WhereNotNull() // poof, gone, very unlikely and probably an anomaly
             .ToArray();
 
-        var contentTypeIdsA = contentTypes.Select(x => x!.Id).ToArray();
+        // all content types that are affected by this data type update must be updated
+        foreach (IPublishedContentType contentType in contentTypes)
+        {
+            SetContentTypeLocked(contentType);
+        }
+
+        var contentTypeIdsA = contentTypes.Select(x => x.Id).ToArray();
         var contentTypeNodes = new Dictionary<int, List<int>>();
         foreach (var id in contentTypeIdsA)
         {
@@ -761,7 +767,7 @@ public class ContentStore
             }
         }
 
-        foreach (IPublishedContentType contentType in contentTypes.WhereNotNull())
+        foreach (IPublishedContentType contentType in contentTypes)
         {
             // again, weird situation
             if (contentTypeNodes.ContainsKey(contentType.Id) == false)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Whenever one makes changes to a data type, these changes are immediately available in the published properties that are based on this data type. That is, until a piece of content with a property based on this data type is either saved or published; then the data type data is rolled back to the previous version on _all_ published properties of _all_ content using this data type.

This can be reproduced by printing out the max allowed chars on a text string configuration:

1. Render the page after a restart - the rendered configuration value is (obviously) correct.
2. Change the configuration value and re-render the page - the rendered configuration value is the updated value (correct).
3. Save (or publish) a piece of content using this text string configuration and re-render the page  - the rendered configuration value is the previously configured value (incorrect)

Steps 2 and 3 can be repeated over and over with the same result. Only a site restart resolves the problem.

While the above is quite the edge case, this issue becomes a whole lot worse for block based editors. They use the published property data type configuration to determine which blocks to include in output (for validation purposes). If a block is added to the data type configuration and a page is subsequently saved (or published), all blocks of this new type are simply stripped from the output. Or even worse, if a block is removed... all blocks of this type will re-appear after a page is saved.

The following template can be used to perform the test scenario:

```cshtml
@using Umbraco.Cms.Core.PropertyEditors
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
@{
    Layout = null;
    var property = Model.GetProperty("textBox") ?? throw new ApplicationException("Model does not contain a textBox property");
    var configuration = property.PropertyType.DataType.ConfigurationAs<TextboxConfiguration>()!;
}
<html lang="en">
<head>
    <title>Property type cache test</title>
</head>
<body>
<ul>
    <li>Max chars: @configuration.MaxChars</li>
</ul>
</body>
</html>
```