### PR TITLE
V13 RC: Revert change to user dialog that accidentally removed user dashboards

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/user/user.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/user/user.html
@@ -99,7 +99,7 @@
       <div class="umb-control-group" ng-if="vm.dashboard.length > 0">
         <div ng-repeat="tab in vm.dashboard">
           <h5 ng-if="tab.label">{{tab.label}}</h5>
-          <div ng-repeat="property in tab.options">
+          <div ng-repeat="property in tab.properties">
             <div ng-include="property.view"></div>
           </div>
         </div>


### PR DESCRIPTION
### Description

Fixes #15240

This reverts an accidental change that changed the property on which user dashboards are shown.
