### PR TITLE
V13: Fix proper serialization of webhook object

### DIFF
--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookFiring.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookFiring.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Net.Mime;
+using System.Text;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
@@ -91,7 +92,7 @@ public class WebhookFiring : IRecurringBackgroundJob
     {
         using var httpClient = new HttpClient();
 
-        var stringContent = new StringContent(serializedObject ?? string.Empty, Encoding.UTF8, "application/json");
+        var stringContent = new StringContent(serializedObject ?? string.Empty, Encoding.UTF8, MediaTypeNames.Application.Json);
         stringContent.Headers.TryAddWithoutValidation("Umb-Webhook-Event", eventName);
 
         foreach (KeyValuePair<string, string> header in webhook.Headers)

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookFiring.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookFiring.cs
@@ -71,7 +71,8 @@ public class WebhookFiring : IRecurringBackgroundJob
                         return;
                     }
 
-                    HttpResponseMessage? response = await SendRequestAsync(webhook, request.EventAlias, request.RequestObject, request.RetryCount, CancellationToken.None);
+                    var actualObject = _jsonSerializer.Deserialize<object>(request.RequestObject?.ToString() ?? string.Empty);
+                    HttpResponseMessage? response = await SendRequestAsync(webhook, request.EventAlias, actualObject, request.RetryCount, CancellationToken.None);
 
                     if ((response?.IsSuccessStatusCode ?? false) || request.RetryCount >= _webhookSettings.MaximumRetries)
                     {


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/15232
- Problem was that we were trying to serialize and already serialized object, this no longer happens.

# How to test
- Create a document type with allow as root: `true`
- Create a webhook with Url using webhook.site (or whatever endpoint you want) and content published event.
- Create some content with your doc type from step 1.
- You should now receive proper JSON in your endpoint:

![image](https://github.com/umbraco/Umbraco-CMS/assets/70372949/ff76e5d3-856c-406d-b670-a24fbed209b4)
