### PR TITLE
Clear cached PublishedDataTypes when content types are updated

### DIFF
--- a/src/Umbraco.Core/Models/PublishedContent/IPublishedContentTypeFactory.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/IPublishedContentTypeFactory.cs
@@ -60,5 +60,5 @@ public interface IPublishedContentTypeFactory
     ///     <para>This is so the factory can flush its caches.</para>
     ///     <para>Invoked by the IPublishedSnapshotService.</para>
     /// </remarks>
-    void NotifyDataTypeChanges(int[] ids);
+    void NotifyDataTypeChanges(params int[] ids);
 }

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentTypeFactory.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentTypeFactory.cs
@@ -73,11 +73,11 @@ public class PublishedContentTypeFactory : IPublishedContentTypeFactory
     }
 
     /// <inheritdoc />
-    public void NotifyDataTypeChanges(int[] ids)
+    public void NotifyDataTypeChanges(params int[] ids)
     {
         lock (_publishedDataTypesLocker)
         {
-            if (_publishedDataTypes == null)
+            if (_publishedDataTypes == null || ids.Length == 0)
             {
                 IEnumerable<IDataType> dataTypes = _dataTypeService.GetAll();
                 _publishedDataTypes = dataTypes.ToDictionary(x => x.Id, CreatePublishedDataType);

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentTypeFactory.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentTypeFactory.cs
@@ -10,8 +10,8 @@ public class PublishedContentTypeFactory : IPublishedContentTypeFactory
 {
     private readonly IDataTypeService _dataTypeService;
     private readonly PropertyValueConverterCollection _propertyValueConverters;
-    private readonly object _publishedDataTypesLocker = new();
     private readonly IPublishedModelFactory _publishedModelFactory;
+    private object _publishedDataTypesLocker = new();
     private Dictionary<int, PublishedDataType>? _publishedDataTypes;
 
     public PublishedContentTypeFactory(
@@ -52,19 +52,12 @@ public class PublishedContentTypeFactory : IPublishedContentTypeFactory
     /// <inheritdoc />
     public PublishedDataType GetDataType(int id)
     {
-        Dictionary<int, PublishedDataType>? publishedDataTypes;
-        lock (_publishedDataTypesLocker)
-        {
-            if (_publishedDataTypes == null)
-            {
-                IEnumerable<IDataType> dataTypes = _dataTypeService.GetAll();
-                _publishedDataTypes = dataTypes.ToDictionary(x => x.Id, CreatePublishedDataType);
-            }
+        Dictionary<int, PublishedDataType> publishedDataTypes = LazyInitializer.EnsureInitialized(
+            ref _publishedDataTypes,
+            ref _publishedDataTypesLocker,
+            () => _dataTypeService.GetAll().ToDictionary(x => x.Id, CreatePublishedDataType));
 
-            publishedDataTypes = _publishedDataTypes;
-        }
-
-        if (publishedDataTypes is null || !publishedDataTypes.TryGetValue(id, out PublishedDataType? dataType))
+        if (!publishedDataTypes.TryGetValue(id, out PublishedDataType? dataType))
         {
             throw new ArgumentException($"Could not find a datatype with identifier {id}.", nameof(id));
         }
@@ -75,22 +68,29 @@ public class PublishedContentTypeFactory : IPublishedContentTypeFactory
     /// <inheritdoc />
     public void NotifyDataTypeChanges(params int[] ids)
     {
+        if (_publishedDataTypes is null)
+        {
+            // Not initialized yet, so skip and avoid lock
+            return;
+        }
+
         lock (_publishedDataTypesLocker)
         {
-            if (_publishedDataTypes == null || ids.Length == 0)
+            if (ids.Length == 0)
             {
-                IEnumerable<IDataType> dataTypes = _dataTypeService.GetAll();
-                _publishedDataTypes = dataTypes.ToDictionary(x => x.Id, CreatePublishedDataType);
+                // Clear cache (and let it lazy initialize again later)
+                _publishedDataTypes = null;
             }
             else
             {
+                // Remove items from cache (in case the data type is removed)
                 foreach (var id in ids)
                 {
                     _publishedDataTypes.Remove(id);
                 }
 
-                IEnumerable<IDataType> dataTypes = _dataTypeService.GetAll(ids);
-                foreach (IDataType dataType in dataTypes)
+                // Update cacheB
+                foreach (IDataType dataType in _dataTypeService.GetAll(ids))
                 {
                     _publishedDataTypes[dataType.Id] = CreatePublishedDataType(dataType);
                 }

--- a/src/Umbraco.PublishedCache.NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.PublishedCache.NuCache/PublishedSnapshotService.cs
@@ -189,6 +189,9 @@ internal class PublishedSnapshotService : IPublishedSnapshotService
             }
         }
 
+        // Ensure all published data types are updated
+        _publishedContentTypeFactory.NotifyDataTypeChanges();
+
         Notify<IContentType>(_contentStore, payloads, RefreshContentTypesLocked);
         Notify<IMediaType>(_mediaStore, payloads, RefreshMediaTypesLocked);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Although batching data type cache refresher operations (reported in https://github.com/umbraco/Umbraco-CMS/pull/13978, fixed in https://github.com/umbraco/Umbraco-CMS/pull/14332) has reduced the possibility of getting an `ArgumentException: Could not find a datatype with identifier 1195. (Parameter 'id')`, we discovered it was still possible in the following case:
1. Within a single scope:
   1. A content type gets updated;
   2. A new data type is saved;
   3. A new content type is saved using this data type.
2. When the scope is completed and notifications are published, the following happens:
   1. The `ContentTypeCacheRefresher` notifies the `IPublishedSnapshotService` to refresh all `PublishedContentType`s: https://github.com/umbraco/Umbraco-CMS/blob/c989c5e214700ac73c6bff10f4d8f132850e217e/src/Umbraco.Core/Cache/Refreshers/Implement/ContentTypeCacheRefresher.cs#L118-L120
   2. This tries to create the new content type, but can't find the `PublishedDataType` in the cache dictionary: https://github.com/umbraco/Umbraco-CMS/blob/e784cfa96073e33f5fd581d1383d275511e47706/src/Umbraco.PublishedCache.NuCache/PublishedSnapshotService.cs#L190
   3. This is caused by the fact that the `DataTypeCacheRefresher` hasn't notified the `IPublishedSnapshotService` about the new data type yet, so this is essentially a race condition.

The can be reproduced (and the fix tested) by adding the following API controller and requesting `/umbraco/api/Test/Create`:

```c#
using Microsoft.AspNetCore.Mvc;
using Umbraco.Cms.Core;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.PropertyEditors;
using Umbraco.Cms.Core.Serialization;
using Umbraco.Cms.Core.Services;
using Umbraco.Cms.Core.Strings;
using Umbraco.Cms.Infrastructure.Scoping;
using Umbraco.Cms.Web.Common.Controllers;

namespace Umbraco.Web.UI;

public class TestController : UmbracoApiController
{
    private readonly IScopeProvider _scopeProvider;
    private readonly IContentTypeService _contentTypeService;
    private readonly IDataTypeService _dataTypeService;
    private readonly IShortStringHelper _shortStringHelper;
    private readonly PropertyEditorCollection _propertyEditors;
    private readonly IConfigurationEditorJsonSerializer _configurationEditorJsonSerializer;

    public TestController(
        IScopeProvider scopeProvider,
        IContentTypeService contentTypeService,
        IDataTypeService dataTypeService,
        IShortStringHelper shortStringHelper,
        PropertyEditorCollection propertyEditors,
        IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
    {
        _scopeProvider = scopeProvider;
        _contentTypeService = contentTypeService;
        _dataTypeService = dataTypeService;
        _shortStringHelper = shortStringHelper;
        _propertyEditors = propertyEditors;
        _configurationEditorJsonSerializer = configurationEditorJsonSerializer;
    }

    [HttpGet]
    public void Create()
    {
        using (IScope scope = _scopeProvider.CreateScope())
        {
            _contentTypeService.Save(new ContentType(_shortStringHelper, Constants.System.Root)
            {
                Name = "Test content type 1 FIXME",
                Alias = "test1"
            });

            scope.Complete();
        }

        using (IScope scope = _scopeProvider.CreateScope())
        {
            // Update existing content type
            var existingContentType = _contentTypeService.Get("test1")!;
            existingContentType.Name = "Test content type 1";
            _contentTypeService.Save(existingContentType);

            // Create new data type
            var labelEditor = _propertyEditors[Constants.PropertyEditors.Aliases.Label]!;
            var newDataType = new DataType(labelEditor, _configurationEditorJsonSerializer)
            {
                Name = "Test data type",
                Configuration = labelEditor.GetConfigurationEditor().DefaultConfigurationObject,
                DatabaseType = ValueStorageType.Ntext
            };
            _dataTypeService.Save(newDataType);

            // Create new content type
            var newContentType = new ContentType(_shortStringHelper, Constants.System.Root)
            {
                Name = "Test content type 2",
                Alias = "test2"
            };
            newContentType.AddPropertyType(new PropertyType(_shortStringHelper, newDataType)
            {
                Alias = "testLabel",
                Name = "Test property"
            });
            _contentTypeService.Save(newContentType);

            scope.Complete();
        }
    }
}
```