### PR TITLE
Add Hotspot property editor

### DIFF
--- a/src/Umbraco.Core/Constants-PropertyEditors.cs
+++ b/src/Umbraco.Core/Constants-PropertyEditors.cs
@@ -81,6 +81,11 @@ public static partial class Constants
             public const string Grid = "Umbraco.Grid";
 
             /// <summary>
+            ///     Hotspot.
+            /// </summary>
+            public const string Hotspot = "Umbraco.Hotspot";
+
+            /// <summary>
             ///     Image Cropper.
             /// </summary>
             public const string ImageCropper = "Umbraco.ImageCropper";

--- a/src/Umbraco.Infrastructure/PropertyEditors/HotspotConfiguration.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/HotspotConfiguration.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Runtime.Serialization;
+using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
+
+namespace Umbraco.Cms.Core.PropertyEditors;
+
+/// <summary>
+///     Represents the configuration for the hotspot value editor.
+/// </summary>
+public class HotspotConfiguration
+{
+    [ConfigurationField("mediaId", "Image", "mediapicker", Description = "Choose the image to select hotspots.")]
+    public GuidUdi? MediaId { get; set; }
+}

--- a/src/Umbraco.Infrastructure/PropertyEditors/HotspotConfigurationEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/HotspotConfigurationEditor.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Core.PropertyEditors;
+
+/// <summary>
+///     Represents the configuration editor for the hotspot value editor.
+/// </summary>
+internal class HotspotConfigurationEditor : ConfigurationEditor<HotspotConfiguration>
+{
+    public HotspotConfigurationEditor(IIOHelper ioHelper, IEditorConfigurationParser editorConfigurationParser)
+        : base(ioHelper, editorConfigurationParser)
+    {
+    }
+
+    /// <inheritdoc />
+    public override IDictionary<string, object> ToValueEditor(object? configuration)
+    {
+        IDictionary<string, object> d = base.ToValueEditor(configuration);
+        if (!d.ContainsKey("focalPoint"))
+        {
+            d["focalPoint"] = new { left = 0.5, top = 0.5 };
+        }
+
+        if (!d.ContainsKey("src"))
+        {
+            d["src"] = string.Empty;
+        }
+
+        return d;
+    }
+}

--- a/src/Umbraco.Infrastructure/PropertyEditors/HotspotPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/HotspotPropertyEditor.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Media;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Core.PropertyEditors;
+
+/// <summary>
+///     Represents a hotspot property editor.
+/// </summary>
+[DataEditor(
+    Constants.PropertyEditors.Aliases.Hotspot,
+    "Hotspot",
+    "hotspot",
+    ValueType = ValueTypes.Json,
+    HideLabel = false,
+    Group = Constants.PropertyEditors.Groups.Media,
+    Icon = "icon-crosshair",
+    ValueEditorIsReusable = true)]
+public class HotspotPropertyEditor : DataEditor
+{
+    private readonly UploadAutoFillProperties _autoFillProperties;
+    private readonly IContentService _contentService;
+    private readonly IDataTypeService _dataTypeService;
+    private readonly IEditorConfigurationParser _editorConfigurationParser;
+    private readonly IIOHelper _ioHelper;
+    private readonly ILogger<HotspotPropertyEditor> _logger;
+    private readonly MediaFileManager _mediaFileManager;
+    private ContentSettings _contentSettings;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="HotspotPropertyEditor" /> class.
+    /// </summary>
+    public HotspotPropertyEditor(
+        IDataValueEditorFactory dataValueEditorFactory,
+        ILoggerFactory loggerFactory,
+        MediaFileManager mediaFileManager,
+        IOptionsMonitor<ContentSettings> contentSettings,
+        IDataTypeService dataTypeService,
+        IIOHelper ioHelper,
+        UploadAutoFillProperties uploadAutoFillProperties,
+        IContentService contentService,
+        IEditorConfigurationParser editorConfigurationParser)
+        : base(dataValueEditorFactory)
+    {
+        _mediaFileManager = mediaFileManager ?? throw new ArgumentNullException(nameof(mediaFileManager));
+        _contentSettings = contentSettings.CurrentValue ?? throw new ArgumentNullException(nameof(contentSettings));
+        _dataTypeService = dataTypeService ?? throw new ArgumentNullException(nameof(dataTypeService));
+        _ioHelper = ioHelper ?? throw new ArgumentNullException(nameof(ioHelper));
+        _autoFillProperties =
+            uploadAutoFillProperties ?? throw new ArgumentNullException(nameof(uploadAutoFillProperties));
+        _contentService = contentService;
+        _editorConfigurationParser = editorConfigurationParser;
+        _logger = loggerFactory.CreateLogger<HotspotPropertyEditor>();
+
+        contentSettings.OnChange(x => _contentSettings = x);
+        SupportsReadOnly = true;
+    }
+
+    public override IPropertyIndexValueFactory PropertyIndexValueFactory { get; } = new NoopPropertyIndexValueFactory();
+
+    /// <summary>
+    ///     Creates the corresponding property value editor.
+    /// </summary>
+    /// <returns>The corresponding property value editor.</returns>
+    protected override IDataValueEditor CreateValueEditor() =>
+        DataValueEditorFactory.Create<HotspotPropertyValueEditor>(Attribute!);
+
+    /// <summary>
+    ///     Creates the corresponding preValue editor.
+    /// </summary>
+    /// <returns>The corresponding preValue editor.</returns>
+    protected override IConfigurationEditor CreateConfigurationEditor() =>
+        new HotspotConfigurationEditor(_ioHelper, _editorConfigurationParser);
+}

--- a/src/Umbraco.Infrastructure/PropertyEditors/HotspotPropertyValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/HotspotPropertyValueEditor.cs
@@ -1,0 +1,123 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Editors;
+using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Strings;
+using Umbraco.Extensions;
+using File = System.IO.File;
+
+namespace Umbraco.Cms.Core.PropertyEditors;
+
+/// <summary>
+///     The value editor for the hotspot property editor.
+/// </summary>
+internal class HotspotPropertyValueEditor : DataValueEditor
+{
+    private readonly IDataTypeService _dataTypeService;
+    private readonly IFileStreamSecurityValidator _fileStreamSecurityValidator;
+    private readonly ILogger<HotspotPropertyValueEditor> _logger;
+    private readonly MediaFileManager _mediaFileManager;
+    private ContentSettings _contentSettings;
+
+    public HotspotPropertyValueEditor(
+        DataEditorAttribute attribute,
+        ILogger<HotspotPropertyValueEditor> logger,
+        MediaFileManager mediaFileSystem,
+        ILocalizedTextService localizedTextService,
+        IShortStringHelper shortStringHelper,
+        IOptionsMonitor<ContentSettings> contentSettings,
+        IJsonSerializer jsonSerializer,
+        IIOHelper ioHelper,
+        IDataTypeService dataTypeService,
+        IFileStreamSecurityValidator fileStreamSecurityValidator)
+        : base(localizedTextService, shortStringHelper, jsonSerializer, ioHelper, attribute)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _mediaFileManager = mediaFileSystem ?? throw new ArgumentNullException(nameof(mediaFileSystem));
+        _contentSettings = contentSettings.CurrentValue;
+        _dataTypeService = dataTypeService;
+        _fileStreamSecurityValidator = fileStreamSecurityValidator;
+        contentSettings.OnChange(x => _contentSettings = x);
+    }
+
+    /// <summary>
+    /// </summary>
+    //public override object? ToEditor(IProperty property, string? culture = null, string? segment = null)
+    //{
+    //    var val = property.GetValue(culture, segment);
+    //    if (val == null)
+    //    {
+    //        return null;
+    //    }
+
+    //    ImageCropperValue? value;
+    //    try
+    //    {
+    //        value = JsonConvert.DeserializeObject<ImageCropperValue>(val.ToString()!);
+    //    }
+    //    catch
+    //    {
+    //        value = new ImageCropperValue { Src = val.ToString() };
+    //    }
+
+    //    IDataType? dataType = _dataTypeService.GetDataType(property.PropertyType.DataTypeId);
+    //    if (dataType?.Configuration != null)
+    //    {
+    //        value?.ApplyConfiguration(dataType.ConfigurationAs<ImageCropperConfiguration>());
+    //    }
+
+    //    return value;
+    //}
+
+    /// <summary>
+    ///     Converts the value received from the editor into the value can be stored in the database.
+    /// </summary>
+    /// <param name="editorValue">The value received from the editor.</param>
+    /// <param name="currentValue">The current value of the property</param>
+    /// <returns>The converted value.</returns>
+    /// <remarks>
+    ///     <para>The <paramref name="currentValue" /> is used to re-use the folder, if possible.</para>
+    ///     <para>
+    ///         editorValue.Value is used to figure out editorFile and, if it has been cleared, remove the old file - but
+    ///         it is editorValue.AdditionalData["files"] that is used to determine the actual file that has been uploaded.
+    ///     </para>
+    /// </remarks>
+    //public override object? FromEditor(ContentPropertyData editorValue, object? currentValue)
+    //{
+
+    //}
+
+    public override string ConvertDbToString(IPropertyType propertyType, object? value)
+    {
+        if (value == null || string.IsNullOrEmpty(value.ToString()))
+        {
+            return string.Empty;
+        }
+
+        // if we don't have a json structure, we will get it from the property type
+        var val = value.ToString();
+        if (val?.DetectIsJson() ?? false)
+        {
+            return val;
+        }
+
+        // more magic here ;-(
+        HotspotConfiguration? configuration = _dataTypeService.GetDataType(propertyType.DataTypeId)
+            ?.ConfigurationAs<HotspotConfiguration>();
+
+        return JsonConvert.SerializeObject(
+            new { src = val },
+            new JsonSerializerSettings { Formatting = Formatting.None, NullValueHandling = NullValueHandling.Ignore });
+    }
+}

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/imaging/umbimagegravity.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/imaging/umbimagegravity.directive.js
@@ -3,7 +3,7 @@
 
     function umbImageGravityController($scope, $element, $timeout) {
 
-        var vm = this;
+        const vm = this;
 
         //Internal values for keeping track of the dot and the size of the editor
         vm.dimensions = {
@@ -11,6 +11,11 @@
             height: 0,
             left: 0,
             top: 0
+        };
+
+        vm.focalPointPosition = {
+            left: 0.5,
+            top: 0.5
         };
 
         var imageElement = null; //DOM element reference
@@ -37,14 +42,16 @@
                 'width': vm.dimensions.width + 'px',
                 'height': vm.dimensions.height + 'px'
             };
-
         };
 
         function resetFocalPoint() {
-            vm.onValueChanged({
+            vm.focalPointPosition = {
                 left: 0.5,
                 top: 0.5
-            });
+            };
+
+            vm.onValueChanged(vm.focalPointPosition);
+        };
         };
 
         function setFocalPoint(event) {
@@ -86,13 +93,11 @@
                     $scope.$evalAsync(calculateGravity(offsetX, offsetY));
 
                     $scope.$emit("imageFocalPointStop");
-
                 }
             });
 
             window.addEventListener('resize.umbImageGravity', onResizeHandler);
             window.addEventListener('resize', onResizeHandler);
-
 
             //if any ancestor directive emits this event, we need to resize
             $scope.$on("editors.content.splitViewChanged", function () {
@@ -175,12 +180,17 @@
 
         /** Watches the one way binding changes */
         function onChanges(changes) {
-            if (changes.center && !changes.center.isFirstChange()
-                && changes.center.currentValue
-                && !Utilities.equals(changes.center.currentValue, changes.center.previousValue)) {
-                //when center changes update the dimensions
-                setDimensions();
-                updateStyle();
+            console.log("onChanges", changes);
+            if (changes.center && !changes.center.isFirstChange()) {
+                if (changes.center.currentValue && !Utilities.equals(changes.center.currentValue, changes.center.previousValue)) {
+                    //when center changes update the dimensions
+                    setDimensions();
+                    updateStyle();
+                }
+
+                if (changes.center.currentValue === null) {
+                    clearFocalPoint();
+                }
             }
         }
 
@@ -203,10 +213,13 @@
          * @param {any} offsetY
          */
         function calculateGravity(offsetX, offsetY) {
-            vm.onValueChanged({
+
+            vm.focalPointPosition = {
                 left: Math.min(Math.max(offsetX, 0), vm.dimensions.width) / vm.dimensions.width,
                 top: Math.min(Math.max(offsetY, 0), vm.dimensions.height) / vm.dimensions.height
-            });
+            };
+
+            vm.onValueChanged(vm.focalPointPosition);
         };
 
     }

--- a/src/Umbraco.Web.UI.Client/src/less/property-editors.less
+++ b/src/Umbraco.Web.UI.Client/src/less/property-editors.less
@@ -3,6 +3,10 @@
 // --------------------------------------------------
 .umb-property-editor {
     width: 100%;
+
+    &--limit-width {
+        .umb-property-editor--limit-width();
+    }
 }
 
 .umb-property-editor-tiny {

--- a/src/Umbraco.Web.UI.Client/src/views/components/imaging/umb-image-gravity.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/imaging/umb-image-gravity.html
@@ -1,19 +1,14 @@
 <div class="umb-cropper-gravity">
 
 	<div class="gravity-container" ng-show="vm.loaded">
-        <div class="viewport">
-
-            <img ng-show="vm.isCroppable" ng-src="{{vm.src}}" src="" alt="" draggable="false" />
-            <img ng-show="!vm.isCroppable && !vm.hasDimensions" ng-src="{{vm.src}}" src="" alt="" draggable="false" class="cursor-default" />
-
-        </div>
-        <div class="overlayViewport">
-
-            <div ng-show="vm.isCroppable && vm.disableFocalPoint !== true" class="overlay umb-outline" ng-style="vm.overlayStyle" ng-click="vm.setFocalPoint($event)">
-                <div class="focalPoint" ng-style="vm.style">
-                </div>
-            </div>
-
-        </div>
+      <div class="viewport">
+          <img ng-show="vm.isCroppable" ng-src="{{vm.src}}" src="" alt="" draggable="false" />
+          <img ng-show="!vm.isCroppable && !vm.hasDimensions" ng-src="{{vm.src}}" src="" alt="" draggable="false" class="cursor-default" />
+      </div>
+      <div class="overlayViewport">
+          <div ng-show="vm.isCroppable && vm.disableFocalPoint !== true" class="overlay umb-outline" ng-style="vm.overlayStyle" ng-click="vm.setFocalPoint($event)">
+              <div class="focalPoint" ng-if="vm.focalPointPosition" ng-style="vm.style"></div>
+          </div>
+      </div>
 	</div>
 </div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/hotspot/hotspot.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/hotspot/hotspot.controller.js
@@ -1,0 +1,84 @@
+function HotspotController($scope, entityResource) {
+
+    const vm = this;
+
+    vm.focalPointChanged = focalPointChanged;
+    vm.imageLoaded = imageLoaded;
+
+    //setup the default config
+    var config = {
+        mediaId: null
+    };
+    
+    // map the user config
+    Utilities.extend(config, $scope.model.config);
+
+    // map back to the model
+    $scope.model.config = config;
+
+    function init() {
+
+      setModelValueWithSrc($scope.model.value);
+
+      retrieveMedia();
+    }
+
+    function retrieveMedia() {
+        
+        var id = $scope.model.config.mediaId || null;
+        
+        if (id == null) {
+            return;
+        }
+        
+      entityResource.getById(id, "Media").then(media => {
+            console.log("media", media);
+            $scope.media = media;
+            $scope.imageSrc = media.metaData.MediaPath;
+        });
+  }
+
+    /**
+    * Used to assign a new model value
+    * @param {any} src
+    */
+    function setModelValueWithSrc(src) {
+      if (!$scope.model.value || !$scope.model.value.src) {
+        //we are copying to not overwrite the original config
+        $scope.model.value = Utilities.extend(Utilities.copy($scope.model.config), { src: src });
+      }
+    }
+
+    /**
+    * Called when the umbImageGravity component updates the focal point value
+    * @param {any} left
+    * @param {any} top
+    */
+    function focalPointChanged(left, top) {
+        console.log("focalPointChanged", left, top);
+        //update the model focalpoint value
+        $scope.model.value.focalPoint = {
+            left: left,
+            top: top
+        };
+
+        //set form to dirty to track changes
+        //setDirty();
+    }
+
+    function imageLoaded(isCroppable, hasDimensions) {
+        $scope.isCroppable = isCroppable;
+        $scope.hasDimensions = hasDimensions;
+    }
+
+    function setDirty() {
+      if ($scope.imageCropperForm) {
+        $scope.imageCropperForm.modelValue.$setDirty();
+      }
+    }
+
+    init();
+
+}
+
+angular.module("umbraco").controller("Umbraco.PropertyEditors.HotspotController", HotspotController);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/hotspot/hotspot.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/hotspot/hotspot.controller.js
@@ -2,6 +2,7 @@ function HotspotController($scope, entityResource) {
 
     const vm = this;
 
+    vm.clear = clear;
     vm.focalPointChanged = focalPointChanged;
     vm.imageLoaded = imageLoaded;
 
@@ -25,7 +26,8 @@ function HotspotController($scope, entityResource) {
 
     function retrieveMedia() {
         
-        var id = $scope.model.config.mediaId || null;
+      var id = $scope.model.config.mediaId || null;
+      console.log("id", id);
         
         if (id == null) {
             return;
@@ -36,7 +38,11 @@ function HotspotController($scope, entityResource) {
             $scope.media = media;
             $scope.imageSrc = media.metaData.MediaPath;
         });
-  }
+    }
+
+    function clear() {
+      focalPointChanged(null, null);
+    }
 
     /**
     * Used to assign a new model value
@@ -56,11 +62,17 @@ function HotspotController($scope, entityResource) {
     */
     function focalPointChanged(left, top) {
         console.log("focalPointChanged", left, top);
-        //update the model focalpoint value
-        $scope.model.value.focalPoint = {
-            left: left,
-            top: top
-        };
+
+        if (left === null && top === null) {
+            $scope.model.value.focalPoint = null;
+        }
+        else {
+            //update the model focalpoint value
+            $scope.model.value.focalPoint = {
+              left: left,
+              top: top
+            };
+        }
 
         //set form to dirty to track changes
         //setDirty();

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/hotspot/hotspot.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/hotspot/hotspot.html
@@ -1,4 +1,4 @@
-<div class="umb-property-editor" ng-controller="Umbraco.PropertyEditors.HotspotController as vm">
+<div class="umb-property-editor umb-property-editor--limit-width" ng-controller="Umbraco.PropertyEditors.HotspotController as vm">
 
   <div class="umb-cropper-imageholder clearfix">
     <umb-image-gravity

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/hotspot/hotspot.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/hotspot/hotspot.html
@@ -1,0 +1,24 @@
+<div class="umb-property-editor" ng-controller="Umbraco.PropertyEditors.HotspotController as vm">
+
+  <div class="umb-cropper-imageholder clearfix">
+    <umb-image-gravity
+      src="imageSrc"
+      center="model.value.focalPoint"
+      on-value-changed="vm.focalPointChanged(left, top)"
+      on-image-loaded="vm.imageLoaded(isCroppable, hasDimensions)"
+      disable-focal-point="readonly">
+    </umb-image-gravity>
+
+    <!--<div ng-if="!readonly" class="umb-cropper-imageholder-buttons">
+      <button type="button" class="btn btn-link btn-crop-delete" ng-click="clear()"><umb-icon icon="icon-delete" class="red"></umb-icon> <localize key="content_uploadClear">Remove file</localize></button>
+      <button type="button" class="sr-only" ng-click="vm.clear()"><localize key="content_uploadClearImageContext">Click here to remove the image from the media item</localize></button>
+      <button type="button" ng-show="(model.value.focalPoint.left !== 0.5 && model.value.focalPoint.top !== 0.5)" class="btn btn-link btn-gravity-reset" ng-click="focalPointChanged(0.5,0.5)">
+        <umb-icon icon="icon-axis-rotation"></umb-icon> <localize key="content_resetFocalPoint">Reset focal point</localize>
+      </button>
+    </div>-->
+
+  </div>
+
+  <pre>{{model.value | json}}</pre>
+
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/hotspot/hotspot.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/hotspot/hotspot.html
@@ -9,13 +9,14 @@
       disable-focal-point="readonly">
     </umb-image-gravity>
 
-    <!--<div ng-if="!readonly" class="umb-cropper-imageholder-buttons">
-      <button type="button" class="btn btn-link btn-crop-delete" ng-click="clear()"><umb-icon icon="icon-delete" class="red"></umb-icon> <localize key="content_uploadClear">Remove file</localize></button>
-      <button type="button" class="sr-only" ng-click="vm.clear()"><localize key="content_uploadClearImageContext">Click here to remove the image from the media item</localize></button>
-      <button type="button" ng-show="(model.value.focalPoint.left !== 0.5 && model.value.focalPoint.top !== 0.5)" class="btn btn-link btn-gravity-reset" ng-click="focalPointChanged(0.5,0.5)">
+    <div ng-if="!readonly" class="umb-cropper-imageholder-buttons">
+      <button type="button" ng-show="model.value.focalPoint" class="btn btn-link btn-gravity-reset" ng-click="vm.clear()">
+        <umb-icon icon="icon-delete"></umb-icon> Clear focal point
+      </button>
+      <button type="button" ng-show="(model.value.focalPoint && model.value.focalPoint.left !== 0.5 && model.value.focalPoint.top !== 0.5)" class="btn btn-link btn-gravity-reset" ng-click="vm.focalPointChanged(0.5,0.5)">
         <umb-icon icon="icon-axis-rotation"></umb-icon> <localize key="content_resetFocalPoint">Reset focal point</localize>
       </button>
-    </div>-->
+    </div>
 
   </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.controller.js
@@ -20,8 +20,9 @@ angular.module('umbraco')
 
             var umbracoSettings = Umbraco.Sys.ServerVariables.umbracoSettings;
             $scope.acceptFileExt = mediaHelper.formatFileTypes(umbracoSettings.imageFileTypes);
+
             /**
-             * Called when the umgImageGravity component updates the focal point value
+             * Called when the umbImageGravity component updates the focal point value
              * @param {any} left
              * @param {any} top
              */
@@ -81,7 +82,7 @@ angular.module('umbraco')
             function imageLoaded(isCroppable, hasDimensions) {
                 $scope.isCroppable = isCroppable;
                 $scope.hasDimensions = hasDimensions;
-            };
+            }
 
             /**
              * Called when the file collection changes


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Adding a simple Hotspot property editor using the existing functionality in Image Cropper regarding focal point, but allows to select a source image to use and select a hotspot on the specific image.

For example it can be useful on location nodes to select the location on an (SVG) Image map of a country, on a product node (in Umbraco Commerce) with multiple products on same image, etc.

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/9e4b7a0c-9f0c-4601-88d3-7691aa15626a)


Also discussed in https://github.com/umbraco/Umbraco-CMS/discussions/15242