### PR TITLE
Fix typo in `umbImageGravity`

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/imagecropper/imagecropper.controller.js
@@ -20,8 +20,9 @@ angular.module('umbraco')
 
             var umbracoSettings = Umbraco.Sys.ServerVariables.umbracoSettings;
             $scope.acceptFileExt = mediaHelper.formatFileTypes(umbracoSettings.imageFileTypes);
+            
             /**
-             * Called when the umgImageGravity component updates the focal point value
+             * Called when the umbImageGravity component updates the focal point value
              * @param {any} left
              * @param {any} top
              */
@@ -81,7 +82,7 @@ angular.module('umbraco')
             function imageLoaded(isCroppable, hasDimensions) {
                 $scope.isCroppable = isCroppable;
                 $scope.hasDimensions = hasDimensions;
-            };
+            }
 
             /**
              * Called when the file collection changes


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Fixed typo in description mentioning `umbImageGravity` component. I only removed a semicolon after a function, which is only needed after a named function.
