### PR TITLE
Cache block item constructors for block based editors

### DIFF
--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -162,6 +162,9 @@ public static partial class UmbracoBuilderExtensions
 
         builder.Services.AddSingleton<RichTextEditorPastedImages>();
         builder.Services.AddSingleton<BlockEditorConverter>();
+        builder.Services.AddSingleton<BlockListPropertyValueConstructorCache>();
+        builder.Services.AddSingleton<BlockGridPropertyValueConstructorCache>();
+        builder.Services.AddSingleton<RichTextBlockPropertyValueConstructorCache>();
 
         // both TinyMceValueConverter (in Core) and RteMacroRenderingValueConverter (in Web) will be
         // discovered when CoreBootManager configures the converters. We will remove the basic one defined

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -370,7 +370,9 @@ public static partial class UmbracoBuilderExtensions
             .AddNotificationHandler<ContentDeletedNotification, ImageCropperPropertyEditor>()
             .AddNotificationHandler<MediaDeletedNotification, ImageCropperPropertyEditor>()
             .AddNotificationHandler<MediaSavingNotification, ImageCropperPropertyEditor>()
-            .AddNotificationHandler<MemberDeletedNotification, ImageCropperPropertyEditor>();
+            .AddNotificationHandler<MemberDeletedNotification, ImageCropperPropertyEditor>()
+            .AddNotificationHandler<ContentTypeCacheRefresherNotification, ConstructorCacheClearNotificationHandler>()
+            .AddNotificationHandler<DataTypeCacheRefresherNotification, ConstructorCacheClearNotificationHandler>();
 
         // add notification handlers for redirect tracking
         builder

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockEditorPropertyValueConstructorCacheBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockEditorPropertyValueConstructorCacheBase.cs
@@ -1,0 +1,19 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Umbraco.Cms.Core.Models.Blocks;
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
+
+public abstract class BlockEditorPropertyValueConstructorCacheBase<T>
+    where T : IBlockReference<IPublishedElement, IPublishedElement>
+{
+    private readonly
+        Dictionary<(Guid, Guid?), Func<Udi, IPublishedElement, Udi?, IPublishedElement?, T>>
+        _constructorCache = new();
+
+    public bool TryGetValue((Guid ContentTypeKey, Guid? SettingsTypeKey) key, [MaybeNullWhen(false)] out Func<Udi, IPublishedElement, Udi?, IPublishedElement?, T> value)
+        => _constructorCache.TryGetValue(key, out value);
+
+    public void SetValue((Guid ContentTypeKey, Guid? SettingsTypeKey) key, Func<Udi, IPublishedElement, Udi?, IPublishedElement?, T> value)
+        => _constructorCache[key] = value;
+}

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockEditorPropertyValueConstructorCacheBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockEditorPropertyValueConstructorCacheBase.cs
@@ -16,4 +16,7 @@ public abstract class BlockEditorPropertyValueConstructorCacheBase<T>
 
     public void SetValue((Guid ContentTypeKey, Guid? SettingsTypeKey) key, Func<Udi, IPublishedElement, Udi?, IPublishedElement?, T> value)
         => _constructorCache[key] = value;
+
+    public void Clear()
+        => _constructorCache.Clear();
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueConstructorCache.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueConstructorCache.cs
@@ -1,0 +1,7 @@
+﻿using Umbraco.Cms.Core.Models.Blocks;
+
+namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
+
+public class BlockGridPropertyValueConstructorCache : BlockEditorPropertyValueConstructorCacheBase<BlockGridItem>
+{
+}

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueConverter.cs
@@ -21,8 +21,9 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
         private readonly BlockEditorConverter _blockConverter;
         private readonly IJsonSerializer _jsonSerializer;
         private readonly IApiElementBuilder _apiElementBuilder;
+        private readonly BlockGridPropertyValueConstructorCache _constructorCache;
 
-        [Obsolete("Please use non-obsolete cconstrutor. This will be removed in Umbraco 14.")]
+        [Obsolete("Please use non-obsolete construtor. This will be removed in Umbraco 14.")]
         public BlockGridPropertyValueConverter(
             IProfilingLogger proflog,
             BlockEditorConverter blockConverter,
@@ -32,16 +33,28 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
 
         }
 
+        [Obsolete("Please use non-obsolete construtor. This will be removed in Umbraco 15.")]
         public BlockGridPropertyValueConverter(
             IProfilingLogger proflog,
             BlockEditorConverter blockConverter,
             IJsonSerializer jsonSerializer,
             IApiElementBuilder apiElementBuilder)
+            : this(proflog, blockConverter, jsonSerializer, apiElementBuilder, StaticServiceProvider.Instance.GetRequiredService<BlockGridPropertyValueConstructorCache>())
+        {
+        }
+
+        public BlockGridPropertyValueConverter(
+            IProfilingLogger proflog,
+            BlockEditorConverter blockConverter,
+            IJsonSerializer jsonSerializer,
+            IApiElementBuilder apiElementBuilder,
+            BlockGridPropertyValueConstructorCache constructorCache)
         {
             _proflog = proflog;
             _blockConverter = blockConverter;
             _jsonSerializer = jsonSerializer;
             _apiElementBuilder = apiElementBuilder;
+            _constructorCache = constructorCache;
         }
 
         /// <inheritdoc />
@@ -129,7 +142,7 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
                     return null;
                 }
 
-                var creator = new BlockGridPropertyValueCreator(_blockConverter, _jsonSerializer);
+                var creator = new BlockGridPropertyValueCreator(_blockConverter, _jsonSerializer, _constructorCache);
                 return creator.CreateBlockModel(referenceCacheLevel, intermediateBlockModelValue, preview, configuration.Blocks, configuration.GridColumns);
             }
         }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueCreator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueCreator.cs
@@ -7,10 +7,14 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 internal class BlockGridPropertyValueCreator : BlockPropertyValueCreatorBase<BlockGridModel, BlockGridItem, BlockGridLayoutItem, BlockGridConfiguration.BlockGridBlockConfiguration>
 {
     private readonly IJsonSerializer _jsonSerializer;
+    private readonly BlockGridPropertyValueConstructorCache _constructorCache;
 
-    public BlockGridPropertyValueCreator(BlockEditorConverter blockEditorConverter, IJsonSerializer jsonSerializer)
+    public BlockGridPropertyValueCreator(BlockEditorConverter blockEditorConverter, IJsonSerializer jsonSerializer, BlockGridPropertyValueConstructorCache constructorCache)
         : base(blockEditorConverter)
-        => _jsonSerializer = jsonSerializer;
+    {
+        _jsonSerializer = jsonSerializer;
+        _constructorCache = constructorCache;
+    }
 
     public BlockGridModel CreateBlockModel(PropertyCacheLevel referenceCacheLevel, string intermediateBlockModelValue, bool preview, BlockGridConfiguration.BlockGridBlockConfiguration[] blockConfigurations, int? gridColumns)
     {
@@ -55,11 +59,12 @@ internal class BlockGridPropertyValueCreator : BlockPropertyValueCreatorBase<Blo
 
     protected override BlockEditorDataConverter CreateBlockEditorDataConverter() => new BlockGridEditorDataConverter(_jsonSerializer);
 
-    protected override BlockItemActivator<BlockGridItem> CreateBlockItemActivator() => new BlockGridItemActivator(BlockEditorConverter);
+    protected override BlockItemActivator<BlockGridItem> CreateBlockItemActivator() => new BlockGridItemActivator(BlockEditorConverter, _constructorCache);
 
     private class BlockGridItemActivator : BlockItemActivator<BlockGridItem>
     {
-        public BlockGridItemActivator(BlockEditorConverter blockConverter) : base(blockConverter)
+        public BlockGridItemActivator(BlockEditorConverter blockConverter, BlockGridPropertyValueConstructorCache constructorCache)
+            : base(blockConverter, constructorCache)
         {
         }
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockListPropertyValueConstructorCache.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockListPropertyValueConstructorCache.cs
@@ -1,0 +1,7 @@
+﻿using Umbraco.Cms.Core.Models.Blocks;
+
+namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
+
+public class BlockListPropertyValueConstructorCache : BlockEditorPropertyValueConstructorCacheBase<BlockListItem>
+{
+}

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockListPropertyValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockListPropertyValueConverter.cs
@@ -23,6 +23,7 @@ public class BlockListPropertyValueConverter : PropertyValueConverterBase, IDeli
     private readonly IProfilingLogger _proflog;
     private readonly BlockEditorConverter _blockConverter;
     private readonly IApiElementBuilder _apiElementBuilder;
+    private readonly BlockListPropertyValueConstructorCache _constructorCache;
 
     [Obsolete("Use the constructor that takes all parameters, scheduled for removal in V14")]
     public BlockListPropertyValueConverter(IProfilingLogger proflog, BlockEditorConverter blockConverter)
@@ -36,12 +37,19 @@ public class BlockListPropertyValueConverter : PropertyValueConverterBase, IDeli
     {
     }
 
+    [Obsolete("Use the constructor that takes all parameters, scheduled for removal in V15")]
     public BlockListPropertyValueConverter(IProfilingLogger proflog, BlockEditorConverter blockConverter, IContentTypeService contentTypeService, IApiElementBuilder apiElementBuilder)
+        : this(proflog, blockConverter, contentTypeService, apiElementBuilder, StaticServiceProvider.Instance.GetRequiredService<BlockListPropertyValueConstructorCache>())
+    {
+    }
+
+    public BlockListPropertyValueConverter(IProfilingLogger proflog, BlockEditorConverter blockConverter, IContentTypeService contentTypeService, IApiElementBuilder apiElementBuilder, BlockListPropertyValueConstructorCache constructorCache)
     {
         _proflog = proflog;
         _blockConverter = blockConverter;
         _contentTypeService = contentTypeService;
         _apiElementBuilder = apiElementBuilder;
+        _constructorCache = constructorCache;
     }
 
     /// <inheritdoc />
@@ -153,7 +161,7 @@ public class BlockListPropertyValueConverter : PropertyValueConverterBase, IDeli
                 return null;
             }
 
-            var creator = new BlockListPropertyValueCreator(_blockConverter);
+            var creator = new BlockListPropertyValueCreator(_blockConverter, _constructorCache);
             return creator.CreateBlockModel(referenceCacheLevel, intermediateBlockModelValue, preview, configuration.Blocks);
         }
     }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockListPropertyValueCreator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockListPropertyValueCreator.cs
@@ -4,10 +4,11 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 
 internal class BlockListPropertyValueCreator : BlockPropertyValueCreatorBase<BlockListModel, BlockListItem, BlockListLayoutItem, BlockListConfiguration.BlockConfiguration>
 {
-    public BlockListPropertyValueCreator(BlockEditorConverter blockEditorConverter)
-        : base(blockEditorConverter)
-    {
-    }
+    private readonly BlockListPropertyValueConstructorCache _constructorCache;
+
+    public BlockListPropertyValueCreator(BlockEditorConverter blockEditorConverter, BlockListPropertyValueConstructorCache constructorCache)
+        : base(blockEditorConverter) =>
+        _constructorCache = constructorCache;
 
     public BlockListModel CreateBlockModel(PropertyCacheLevel referenceCacheLevel, string intermediateBlockModelValue, bool preview, BlockListConfiguration.BlockConfiguration[] blockConfigurations)
     {
@@ -22,11 +23,12 @@ internal class BlockListPropertyValueCreator : BlockPropertyValueCreatorBase<Blo
 
     protected override BlockEditorDataConverter CreateBlockEditorDataConverter() => new BlockListEditorDataConverter();
 
-    protected override BlockItemActivator<BlockListItem> CreateBlockItemActivator() => new BlockListItemActivator(BlockEditorConverter);
+    protected override BlockItemActivator<BlockListItem> CreateBlockItemActivator() => new BlockListItemActivator(BlockEditorConverter, _constructorCache);
 
     private class BlockListItemActivator : BlockItemActivator<BlockListItem>
     {
-        public BlockListItemActivator(BlockEditorConverter blockConverter) : base(blockConverter)
+        public BlockListItemActivator(BlockEditorConverter blockConverter, BlockListPropertyValueConstructorCache constructorCache)
+            : base(blockConverter, constructorCache)
         {
         }
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/ConstructorCacheClearNotificationHandler.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/ConstructorCacheClearNotificationHandler.cs
@@ -1,0 +1,38 @@
+﻿using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+
+namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
+
+public class ConstructorCacheClearNotificationHandler :
+    INotificationHandler<ContentTypeCacheRefresherNotification>,
+    INotificationHandler<DataTypeCacheRefresherNotification>
+{
+    private readonly BlockListPropertyValueConstructorCache _blockListPropertyValueConstructorCache;
+    private readonly BlockGridPropertyValueConstructorCache _blockGridPropertyValueConstructorCache;
+    private readonly RichTextBlockPropertyValueConstructorCache _richTextBlockPropertyValueConstructorCache;
+
+    public ConstructorCacheClearNotificationHandler(
+        BlockListPropertyValueConstructorCache blockListPropertyValueConstructorCache,
+        BlockGridPropertyValueConstructorCache blockGridPropertyValueConstructorCache,
+        RichTextBlockPropertyValueConstructorCache richTextBlockPropertyValueConstructorCache)
+    {
+        _blockListPropertyValueConstructorCache = blockListPropertyValueConstructorCache;
+        _blockGridPropertyValueConstructorCache = blockGridPropertyValueConstructorCache;
+        _richTextBlockPropertyValueConstructorCache = richTextBlockPropertyValueConstructorCache;
+    }
+
+    public void Handle(ContentTypeCacheRefresherNotification notification)
+        => ClearCaches();
+
+    public void Handle(DataTypeCacheRefresherNotification notification)
+        => ClearCaches();
+
+    private void ClearCaches()
+    {
+        // must clear the block item constructor caches whenever content types and data types change,
+        // otherwise InMemoryAuto generated models will not work.
+        _blockListPropertyValueConstructorCache.Clear();
+        _blockGridPropertyValueConstructorCache.Clear();
+        _richTextBlockPropertyValueConstructorCache.Clear();
+    }
+}

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RichTextBlockPropertyValueConstructorCache.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RichTextBlockPropertyValueConstructorCache.cs
@@ -1,0 +1,7 @@
+﻿using Umbraco.Cms.Core.Models.Blocks;
+
+namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
+
+public class RichTextBlockPropertyValueConstructorCache : BlockEditorPropertyValueConstructorCacheBase<RichTextBlockItem>
+{
+}

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RichTextBlockPropertyValueCreator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RichTextBlockPropertyValueCreator.cs
@@ -7,10 +7,11 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 
 internal class RichTextBlockPropertyValueCreator : BlockPropertyValueCreatorBase<RichTextBlockModel, RichTextBlockItem, RichTextBlockLayoutItem, RichTextConfiguration.RichTextBlockConfiguration>
 {
-    public RichTextBlockPropertyValueCreator(BlockEditorConverter blockEditorConverter)
+    private readonly RichTextBlockPropertyValueConstructorCache _constructorCache;
+
+    public RichTextBlockPropertyValueCreator(BlockEditorConverter blockEditorConverter, RichTextBlockPropertyValueConstructorCache constructorCache)
         : base(blockEditorConverter)
-    {
-    }
+        => _constructorCache = constructorCache;
 
     public RichTextBlockModel CreateBlockModel(PropertyCacheLevel referenceCacheLevel, BlockValue blockValue, bool preview, RichTextConfiguration.RichTextBlockConfiguration[] blockConfigurations)
     {
@@ -25,11 +26,12 @@ internal class RichTextBlockPropertyValueCreator : BlockPropertyValueCreatorBase
 
     protected override BlockEditorDataConverter CreateBlockEditorDataConverter() => new RichTextEditorBlockDataConverter();
 
-    protected override BlockItemActivator<RichTextBlockItem> CreateBlockItemActivator() => new RichTextBlockItemActivator(BlockEditorConverter);
+    protected override BlockItemActivator<RichTextBlockItem> CreateBlockItemActivator() => new RichTextBlockItemActivator(BlockEditorConverter, _constructorCache);
 
     private class RichTextBlockItemActivator : BlockItemActivator<RichTextBlockItem>
     {
-        public RichTextBlockItemActivator(BlockEditorConverter blockConverter) : base(blockConverter)
+        public RichTextBlockItemActivator(BlockEditorConverter blockConverter, RichTextBlockPropertyValueConstructorCache constructorCache)
+            : base(blockConverter, constructorCache)
         {
         }
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RteMacroRenderingValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RteMacroRenderingValueConverter.cs
@@ -46,6 +46,7 @@ public class RteMacroRenderingValueConverter : SimpleTinyMceValueConverter, IDel
     private readonly IJsonSerializer _jsonSerializer;
     private readonly ILogger<RteMacroRenderingValueConverter> _logger;
     private readonly IApiElementBuilder _apiElementBuilder;
+    private readonly RichTextBlockPropertyValueConstructorCache _constructorCache;
     private DeliveryApiSettings _deliveryApiSettings;
 
     [Obsolete("Please use the constructor that takes all arguments. Will be removed in V14.")]
@@ -79,6 +80,7 @@ public class RteMacroRenderingValueConverter : SimpleTinyMceValueConverter, IDel
             StaticServiceProvider.Instance.GetRequiredService<BlockEditorConverter>(),
             StaticServiceProvider.Instance.GetRequiredService<IJsonSerializer>(),
             StaticServiceProvider.Instance.GetRequiredService<IApiElementBuilder>(),
+            StaticServiceProvider.Instance.GetRequiredService<RichTextBlockPropertyValueConstructorCache>(),
             StaticServiceProvider.Instance.GetRequiredService<ILogger<RteMacroRenderingValueConverter>>(),
             deliveryApiSettingsMonitor
         )
@@ -89,7 +91,7 @@ public class RteMacroRenderingValueConverter : SimpleTinyMceValueConverter, IDel
         HtmlLocalLinkParser linkParser, HtmlUrlParser urlParser, HtmlImageSourceParser imageSourceParser,
         IApiRichTextElementParser apiRichTextElementParser, IApiRichTextMarkupParser apiRichTextMarkupParser,
         IPartialViewBlockEngine partialViewBlockEngine, BlockEditorConverter blockEditorConverter, IJsonSerializer jsonSerializer,
-        IApiElementBuilder apiElementBuilder, ILogger<RteMacroRenderingValueConverter> logger,
+        IApiElementBuilder apiElementBuilder, RichTextBlockPropertyValueConstructorCache constructorCache, ILogger<RteMacroRenderingValueConverter> logger,
         IOptionsMonitor<DeliveryApiSettings> deliveryApiSettingsMonitor)
     {
         _umbracoContextAccessor = umbracoContextAccessor;
@@ -103,6 +105,7 @@ public class RteMacroRenderingValueConverter : SimpleTinyMceValueConverter, IDel
         _blockEditorConverter = blockEditorConverter;
         _jsonSerializer = jsonSerializer;
         _apiElementBuilder = apiElementBuilder;
+        _constructorCache = constructorCache;
         _logger = logger;
         _deliveryApiSettings = deliveryApiSettingsMonitor.CurrentValue;
         deliveryApiSettingsMonitor.OnChange(settings => _deliveryApiSettings = settings);
@@ -267,7 +270,7 @@ public class RteMacroRenderingValueConverter : SimpleTinyMceValueConverter, IDel
             return null;
         }
 
-        var creator = new RichTextBlockPropertyValueCreator(_blockEditorConverter);
+        var creator = new RichTextBlockPropertyValueCreator(_blockEditorConverter, _constructorCache);
         return creator.CreateBlockModel(referenceCacheLevel, blocks, preview, configuration.Blocks);
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/BlockGridPropertyValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/BlockGridPropertyValueConverterTests.cs
@@ -37,7 +37,8 @@ public class BlockGridPropertyValueConverterTests : BlockPropertyValueConverterT
             Mock.Of<IProfilingLogger>(),
             new BlockEditorConverter(publishedSnapshotAccessor, publishedModelFactory),
             new JsonNetSerializer(),
-            new ApiElementBuilder(Mock.Of<IOutputExpansionStrategyAccessor>()));
+            new ApiElementBuilder(Mock.Of<IOutputExpansionStrategyAccessor>()),
+            new BlockGridPropertyValueConstructorCache());
         return editor;
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/BlockListPropertyValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/BlockListPropertyValueConverterTests.cs
@@ -27,7 +27,8 @@ public class BlockListPropertyValueConverterTests : BlockPropertyValueConverterT
             Mock.Of<IProfilingLogger>(),
             new BlockEditorConverter(publishedSnapshotAccessor, publishedModelFactory),
             Mock.Of<IContentTypeService>(),
-            new ApiElementBuilder(Mock.Of<IOutputExpansionStrategyAccessor>()));
+            new ApiElementBuilder(Mock.Of<IOutputExpansionStrategyAccessor>()),
+            new BlockListPropertyValueConstructorCache());
         return editor;
     }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When block based editors construct their published values, they use a whole lot of reflection and on-the-fly IL generated types to construct their contained block items. In short, they activate a lot of what's going on in [`ReflectionUtilities`](https://github.com/umbraco/Umbraco-CMS/blob/release/13.0/src/Umbraco.Core/ReflectionUtilities.cs). 

Unfortunately the reflected results are not cached between requests, even though they can never differ as they are type bound. In fact, the results are not even cached between block based editors, so if two block based editors exist on the same page one or more of the same block types, the reflection is repeated for each editor. This also even applies to nested block editors.

The block editors do cache their published values, but all this reflection will still happen for each "first page render" (and after a page publish). The result is a fair amount of CPU time spent churning reflection:

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/272315e7-d7b8-466d-94fe-d8c8479c4955)

This PR aims to cache as much of this reflection as possible, so we don't have to do all of this reflection over and over.

Since block items are typed to the individual block based editors, caches must be introduced and isolated for each of them ([`BlockListItem<TContent, TSettings>`](https://github.com/umbraco/Umbraco-CMS/blob/release/13.0/src/Umbraco.Core/Models/Blocks/BlockListItem.cs), [`BlockGridItem<TContent, TSettings>`](https://github.com/umbraco/Umbraco-CMS/blob/release/13.0/src/Umbraco.Core/Models/Blocks/BlockGridItem.cs) and [`RichTextBlockItem<TContent, TSettings>`](https://github.com/umbraco/Umbraco-CMS/blob/release/13.0/src/Umbraco.Core/Models/Blocks/RichTextBlockItem.cs) respectively).

### Testing this PR

To test this PR, we must ensure that the Block List, the Block Grid and the Rich Text Editor all continue to work the same for their contained blocks. This means they must work:

- [ ] With ModelsBuilder disabled having _no_ generated models built into the site.
- [ ] With ModelsBuilder disabled having _some_ generated models built into the site.
- [ ] With ModelsBuilder disabled having _all_ generated models built into the site.
- [ ] With ModelsBuilder enabled in all modes.
- [ ] With ModelsBuilder running "SourceCode" modes having _no_ generated models built into the site.
- [ ] With ModelsBuilder running "SourceCode" modes having _some_ generated models built into the site.
- [ ] With ModelsBuilder running "SourceCode" modes having _all_ generated models built into the site.

...and probably a few other permutations.

It might be best to reach out to @kjac for testing 😆 