### PR TITLE
V14: Allowing custom backoffice host with CORS policy

### DIFF
--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeCorsPolicyBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeCorsPolicyBuilderExtensions.cs
@@ -35,7 +35,8 @@ internal static class BackOfficeCorsPolicyBuilderExtensions
                     policy
                         .WithOrigins(customOrigin)
                         .AllowAnyHeader()
-                        .AllowAnyMethod();
+                        .AllowAnyMethod()
+                        .AllowCredentials();
                 });
         });
 

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeCorsPolicyBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeCorsPolicyBuilderExtensions.cs
@@ -1,0 +1,52 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Models.Configuration;
+using Umbraco.Cms.Web.Common.ApplicationBuilder;
+
+namespace Umbraco.Cms.Api.Management.DependencyInjection;
+
+internal static class BackOfficeCorsPolicyBuilderExtensions
+{
+    internal static IUmbracoBuilder AddCorsPolicy(this IUmbracoBuilder builder)
+    {
+        // FIXME: Get the correct settings once NewBackOfficeSettings is merged with relevant existing settings from Core
+        Uri? backOfficeHost = builder.Config
+            .GetSection($"{Constants.Configuration.ConfigPrefix}NewBackOffice")
+            .Get<NewBackOfficeSettings>()?.BackOfficeHost;
+
+        if (backOfficeHost is null)
+        {
+            return builder;
+        }
+
+        const string policyName = "AllowCustomBackOfficeOrigin";
+
+        // The specified URL must not contain a trailing slash (/)
+        var customOrigin = backOfficeHost.ToString().TrimEnd(Constants.CharArrays.ForwardSlash);
+
+        builder.Services.AddCors(options =>
+        {
+            options.AddPolicy(name: policyName,
+                policy =>
+                {
+                    policy
+                        .WithOrigins(customOrigin)
+                        .AllowAnyHeader()
+                        .AllowAnyMethod();
+                });
+        });
+
+        builder.Services.Configure<UmbracoPipelineOptions>(options =>
+        {
+            options.AddFilter(new UmbracoPipelineFilter("UmbracoManagementApiCustomHostCorsPolicy")
+            {
+                PostRouting = app => app.UseCors(policyName)
+            });
+        });
+
+        return builder;
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/ManagementApiComposer.cs
+++ b/src/Umbraco.Cms.Api.Management/ManagementApiComposer.cs
@@ -52,6 +52,7 @@ public class ManagementApiComposer : IComposer
             .AddScripts()
             .AddPartialViews()
             .AddStylesheets()
+            .AddCorsPolicy()
             .AddBackOfficeAuthentication();
 
         services


### PR DESCRIPTION
## Details
- Allows the backoffice to run from a different host than the API host if `BackOfficeHost` setting is configured:
  - by adding a CORS policy for the custom backoffice host - it respects the [middleware order](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/middleware/?view=aspnetcore-8.0#middleware-order) _(placed after `UseRouting()`, but before `UseAuthorization()`)_

## Test
> Setup:
- In `Umbraco.Web.UI.New.Client` project create a file `.env.local` and add the following contents:
```
VITE_UMBRACO_USE_MSW=off # on = turns on MSW, off = disables all mock handlers
VITE_UMBRACO_API_URL=https://localhost:44339
VITE_UMBRACO_INSTALL_STATUS=running # running or must-install or must-upgrade
VITE_MSW_QUIET=off # on = turns off MSW console logs, off = turns on MSW console logs
VITE_UMBRACO_EXTENSION_MOCKS=off # on = turns on extension mocks, off = turns off extension mocks
```
- Run the `npm install`, `npm run dev` into the client project;
- Add the following `NewBackOffice` setting to your **appsettings.json** (`Umbraco.Web.UI.New` project):
```json
"Umbraco": {
    "CMS": {
        "NewBackOffice":{
            "BackOfficeHost": "http://localhost:5173",
            "AuthorizeCallbackPathName": "/"
        },
        . . .
```
> Test:
- Run new Backoffice project: `Umbraco.Web.UI.New`;
- Go to `http://localhost:5173` which will redirect to `https://localhost:44339` for authentication and then redirect back to `http://localhost:5173`;
- Verify that there are no CORS errors in the dev tools.