### PR TITLE
Add HealthCheckCompletedNotification

### DIFF
--- a/src/Umbraco.Core/HealthChecks/HealthCheckResults.cs
+++ b/src/Umbraco.Core/HealthChecks/HealthCheckResults.cs
@@ -53,6 +53,8 @@ public class HealthCheckResults
         return new HealthCheckResults(results, allChecksSuccessful);
     }
 
+    public static async Task<HealthCheckResults> Create(HealthCheck check) => await Create(new List<HealthCheck>() { check });
+
     public void LogResults()
     {
         Logger.LogInformation("Scheduled health check results:");

--- a/src/Umbraco.Core/Notifications/HealthCheckCompletedNotification.cs
+++ b/src/Umbraco.Core/Notifications/HealthCheckCompletedNotification.cs
@@ -1,0 +1,13 @@
+using Umbraco.Cms.Core.HealthChecks;
+
+namespace Umbraco.Cms.Core.Notifications;
+
+public class HealthCheckCompletedNotification : INotification
+{
+    public HealthCheckCompletedNotification(HealthCheckResults healthCheckResults)
+    {
+        HealthCheckResults = healthCheckResults;
+    }
+
+    public HealthCheckResults HealthCheckResults { get; }
+}

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/HealthCheckNotifierJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/HealthCheckNotifierJob.cs
@@ -1,11 +1,13 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.HealthChecks;
 using Umbraco.Cms.Core.HealthChecks.NotificationMethods;
@@ -43,6 +45,26 @@ public class HealthCheckNotifierJob : IRecurringBackgroundJob
     private readonly IEventAggregator _eventAggregator;
     private readonly ICoreScopeProvider _scopeProvider;
     private HealthChecksSettings _healthChecksSettings;
+
+    [Obsolete("Use constructor that accepts IEventAggregator as a parameter, scheduled for removal in V14")]
+    public HealthCheckNotifierJob(
+        IOptionsMonitor<HealthChecksSettings> healthChecksSettings,
+        HealthCheckCollection healthChecks,
+        HealthCheckNotificationMethodCollection notifications,
+        ICoreScopeProvider scopeProvider,
+        ILogger<HealthCheckNotifierJob> logger,
+        IProfilingLogger profilingLogger,
+        ICronTabParser cronTabParser)
+        : this(
+            healthChecksSettings,
+            healthChecks,
+            notifications,
+            scopeProvider,
+            logger,
+            profilingLogger,
+            cronTabParser,
+            StaticServiceProvider.Instance.GetRequiredService<IEventAggregator>())
+    { }
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="HealthCheckNotifierJob" /> class.

--- a/src/Umbraco.Web.BackOffice/HealthChecks/HealthCheckController.cs
+++ b/src/Umbraco.Web.BackOffice/HealthChecks/HealthCheckController.cs
@@ -3,10 +3,12 @@
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.HealthChecks;
 using Umbraco.Cms.Core.Notifications;
@@ -32,6 +34,15 @@ public class HealthCheckController : UmbracoAuthorizedJsonController
     /// <summary>
     ///     Initializes a new instance of the <see cref="HealthCheckController" /> class.
     /// </summary>
+    [Obsolete("Use constructor that accepts IEventAggregator as a parameter, scheduled for removal in V14")]
+    public HealthCheckController(HealthCheckCollection checks, ILogger<HealthCheckController> logger, IOptions<HealthChecksSettings> healthChecksSettings)
+        : this(checks, logger, healthChecksSettings, StaticServiceProvider.Instance.GetRequiredService<IEventAggregator>())
+    { }
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="HealthCheckController" /> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
     public HealthCheckController(HealthCheckCollection checks, ILogger<HealthCheckController> logger, IOptions<HealthChecksSettings> healthChecksSettings, IEventAggregator eventAggregator)
     {
         _checks = checks ?? throw new ArgumentNullException(nameof(checks));

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/HealthCheckNotifierJobTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/HealthCheckNotifierJobTests.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.HealthChecks;
 using Umbraco.Cms.Core.HealthChecks.NotificationMethods;
 using Umbraco.Cms.Core.Logging;
@@ -105,7 +106,8 @@ public class HealthCheckNotifierJobTests
             mockScopeProvider.Object,
             mockLogger.Object,
             mockProfilingLogger.Object,
-            Mock.Of<ICronTabParser>());
+            Mock.Of<ICronTabParser>(),
+            Mock.Of<IEventAggregator>());
     }
 
     private void VerifyNotificationsNotSent() => VerifyNotificationsSentTimes(Times.Never());


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I was testing the Webhooks feature that has been added to Umbraco 13 and thought it would be nice if a webhook call could be made when one or more health checks are completed. To achieve this, a notification is needed. This PR introduces a `HealthCheckCompletedNotification`.

I intentionally created this PR in the v13 branch because it causes a breaking change due to modifications in the constructors of the `HealthCheckController` and the `HealthCheckNotifierJob`.

This PR can be tested by creating a notification and registering it in the Program.cs class like so:

```csharp
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Notifications;

namespace Umbraco.Cms.Web.UI.Notifications;

public class TestHealthCheckCompletedNotification : INotificationHandler<HealthCheckCompletedNotification>
{
    public void Handle(HealthCheckCompletedNotification notification)
    {
       // Do something
    }
}
```

`Program.cs`:
```charp
builder.CreateUmbracoBuilder()
    .AddBackOffice()
    .AddWebsite()
    .AddDeliveryApi()
    .AddComposers()
    .AddNotificationHandler<HealthCheckCompletedNotification, TestHealthCheckCompletedNotification>()
    .Build();
```