### PR TITLE
V13: Fix missing contenttype in webhook

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/webhooks/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/webhooks/edit.controller.js
@@ -162,16 +162,16 @@
                 let name;
                 switch (eventType.toCamelCase()) {
                   case "content":
-                    name = "Deleted content type";
+                    name = "Unknown content type";
                     break;
                   case "media":
-                    name = "Deleted media type";
+                    name = "Unknown media type";
                     break;
                   case "member":
-                    name = "Deleted member type";
+                    name = "Unknown member type";
                     break;
                   default:
-                    name = "Deleted type";
+                    name = "Unknown type";
                 }
 
                 let data = {

--- a/src/Umbraco.Web.UI.Client/src/views/webhooks/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/webhooks/edit.controller.js
@@ -52,7 +52,7 @@
             promises.push(loadEvents());
 
             if (!$routeParams.create) {
-                
+
                 promises.push(webhooksResource.getByKey($routeParams.id).then(webhook => {
 
                     vm.webhook = webhook;
@@ -60,7 +60,7 @@
 
                     const eventType = vm.webhook ? vm.webhook.events[0].eventType.toLowerCase() : null;
                     const contentTypes = webhook.contentTypeKeys.map(x => ({ key: x }));
-                    
+
                     getEntities(contentTypes, eventType);
 
                     makeBreadcrumbs();
@@ -154,10 +154,34 @@
           selection.forEach(entity => {
             resource.getById(entity.key)
               .then(data => {
+                console.log("data", data);
                 if (!vm.contentTypes.some(x => x.key === data.key)) {
                   vm.contentTypes.push(data);
                 }
-              });
+              }).catch(err => {
+                let name;
+                switch (eventType.toCamelCase()) {
+                  case "content":
+                    name = "Deleted content type";
+                    break;
+                  case "media":
+                    name = "Deleted media type";
+                    break;
+                  case "member":
+                    name = "Deleted member type";
+                    break;
+                  default:
+                    name = "Deleted type";
+                }
+
+                let data = {
+                  icon: "icon-alert",
+                  name: name,
+                  description: "An error occurred while loading the content type.",
+                  key: entity.key
+                }
+                vm.contentTypes.push(data);
+            });
           });
         }
 

--- a/src/Umbraco.Web.UI.Client/src/views/webhooks/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/webhooks/edit.controller.js
@@ -150,11 +150,10 @@
             default:
               return;
           }
-
+          vm.contentTypes = [];
           selection.forEach(entity => {
             resource.getById(entity.key)
               .then(data => {
-                console.log("data", data);
                 if (!vm.contentTypes.some(x => x.key === data.key)) {
                   vm.contentTypes.push(data);
                 }


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/15244

# Notes
- Introduces new "Unknown node" when we cannot find the node.
- This way you should be able to delete them from you webhooks.

# How to test
Follow steps in original issue