### PR TITLE
Fixed StackOverflow exception when using NoopPropertyIndexValueFactory

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/NoopPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Core/PropertyEditors/NoopPropertyIndexValueFactory.cs
@@ -12,5 +12,5 @@ public class NoopPropertyIndexValueFactory : IPropertyIndexValueFactory
 
     [Obsolete("Use the overload with the availableCultures parameter instead, scheduled for removal in v14")]
     public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published)
-        => GetIndexValues(property, culture, segment, published);
+        => GetIndexValues(property, culture, segment, published, Enumerable.Empty<string>());
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This is related to the issue https://github.com/umbraco/Umbraco-CMS/issues/14556, which has been partially fixed for `RichTextPropertyEditor`, but not for property editors that use `NoopPropertyIndexValueFactory`.

### Description
Removed recursive call from the `GetIndexValues` method of `NoopPropertyIndexValueFactory` which is now marked as `obsolete`. Even though it is an obsolete method and it is not directly called within Umbraco CMS codebase anymore, I thought it would be good to fix it for backward compatibility with modules and libraries that may be still using it, for example https://github.com/umbraco/Umbraco.Cms.Integrations.

This is how this method looked prior to this change, see the recursive call in red:
![Recursive call](https://github.com/umbraco/Umbraco-CMS/assets/4091048/3cbb213f-09f3-4ba4-993a-f6487df67c43)

Instead of making a recursive call it now calls the other method overload with 5 parameters, as seen in other property index value factory classes (`DefaultPropertyIndexValueFactory`, `JsonPropertyIndexValueFactoryBase`, `GridPropertyIndexValueFactory` and `RichTextPropertyIndexValueFactory`). 

### Steps to reproduce 
I've tried it with **Umbraco 12.2.0/12.3.0** and **Umbraco.Cms.Integrations.Search.Algolia library version 1.5.0**.

1. Install the package `Umbraco.Cms.Integrations.Search.Algolia`.
2. Configure an index with at least one content type and include a field of the type `Umbraco.MediaPicker3`.
3. Make a change to a document of this content type and save it. The application will crash with `StackOverflowException`:

```
Stack overflow.
Repeat 23771 times:
--------------------------------
   at Umbraco.Cms.Core.PropertyEditors.NoopPropertyIndexValueFactory.GetIndexValues(Umbraco.Cms.Core.Models.IProperty, System.String, System.String, Boolean)
--------------------------------
   at Umbraco.Cms.Integrations.Search.Algolia.Services.AlgoliaSearchPropertyIndexValueFactory.GetValue(Umbraco.Cms.Core.Models.IProperty, System.String)
   at Umbraco.Cms.Integrations.Search.Algolia.Builders.ContentRecordBuilder.BuildFromContent(Umbraco.Cms.Core.Models.IContent, System.Func`2<Umbraco.Cms.Core.Models.IProperty,Boolean>)
   at Umbraco.Cms.Integrations.Search.Algolia.Handlers.AlgoliaContentCacheRefresherHandler+<RebuildIndex>d__10.MoveNext()
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[[Umbraco.Cms.Integrations.Search.Algolia.Handlers.AlgoliaContentCacheRefresherHandler+<RebuildIndex>d__10, Umbraco.Cms.Integrations.Search.Algolia, Version=1.5.0.0, Culture=neutral, PublicKeyToken=null]](<RebuildIndex>d__10 ByRef)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start[[Umbraco.Cms.Integrations.Search.Algolia.Handlers.AlgoliaContentCacheRefresherHandler+<RebuildIndex>d__10, Umbraco.Cms.Integrations.Search.Algolia, Version=1.5.0.0, Culture=neutral, PublicKeyToken=null]](<RebuildIndex>d__10 ByRef)
   at Umbraco.Cms.Integrations.Search.Algolia.Handlers.AlgoliaContentCacheRefresherHandler.RebuildIndex(System.Collections.Generic.IEnumerable`1<Umbraco.Cms.Core.Models.IContent>)
   at Umbraco.Cms.Integrations.Search.Algolia.Handlers.AlgoliaContentCacheRefresherHandler+<HandleAsync>d__9.MoveNext()
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[[Umbraco.Cms.Integrations.Search.Algolia.Handlers.AlgoliaContentCacheRefresherHandler+<HandleAsync>d__9, Umbraco.Cms.Integrations.Search.Algolia, Version=1.5.0.0, Culture=neutral, PublicKeyToken=null]](<HandleAsync>d__9 ByRef)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start[[Umbraco.Cms.Integrations.Search.Algolia.Handlers.AlgoliaContentCacheRefresherHandler+<HandleAsync>d__9, Umbraco.Cms.Integrations.Search.Algolia, Version=1.5.0.0, Culture=neutral, PublicKeyToken=null]](<HandleAsync>d__9 ByRef)
   at Umbraco.Cms.Integrations.Search.Algolia.Handlers.AlgoliaContentCacheRefresherHandler.HandleAsync(Umbraco.Cms.Core.Notifications.ContentCacheRefresherNotification, System.Threading.CancellationToken)
   at Umbraco.Cms.Core.Events.INotificationAsyncHandler`1+<HandleAsync>d__1[[System.__Canon, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].MoveNext()
...
```

I have previously raised an issue in https://github.com/umbraco/Umbraco.Cms.Integrations/issues/150 to remove the obsolete method call, but then realised that there could be other packages using this method and it would be good to fix this method until it's fully deprecated in v14.