### PR TITLE
V13: Login page backwards compatibility

### DIFF
--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoBackOffice/Default.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoBackOffice/Default.cshtml
@@ -45,13 +45,9 @@
 <body ng-class="{'touch':touchDevice, 'emptySection':emptySection, 'umb-drawer-is-visible':drawer.show, 'umb-tour-is-visible': tour.show, 'tabbing-active':tabbingActive}" ng-controller="Umbraco.MainController" id="umbracoMainPageBody">
     <noscript>
         <div class="flex flex-wrap flex-column items-center justify-center" style="height: 100%">
-            <h1 class="h3">
-                <span style="width: 30px; height: 30px; vertical-align: text-bottom" class="flex-inline">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 315.89 315.89" fill="#3544b1">
-                        <path d="M0,157.74A157.95,157.95,0,1,1,158,315.89,157.95,157.95,0,0,1,0,157.74Zm154.74,54.09a155.41,155.41,0,0,1-36.5-3.29,27.92,27.92,0,0,1-19.94-16q-5.35-12.34-5.21-38.1a243,243,0,0,1,1.69-26.84q1.55-13,3.09-21.46l1.07-5.59a2,2,0,0,0,0-.49,3.2,3.2,0,0,0-2.65-3.17L75.92,93.67h-.44a3.19,3.19,0,0,0-3.11,2.48c-.35,1.31-.56,2.27-1.17,5.38-1.16,6-2.24,11.85-3.43,20.38a264.17,264.17,0,0,0-2.3,27.94,145.24,145.24,0,0,0,0,19.57q.72,25.94,8.9,41.42t27.72,22.3q19.53,6.81,54.43,6.66h2.91q34.94.15,54.41-6.66t27.71-22.3q8.17-15.53,8.91-41.42a145.24,145.24,0,0,0,0-19.57,266.84,266.84,0,0,0-2.3-27.94c-1.2-8.44-2.27-14.26-3.44-20.38-.61-3.11-.81-4.07-1.16-5.38a3.21,3.21,0,0,0-3.12-2.48h-.52l-20.38,3.18a3.2,3.2,0,0,0-2.68,3.17,4,4,0,0,0,0,.49l1.08,5.59q1.55,8.48,3.12,21.46a245.68,245.68,0,0,1,1.65,26.84q.27,25.69-5.21,38.07a27.9,27.9,0,0,1-19.76,16.07,155.19,155.19,0,0,1-36.48,3.29Z" />
-                    </svg>
-                </span>
-                Umbraco
+            <h1 class="h3" style="display: inline-flex; align-items: center; gap: 10px">
+                <img aria-hidden="true" alt="logo" src="~/umbraco/assets/img/application/logo.svg" style="width: 30px" />
+                <span>Umbraco</span>
             </h1>
             <p>For full functionality of Umbraco CMS it is necessary to enable JavaScript.</p>
             <p>Here are the <a href="https://www.enable-javascript.com/" target="_blank" rel="noopener" style="text-decoration: underline;">instructions how to enable JavaScript in your web browser</a>.</p>

--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoLogin/Index.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoLogin/Index.cshtml
@@ -36,6 +36,9 @@
         <base href="@backOfficePath.EnsureEndsWith('/')"/>
         <link rel="icon" type="image/svg+xml" href="~/umbraco/login/favicon.svg"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+        <meta name="apple-mobile-web-app-capable" content="yes"/>
+        <meta name="robots" content="noindex, nofollow"/>
+        <meta name="pinterest" content="nopin"/>
         <title>Umbraco</title>
         <link rel="stylesheet" href="~/umbraco/login/style.css" asp-append-version="true" />
         <script type="module" src="~/umbraco/login/external.js" asp-append-version="true"></script>

--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoLogin/Index.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoLogin/Index.cshtml
@@ -54,14 +54,38 @@
     <script type="module" src="~/umbraco/login/external.js" asp-append-version="true"></script>
     <script type="module" src="~/umbraco/login/index.js" asp-append-version="true"></script>
     <style>
-          body {
-            margin: 0;
-            padding: 0;
-          }
-        </style>
+      body {
+        margin: 0;
+        padding: 0;
+        background-color: #f4f4f4;
+      }
+    </style>
 </head>
 
 <body class="uui-font uui-text" style="margin: 0; padding: 0; overflow: hidden">
+<noscript>
+    <style>
+        #noscript-container {
+            display: flex;
+            flex-wrap: wrap;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            padding: 0 20px;
+            text-align: center;
+        }
+    </style>
+    <div id="noscript-container">
+        <h1 class="uui-h3" style="display: inline-flex; align-items: center; gap: 10px">
+            <img aria-hidden="true" alt="logo" src="~/umbraco/assets/img/application/logo.svg" style="width: 30px" />
+            <span>Umbraco</span>
+        </h1>
+        <p>For full functionality of Umbraco CMS it is necessary to enable JavaScript.</p>
+        <p>Here are the <a href="https://www.enable-javascript.com/" target="_blank" rel="noopener" style="text-decoration: underline;">instructions how to enable JavaScript in your web browser</a>.</p>
+    </div>
+</noscript>
+
 <umb-backoffice-icon-registry>
     <umb-auth
         return-url="@backOfficePath"

--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoLogin/Index.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoLogin/Index.cshtml
@@ -4,7 +4,10 @@
 @using Umbraco.Cms.Core
 @using Umbraco.Cms.Core.Configuration.Models
 @using Umbraco.Cms.Core.Hosting
+@using Umbraco.Cms.Core.Logging
 @using Umbraco.Cms.Core.Mail
+@using Umbraco.Cms.Core.WebAssets
+@using Umbraco.Cms.Infrastructure.WebAssets
 @using Umbraco.Cms.Web.BackOffice.Controllers
 @using Umbraco.Cms.Web.BackOffice.Security
 @using Umbraco.Extensions
@@ -13,9 +16,12 @@
 @inject IEmailSender EmailSender
 @inject IHostingEnvironment HostingEnvironment
 @inject IOptions<GlobalSettings> GlobalSettings
+@inject IRuntimeMinifier RuntimeMinifier
+@inject IProfilerHtml ProfilerHtml
 @inject IBackOfficeExternalLoginProviders ExternalLogins
 @inject LinkGenerator LinkGenerator
 @{
+    bool.TryParse(Context.Request.Query["umbDebug"], out var isDebug);
     var backOfficePath = GlobalSettings.Value.GetBackOfficePath(HostingEnvironment);
     var loginLogoImage = ContentSettings.Value.LoginLogoImage;
     var loginLogoImageAlternative = ContentSettings.Value.LoginLogoImageAlternative;
@@ -31,51 +37,60 @@
 
 <!DOCTYPE html>
 <html lang="@CultureInfo.CurrentCulture.Name.ToLowerInvariant()">
-    <head>
-        <meta charset="UTF-8"/>
-        <base href="@backOfficePath.EnsureEndsWith('/')"/>
-        <link rel="icon" type="image/svg+xml" href="~/umbraco/login/favicon.svg"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-        <meta name="apple-mobile-web-app-capable" content="yes"/>
-        <meta name="robots" content="noindex, nofollow"/>
-        <meta name="pinterest" content="nopin"/>
-        <title>Umbraco</title>
-        <link rel="stylesheet" href="~/umbraco/login/style.css" asp-append-version="true" />
-        <script type="module" src="~/umbraco/login/external.js" asp-append-version="true"></script>
-        <script type="module" src="~/umbraco/login/index.js" asp-append-version="true"></script>
-        <style>
+<head>
+    <meta charset="UTF-8"/>
+    <base href="@backOfficePath.EnsureEndsWith('/')"/>
+    <link rel="icon" type="image/svg+xml" href="~/umbraco/login/favicon.svg"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="apple-mobile-web-app-capable" content="yes"/>
+    <meta name="robots" content="noindex, nofollow"/>
+    <meta name="pinterest" content="nopin"/>
+    <title>Umbraco</title>
+
+    @Html.Raw(await RuntimeMinifier.RenderCssHereAsync(BackOfficeWebAssets.UmbracoNonOptimizedPackageCssBundleName))
+    @Html.Raw(await RuntimeMinifier.RenderCssHereAsync(BackOfficeWebAssets.UmbracoCssBundleName))
+
+    <link rel="stylesheet" href="~/umbraco/login/style.css" asp-append-version="true"/>
+    <script type="module" src="~/umbraco/login/external.js" asp-append-version="true"></script>
+    <script type="module" src="~/umbraco/login/index.js" asp-append-version="true"></script>
+    <style>
           body {
             margin: 0;
             padding: 0;
           }
         </style>
-    </head>
+</head>
 
-    <body class="uui-font uui-text" style="margin: 0; padding: 0; overflow: hidden">
-        <umb-backoffice-icon-registry>
-            <umb-auth
-                return-url="@backOfficePath"
-                logo-image="@loginLogoImage"
-                logo-image-alternative="@loginLogoImageAlternative"
-                background-image="@loginBackgroundImage"
-                username-is-email="@usernameIsEmail"
-                allow-user-invite="@allowUserInvite"
-                allow-password-reset="@allowPasswordReset"
-                disable-local-login="@disableLocalLogin">
-                @foreach (var provider in externalLoginProviders)
-                {
-                    <umb-external-login-provider
-                        slot="external"
-                        display-name="@provider.AuthenticationScheme.DisplayName"
-                        provider-name="@provider.ExternalLoginProvider.AuthenticationType"
-                        icon="@provider.ExternalLoginProvider.Options.Icon"
-                        external-login-url="@externalLoginsUrl"
-                        button-look="@provider.ExternalLoginProvider.Options.ButtonLook.ToString().ToLowerInvariant()"
-                        button-color="@provider.ExternalLoginProvider.Options.ButtonColor.ToString().ToLowerInvariant()"
-                        custom-view="@provider.ExternalLoginProvider.Options.CustomBackOfficeView">
-                    </umb-external-login-provider>
-                }
-            </umb-auth>
-        </umb-backoffice-icon-registry>
-    </body>
+<body class="uui-font uui-text" style="margin: 0; padding: 0; overflow: hidden">
+<umb-backoffice-icon-registry>
+    <umb-auth
+        return-url="@backOfficePath"
+        logo-image="@loginLogoImage"
+        logo-image-alternative="@loginLogoImageAlternative"
+        background-image="@loginBackgroundImage"
+        username-is-email="@usernameIsEmail"
+        allow-user-invite="@allowUserInvite"
+        allow-password-reset="@allowPasswordReset"
+        disable-local-login="@disableLocalLogin">
+        @foreach (var provider in externalLoginProviders)
+        {
+            <umb-external-login-provider
+                slot="external"
+                display-name="@provider.AuthenticationScheme.DisplayName"
+                provider-name="@provider.ExternalLoginProvider.AuthenticationType"
+                icon="@provider.ExternalLoginProvider.Options.Icon"
+                external-login-url="@externalLoginsUrl"
+                button-look="@provider.ExternalLoginProvider.Options.ButtonLook.ToString().ToLowerInvariant()"
+                button-color="@provider.ExternalLoginProvider.Options.ButtonColor.ToString().ToLowerInvariant()"
+                custom-view="@provider.ExternalLoginProvider.Options.CustomBackOfficeView">
+            </umb-external-login-provider>
+        }
+    </umb-auth>
+</umb-backoffice-icon-registry>
+
+@if (isDebug)
+{
+    @Html.Raw(ProfilerHtml.Render())
+}
+</body>
 </html>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/bs.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/bs.xml
@@ -1051,13 +1051,13 @@ Da upravljate svojom web lokacijom, jednostavno otvorite Umbraco backoffice i po
     <key alias="renewSession">Obnovite sada da sačuvate svoj rad</key>
   </area>
   <area alias="login">
-    <key alias="greeting0">Sretna super nedelja</key>
-    <key alias="greeting1">Sretan divan ponedeljak</key>
-    <key alias="greeting2">Sretan specifičan utorak</key>
-    <key alias="greeting3">Sretna divna srijeda</key>
-    <key alias="greeting4">Sretan gromoglasan četvrtak</key>
-    <key alias="greeting5">Sretan zanimljiv petak</key>
-    <key alias="greeting6">Sretna opuštena subota</key>
+    <key alias="greeting0">Dobrodošli</key>
+    <key alias="greeting1">Dobrodošli</key>
+    <key alias="greeting2">Dobrodošli</key>
+    <key alias="greeting3">Dobrodošli</key>
+    <key alias="greeting4">Dobrodošli</key>
+    <key alias="greeting5">Dobrodošli</key>
+    <key alias="greeting6">Dobrodošli</key>
     <key alias="instruction">Prijavite se ispod</key>
     <key alias="signInWith">Prijavite se sa</key>
     <key alias="timeout">Isteklo je vrijeme sesije</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/bs.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/bs.xml
@@ -856,7 +856,7 @@
     <key alias="username">Korisničko ime</key>
     <key alias="value">Vrijednost</key>
     <key alias="view">Pogled</key>
-    <key alias="welcome">Dobrodošli</key>
+    <key alias="welcome">Dobrodošli...</key>
     <key alias="width">Širina</key>
     <key alias="yes">Da</key>
     <key alias="folder">Mapa</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/cs.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/cs.xml
@@ -871,13 +871,13 @@
     <key alias="renewSession">Obnovte nyní pro uložení práce</key>
   </area>
   <area alias="login">
-    <key alias="greeting0">Šťastnou super neděli</key>
-    <key alias="greeting1">Šťastné šílené pondělí</key>
-    <key alias="greeting2">Šťastné husté úterý</key>
-    <key alias="greeting3">Šťastnou překrásnou středu</key>
-    <key alias="greeting4">Šťastný bouřlivý čtvrtek</key>
-    <key alias="greeting5">Šťastný bláznivý pátek</key>
-    <key alias="greeting6">Šťastnou kočkobotu</key>
+    <key alias="greeting0">Vítejte</key>
+    <key alias="greeting1">Vítejte</key>
+    <key alias="greeting2">Vítejte</key>
+    <key alias="greeting3">Vítejte</key>
+    <key alias="greeting4">Vítejte</key>
+    <key alias="greeting5">Vítejte</key>
+    <key alias="greeting6">Vítejte</key>
     <key alias="instruction">přihlašte se níže</key>
     <key alias="signInWith">Přihlásit se pomocí</key>
     <key alias="timeout">Relace vypršela</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/cs.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/cs.xml
@@ -714,7 +714,7 @@
     <key alias="username">Uživatelské jméno</key>
     <key alias="value">Hodnota</key>
     <key alias="view">Pohled</key>
-    <key alias="welcome">Vítejte</key>
+    <key alias="welcome">Vítejte...</key>
     <key alias="width">Šířka</key>
     <key alias="yes">Ano</key>
     <key alias="folder">Složka</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/cy.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/cy.xml
@@ -596,7 +596,7 @@
     <key alias="indexCannotRebuild">Ni ellir ailadeiladu'r mynegai hwn oherwydd nad yw wedi'i aseinio</key>
     <key alias="iIndexPopulator">IIndexPopulator</key>
 
-    
+
     <key alias="contentInIndex">Cynnwys yn y mynegai</key>
     <key alias="noResults">Ni ddarganfuwyd unrhyw ganlyniadau</key>
     <key alias="searchResultsFound">Dangos %0% - %1% o %2% canlyniad(au) - Tudalen %3% o %4%</key>
@@ -1051,13 +1051,13 @@ Er mwyn gweinyddu eich gwefan, agorwch swyddfa gefn Umbraco a dechreuwch ychwang
     <key alias="renewSession">Adnewyddwch rwan er mwyn achub eich gwaith</key>
   </area>
   <area alias="login">
-    <key alias="greeting0">Dydd Sul Swmpus</key>
-    <key alias="greeting1">Dydd Llun Llwyddiannus</key>
-    <key alias="greeting2">Dydd Mawrth Moethus</key>
-    <key alias="greeting3">Dydd Mercher Melys</key>
-    <key alias="greeting4">Dydd Iau Iachus</key>
-    <key alias="greeting5">Dydd Gwener Gwych</key>
-    <key alias="greeting6">Dydd Sadwrn Syfrdannus</key>
+    <key alias="greeting0">Croeso</key>
+    <key alias="greeting1">Croeso</key>
+    <key alias="greeting2">Croeso</key>
+    <key alias="greeting3">Croeso</key>
+    <key alias="greeting4">Croeso</key>
+    <key alias="greeting5">Croeso</key>
+    <key alias="greeting6">Croeso</key>
     <key alias="instruction">Mewngofnodwch isod</key>
     <key alias="signInWith">Mewngofnodwch gyda</key>
     <key alias="timeout">Sesiwn wedi cyrraedd terfyn amser</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/cy.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/cy.xml
@@ -596,7 +596,7 @@
     <key alias="indexCannotRebuild">Ni ellir ailadeiladu'r mynegai hwn oherwydd nad yw wedi'i aseinio</key>
     <key alias="iIndexPopulator">IIndexPopulator</key>
 
-
+    
     <key alias="contentInIndex">Cynnwys yn y mynegai</key>
     <key alias="noResults">Ni ddarganfuwyd unrhyw ganlyniadau</key>
     <key alias="searchResultsFound">Dangos %0% - %1% o %2% canlyniad(au) - Tudalen %3% o %4%</key>
@@ -822,7 +822,7 @@
     <key alias="username">Enw defnyddiwr</key>
     <key alias="value">Gwerth</key>
     <key alias="view">Gwedd</key>
-    <key alias="welcome">Croeso</key>
+    <key alias="welcome">Croeso...</key>
     <key alias="width">Lled</key>
     <key alias="yes">Ie</key>
     <key alias="folder">Ffolder</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
@@ -480,7 +480,7 @@
     <key alias="editDictionary">Rediger ordbogsnøgle</key>
     <key alias="editLanguage">Rediger sprog</key>
     <key alias="editSelectedMedia">Rediger det valgte medie</key>
-    <key alias="editWebhook">Edit webhook</key> 
+    <key alias="editWebhook">Edit webhook</key>
     <key alias="insertAnchor">Indsæt lokalt link</key>
     <key alias="insertCharacter">Indsæt tegn</key>
     <key alias="insertgraphicheadline">Indsæt grafisk overskrift</key>
@@ -1024,13 +1024,13 @@
     <key alias="renewSession">Forny for at gemme dine ændringer</key>
   </area>
   <area alias="login">
-    <key alias="greeting0">Så er det søndag!</key>
-    <key alias="greeting1">Smil, det er mandag!</key>
-    <key alias="greeting2">Hurra, det er tirsdag!</key>
-    <key alias="greeting3">Hvilken herlig onsdag!</key>
-    <key alias="greeting4">Glædelig torsdag!</key>
-    <key alias="greeting5">Endelig fredag!</key>
-    <key alias="greeting6">Glædelig lørdag</key>
+    <key alias="greeting0">Velkommen</key>
+    <key alias="greeting1">Velkommen</key>
+    <key alias="greeting2">Velkommen</key>
+    <key alias="greeting3">Velkommen</key>
+    <key alias="greeting4">Velkommen</key>
+    <key alias="greeting5">Velkommen</key>
+    <key alias="greeting6">Velkommen</key>
     <key alias="instruction">Log ind nedenfor</key>
     <key alias="signInWith">Log ind med</key>
     <key alias="timeout">Din session er udløbet</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
@@ -849,7 +849,7 @@
     <key alias="username">Brugernavn</key>
     <key alias="value">Værdi</key>
     <key alias="view">Vis</key>
-    <key alias="welcome">Velkommen</key>
+    <key alias="welcome">Velkommen...</key>
     <key alias="width">Bredde</key>
     <key alias="yes">Ja</key>
     <key alias="folder">Mappe</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/de.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/de.xml
@@ -1054,13 +1054,13 @@
     <key alias="renewSession">Erneuern Sie, um Ihre Arbeit zu speichern ...</key>
   </area>
   <area alias="login">
-    <key alias="greeting0">Einen wunderbaren Sonntag</key>
-    <key alias="greeting1">Schönen Montag</key>
-    <key alias="greeting2">Einen großartigen Dienstag</key>
-    <key alias="greeting3">Wunderbaren Mittwoch</key>
-    <key alias="greeting4">Donnerwetter Donnerstag</key>
-    <key alias="greeting5">Frohen freundlichen Freitag</key>
-    <key alias="greeting6">Wunderbaren sonnigen Samstag</key>
+    <key alias="greeting0">Willkommen</key>
+    <key alias="greeting1">Willkommen</key>
+    <key alias="greeting2">Willkommen</key>
+    <key alias="greeting3">Willkommen</key>
+    <key alias="greeting4">Willkommen</key>
+    <key alias="greeting5">Willkommen</key>
+    <key alias="greeting6">Willkommen</key>
     <key alias="instruction">Hier anmelden:</key>
     <key alias="signInWith">Anmelden mit</key>
     <key alias="timeout">Sitzung abgelaufen</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/de.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/de.xml
@@ -892,7 +892,7 @@
     <key alias="validate">Validieren</key>
     <key alias="value">Wert</key>
     <key alias="view">Ansicht</key>
-    <key alias="welcome">Willkommen </key>
+    <key alias="welcome">Willkommen ...</key>
     <key alias="width">Breite</key>
     <key alias="yes">Ja</key>
     <key alias="folder">Ordner</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -1067,13 +1067,13 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="renewSession">Renew now to save your work</key>
   </area>
   <area alias="login">
-    <key alias="greeting0">Happy super Sunday</key>
-    <key alias="greeting1">Happy marvelous Monday</key>
-    <key alias="greeting2">Happy tubular Tuesday</key>
-    <key alias="greeting3">Happy wonderful Wednesday</key>
-    <key alias="greeting4">Happy thunderous Thursday</key>
-    <key alias="greeting5">Happy funky Friday</key>
-    <key alias="greeting6">Happy Caturday</key>
+    <key alias="greeting0">Welcome</key>
+    <key alias="greeting1">Welcome</key>
+    <key alias="greeting2">Welcome</key>
+    <key alias="greeting3">Welcome</key>
+    <key alias="greeting4">Welcome</key>
+    <key alias="greeting5">Welcome</key>
+    <key alias="greeting6">Welcome</key>
     <key alias="instruction">Log in below</key>
     <key alias="signInWith">Sign in with</key>
     <key alias="timeout">Session timed out</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -869,7 +869,7 @@
     <key alias="username">Username</key>
     <key alias="value">Value</key>
     <key alias="view">View</key>
-    <key alias="welcome">Welcome</key>
+    <key alias="welcome">Welcome...</key>
     <key alias="width">Width</key>
     <key alias="yes">Yes</key>
     <key alias="folder">Folder</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -1096,13 +1096,13 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="renewSession">Renew now to save your work</key>
   </area>
   <area alias="login">
-    <key alias="greeting0">Happy super Sunday</key>
-    <key alias="greeting1">Happy marvelous Monday</key>
-    <key alias="greeting2">Happy tubular Tuesday</key>
-    <key alias="greeting3">Happy wonderful Wednesday</key>
-    <key alias="greeting4">Happy thunderous Thursday</key>
-    <key alias="greeting5">Happy funky Friday</key>
-    <key alias="greeting6">Happy Caturday</key>
+    <key alias="greeting0">Welcome</key>
+    <key alias="greeting1">Welcome</key>
+    <key alias="greeting2">Welcome</key>
+    <key alias="greeting3">Welcome</key>
+    <key alias="greeting4">Welcome</key>
+    <key alias="greeting5">Welcome</key>
+    <key alias="greeting6">Welcome</key>
     <key alias="instruction">Log in below</key>
     <key alias="signInWith">Sign in with</key>
     <key alias="timeout">Session timed out</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -899,7 +899,7 @@
     <key alias="validate">Validate</key>
     <key alias="value">Value</key>
     <key alias="view">View</key>
-    <key alias="welcome">Welcome</key>
+    <key alias="welcome">Welcome...</key>
     <key alias="width">Width</key>
     <key alias="yes">Yes</key>
     <key alias="folder">Folder</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/es.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/es.xml
@@ -672,13 +672,13 @@
     <key alias="renewSession">Renovar tu sesión para guardar sus cambios</key>
   </area>
   <area alias="login">
-    <key alias="greeting0">Feliz super domingo</key>
-    <key alias="greeting1">Feliz lunes</key>
-    <key alias="greeting2">Tremendo martes</key>
-    <key alias="greeting3">Maravilloso miércoles</key>
-    <key alias="greeting4">Fantástico jueves</key>
-    <key alias="greeting5">¡Ya es viernes!</key>
-    <key alias="greeting6">Resplandeciente sábado</key>
+    <key alias="greeting0">Bienvenido</key>
+    <key alias="greeting1">Bienvenido</key>
+    <key alias="greeting2">Bienvenido</key>
+    <key alias="greeting3">Bienvenido</key>
+    <key alias="greeting4">Bienvenido</key>
+    <key alias="greeting5">Bienvenido</key>
+    <key alias="greeting6">Bienvenido</key>
     <key alias="instruction">Iniciar sesión</key>
     <key alias="timeout">La sesión ha caducado</key>
     <key alias="bottomText"><![CDATA[<p style="text-align:right;">&copy; 2001 - %0% <br /><a href="https://umbraco.com" style="text-decoration: none" target="_blank" rel="noopener">umbraco.com</a></p> ]]></key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/es.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/es.xml
@@ -556,7 +556,7 @@
     <key alias="username">Nombre de usuario</key>
     <key alias="value">Valor</key>
     <key alias="view">Ver</key>
-    <key alias="welcome">Bienvenido</key>
+    <key alias="welcome">Bienvenido...</key>
     <key alias="width">Ancho</key>
     <key alias="yes">Si</key>
     <key alias="folder">Carpeta</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/fr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/fr.xml
@@ -727,7 +727,7 @@
     <key alias="username">Nom d'utilisateur</key>
     <key alias="value">Valeur</key>
     <key alias="view">Voir</key>
-    <key alias="welcome">Bienvenue</key>
+    <key alias="welcome">Bienvenue...</key>
     <key alias="width">Largeur</key>
     <key alias="yes">Oui</key>
     <key alias="folder">Dossier</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/fr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/fr.xml
@@ -892,13 +892,13 @@ Pour gérer votre site, ouvrez simplement le backoffice Umbraco et commencez à 
     <key alias="renewSession">Renouvellez votre session maintenant pour sauvegarder votre travail</key>
   </area>
   <area alias="login">
-    <key alias="greeting0">Joyeux dimanche détonnant</key>
-    <key alias="greeting1">Joyeux lundi lumineux</key>
-    <key alias="greeting2">Joyeux mardi magique</key>
-    <key alias="greeting3">Joyeux mercredi merveilleux</key>
-    <key alias="greeting4">Joyeux jeudi</key>
-    <key alias="greeting5">Joyeux vendredi</key>
-    <key alias="greeting6">Joyeux chamedi</key>
+    <key alias="greeting0">Bienvenue</key>
+    <key alias="greeting1">Bienvenue</key>
+    <key alias="greeting2">Bienvenue</key>
+    <key alias="greeting3">Bienvenue</key>
+    <key alias="greeting4">Bienvenue</key>
+    <key alias="greeting5">Bienvenue</key>
+    <key alias="greeting6">Bienvenue</key>
     <key alias="instruction">Connectez-vous ci-dessous</key>
     <key alias="signInWith">Identifiez-vous avec</key>
     <key alias="timeout">La session a expiré</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/he.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/he.xml
@@ -453,6 +453,13 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="renewSession">יש לבצע חידוש פעילות על מנת לשמור על התוכן</key>
   </area>
   <area alias="login">
+    <key alias="greeting0">ברוכים הבאים</key>
+    <key alias="greeting1">ברוכים הבאים</key>
+    <key alias="greeting2">ברוכים הבאים</key>
+    <key alias="greeting3">ברוכים הבאים</key>
+    <key alias="greeting4">ברוכים הבאים</key>
+    <key alias="greeting5">ברוכים הבאים</key>
+    <key alias="greeting6">ברוכים הבאים</key>
     <key alias="bottomText"><![CDATA[<p style="text-align:right;">&copy; 2001 - %0% <br /><a href="https://umbraco.com" style="text-decoration: none" target="_blank" rel="noopener">umbraco.com</a></p> ]]></key>
   </area>
   <area alias="main">

--- a/src/Umbraco.Core/EmbeddedResources/Lang/he.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/he.xml
@@ -328,7 +328,7 @@
     <key alias="username">שם משתמש</key>
     <key alias="value">ערך</key>
     <key alias="view">צפיה</key>
-    <key alias="welcome">ברוכים הבאים</key>
+    <key alias="welcome">ברוכים הבאים...</key>
     <key alias="width">רוחב</key>
     <key alias="yes">כן</key>
     <key alias="reorder">Reorder</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/hr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/hr.xml
@@ -1041,13 +1041,13 @@ Da bi upravljali svojom web lokacijom, jednostavno otvorite Umbraco backoffice i
     <key alias="renewSession">Obnovite sada da sačuvate svoj rad</key>
   </area>
   <area alias="login">
-    <key alias="greeting0">Sretna super nedelja</key>
-    <key alias="greeting1">Sretan divan ponedeljak</key>
-    <key alias="greeting2">Sretan specifičan utorak</key>
-    <key alias="greeting3">Sretna divna srijeda</key>
-    <key alias="greeting4">Sretan gromoglasan četvrtak</key>
-    <key alias="greeting5">Sretan zanimljiv petak</key>
-    <key alias="greeting6">Sretna opuštena subota</key>
+    <key alias="greeting0">Dobrodošli</key>
+    <key alias="greeting1">Dobrodošli</key>
+    <key alias="greeting2">Dobrodošli</key>
+    <key alias="greeting3">Dobrodošli</key>
+    <key alias="greeting4">Dobrodošli</key>
+    <key alias="greeting5">Dobrodošli</key>
+    <key alias="greeting6">Dobrodošli</key>
     <key alias="instruction">Prijavite se u nastavku</key>
     <key alias="signInWith">Prijav sa</key>
     <key alias="timeout">Isteklo je vrijeme sesije</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/hr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/hr.xml
@@ -846,7 +846,7 @@
     <key alias="username">Korisničko ime</key>
     <key alias="value">Vrijednost</key>
     <key alias="view">Pogled</key>
-    <key alias="welcome">Dobrodošli</key>
+    <key alias="welcome">Dobrodošli...</key>
     <key alias="width">Širina</key>
     <key alias="yes">Da</key>
     <key alias="folder">Mapa</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/it.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/it.xml
@@ -863,7 +863,7 @@
     <key alias="username"><![CDATA[Username]]></key>
     <key alias="value">Valore</key>
     <key alias="view">Vedi</key>
-    <key alias="welcome">Benvenuto</key>
+    <key alias="welcome">Benvenuto...</key>
     <key alias="width">Larghezza</key>
     <key alias="yes">Si</key>
     <key alias="folder">Cartella</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/it.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/it.xml
@@ -1074,13 +1074,13 @@ Per gestire il tuo sito web, è sufficiente aprire il backoffice di Umbraco e in
     <key alias="renewSession">Riconnetti adesso per salvare il tuo lavoro</key>
   </area>
   <area alias="login">
-    <key alias="greeting0"><![CDATA[Buona Domenica!]]></key>
-    <key alias="greeting1"><![CDATA[Buon Lunedì!]]></key>
-    <key alias="greeting2"><![CDATA[Buon Martedì!]]></key>
-    <key alias="greeting3"><![CDATA[Buon Mercoledì!]]></key>
-    <key alias="greeting4"><![CDATA[Buon Giovedì!]]></key>
-    <key alias="greeting5"><![CDATA[Buon Venerdì!]]></key>
-    <key alias="greeting6"><![CDATA[Buon Sabato!]]></key>
+    <key alias="greeting0">Benvenuto</key>
+    <key alias="greeting1">Benvenuto</key>
+    <key alias="greeting2">Benvenuto</key>
+    <key alias="greeting3">Benvenuto</key>
+    <key alias="greeting4">Benvenuto</key>
+    <key alias="greeting5">Benvenuto</key>
+    <key alias="greeting6">Benvenuto</key>
     <key alias="instruction">Fai il login qui sotto</key>
     <key alias="signInWith">Fai il login con</key>
     <key alias="timeout">Sessione scaduta</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/ja.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/ja.xml
@@ -568,13 +568,13 @@ Runwayをインストールして作られた新しいウェブサイトがど�
     <key alias="renewSession">作業を保存して今すぐ更新</key>
   </area>
   <area alias="login">
-    <key alias="greeting0">ハッピー スーパー日曜日</key>
-    <key alias="greeting1">ハッピー マニアック月曜日</key>
-    <key alias="greeting2">ハッピー最高の火曜日</key>
-    <key alias="greeting3">ハッピー ワンダフル水曜日</key>
-    <key alias="greeting4">ハッピー サンダー木曜日</key>
-    <key alias="greeting5">ハッピー ファンキー金曜日</key>
-    <key alias="greeting6">ハッピー土曜日</key>
+    <key alias="greeting0">ようこそ</key>
+    <key alias="greeting1">ようこそ</key>
+    <key alias="greeting2">ようこそ</key>
+    <key alias="greeting3">ようこそ</key>
+    <key alias="greeting4">ようこそ</key>
+    <key alias="greeting5">ようこそ</key>
+    <key alias="greeting6">ようこそ</key>
     <key alias="instruction">ウェブサイトにログインします。</key>
     <key alias="timeout">セッションタイムアウトしました。</key>
     <key alias="bottomText"><![CDATA[<p style="text-align:right;">&copy; 2001 - %0% <br /><a href="https://umbraco.com" style="text-decoration: none" target="_blank" rel="noopener">umbraco.org</a></p> ]]></key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/ja.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/ja.xml
@@ -417,7 +417,7 @@
     <key alias="username">ユーザー名</key>
     <key alias="value">値</key>
     <key alias="view">ビュー</key>
-    <key alias="welcome">ようこそ</key>
+    <key alias="welcome">ようこそ...</key>
     <key alias="width">幅</key>
     <key alias="yes">はい</key>
     <key alias="folder">フォルダー</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/ko.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/ko.xml
@@ -441,6 +441,13 @@
     <key alias="renewSession">TRANSLATE ME: 'Renew now to save your work'</key>
   </area>
   <area alias="login">
+    <key alias="greeting0">환영합니다</key>
+    <key alias="greeting1">환영합니다</key>
+    <key alias="greeting2">환영합니다</key>
+    <key alias="greeting3">환영합니다</key>
+    <key alias="greeting4">환영합니다</key>
+    <key alias="greeting5">환영합니다</key>
+    <key alias="greeting6">환영합니다</key>
     <key alias="bottomText"><![CDATA[<p style="text-align:right;">&copy; 2001 - %0% <br /><a href="https://umbraco.com" style="text-decoration: none" target="_blank" rel="noopener">umbraco.com</a></p> ]]></key>
   </area>
   <area alias="main">

--- a/src/Umbraco.Core/EmbeddedResources/Lang/ko.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/ko.xml
@@ -328,7 +328,7 @@
     <key alias="username">사용자</key>
     <key alias="value">값</key>
     <key alias="view">보기</key>
-    <key alias="welcome">환영합니다</key>
+    <key alias="welcome">환영합니다...</key>
     <key alias="width">너비</key>
     <key alias="yes">예</key>
     <key alias="reorder">Reorder</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/nb.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/nb.xml
@@ -474,13 +474,13 @@
     <key alias="renewSession">Forny innlogging for å lagre</key>
   </area>
   <area alias="login">
-    <key alias="greeting0">Da er det søndag!</key>
-    <key alias="greeting1">Smil, det er mandag!</key>
-    <key alias="greeting2">Hurra, det er tirsdag!</key>
-    <key alias="greeting3">For en herlig onsdag!</key>
-    <key alias="greeting4">Gledelig torsdag!</key>
-    <key alias="greeting5">Endelig fredag!</key>
-    <key alias="greeting6">Gledelig lørdag</key>
+    <key alias="greeting0">Velkommen</key>
+    <key alias="greeting1">Velkommen</key>
+    <key alias="greeting2">Velkommen</key>
+    <key alias="greeting3">Velkommen</key>
+    <key alias="greeting4">Velkommen</key>
+    <key alias="greeting5">Velkommen</key>
+    <key alias="greeting6">Velkommen</key>
     <key alias="instruction">Logg på nedenfor</key>
     <key alias="signInWith">Logg på med</key>
     <key alias="timeout">Din sesjon er utløpt</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/nb.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/nb.xml
@@ -382,7 +382,7 @@
     <key alias="username">Brukernavn</key>
     <key alias="value">Verdi</key>
     <key alias="view">Visning</key>
-    <key alias="welcome">Velkommen</key>
+    <key alias="welcome">Velkommen...</key>
     <key alias="width">Bredde</key>
     <key alias="yes">Ja</key>
     <key alias="folder">Mappe</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
@@ -978,13 +978,13 @@ Echter, Runway biedt een gemakkelijke basis om je snel op weg te helpen. Als je 
     <key alias="renewSession">Vernieuw je sessie om je wijzigingen te behouden</key>
   </area>
   <area alias="login">
-    <key alias="greeting0">Fijne super zondag</key>
-    <key alias="greeting1">Fijne manische maandag</key>
-    <key alias="greeting2">Fijne dinsdag</key>
-    <key alias="greeting3">Fijne geweldige woensdag</key>
-    <key alias="greeting4">Fijne donderende donderdag</key>
-    <key alias="greeting5">Fijne funky vrijdag</key>
-    <key alias="greeting6">Fijne zaterdag</key>
+    <key alias="greeting0">Welkom</key>
+    <key alias="greeting1">Welkom</key>
+    <key alias="greeting2">Welkom</key>
+    <key alias="greeting3">Welkom</key>
+    <key alias="greeting4">Welkom</key>
+    <key alias="greeting5">Welkom</key>
+    <key alias="greeting6">Welkom</key>
     <key alias="instruction">log hieronder in</key>
     <key alias="signInWith">Inloggen met</key>
     <key alias="timeout">Sessie is verlopen</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
@@ -823,7 +823,7 @@
     <key alias="username">Gebruikersnaam</key>
     <key alias="value">Waarde</key>
     <key alias="view">Bekijk</key>
-    <key alias="welcome">Welkom</key>
+    <key alias="welcome">Welkom...</key>
     <key alias="width">Breedte</key>
     <key alias="yes">Ja</key>
     <key alias="folder">Map</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/pl.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/pl.xml
@@ -683,13 +683,13 @@ Naciśnij przycisk <strong>instaluj</strong>, aby zainstalować bazę danych Umb
     <key alias="renewSession">Wznów sesję teraz, aby zapisać swoją pracę</key>
   </area>
   <area alias="login">
-    <key alias="greeting0">Szczęśliwej super niedzieli</key>
-    <key alias="greeting1">Szczęśliwego maniakalnego poniedziałku </key>
-    <key alias="greeting2">Szczęśliwego świetnego wtorku</key>
-    <key alias="greeting3">Szczęśliwej niesamowitej środy</key>
-    <key alias="greeting4">Szczęśliwego wyjątkowego czwartku</key>
-    <key alias="greeting5">Szczęśliwego odjechanego piątku</key>
-    <key alias="greeting6">Szczęśliwej cudownej soboty</key>
+    <key alias="greeting0">Witaj</key>
+    <key alias="greeting1">Witaj</key>
+    <key alias="greeting2">Witaj</key>
+    <key alias="greeting3">Witaj</key>
+    <key alias="greeting4">Witaj</key>
+    <key alias="greeting5">Witaj</key>
+    <key alias="greeting6">Witaj</key>
     <key alias="instruction">Zaloguj się poniżej</key>
     <key alias="signInWith">Zaloguj się z</key>
     <key alias="timeout">Sesja wygasła</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/pl.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/pl.xml
@@ -523,7 +523,7 @@
     <key alias="username">Nazwa użytkownika</key>
     <key alias="value">Wartość</key>
     <key alias="view">Widok</key>
-    <key alias="welcome">Witaj</key>
+    <key alias="welcome">Witaj...</key>
     <key alias="width">Szerokość</key>
     <key alias="yes">Tak</key>
     <key alias="folder">Folder</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/pt.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/pt.xml
@@ -435,6 +435,13 @@ Pressione <strong>"próximo"</strong> para iniciar o assistente.]]></key>
     <key alias="renewSession">Renovar agora para salvar seu trabalho</key>
   </area>
   <area alias="login">
+    <key alias="greeting0">Bem Vindo(a)</key>
+    <key alias="greeting1">Bem Vindo(a)</key>
+    <key alias="greeting2">Bem Vindo(a)</key>
+    <key alias="greeting3">Bem Vindo(a)</key>
+    <key alias="greeting4">Bem Vindo(a)</key>
+    <key alias="greeting5">Bem Vindo(a)</key>
+    <key alias="greeting6">Bem Vindo(a)</key>
     <key alias="bottomText"><![CDATA[<p style="text-align:right;">&copy; 2001 - %0% <br /><a href="https://umbraco.com" style="text-decoration: none" target="_blank" rel="noopener">umbraco.com</a></p> ]]></key>
   </area>
   <area alias="main">

--- a/src/Umbraco.Core/EmbeddedResources/Lang/pt.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/pt.xml
@@ -326,7 +326,7 @@
     <key alias="username">Usuário</key>
     <key alias="value">Valor</key>
     <key alias="view">Ver</key>
-    <key alias="welcome">Bem Vindo(a)</key>
+    <key alias="welcome">Bem Vindo(a)...</key>
     <key alias="width">Largura</key>
     <key alias="yes">Sim</key>
     <key alias="reorder">Reorder</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/ru.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/ru.xml
@@ -806,13 +806,13 @@
   </area>
   <area alias="login">
     <key alias="bottomText"><![CDATA[<p style="text-align:right;">&copy; 2001 - %0% <br /><a href="https://umbraco.com" style="text-decoration: none" target="_blank" rel="noopener">umbraco.com</a></p>]]></key>
-    <key alias="greeting0">Сегодня же выходной!</key>
-    <key alias="greeting1">Понедельник — день тяжелый...</key>
-    <key alias="greeting2">Вот уже вторник...</key>
-    <key alias="greeting3">Берегите окружающую среду</key>
-    <key alias="greeting4">Рыбный день</key>
-    <key alias="greeting5">Слава Богу, сегодня пятница!</key>
-    <key alias="greeting6">Понедельник начинается в субботу</key>
+    <key alias="greeting0">Добро пожаловать</key>
+    <key alias="greeting1">Добро пожаловать</key>
+    <key alias="greeting2">Добро пожаловать</key>
+    <key alias="greeting3">Добро пожаловать</key>
+    <key alias="greeting4">Добро пожаловать</key>
+    <key alias="greeting5">Добро пожаловать</key>
+    <key alias="greeting6">Добро пожаловать</key>
     <key alias="instruction">Укажите имя пользователя и пароль</key>
     <key alias="timeout">Время сессии истекло</key>
     <key alias="forgottenPassword">Забыли пароль?</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/ru.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/ru.xml
@@ -574,7 +574,7 @@
     <key alias="username">Имя пользователя</key>
     <key alias="value">Значение</key>
     <key alias="view">Просмотр</key>
-    <key alias="welcome">Добро пожаловать</key>
+    <key alias="welcome">Добро пожаловать...</key>
     <key alias="width">Ширина</key>
     <key alias="yes">Да</key>
     <key alias="reorder">Пересортировать</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/sv.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/sv.xml
@@ -114,7 +114,7 @@
   </area>
   <area alias="validation">
     <key alias="entriesShort"><![CDATA[Minsta %0% poster, kräver <strong>%1%</strong> mer.]]></key>
-    <key alias="entriesExceed"><![CDATA[Max %0% poster, <strong>%1%</strong> för många.]]></key>  
+    <key alias="entriesExceed"><![CDATA[Max %0% poster, <strong>%1%</strong> för många.]]></key>
   </area>
   <area alias="blueprints">
     <key alias="createBlueprintFrom"><![CDATA[Skapa en ny innehållsmall för <em>%0%</em>]]></key>
@@ -223,7 +223,7 @@
     <key alias="publishedPendingChanges">Publicerad (osparade ändringar)</key>
     <key alias="listViewNoContent">Inga undernoder har lagts till</key>
     <key alias="noChanges">Inga ändringar har gjorts</key>
-    <key alias="notCreated">Ej skapad</key>    
+    <key alias="notCreated">Ej skapad</key>
   </area>
   <area alias="contentTypeEditor">
     <key alias="yesDelete">Ja, ta bort</key>
@@ -636,13 +636,13 @@
   </area>
   <area alias="login">
     <key alias="bottomText"><![CDATA[<p style="text-align:right;">&copy; 2001 - %0% <br /><a href="https://umbraco.com" style="text-decoration: none" target="_blank" rel="noopener">umbraco.com</a></p> ]]></key>
-    <key alias="greeting0">Happy super Sunday</key>
-    <key alias="greeting1">Happy manic Monday</key>
-    <key alias="greeting2">Happy tremendous Tuesday</key>
-    <key alias="greeting3">Happy wonderful Wednesday</key>
-    <key alias="greeting4">Happy thunderous Thursday</key>
-    <key alias="greeting5">Happy friendly Friday</key>
-    <key alias="greeting6">Happy shiny Saturday</key>
+    <key alias="greeting0">Välkommen</key>
+    <key alias="greeting1">Välkommen</key>
+    <key alias="greeting2">Välkommen</key>
+    <key alias="greeting3">Välkommen</key>
+    <key alias="greeting4">Välkommen</key>
+    <key alias="greeting5">Välkommen</key>
+    <key alias="greeting6">Välkommen</key>
     <key alias="instruction">Logga in nedan</key>
     <key alias="signInWith">Logga in med</key>
     <key alias="timeout">Sessionen har nått sin maxgräns</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/sv.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/sv.xml
@@ -114,7 +114,7 @@
   </area>
   <area alias="validation">
     <key alias="entriesShort"><![CDATA[Minsta %0% poster, kräver <strong>%1%</strong> mer.]]></key>
-    <key alias="entriesExceed"><![CDATA[Max %0% poster, <strong>%1%</strong> för många.]]></key>
+    <key alias="entriesExceed"><![CDATA[Max %0% poster, <strong>%1%</strong> för många.]]></key>  
   </area>
   <area alias="blueprints">
     <key alias="createBlueprintFrom"><![CDATA[Skapa en ny innehållsmall för <em>%0%</em>]]></key>
@@ -223,7 +223,7 @@
     <key alias="publishedPendingChanges">Publicerad (osparade ändringar)</key>
     <key alias="listViewNoContent">Inga undernoder har lagts till</key>
     <key alias="noChanges">Inga ändringar har gjorts</key>
-    <key alias="notCreated">Ej skapad</key>
+    <key alias="notCreated">Ej skapad</key>    
   </area>
   <area alias="contentTypeEditor">
     <key alias="yesDelete">Ja, ta bort</key>
@@ -543,7 +543,7 @@
     <key alias="user">Användare</key>
     <key alias="username">Användarnamn</key>
     <key alias="value">Värde</key>
-    <key alias="welcome">Välkommen</key>
+    <key alias="welcome">Välkommen...</key>
     <key alias="width">Bredd</key>
     <key alias="view">Titta på</key>
     <key alias="yes">Ja</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/tr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/tr.xml
@@ -739,7 +739,7 @@
     <key alias="username">Kullanıcı adı</key>
     <key alias="value">Değer</key>
     <key alias="view">Görüntüle</key>
-    <key alias="welcome">Hoş geldiniz </key>
+    <key alias="welcome">Hoş geldiniz ...</key>
     <key alias="width">Genişlik</key>
     <key alias="yes">Evet</key>
     <key alias="folder">Klasör</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/tr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/tr.xml
@@ -937,13 +937,13 @@ Web sitenizi yönetmek için, Umbraco'nun arka ofisini açın ve içerik eklemey
     <key alias="renewSession">Çalışmanızı kaydetmek için şimdi yenileyin</key>
   </area>
   <area alias="login">
-    <key alias="greeting0">Mutlu Pazarlar</key>
-    <key alias="greeting1">Mutlu manik Pazartesi</key>
-    <key alias="greeting2">Mutlu salı günleri</key>
-    <key alias="greeting3">Harika Çarşamba Günleri</key>
-    <key alias="greeting4">Mutlu, gök gürültülü Perşembe</key>
-    <key alias="greeting5">Mutlu Cuma Günü</key>
-    <key alias="greeting6">Mutlu Yıllar</key>
+    <key alias="greeting0">Hoş geldiniz</key>
+    <key alias="greeting1">Hoş geldiniz</key>
+    <key alias="greeting2">Hoş geldiniz</key>
+    <key alias="greeting3">Hoş geldiniz</key>
+    <key alias="greeting4">Hoş geldiniz</key>
+    <key alias="greeting5">Hoş geldiniz</key>
+    <key alias="greeting6">Hoş geldiniz</key>
     <key alias="instruction">Aşağıda oturum açın</key>
     <key alias="signInWith">ile oturum açın</key>
     <key alias="timeout">Oturum zaman aşımına uğradı</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/ua.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/ua.xml
@@ -806,13 +806,13 @@
   </area>
   <area alias="login">
     <key alias="bottomText"><![CDATA[<p style="text-align:right;">&copy; 2001 - %0% <br /><a href="https://umbraco.com" style="text-decoration: none" target="_blank" rel="noopener">umbraco.com</a></p>]]></key>
-    <key alias="greeting0">Сьогодні ж вихідний!</key>
-    <key alias="greeting1">Гарного і продуктивного понеділка</key>
-    <key alias="greeting2">Ось уже вівторок...</key>
-    <key alias="greeting3">Бережіть довкілля</key>
-    <key alias="greeting4">Скоро п'ятниця</key>
-    <key alias="greeting5">Слава Богу, сьогодні п'ятниця!</key>
-    <key alias="greeting6">Понеділок починається у суботу</key>
+    <key alias="greeting0">Вітаємо</key>
+    <key alias="greeting1">Вітаємо</key>
+    <key alias="greeting2">Вітаємо</key>
+    <key alias="greeting3">Вітаємо</key>
+    <key alias="greeting4">Вітаємо</key>
+    <key alias="greeting5">Вітаємо</key>
+    <key alias="greeting6">Вітаємо</key>
     <key alias="instruction">Вкажіть ім'я користувача та пароль</key>
     <key alias="timeout">Час сесії закінчився</key>
     <key alias="forgottenPassword">Забули пароль?</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/ua.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/ua.xml
@@ -574,7 +574,7 @@
     <key alias="username">Ім'я користувача</key>
     <key alias="value">Значення</key>
     <key alias="view">Перегляд</key>
-    <key alias="welcome">Ласкаво просимо</key>
+    <key alias="welcome">Ласкаво просимо...</key>
     <key alias="width">Ширина</key>
     <key alias="yes">Так</key>
     <key alias="reorder">Пересортувати</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/zh.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/zh.xml
@@ -588,13 +588,13 @@
     <key alias="renewSession">已更新，继续工作。</key>
   </area>
   <area alias="login">
-    <key alias="greeting0">星期一快乐</key>
-    <key alias="greeting1">星期二快乐</key>
-    <key alias="greeting2">星期三快乐</key>
-    <key alias="greeting3">星期四快乐</key>
-    <key alias="greeting4">星期五快乐</key>
-    <key alias="greeting5">星期六快乐</key>
-    <key alias="greeting6">星期天快乐</key>
+    <key alias="greeting0">欢迎</key>
+    <key alias="greeting1">欢迎</key>
+    <key alias="greeting2">欢迎</key>
+    <key alias="greeting3">欢迎</key>
+    <key alias="greeting4">欢迎</key>
+    <key alias="greeting5">欢迎</key>
+    <key alias="greeting6">欢迎</key>
     <key alias="instruction">在下方登录</key>
     <key alias="signInWith">登录</key>
     <key alias="timeout">会话超时</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/zh_tw.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/zh_tw.xml
@@ -579,13 +579,13 @@
     <key alias="renewSession">已更新，繼續工作。</key>
   </area>
   <area alias="login">
-    <key alias="greeting0">超級星期天快樂</key>
-    <key alias="greeting1">瘋狂星期一快樂</key>
-    <key alias="greeting2">熱鬧星期二快樂</key>
-    <key alias="greeting3">美妙星期三快樂</key>
-    <key alias="greeting4">悅耳星期四快樂</key>
-    <key alias="greeting5">時髦星期五快樂</key>
-    <key alias="greeting6">喵喵星期六快樂</key>
+    <key alias="greeting0">歡迎</key>
+    <key alias="greeting1">歡迎</key>
+    <key alias="greeting2">歡迎</key>
+    <key alias="greeting3">歡迎</key>
+    <key alias="greeting4">歡迎</key>
+    <key alias="greeting5">歡迎</key>
+    <key alias="greeting6">歡迎</key>
     <key alias="instruction">下方登入</key>
     <key alias="signInWith">登入使用</key>
     <key alias="timeout">連線時間過了</key>

--- a/src/Umbraco.Web.UI.Login/index.html
+++ b/src/Umbraco.Web.UI.Login/index.html
@@ -5,6 +5,9 @@
   <base href="/"/>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="apple-mobile-web-app-capable" content="yes"/>
+  <meta name="robots" content="noindex, nofollow"/>
+  <meta name="pinterest" content="nopin"/>
   <title>Umbraco</title>
   <script type="module">
     import {startMockServiceWorker} from './src/mocks/index.ts';

--- a/src/Umbraco.Web.UI.Login/index.html
+++ b/src/Umbraco.Web.UI.Login/index.html
@@ -47,6 +47,7 @@
       logo-image="/logo_dark.svg"
       logo-image-alternative="/logo_dark.svg"
       background-image="/login.jpg"
+      username-is-email="true"
       allow-password-reset
       allow-user-invite>
       <umb-external-login-provider

--- a/src/Umbraco.Web.UI.Login/index.html
+++ b/src/Umbraco.Web.UI.Login/index.html
@@ -20,6 +20,28 @@
   <script type="module" src="/src/index.ts"></script>
 </head>
 <body class="uui-font uui-text" style="margin: 0; padding: 0; overflow: hidden">
+  <noscript>
+    <style>
+      #noscript-container {
+        display: flex;
+        flex-wrap: wrap;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        height: 100vh;
+        padding: 0 20px;
+        text-align: center;
+      }
+    </style>
+    <div id="noscript-container">
+      <h1 class="uui-h3" style="display: inline-flex; align-items: center; gap: 10px">
+        <img aria-hidden="true" alt="logo" src="/favicon.svg" style="width: 30px" />
+        <span>Umbraco</span>
+      </h1>
+      <p>For full functionality of Umbraco CMS it is necessary to enable JavaScript.</p>
+      <p>Here are the <a href="https://www.enable-javascript.com/" target="_blank" rel="noopener" style="text-decoration: underline;">instructions how to enable JavaScript in your web browser</a>.</p>
+    </div>
+  </noscript>
   <umb-backoffice-icon-registry>
     <umb-auth
       logo-image="/logo_dark.svg"

--- a/src/Umbraco.Web.UI.Login/src/auth.element.ts
+++ b/src/Umbraco.Web.UI.Login/src/auth.element.ts
@@ -152,8 +152,8 @@ export default class UmbAuthElement extends LitElement {
    */
   async #initializeForm() {
     const labelUsername = this.usernameIsEmail
-      ? await umbLocalizationContext.localize('general_username', undefined, 'Username')
-      : await umbLocalizationContext.localize('general_email', undefined, 'Email');
+      ? await umbLocalizationContext.localize('general_email', undefined, 'Email')
+      : await umbLocalizationContext.localize('general_username', undefined, 'Username');
     const labelPassword = await umbLocalizationContext.localize('general_password', undefined, 'Password');
     const requiredMessage = await umbLocalizationContext.localize('general_required', undefined, 'Required');
 
@@ -179,7 +179,7 @@ export default class UmbAuthElement extends LitElement {
       forId: 'username-input',
       localizeAlias: this.usernameIsEmail ? 'general_email' : 'general_username',
     });
-    this._passwordLabel = createLabel({forId: 'password-input', localizeAlias: 'user_password'});
+    this._passwordLabel = createLabel({forId: 'password-input', localizeAlias: 'general_password'});
 
     this._usernameLayoutItem = createFormLayoutItem(this._usernameLabel, this._usernameInput);
     this._passwordLayoutItem = createFormLayoutItem(this._passwordLabel, this._passwordInput);

--- a/src/Umbraco.Web.UI.Login/src/components/layouts/auth-layout.element.ts
+++ b/src/Umbraco.Web.UI.Login/src/components/layouts/auth-layout.element.ts
@@ -2,6 +2,22 @@ import { css, CSSResultGroup, html, LitElement, nothing, PropertyValueMap } from
 import { customElement, property } from 'lit/decorators.js';
 import { when } from 'lit/directives/when.js';
 
+/**
+ * The auth layout component.
+ *
+ * @element umb-auth-layout
+ * @slot - The content of the layout
+ * @cssprop --umb-login-background - The background of the layout (default: #f4f4f4)
+ * @cssprop --umb-login-image - The background of the image wrapper (default: the value of the backgroundImage property)
+ * @cssprop --umb-login-image-display - The display of the image wrapper (default: flex)
+ * @cssprop --umb-login-content-background - The background of the content wrapper (default: none)
+ * @cssprop --umb-login-content-display - The display of the content wrapper (default: flex)
+ * @cssprop --umb-login-content-width - The width of the content wrapper (default: 100%)
+ * @cssprop --umb-login-content-height - The height of the content wrapper (default: 100%)
+ * @cssprop --umb-login-align-items - The align-items of the main wrapper (default: unset)
+ * @cssprop --umb-curves-color - The color of the curves (default: #f5c1bc)
+ * @cssprop --umb-curves-display - The display of the curves (default: inline)
+ */
 @customElement('umb-auth-layout')
 export class UmbAuthLayoutElement extends LitElement {
   @property({ attribute: 'background-image' })
@@ -18,7 +34,7 @@ export class UmbAuthLayoutElement extends LitElement {
 
     if (_changedProperties.has<keyof this>('backgroundImage')) {
       this.style.setProperty('--logo-alternative-display', this.backgroundImage ? 'none' : 'unset');
-      this.style.setProperty('--background', `url('${this.backgroundImage}') no-repeat center center/cover`);
+      this.style.setProperty('--image', `url('${this.backgroundImage}') no-repeat center center/cover`);
     }
   }
 
@@ -94,13 +110,14 @@ export class UmbAuthLayoutElement extends LitElement {
         --curves-display: var(--umb-curves-display, inline);
 
         display: block;
-        background-color: #f4f4f4;
+        background: var(--umb-login-background, #f4f4f4);
       }
 
       #main-no-image,
       #main {
         max-width: 1920px;
         display: flex;
+        justify-content: center;
         height: 100vh;
         padding: 8px;
         box-sizing: border-box;
@@ -108,13 +125,15 @@ export class UmbAuthLayoutElement extends LitElement {
       }
 
       #image-container {
-        display: none;
+        display: var(--umb-login-image-display, none);
         width: 100%;
       }
 
       #content-container {
-        display: flex;
-        width: 100%;
+        background: var(--umb-login-content-background, none);
+        display: var(--umb-login-content-display, flex);
+        width: var(--umb-login-content-width, 100%);
+        height: var(--umb-login-content-height, 100%);
         box-sizing: border-box;
         overflow: auto;
       }
@@ -126,7 +145,7 @@ export class UmbAuthLayoutElement extends LitElement {
       }
 
       #image {
-        background: var(--background);
+        background: var(--umb-login-image, var(--image));
         width: 100%;
         height: 100%;
         border-radius: 38px;
@@ -168,14 +187,15 @@ export class UmbAuthLayoutElement extends LitElement {
         #main {
           padding: 32px;
           padding-right: 0;
+          align-items: var(--umb-login-align-items, unset);
         }
 
         #image-container {
-          display: block;
+          display: var(--umb-login-image-display, block);
         }
 
         #content-container {
-          display: flex;
+          display: var(--umb-login-content-display, flex);
           padding: 16px;
         }
 

--- a/src/Umbraco.Web.UI.Login/src/components/layouts/auth-layout.element.ts
+++ b/src/Umbraco.Web.UI.Login/src/components/layouts/auth-layout.element.ts
@@ -18,7 +18,7 @@ export class UmbAuthLayoutElement extends LitElement {
 
     if (_changedProperties.has<keyof this>('backgroundImage')) {
       this.style.setProperty('--logo-alternative-display', this.backgroundImage ? 'none' : 'unset');
-      this.style.setProperty('--image', `url('${this.backgroundImage}')`);
+      this.style.setProperty('--background', `url('${this.backgroundImage}') no-repeat center center/cover`);
     }
   }
 
@@ -35,7 +35,7 @@ export class UmbAuthLayoutElement extends LitElement {
             viewBox="0 0 1746 1374"
             fill="none"
             xmlns="http://www.w3.org/2000/svg">
-            <path d="M8 1C61.5 722.5 206.5 1366.5 1745.5 1366.5" stroke="#F5C1BC" stroke-width="15"/>
+            <path d="M8 1C61.5 722.5 206.5 1366.5 1745.5 1366.5" stroke="currentColor" stroke-width="15"/>
           </svg>
           <svg
             id="curve-bottom"
@@ -44,7 +44,7 @@ export class UmbAuthLayoutElement extends LitElement {
             viewBox="0 0 1364 552"
             fill="none"
             xmlns="http://www.w3.org/2000/svg">
-            <path d="M1 8C387 24 1109 11 1357 548" stroke="#F5C1BC" stroke-width="15"/>
+            <path d="M1 8C387 24 1109 11 1357 548" stroke="currentColor" stroke-width="15"/>
           </svg>
 
           ${when(
@@ -90,6 +90,9 @@ export class UmbAuthLayoutElement extends LitElement {
         --input-height: 40px;
         --header-font-size: 3rem;
         --header-secondary-font-size: 2.4rem;
+        --curves-color: var(--umb-curves-color, #f5c1bc);
+        --curves-display: var(--umb-curves-display, inline);
+
         display: block;
         background-color: #f4f4f4;
       }
@@ -123,21 +126,20 @@ export class UmbAuthLayoutElement extends LitElement {
       }
 
       #image {
-        background-image: var(--image);
-        background-position: 50%;
-        background-repeat: no-repeat;
-        background-size: cover;
+        background: var(--background);
         width: 100%;
         height: 100%;
         border-radius: 38px;
         position: relative;
         overflow: hidden;
+        color: var(--curves-color);
       }
 
       #image svg {
         position: absolute;
         width: 45%;
         height: fit-content;
+        display: var(--curves-display);
       }
 
       #curve-top {

--- a/src/Umbraco.Web.UI.Login/src/components/pages/login.page.element.ts
+++ b/src/Umbraco.Web.UI.Login/src/components/pages/login.page.element.ts
@@ -89,6 +89,18 @@ export default class UmbLoginPageElement extends LitElement {
     this.dispatchEvent(new CustomEvent('umb-login-success', {bubbles: true, composed: true, detail: response.data}));
   };
 
+  get #greetingLocalizationKey() {
+    return [
+      'login_greeting0',
+      'login_greeting1',
+      'login_greeting2',
+      'login_greeting3',
+      'login_greeting4',
+      'login_greeting5',
+      'login_greeting6',
+    ][new Date().getDay()];
+  }
+
   #onSubmitClick = () => {
     this.#formElement?.requestSubmit();
   };
@@ -97,7 +109,7 @@ export default class UmbLoginPageElement extends LitElement {
     return html`
       <header id="header">
         <h1 id="greeting">
-          <umb-localize key="general_welcome">Welcome</umb-localize>
+          <umb-localize .key=${this.#greetingLocalizationKey}></umb-localize>
         </h1>
         <slot name="subheadline"></slot>
       </header>

--- a/src/Umbraco.Web.UI.Login/src/mocks/data/texts.json
+++ b/src/Umbraco.Web.UI.Login/src/mocks/data/texts.json
@@ -11,6 +11,13 @@
     "required": "Required"
   },
   "login": {
+    "greeting0": "Welcome",
+    "greeting1": "Welcome",
+    "greeting2": "Welcome",
+    "greeting3": "Welcome",
+    "greeting4": "Welcome",
+    "greeting5": "Welcome",
+    "greeting6": "Welcome",
     "forgottenPassword": "Forgot password?",
     "signInWith": "Sign in with",
     "forgottenPasswordInstruction": "Enter your email address and we'll send you a link to reset your password.",

--- a/src/Umbraco.Web.UI.Login/src/mocks/data/texts.json
+++ b/src/Umbraco.Web.UI.Login/src/mocks/data/texts.json
@@ -8,7 +8,8 @@
     "or": "Or",
     "validate": "Validate",
     "back": "Back",
-    "required": "Required"
+    "required": "Required",
+    "continue": "Continue"
   },
   "login": {
     "greeting0": "Welcome",
@@ -18,7 +19,7 @@
     "greeting4": "Welcome",
     "greeting5": "Welcome",
     "greeting6": "Welcome",
-    "forgottenPassword": "Forgot password?",
+    "forgottenPassword": "Forgotten password?",
     "signInWith": "Sign in with",
     "forgottenPasswordInstruction": "Enter your email address and we'll send you a link to reset your password.",
     "returnToLogin": "Return to login",
@@ -31,11 +32,8 @@
   "user": {
     "username": "Username",
     "email": "Email",
-    "password": "Password"
-  },
-  "placeholders": {
-    "username": "Enter your username",
-    "email": "Enter your email",
-    "password": "Enter your password"
+    "password": "Password",
+    "newPassword": "New password",
+    "confirmNewPassword": "Confirm password"
   }
 }


### PR DESCRIPTION
### Description

This PR aims to add a bit of backward compatibility with the V12 login screen in the following areas:

- We are now loading the package bundle CSS on the login screen to allow to override CSS custom properties
- We have added more variables that are overridable to allow to change the background and SVG graphics
- The <noscript> section is now present on the login screen as well as the backoffice
- The debugger is now once again present on the login screen
- Added a few missing meta tags that were present on the V12 login screen
- The customizable greeting variables are back but have been reset to a variant of the word "Welcome" for all languages, but it allows previous user translations to take effect
- Fixed a couple of language keys that were used incorrectly