### PR TITLE
Fix `IWebhook.GetUdi()` and `IEntity.GetUdi()` extension methods

### DIFF
--- a/src/Umbraco.Core/Extensions/UdiGetterExtensions.cs
+++ b/src/Umbraco.Core/Extensions/UdiGetterExtensions.cs
@@ -363,7 +363,7 @@ public static class UdiGetterExtensions
     /// </summary>
     /// <param name="entity">The entity.</param>
     /// <returns>The entity identifier of the entity.</returns>
-    public static GuidUdi GetUdi(this Webhook entity)
+    public static GuidUdi GetUdi(this IWebhook entity)
     {
         if (entity == null)
         {
@@ -495,6 +495,11 @@ public static class UdiGetterExtensions
         if (entity is ILanguage language)
         {
             return language.GetUdi();
+        }
+
+        if (entity is IWebhook webhook)
+        {
+            return webhook.GetUdi();
         }
 
         throw new NotSupportedException(string.Format("Entity type {0} is not supported.", entity.GetType().FullName));

--- a/src/Umbraco.Core/Extensions/UdiGetterExtensions.cs
+++ b/src/Umbraco.Core/Extensions/UdiGetterExtensions.cs
@@ -8,146 +8,126 @@ using Umbraco.Cms.Core.Models.Entities;
 namespace Umbraco.Extensions;
 
 /// <summary>
-///     Provides extension methods that return udis for Umbraco entities.
+/// Provides extension methods that return udis for Umbraco entities.
 /// </summary>
 public static class UdiGetterExtensions
 {
     /// <summary>
-    ///     Gets the entity identifier of the entity.
+    /// Gets the entity identifier of the entity.
     /// </summary>
     /// <param name="entity">The entity.</param>
-    /// <returns>The entity identifier of the entity.</returns>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
     public static GuidUdi GetUdi(this ITemplate entity)
     {
-        if (entity == null)
-        {
-            throw new ArgumentNullException("entity");
-        }
+        ArgumentNullException.ThrowIfNull(entity);
 
         return new GuidUdi(Constants.UdiEntityType.Template, entity.Key).EnsureClosed();
     }
 
     /// <summary>
-    ///     Gets the entity identifier of the entity.
+    /// Gets the entity identifier of the entity.
     /// </summary>
     /// <param name="entity">The entity.</param>
-    /// <returns>The entity identifier of the entity.</returns>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
     public static GuidUdi GetUdi(this IContentType entity)
     {
-        if (entity == null)
-        {
-            throw new ArgumentNullException("entity");
-        }
+        ArgumentNullException.ThrowIfNull(entity);
 
         return new GuidUdi(Constants.UdiEntityType.DocumentType, entity.Key).EnsureClosed();
     }
 
     /// <summary>
-    ///     Gets the entity identifier of the entity.
+    /// Gets the entity identifier of the entity.
     /// </summary>
     /// <param name="entity">The entity.</param>
-    /// <returns>The entity identifier of the entity.</returns>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
     public static GuidUdi GetUdi(this IMediaType entity)
     {
-        if (entity == null)
-        {
-            throw new ArgumentNullException("entity");
-        }
+        ArgumentNullException.ThrowIfNull(entity);
 
         return new GuidUdi(Constants.UdiEntityType.MediaType, entity.Key).EnsureClosed();
     }
 
     /// <summary>
-    ///     Gets the entity identifier of the entity.
+    /// Gets the entity identifier of the entity.
     /// </summary>
     /// <param name="entity">The entity.</param>
-    /// <returns>The entity identifier of the entity.</returns>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
     public static GuidUdi GetUdi(this IMemberType entity)
     {
-        if (entity == null)
-        {
-            throw new ArgumentNullException("entity");
-        }
+        ArgumentNullException.ThrowIfNull(entity);
 
         return new GuidUdi(Constants.UdiEntityType.MemberType, entity.Key).EnsureClosed();
     }
 
     /// <summary>
-    ///     Gets the entity identifier of the entity.
+    /// Gets the entity identifier of the entity.
     /// </summary>
     /// <param name="entity">The entity.</param>
-    /// <returns>The entity identifier of the entity.</returns>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
     public static GuidUdi GetUdi(this IMemberGroup entity)
     {
-        if (entity == null)
-        {
-            throw new ArgumentNullException("entity");
-        }
+        ArgumentNullException.ThrowIfNull(entity);
 
         return new GuidUdi(Constants.UdiEntityType.MemberGroup, entity.Key).EnsureClosed();
     }
 
     /// <summary>
-    ///     Gets the entity identifier of the entity.
+    /// Gets the entity identifier of the entity.
     /// </summary>
     /// <param name="entity">The entity.</param>
-    /// <returns>The entity identifier of the entity.</returns>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
     public static GuidUdi GetUdi(this IContentTypeComposition entity)
     {
-        if (entity == null)
-        {
-            throw new ArgumentNullException("entity");
-        }
+        ArgumentNullException.ThrowIfNull(entity);
 
-        string type;
-        if (entity is IContentType)
+        string entityType = entity switch
         {
-            type = Constants.UdiEntityType.DocumentType;
-        }
-        else if (entity is IMediaType)
-        {
-            type = Constants.UdiEntityType.MediaType;
-        }
-        else if (entity is IMemberType)
-        {
-            type = Constants.UdiEntityType.MemberType;
-        }
-        else
-        {
-            throw new NotSupportedException(string.Format(
-                "Composition type {0} is not supported.",
-                entity.GetType().FullName));
-        }
+            IContentType => Constants.UdiEntityType.DocumentType,
+            IMediaType => Constants.UdiEntityType.MediaType,
+            IMemberType => Constants.UdiEntityType.MemberType,
+            _ => throw new NotSupportedException(string.Format("Composition type {0} is not supported.", entity.GetType().FullName)),
+        };
 
-        return new GuidUdi(type, entity.Key).EnsureClosed();
+        return new GuidUdi(entityType, entity.Key).EnsureClosed();
     }
 
     /// <summary>
-    ///     Gets the entity identifier of the entity.
+    /// Gets the entity identifier of the entity.
     /// </summary>
     /// <param name="entity">The entity.</param>
-    /// <returns>The entity identifier of the entity.</returns>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
     public static GuidUdi GetUdi(this IDataType entity)
     {
-        if (entity == null)
-        {
-            throw new ArgumentNullException("entity");
-        }
+        ArgumentNullException.ThrowIfNull(entity);
 
         return new GuidUdi(Constants.UdiEntityType.DataType, entity.Key).EnsureClosed();
     }
 
     /// <summary>
-    ///     Gets the entity identifier of the entity.
+    /// Gets the entity identifier of the entity.
     /// </summary>
     /// <param name="entity">The entity.</param>
-    /// <returns>The entity identifier of the entity.</returns>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
     public static GuidUdi GetUdi(this EntityContainer entity)
     {
-        if (entity == null)
-        {
-            throw new ArgumentNullException("entity");
-        }
+        ArgumentNullException.ThrowIfNull(entity);
 
         string entityType;
         if (entity.ContainedObjectType == Constants.ObjectTypes.DataType)
@@ -164,344 +144,250 @@ public static class UdiGetterExtensions
         }
         else
         {
-            throw new NotSupportedException(string.Format(
-                "Contained object type {0} is not supported.",
-                entity.ContainedObjectType));
+            throw new NotSupportedException(string.Format("Contained object type {0} is not supported.", entity.ContainedObjectType));
         }
 
         return new GuidUdi(entityType, entity.Key).EnsureClosed();
     }
 
     /// <summary>
-    ///     Gets the entity identifier of the entity.
+    /// Gets the entity identifier of the entity.
     /// </summary>
     /// <param name="entity">The entity.</param>
-    /// <returns>The entity identifier of the entity.</returns>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
     public static GuidUdi GetUdi(this IMedia entity)
     {
-        if (entity == null)
-        {
-            throw new ArgumentNullException("entity");
-        }
+        ArgumentNullException.ThrowIfNull(entity);
 
         return new GuidUdi(Constants.UdiEntityType.Media, entity.Key).EnsureClosed();
     }
 
     /// <summary>
-    ///     Gets the entity identifier of the entity.
+    /// Gets the entity identifier of the entity.
     /// </summary>
     /// <param name="entity">The entity.</param>
-    /// <returns>The entity identifier of the entity.</returns>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
     public static GuidUdi GetUdi(this IContent entity)
     {
-        if (entity == null)
-        {
-            throw new ArgumentNullException("entity");
-        }
+        ArgumentNullException.ThrowIfNull(entity);
 
-        return new GuidUdi(
-                entity.Blueprint ? Constants.UdiEntityType.DocumentBlueprint : Constants.UdiEntityType.Document,
-                entity.Key)
-            .EnsureClosed();
+        string entityType = entity.Blueprint ? Constants.UdiEntityType.DocumentBlueprint : Constants.UdiEntityType.Document;
+
+        return new GuidUdi(entityType, entity.Key).EnsureClosed();
     }
 
     /// <summary>
-    ///     Gets the entity identifier of the entity.
+    /// Gets the entity identifier of the entity.
     /// </summary>
     /// <param name="entity">The entity.</param>
-    /// <returns>The entity identifier of the entity.</returns>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
     public static GuidUdi GetUdi(this IMember entity)
     {
-        if (entity == null)
-        {
-            throw new ArgumentNullException("entity");
-        }
+        ArgumentNullException.ThrowIfNull(entity);
 
         return new GuidUdi(Constants.UdiEntityType.Member, entity.Key).EnsureClosed();
     }
 
     /// <summary>
-    ///     Gets the entity identifier of the entity.
+    /// Gets the entity identifier of the entity.
     /// </summary>
     /// <param name="entity">The entity.</param>
-    /// <returns>The entity identifier of the entity.</returns>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
     public static StringUdi GetUdi(this Stylesheet entity)
     {
-        if (entity == null)
-        {
-            throw new ArgumentNullException("entity");
-        }
+        ArgumentNullException.ThrowIfNull(entity);
 
         return GetUdiFromPath(Constants.UdiEntityType.Stylesheet, entity.Path);
     }
 
     /// <summary>
-    ///     Gets the entity identifier of the entity.
+    /// Gets the entity identifier of the entity.
     /// </summary>
     /// <param name="entity">The entity.</param>
-    /// <returns>The entity identifier of the entity.</returns>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
     public static StringUdi GetUdi(this Script entity)
     {
-        if (entity == null)
-        {
-            throw new ArgumentNullException("entity");
-        }
+        ArgumentNullException.ThrowIfNull(entity);
 
         return GetUdiFromPath(Constants.UdiEntityType.Script, entity.Path);
     }
 
+    /// <summary>
+    /// Gets the UDI from a path.
+    /// </summary>
+    /// <param name="entityType">The type of the entity.</param>
+    /// <param name="path">The path.</param>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
     private static StringUdi GetUdiFromPath(string entityType, string path)
     {
-        var id = path
-            .TrimStart(Constants.CharArrays.ForwardSlash)
-            .Replace("\\", "/");
+        string id = path.TrimStart(Constants.CharArrays.ForwardSlash).Replace("\\", "/");
+
         return new StringUdi(entityType, id).EnsureClosed();
     }
 
     /// <summary>
-    ///     Gets the entity identifier of the entity.
+    /// Gets the entity identifier of the entity.
     /// </summary>
     /// <param name="entity">The entity.</param>
-    /// <returns>The entity identifier of the entity.</returns>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
     public static GuidUdi GetUdi(this IDictionaryItem entity)
     {
-        if (entity == null)
-        {
-            throw new ArgumentNullException("entity");
-        }
+        ArgumentNullException.ThrowIfNull(entity);
 
         return new GuidUdi(Constants.UdiEntityType.DictionaryItem, entity.Key).EnsureClosed();
     }
 
     /// <summary>
-    ///     Gets the entity identifier of the entity.
+    /// Gets the entity identifier of the entity.
     /// </summary>
     /// <param name="entity">The entity.</param>
-    /// <returns>The entity identifier of the entity.</returns>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
     public static GuidUdi GetUdi(this IMacro entity)
     {
-        if (entity == null)
-        {
-            throw new ArgumentNullException("entity");
-        }
+        ArgumentNullException.ThrowIfNull(entity);
 
         return new GuidUdi(Constants.UdiEntityType.Macro, entity.Key).EnsureClosed();
     }
 
     /// <summary>
-    ///     Gets the entity identifier of the entity.
+    /// Gets the entity identifier of the entity.
     /// </summary>
     /// <param name="entity">The entity.</param>
-    /// <returns>The entity identifier of the entity.</returns>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
     public static StringUdi GetUdi(this IPartialView entity)
     {
-        if (entity == null)
-        {
-            throw new ArgumentNullException("entity");
-        }
+        ArgumentNullException.ThrowIfNull(entity);
 
-        // we should throw on Unknown but for the time being, assume it means PartialView
-        var entityType = entity.ViewType == PartialViewType.PartialViewMacro
-            ? Constants.UdiEntityType.PartialViewMacro
-            : Constants.UdiEntityType.PartialView;
+        // TODO: We should throw on Unknown, but for the time being, assume it means PartialView
+        string entityType = entity.ViewType switch
+        {
+            PartialViewType.PartialViewMacro => Constants.UdiEntityType.PartialViewMacro,
+            _ => Constants.UdiEntityType.PartialView,
+        };
 
         return GetUdiFromPath(entityType, entity.Path);
     }
 
     /// <summary>
-    ///     Gets the entity identifier of the entity.
+    /// Gets the entity identifier of the entity.
     /// </summary>
     /// <param name="entity">The entity.</param>
-    /// <returns>The entity identifier of the entity.</returns>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
     public static GuidUdi GetUdi(this IContentBase entity)
     {
-        if (entity == null)
-        {
-            throw new ArgumentNullException("entity");
-        }
+        ArgumentNullException.ThrowIfNull(entity);
 
-        string type;
-        if (entity is IContent)
+        string type = entity switch
         {
-            type = Constants.UdiEntityType.Document;
-        }
-        else if (entity is IMedia)
-        {
-            type = Constants.UdiEntityType.Media;
-        }
-        else if (entity is IMember)
-        {
-            type = Constants.UdiEntityType.Member;
-        }
-        else
-        {
-            throw new NotSupportedException(string.Format(
-                "ContentBase type {0} is not supported.",
-                entity.GetType().FullName));
-        }
+            IContent => Constants.UdiEntityType.Document,
+            IMedia => Constants.UdiEntityType.Media,
+            IMember => Constants.UdiEntityType.Member,
+            _ => throw new NotSupportedException(string.Format("Content base type {0} is not supported.", entity.GetType().FullName)),
+        };
 
         return new GuidUdi(type, entity.Key).EnsureClosed();
     }
 
     /// <summary>
-    ///     Gets the entity identifier of the entity.
+    /// Gets the entity identifier of the entity.
     /// </summary>
     /// <param name="entity">The entity.</param>
-    /// <returns>The entity identifier of the entity.</returns>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
     public static GuidUdi GetUdi(this IRelationType entity)
     {
-        if (entity == null)
-        {
-            throw new ArgumentNullException("entity");
-        }
+        ArgumentNullException.ThrowIfNull(entity);
 
         return new GuidUdi(Constants.UdiEntityType.RelationType, entity.Key).EnsureClosed();
     }
 
     /// <summary>
-    ///     Gets the entity identifier of the entity.
+    /// Gets the entity identifier of the entity.
     /// </summary>
     /// <param name="entity">The entity.</param>
-    /// <returns>The entity identifier of the entity.</returns>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
     public static GuidUdi GetUdi(this IWebhook entity)
     {
-        if (entity == null)
-        {
-            throw new ArgumentNullException("entity");
-        }
+        ArgumentNullException.ThrowIfNull(entity);
 
         return new GuidUdi(Constants.UdiEntityType.Webhook, entity.Key).EnsureClosed();
     }
 
     /// <summary>
-    ///     Gets the entity identifier of the entity.
+    /// Gets the entity identifier of the entity.
     /// </summary>
     /// <param name="entity">The entity.</param>
-    /// <returns>The entity identifier of the entity.</returns>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
     public static StringUdi GetUdi(this ILanguage entity)
     {
-        if (entity == null)
-        {
-            throw new ArgumentNullException("entity");
-        }
+        ArgumentNullException.ThrowIfNull(entity);
 
         return new StringUdi(Constants.UdiEntityType.Language, entity.IsoCode).EnsureClosed();
     }
 
     /// <summary>
-    ///     Gets the entity identifier of the entity.
+    /// Gets the entity identifier of the entity.
     /// </summary>
     /// <param name="entity">The entity.</param>
-    /// <returns>The entity identifier of the entity.</returns>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
     public static Udi GetUdi(this IEntity entity)
     {
-        if (entity == null)
-        {
-            throw new ArgumentNullException("entity");
-        }
+        ArgumentNullException.ThrowIfNull(entity);
 
-        // entity could eg be anything implementing IThing
-        // so we have to go through casts here
-        if (entity is ITemplate template)
+        return entity switch
         {
-            return template.GetUdi();
-        }
-
-        if (entity is IContentType contentType)
-        {
-            return contentType.GetUdi();
-        }
-
-        if (entity is IMediaType mediaType)
-        {
-            return mediaType.GetUdi();
-        }
-
-        if (entity is IMemberType memberType)
-        {
-            return memberType.GetUdi();
-        }
-
-        if (entity is IMemberGroup memberGroup)
-        {
-            return memberGroup.GetUdi();
-        }
-
-        if (entity is IContentTypeComposition contentTypeComposition)
-        {
-            return contentTypeComposition.GetUdi();
-        }
-
-        if (entity is IDataType dataTypeComposition)
-        {
-            return dataTypeComposition.GetUdi();
-        }
-
-        if (entity is EntityContainer container)
-        {
-            return container.GetUdi();
-        }
-
-        if (entity is IMedia media)
-        {
-            return media.GetUdi();
-        }
-
-        if (entity is IContent content)
-        {
-            return content.GetUdi();
-        }
-
-        if (entity is IMember member)
-        {
-            return member.GetUdi();
-        }
-
-        if (entity is Stylesheet stylesheet)
-        {
-            return stylesheet.GetUdi();
-        }
-
-        if (entity is Script script)
-        {
-            return script.GetUdi();
-        }
-
-        if (entity is IDictionaryItem dictionaryItem)
-        {
-            return dictionaryItem.GetUdi();
-        }
-
-        if (entity is IMacro macro)
-        {
-            return macro.GetUdi();
-        }
-
-        if (entity is IPartialView partialView)
-        {
-            return partialView.GetUdi();
-        }
-
-        if (entity is IContentBase contentBase)
-        {
-            return contentBase.GetUdi();
-        }
-
-        if (entity is IRelationType relationType)
-        {
-            return relationType.GetUdi();
-        }
-
-        if (entity is ILanguage language)
-        {
-            return language.GetUdi();
-        }
-
-        if (entity is IWebhook webhook)
-        {
-            return webhook.GetUdi();
-        }
-
-        throw new NotSupportedException(string.Format("Entity type {0} is not supported.", entity.GetType().FullName));
+            // Concrete types
+            EntityContainer container => container.GetUdi(),
+            Stylesheet stylesheet => stylesheet.GetUdi(),
+            Script script => script.GetUdi(),
+            // Content types
+            IContentType contentType => contentType.GetUdi(),
+            IMediaType mediaType => mediaType.GetUdi(),
+            IMemberType memberType => memberType.GetUdi(),
+            IContentTypeComposition contentTypeComposition => contentTypeComposition.GetUdi(),
+            // Content
+            IContent content => content.GetUdi(),
+            IMedia media => media.GetUdi(),
+            IMember member => member.GetUdi(),
+            IContentBase contentBase => contentBase.GetUdi(),
+            // Other
+            IDataType dataTypeComposition => dataTypeComposition.GetUdi(),
+            IDictionaryItem dictionaryItem => dictionaryItem.GetUdi(),
+            ILanguage language => language.GetUdi(),
+            IMacro macro => macro.GetUdi(),
+            IMemberGroup memberGroup => memberGroup.GetUdi(),
+            IPartialView partialView => partialView.GetUdi(),
+            IRelationType relationType => relationType.GetUdi(),
+            ITemplate template => template.GetUdi(),
+            IWebhook webhook => webhook.GetUdi(),
+            _ => throw new NotSupportedException(string.Format("Entity type {0} is not supported.", entity.GetType().FullName)),
+        };
     }
 }

--- a/tests/Umbraco.Tests.Common/Builders/WebhookBuilder.cs
+++ b/tests/Umbraco.Tests.Common/Builders/WebhookBuilder.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Tests.Common.Builders.Interfaces;
+
+namespace Umbraco.Cms.Tests.Common.Builders;
+
+public class WebhookBuilder
+    : BuilderBase<IWebhook>,
+        IWithIdBuilder,
+        IWithKeyBuilder
+{
+    private int? _id;
+    private Guid? _key;
+    private string? _url;
+    private bool? _enabled;
+    private Guid[] _entityKeys;
+    private string[]? _events;
+    private Dictionary<string, string>? _headers;
+
+    int? IWithIdBuilder.Id
+    {
+        get => _id;
+        set => _id = value;
+    }
+
+    Guid? IWithKeyBuilder.Key
+    {
+        get => _key;
+        set => _key = value;
+    }
+
+    public WebhookBuilder WithUrl(string url)
+    {
+        _url = url;
+        return this;
+    }
+
+    public WebhookBuilder WithEnabled(bool enabled)
+    {
+        _enabled = enabled;
+        return this;
+    }
+
+    public WebhookBuilder WithEntityKeys(Guid[] entityKeys)
+    {
+        _entityKeys = entityKeys;
+        return this;
+    }
+
+    public WebhookBuilder WithEvents(string[] events)
+    {
+        _events = events;
+        return this;
+    }
+
+    public WebhookBuilder WithHeaders(Dictionary<string, string> headers)
+    {
+        _headers = headers;
+        return this;
+    }
+
+    public override Webhook Build()
+    {
+        var id = _id ?? 1;
+        var key = _key ?? Guid.NewGuid();
+        var url = _url ?? "https://example.com";
+        var enabled = _enabled ?? true;
+        var entityKeys = _entityKeys;
+        var events = _events;
+        var headers = _headers;
+
+        return new Webhook(url, enabled, entityKeys, events, headers)
+        {
+            Id = id,
+            Key = key
+        };
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/UdiGetterExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/UdiGetterExtensionsTests.cs
@@ -2,7 +2,9 @@
 // See LICENSE for more details.
 
 using NUnit.Framework;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Extensions;
 
@@ -47,6 +49,21 @@ public class UdiGetterExtensionsTests
             .WithViewType(viewType)
             .Build();
         var result = partialView.GetUdi();
+        Assert.AreEqual(expected, result.ToString());
+    }
+
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://webhook/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForWebhook(string key, string expected)
+    {
+        IWebhook webhook = new Webhook("https://example.com")
+        {
+            Key = Guid.Parse(key)
+        };
+
+        Udi result = webhook.GetUdi();
+        Assert.AreEqual(expected, result.ToString());
+
+        result = ((IEntity)webhook).GetUdi();
         Assert.AreEqual(expected, result.ToString());
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/UdiGetterExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/UdiGetterExtensionsTests.cs
@@ -6,6 +6,7 @@ using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Extensions;
@@ -55,10 +56,10 @@ public class UdiGetterExtensionsTests
     [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://webhook/6ad82c70685c4e049b36d81bd779d16f")]
     public void GetUdiForWebhook(string key, string expected)
     {
-        IWebhook webhook = new Webhook("https://example.com")
-        {
-            Key = Guid.Parse(key)
-        };
+        var builder = new WebhookBuilder();
+        var webhook = builder
+            .WithKey(Guid.Parse(key))
+            .Build();
 
         Udi result = webhook.GetUdi();
         Assert.AreEqual(expected, result.ToString());

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Tests.Common/Builders/WebhookBuilderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Tests.Common/Builders/WebhookBuilderTests.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using NUnit.Framework;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Tests.Common.Builders;
+
+[TestFixture]
+public class WebhookBuilderTests
+{
+    [Test]
+    public void Is_Built_Correctly()
+    {
+        // Arrange
+        const int id = 1;
+        var key = Guid.NewGuid();
+        const string url = "https://www.test.com";
+        const bool enabled = true;
+        Guid[] entityKeys = new Guid[] { Guid.NewGuid() };
+        string[] events = new string[] { "ContentPublished" };
+        var headers = new Dictionary<string, string>() { { "Content-Type", "application/json" } };
+
+        var builder = new WebhookBuilder();
+
+        // Act
+        var webhook = builder
+            .WithId(id)
+            .WithKey(key)
+            .WithUrl(url)
+            .WithEnabled(enabled)
+            .WithEntityKeys(entityKeys)
+            .WithEvents(events)
+            .WithHeaders(headers)
+            .Build();
+
+        // Assert
+        Assert.AreEqual(id, webhook.Id);
+        Assert.AreEqual(key, webhook.Key);
+        Assert.AreEqual(url, webhook.Url);
+        Assert.AreEqual(enabled, webhook.Enabled);
+        Assert.AreEqual(entityKeys.Length, webhook.ContentTypeKeys.Length);
+        Assert.AreEqual(entityKeys[0], webhook.ContentTypeKeys[0]);
+        Assert.AreEqual(events.Length, webhook.Events.Length);
+        Assert.AreEqual(events[0], webhook.Events[0]);
+        Assert.AreEqual(events.Length, webhook.Events.Length);
+        Assert.AreEqual("application/json", webhook.Headers["Content-Type"]);
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Although PR https://github.com/umbraco/Umbraco-CMS/pull/15267 includes most of the boilerplate code to make `Webhook` implement `IEntity`, the `GetUdi()` extension method wasn't updated to use the interface and the `IEntity.GetUdi()` extension method didn't support the webhook entity type. This PR fixes both of these issues in the first commit.

I've also taken the opportunity to refactor the code in the second commit, so it's much more compact and readable by using:
- `ArgumentNullException.ThrowIfNull()` for all null checks (although we're already in a nullable context);
- `switch` expressions, which also takes care of detecting unreachable code, in case multiple types would match (e.g. `IContent` and `IContentBase`).

Finally, I've also added a quick unit test to verify the `GetUdi()` extension methods do what they should 😄 