### PR TITLE
Add content item resolver filter

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/filters/contentItemResolver.filter.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/contentItemResolver.filter.js
@@ -44,7 +44,7 @@
 
 
   // Filter loads content Item Model from a content Key.
-  // Usage: {{ mycontentProperty[0].contentKey | contentItemResolver }}
+  // Usage: {{ mycontentProperty[0].key | contentItemResolver }}
   angular.module("umbraco.filters").filter("contentItemResolver", function (contentItemResolverFilterService) {
 
     contentItemResolverFilter.$stateful = true;

--- a/src/Umbraco.Web.UI.Client/src/common/filters/contentItemResolver.filter.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/contentItemResolver.filter.js
@@ -1,0 +1,65 @@
+(function () {
+  "use strict";
+
+  function contentItemResolverFilterService(contentResource, eventsService) {
+    
+    var contentKeysRequest = [];
+    var contentItemCache = [];
+
+    var service = {
+      
+      getByKey: function (key) {
+        // Is it cached, then get that:
+        const cachedcontentItem = contentItemCache.find(cache => key === cache.key);
+        if (cachedcontentItem) {
+          return cachedcontentItem;
+        }
+
+        // check its not already being loaded, and then start loading:
+        if (contentKeysRequest.indexOf(key) === -1) {
+          contentKeysRequest.push(key);
+          contentResource.getById(key).then(contentItem => {
+            if (contentItem) {
+              contentItemCache.push(contentItem);
+            }
+          });
+        }
+
+        return null;
+      }
+    };
+
+    eventsService.on("content.saved", function (name, args) {
+      const index = contentItemCache.findIndex(cache => cache.key === args.content.key);
+      if (index !== -1) {
+        contentItemCache[index] = args.content;
+      }
+    });
+
+    return service;
+
+  }
+  
+  angular.module("umbraco.filters").factory("contentItemResolverFilterService", contentItemResolverFilterService);
+
+
+  // Filter loads content Item Model from a content Key.
+  // Usage: {{ mycontentProperty[0].contentKey | contentItemResolver }}
+  angular.module("umbraco.filters").filter("contentItemResolver", function (contentItemResolverFilterService) {
+
+    contentItemResolverFilter.$stateful = true;
+    function contentItemResolverFilter(input) {
+
+      // Check we have a value at all
+      if (typeof input === 'string' && input.length > 0) {
+        return contentItemResolverFilterService.getByKey(input);
+      }
+
+      return null;
+    }
+
+    return contentItemResolverFilter;
+
+  });
+
+})();

--- a/src/Umbraco.Web.UI.Client/src/common/filters/mediaItemResolver.filter.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/mediaItemResolver.filter.js
@@ -1,4 +1,4 @@
-﻿(function () {
+(function () {
   "use strict";
 
   function mediaItemResolverFilterService(mediaResource, eventsService) {
@@ -11,15 +11,15 @@
       getByKey: function (key) {
         // Is it cached, then get that:
         const cachedMediaItem = mediaItemCache.find(cache => key === cache.key);
-        if(cachedMediaItem) {
+        if (cachedMediaItem) {
           return cachedMediaItem;
         }
 
         // check its not already being loaded, and then start loading:
-        if(mediaKeysRequest.indexOf(key) === -1) {
+        if (mediaKeysRequest.indexOf(key) === -1) {
           mediaKeysRequest.push(key);
-          mediaResource.getById(key).then(function (mediaItem) {
-            if(mediaItem) {
+          mediaResource.getById(key).then(mediaItem => {
+            if (mediaItem) {
               mediaItemCache.push(mediaItem);
             }
           });
@@ -31,7 +31,7 @@
 
     eventsService.on("editors.media.saved", function (name, args) {
       const index = mediaItemCache.findIndex(cache => cache.key === args.media.key);
-      if(index !== -1) {
+      if (index !== -1) {
         mediaItemCache[index] = args.media;
       }
     });


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Currently we have a `mediaItemResolver` filter, which is useful in block previews, label expressions, dashboards, property editors etc.
However we don't have a equivalent `contentItemResolver` for content.

While `mediaItemResolver` listen to `editors.media.saved` event, I noticed it is just called `content.saved` for content.

https://github.com/umbraco/Umbraco-CMS/blob/ade61f7ec574ae1790f6c217c0da0816ff77b2c3/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js#L510

**Media**

```
myMediaProperty[0].mediaKey | mediaItemResolver
```

**Content**

```
myMediaProperty[0].key | contentItemResolver
```

Furthermore `ncNodeName` filter is great, but only resolved node name - often it is useful to fetch another property like a title or another custom property.