### PR TITLE
Make InstallMissingDatabase nullable.

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
@@ -130,7 +130,7 @@ public class GlobalSettings
     ///     Gets or sets a value indicating whether to install the database when it is missing.
     /// </summary>
     [DefaultValue(StaticInstallMissingDatabase)]
-    public bool InstallMissingDatabase { get; set; } = StaticInstallMissingDatabase;
+    public bool? InstallMissingDatabase { get; set; } = StaticInstallMissingDatabase;
 
     /// <summary>
     ///     Gets or sets a value indicating whether to disable the election for a single server.

--- a/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
@@ -25,7 +25,6 @@ public class GlobalSettings
     internal const string StaticUmbracoCssPath = "~/css";
     internal const string StaticUmbracoScriptsPath = "~/scripts";
     internal const string StaticUmbracoMediaPath = "~/media";
-    internal const bool StaticInstallMissingDatabase = false;
     internal const bool StaticDisableElectionForSingleServer = false;
     internal const string StaticNoNodesViewPath = "~/umbraco/UmbracoWebsite/NoNodes.cshtml";
     internal const string StaticDistributedLockingReadLockDefaultTimeout = "00:01:00";
@@ -129,8 +128,7 @@ public class GlobalSettings
     /// <summary>
     ///     Gets or sets a value indicating whether to install the database when it is missing.
     /// </summary>
-    [DefaultValue(StaticInstallMissingDatabase)]
-    public bool? InstallMissingDatabase { get; set; } = StaticInstallMissingDatabase;
+    public bool? InstallMissingDatabase { get; set; } = null;
 
     /// <summary>
     ///     Gets or sets a value indicating whether to disable the election for a single server.

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseBuilder.cs
@@ -225,17 +225,25 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install
                     throw new InstallException("Didn't retrieve updated connection string within 10 seconds, try manual configuration instead.");
                 }
 
-                Configure(_globalSettings.CurrentValue.InstallMissingDatabase || providerMeta.ForceCreateDatabase);
+                Configure(_globalSettings.CurrentValue.InstallMissingDatabase, providerMeta.ForceCreateDatabase);
             }
 
             return true;
         }
 
-        private void Configure(bool installMissingDatabase)
+        private void Configure(bool? installMissingDatabase, bool forceCreateDatabase)
         {
             _databaseFactory.Configure(_connectionStrings.CurrentValue);
 
-            if (installMissingDatabase)
+            if (installMissingDatabase == false)
+            {
+                return;
+            }
+            else if (installMissingDatabase == null && forceCreateDatabase == true)
+            {
+                CreateDatabase();
+            }
+            else if (installMissingDatabase == true)
             {
                 CreateDatabase();
             }


### PR DESCRIPTION
InstallMissingDatabase should be nullable so that if 1. the variable is false, Umbraco will not install missing database under any circumstances and 2. if the variable is null, the installation of the missing database is deferred to CanForceCreateDatabase and 3. if the variable is true, the missing database will always be created.

### Prerequisites

- [] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [14956](https://github.com/umbraco/Umbraco-CMS/issues/14956)

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
