### PR TITLE
feat: Add XML docs to the swagger UI

### DIFF
--- a/src/Umbraco.Cms.Api.Common/Configuration/ConfigureUmbracoSwaggerGenOptions.cs
+++ b/src/Umbraco.Cms.Api.Common/Configuration/ConfigureUmbracoSwaggerGenOptions.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Controllers;
@@ -57,9 +58,26 @@ public class ConfigureUmbracoSwaggerGenOptions : IConfigureOptions<SwaggerGenOpt
         swaggerGenOptions.SchemaFilter<EnumSchemaFilter>();
         swaggerGenOptions.CustomSchemaIds(_schemaIdSelector.SchemaId);
         swaggerGenOptions.SupportNonNullableReferenceTypes();
+
+        AddXmlCommentsToSwagger(swaggerGenOptions);
     }
 
     // see https://github.com/domaindrivendev/Swashbuckle.AspNetCore#change-operation-sort-order-eg-for-ui-sorting
     private static string ActionOrderBy(ApiDescription apiDesc)
         => $"{apiDesc.GroupName}_{apiDesc.ActionDescriptor.AttributeRouteInfo?.Template ?? apiDesc.ActionDescriptor.RouteValues["controller"]}_{apiDesc.ActionDescriptor.RouteValues["action"]}_{apiDesc.HttpMethod}";
+
+    private static void AddXmlCommentsToSwagger(SwaggerGenOptions options)
+    {
+        Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
+
+        foreach (Assembly assembly in assemblies)
+        {
+            string xmlFile = $"{assembly.GetName().Name}.xml";
+            string xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
+            if (File.Exists(xmlPath))
+            {
+                options.IncludeXmlComments(xmlPath);
+            }
+        }
+    }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

This PR adds the XML documentation in the source code to the Swagger UI making the documentation of the endpoints more clear. This works both for Umbracos APIs that are exposed in Swagger and any custom APIs that are exposed.

This is done by scanning all assemblies for XML documentation.

To add XML documentation from custom APIs the project where the endpoints/controllers are defined needs to have the `<GenerateDocumentationFile>true</GenerateDocumentationFile>` setting set in the `csproj` file.

Example of the Delivery API:

Before:
![image](https://github.com/umbraco/Umbraco-CMS/assets/24605285/972a152a-b636-45fc-835f-66b15e599737)


After:
![image](https://github.com/umbraco/Umbraco-CMS/assets/24605285/7607f114-c632-4091-bc38-b53875a5f83e)


<!-- Thanks for contributing to Umbraco CMS! -->
