### PR TITLE
Suggestion: Always register SwaggerUI

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Delivery/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -39,7 +39,6 @@ public static class UmbracoBuilderExtensions
         builder.Services.AddTransient<IRequestMemberAccessService, RequestMemberAccessService>();
 
         builder.Services.ConfigureOptions<ConfigureUmbracoDeliveryApiSwaggerGenOptions>();
-        builder.AddUmbracoApiOpenApiUI();
 
         builder
             .Services

--- a/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Api.Common.DependencyInjection;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.IO;
@@ -55,7 +56,8 @@ public static partial class UmbracoBuilderExtensions
             .AddExamine()
             .AddExamineIndexes()
             .AddControllersWithAmbiguousConstructors()
-            .AddSupplemenataryLocalizedTextFileSources();
+            .AddSupplemenataryLocalizedTextFileSources()
+            .AddUmbracoApiOpenApiUI();
 
     public static IUmbracoBuilder AddUnattendedInstallInstallCreateUser(this IUmbracoBuilder builder)
     {

--- a/src/Umbraco.Web.BackOffice/Umbraco.Web.BackOffice.csproj
+++ b/src/Umbraco.Web.BackOffice/Umbraco.Web.BackOffice.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Umbraco.Cms.Api.Common\Umbraco.Cms.Api.Common.csproj" />
     <ProjectReference Include="..\Umbraco.Web.Common\Umbraco.Web.Common.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

This PR moves the SwaggerUI registration to the `AddBackOffice` call instead of the `AddDeliveryApi` call. This makes sure that the SwaggerUI is active even when you are not using the DeliveryAPI.

#### Reasoning
I'll just preface this with "I'm not sure if this is the best place to put it", but I think it's a bit weird that all the setup of SwaggerUI is lost when turning off the delivery API. I think there's a great possibility for developers just using the built-in setup for documenting custom APIs in their Umbraco implementation.

Also, I think this would be great for package developers who would like to expose Swagger definitions of the endpoints from the package installed.

### To test this

For testing you just comment out the `.AddDeliveryApi` call in the setup and navigate to `/umbraco/swagger` and the SwaggerUI will be shown.

<!-- Thanks for contributing to Umbraco CMS! -->
