### PR TITLE
Log meaningful job names and use template based log messages

### DIFF
--- a/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedServiceRunner.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedServiceRunner.cs
@@ -11,7 +11,7 @@ public class RecurringBackgroundJobHostedServiceRunner : IHostedService
     private readonly ILogger<RecurringBackgroundJobHostedServiceRunner> _logger;
     private readonly List<IRecurringBackgroundJob> _jobs;
     private readonly Func<IRecurringBackgroundJob, IHostedService> _jobFactory;
-    private readonly List<(IHostedService HostedService, string JobName)> _hostedServices = new();
+    private readonly List<NamedServiceJob> _hostedServices = new();
 
 
     public RecurringBackgroundJobHostedServiceRunner(
@@ -34,13 +34,13 @@ public class RecurringBackgroundJobHostedServiceRunner : IHostedService
             try
             {
 
-                _logger.LogInformation("Creating background hosted service for {job}", jobName);
+                _logger.LogDebug("Creating background hosted service for {job}", jobName);
                 IHostedService hostedService = _jobFactory(job);
 
                 _logger.LogInformation("Starting background hosted service for {job}", jobName);
                 await hostedService.StartAsync(cancellationToken).ConfigureAwait(false);
 
-                _hostedServices.Add((hostedService, jobName));
+                _hostedServices.Add(new NamedServiceJob(jobName, hostedService));
             }
             catch (Exception exception)
             {
@@ -55,20 +55,32 @@ public class RecurringBackgroundJobHostedServiceRunner : IHostedService
     {
         _logger.LogInformation("Stopping recurring background jobs hosted services");
 
-        foreach ((IHostedService HostedService, string JobName) pair in _hostedServices)
+        foreach (NamedServiceJob namedServiceJob in _hostedServices)
         {
             try
             {
-                _logger.LogInformation("Stopping background hosted service for {job}", pair.JobName);
-                await pair.HostedService.StopAsync(stoppingToken).ConfigureAwait(false);
+                _logger.LogInformation("Stopping background hosted service for {job}", namedServiceJob.Name);
+                await namedServiceJob.HostedService.StopAsync(stoppingToken).ConfigureAwait(false);
             }
             catch (Exception exception)
             {
-                _logger.LogError(exception, "Failed to stop background hosted service for {job}", pair.JobName);
+                _logger.LogError(exception, "Failed to stop background hosted service for {job}", namedServiceJob.Name);
             }
         }
 
         _logger.LogInformation("Completed stopping recurring background jobs hosted services");
+    }
 
+    private class NamedServiceJob
+    {
+        public NamedServiceJob(string name, IHostedService hostedService)
+        {
+            Name = name;
+            HostedService = hostedService;
+        }
+
+        public string Name { get; }
+
+        public IHostedService HostedService { get; }
     }
 }

--- a/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedServiceRunner.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedServiceRunner.cs
@@ -1,12 +1,5 @@
-using System.Linq;
-using System.Threading;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Umbraco.Cms.Core.Runtime;
-using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Core.Sync;
-using Umbraco.Cms.Infrastructure.ModelsBuilder;
 
 namespace Umbraco.Cms.Infrastructure.BackgroundJobs;
 
@@ -18,7 +11,7 @@ public class RecurringBackgroundJobHostedServiceRunner : IHostedService
     private readonly ILogger<RecurringBackgroundJobHostedServiceRunner> _logger;
     private readonly List<IRecurringBackgroundJob> _jobs;
     private readonly Func<IRecurringBackgroundJob, IHostedService> _jobFactory;
-    private IList<IHostedService> _hostedServices = new List<IHostedService>();
+    private readonly List<(IHostedService HostedService, string JobName)> _hostedServices = new();
 
 
     public RecurringBackgroundJobHostedServiceRunner(
@@ -33,45 +26,45 @@ public class RecurringBackgroundJobHostedServiceRunner : IHostedService
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Creating recurring background jobs hosted services");
-
-        // create hosted services for each background job
-        _hostedServices = _jobs.Select(_jobFactory).ToList();
-
         _logger.LogInformation("Starting recurring background jobs hosted services");
 
-        foreach (IHostedService hostedService in _hostedServices)
+        foreach (IRecurringBackgroundJob job in _jobs)
         {
+            var jobName = job.GetType().Name;
             try
             {
-                _logger.LogInformation($"Starting background hosted service for {hostedService.GetType().Name}");
+
+                _logger.LogInformation("Creating background hosted service for {job}", jobName);
+                IHostedService hostedService = _jobFactory(job);
+
+                _logger.LogInformation("Starting background hosted service for {job}", jobName);
                 await hostedService.StartAsync(cancellationToken).ConfigureAwait(false);
+
+                _hostedServices.Add((hostedService, jobName));
             }
             catch (Exception exception)
             {
-                _logger.LogError(exception, $"Failed to start background hosted service for {hostedService.GetType().Name}");
+                _logger.LogError(exception, "Failed to start background hosted service for {job}", jobName);
             }
         }
 
         _logger.LogInformation("Completed starting recurring background jobs hosted services");
-
-
     }
 
     public async Task StopAsync(CancellationToken stoppingToken)
     {
         _logger.LogInformation("Stopping recurring background jobs hosted services");
 
-        foreach (IHostedService hostedService in _hostedServices)
+        foreach ((IHostedService HostedService, string JobName) pair in _hostedServices)
         {
             try
             {
-                _logger.LogInformation($"Stopping background hosted service for {hostedService.GetType().Name}");
-                await hostedService.StopAsync(stoppingToken).ConfigureAwait(false);
+                _logger.LogInformation("Stopping background hosted service for {job}", pair.JobName);
+                await pair.HostedService.StopAsync(stoppingToken).ConfigureAwait(false);
             }
             catch (Exception exception)
             {
-                _logger.LogError(exception, $"Failed to stop background hosted service for {hostedService.GetType().Name}");
+                _logger.LogError(exception, "Failed to stop background hosted service for {job}", pair.JobName);
             }
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/15302

### Description

As described in the linked issue, the new `RecurringBackgroundJobHostedServiceRunner` has a little flaw in its logging: It doesn't log the actual names of the jobs it's starting, but the generic type of the hosted service instead:

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/5249afc4-3b3c-45ae-af1e-d6977ce6cdc5)

This PR makes the logging a little bit more verbose, in order to log both the creation and the start-up of each individual hosted service - this time using the job names:

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/b231f443-7206-403d-8207-1f3a67e556a4)

While I was here, I also changed all logging to use template based log messages.

### Testing this PR

All recurring jobs (hosted services) should start and run as per usual. The log should display the names of the jobs rather than the generic type of the hosted service.
