### PR TITLE
Add missing API version attributes to Management API controllers

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/AllowedChildrenDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/AllowedChildrenDocumentController.cs
@@ -13,6 +13,7 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document;
 
+[ApiVersion("1.0")]
 [Authorize(Policy = "New" + AuthorizationPolicies.TreeAccessDocumentsOrDocumentTypes)]
 public class AllowedChildrenDocumentController : DocumentControllerBase
 {

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/CreatePublicAccessDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/CreatePublicAccessDocumentController.cs
@@ -10,6 +10,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document;
 
+[ApiVersion("1.0")]
 public class CreatePublicAccessDocumentController : DocumentControllerBase
 {
     private readonly IPublicAccessService _publicAccessService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/DeletePublicAccessDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/DeletePublicAccessDocumentController.cs
@@ -5,6 +5,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document;
 
+[ApiVersion("1.0")]
 public class DeletePublicAccessDocumentController : DocumentControllerBase
 {
     private readonly IPublicAccessService _publicAccessService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/GetPublicAccessDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/GetPublicAccessDocumentController.cs
@@ -10,6 +10,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document;
 
+[ApiVersion("1.0")]
 public class GetPublicAccessDocumentController : DocumentControllerBase
 {
     private readonly IPublicAccessService _publicAccessService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/PublishDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/PublishDocumentController.cs
@@ -9,6 +9,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document;
 
+[ApiVersion("1.0")]
 public class PublishDocumentController : DocumentControllerBase
 {
     private readonly IContentPublishingService _contentPublishingService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/PublishDocumentWithDescendantsController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/PublishDocumentWithDescendantsController.cs
@@ -9,6 +9,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document;
 
+[ApiVersion("1.0")]
 public class PublishDocumentWithDescendantsController : DocumentControllerBase
 {
     private readonly IContentPublishingService _contentPublishingService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/UnpublishDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/UnpublishDocumentController.cs
@@ -9,6 +9,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document;
 
+[ApiVersion("1.0")]
 public class UnpublishDocumentController : DocumentControllerBase
 {
     private readonly IContentPublishingService _contentPublishingService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/UpdatePublicAccessDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/UpdatePublicAccessDocumentController.cs
@@ -10,6 +10,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document;
 
+[ApiVersion("1.0")]
 public class UpdatePublicAccessDocumentController : DocumentControllerBase
 {
     private readonly IPublicAccessPresentationFactory _publicAccessPresentationFactory;

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/Current/GetDocumentPermissionsCurrentUserController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/Current/GetDocumentPermissionsCurrentUserController.cs
@@ -11,6 +11,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User.Current;
 
+[ApiVersion("1.0")]
 public class GetDocumentPermissionsCurrentUserController : CurrentUserControllerBase
 {
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/Current/GetMediaPermissionsCurrentUserController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/Current/GetMediaPermissionsCurrentUserController.cs
@@ -11,6 +11,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User.Current;
 
+[ApiVersion("1.0")]
 public class GetMediaPermissionsCurrentUserController : CurrentUserControllerBase
 {
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -4455,6 +4455,315 @@
         ]
       }
     },
+    "/umbraco/management/api/v1/document/{id}/publish": {
+      "put": {
+        "tags": [
+          "Document"
+        ],
+        "operationId": "PutDocumentByIdPublish",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/PublishDocumentRequestModel"
+                  },
+                  {
+                    "$ref": "#/components/schemas/PublishDocumentWithDescendantsRequestModel"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/PublishDocumentRequestModel"
+                  },
+                  {
+                    "$ref": "#/components/schemas/PublishDocumentWithDescendantsRequestModel"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/PublishDocumentRequestModel"
+                  },
+                  {
+                    "$ref": "#/components/schemas/PublishDocumentWithDescendantsRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/document/{id}/publish-with-descendants": {
+      "put": {
+        "tags": [
+          "Document"
+        ],
+        "operationId": "PutDocumentByIdPublishWithDescendants",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/PublishDocumentWithDescendantsRequestModel"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/PublishDocumentWithDescendantsRequestModel"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/PublishDocumentWithDescendantsRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/document/{id}/unpublish": {
+      "put": {
+        "tags": [
+          "Document"
+        ],
+        "operationId": "PutDocumentByIdUnpublish",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UnpublishDocumentRequestModel"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UnpublishDocumentRequestModel"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/UnpublishDocumentRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
     "/umbraco/management/api/v1/document/allowed-document-types": {
       "get": {
         "tags": [
@@ -17999,6 +18308,11 @@
           }
         ],
         "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
           "parentId": {
             "type": "string",
             "format": "uuid",
@@ -21319,6 +21633,32 @@
         },
         "additionalProperties": false
       },
+      "PublishDocumentRequestModel": {
+        "type": "object",
+        "properties": {
+          "cultures": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "PublishDocumentWithDescendantsRequestModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PublishDocumentRequestModel"
+          }
+        ],
+        "properties": {
+          "includeUnpublishedDescendants": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
       "PublishedStateModel": {
         "enum": [
           "Published",
@@ -22236,6 +22576,16 @@
               "type": "string",
               "format": "uuid"
             }
+          }
+        },
+        "additionalProperties": false
+      },
+      "UnpublishDocumentRequestModel": {
+        "type": "object",
+        "properties": {
+          "culture": {
+            "type": "string",
+            "nullable": true
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Some of the Management API controllers are lacking an explicit API version assignment, which means they become available in all API versions. As the Delivery API now has V2, those Management API controllers then map to both V1 and V2:

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/462d4570-95f8-427b-bdcc-e37957836e0d)

This PR ensures that all controllers have explicit API version assignments.

### Testing this PR

The Swagger doc for the Management API should _not_ have any V2 APIs 😄 
