### PR TITLE
Feature/contextual permissions

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Factories/UserGroupPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/UserGroupPresentationFactory.cs
@@ -49,8 +49,8 @@ public class UserGroupPresentationFactory : IUserGroupPresentationFactory
             Icon = userGroup.Icon,
             Languages = languageIsoCodesMappingAttempt.Result,
             HasAccessToAllLanguages = userGroup.HasAccessToAllLanguages,
-            Permissions = userGroup.PermissionNames,
             Sections = userGroup.AllowedSections.Select(SectionMapper.GetName),
+            ContextualPermissions = userGroup.ContextualPermissions
         };
     }
     /// <inheritdoc />
@@ -76,8 +76,8 @@ public class UserGroupPresentationFactory : IUserGroupPresentationFactory
             Icon = userGroup.Icon,
             Languages = languageIsoCodesMappingAttempt.Result,
             HasAccessToAllLanguages = userGroup.HasAccessToAllLanguages,
-            Permissions = userGroup.PermissionNames,
             Sections = userGroup.AllowedSections.Select(SectionMapper.GetName),
+            ContextualPermissions = userGroup.ContextualPermissions
         };
     }
 
@@ -115,7 +115,7 @@ public class UserGroupPresentationFactory : IUserGroupPresentationFactory
             Alias = cleanedName,
             Icon = requestModel.Icon,
             HasAccessToAllLanguages = requestModel.HasAccessToAllLanguages,
-            PermissionNames = requestModel.Permissions,
+            ContextualPermissions = requestModel.ContextualPermissions,
         };
 
         Attempt<UserGroupOperationStatus> assignmentAttempt = AssignStartNodesToUserGroup(requestModel, group);
@@ -173,7 +173,7 @@ public class UserGroupPresentationFactory : IUserGroupPresentationFactory
         current.Name = request.Name.CleanForXss('[', ']', '(', ')', ':');
         current.Icon = request.Icon;
         current.HasAccessToAllLanguages = request.HasAccessToAllLanguages;
-        current.PermissionNames = request.Permissions;
+        current.ContextualPermissions = request.ContextualPermissions;
 
 
         return Attempt.SucceedWithStatus(UserGroupOperationStatus.Success, current);

--- a/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
@@ -121,7 +121,7 @@ public class UserPresentationFactory : IUserPresentationFactory
         var mediaStartNodeKeys = GetKeysFromIds(user.CalculateMediaStartNodeIds(_entityService, _appCaches), UmbracoObjectTypes.Media);
         var documentStartNodeKeys = GetKeysFromIds(user.CalculateContentStartNodeIds(_entityService, _appCaches), UmbracoObjectTypes.Document);
 
-        var permissions = presentationGroups.SelectMany(x => x.Permissions).Distinct().ToHashSet();
+        var contextualPermissions = presentationGroups.SelectMany(x => x.ContextualPermissions).Distinct().ToHashSet();
         var hasAccessToAllLanguages = presentationGroups.Any(x => x.HasAccessToAllLanguages);
 
         return await Task.FromResult(new CurrentUserResponseModel()
@@ -135,7 +135,7 @@ public class UserPresentationFactory : IUserPresentationFactory
             LanguageIsoCode = presentationUser.LanguageIsoCode,
             MediaStartNodeIds = mediaStartNodeKeys,
             ContentStartNodeIds = documentStartNodeKeys,
-            Permissions = permissions,
+            ContextualPermissions = contextualPermissions,
             HasAccessToAllLanguages = hasAccessToAllLanguages
         });
     }

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -17708,6 +17708,22 @@
         },
         "additionalProperties": false
       },
+      "ContextualPermissionModel": {
+        "type": "object",
+        "properties": {
+          "context": {
+            "type": "string"
+          },
+          "identifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "permission": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
       "CopyDataTypeRequestModel": {
         "type": "object",
         "properties": {
@@ -17999,6 +18015,11 @@
           }
         ],
         "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
           "parentId": {
             "type": "string",
             "format": "uuid",
@@ -18352,11 +18373,11 @@
           "hasAccessToAllLanguages": {
             "type": "boolean"
           },
-          "permissions": {
+          "contextualPermissions": {
             "uniqueItems": true,
             "type": "array",
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/ContextualPermissionModel"
             }
           }
         },
@@ -22810,11 +22831,11 @@
             "format": "uuid",
             "nullable": true
           },
-          "permissions": {
+          "contextualPermissions": {
             "uniqueItems": true,
             "type": "array",
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/ContextualPermissionModel"
             }
           }
         },

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/Current/CurrentUserResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/Current/CurrentUserResponseModel.cs
@@ -1,3 +1,5 @@
+using Umbraco.Cms.Core.Models.Membership;
+
 namespace Umbraco.Cms.Api.Management.ViewModels.User.Current;
 
 public class CurrentUserResponseModel : INamedEntityPresentationModel
@@ -22,5 +24,5 @@ public class CurrentUserResponseModel : INamedEntityPresentationModel
 
     public required bool HasAccessToAllLanguages { get; init; }
 
-    public required ISet<string> Permissions { get; init; }
+    public required ISet<ContextualPermission> ContextualPermissions { get; init; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/UserGroup/UserGroupBase.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/UserGroup/UserGroupBase.cs
@@ -1,4 +1,6 @@
-﻿namespace Umbraco.Cms.Api.Management.ViewModels.UserGroup;
+﻿using Umbraco.Cms.Core.Models.Membership;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.UserGroup;
 
 /// <summary>
 /// <para>
@@ -51,8 +53,5 @@ public class UserGroupBase
     /// </summary>
     public Guid? MediaStartNodeId { get; init; }
 
-    /// <summary>
-    /// Ad-hoc list of permissions provided, and maintained by the front-end. The server has no concept of what these mean.
-    /// </summary>
-    public required ISet<string> Permissions { get; init; }
+    public required ISet<ContextualPermission> ContextualPermissions { get; set; } // todo permissions: do we need a viewmodel mapping for ContextualPermissions
 }

--- a/src/Umbraco.Core/Constants-Permissions.cs
+++ b/src/Umbraco.Core/Constants-Permissions.cs
@@ -1,0 +1,21 @@
+namespace Umbraco.Cms.Core;
+
+// todo permissions: xml comments
+public static partial class Constants
+{
+    /// <summary>
+    ///     Defines the permission (verbs) used in Umbraco
+    /// </summary>
+    public static class Permissions
+    {
+        public const string Assign = "assign";
+        public const string Browse = "browse";
+        public const string Copy = "copy";
+    }
+
+    public static class PermissionContexts
+    {
+        public const string Domain = "domain";
+        public const string Content = "content";
+    }
+}

--- a/src/Umbraco.Core/Models/Mapping/UserMapDefinition.cs
+++ b/src/Umbraco.Core/Models/Mapping/UserMapDefinition.cs
@@ -139,7 +139,7 @@ public class UserMapDefinition : IMapDefinition
         target.Permissions = source.DefaultPermissions;
         target.Key = source.Key;
         target.HasAccessToAllLanguages = source.HasAccessToAllLanguages;
-        target.PermissionNames = source.Permissions ?? new HashSet<string>();
+        target.ContextualPermissions = new HashSet<ContextualPermission>(); // todo permissions: verify this whole class gets deleted when old backoffice gets removed.
 
         var id = GetIntId(source.Id);
         if (id > 0)

--- a/src/Umbraco.Core/Models/Membership/ContextualPermission.cs
+++ b/src/Umbraco.Core/Models/Membership/ContextualPermission.cs
@@ -1,0 +1,56 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Umbraco.Cms.Core.Models.Entities;
+
+namespace Umbraco.Cms.Core.Models.Membership;
+
+/// <summary>
+/// A contextual permission with optional granularity
+/// </summary>
+public struct ContextualPermission
+{
+    public ContextualPermission()
+    {
+        Identifier = null;
+    }
+
+    public ContextualPermission(string context, string permission)
+    {
+        Context = context;
+        Permission = permission;
+    }
+
+    public ContextualPermission(string context, string? identifier, string permission)
+    {
+        Context = context;
+        Permission = permission;
+        Identifier = identifier;
+    }
+
+    /// <summary>
+    /// The context in which the Identifier and permission makes sense
+    /// </summary>
+    /// <example>
+    /// umb-node, umb-document, umb-media, ...
+    /// </example>
+    /// <remarks>
+    /// Implementers are encouraged to prefix their contexts with a unique slug to avoid collisions
+    /// </remarks> // todo granular permissions: bellisima global permissions context name
+    public string Context { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Data that specifies a subset of the given context. If null, the permission targets the whole context.
+    /// </summary>
+    /// <remarks>
+    /// For now will be Guid[] to be able to specify node-ids
+    /// </remarks>
+    public string? Identifier { get; set; }
+
+    /// <summary>
+    /// The string representation of the permission within the defined Context.
+    /// </summary>
+    /// <example>
+    /// Umbraco examples: browse, read, write, ...
+    /// </example>
+    public string Permission { get; set; } = string.Empty;
+}

--- a/src/Umbraco.Core/Models/Membership/IReadOnlyUserGroup.cs
+++ b/src/Umbraco.Core/Models/Membership/IReadOnlyUserGroup.cs
@@ -32,11 +32,13 @@ public interface IReadOnlyUserGroup
     ///     By default each permission is simply a single char but we've made this an enumerable{string} to support a more
     ///     flexible permissions structure in the future.
     /// </remarks>
-    IEnumerable<string>? Permissions { get; set; }
-    ISet<string> PermissionNames { get; }
-    IEnumerable<string> AllowedSections { get; }
+    IEnumerable<string>? Permissions { get; set; } // todo v14 remove when old backoffice is removed, is superseded by ContextualPermissions
+
+    IEnumerable<string> AllowedSections { get; } // todo v14 try to move this into ContextualPermissions
 
     IEnumerable<int> AllowedLanguages => Enumerable.Empty<int>();
 
-    public bool HasAccessToLanguage( int languageId) => HasAccessToAllLanguages || AllowedLanguages.Contains(languageId);
+    public bool HasAccessToLanguage(int languageId) => HasAccessToAllLanguages || AllowedLanguages.Contains(languageId);
+
+    ISet<ContextualPermission> ContextualPermissions { get; } // todo v14 rename to permissions when others have been cleaned up
 }

--- a/src/Umbraco.Core/Models/Membership/IUserGroup.cs
+++ b/src/Umbraco.Core/Models/Membership/IUserGroup.cs
@@ -38,19 +38,9 @@ public interface IUserGroup : IEntity, IRememberBeingDirty
     ///     By default each permission is simply a single char but we've made this an enumerable{string} to support a more
     ///     flexible permissions structure in the future.
     /// </remarks>
-    IEnumerable<string>? Permissions { get; set; }
+    IEnumerable<string>? Permissions { get; set; } // todo v14 remove when old backoffice is removed, is superseded by ContextualPermissions
 
-    /// <summary>
-    /// The set of permissions provided by the frontend.
-    /// </summary>
-    /// <remarks>
-    /// By default the server has no concept of what these strings mean, we simple store them and return them to the UI.
-    /// FIXME: For now this is named PermissionNames since Permissions already exists, but is subject to change in the future
-    /// when we know more about how we want to handle permissions, potentially those will be migrated in the these "soft" permissions.
-    /// </remarks>
-    ISet<string> PermissionNames { get; set; }
-
-    IEnumerable<string> AllowedSections { get; }
+    IEnumerable<string> AllowedSections { get; } // todo v14 try to move this into ContextualPermissions
 
     void RemoveAllowedSection(string sectionAlias);
 
@@ -76,4 +66,6 @@ public interface IUserGroup : IEntity, IRememberBeingDirty
     ///     Specifies the number of users assigned to this group
     /// </summary>
     int UserCount { get; }
+
+    ISet<ContextualPermission> ContextualPermissions { get; set; } // todo v14 rename to permissions when others have been cleaned up
 }

--- a/src/Umbraco.Core/Models/Membership/ReadOnlyUserGroup.cs
+++ b/src/Umbraco.Core/Models/Membership/ReadOnlyUserGroup.cs
@@ -13,8 +13,8 @@ public class ReadOnlyUserGroup : IReadOnlyUserGroup, IEquatable<ReadOnlyUserGrou
         IEnumerable<int> allowedLanguages,
         IEnumerable<string> allowedSections,
         IEnumerable<string>? permissions,
-        ISet<string> permissionNames,
-        bool hasAccessToAllLanguages)
+        bool hasAccessToAllLanguages,
+        ISet<ContextualPermission> contextualPermissions)
     {
         Name = name ?? string.Empty;
         Icon = icon;
@@ -24,12 +24,12 @@ public class ReadOnlyUserGroup : IReadOnlyUserGroup, IEquatable<ReadOnlyUserGrou
         AllowedLanguages = allowedLanguages.ToArray();
         AllowedSections = allowedSections.ToArray();
         Permissions = permissions?.ToArray();
+        ContextualPermissions = contextualPermissions;
 
         // Zero is invalid and will be treated as Null
         StartContentId = startContentId == 0 ? null : startContentId;
         StartMediaId = startMediaId == 0 ? null : startMediaId;
         HasAccessToAllLanguages = hasAccessToAllLanguages;
-        PermissionNames = permissionNames;
     }
 
     public int Id { get; }
@@ -73,7 +73,7 @@ public class ReadOnlyUserGroup : IReadOnlyUserGroup, IEquatable<ReadOnlyUserGrou
     public IEnumerable<string>? Permissions { get; set; }
 
     public IEnumerable<int> AllowedLanguages { get; private set; }
-    public ISet<string> PermissionNames { get; private set; }
+
     public IEnumerable<string> AllowedSections { get; private set; }
 
     public static bool operator ==(ReadOnlyUserGroup left, ReadOnlyUserGroup right) => Equals(left, right);
@@ -101,4 +101,6 @@ public class ReadOnlyUserGroup : IReadOnlyUserGroup, IEquatable<ReadOnlyUserGrou
     public override int GetHashCode() => Alias?.GetHashCode() ?? base.GetHashCode();
 
     public static bool operator !=(ReadOnlyUserGroup left, ReadOnlyUserGroup right) => !Equals(left, right);
+
+    public ISet<ContextualPermission> ContextualPermissions { get; private set; }
 }

--- a/src/Umbraco.Core/Models/Membership/UserGroup.cs
+++ b/src/Umbraco.Core/Models/Membership/UserGroup.cs
@@ -19,6 +19,12 @@ public class UserGroup : EntityBase, IUserGroup, IReadOnlyUserGroup
             (enum1, enum2) => enum1.UnsortedSequenceEqual(enum2),
             enum1 => enum1.GetHashCode());
 
+    // todo permissions: understand this
+    private static readonly DelegateEqualityComparer<IEnumerable<ContextualPermission>> _contextualPermissionEnumerableComparer =
+        new(
+            (enum1, enum2) => enum1.UnsortedSequenceEqual(enum2),
+            enum1 => enum1.GetHashCode());
+
     private readonly IShortStringHelper _shortStringHelper;
     private string _alias;
     private string? _icon;
@@ -26,6 +32,7 @@ public class UserGroup : EntityBase, IUserGroup, IReadOnlyUserGroup
     private bool _hasAccessToAllLanguages;
     private IEnumerable<string>? _permissions;
     private ISet<string> _permissionNames = new HashSet<string>();
+    private ISet<ContextualPermission> _contextualPermissions = new HashSet<ContextualPermission>();
     private List<string> _sectionCollection;
     private List<int> _languageCollection;
     private int? _startContentId;
@@ -127,10 +134,10 @@ public class UserGroup : EntityBase, IUserGroup, IReadOnlyUserGroup
     }
 
     /// <inheritdoc />
-    public ISet<string> PermissionNames
+    public ISet<ContextualPermission> ContextualPermissions
     {
-        get => _permissionNames;
-        set => SetPropertyValueAndDetectChanges(value, ref _permissionNames!, nameof(PermissionNames), _stringEnumerableComparer);
+        get => _contextualPermissions;
+        set => SetPropertyValueAndDetectChanges(value, ref _contextualPermissions!, nameof(ContextualPermissions), _contextualPermissionEnumerableComparer);
     }
 
     public IEnumerable<string> AllowedSections => _sectionCollection;

--- a/src/Umbraco.Core/Models/Membership/UserGroupExtensions.cs
+++ b/src/Umbraco.Core/Models/Membership/UserGroupExtensions.cs
@@ -25,8 +25,8 @@ public static class UserGroupExtensions
             group.AllowedLanguages,
             group.AllowedSections,
             group.Permissions,
-            group.PermissionNames,
-            group.HasAccessToAllLanguages);
+            group.HasAccessToAllLanguages,
+            group.ContextualPermissions);
     }
 
     public static bool IsSystemUserGroup(this IUserGroup group) =>

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/UserGroup2PermissionDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/UserGroup2PermissionDto.cs
@@ -19,4 +19,13 @@ public class UserGroup2PermissionDto
     [Column("permission")]
     [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
     public required string Permission { get; set; }
+
+    [Column("context")]
+    [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
+    public required string Context { get; set; }
+
+    [Column("identifier")]
+    [NullSetting(NullSetting = NullSettings.Null)]
+    [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
+    public string? Identifier { get; set; }
 }

--- a/src/Umbraco.Infrastructure/Persistence/Factories/UserFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Factories/UserFactory.cs
@@ -132,7 +132,9 @@ internal static class UserFactory
             group.UserGroup2LanguageDtos.Select(x => x.LanguageId),
             group.UserGroup2AppDtos.Select(x => x.AppAlias).WhereNotNull().ToArray(),
             permissions,
-            group.UserGroup2PermissionDtos.Select(x => x.Permission).ToHashSet(),
-            group.HasAccessToAllLanguages);
+            group.HasAccessToAllLanguages,
+            group.UserGroup2PermissionDtos
+                .Where(ugp => ugp.Context != null)
+                .Select(ugp => new ContextualPermission(ugp.Context!, ugp.Identifier, ugp.Permission)).ToHashSet());
     }
 }

--- a/src/Umbraco.Infrastructure/Persistence/Factories/UserGroupFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Factories/UserGroupFactory.cs
@@ -27,7 +27,6 @@ internal static class UserGroupFactory
             userGroup.UpdateDate = dto.UpdateDate;
             userGroup.StartContentId = dto.StartContentId;
             userGroup.StartMediaId = dto.StartMediaId;
-            userGroup.PermissionNames = dto.UserGroup2PermissionDtos.Select(x => x.Permission).ToHashSet();
             userGroup.HasAccessToAllLanguages = dto.HasAccessToAllLanguages;
             if (dto.UserGroup2AppDtos != null)
             {
@@ -41,6 +40,9 @@ internal static class UserGroupFactory
             {
                 userGroup.AddAllowedLanguage(language.LanguageId);
             }
+
+            userGroup.ContextualPermissions = dto.UserGroup2PermissionDtos
+                .Select(ugp => new ContextualPermission(ugp.Context, ugp.Identifier, ugp.Permission)).ToHashSet();
 
             userGroup.ResetDirtyProperties(false);
             return userGroup;

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
@@ -438,7 +438,7 @@ SELECT 4 AS [Key], COUNT(id) AS [Value] FROM umbracoUser WHERE userDisabled = 0 
             groups = Database.Fetch<UserGroupDto>(sql)
                 .ToDictionary(x => x.Id, x => x);
         }
-        catch(Exception e)
+        catch(Exception e) //todo v14 figure out when this was added and if this was added before the latest LTS [v13]
         {
             Logger.LogDebug(e, "Couldn't get user groups. This should only happens doing the migration that add new columns to user groups");
 
@@ -487,6 +487,7 @@ SELECT 4 AS [Key], COUNT(id) AS [Value] FROM umbracoUser WHERE userDisabled = 0 
         }
         catch
         {
+            //todo v14 figure out when this was added and if this was added before the latest LTS [v13]
             // If we get an error, the table has not been made in the database yet, set the list to an empty one
             groups2languages = new Dictionary<int, IGrouping<int, UserGroup2LanguageDto>>();
         }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Editors/UserEditorAuthorizationHelperTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Editors/UserEditorAuthorizationHelperTests.cs
@@ -116,7 +116,7 @@ public class UserEditorAuthorizationHelperTests
     {
         var currentUser = Mock.Of<IUser>(user => user.Groups == new[]
         {
-            new ReadOnlyUserGroup(1, Guid.NewGuid(), "CurrentUser", "icon-user", null, null, groupAlias, new int[0], new string[0], new string[0], new HashSet<string>(), true),
+            new ReadOnlyUserGroup(1, Guid.NewGuid(), "CurrentUser", "icon-user", null, null, groupAlias, new int[0], new string[0], new string[0],  true,new HashSet<ContextualPermission>()),
         });
         IUser savingUser = null; // This means it is a new created user
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Added Contextual permissions to usergroups from the management api layer down to the repo
This is the first step in gradually revamping the user permissions.

### Testing
- [ ] Adding a list of Contextual Permissions when posting/putting a user group should be possible.
- [ ] Retrieving that user group should then show that same list.
- [ ] Posting/putting contextual permissions without a permission or context should not be possible