### PR TITLE
Reload the List View after a copy, if to the same parent

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -650,8 +650,17 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
   };
 
   function performCopy(target, relateToOriginal, includeDescendants) {
+    var newPath = null;
+    var newTarget = null;
     applySelected(
-      function (selected, index) { return contentResource.copy({ parentId: target.id, id: getIdCallback(selected[index]), relateToOriginal: relateToOriginal, recursive: includeDescendants }); },
+      function (selected, index) {
+        return contentResource.copy({ parentId: target.id, id: getIdCallback(selected[index]), relateToOriginal: relateToOriginal, recursive: includeDescendants })
+          .then(function (path) {
+            newPath = path;
+            newTarget = parseInt(target.id);
+            return path;
+          });
+      },
       function (count, total) {
         var key = (total === 1 ? "bulk_copiedItemOfItem" : "bulk_copiedItemOfItems");
         return localizationService.localize(key, [count, total]);
@@ -659,6 +668,18 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
       function (total) {
         var key = (total === 1 ? "bulk_copiedItem" : "bulk_copiedItems");
         return localizationService.localize(key, [total]);
+      })
+      .then(function () {
+        //executes if all is successful
+        if (newPath) {
+          if (newTarget === $scope.contentId) {
+            // if we copied this to the same parent, reload the current view completely
+            $scope.reloadView($scope.contentId);
+          } else {
+            // Otherwise just clear the current selection but don't reload
+            $scope.clearSelection();
+          }
+        }
       });
   }
 


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #15300 

### Description
Following recommendation on the ticket comments, the performCopy method has been extended to ensure a refresh after a copy. The existing performMove method has been used as the base for this, with the key difference being it is simpler as it does not have to reload two nodes, and also a reload of the current screen is only performed if the copy destination is to the same parent as the node being copied. If it is copied to a different parent no reload is needed, however the selected nodes are deselected instead as the task has still been performed.

### Testing
To test this, the original description on the linked bug can be followed:-

_Create a doc type A with any textstring property. Create another document type B and configure as list view and allow to be created at root. Allow doc type A as child node type of doc B.

Create node of type doc type B, create multiple nodes of type doc type A.

Select one or more doc type A instances in list view, and click on 'Copy'._

After the copy, the new nodes should be shown without manually needing to refresh the browser.

Some additional scenarios checked to validate the fix:-
* Checked copying single node to same parent (reloads with new nodes, confirmed by network debugger call)
* Checked copying single node to different parent (doesn't reload, confirmed by network debugger, but clears selection)
* Checked copying multiple nodes to same parent (counts then reloads)
* Checked copying multiple nodes to different parent (counts then clears selection without reload)
* Other operations in list view (move, delete) behave as before
* Navigating in to newly copied node from list view without manual browser refresh works as expected

Thanks
