### PR TITLE
Add sorting option for media picker

### DIFF
--- a/src/Umbraco.Core/Constants-DataTypes.cs
+++ b/src/Umbraco.Core/Constants-DataTypes.cs
@@ -235,24 +235,14 @@ public static partial class Constants
             public const string LabelDecimal = "8f1ef1e1-9de4-40d3-a072-6673f631ca64";
 
             /// <summary>
-            ///     Guid for Label as sort by name asc
+            ///     Guid for Label as sort by name
             /// </summary>
-            public const string LabelSortByNameAsc = "7e4473a8-bf83-426e-bbf0-64e176181eca";
+            public const string LabelSortByName = "84cb8b65-dbf5-4cd2-a501-2f5795dd0382";
 
             /// <summary>
-            ///     Guid for Label as sort by name desc
+            ///     Guid for Label as sort by update date
             /// </summary>
-            public const string LabelSortByNameDesc = "84cb8b65-dbf5-4cd2-a501-2f5795dd0382";
-
-            /// <summary>
-            ///     Guid for Label as sort by update date asc
-            /// </summary>
-            public const string LabelSortByUpdateDateAsc = "ef51bfde-872e-4863-aa14-87aa00a12b34";
-
-            /// <summary>
-            ///     Guid for Label as sort by update date desc
-            /// </summary>
-            public const string LabelSortByUpdateDateDesc = "6ba464c2-fc5f-4428-ae0e-91067486ec1c";
+            public const string LabelSortByUpdateDate = "6ba464c2-fc5f-4428-ae0e-91067486ec1c";
 
             /// <summary>
             ///     Guid for Content Picker
@@ -445,24 +435,14 @@ public static partial class Constants
             public static readonly Guid LabelDecimalGuid = new(LabelDecimal);
 
             /// <summary>
-            ///     GGuid for Label as sort by name asc
+            ///     Guid for Label as sort by name
             /// </summary>
-            public static readonly Guid LabelSortByNameAscGuid = new(LabelSortByNameAsc);
+            public static readonly Guid LabelSortByNameGuid = new(LabelSortByName);
 
             /// <summary>
-            ///     Guid for Label as sort by name desc
+            ///     Guid for Label as sort by update date
             /// </summary>
-            public static readonly Guid LabelSortByNameDescGuid = new(LabelSortByNameDesc);
-
-            /// <summary>
-            ///     Guid for Label as sort by update date asc
-            /// </summary>
-            public static readonly Guid LabelSortByUpdateDateAscGuid = new(LabelSortByUpdateDateAsc);
-
-            /// <summary>
-            ///     Guid for Label as sort by update date desc
-            /// </summary>
-            public static readonly Guid LabelSortByUpdateDateDescGuid = new(LabelSortByUpdateDateDesc);
+            public static readonly Guid LabelSortByUpdateDateGuid = new(LabelSortByUpdateDate);
         }
     }
 }

--- a/src/Umbraco.Core/Constants-DataTypes.cs
+++ b/src/Umbraco.Core/Constants-DataTypes.cs
@@ -235,6 +235,26 @@ public static partial class Constants
             public const string LabelDecimal = "8f1ef1e1-9de4-40d3-a072-6673f631ca64";
 
             /// <summary>
+            ///     Guid for Label as sort by name asc
+            /// </summary>
+            public const string LabelSortByNameAsc = "7e4473a8-bf83-426e-bbf0-64e176181eca";
+
+            /// <summary>
+            ///     Guid for Label as sort by name desc
+            /// </summary>
+            public const string LabelSortByNameDesc = "84cb8b65-dbf5-4cd2-a501-2f5795dd0382";
+
+            /// <summary>
+            ///     Guid for Label as sort by update date asc
+            /// </summary>
+            public const string LabelSortByUpdateDateAsc = "ef51bfde-872e-4863-aa14-87aa00a12b34";
+
+            /// <summary>
+            ///     Guid for Label as sort by update date desc
+            /// </summary>
+            public const string LabelSortByUpdateDateDesc = "6ba464c2-fc5f-4428-ae0e-91067486ec1c";
+
+            /// <summary>
             ///     Guid for Content Picker
             /// </summary>
             public static readonly Guid ContentPickerGuid = new(ContentPicker);
@@ -423,6 +443,26 @@ public static partial class Constants
             ///     Guid for Label decimal
             /// </summary>
             public static readonly Guid LabelDecimalGuid = new(LabelDecimal);
+
+            /// <summary>
+            ///     GGuid for Label as sort by name asc
+            /// </summary>
+            public static readonly Guid LabelSortByNameAscGuid = new(LabelSortByNameAsc);
+
+            /// <summary>
+            ///     Guid for Label as sort by name desc
+            /// </summary>
+            public static readonly Guid LabelSortByNameDescGuid = new(LabelSortByNameDesc);
+
+            /// <summary>
+            ///     Guid for Label as sort by update date asc
+            /// </summary>
+            public static readonly Guid LabelSortByUpdateDateAscGuid = new(LabelSortByUpdateDateAsc);
+
+            /// <summary>
+            ///     Guid for Label as sort by update date desc
+            /// </summary>
+            public static readonly Guid LabelSortByUpdateDateDescGuid = new(LabelSortByUpdateDateDesc);
         }
     }
 }

--- a/src/Umbraco.Core/Constants-PropertyEditors.cs
+++ b/src/Umbraco.Core/Constants-PropertyEditors.cs
@@ -221,6 +221,12 @@ public static partial class Constants
             /// </summary>
             /// <remarks>Must be a valid <see cref="ValueTypes" /> value.</remarks>
             public const string DataValueType = "umbracoDataValueType";
+
+            /// <summary>
+            ///     The sort by type of property data (i.e., name asc, update date asc, etc)
+            /// </summary>
+            /// <remarks>Must be a valid <see cref="SortByTypes" /> value.</remarks>
+            public const string SortByType = "sortByType";
         }
 
         /// <summary>
@@ -242,3 +248,4 @@ public static partial class Constants
         }
     }
 }
+

--- a/src/Umbraco.Core/Models/DataTypeExtensions.cs
+++ b/src/Umbraco.Core/Models/DataTypeExtensions.cs
@@ -44,10 +44,8 @@ public static class DataTypeExtensions
         Constants.DataTypes.Guids.LabelBigIntGuid,
         Constants.DataTypes.Guids.LabelTimeGuid,
         Constants.DataTypes.Guids.LabelDateTimeGuid,
-        Constants.DataTypes.Guids.LabelSortByNameAscGuid,
-        Constants.DataTypes.Guids.LabelSortByNameDescGuid,
-        Constants.DataTypes.Guids.LabelSortByUpdateDateAscGuid,
-        Constants.DataTypes.Guids.LabelSortByUpdateDateDescGuid,
+        Constants.DataTypes.Guids.LabelSortByNameGuid,
+        Constants.DataTypes.Guids.LabelSortByUpdateDateGuid,
     };
 
     /// <summary>

--- a/src/Umbraco.Core/Models/DataTypeExtensions.cs
+++ b/src/Umbraco.Core/Models/DataTypeExtensions.cs
@@ -44,6 +44,10 @@ public static class DataTypeExtensions
         Constants.DataTypes.Guids.LabelBigIntGuid,
         Constants.DataTypes.Guids.LabelTimeGuid,
         Constants.DataTypes.Guids.LabelDateTimeGuid,
+        Constants.DataTypes.Guids.LabelSortByNameAscGuid,
+        Constants.DataTypes.Guids.LabelSortByNameDescGuid,
+        Constants.DataTypes.Guids.LabelSortByUpdateDateAscGuid,
+        Constants.DataTypes.Guids.LabelSortByUpdateDateDescGuid,
     };
 
     /// <summary>

--- a/src/Umbraco.Core/PropertyEditors/MediaPicker3Configuration.cs
+++ b/src/Umbraco.Core/PropertyEditors/MediaPicker3Configuration.cs
@@ -36,6 +36,13 @@ public class MediaPicker3Configuration : IIgnoreUserStartNodesConfig
         Description = "Selecting this option allows a user to choose nodes that they normally don't have access to.")]
     public bool IgnoreUserStartNodes { get; set; }
 
+    [ConfigurationField(
+        Constants.PropertyEditors.ConfigurationKeys.SortByType,
+        "Sort by",
+        "sortByType",
+        Description = "Default sort by for media grid")]
+    public string DefaultSorting { get; set; } = SortByTypes.UpdateDateAsc;
+
     [DataContract]
     public class NumberRange
     {

--- a/src/Umbraco.Core/PropertyEditors/MediaPicker3Configuration.cs
+++ b/src/Umbraco.Core/PropertyEditors/MediaPicker3Configuration.cs
@@ -7,6 +7,13 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 /// </summary>
 public class MediaPicker3Configuration : IIgnoreUserStartNodesConfig
 {
+    public MediaPicker3Configuration()
+    {
+        // initialize defaults
+        OrderBy = "updateDate";
+        OrderDirection = "asc";
+    }
+
     [ConfigurationField("filter", "Accepted types", "treesourcetypepicker", Description = "Limit to specific types")]
     public string? Filter { get; set; }
 
@@ -36,12 +43,11 @@ public class MediaPicker3Configuration : IIgnoreUserStartNodesConfig
         Description = "Selecting this option allows a user to choose nodes that they normally don't have access to.")]
     public bool IgnoreUserStartNodes { get; set; }
 
-    [ConfigurationField(
-        Constants.PropertyEditors.ConfigurationKeys.SortByType,
-        "Sort by",
-        "sortByType",
-        Description = "Default sort by for media grid")]
-    public string DefaultSorting { get; set; } = SortByTypes.UpdateDateAsc;
+    [ConfigurationField("orderBy", "Order By", "views/propertyeditors/mediapicker3/sortby.prevalues.html", Description = "The default sort order for the data")]
+    public string OrderBy { get; set; }
+
+    [ConfigurationField("orderDirection", "Order Direction", "views/propertyeditors/mediapicker3/orderDirection.prevalues.html")]
+    public string OrderDirection { get; set; }
 
     [DataContract]
     public class NumberRange

--- a/src/Umbraco.Core/PropertyEditors/SortByTypes.cs
+++ b/src/Umbraco.Core/PropertyEditors/SortByTypes.cs
@@ -1,0 +1,69 @@
+﻿using System.Reflection;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Core.PropertyEditors;
+
+/// <summary>
+///     Represents the types of default sorting options.
+/// </summary>
+/// <remarks>
+///     <para>
+///         These types are used to determine the storage type, but also for
+///         validation. Therefore, they are more detailed than the storage types.
+///     </para>
+/// </remarks>
+public static class SortByTypes
+{
+    /// <summary>
+    ///     Name ascending.
+    /// </summary>
+    public const string NameAsc = "name-asc";
+
+    /// <summary>
+    ///     Name descending.
+    /// </summary>
+    public const string NameDesc = "name-desc";
+
+    /// <summary>
+    ///     Update date ascending.
+    /// </summary>
+    public const string UpdateDateAsc = "updateDate-asc";
+
+    /// <summary>
+    ///     Update date descending.
+    /// </summary>
+    public const string UpdateDateDesc = "updateDate-desc";
+
+    // the auto, static, set of valid values
+    private static readonly HashSet<string?> Values
+        = new(typeof(ValueTypes)
+            .GetFields(BindingFlags.Static | BindingFlags.Public)
+            .Where(x => x.IsLiteral && !x.IsInitOnly)
+            .Select(x => (string?)x.GetRawConstantValue()));
+
+    /// <summary>
+    ///     Determines whether a string value is a valid SortByTypes value.
+    /// </summary>
+    public static bool IsValue(string s)
+        => Values.Contains(s);
+
+    /// <summary>
+    ///     Gets the <see cref="ValueStorageType" /> value corresponding to a SortByTypes value.
+    /// </summary>
+    public static ValueStorageType ToStorageType(string valueType)
+    {
+        switch (valueType.ToUpperInvariant())
+        {
+            case NameAsc:
+            case NameDesc:
+            case UpdateDateAsc:
+            case UpdateDateDesc:
+                return ValueStorageType.Nvarchar;
+
+            default:
+                throw new ArgumentOutOfRangeException(
+                    nameof(valueType),
+                    $"Value \"{valueType}\" is not a valid SortByType.");
+        }
+    }
+}

--- a/src/Umbraco.Core/PropertyEditors/SortByTypes.cs
+++ b/src/Umbraco.Core/PropertyEditors/SortByTypes.cs
@@ -15,24 +15,14 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 public static class SortByTypes
 {
     /// <summary>
-    ///     Name ascending.
+    ///     Name.
     /// </summary>
-    public const string NameAsc = "name-asc";
+    public const string Name = "name";
 
     /// <summary>
-    ///     Name descending.
+    ///     Update date.
     /// </summary>
-    public const string NameDesc = "name-desc";
-
-    /// <summary>
-    ///     Update date ascending.
-    /// </summary>
-    public const string UpdateDateAsc = "updateDate-asc";
-
-    /// <summary>
-    ///     Update date descending.
-    /// </summary>
-    public const string UpdateDateDesc = "updateDate-desc";
+    public const string UpdateDate = "updateDate";
 
     // the auto, static, set of valid values
     private static readonly HashSet<string?> Values
@@ -54,10 +44,8 @@ public static class SortByTypes
     {
         switch (valueType.ToUpperInvariant())
         {
-            case NameAsc:
-            case NameDesc:
-            case UpdateDateAsc:
-            case UpdateDateDesc:
+            case Name:
+            case UpdateDate:
                 return ValueStorageType.Nvarchar;
 
             default:

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -557,6 +557,11 @@ angular.module("umbraco")
 
                     var allowedTypes = dialogOptions.filter ? dialogOptions.filter.split(",") : null;
 
+                    if ($scope.model.sortBy === "updateDate") {
+                      data = sortByUpdateDate(data, $scope.model.sortType);
+                    } else {
+                      data = sortByUpdateName(data, $scope.model.sortType);
+                    }
                     for (var i = 0; i < data.length; i++) {
                         setDefaultData(data[i]);
                         data[i].filtered = allowedTypes && allowedTypes.indexOf(data[i].metaData.ContentTypeAlias) < 0;
@@ -569,6 +574,32 @@ angular.module("umbraco")
                     preSelectMedia();
                     vm.loading = false;
                 });
+            }
+
+            function sortByUpdateDate(data, sortType) {
+              data.sort(function(a, b){
+                // Turn your strings into dates, and then subtract them
+                // to get a value that is either negative, positive, or zero.
+                return new Date(b).date - new Date(a).date;
+              });
+
+              if (sortType === "desc") {
+                data = data.reverse();
+              }
+
+              return data;
+            }
+
+            function sortByUpdateName(data, sortType) {
+              data.sort(function(a, b){
+                return a.name.localeCompare(b.name);
+              });
+
+              if (sortType === "desc") {
+                data = data.reverse();
+              }
+
+              return data;
             }
 
             function setDefaultData(item) {

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -557,11 +557,8 @@ angular.module("umbraco")
 
                     var allowedTypes = dialogOptions.filter ? dialogOptions.filter.split(",") : null;
 
-                    if ($scope.model.sortBy === "updateDate") {
-                      data = sortByUpdateDate(data, $scope.model.sortType);
-                    } else {
-                      data = sortByUpdateName(data, $scope.model.sortType);
-                    }
+                    sortByProperty(data, $scope.model.orderBy, $scope.model.orderDirection)
+
                     for (var i = 0; i < data.length; i++) {
                         setDefaultData(data[i]);
                         data[i].filtered = allowedTypes && allowedTypes.indexOf(data[i].metaData.ContentTypeAlias) < 0;
@@ -576,26 +573,18 @@ angular.module("umbraco")
                 });
             }
 
-            function sortByUpdateDate(data, sortType) {
-              data.sort(function(a, b){
-                // Turn your strings into dates, and then subtract them
-                // to get a value that is either negative, positive, or zero.
-                return new Date(b).date - new Date(a).date;
+            function sortByProperty(data, property, direction) {
+              data.sort((a, b) => {
+                if (a[property] < b[property]) {
+                  return -1;
+                } else if (a[property] > b[property]) {
+                  return 1;
+                } else {
+                  return 0;
+                }
               });
 
-              if (sortType === "desc") {
-                data = data.reverse();
-              }
-
-              return data;
-            }
-
-            function sortByUpdateName(data, sortType) {
-              data.sort(function(a, b){
-                return a.name.localeCompare(b.name);
-              });
-
-              if (sortType === "desc") {
+              if (direction === "desc") {
                 data = data.reverse();
               }
 

--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/sortByType.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/sortByType.html
@@ -1,0 +1,6 @@
+<select ng-model="model.value" required>
+  <option value="name-asc">Name ascending</option>
+  <option value="name-desc">Name descending</option>
+  <option value="updateDate-asc">Update date ascending</option>
+  <option value="updateDate-desc">Update date descending</option>
+</select>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/orderDirection.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/orderDirection.prevalues.html
@@ -1,0 +1,22 @@
+﻿<div>
+    <ng-form name="mediapickerViewOrderDirectionForm" class="flex">
+        <ul class="inline">
+            <li class="-no-padding-left">
+                <umb-radiobutton name="orderDirection"
+                                 value="asc"
+                                 model="model.value"
+                                 text="Ascending [a-z]"
+                                 required="true">
+                </umb-radiobutton>
+            </li>
+            <li>
+                <umb-radiobutton name="orderDirection"
+                                 value="desc"
+                                 model="model.value"
+                                 text="Descending [z-a]"
+                                 required="true">
+                </umb-radiobutton>
+            </li>
+        </ul>
+    </ng-form>
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/sortby.prevalues.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/sortby.prevalues.html
@@ -1,0 +1,4 @@
+﻿<select ng-model="model.value" required>
+  <option value="name">Name</option>
+  <option value="updateDate">Last edited</option>
+</select>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umbMediaPicker3PropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umbMediaPicker3PropertyEditor.component.js
@@ -246,15 +246,13 @@
         function addMediaAt(createIndex, $event) {
             if (!vm.allowAddMedia) return;
 
-
-
             const mediaPicker = {
                 startNodeId: vm.model.config.startNodeId,
                 startNodeIsVirtual: vm.model.config.startNodeIsVirtual,
                 dataTypeKey: vm.model.dataTypeKey,
                 multiPicker: vm.singleMode !== true,
-                sortBy: getSortBy(),
-                sortType: getSortByType(),
+                orderBy: vm.model.config.orderBy,
+                orderDirection: vm.model.config.orderDirection,
                 clickPasteItem: function(item, mouseEvent) {
 
                     if (Array.isArray(item.data)) {
@@ -307,25 +305,6 @@
             editorService.mediaPicker(mediaPicker);
         }
 
-        function getSortBy() {
-          let sortBy = "name";
-          if (vm.model.config.sortByType) {
-            const sortPart = vm.model.config.sortByType.split('-');
-            sortBy = sortPart[0];
-          }
-
-          return sortBy;
-        }
-
-      function getSortByType() {
-        let sortType = "asc";
-        if (vm.model.config.sortByType) {
-          const sortPart = vm.model.config.sortByType.split('-');
-          sortType = sortPart[1];
-        }
-
-        return sortType;
-      }
         // To be used by infinite editor. (defined here cause we need configuration from property editor)
         function changeMediaFor(mediaEntry, onSuccess) {
             if (!vm.allowAddMedia) return;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umbMediaPicker3PropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umbMediaPicker3PropertyEditor.component.js
@@ -246,11 +246,21 @@
         function addMediaAt(createIndex, $event) {
             if (!vm.allowAddMedia) return;
 
+            let sortBy = "name";
+            let sortType = "asc";
+            if (vm.model.config.sortByType) {
+              const sortPart = vm.model.config.sortByType.split('-');
+              sortBy = sortPart[0];
+              sortType = sortPart[1];
+            }
+
             const mediaPicker = {
                 startNodeId: vm.model.config.startNodeId,
                 startNodeIsVirtual: vm.model.config.startNodeIsVirtual,
                 dataTypeKey: vm.model.dataTypeKey,
                 multiPicker: vm.singleMode !== true,
+                sortBy: sortBy,
+                sortType: sortType,
                 clickPasteItem: function(item, mouseEvent) {
 
                     if (Array.isArray(item.data)) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umbMediaPicker3PropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker3/umbMediaPicker3PropertyEditor.component.js
@@ -246,21 +246,15 @@
         function addMediaAt(createIndex, $event) {
             if (!vm.allowAddMedia) return;
 
-            let sortBy = "name";
-            let sortType = "asc";
-            if (vm.model.config.sortByType) {
-              const sortPart = vm.model.config.sortByType.split('-');
-              sortBy = sortPart[0];
-              sortType = sortPart[1];
-            }
+
 
             const mediaPicker = {
                 startNodeId: vm.model.config.startNodeId,
                 startNodeIsVirtual: vm.model.config.startNodeIsVirtual,
                 dataTypeKey: vm.model.dataTypeKey,
                 multiPicker: vm.singleMode !== true,
-                sortBy: sortBy,
-                sortType: sortType,
+                sortBy: getSortBy(),
+                sortType: getSortByType(),
                 clickPasteItem: function(item, mouseEvent) {
 
                     if (Array.isArray(item.data)) {
@@ -313,6 +307,25 @@
             editorService.mediaPicker(mediaPicker);
         }
 
+        function getSortBy() {
+          let sortBy = "name";
+          if (vm.model.config.sortByType) {
+            const sortPart = vm.model.config.sortByType.split('-');
+            sortBy = sortPart[0];
+          }
+
+          return sortBy;
+        }
+
+      function getSortByType() {
+        let sortType = "asc";
+        if (vm.model.config.sortByType) {
+          const sortPart = vm.model.config.sortByType.split('-');
+          sortType = sortPart[1];
+        }
+
+        return sortType;
+      }
         // To be used by infinite editor. (defined here cause we need configuration from property editor)
         function changeMediaFor(mediaEntry, onSuccess) {
             if (!vm.allowAddMedia) return;


### PR DESCRIPTION
### Description
#### Summary

This pull request adds a new sorting option for the media picker. Users can now choose to sort the list of media by name (ascending or descending) or by update date (ascending or descending). and default is still update date ascending (same as before)

#### Implementation Details

The sorting option is implemented by adding a new dropdown menu to the media picker. The user can select the desired sorting option from the dropdown menu. The media picker will then sort the list of media according to the selected option.

#### Benefits

This feature provides users with more control over how they view the list of media. This can be helpful when users are looking for specific media or when they want to view the media in a particular order.

Please review and merge this pull request.

Thanks,
Esmaeil