### PR TITLE
Add Code Editor property editor

### DIFF
--- a/src/Umbraco.Core/Constants-PropertyEditors.cs
+++ b/src/Umbraco.Core/Constants-PropertyEditors.cs
@@ -41,14 +41,19 @@ public static partial class Constants
             public const string BlockList = "Umbraco.BlockList";
 
             /// <summary>
-            /// Block Grid.
+            ///     Block Grid.
             /// </summary>
             public const string BlockGrid = "Umbraco.BlockGrid";
 
-                /// <summary>
+            /// <summary>
             ///     CheckBox List.
             /// </summary>
             public const string CheckBoxList = "Umbraco.CheckBoxList";
+
+            /// <summary>
+            ///     Code Editor.
+            /// </summary>
+            public const string CodeEditor = "Umbraco.CodeEditor";
 
             /// <summary>
             ///     Color Picker.

--- a/src/Umbraco.Core/PropertyEditors/CodeEditorConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/CodeEditorConfiguration.cs
@@ -1,0 +1,13 @@
+namespace Umbraco.Cms.Core.PropertyEditors;
+
+/// <summary>
+///     Represents the configuration for the Code Editor value editor.
+/// </summary>
+public class CodeEditorConfiguration
+{
+    [ConfigurationField("mode", "Mode", "textstring", Description = "")]
+    public string? Mode { get; set; }
+
+    [ConfigurationField("theme", "Theme", "textstring", Description = "")]
+    public string? Theme { get; set; }
+}

--- a/src/Umbraco.Core/PropertyEditors/CodeEditorConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/CodeEditorConfiguration.cs
@@ -5,9 +5,18 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 /// </summary>
 public class CodeEditorConfiguration
 {
-    [ConfigurationField("mode", "Mode", "textstring", Description = "")]
+    [ConfigurationField("mode", "Mode", "textstring", Description = "Select the programming language mode. The default mode is 'Razor'.")]
     public string? Mode { get; set; }
 
-    [ConfigurationField("theme", "Theme", "textstring", Description = "")]
+    [ConfigurationField("theme", "Theme", "textstring", Description = "Set the theme for the code editor. The default theme is 'Chrome'.")]
     public string? Theme { get; set; }
+
+    [ConfigurationField("useWrapMode", "Word wrapping", "boolean", Description = "Select to enable word wrapping.")]
+    public bool UseWrapMode { get; set; }
+
+    [ConfigurationField("minLines", "Minimum lines", "number", Description = "Set the minimum number of lines that the editor will be. The default is 12 lines.")]
+    public int MinLines { get; set; }
+
+    [ConfigurationField("maxLines", "Maximum lines", "number", Description = "Set the maximum number of lines that the editor can be. If left empty, the editor will not auto-scale.")]
+    public int MaxLines { get; set; }
 }

--- a/src/Umbraco.Core/PropertyEditors/CodeEditorConfigurationEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/CodeEditorConfigurationEditor.cs
@@ -1,0 +1,46 @@
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Core.PropertyEditors;
+
+internal class CodeEditorConfigurationEditor : ConfigurationEditor<CodeEditorConfiguration>
+{
+    internal const string Mode = "mode";
+    internal const string Theme = "theme";
+
+    public CodeEditorConfigurationEditor(
+        IIOHelper ioHelper,
+        IEditorConfigurationParser editorConfigurationParser)
+        : base(ioHelper, editorConfigurationParser)
+    {
+    }
+
+    /// <inheritdoc />
+    public override Dictionary<string, object> ToConfigurationEditor(CodeEditorConfiguration? configuration) =>
+        new()
+        {
+            { "mode", configuration?.Mode ?? "razor" },
+            { "theme", configuration?.Theme ?? "chrome" },
+        };
+
+    /// <inheritdoc />
+    public override CodeEditorConfiguration FromConfigurationEditor(
+        IDictionary<string, object?>? editorValues, CodeEditorConfiguration? configuration)
+    {
+        string? mode = null;
+        string? theme = null;
+
+        if (editorValues is not null && editorValues.TryGetValue("mode", out var modeVal))
+        {
+            mode = modeVal?.ToString();
+        }
+
+        if (editorValues is not null && editorValues.TryGetValue("theme", out var themeVal))
+        {
+            theme = themeVal?.ToString();
+        }
+
+        return new CodeEditorConfiguration { Mode = mode, Theme = theme };
+    }
+}

--- a/src/Umbraco.Core/PropertyEditors/CodeEditorPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/CodeEditorPropertyEditor.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Core.PropertyEditors;
+
+[DataEditor(
+    Constants.PropertyEditors.Aliases.CodeEditor,
+    EditorType.PropertyValue | EditorType.MacroParameter,
+    "Code Editor",
+    "codeeditor",
+    Icon = "icon-code",
+    Group = Constants.PropertyEditors.Groups.Common,
+    ValueEditorIsReusable = true)]
+public class CodeEditorPropertyEditor : DataEditor
+{
+    private readonly IEditorConfigurationParser _editorConfigurationParser;
+    private readonly IIOHelper _ioHelper;
+
+    public CodeEditorPropertyEditor(
+        IDataValueEditorFactory dataValueEditorFactory,
+        IIOHelper ioHelper,
+        IEditorConfigurationParser editorConfigurationParser,
+        EditorType type = EditorType.PropertyValue)
+        : base(dataValueEditorFactory, type)
+    {
+        _ioHelper = ioHelper;
+        _editorConfigurationParser = editorConfigurationParser;
+        SupportsReadOnly = true;
+    }
+
+    /// <inheritdoc />
+    protected override IConfigurationEditor CreateConfigurationEditor() =>
+        new CodeEditorConfigurationEditor(_ioHelper, _editorConfigurationParser);
+}

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/CodeEditorValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/CodeEditorValueConverter.cs
@@ -1,0 +1,20 @@
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
+
+[DefaultPropertyValueConverter]
+public class CodeEditorValueConverter : PropertyValueConverterBase
+{
+    public override bool IsConverter(IPublishedPropertyType propertyType)
+        => propertyType.EditorAlias.InvariantEquals(Constants.PropertyEditors.Aliases.CodeEditor);
+
+    public override Type GetPropertyValueType(IPublishedPropertyType propertyType)
+        => typeof(string);
+
+    public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType)
+        => PropertyCacheLevel.Element;
+
+    public override object ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel cacheLevel, object? source, bool preview)
+        => source?.ToString() ?? string.Empty;
+}

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/codeeditor/codeeditor.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/codeeditor/codeeditor.controller.js
@@ -13,7 +13,7 @@ function CodeEditorController($scope) {
         theme: "chrome",
         mode: "razor",
         firstLineNumber: 1,
-        fontSize: "small",
+        fontSize: "14px",
         enableSnippets: 0,
         enableBasicAutocompletion: 0,
         enableLiveAutocompletion: 0,
@@ -40,7 +40,7 @@ function CodeEditorController($scope) {
           useSoftTabs: Object.toBoolean(config.useSoftTabs),
           showPrintMargin: Object.toBoolean(config.showPrintMargin),
           disableSearch: Object.toBoolean(config.disableSearch),
-          mode: config.theme,
+          mode: config.mode,
           theme: config.theme,
           firstLineNumber: config.firstLineNumber,
           advanced: {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/codeeditor/codeeditor.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/codeeditor/codeeditor.controller.js
@@ -1,0 +1,82 @@
+function CodeEditorController($scope) {
+
+    const vm = this;
+
+    const config = {
+        showGutter: 1,
+        useWrapMode: 1,
+        showInvisibles: 0,
+        showIndentGuides: 0,
+        useSoftTabs: 1,
+        showPrintMargin: 0,
+        disableSearch: 0,
+        theme: "chrome",
+        mode: "javascript",
+        firstLineNumber: 1,
+        fontSize: "small",
+        enableSnippets: 0,
+        enableBasicAutocompletion: 0,
+        enableLiveAutocompletion: 0,
+        readonly: 0,
+        minLines: undefined,
+        maxLines: undefined
+    };
+    
+    Utilities.extend(config, $scope.model.config);
+
+    // map back to the model
+    $scope.model.config = config;
+
+    function init() {
+
+      vm.readonly = Object.toBoolean(config.readonly);
+
+      //vm.options = {
+      //    autoFocus: false,
+      //    showGutter: Object.toBoolean(config.showGutter),
+      //    useWrapMode: Object.toBoolean(config.useWrapMode),
+      //    showInvisibles: Object.toBoolean(config.showInvisibles),
+      //    showIndentGuides: Object.toBoolean(config.showIndentGuides),
+      //    useSoftTabs: Object.toBoolean(config.useSoftTabs),
+      //    showPrintMargin: Object.toBoolean(config.showPrintMargin),
+      //    disableSearch: Object.toBoolean(config.disableSearch),
+      //    theme: config.theme,
+      //    mode: config.mode,
+      //    firstLineNumber: config.firstLineNumber,
+      //    advanced: {
+      //        fontSize: config.fontSize,
+      //        enableSnippets: Object.toBoolean(config.enableSnippets),
+      //        enableBasicAutocompletion: Object.toBoolean(config.enableBasicAutocompletion),
+      //        enableLiveAutocompletion: Object.toBoolean(config.enableLiveAutocompletion),
+      //        minLines: config.minLines,
+      //        maxLines: config.maxLines,
+      //        wrap: Object.toBoolean(config.useWrapMode)
+      //    }
+      //};
+
+      vm.aceOption = {
+          mode: "razor",
+          theme: "chrome",
+          showPrintMargin: false,
+          autoFocus: false,
+          advanced: {
+              fontSize: "14px",
+              enableSnippets: false,
+              enableBasicAutocompletion: true,
+              enableLiveAutocompletion: false,
+              //minLines: config.minLines,
+              //maxLines: config.maxLines,
+              wrap: true
+          },
+          onLoad: function (aceEditor) {
+              vm.aceEditor = aceEditor;
+          }
+      }
+
+    };
+
+    init();
+
+}
+
+angular.module("umbraco").controller("Umbraco.PropertyEditors.CodeEditorController", CodeEditorController);

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/codeeditor/codeeditor.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/codeeditor/codeeditor.controller.js
@@ -29,6 +29,8 @@ function CodeEditorController($scope) {
 
     function init() {
 
+      vm.cssClasses = !$scope.model.labelOnTop ? ["umb-property-editor--limit-width"] : [];
+
       vm.readonly = Object.toBoolean(config.readonly);
 
       vm.aceOption = {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/codeeditor/codeeditor.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/codeeditor/codeeditor.controller.js
@@ -11,7 +11,7 @@ function CodeEditorController($scope) {
         showPrintMargin: 0,
         disableSearch: 0,
         theme: "chrome",
-        mode: "javascript",
+        mode: "razor",
         firstLineNumber: 1,
         fontSize: "small",
         enableSnippets: 0,
@@ -31,42 +31,26 @@ function CodeEditorController($scope) {
 
       vm.readonly = Object.toBoolean(config.readonly);
 
-      //vm.options = {
-      //    autoFocus: false,
-      //    showGutter: Object.toBoolean(config.showGutter),
-      //    useWrapMode: Object.toBoolean(config.useWrapMode),
-      //    showInvisibles: Object.toBoolean(config.showInvisibles),
-      //    showIndentGuides: Object.toBoolean(config.showIndentGuides),
-      //    useSoftTabs: Object.toBoolean(config.useSoftTabs),
-      //    showPrintMargin: Object.toBoolean(config.showPrintMargin),
-      //    disableSearch: Object.toBoolean(config.disableSearch),
-      //    theme: config.theme,
-      //    mode: config.mode,
-      //    firstLineNumber: config.firstLineNumber,
-      //    advanced: {
-      //        fontSize: config.fontSize,
-      //        enableSnippets: Object.toBoolean(config.enableSnippets),
-      //        enableBasicAutocompletion: Object.toBoolean(config.enableBasicAutocompletion),
-      //        enableLiveAutocompletion: Object.toBoolean(config.enableLiveAutocompletion),
-      //        minLines: config.minLines,
-      //        maxLines: config.maxLines,
-      //        wrap: Object.toBoolean(config.useWrapMode)
-      //    }
-      //};
-
       vm.aceOption = {
-          mode: "razor",
-          theme: "chrome",
-          showPrintMargin: false,
           autoFocus: false,
+          showGutter: Object.toBoolean(config.showGutter),
+          useWrapMode: Object.toBoolean(config.useWrapMode),
+          showInvisibles: Object.toBoolean(config.showInvisibles),
+          showIndentGuides: Object.toBoolean(config.showIndentGuides),
+          useSoftTabs: Object.toBoolean(config.useSoftTabs),
+          showPrintMargin: Object.toBoolean(config.showPrintMargin),
+          disableSearch: Object.toBoolean(config.disableSearch),
+          mode: config.theme,
+          theme: config.theme,
+          firstLineNumber: config.firstLineNumber,
           advanced: {
-              fontSize: "14px",
-              enableSnippets: false,
-              enableBasicAutocompletion: true,
-              enableLiveAutocompletion: false,
-              //minLines: config.minLines,
-              //maxLines: config.maxLines,
-              wrap: true
+              fontSize: config.fontSize,
+              enableSnippets: Object.toBoolean(config.enableSnippets),
+              enableBasicAutocompletion: Object.toBoolean(config.enableBasicAutocompletion),
+              enableLiveAutocompletion: Object.toBoolean(config.enableLiveAutocompletion),
+              minLines: config.minLines,
+              maxLines: config.maxLines,
+              wrap: Object.toBoolean(config.useWrapMode)
           },
           onLoad: function (aceEditor) {
               vm.aceEditor = aceEditor;

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/codeeditor/codeeditor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/codeeditor/codeeditor.html
@@ -1,4 +1,4 @@
-<div class="umb-property-editor--limit-width" ng-controller="Umbraco.PropertyEditors.CodeEditorController as vm">
+<div ng-class="vm.cssClasses" ng-controller="Umbraco.PropertyEditors.CodeEditorController as vm">
 
   <div umb-ace-editor="vm.aceOption" model="model.value" ng-readonly="vm.readonly"></div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/codeeditor/codeeditor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/codeeditor/codeeditor.html
@@ -1,0 +1,5 @@
+<div ng-controller="Umbraco.PropertyEditors.CodeEditorController as vm">
+
+  <div umb-ace-editor="vm.aceOption" model="model.value" ng-readonly="vm.readonly"></div>
+
+</div>

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/codeeditor/codeeditor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/codeeditor/codeeditor.html
@@ -1,4 +1,4 @@
-<div ng-controller="Umbraco.PropertyEditors.CodeEditorController as vm">
+<div class="umb-property-editor--limit-width" ng-controller="Umbraco.PropertyEditors.CodeEditorController as vm">
 
   <div umb-ace-editor="vm.aceOption" model="model.value" ng-readonly="vm.readonly"></div>
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Composing/TypeLoaderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Composing/TypeLoaderTests.cs
@@ -173,7 +173,7 @@ public class TypeLoaderTests
     public void GetDataEditors()
     {
         var types = _typeLoader.GetDataEditors();
-        Assert.AreEqual(42, types.Count());
+        Assert.AreEqual(43, types.Count());
     }
 
     /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Reference to discussion: https://github.com/umbraco/Umbraco-CMS/discussions/15262

### Description
This add a new Code Editor property editor using the existing code editor in Umbraco (currently Ace editor).
Often there's at need to embed third party code in `<head>`, `<body>` (start or end) or just embed e.g. `<iframe>` or `<video>` element.
Sometimes it can be constructed using one or more properties, but not already.

Often this is solved using a text area, but it doesn't allow syntax highlighting and code formatting and the richtext editor (TinyMCE) isn't great for this + it doesn't allow `<script>` by default.

@leekelleher added a [Code Editor](https://github.com/leekelleher/umbraco-contentment/blob/develop/docs/editors/code-editor.md ) to the Contentment package, but I think this a something most projects can benefits from and many wrapping the existing code editor.