### PR TITLE
Rollback some #14816 changes to fix 2FA

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/AuthenticationController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/AuthenticationController.cs
@@ -526,7 +526,7 @@ public class AuthenticationController : UmbracoApiControllerBase
             await _signInManager.TwoFactorSignInAsync(model.Provider, model.Code, model.IsPersistent, model.RememberClient);
         if (result.Succeeded)
         {
-            return GetUserDetail(_userService.GetByUsername(user.UserName));
+            return Ok(GetUserDetail(_userService.GetByUsername(user.UserName)));
         }
 
         if (result.IsLockedOut)

--- a/src/Umbraco.Web.UI.Client/src/views/common/login-2fa.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/login-2fa.html
@@ -1,6 +1,6 @@
-<div ng-controller="Umbraco.Login2faController as vm" class="umb-login-container">
+<div ng-controller="Umbraco.Login2faController as cvm" class="umb-login-container">
   <div id="twoFactorlogin" ng-cloak="">
-    <form name="vm.authForm" method="POST" ng-submit="vm.validate()">
+    <form name="cvm.authForm" method="POST" ng-submit="cvm.validate()">
       <header class="h4">
         <localize key="login_2fatitle">One last step</localize>
       </header>
@@ -12,19 +12,19 @@
       <br>
 
       <!-- if there's only one provider active, it will skip this step! -->
-      <umb-control-group ng-if="vm.providers.length > 1" label="@login_2faMultipleText" label-for="provider" alias="2faprovider">
-        <select id="2faprovider" name="provider" ng-model="vm.provider">
-          <option ng-repeat="provider in vm.providers" ng-value="provider">{{provider}}</option>
+      <umb-control-group ng-if="cvm.providers.length > 1" label="@login_2faMultipleText" label-for="provider" alias="2faprovider">
+        <select id="2faprovider" name="provider" ng-model="cvm.provider">
+          <option ng-repeat="provider in cvm.providers" ng-value="provider">{{provider}}</option>
         </select>
       </umb-control-group>
 
       <umb-control-group label-for="token" alias="2facode" label="@login_2faCodeInput" description="@user_2faDisableText" required="true">
 
         <input type="text" id="2facode" class="-full-width-input input-xlarge" name="token"
-          inputmode="numeric" autocomplete="one-time-code" ng-model="vm.code" localize="placeholder"
+          inputmode="numeric" autocomplete="one-time-code" ng-model="cvm.code" localize="placeholder"
           placeholder="@login_2faCodeInputHelp" aria-required="true" required umb-auto-focus no-dirty-check />
 
-        <div ng-messages="vm.authForm.token.$error" role="alert">
+        <div ng-messages="cvm.authForm.token.$error" role="alert">
           <span class="umb-validation-label" ng-message="token">
             <localize key="login_2faInvalidCode">Invalid code entered</localize>
           </span>
@@ -37,14 +37,14 @@
           button-style="success"
           size="m"
           label-key="general_validate"
-          state="vm.stateValidateButton"
-          disabled="vm.code.length === 0">
+          state="cvm.stateValidateButton"
+          disabled="cvm.code.length === 0">
         </umb-button>
         <umb-button
           type="button"
           size="m"
           label-key="general_back"
-          action="vm.goBack()">
+          action="cvm.goBack()">
         </umb-button>
       </div>
     </form>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/15259

### Description

The well-intended changes in #14816 has the unfortunate downside of breaking 2FA, as described in the linked issue.

I have rolled back the necessary parts of #14816 to make 2FA work again. Also, the `AuthenticationController` should really return an explicit `ActionResult` when the 2FA validation succeeds, so I have updated that as well.

### Testing this PR

Get in touch with @kjac to do a pair testing session 😄 or setup 2FA as per [the docs](https://docs.umbraco.com/umbraco-cms/reference/security/two-factor-authentication) to verify that it works.