### PR TITLE
v13: Update deploy types (add setter to `ArtifactDependency.Checksum` and `TryGetValue()`/`GetEntityTypes()` to `IFileTypeCollection`)

### DIFF
--- a/src/Umbraco.Core/Deploy/ArtifactBase.cs
+++ b/src/Umbraco.Core/Deploy/ArtifactBase.cs
@@ -1,49 +1,69 @@
 namespace Umbraco.Cms.Core.Deploy;
 
 /// <summary>
-/// Provides a base class to all artifacts.
+/// Provides a base class for all artifacts.
 /// </summary>
+/// <typeparam name="TUdi">The UDI type.</typeparam>
 public abstract class ArtifactBase<TUdi> : IArtifact
     where TUdi : Udi
 {
+    private IEnumerable<ArtifactDependency> _dependencies;
+    private readonly Lazy<string> _checksum;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArtifactBase{TUdi}" /> class.
+    /// </summary>
+    /// <param name="udi">The UDI.</param>
+    /// <param name="dependencies">The dependencies.</param>
     protected ArtifactBase(TUdi udi, IEnumerable<ArtifactDependency>? dependencies = null)
     {
-        Udi = udi ?? throw new ArgumentNullException("udi");
+        Udi = udi ?? throw new ArgumentNullException(nameof(udi));
         Name = Udi.ToString();
 
         _dependencies = dependencies ?? Enumerable.Empty<ArtifactDependency>();
         _checksum = new Lazy<string>(GetChecksum);
     }
 
-    private readonly Lazy<string> _checksum;
-
-    private IEnumerable<ArtifactDependency> _dependencies;
-
-    protected abstract string GetChecksum();
-
+    /// <inheritdoc />
     Udi IArtifactSignature.Udi => Udi;
 
+    /// <inheritdoc />
     public TUdi Udi { get; set; }
 
-    public string Checksum => _checksum.Value;
-
-    /// <summary>
-    /// Prevents the <see cref="Checksum" /> property from being serialized.
-    /// </summary>
-    /// <remarks>
-    /// Note that we can't use <see cref="NonSerializedAttribute"/> here as that works only on fields, not properties.  And we want to avoid using [JsonIgnore]
-    /// as that would require an external dependency in Umbraco.Cms.Core.
-    /// So using this method of excluding properties from serialized data, documented here: https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm
-    /// </remarks>
-    public bool ShouldSerializeChecksum() => false;
-
+    /// <inheritdoc />
     public IEnumerable<ArtifactDependency> Dependencies
     {
         get => _dependencies;
         set => _dependencies = value.OrderBy(x => x.Udi);
     }
 
+    /// <inheritdoc />
+    public string Checksum => _checksum.Value;
+
+    /// <inheritdoc />
     public string Name { get; set; }
 
+    /// <inheritdoc />
     public string Alias { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the checksum.
+    /// </summary>
+    /// <returns>
+    /// The checksum.
+    /// </returns>
+    protected abstract string GetChecksum();
+
+    /// <summary>
+    /// Prevents the <see cref="Checksum" /> property from being serialized.
+    /// </summary>
+    /// <returns>
+    /// Returns <c>false</c> to prevent the property from being serialized.
+    /// </returns>
+    /// <remarks>
+    /// Note that we can't use <see cref="NonSerializedAttribute" /> here as that works only on fields, not properties.  And we want to avoid using [JsonIgnore]
+    /// as that would require an external dependency in Umbraco.Cms.Core.
+    /// So using this method of excluding properties from serialized data, documented here: https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm
+    /// </remarks>
+    public bool ShouldSerializeChecksum() => false;
 }

--- a/src/Umbraco.Core/Deploy/ArtifactDependency.cs
+++ b/src/Umbraco.Core/Deploy/ArtifactDependency.cs
@@ -1,27 +1,17 @@
-using System.Text.Json.Serialization;
-
 namespace Umbraco.Cms.Core.Deploy;
 
 /// <summary>
 /// Represents an artifact dependency.
 /// </summary>
-/// <remarks>
-/// <para>
-/// Dependencies have an order property which indicates whether it must be respected when ordering artifacts.
-/// </para>
-/// <para>
-/// Dependencies have a mode which can be <see cref="ArtifactDependencyMode.Match" /> or <see cref="ArtifactDependencyMode.Exist" /> depending on whether the checksum should match.
-/// </para>
-/// </remarks>
 public class ArtifactDependency
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="ArtifactDependency" /> class.
     /// </summary>
     /// <param name="udi">The entity identifier of the artifact dependency.</param>
-    /// <param name="ordering">A value indicating whether the dependency is ordering.</param>
-    /// <param name="mode">The dependency mode.</param>
-    /// <param name="checksum">The checksum.</param>
+    /// <param name="ordering">A value indicating whether the dependency must be included when building a dependency tree and ensure the artifact gets deployed in the correct order.</param>
+    /// <param name="mode">A value indicating whether the checksum must match or the artifact just needs to exist.</param>
+    /// <param name="checksum">The checksum of the dependency.</param>
     public ArtifactDependency(Udi udi, bool ordering, ArtifactDependencyMode mode, string? checksum = null)
     {
         Udi = udi;
@@ -39,10 +29,10 @@ public class ArtifactDependency
     public Udi Udi { get; }
 
     /// <summary>
-    /// Gets a value indicating whether the dependency is ordering.
+    /// Gets a value indicating whether the dependency is included when building a dependency tree and gets deployed in the correct order.
     /// </summary>
     /// <value>
-    ///   <c>true</c> if the dependency is ordering; otherwise, <c>false</c>.
+    ///   <c>true</c> if the dependency is included when building a dependency tree and gets deployed in the correct order; otherwise, <c>false</c>.
     /// </value>
     public bool Ordering { get; }
 

--- a/src/Umbraco.Core/Deploy/ArtifactDependency.cs
+++ b/src/Umbraco.Core/Deploy/ArtifactDependency.cs
@@ -55,10 +55,10 @@ public class ArtifactDependency
     public ArtifactDependencyMode Mode { get; }
 
     /// <summary>
-    /// Gets the checksum.
+    /// Gets or sets the checksum.
     /// </summary>
     /// <value>
     /// The checksum.
     /// </value>
-    public string? Checksum { get; }
+    public string? Checksum { get; set; }
 }

--- a/src/Umbraco.Core/Deploy/ArtifactDependencyCollection.cs
+++ b/src/Umbraco.Core/Deploy/ArtifactDependencyCollection.cs
@@ -3,42 +3,53 @@ using System.Collections;
 namespace Umbraco.Cms.Core.Deploy;
 
 /// <summary>
-///     Represents a collection of distinct <see cref="ArtifactDependency" />.
+/// Represents a collection of distinct <see cref="ArtifactDependency" />.
 /// </summary>
-/// <remarks>The collection cannot contain duplicates and modes are properly managed.</remarks>
+/// <remarks>
+/// The collection cannot contain duplicates and modes are properly managed.
+/// </remarks>
 public class ArtifactDependencyCollection : ICollection<ArtifactDependency>
 {
     private readonly Dictionary<Udi, ArtifactDependency> _dependencies = new();
 
+    /// <inheritdoc />
     public int Count => _dependencies.Count;
 
-    public IEnumerator<ArtifactDependency> GetEnumerator() => _dependencies.Values.GetEnumerator();
+    /// <inheritdoc />
+    public bool IsReadOnly => false;
 
-    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
+    /// <inheritdoc />
     public void Add(ArtifactDependency item)
     {
-        if (_dependencies.ContainsKey(item.Udi))
+        if (item.Mode == ArtifactDependencyMode.Exist &&
+            _dependencies.TryGetValue(item.Udi, out ArtifactDependency? existingItem) &&
+            existingItem.Mode == ArtifactDependencyMode.Match)
         {
-            ArtifactDependency exist = _dependencies[item.Udi];
-            if (item.Mode == ArtifactDependencyMode.Exist || item.Mode == exist.Mode)
-            {
-                return;
-            }
+            // Don't downgrade dependency mode from Match to Exist
+            return;
         }
 
         _dependencies[item.Udi] = item;
     }
 
+    /// <inheritdoc />
     public void Clear() => _dependencies.Clear();
 
-    public bool Contains(ArtifactDependency item) =>
-        _dependencies.ContainsKey(item.Udi) &&
-        (_dependencies[item.Udi].Mode == item.Mode || _dependencies[item.Udi].Mode == ArtifactDependencyMode.Match);
+    /// <inheritdoc />
+    public bool Contains(ArtifactDependency item)
+        => _dependencies.TryGetValue(item.Udi, out ArtifactDependency? existingItem) &&
+        // Check whether it has the same or higher dependency mode
+        (existingItem.Mode == item.Mode || existingItem.Mode == ArtifactDependencyMode.Match);
 
+    /// <inheritdoc />
     public void CopyTo(ArtifactDependency[] array, int arrayIndex) => _dependencies.Values.CopyTo(array, arrayIndex);
 
-    public bool Remove(ArtifactDependency item) => throw new NotSupportedException();
+    /// <inheritdoc />
+    public bool Remove(ArtifactDependency item) => _dependencies.Remove(item.Udi);
 
-    public bool IsReadOnly => false;
+    /// <inheritdoc />
+    public IEnumerator<ArtifactDependency> GetEnumerator() => _dependencies.Values.GetEnumerator();
+
+    /// <inheritdoc />
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/Umbraco.Core/Deploy/ArtifactDependencyMode.cs
+++ b/src/Umbraco.Core/Deploy/ArtifactDependencyMode.cs
@@ -1,17 +1,16 @@
 namespace Umbraco.Cms.Core.Deploy;
 
 /// <summary>
-///     Indicates the mode of the dependency.
+/// Indicates the mode of the dependency.
 /// </summary>
 public enum ArtifactDependencyMode
 {
     /// <summary>
-    ///     The dependency must match exactly.
+    /// The dependency must match exactly.
     /// </summary>
     Match,
-
     /// <summary>
-    ///     The dependency must exist.
+    /// The dependency must exist.
     /// </summary>
     Exist,
 }

--- a/src/Umbraco.Core/Deploy/ArtifactDeployState.cs
+++ b/src/Umbraco.Core/Deploy/ArtifactDeployState.cs
@@ -1,27 +1,36 @@
 namespace Umbraco.Cms.Core.Deploy;
 
 /// <summary>
-///     Represent the state of an artifact being deployed.
+/// Represent the state of an artifact being deployed.
 /// </summary>
 public abstract class ArtifactDeployState
 {
     /// <summary>
-    ///     Gets the artifact.
+    /// Gets the artifact.
     /// </summary>
+    /// <value>
+    /// The artifact.
+    /// </value>
     public IArtifact Artifact => GetArtifactAsIArtifact();
 
     /// <summary>
-    ///     Gets or sets the service connector in charge of deploying the artifact.
+    /// Gets or sets the service connector in charge of deploying the artifact.
     /// </summary>
+    /// <value>
+    /// The connector.
+    /// </value>
     public IServiceConnector? Connector { get; set; }
 
     /// <summary>
-    ///     Gets or sets the next pass number.
+    /// Gets or sets the next pass number.
     /// </summary>
+    /// <value>
+    /// The next pass.
+    /// </value>
     public int NextPass { get; set; }
 
     /// <summary>
-    ///     Creates a new instance of the <see cref="ArtifactDeployState" /> class from an artifact and an entity.
+    /// Creates a new instance of the <see cref="ArtifactDeployState" /> class from an artifact and an entity.
     /// </summary>
     /// <typeparam name="TArtifact">The type of the artifact.</typeparam>
     /// <typeparam name="TEntity">The type of the entity.</typeparam>
@@ -29,24 +38,28 @@ public abstract class ArtifactDeployState
     /// <param name="entity">The entity.</param>
     /// <param name="connector">The service connector deploying the artifact.</param>
     /// <param name="nextPass">The next pass number.</param>
-    /// <returns>A deploying artifact.</returns>
+    /// <returns>
+    /// A deploying artifact.
+    /// </returns>
     public static ArtifactDeployState<TArtifact, TEntity> Create<TArtifact, TEntity>(TArtifact art, TEntity? entity, IServiceConnector connector, int nextPass)
         where TArtifact : IArtifact =>
         new ArtifactDeployState<TArtifact, TEntity>(art, entity, connector, nextPass);
 
     /// <summary>
-    ///     Gets the artifact as an <see cref="IArtifact" />.
+    /// Gets the artifact as an <see cref="IArtifact" />.
     /// </summary>
-    /// <returns>The artifact, as an <see cref="IArtifact" />.</returns>
+    /// <returns>
+    /// The artifact, as an <see cref="IArtifact" />.
+    /// </returns>
     /// <remarks>
-    ///     This is because classes that inherit from this class cannot override the Artifact property
-    ///     with a property that specializes the return type, and so they need to 'new' the property.
+    /// This is because classes that inherit from this class cannot override the Artifact property
+    /// with a property that specializes the return type, and so they need to 'new' the property.
     /// </remarks>
     protected abstract IArtifact GetArtifactAsIArtifact();
 }
 
 /// <summary>
-///     Represent the state of an artifact being deployed.
+/// Represent the state of an artifact being deployed.
 /// </summary>
 /// <typeparam name="TArtifact">The type of the artifact.</typeparam>
 /// <typeparam name="TEntity">The type of the entity.</typeparam>
@@ -54,7 +67,7 @@ public class ArtifactDeployState<TArtifact, TEntity> : ArtifactDeployState
     where TArtifact : IArtifact
 {
     /// <summary>
-    ///     Initializes a new instance of the <see cref="ArtifactDeployState{TArtifact,TEntity}" /> class.
+    /// Initializes a new instance of the <see cref="ArtifactDeployState{TArtifact,TEntity}" /> class.
     /// </summary>
     /// <param name="art">The artifact.</param>
     /// <param name="entity">The entity.</param>
@@ -69,13 +82,19 @@ public class ArtifactDeployState<TArtifact, TEntity> : ArtifactDeployState
     }
 
     /// <summary>
-    ///     Gets or sets the artifact.
+    /// Gets or sets the artifact.
     /// </summary>
+    /// <value>
+    /// The artifact.
+    /// </value>
     public new TArtifact Artifact { get; set; }
 
     /// <summary>
-    ///     Gets or sets the entity.
+    /// Gets or sets the entity.
     /// </summary>
+    /// <value>
+    /// The entity.
+    /// </value>
     public TEntity? Entity { get; set; }
 
     /// <inheritdoc />

--- a/src/Umbraco.Core/Deploy/ArtifactSignature.cs
+++ b/src/Umbraco.Core/Deploy/ArtifactSignature.cs
@@ -1,17 +1,27 @@
 namespace Umbraco.Cms.Core.Deploy;
 
+/// <inheritdoc />
 public sealed class ArtifactSignature : IArtifactSignature
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArtifactSignature" /> class.
+    /// </summary>
+    /// <param name="udi">The UDI.</param>
+    /// <param name="checksum">The checksum.</param>
+    /// <param name="dependencies">The artifact dependencies.</param>
     public ArtifactSignature(Udi udi, string checksum, IEnumerable<ArtifactDependency>? dependencies = null)
     {
         Udi = udi;
         Checksum = checksum;
-        Dependencies = dependencies ?? Enumerable.Empty<ArtifactDependency>();
+        Dependencies = dependencies ?? Array.Empty<ArtifactDependency>();
     }
 
+    /// <inheritdoc />
     public Udi Udi { get; }
 
+    /// <inheritdoc />
     public string Checksum { get; }
 
+    /// <inheritdoc />
     public IEnumerable<ArtifactDependency> Dependencies { get; }
 }

--- a/src/Umbraco.Core/Deploy/Difference.cs
+++ b/src/Umbraco.Core/Deploy/Difference.cs
@@ -1,7 +1,16 @@
 namespace Umbraco.Cms.Core.Deploy;
 
+/// <summary>
+/// Represents a difference between two artifacts.
+/// </summary>
 public class Difference
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Difference" /> class.
+    /// </summary>
+    /// <param name="title">The title.</param>
+    /// <param name="text">The text.</param>
+    /// <param name="category">The category.</param>
     public Difference(string title, string? text = null, string? category = null)
     {
         Title = title;
@@ -9,12 +18,36 @@ public class Difference
         Category = category;
     }
 
+    /// <summary>
+    /// Gets or sets the title.
+    /// </summary>
+    /// <value>
+    /// The title.
+    /// </value>
     public string Title { get; set; }
 
+    /// <summary>
+    /// Gets or sets the text.
+    /// </summary>
+    /// <value>
+    /// The text.
+    /// </value>
     public string? Text { get; set; }
 
+    /// <summary>
+    /// Gets or sets the category.
+    /// </summary>
+    /// <value>
+    /// The category.
+    /// </value>
     public string? Category { get; set; }
 
+    /// <summary>
+    /// Converts the difference to a <see cref="string" />.
+    /// </summary>
+    /// <returns>
+    /// A <see cref="string" /> that represents the difference.
+    /// </returns>
     public override string ToString()
     {
         var s = Title;

--- a/src/Umbraco.Core/Deploy/Direction.cs
+++ b/src/Umbraco.Core/Deploy/Direction.cs
@@ -1,7 +1,16 @@
 namespace Umbraco.Cms.Core.Deploy;
 
+/// <summary>
+/// Represents the direction when replacing an attribute value while parsing macros.
+/// </summary>
 public enum Direction
 {
+    /// <summary>
+    /// Replacing an attribute value while converting to an artifact.
+    /// </summary>
     ToArtifact,
+    /// <summary>
+    /// Replacing an attribute value while converting from an artifact.
+    /// </summary>
     FromArtifact,
 }

--- a/src/Umbraco.Core/Deploy/IArtifact.cs
+++ b/src/Umbraco.Core/Deploy/IArtifact.cs
@@ -1,11 +1,23 @@
 namespace Umbraco.Cms.Core.Deploy;
 
 /// <summary>
-///     Represents an artifact ie an object that can be transfered between environments.
+/// Represents an artifact ie an object that can be transfered between environments.
 /// </summary>
 public interface IArtifact : IArtifactSignature
 {
+    /// <summary>
+    /// Gets the name.
+    /// </summary>
+    /// <value>
+    /// The name.
+    /// </value>
     string Name { get; }
 
+    /// <summary>
+    /// Gets the alias.
+    /// </summary>
+    /// <value>
+    /// The alias.
+    /// </value>
     string? Alias { get; }
 }

--- a/src/Umbraco.Core/Deploy/IArtifactSignature.cs
+++ b/src/Umbraco.Core/Deploy/IArtifactSignature.cs
@@ -1,46 +1,55 @@
 namespace Umbraco.Cms.Core.Deploy;
 
 /// <summary>
-///     Represents the signature of an artifact.
+/// Represents the signature of an artifact.
 /// </summary>
 public interface IArtifactSignature
 {
     /// <summary>
-    ///     Gets the entity unique identifier of this artifact.
+    /// Gets the entity unique identifier of this artifact.
     /// </summary>
+    /// <value>
+    /// The udi.
+    /// </value>
     /// <remarks>
-    ///     <para>
-    ///         The project identifier is independent from the state of the artifact, its data
-    ///         values, dependencies, anything. It never changes and fully identifies the artifact.
-    ///     </para>
-    ///     <para>
-    ///         What an entity uses as a unique identifier will influence what we can transfer
-    ///         between environments. Eg content type "Foo" on one environment is not necessarily the
-    ///         same as "Foo" on another environment, if guids are used as unique identifiers. What is
-    ///         used should be documented for each entity, along with the consequences of the choice.
-    ///     </para>
+    /// <para>
+    /// The project identifier is independent from the state of the artifact, its data
+    /// values, dependencies, anything. It never changes and fully identifies the artifact.
+    /// </para>
+    /// <para>
+    /// What an entity uses as a unique identifier will influence what we can transfer
+    /// between environments. Eg content type "Foo" on one environment is not necessarily the
+    /// same as "Foo" on another environment, if guids are used as unique identifiers. What is
+    /// used should be documented for each entity, along with the consequences of the choice.
+    /// </para>
     /// </remarks>
     Udi Udi { get; }
 
     /// <summary>
-    ///     Gets the checksum of this artifact.
+    /// Gets the checksum of this artifact.
     /// </summary>
+    /// <value>
+    /// The checksum.
+    /// </value>
     /// <remarks>
-    ///     <para>
-    ///         The checksum depends on the artifact's properties, and on the identifiers of all its dependencies,
-    ///         but not on their checksums. So the checksum changes when any of the artifact's properties changes,
-    ///         or when the list of dependencies changes. But not if one of these dependencies change.
-    ///     </para>
-    ///     <para>
-    ///         It is assumed that checksum collisions cannot happen ie that no two different artifact's
-    ///         states will ever produce the same checksum, so that if two artifacts have the same checksum then
-    ///         they are identical.
-    ///     </para>
+    /// <para>
+    /// The checksum depends on the artifact's properties, and on the identifiers of all its dependencies,
+    /// but not on their checksums. So the checksum changes when any of the artifact's properties changes,
+    /// or when the list of dependencies changes. But not if one of these dependencies change.
+    /// </para>
+    /// <para>
+    /// It is assumed that checksum collisions cannot happen ie that no two different artifact's
+    /// states will ever produce the same checksum, so that if two artifacts have the same checksum then
+    /// they are identical.
+    /// </para>
     /// </remarks>
     string Checksum { get; }
 
     /// <summary>
-    ///     Gets the dependencies of this artifact.
+    /// Gets the dependencies of this artifact.
     /// </summary>
+    /// <value>
+    /// The dependencies.
+    /// </value>
     IEnumerable<ArtifactDependency> Dependencies { get; }
 }

--- a/src/Umbraco.Core/Deploy/IDeployContext.cs
+++ b/src/Umbraco.Core/Deploy/IDeployContext.cs
@@ -1,39 +1,56 @@
 namespace Umbraco.Cms.Core.Deploy;
 
 /// <summary>
-///     Represents a deployment context.
+/// Represents a deployment context.
 /// </summary>
 public interface IDeployContext
 {
     /// <summary>
-    ///     Gets the unique identifier of the deployment.
+    /// Gets the unique identifier of the deployment.
     /// </summary>
+    /// <value>
+    /// The session identifier.
+    /// </value>
     Guid SessionId { get; }
 
     /// <summary>
-    ///     Gets the file source.
+    /// Gets the file source.
     /// </summary>
-    /// <remarks>The file source is used to obtain files from the source environment.</remarks>
+    /// <value>
+    /// The file source.
+    /// </value>
+    /// <remarks>
+    /// The file source is used to obtain files from the source environment.
+    /// </remarks>
     IFileSource FileSource { get; }
 
     /// <summary>
-    ///     Gets items.
+    /// Gets items.
     /// </summary>
+    /// <value>
+    /// The items.
+    /// </value>
     IDictionary<string, object> Items { get; }
 
     /// <summary>
-    ///     Gets the next number in a numerical sequence.
+    /// Gets the next number in a numerical sequence.
     /// </summary>
-    /// <returns>The next sequence number.</returns>
-    /// <remarks>Can be used to uniquely number things during a deployment.</remarks>
+    /// <returns>
+    /// The next sequence number.
+    /// </returns>
+    /// <remarks>
+    /// Can be used to uniquely number things during a deployment.
+    /// </remarks>
     int NextSeq();
 
     /// <summary>
-    ///     Gets item.
+    /// Gets item.
     /// </summary>
     /// <typeparam name="T">The type of the item.</typeparam>
     /// <param name="key">The key of the item.</param>
-    /// <returns>The item with the specified key and type, if any, else null.</returns>
+    /// <returns>
+    /// The item with the specified key and type, if any, else null.
+    /// </returns>
     T? Item<T>(string key)
         where T : class;
 

--- a/src/Umbraco.Core/Deploy/IFileSource.cs
+++ b/src/Umbraco.Core/Deploy/IFileSource.cs
@@ -1,70 +1,86 @@
 namespace Umbraco.Cms.Core.Deploy;
 
 /// <summary>
-///     Represents a file source, ie a mean for a target environment involved in a
-///     deployment to obtain the content of files being deployed.
+/// Represents a file source, ie a mean for a target environment involved in a
+/// deployment to obtain the content of files being deployed.
 /// </summary>
 public interface IFileSource
 {
     /// <summary>
-    ///     Gets the content of a file as a stream.
+    /// Gets the content of a file as a stream.
     /// </summary>
     /// <param name="udi">A file entity identifier.</param>
-    /// <returns>A stream with read access to the file content.</returns>
+    /// <returns>
+    /// A stream with read access to the file content.
+    /// </returns>
     /// <remarks>
-    ///     <para>Returns null if no content could be read.</para>
-    ///     <para>The caller should ensure that the stream is properly closed/disposed.</para>
+    /// <para>Returns null if no content could be read.</para>
+    /// <para>The caller should ensure that the stream is properly closed/disposed.</para>
     /// </remarks>
     Stream GetFileStream(StringUdi udi);
 
     /// <summary>
-    ///     Gets the content of a file as a stream.
+    /// Gets the content of a file as a stream.
     /// </summary>
     /// <param name="udi">A file entity identifier.</param>
     /// <param name="token">A cancellation token.</param>
-    /// <returns>A stream with read access to the file content.</returns>
+    /// <returns>
+    /// A stream with read access to the file content.
+    /// </returns>
     /// <remarks>
-    ///     <para>Returns null if no content could be read.</para>
-    ///     <para>The caller should ensure that the stream is properly closed/disposed.</para>
+    /// <para>Returns null if no content could be read.</para>
+    /// <para>The caller should ensure that the stream is properly closed/disposed.</para>
     /// </remarks>
     Task<Stream> GetFileStreamAsync(StringUdi udi, CancellationToken token);
 
     /// <summary>
-    ///     Gets the content of a file as a string.
+    /// Gets the content of a file as a string.
     /// </summary>
     /// <param name="udi">A file entity identifier.</param>
-    /// <returns>A string containing the file content.</returns>
-    /// <remarks>Returns null if no content could be read.</remarks>
+    /// <returns>
+    /// A string containing the file content.
+    /// </returns>
+    /// <remarks>
+    /// Returns null if no content could be read.
+    /// </remarks>
     string GetFileContent(StringUdi udi);
 
     /// <summary>
-    ///     Gets the content of a file as a string.
+    /// Gets the content of a file as a string.
     /// </summary>
     /// <param name="udi">A file entity identifier.</param>
     /// <param name="token">A cancellation token.</param>
-    /// <returns>A string containing the file content.</returns>
-    /// <remarks>Returns null if no content could be read.</remarks>
+    /// <returns>
+    /// A string containing the file content.
+    /// </returns>
+    /// <remarks>
+    /// Returns null if no content could be read.
+    /// </remarks>
     Task<string> GetFileContentAsync(StringUdi udi, CancellationToken token);
 
     /// <summary>
-    ///     Gets the length of a file.
+    /// Gets the length of a file.
     /// </summary>
     /// <param name="udi">A file entity identifier.</param>
-    /// <returns>The length of the file, or -1 if the file does not exist.</returns>
+    /// <returns>
+    /// The length of the file, or -1 if the file does not exist.
+    /// </returns>
     long GetFileLength(StringUdi udi);
 
     /// <summary>
-    ///     Gets the length of a file.
+    /// Gets the length of a file.
     /// </summary>
     /// <param name="udi">A file entity identifier.</param>
     /// <param name="token">A cancellation token.</param>
-    /// <returns>The length of the file, or -1 if the file does not exist.</returns>
+    /// <returns>
+    /// The length of the file, or -1 if the file does not exist.
+    /// </returns>
     Task<long> GetFileLengthAsync(StringUdi udi, CancellationToken token);
 
     // TODO (V14): Remove obsolete methods and default implementations for GetFiles and GetFilesAsync overloads.
 
     /// <summary>
-    ///     Gets files and store them using a file store.
+    /// Gets files and store them using a file store.
     /// </summary>
     /// <param name="udis">The UDIs of the files to get.</param>
     /// <param name="fileTypes">A collection of file types which can store the files.</param>
@@ -72,32 +88,38 @@ public interface IFileSource
     void GetFiles(IEnumerable<StringUdi> udis, IFileTypeCollection fileTypes);
 
     /// <summary>
-    ///     Gets files and store them using a file store.
+    /// Gets files and store them using a file store.
     /// </summary>
     /// <param name="udis">The UDIs of the files to get.</param>
-    /// <param name="fileTypes">A collection of file types which can store the files.</param>
     /// <param name="continueOnFileNotFound">A flag indicating whether to continue if a file isn't found or to stop and throw a FileNotFoundException.</param>
+    /// <param name="fileTypes">A collection of file types which can store the files.</param>
     void GetFiles(IEnumerable<StringUdi> udis, bool continueOnFileNotFound, IFileTypeCollection fileTypes)
 #pragma warning disable CS0618 // Type or member is obsolete
         => GetFiles(udis, fileTypes);
 #pragma warning restore CS0618 // Type or member is obsolete
 
     /// <summary>
-    ///     Gets files and store them using a file store.
+    /// Gets files and store them using a file store.
     /// </summary>
     /// <param name="udis">The UDIs of the files to get.</param>
     /// <param name="fileTypes">A collection of file types which can store the files.</param>
     /// <param name="token">A cancellation token.</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation.
+    /// </returns>
     [Obsolete("Please use the method overload taking all parameters. This method overload will be removed in Umbraco 14.")]
     Task GetFilesAsync(IEnumerable<StringUdi> udis, IFileTypeCollection fileTypes, CancellationToken token);
 
     /// <summary>
-    ///     Gets files and store them using a file store.
+    /// Gets files and store them using a file store.
     /// </summary>
     /// <param name="udis">The UDIs of the files to get.</param>
     /// <param name="fileTypes">A collection of file types which can store the files.</param>
     /// <param name="continueOnFileNotFound">A flag indicating whether to continue if a file isn't found or to stop and throw a FileNotFoundException.</param>
     /// <param name="token">A cancellation token.</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation.
+    /// </returns>
     Task GetFilesAsync(IEnumerable<StringUdi> udis, IFileTypeCollection fileTypes, bool continueOnFileNotFound, CancellationToken token)
 #pragma warning disable CS0618 // Type or member is obsolete
         => GetFilesAsync(udis, fileTypes, token);

--- a/src/Umbraco.Core/Deploy/IFileType.cs
+++ b/src/Umbraco.Core/Deploy/IFileType.cs
@@ -1,27 +1,101 @@
 namespace Umbraco.Cms.Core.Deploy;
 
+/// <summary>
+/// Represents a deployable file type.
+/// </summary>
 public interface IFileType
 {
+    /// <summary>
+    /// Gets a value indicating whether the file can be set using a physical path.
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if the file can be set using a physical path; otherwise, <c>false</c>.
+    /// </value>
     bool CanSetPhysical { get; }
 
+    /// <summary>
+    /// Gets the stream.
+    /// </summary>
+    /// <param name="udi">The UDI.</param>
+    /// <returns>
+    /// The stream.
+    /// </returns>
     Stream GetStream(StringUdi udi);
 
+    /// <summary>
+    /// Gets the stream as an asynchronous operation.
+    /// </summary>
+    /// <param name="udi">The UDI.</param>
+    /// <param name="token">The cancellation token.</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation.
+    /// </returns>
     Task<Stream> GetStreamAsync(StringUdi udi, CancellationToken token);
 
+    /// <summary>
+    /// Gets the checksum stream.
+    /// </summary>
+    /// <param name="udi">The UDI.</param>
+    /// <returns>
+    /// The checksum stream.
+    /// </returns>
     Stream GetChecksumStream(StringUdi udi);
 
+    /// <summary>
+    /// Gets the file length in bytes or <c>-1</c> if not found.
+    /// </summary>
+    /// <param name="udi">The UDI.</param>
+    /// <returns>
+    /// The file length in bytes or <c>-1</c> if not found.
+    /// </returns>
     long GetLength(StringUdi udi);
 
+    /// <summary>
+    /// Sets the stream.
+    /// </summary>
+    /// <param name="udi">The UDI.</param>
+    /// <param name="stream">The stream.</param>
     void SetStream(StringUdi udi, Stream stream);
 
+    /// <summary>
+    /// Sets the stream as an asynchronous operation.
+    /// </summary>
+    /// <param name="udi">The UDI.</param>
+    /// <param name="stream">The stream.</param>
+    /// <param name="token">The cancellation token.</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation.
+    /// </returns>
     Task SetStreamAsync(StringUdi udi, Stream stream, CancellationToken token);
 
+    /// <summary>
+    /// Sets the physical path of the file.
+    /// </summary>
+    /// <param name="udi">The UDI.</param>
+    /// <param name="physicalPath">The physical path.</param>
+    /// <param name="copy">If set to <c>true</c> copies the file instead of moving.</param>
     void Set(StringUdi udi, string physicalPath, bool copy = false);
 
-    // this is not pretty as *everywhere* in Deploy we take care of ignoring
-    // the physical path and always rely on Core's virtual IFileSystem but
-    // Cloud wants to add some of these files to Git and needs the path...
+    /// <summary>
+    /// Gets the physical path or <see cref="string.Empty"/> if not found.
+    /// </summary>
+    /// <param name="udi">The UDI.</param>
+    /// <returns>
+    /// The physical path or <see cref="string.Empty"/> if not found.
+    /// </returns>
+    /// <remarks>
+    /// This is not pretty as *everywhere* in Deploy we take care of ignoring
+    /// the physical path and always rely on the virtual IFileSystem,
+    /// but Cloud wants to add some of these files to Git and needs the path...
+    /// </remarks>
     string GetPhysicalPath(StringUdi udi);
 
+    /// <summary>
+    /// Gets the virtual path or <see cref="string.Empty"/> if not found.
+    /// </summary>
+    /// <param name="udi">The UDI.</param>
+    /// <returns>
+    /// The virtual path or <see cref="string.Empty"/> if not found.
+    /// </returns>
     string GetVirtualPath(StringUdi udi);
 }

--- a/src/Umbraco.Core/Deploy/IFileTypeCollection.cs
+++ b/src/Umbraco.Core/Deploy/IFileTypeCollection.cs
@@ -1,8 +1,48 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Umbraco.Cms.Core.Deploy;
 
+/// <summary>
+/// Represents a collection of deployable file types used for each specific entity type.
+/// </summary>
 public interface IFileTypeCollection
 {
+    /// <summary>
+    /// Gets the <see cref="IFileType"/> for the specified entity type.
+    /// </summary>
+    /// <value>
+    /// The <see cref="IFileType"/>.
+    /// </value>
+    /// <param name="entityType">The entity type.</param>
+    /// <returns>
+    /// The <see cref="IFileType"/> for the specified entity type.
+    /// </returns>
     IFileType this[string entityType] { get; }
 
+    /// <summary>
+    /// Gets the <see cref="IFileType" /> for the specified entity type.
+    /// </summary>
+    /// <param name="entityType">The entity type.</param>
+    /// <param name="fileType">When this method returns, contains the file type associated with the specified entity type, if the item is found; otherwise, <c>null</c>.</param>
+    /// <returns>
+    ///   <c>true</c> if the file type associated with the specified entity type was found; otherwise, <c>false</c>.
+    /// </returns>
+    bool TryGetValue(string entityType, [NotNullWhen(true)] out IFileType? fileType);
+
+    /// <summary>
+    /// Determines whether this collection contains a file type for the specified entity type.
+    /// </summary>
+    /// <param name="entityType">The entity type.</param>
+    /// <returns>
+    ///   <c>true</c> if this collection contains a file type for the specified entity type; otherwise, <c>false</c>.
+    /// </returns>
     bool Contains(string entityType);
+
+    /// <summary>
+    /// Gets the entity types.
+    /// </summary>
+    /// <returns>
+    /// The entity types.
+    /// </returns>
+    ICollection<string> GetEntityTypes();
 }

--- a/src/Umbraco.Core/Deploy/IImageSourceParser.cs
+++ b/src/Umbraco.Core/Deploy/IImageSourceParser.cs
@@ -1,49 +1,67 @@
 namespace Umbraco.Cms.Core.Deploy;
 
 /// <summary>
-///     Provides methods to parse image tag sources in property values.
+/// Provides methods to parse image tag sources in property values.
 /// </summary>
 public interface IImageSourceParser
 {
     /// <summary>
-    ///     Parses an Umbraco property value and produces an artifact property value.
+    /// Parses an Umbraco property value and produces an artifact property value.
     /// </summary>
     /// <param name="value">The property value.</param>
     /// <param name="dependencies">A list of dependencies.</param>
-    /// <returns>The parsed value.</returns>
-    /// <remarks>Turns src="/media/..." into src="umb://media/..." and adds the corresponding udi to the dependencies.</remarks>
+    /// <returns>
+    /// The parsed value.
+    /// </returns>
+    /// <remarks>
+    /// Turns src="/media/..." into src="umb://media/..." and adds the corresponding udi to the dependencies.
+    /// </remarks>
     [Obsolete("Please use the overload taking all parameters. This method will be removed in Umbraco 14.")]
     string ToArtifact(string value, ICollection<Udi> dependencies);
 
     /// <summary>
-    ///     Parses an Umbraco property value and produces an artifact property value.
+    /// Parses an Umbraco property value and produces an artifact property value.
     /// </summary>
     /// <param name="value">The property value.</param>
     /// <param name="dependencies">A list of dependencies.</param>
     /// <param name="contextCache">The context cache.</param>
-    /// <returns>The parsed value.</returns>
-    /// <remarks>Turns src="/media/..." into src="umb://media/..." and adds the corresponding udi to the dependencies.</remarks>
+    /// <returns>
+    /// The parsed value.
+    /// </returns>
+    /// <remarks>
+    /// Turns src="/media/..." into src="umb://media/..." and adds the corresponding udi to the dependencies.
+    /// </remarks>
+    string ToArtifact(string value, ICollection<Udi> dependencies, IContextCache contextCache)
 #pragma warning disable CS0618 // Type or member is obsolete
-    string ToArtifact(string value, ICollection<Udi> dependencies, IContextCache contextCache) => ToArtifact(value, dependencies);
+        => ToArtifact(value, dependencies);
 #pragma warning restore CS0618 // Type or member is obsolete
 
     /// <summary>
-    ///     Parses an artifact property value and produces an Umbraco property value.
+    /// Parses an artifact property value and produces an Umbraco property value.
     /// </summary>
     /// <param name="value">The artifact property value.</param>
-    /// <returns>The parsed value.</returns>
-    /// <remarks>Turns umb://media/... into /media/....</remarks>
+    /// <returns>
+    /// The parsed value.
+    /// </returns>
+    /// <remarks>
+    /// Turns umb://media/... into /media/....
+    /// </remarks>
     [Obsolete("Please use the overload taking all parameters. This method will be removed in Umbraco 14.")]
     string FromArtifact(string value);
 
     /// <summary>
-    ///     Parses an artifact property value and produces an Umbraco property value.
+    /// Parses an artifact property value and produces an Umbraco property value.
     /// </summary>
     /// <param name="value">The artifact property value.</param>
     /// <param name="contextCache">The context cache.</param>
-    /// <returns>The parsed value.</returns>
-    /// <remarks>Turns umb://media/... into /media/....</remarks>
+    /// <returns>
+    /// The parsed value.
+    /// </returns>
+    /// <remarks>
+    /// Turns umb://media/... into /media/....
+    /// </remarks>
+    string FromArtifact(string value, IContextCache contextCache)
 #pragma warning disable CS0618 // Type or member is obsolete
-    string FromArtifact(string value, IContextCache contextCache) => FromArtifact(value);
+        => FromArtifact(value);
 #pragma warning restore CS0618 // Type or member is obsolete
 }

--- a/src/Umbraco.Core/Deploy/ILocalLinkParser.cs
+++ b/src/Umbraco.Core/Deploy/ILocalLinkParser.cs
@@ -1,55 +1,69 @@
 namespace Umbraco.Cms.Core.Deploy;
 
 /// <summary>
-///     Provides methods to parse local link tags in property values.
+/// Provides methods to parse local link tags in property values.
 /// </summary>
 public interface ILocalLinkParser
 {
     /// <summary>
-    ///     Parses an Umbraco property value and produces an artifact property value.
+    /// Parses an Umbraco property value and produces an artifact property value.
     /// </summary>
     /// <param name="value">The property value.</param>
     /// <param name="dependencies">A list of dependencies.</param>
-    /// <returns>The parsed value.</returns>
+    /// <returns>
+    /// The parsed value.
+    /// </returns>
     /// <remarks>
-    ///     Turns {{localLink:1234}} into {{localLink:umb://{type}/{id}}} and adds the corresponding udi to the
-    ///     dependencies.
+    /// Turns {{localLink:1234}} into {{localLink:umb://{type}/{id}}} and adds the corresponding udi to the
+    /// dependencies.
     /// </remarks>
     [Obsolete("Please use the overload taking all parameters. This method will be removed in Umbraco 14.")]
     string ToArtifact(string value, ICollection<Udi> dependencies);
 
     /// <summary>
-    ///     Parses an Umbraco property value and produces an artifact property value.
+    /// Parses an Umbraco property value and produces an artifact property value.
     /// </summary>
     /// <param name="value">The property value.</param>
     /// <param name="dependencies">A list of dependencies.</param>
     /// <param name="contextCache">The context cache.</param>
-    /// <returns>The parsed value.</returns>
+    /// <returns>
+    /// The parsed value.
+    /// </returns>
     /// <remarks>
-    ///     Turns {{localLink:1234}} into {{localLink:umb://{type}/{id}}} and adds the corresponding udi to the
-    ///     dependencies.
+    /// Turns {{localLink:1234}} into {{localLink:umb://{type}/{id}}} and adds the corresponding udi to the
+    /// dependencies.
     /// </remarks>
+    string ToArtifact(string value, ICollection<Udi> dependencies, IContextCache contextCache)
 #pragma warning disable CS0618 // Type or member is obsolete
-    string ToArtifact(string value, ICollection<Udi> dependencies, IContextCache contextCache) => ToArtifact(value, dependencies);
+        => ToArtifact(value, dependencies);
 #pragma warning restore CS0618 // Type or member is obsolete
 
     /// <summary>
-    ///     Parses an artifact property value and produces an Umbraco property value.
+    /// Parses an artifact property value and produces an Umbraco property value.
     /// </summary>
     /// <param name="value">The artifact property value.</param>
-    /// <returns>The parsed value.</returns>
-    /// <remarks>Turns {{localLink:umb://{type}/{id}}} into {{localLink:1234}}.</remarks>
+    /// <returns>
+    /// The parsed value.
+    /// </returns>
+    /// <remarks>
+    /// Turns {{localLink:umb://{type}/{id}}} into {{localLink:1234}}.
+    /// </remarks>
     [Obsolete("Please use the overload taking all parameters. This method will be removed in Umbraco 14.")]
     string FromArtifact(string value);
 
     /// <summary>
-    ///     Parses an artifact property value and produces an Umbraco property value.
+    /// Parses an artifact property value and produces an Umbraco property value.
     /// </summary>
     /// <param name="value">The artifact property value.</param>
     /// <param name="contextCache">The context cache.</param>
-    /// <returns>The parsed value.</returns>
-    /// <remarks>Turns {{localLink:umb://{type}/{id}}} into {{localLink:1234}}.</remarks>
+    /// <returns>
+    /// The parsed value.
+    /// </returns>
+    /// <remarks>
+    /// Turns {{localLink:umb://{type}/{id}}} into {{localLink:1234}}.
+    /// </remarks>
+    string FromArtifact(string value, IContextCache contextCache)
 #pragma warning disable CS0618 // Type or member is obsolete
-    string FromArtifact(string value, IContextCache contextCache) => FromArtifact(value);
+        => FromArtifact(value);
 #pragma warning restore CS0618 // Type or member is obsolete
 }

--- a/src/Umbraco.Core/Deploy/IMacroParser.cs
+++ b/src/Umbraco.Core/Deploy/IMacroParser.cs
@@ -1,65 +1,82 @@
 namespace Umbraco.Cms.Core.Deploy;
 
+/// <summary>
+/// Provides methods to parse macro tags in property values.
+/// </summary>
 public interface IMacroParser
 {
     /// <summary>
-    ///     Parses an Umbraco property value and produces an artifact property value.
+    /// Parses an Umbraco property value and produces an artifact property value.
     /// </summary>
     /// <param name="value">Property value.</param>
     /// <param name="dependencies">A list of dependencies.</param>
-    /// <returns>Parsed value.</returns>
+    /// <returns>
+    /// Parsed value.
+    /// </returns>
     [Obsolete("Please use the overload taking all parameters. This method will be removed in Umbraco 14.")]
     string ToArtifact(string value, ICollection<Udi> dependencies);
 
     /// <summary>
-    ///     Parses an Umbraco property value and produces an artifact property value.
+    /// Parses an Umbraco property value and produces an artifact property value.
     /// </summary>
     /// <param name="value">Property value.</param>
     /// <param name="dependencies">A list of dependencies.</param>
     /// <param name="contextCache">The context cache.</param>
-    /// <returns>Parsed value.</returns>
+    /// <returns>
+    /// Parsed value.
+    /// </returns>
+    string ToArtifact(string value, ICollection<Udi> dependencies, IContextCache contextCache)
 #pragma warning disable CS0618 // Type or member is obsolete
-    string ToArtifact(string value, ICollection<Udi> dependencies, IContextCache contextCache) => ToArtifact(value, dependencies);
+        => ToArtifact(value, dependencies);
 #pragma warning restore CS0618 // Type or member is obsolete
 
     /// <summary>
-    ///     Parses an artifact property value and produces an Umbraco property value.
+    /// Parses an artifact property value and produces an Umbraco property value.
     /// </summary>
     /// <param name="value">Artifact property value.</param>
-    /// <returns>Parsed value.</returns>
+    /// <returns>
+    /// Parsed value.
+    /// </returns>
     [Obsolete("Please use the overload taking all parameters. This method will be removed in Umbraco 14.")]
     string FromArtifact(string value);
 
     /// <summary>
-    ///     Parses an artifact property value and produces an Umbraco property value.
+    /// Parses an artifact property value and produces an Umbraco property value.
     /// </summary>
     /// <param name="value">Artifact property value.</param>
     /// <param name="contextCache">The context cache.</param>
-    /// <returns>Parsed value.</returns>
+    /// <returns>
+    /// Parsed value.
+    /// </returns>
+    string FromArtifact(string value, IContextCache contextCache)
 #pragma warning disable CS0618 // Type or member is obsolete
-    string FromArtifact(string value, IContextCache contextCache) => FromArtifact(value);
+        => FromArtifact(value);
 #pragma warning restore CS0618 // Type or member is obsolete
 
     /// <summary>
-    ///     Tries to replace the value of the attribute/parameter with a value containing a converted identifier.
+    /// Tries to replace the value of the attribute/parameter with a value containing a converted identifier.
     /// </summary>
     /// <param name="value">Value to attempt to convert</param>
     /// <param name="editorAlias">Alias of the editor used for the parameter</param>
     /// <param name="dependencies">Collection to add dependencies to when performing ToArtifact</param>
     /// <param name="direction">Indicates which action is being performed (to or from artifact)</param>
-    /// <returns>Value with converted identifiers</returns>
+    /// <returns>
+    /// Value with converted identifiers
+    /// </returns>
     [Obsolete("Please use the overload taking all parameters. This method will be removed in Umbraco 14.")]
     string ReplaceAttributeValue(string value, string editorAlias, ICollection<Udi> dependencies, Direction direction);
 
     /// <summary>
-    ///     Tries to replace the value of the attribute/parameter with a value containing a converted identifier.
+    /// Tries to replace the value of the attribute/parameter with a value containing a converted identifier.
     /// </summary>
     /// <param name="value">Value to attempt to convert</param>
     /// <param name="editorAlias">Alias of the editor used for the parameter</param>
     /// <param name="dependencies">Collection to add dependencies to when performing ToArtifact</param>
     /// <param name="direction">Indicates which action is being performed (to or from artifact)</param>
     /// <param name="contextCache">The context cache.</param>
-    /// <returns>Value with converted identifiers</returns>
+    /// <returns>
+    /// Value with converted identifiers
+    /// </returns>
     string ReplaceAttributeValue(string value, string editorAlias, ICollection<Udi> dependencies, Direction direction, IContextCache contextCache)
 #pragma warning disable CS0618 // Type or member is obsolete
         => ReplaceAttributeValue(value, editorAlias, dependencies, direction);

--- a/src/Umbraco.Core/Deploy/IServiceConnector.cs
+++ b/src/Umbraco.Core/Deploy/IServiceConnector.cs
@@ -5,7 +5,6 @@ namespace Umbraco.Cms.Core.Deploy;
 /// <summary>
 /// Connects to an Umbraco service.
 /// </summary>
-/// <seealso cref="Umbraco.Cms.Core.Composing.IDiscoverable" />
 public interface IServiceConnector : IDiscoverable
 {
     /// <summary>

--- a/src/Umbraco.Core/Deploy/IUniqueIdentifyingServiceConnector.cs
+++ b/src/Umbraco.Core/Deploy/IUniqueIdentifyingServiceConnector.cs
@@ -1,24 +1,26 @@
 namespace Umbraco.Cms.Core.Deploy;
 
 /// <summary>
-///     Provides a method to retrieve an artifact's unique identifier.
+/// Provides a method to retrieve an artifact's unique identifier.
 /// </summary>
 /// <remarks>
-///     Artifacts are uniquely identified by their <see cref="Udi" />, however they represent
-///     elements in Umbraco that may be uniquely identified by another value. For example,
-///     a content type is uniquely identified by its alias. If someone creates a new content
-///     type, and tries to deploy it to a remote environment where a content type with the
-///     same alias already exists, both content types end up having different <see cref="Udi" />
-///     but the same alias. By default, Deploy would fail and throw when trying to save the
-///     new content type (duplicate alias). However, if the connector also implements this
-///     interface, the situation can be detected beforehand and reported in a nicer way.
+/// Artifacts are uniquely identified by their <see cref="Udi" />, however they represent
+/// elements in Umbraco that may be uniquely identified by another value. For example,
+/// a content type is uniquely identified by its alias. If someone creates a new content
+/// type, and tries to deploy it to a remote environment where a content type with the
+/// same alias already exists, both content types end up having different <see cref="Udi" />
+/// but the same alias. By default, Deploy would fail and throw when trying to save the
+/// new content type (duplicate alias). However, if the connector also implements this
+/// interface, the situation can be detected beforehand and reported in a nicer way.
 /// </remarks>
 public interface IUniqueIdentifyingServiceConnector
 {
     /// <summary>
-    ///     Gets the unique identifier of the specified artifact.
+    /// Gets the unique identifier of the specified artifact.
     /// </summary>
     /// <param name="artifact">The artifact.</param>
-    /// <returns>The unique identifier.</returns>
+    /// <returns>
+    /// The unique identifier.
+    /// </returns>
     string GetUniqueIdentifier(IArtifact artifact);
 }


### PR DESCRIPTION
PR https://github.com/umbraco/Umbraco-CMS/pull/15144 added the `Checksum` property to `ArtifactDependency` to be able to remove the custom `JsonConverter` workaround in Deploy 13 that (de)serializes this property to/from the artifact JSON. The checksums are only calculated/populated when doing an export and without the workaround we don't need to create a new instance of a subclassed type anymore, so we should actually make the property settable/writable 😄 

The `IFileTypeCollection` implementation in Deploy now also requires being able to return all registered entity types in `GetEntityTypes()` and we've added a `TryGetValue()` method for a more performant lookup. These methods are now added to the interface.

Finally, I've updated all deploy related XML docs/comments, because some didn't have any or were not really explaining the concepts correctly.