### PR TITLE
14263 user password validation missing requirements

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/bs.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/bs.xml
@@ -2039,6 +2039,9 @@ Da upravljate svojom web lokacijom, jednostavno otvorite Umbraco backoffice i po
     <key alias="newPassword">Nova lozinka</key>
     <key alias="newPasswordFormatLengthTip">Najmanje %0% znakova!</key>
     <key alias="newPasswordFormatNonAlphaTip">Trebalo bi biti najmanje %0% specijalnih znakova.</key>
+    <key alias="newPasswordFormatDigitTip">Tamo bi trebalo biti najmanje %0% cifara.</key>
+    <key alias="newPasswordFormatUppercaseTip">Tu bi trebalo biti najmanje %0% velikih znakova.</key>
+    <key alias="newPasswordFormatLowercaseTip">Tu bi trebalo biti najmanje %0% malih slova.</key>
     <key alias="noLockouts">nije zaključan</key>
     <key alias="noPasswordChange">Lozinka nije promijenjena</key>
     <key alias="confirmNewPassword">Potvrdite novu lozinku</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/cs.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/cs.xml
@@ -1693,6 +1693,11 @@
     <key alias="changePassword">Změnit heslo</key>
     <key alias="changePhoto">Změnit fotku</key>
     <key alias="newPassword">Změnit heslo</key>
+    <key alias="newPasswordFormatLengthTip">Minimální počet znaků: %0%!</key>
+    <key alias="newPasswordFormatNonAlphaTip">Mělo by tam být alespoň %0% speciálních znaků.</key>
+    <key alias="newPasswordFormatDigitTip">Mělo by tam být alespoň %0% číslic.</key>
+    <key alias="newPasswordFormatUppercaseTip">Mělo by tam být alespoň %0% velkých písmen.</key>
+    <key alias="newPasswordFormatLowercaseTip">Mělo by tam být alespoň %0% malých písmen.</key>
     <key alias="noLockouts">nebyl uzamčen</key>
     <key alias="noPasswordChange">Heslo nebylo změněno</key>
     <key alias="confirmNewPassword">Potvrdit heslo</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/cy.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/cy.xml
@@ -2030,6 +2030,9 @@ Er mwyn gweinyddu eich gwefan, agorwch swyddfa gefn Umbraco a dechreuwch ychwang
     <key alias="newPassword">Cyfrinair newydd</key>
     <key alias="newPasswordFormatLengthTip">O leiaf %0% nod(au) i fynd!</key>
     <key alias="newPasswordFormatNonAlphaTip">Dylai fod o leiaf %0% nod(au) arbennig yno.</key>
+    <key alias="newPasswordFormatDigitTip">Dylai fod o leiaf %0% o ddigid(iau) i mewn yno.</key>
+    <key alias="newPasswordFormatUppercaseTip">Dylai fod o leiaf %0% o nodau priflythrennau yno.</key>
+    <key alias="newPasswordFormatLowercaseTip">Dylai fod o leiaf %0% o nodau llythrennau bach yno.</key>
     <key alias="noLockouts">ddim wedi cloi allan</key>
     <key alias="noPasswordChange">Nid yw'r cyfrinair wedi'i newid</key>
     <key alias="confirmNewPassword">Cadarnhau cyfrinair newydd</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
@@ -1824,6 +1824,9 @@ Mange hilsner fra Umbraco robotten
     <key alias="newPassword">Nyt kodeord</key>
     <key alias="newPasswordFormatLengthTip">Minium %0% karakterer tilbage!</key>
     <key alias="newPasswordFormatNonAlphaTip">Der skal som minium være %0% specielle karakterer.</key>
+    <key alias="newPasswordFormatDigitTip">Der skal være mindst %0% ciffer derinde.</key>
+    <key alias="newPasswordFormatUppercaseTip">Der skal være mindst %0% store bogstaver deri.</key>
+    <key alias="newPasswordFormatLowercaseTip">Der skal være mindst %0% små bogstaver deri.</key>
     <key alias="noLockouts">er ikke blevet låst ude</key>
     <key alias="noPasswordChange">Kodeordet er ikke blevet ændret</key>
     <key alias="confirmNewPassword">Gentag dit nye kodeord</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/de.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/de.xml
@@ -1990,6 +1990,9 @@
     <key alias="newPassword">Neues Kennwort</key>
     <key alias="newPasswordFormatLengthTip">Noch %0% Zeichen benötigt!</key>
     <key alias="newPasswordFormatNonAlphaTip">Es sollten mindestens %0% Sonderzeichen verwendet werden.</key>
+    <key alias="newPasswordFormatDigitTip">Es sollten mindestens %0% Ziffer(n) darin sein.</key>
+    <key alias="newPasswordFormatUppercaseTip">Es sollten mindestens %0% Großbuchstaben darin enthalten sein.</key>
+    <key alias="newPasswordFormatLowercaseTip">Es sollten mindestens %0% Kleinbuchstaben darin enthalten sein.</key>
     <key alias="noLockouts">wurde nicht ausgeschlossen</key>
     <key alias="noPasswordChange">Das Kennwort wurde nicht geändert</key>
     <key alias="confirmNewPassword">Neues Kennwort (Bestätigung)</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -2057,6 +2057,9 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="newPassword">New password</key>
     <key alias="newPasswordFormatLengthTip">Minimum %0% character(s) to go!</key>
     <key alias="newPasswordFormatNonAlphaTip">There should be at least %0% special character(s) in there.</key>
+    <key alias="newPasswordFormatDigitTip">There should be at least %0% digit(s) in there.</key>
+    <key alias="newPasswordFormatUppercaseTip">There should be at least %0% uppercase characters in there.</key>
+    <key alias="newPasswordFormatLowercaseTip">There should be at least %0% lowercase characters in there.</key>
     <key alias="noLockouts">hasn't been locked out</key>
     <key alias="noPasswordChange">The password hasn't been changed</key>
     <key alias="confirmNewPassword">Confirm new password</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -2139,6 +2139,9 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="newPassword">New password</key>
     <key alias="newPasswordFormatLengthTip">Minimum %0% character(s) to go!</key>
     <key alias="newPasswordFormatNonAlphaTip">There should be at least %0% special character(s) in there.</key>
+    <key alias="newPasswordFormatDigitTip">There should be at least %0% digit(s) in there.</key>
+    <key alias="newPasswordFormatUppercaseTip">There should be at least %0% uppercase characters in there.</key>
+    <key alias="newPasswordFormatLowercaseTip">There should be at least %0% lowercase characters in there.</key>
     <key alias="noLockouts">hasn't been locked out</key>
     <key alias="noPasswordChange">The password hasn't been changed</key>
     <key alias="confirmNewPassword">Confirm new password</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/es.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/es.xml
@@ -1325,6 +1325,11 @@
     <key alias="changePassword">Cambiar contraseña</key>
     <key alias="changePhoto">Cambiar foto</key>
     <key alias="newPassword">Nueva contraseña</key>
+    <key alias="newPasswordFormatLengthTip">¡Mínimo %0% caracteres restantes!</key>
+    <key alias="newPasswordFormatNonAlphaTip">Debe haber al menos %0% caracteres especiales allí.</key>
+    <key alias="newPasswordFormatDigitTip">Debe haber al menos %0% dígito(s) allí.</key>
+    <key alias="newPasswordFormatUppercaseTip">Debe haber al menos %0% caracteres en mayúsculas.</key>
+    <key alias="newPasswordFormatLowercaseTip">Debe haber al menos %0% caracteres en minúscula.</key>
     <key alias="noLockouts">no ha sido bloqueado</key>
     <key alias="noPasswordChange">La contraseña no se ha cambiado</key>
     <key alias="confirmNewPassword">Confirma nueva contraseña</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/fr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/fr.xml
@@ -1758,6 +1758,9 @@ Pour gérer votre site, ouvrez simplement le backoffice Umbraco et commencez à 
     <key alias="newPassword">Nouveau mot de passe</key>
     <key alias="newPasswordFormatLengthTip">Plus que %0% caractère(s) minimum!</key>
     <key alias="newPasswordFormatNonAlphaTip">Il devrait y avoir au moins %0% caractère(s) spéciaux.</key>
+    <key alias="newPasswordFormatDigitTip">Il devrait y avoir au moins %0% de chiffre(s).</key>
+    <key alias="newPasswordFormatUppercaseTip">Il doit y avoir au moins %0% de caractères majuscules.</key>
+    <key alias="newPasswordFormatLowercaseTip">Il doit contenir au moins %0 % de caractères minuscules.</key>
     <key alias="noLockouts">n'a pas été bloqué</key>
     <key alias="noPasswordChange">Le mot de passe n'a pas été modifié</key>
     <key alias="confirmNewPassword">Confirmez votre nouveau mot de passe</key>
@@ -1775,7 +1778,7 @@ Pour gérer votre site, ouvrez simplement le backoffice Umbraco et commencez à 
     <key alias="groupsHelp">Ajouter des groupes pour donner les accès et permissions</key>
     <key alias="inviteAnotherUser">Inviter un autre utilisateur</key>
     <key alias="inviteUserHelp">Inviter de nouveaux utilisateurs pour leur donner accès à Umbraco. Un email d'invitation sera envoyé à chaque utilisateur avec des informations concernant la connexion à Umbraco. Les invitations sont valables pendant 72 heures.</key>
-    <key alias="language">Langue</key>
+    <key alias="language">Langue</
     <key alias="languageHelp">Spécifiez la langue dans laquelle vous souhaitez voir les menus et dialogues</key>
     <key alias="lastLockoutDate">Date du dernier bloquage</key>
     <key alias="lastLogin">Dernière connexion</key>
@@ -1798,7 +1801,7 @@ Pour gérer votre site, ouvrez simplement le backoffice Umbraco et commencez à 
     <key alias="passwordCurrent">Mot de passe actuel</key>
     <key alias="passwordInvalid">Mot de passe actuel invalide</key>
     <key alias="passwordIsDifferent">Il y a une différence entre le nouveau mot de passe et le mot de passe confirmé. Veuillez réessayer.</key>
-    <key alias="passwordMismatch">Le mot de passe confirmé ne correspond pas au nouveau mot de passe saisi!</key>
+    <key alias="passwordMismatkey>ch">Le mot de passe confirmé ne correspond pas au nouveau mot de passe saisi!</key>
     <key alias="permissionReplaceChildren">Remplacer les permissions sur les noeuds enfants</key>
     <key alias="permissionSelectedPages">Vous êtes en train de modifiez les permissions pour les pages :</key>
     <key alias="permissionSelectPages">Choisissez les pages dont les permissions doivent être modifiées</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/he.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/he.xml
@@ -817,6 +817,12 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
   <area alias="user">
     <key alias="administrators">מנהל ראשי</key>
     <key alias="categoryField">שדה קטגוריה</key>
+    <key alias="newPassword">סיסמה חדשה</key>
+    <key alias="newPasswordFormatLengthTip">מינימום %0% תווים לסיום!</key>
+    <key alias="newPasswordFormatNonAlphaTip">צריכים להיות שם לפחות %0% תווים מיוחדים.</key>
+    <key alias="newPasswordFormatDigitTip">צריכה להיות שם לפחות %0% ספרות.</key>
+    <key alias="newPasswordFormatUppercaseTip">צריכים להיות שם לפחות %0% תווים רישיות.</key>
+    <key alias="newPasswordFormatLowercaseTip">צריכים להיות שם לפחות %0% תווים קטנים.</key>
     <key alias="changePassword">שנה את הסיסמה שלך</key>
     <key alias="changePasswordDescription">בעמוד זה ניתן לשנות את הסיסמה שלך ולאחר מכן ללחוץ על הכפתור 'שנה סיסמה'	 למטה</key>
     <key alias="contentChannel">ערוץ תוכן</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/hr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/hr.xml
@@ -2009,6 +2009,9 @@ Da bi upravljali svojom web lokacijom, jednostavno otvorite Umbraco backoffice i
     <key alias="newPassword">Nova lozinka</key>
     <key alias="newPasswordFormatLengthTip">Najmanje %0% znakova!</key>
     <key alias="newPasswordFormatNonAlphaTip">Trebalo bi biti najmanje %0% specijalnih znakova.</key>
+    <key alias="newPasswordFormatDigitTip">Tamo bi trebalo biti najmanje %0% znamenki.</key>
+    <key alias="newPasswordFormatUppercaseTip">Tamo bi trebalo biti najmanje %0% velikih slova.</key>
+    <key alias="newPasswordFormatLowercaseTip">Tu bi trebalo biti najmanje %0% malih slova.</key>
     <key alias="noLockouts">nije zaključan</key>
     <key alias="noPasswordChange">Lozinka nije promijenjena</key>
     <key alias="confirmNewPassword">Potvrdite novu lozinku</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/it.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/it.xml
@@ -2126,6 +2126,9 @@ Per gestire il tuo sito web, è sufficiente aprire il backoffice di Umbraco e in
     <key alias="newPassword">Nuova password</key>
     <key alias="newPasswordFormatLengthTip">Minimo %0% caratteri!</key>
     <key alias="newPasswordFormatNonAlphaTip">Dovrebbero esserci almeno %0% caratteri speciali qui.</key>
+    <key alias="newPasswordFormatDigitTip">Ci dovrebbero essere almeno %0% cifre.</key>
+    <key alias="newPasswordFormatUppercaseTip">Ci dovrebbero essere almeno %0% caratteri maiuscoli.</key>
+    <key alias="newPasswordFormatLowercaseTip">Ci dovrebbero essere almeno %0% caratteri minuscoli.</key>
     <key alias="noLockouts"><![CDATA[non è stato bloccato]]></key>
     <key alias="noPasswordChange"><![CDATA[La password non è stata modificata]]></key>
     <key alias="confirmNewPassword">Conferma la nuova password</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/ja.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/ja.xml
@@ -1026,6 +1026,11 @@ Runwayをインストールして作られた新しいウェブサイトがど�
     <key alias="categoryField">フィールドのカテゴリー</key>
     <key alias="changePassword">パスワードの変更</key>
     <key alias="newPassword">新パスワード</key>
+    <key alias="newPasswordFormatLengthTip">あと残り %0% 文字!</key>
+    <key alias="newPasswordFormatNonAlphaTip">少なくとも %0% の特殊文字が含まれている必要があります。</key>
+    <key alias="newPasswordFormatDigitTip">少なくとも %0% の数字が含まれている必要があります。</key>
+    <key alias="newPasswordFormatUppercaseTip">少なくとも %0% の大文字が含まれている必要があります。</key>
+    <key alias="newPasswordFormatLowercaseTip">少なくとも %0% の小文字が含まれている必要があります。</key>
     <key alias="confirmNewPassword">新パスワードの確認</key>
     <key alias="changePasswordDescription">Umbracoの管理画面にアクセスするためのパスワードを変更するには、以下のフォームに新しいパスワード入力して「パスワードの変更」ボタンをクリックしてください。</key>
     <key alias="contentChannel">コンテントチャンネル</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/ko.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/ko.xml
@@ -803,6 +803,11 @@
     <key alias="categoryField">카테고리 필드</key>
     <key alias="changePassword">Change Your Password</key>
     <key alias="changePasswordDescription">You can change your password for accessing the Umbraco backoffice by filling out the form below and click the 'Change Password' button</key>
+    <key alias="newPasswordFormatLengthTip">최소 %0%자 이상이어야 합니다!</key>
+    <key alias="newPasswordFormatNonAlphaTip">여기에는 최소한 %0%개의 특수 문자가 있어야 합니다.</key>
+    <key alias="newPasswordFormatDigitTip">적어도 %0%자리 숫자가 있어야 합니다.</key>
+    <key alias="newPasswordFormatUppercaseTip">대문자가 %0% 이상 있어야 합니다.</key>
+    <key alias="newPasswordFormatLowercaseTip">소문자가 %0% 이상 있어야 합니다.</key>
     <key alias="contentChannel">컨텐츠 채널</key>
     <key alias="descriptionField">설명 필드</key>
     <key alias="disabled">사용자 비활성화</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/nb.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/nb.xml
@@ -875,6 +875,11 @@ Vennlig hilsen Umbraco roboten
     <key alias="categoryField">Kategorifelt</key>
     <key alias="changePassword">Bytt passord</key>
     <key alias="newPassword">Nytt passord</key>
+    <key alias="newPasswordFormatLengthTip">Minimum %0% tegn igjen!</key>
+    <key alias="newPasswordFormatNonAlphaTip">Det bør være minst %0% spesialtegn der.</key>
+    <key alias="newPasswordFormatDigitTip">Det bør være minst %0% siffer der.</key>
+    <key alias="newPasswordFormatUppercaseTip">Det bør være minst %0% store bokstaver der.</key>
+    <key alias="newPasswordFormatLowercaseTip">Det bør være minst %0% små bokstaver der.</key>
     <key alias="confirmNewPassword">Bekreft nytt passord</key>
     <key alias="changePasswordDescription">Du kan endre passordet til Umbraco ved å fylle ut skjemaet under og klikke "Bytt passord" knappen.</key>
     <key alias="contentChannel">Innholdskanal</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
@@ -1868,6 +1868,10 @@ Echter, Runway biedt een gemakkelijke basis om je snel op weg te helpen. Als je 
     <key alias="changePhoto">Wijzig je foto</key>
     <key alias="newPassword">Wijzig je wachtwoord</key>
     <key alias="newPasswordFormatLengthTip">Nog minimaal %0% teken(s) te gaan!</key>
+    <key alias="newPasswordFormatNonAlphaTip">Er moeten minstens %0% speciale tekens in staan.</key>
+    <key alias="newPasswordFormatDigitTip">Er moeten minstens %0% cijfers in zitten.</key>
+    <key alias="newPasswordFormatUppercaseTip">Er moeten minstens %0% hoofdletters in staan.</key>
+    <key alias="newPasswordFormatLowercaseTip">Er moeten minstens %0% kleine letters in staan.</key>
     <key alias="noLockouts">is niet gedeblokkeerd</key>
     <key alias="noPasswordChange">Het wachtwoord is niet gewijzigd</key>
     <key alias="confirmNewPassword">Bevestig nieuw wachtwoord</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/pl.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/pl.xml
@@ -1253,6 +1253,11 @@ Naciśnij przycisk <strong>instaluj</strong>, aby zainstalować bazę danych Umb
     <key alias="categoryField">Pole kategorii</key>
     <key alias="changePassword">Zmień hasło!</key>
     <key alias="newPassword">Nowe hasło</key>
+    <key alias="newPasswordFormatLengthTip">Minimalnie %0% znaków do końca!</key>
+    <key alias="newPasswordFormatNonAlphaTip">Powinno tam znajdować się co najmniej %0% znaków specjalnych.</key>
+    <key alias="newPasswordFormatDigitTip">Powinno tam znajdować się co najmniej %0% cyfr.</key>
+    <key alias="newPasswordFormatUppercaseTip">Powinno się tam znajdować co najmniej %0% wielkich liter.</key>
+    <key alias="newPasswordFormatLowercaseTip">Powinno się tam znajdować co najmniej %0% małych liter.</key>
     <key alias="confirmNewPassword">Potwierdź nowe hasło</key>
     <key alias="changePasswordDescription">Możesz zmienić swoje hasło w Umbraco backoffice przez wypełnienie formularza poniżej i kliknięcie przycisku "Zmień hasło"</key>
     <key alias="contentChannel">Kanał zawartości</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/pt.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/pt.xml
@@ -792,6 +792,12 @@ Você pode publicar esta página e todas suas sub-páginas ao selecionar <em>pub
   <area alias="user">
     <key alias="administrators">Administrador</key>
     <key alias="categoryField">Campo de Categoria</key>
+    <key alias="newPassword">Nova senha</key>
+    <key alias="newPasswordFormatLengthTip">Mínimo de %0% caracteres restantes!</key>
+    <key alias="newPasswordFormatNonAlphaTip">Deve haver pelo menos %0% de caracteres especiais.</key>
+    <key alias="newPasswordFormatDigitTip">Deve haver pelo menos %0% dígito(s) ali.</key>
+    <key alias="newPasswordFormatUppercaseTip">Deve haver pelo menos %0% caracteres maiúsculos.</key>
+    <key alias="newPasswordFormatLowercaseTip">Deve haver pelo menos %0% caracteres minúsculos.</key>
     <key alias="changePassword">Alterar Sua Senha</key>
     <key alias="changePasswordDescription">você pode alterar sua senha para acessar a área administrativa do Umbraco preenchendo o formulário abaixo e clicando no botão 'Alterar Senha'</key>
     <key alias="contentChannel">Canal de Conteúdo</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/ro.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/ro.xml
@@ -54,4 +54,12 @@
     <key alias="templatingGroup">Modelare</key>
     <key alias="thirdPartyGroup">Terț</key>
   </area>
+  <area alias="user">
+    <key alias="newPassword">Parolă nouă</key>
+    <key alias="newPasswordFormatLengthTip">Minimum %0% caractere(e) de parcurs!</key>
+    <key alias="newPasswordFormatNonAlphaTip">Ar trebui să existe cel puțin %0% caractere speciale acolo.</key>
+    <key alias="newPasswordFormatDigitTip">Ar trebui să existe cel puțin %0% cifre acolo.</key>
+    <key alias="newPasswordFormatUppercaseTip">Ar trebui să existe cel puțin %0% caractere majuscule acolo.</key>
+    <key alias="newPasswordFormatLowercaseTip">Ar trebui să existe cel puțin %0% caractere mici acolo.</key>
+  </area>
 </language>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/ru.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/ru.xml
@@ -1540,6 +1540,12 @@
     <key alias="changePassword">Изменить пароль</key>
     <key alias="changePasswordDescription">Вы можете сменить свой пароль для доступа к административной панели Umbraco, заполнив нижеследующие поля и нажав на кнопку 'Изменить пароль'</key>
     <key alias="changePhoto">Сменить аватар</key>
+    <key alias="newPassword">Новый пароль</key>
+    <key alias="newPasswordFormatLengthTip">Осталось минимум %0% символов!</key>
+    <key alias="newPasswordFormatNonAlphaTip">Там должно быть не менее %0% специальных символов.</key>
+    <key alias="newPasswordFormatDigitTip">Здесь должно быть не менее %0% цифр.</key>
+    <key alias="newPasswordFormatUppercaseTip">Здесь должно быть не менее %0% символов верхнего регистра.</key>
+    <key alias="newPasswordFormatLowercaseTip">Там должно быть не менее %0% символов нижнего регистра.</key>
     <key alias="confirmNewPassword">Подтверждение нового пароля</key>
     <key alias="contentChannel">Канал содержимого</key>
     <key alias="createAnotherUser">Создать еще одного пользователя</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/sv.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/sv.xml
@@ -1006,6 +1006,12 @@
     <key alias="createDate">Användare skapad</key>
     <key alias="changePassword">Ändra lösenord</key>
     <key alias="changePhoto">Ändra bild</key>
+    <key alias="newPassword">Nytt lösenord</key>
+    <key alias="newPasswordFormatLengthTip">Minst %0% tecken kvar!</key>
+    <key alias="newPasswordFormatNonAlphaTip">Det bör finnas minst %0% specialtecken där.</key>
+    <key alias="newPasswordFormatDigitTip">Det bör finnas minst %0% siffra(r) där.</key>
+    <key alias="newPasswordFormatUppercaseTip">Det bör finnas minst %0% versaler där.</key>
+    <key alias="newPasswordFormatLowercaseTip">Det bör finnas minst %0% gemener däri.</key>
     <key alias="confirmNewPassword">Bekräfta det nya lösenordet</key>
     <key alias="changePasswordDescription">Du kan byta ditt lösenord för Umbraco backoffice genom att fylla i nedanstående formulär och klicka på knappen "Ändra lösenord".</key>
     <key alias="contentChannel">Innehållskanal</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/tr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/tr.xml
@@ -1828,6 +1828,11 @@ Web sitenizi yönetmek için, Umbraco'nun arka ofisini açın ve içerik eklemey
     <key alias="changePassword">Şifrenizi değiştirin</key>
     <key alias="changePhoto">Fotoğrafı değiştir</key>
     <key alias="newPassword">Yeni şifre</key>
+    <key alias="newPasswordFormatLengthTip">Minimum %0% karakter kaldı!</key>
+    <key alias="newPasswordFormatNonAlphaTip">Orada en az %0% özel karakter bulunmalıdır.</key>
+    <key alias="newPasswordFormatDigitTip">Orada en az %0% rakam bulunmalıdır.</key>
+    <key alias="newPasswordFormatUppercaseTip">Burada en az %0% büyük harf karakterler bulunmalıdır.</key>
+    <key alias="newPasswordFormatLowercaseTip">Burada en az %0% küçük harf karakterleri bulunmalıdır.</key>
     <key alias="noLockouts">kilitlenmedi</key>
     <key alias="noPasswordChange">Şifre değiştirilmedi</key>
     <key alias="confirmNewPassword">Yeni şifreyi onaylayın</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/ua.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/ua.xml
@@ -1540,6 +1540,12 @@
     <key alias="changePassword">Змінити пароль</key>
     <key alias="changePasswordDescription">Ви можете змінити свій пароль для доступу до адміністративної панелі Umbraco, заповнивши нижченаведені поля та натиснувши кнопку 'Змінити пароль'</key>
     <key alias="changePhoto">Змінити аватар</key>
+    <key alias="newPassword">Новий пароль</key>
+    <key alias="newPasswordFormatLengthTip">Щонайменше %0% символ(ів)!</key>
+    <key alias="newPasswordFormatNonAlphaTip">Там має бути принаймні %0% спеціальних символів.</key>
+    <key alias="newPasswordFormatDigitTip">Там має бути принаймні %0% цифр(и).</key>
+    <key alias="newPasswordFormatUppercaseTip">Там має бути принаймні %0% символів у верхньому регістрі.</key>
+    <key alias="newPasswordFormatLowercaseTip">Там має бути принаймні %0% малих символів.</key>
     <key alias="confirmNewPassword">Підтвердження нового пароля</key>
     <key alias="contentChannel">Канал вмісту</key>
     <key alias="createAnotherUser">Створити ще одного користувача</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/zh.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/zh.xml
@@ -1069,6 +1069,11 @@
     <key alias="categoryField">分类字段</key>
     <key alias="changePassword">更改密码</key>
     <key alias="newPassword">更改密码</key>
+    <key alias="newPasswordFormatLengthTip">最少 %0% 个字符！</key>
+    <key alias="newPasswordFormatNonAlphaTip">其中至少应有 %0% 的特殊字符。</key>
+    <key alias="newPasswordFormatDigitTip">其中至少应有 %0% 的数字。</key>
+    <key alias="newPasswordFormatUppercaseTip">其中至少应有 %0% 大写字符。</key>
+    <key alias="newPasswordFormatLowercaseTip">其中至少应有 %0% 小写字符。</key>
     <key alias="confirmNewPassword">确认新密码</key>
     <key alias="changePasswordDescription">要改变密码，请在框中输入新密码，然后单击“更改密码”。</key>
     <key alias="contentChannel">内容频道</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/zh_tw.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/zh_tw.xml
@@ -1054,6 +1054,11 @@
     <key alias="categoryField">分類欄位</key>
     <key alias="changePassword">更改密碼</key>
     <key alias="newPassword">更改密碼</key>
+    <key alias="newPasswordFormatLengthTip">最少 %0% 字元!</key>
+    <key alias="newPasswordFormatNonAlphaTip">其中至少應有 %0% 的特殊字元。</key>
+    <key alias="newPasswordFormatDigitTip">其中至少應有 %0% 的數字。</key>
+    <key alias="newPasswordFormatUppercaseTip">其中至少應有 %0% 大寫字元。</key>
+    <key alias="newPasswordFormatLowercaseTip">其中至少應有 %0% 小寫字元。</key>
     <key alias="confirmNewPassword">確認新密碼</key>
     <key alias="changePasswordDescription">要改變密碼，請在框中輸入新密碼，然後按一下“更改密碼”。</key>
     <key alias="contentChannel">內容頻道</key>

--- a/src/Umbraco.Core/Extensions/PasswordConfigurationExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PasswordConfigurationExtensions.cs
@@ -31,4 +31,14 @@ public static class PasswordConfigurationExtensions
 
     public static int GetMinNonAlphaNumericChars(this IPasswordConfiguration passwordConfiguration) =>
         passwordConfiguration.RequireNonLetterOrDigit ? 1 : 0;
+
+    public static int GetMinDigits(this IPasswordConfiguration passwordConfiguration) =>
+        passwordConfiguration.RequireDigit ? 1 : 0;
+
+    public static int GetMinUppercase(this IPasswordConfiguration passwordConfiguration) =>
+        passwordConfiguration.RequireUppercase ? 1 : 0;
+
+    public static int GetMinLowercase(this IPasswordConfiguration passwordConfiguration) =>
+        passwordConfiguration.RequireLowercase ? 1 : 0;
+
 }

--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeServerVariables.cs
@@ -279,7 +279,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             // add a few extras for backoffice users (server vars we don't want floating around for anonymous users)
             if (isBackofficeUser)
             {
-                umbracoSettings.AddRange(new[] { "maxFileSize", "minimumPasswordLength", "minimumPasswordNonAlphaNum" });
+                umbracoSettings.AddRange(new[] { "maxFileSize", "minimumPasswordLength", "minimumPasswordNonAlphaNum", "minimumPasswordDigit", "minimumPasswordUppercase", "minimumPasswordLowercase"});
             }
 
             var keepOnlyKeys = new Dictionary<string, string[]>
@@ -623,6 +623,9 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                         {"showAllowSegmentationForDocumentTypes", false},
                         {"minimumPasswordLength", _memberPasswordConfigurationSettings.RequiredLength},
                         {"minimumPasswordNonAlphaNum", _memberPasswordConfigurationSettings.GetMinNonAlphaNumericChars()},
+                        {"minimumPasswordDigit", _memberPasswordConfigurationSettings.GetMinDigits() },
+                        {"minimumPasswordUppercase", _memberPasswordConfigurationSettings.GetMinUppercase()},
+                        {"minimumPasswordLowercase", _memberPasswordConfigurationSettings.GetMinLowercase()},
                         {"sanitizeTinyMce", _globalSettings.SanitizeTinyMce},
                         {"dataTypesCanBeChanged", _dataTypesSettings.CanBeChanged.ToString()},
                         {"allowEditInvariantFromNonDefault", _contentSettings.AllowEditInvariantFromNonDefault},

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbpasswordtip.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbpasswordtip.directive.js
@@ -11,7 +11,10 @@
             bindings: {
                 passwordVal: "<",
                 minPwdLength: "<",
-                minPwdNonAlphaNum: "<"
+                minPwdNonAlphaNum: "<",
+                minPwdDigit: "<",
+                minPwdUppercase: "<",
+                minPwdLowercase: "<"
             }
         });
 
@@ -27,7 +30,7 @@
 
 
         vm.$onInit = onInit;
-      vm.$onChanges = onChanges;
+        vm.$onChanges = onChanges;
 
 
 
@@ -113,12 +116,21 @@
             
             if (remainingLength > 0) {
                 localizationService.localize('user_newPasswordFormatLengthTip', [remainingLength]).then(data => {
-                    vm.passwordTip = data;
-                    vm.tips.forEach((tip) => vm.passwordTip += `<br/>${tip}`);
+                  vm.passwordTip = data;
+                  vm.passwordTip += `<br/>`
+                  vm.tips.forEach((tip) => {
+                    if (tip != '') {
+                      vm.passwordTip += `${tip}<br/>`
+                    }
+                  });
                 });
             } else {
               vm.passwordTip = '';
-              vm.tips.forEach((tip) => vm.passwordTip += `<br/>${tip}`);
+              vm.tips.forEach((tip) => {
+                if (tip != '') {
+                  vm.passwordTip += `${tip}<br/>`
+                }
+              });
             }
         }
     }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbpasswordtip.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbpasswordtip.directive.js
@@ -19,15 +19,17 @@
 
         let defaultMinPwdLength = Umbraco.Sys.ServerVariables.umbracoSettings.minimumPasswordLength;
         let defaultMinPwdNonAlphaNum = Umbraco.Sys.ServerVariables.umbracoSettings.minimumPasswordNonAlphaNum;
+        let defaultMinPwdDigit = Umbraco.Sys.ServerVariables.umbracoSettings.minimumPasswordDigit;
+        let defaultMinPwdUppercase = Umbraco.Sys.ServerVariables.umbracoSettings.minimumPasswordUppercase;
+        let defaultMinPwdLowercase = Umbraco.Sys.ServerVariables.umbracoSettings.minimumPasswordLowercase;
 
         var vm = this;
 
-        vm.passwordNonAlphaTip = '';
-        vm.passwordTip = '';
-        vm.passwordLength = 0;
 
         vm.$onInit = onInit;
-        vm.$onChanges = onChanges;
+      vm.$onChanges = onChanges;
+
+
 
         function onInit() {
             if (vm.minPwdLength === undefined) {
@@ -38,13 +40,60 @@
                 vm.minPwdNonAlphaNum = defaultMinPwdNonAlphaNum;
             }
 
+            if (vm.minPwdDigit === undefined) {
+                vm.minPwdDigit = defaultMinPwdDigit;
+            }
+
+            if (vm.minPwdDigit === undefined) {
+                vm.minPwdDigit = defaultMinPwdDigit;
+            }
+
+            if (vm.minPwdUppercase === undefined) {
+                vm.minPwdUppercase = defaultMinPwdUppercase;
+            }
+
+            if (vm.minPwdLowercase === undefined) {
+              vm.minPwdLowercase = defaultMinPwdLowercase;
+          }
+
+          vm.passwordLength = 0;
+          vm.passwordNonAlphaTip = '';
+          vm.passwordDigitTip = '';
+          vm.passwordUppercaseTip = '';
+          vm.passwordLowercaseTip = '';
+          vm.passwordTip = '';
+
+          vm.tips = []
+          vm.tipStrs = ['NonAlpha', 'Digit', 'Uppercase', 'Lowercase']
+          vm.mins = [vm.minPwdNonAlphaNum, vm.minPwdDigit, vm.minPwdUppercase, vm.minPwdLowercase]
+
+
+          for (var i = 0; i < vm.tipStrs.length; i++) {
+            setUpTip(vm.tipStrs[i], vm.mins[i]);
+            }
+
+            /*
             if (vm.minPwdNonAlphaNum > 0) {
-                localizationService.localize('user_newPasswordFormatNonAlphaTip', [vm.minPwdNonAlphaNum]).then(data => {
+                localizationService.localize('user_newPasswordFormatNonAlphaTip', [tip]).then(data => {
                     vm.passwordNonAlphaTip = data;
                     updatePasswordTip(vm.passwordLength);
                 });
             } else {
                 vm.passwordNonAlphaTip = '';
+                updatePasswordTip(vm.passwordLength);
+            }
+            */
+        }
+
+        // Need to use minimum here
+        function setUpTip(str, min) {
+          if (min > 0) {
+            localizationService.localize(`user_newPasswordFormat${str}Tip`, [min]).then(data => {
+                    vm.tips.push(data);
+                    updatePasswordTip(vm.passwordLength);
+                });
+            } else {
+                vm.tips.push('')
                 updatePasswordTip(vm.passwordLength);
             }
         }
@@ -65,12 +114,11 @@
             if (remainingLength > 0) {
                 localizationService.localize('user_newPasswordFormatLengthTip', [remainingLength]).then(data => {
                     vm.passwordTip = data;
-                    if (vm.passwordNonAlphaTip) {
-                        vm.passwordTip += `<br/>${vm.passwordNonAlphaTip}`;
-                    }
+                    vm.tips.forEach((tip) => vm.passwordTip += `<br/>${tip}`);
                 });
             } else {
-                vm.passwordTip = vm.passwordNonAlphaTip;
+              vm.passwordTip = '';
+              vm.tips.forEach((tip) => vm.passwordTip += `<br/>${tip}`);
             }
         }
     }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [14263](https://github.com/umbraco/Umbraco-CMS/issues/14263)

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

The following changes were made:

- Update password tip directive to include information about all password tips and not just minimum password length and non-alphanumeric characters. Now, in addition to minimum password length and non-alphanumeric tips, there are tips for digit, uppercase, and lowercase if they are present in the app settings.
- Update embedded resources for en and en_us to include the new password tip strings. This pull request will be draft until all embedded resources have been updated.

How to test:

1. Update user and member password settings in appsettings.json to include the desired password requirements.

![image](https://github.com/umbraco/Umbraco-CMS/assets/50598649/dcdb15d0-9fbe-436e-926d-2b0e8e64dd05)

2. Run Umbraco

3. Change your password. Observe that new tips are present for desired user settings.

![image](https://github.com/umbraco/Umbraco-CMS/assets/50598649/f355ce73-dcd9-4bd7-a452-37e880f3128a)

4. Create a new member. Observe that new tips are present for desired member settings.

![image](https://github.com/umbraco/Umbraco-CMS/assets/50598649/94eab720-9b4d-4f3c-8cf8-3d50de73f0e0)

<!-- Thanks for contributing to Umbraco CMS! -->
