### PR TITLE
Update z-index of block actions

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/variables.less
+++ b/src/Umbraco.Web.UI.Client/src/less/variables.less
@@ -353,7 +353,7 @@
 // Try to avoid customizing these :)
 @zIndexEditor: 100;
 @zIndexTree: 100;
-@zIndexBlockActions: 500;
+@zIndexBlockActions: 90; // Should be less than "zIndexEditor" to be behind editor overlay in infinite mode.
 @zindexDropdown: 1000;
 @zindexPopover: 1010;
 @zindexTooltip: 1030;

--- a/src/Umbraco.Web.UI.Client/src/less/variables.less
+++ b/src/Umbraco.Web.UI.Client/src/less/variables.less
@@ -353,7 +353,7 @@
 // Try to avoid customizing these :)
 @zIndexEditor: 100;
 @zIndexTree: 100;
-@zIndexBlockActions: 90; // Should be less than "zIndexEditor" to be behind editor overlay in infinite mode.
+@zIndexBlockActions: 90; // Should be less than "zIndexEditor" to stay behind editor overlay in infinite mode.
 @zindexDropdown: 1000;
 @zindexPopover: 1010;
 @zindexTooltip: 1030;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

PR https://github.com/umbraco/Umbraco-CMS/pull/13179 changed z-index of block actions, but it did had a side-effect that the block actions are now on top over `umb-editor` which is shown in infinite editing.

**Before**

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/5af0f6b3-2c56-40fa-9cd5-daaee0255282)

**After**

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/c7e576a5-d5cf-4124-a34f-21086f8c268b)
