### PR TITLE
Media Picker 3 should not be used as a macro parameter

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/MediaPicker3PropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MediaPicker3PropertyEditor.cs
@@ -20,7 +20,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 /// </summary>
 [DataEditor(
     Constants.PropertyEditors.Aliases.MediaPicker3,
-    EditorType.PropertyValue | EditorType.MacroParameter,
+    EditorType.PropertyValue,
     "Media Picker",
     "mediapicker3",
     ValueType = ValueTypes.Json,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/14913

### Description

As the linked issue describes, Media Picker 3 does not work as a macro parameter. 

Since macros are obsolete from V14, this PR removes Media Picker 3 from the list of applicable macro parameters.

### Testing this PR

1. Create a macro.
2. Add a macro parameter.
3. Verify that Media Picker 3 is _not_ selectable as macro editor - only Multiple Media Picker and the legacy Media Picker should be available.

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/4a4e1970-fd0f-490f-953e-7b79af115a4d)
