### PR TITLE
V13: Migrate webhook url columms to NVarCharMax

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -103,5 +103,6 @@ public class UmbracoPlan : MigrationPlan
         To<V_13_0_0.AddWebhookDatabaseLock>("{23BA95A4-FCCE-49B0-8AA1-45312B103A9B}");
         To<V_13_0_0.ChangeLogStatusCode>("{7DDCE198-9CA4-430C-8BBC-A66D80CA209F}");
         To<V_13_0_0.ChangeWebhookRequestObjectColumnToNvarcharMax>("{F74CDA0C-7AAA-48C8-94C6-C6EC3C06F599}");
+        To<V_13_0_0.ChangeWebhookUrlColumnsToNvarcharMax>("{21C42760-5109-4C03-AB4F-7EA53577D1F5}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_0_0/ChangeWebhookUrlColumnsToNvarcharMax.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_0_0/ChangeWebhookUrlColumnsToNvarcharMax.cs
@@ -1,0 +1,89 @@
+﻿using System.Linq.Expressions;
+using System.Text;
+using NPoco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Migrations.Expressions.Create.Column;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_13_0_0;
+
+public class ChangeWebhookUrlColumnsToNvarcharMax : MigrationBase
+{
+    public ChangeWebhookUrlColumnsToNvarcharMax(IMigrationContext context) : base(context)
+    {
+    }
+
+    protected override void Migrate()
+    {
+        // We don't need to run this migration for SQLite, since ntext is not a thing there, text is just text.
+        if (DatabaseType == DatabaseType.SQLite)
+        {
+            return;
+        }
+
+        MigrateNtextColumn<WebhookDto>("url", Constants.DatabaseSchema.Tables.Webhook, x => x.Url);
+        MigrateNtextColumn<WebhookLogDto>("url", Constants.DatabaseSchema.Tables.WebhookLog, x => x.Url);
+    }
+
+    private void MigrateNtextColumn<TDto>(string columnName, string tableName, Expression<Func<TDto, object?>> fieldSelector, bool nullable = true)
+    {
+        var columnType = ColumnType(tableName, columnName);
+        if (columnType is null || columnType.Equals("nvarchar", StringComparison.InvariantCultureIgnoreCase) is false)
+        {
+            return;
+        }
+
+        var oldColumnName = $"Old{columnName}";
+
+        // Rename the column so we can create the new one and copy over the data.
+        Rename
+            .Column(columnName)
+            .OnTable(tableName)
+            .To(oldColumnName)
+            .Do();
+
+        // Create new column with the correct type
+        // This is pretty ugly, but we have to do ti this way because the CacheInstruction.Instruction column doesn't support nullable.
+        // So we have to populate with some temporary placeholder value before we copy over the actual data.
+        ICreateColumnOptionBuilder builder = Create
+            .Column(columnName)
+            .OnTable(tableName)
+            .AsCustom("nvarchar(max)");
+
+        if (nullable is false)
+        {
+            builder
+                .NotNullable()
+                .WithDefaultValue("Placeholder");
+        }
+        else
+        {
+            builder.Nullable();
+        }
+
+        builder.Do();
+
+        // Copy over data NPOCO doesn't support this for some reason, so we'll have to do it like so
+        // While we're add it we'll also set all the old values to be NULL since it's recommended here:
+        // https://learn.microsoft.com/en-us/sql/t-sql/data-types/ntext-text-and-image-transact-sql?view=sql-server-ver16#remarks
+        StringBuilder queryBuilder = new StringBuilder()
+            .AppendLine($"UPDATE {tableName}")
+            .AppendLine("SET")
+            .Append($"\t{SqlSyntax.GetFieldNameForUpdate(fieldSelector)} = {SqlSyntax.GetQuotedTableName(tableName)}.{SqlSyntax.GetQuotedColumnName(oldColumnName)}");
+
+        if (nullable)
+        {
+            queryBuilder.AppendLine($"\n,\t{SqlSyntax.GetQuotedColumnName(oldColumnName)} = NULL");
+        }
+
+        Sql<ISqlContext> copyDataQuery = Database.SqlContext.Sql(queryBuilder.ToString());
+        Database.Execute(copyDataQuery);
+
+        // Delete old column
+        Delete
+            .Column(oldColumnName)
+            .FromTable(tableName)
+            .Do();
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/WebhookDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/WebhookDto.cs
@@ -19,6 +19,7 @@ internal class WebhookDto
     public Guid Key { get; set; }
 
     [Column(Name = "url")]
+    [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
     [NullSetting(NullSetting = NullSettings.NotNull)]
     public string Url { get; set; } = string.Empty;
 

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/WebhookLogDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/WebhookLogDto.cs
@@ -30,6 +30,7 @@ internal class WebhookLogDto
     public DateTime Date { get; set; }
 
     [Column(Name = "url")]
+    [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
     [NullSetting(NullSetting = NullSettings.NotNull)]
     public string Url { get; set; } = string.Empty;
 


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/15320 & https://github.com/umbraco/Umbraco-CMS/issues/15321

# Notes
- Changes the `url` columns to nvarchar max, as URLs can apparently be up to 2000 characters
- Reuses the`MigrateNtextColumn` from previous migration

# How to test
- Follow step in original issues
- Remember to use SQLServer, as this is not a problem on SQLite