### PR TITLE
Management API should expose if a user group is a system group

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Factories/UserGroupPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/UserGroupPresentationFactory.cs
@@ -51,6 +51,7 @@ public class UserGroupPresentationFactory : IUserGroupPresentationFactory
             HasAccessToAllLanguages = userGroup.HasAccessToAllLanguages,
             Permissions = userGroup.PermissionNames,
             Sections = userGroup.AllowedSections.Select(SectionMapper.GetName),
+            IsSystemGroup = userGroup.IsSystemUserGroup()
         };
     }
     /// <inheritdoc />

--- a/src/Umbraco.Cms.Api.Management/ViewModels/UserGroup/UserGroupResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/UserGroup/UserGroupResponseModel.cs
@@ -7,4 +7,8 @@ public class UserGroupResponseModel : UserGroupBase, INamedEntityPresentationMod
     /// </summary>
     public required Guid Id { get; init; }
 
+    /// <summary>
+    /// Whether this user group is required at system level (thus cannot be removed)
+    /// </summary>
+    public bool IsSystemGroup { get; set; }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserGroupServiceValidationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserGroupServiceValidationTests.cs
@@ -168,4 +168,41 @@ public class UserGroupServiceValidationTests : UmbracoIntegrationTest
         var updatedGroup = updateResult.Result;
         Assert.AreEqual(updateName, updatedGroup.Name);
     }
+
+    // these keys are not defined as "const" in Constants.Security but as "static readonly", so we have to hardcode
+    // them here ("static readonly" can't be used as testcase inputs as they are not constants)
+    [TestCase("E5E7F6C8-7F9C-4B5B-8D5D-9E1E5A4F7E4D", "admin")]
+    [TestCase("8C6AD70F-D307-4E4A-AF58-72C2E4E9439D", "sensitiveData")]
+    [TestCase("F2012E4C-D232-4BD1-8EAE-4384032D97D8", "translator")]
+    public async Task Cannot_Delete_System_UserGroups(string userGroupKeyAsString, string expectedGroupAlias)
+    {
+        // since we can't use the constants as input, let's make sure we don't get false positives by double checking the group alias
+        var key = Guid.Parse(userGroupKeyAsString);
+        var userGroup = await UserGroupService.GetAsync(key);
+        Assert.IsNotNull(userGroup);
+        Assert.AreEqual(expectedGroupAlias, userGroup.Alias);
+
+        var result = await UserGroupService.DeleteAsync(key);
+
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(UserGroupOperationStatus.IsSystemUserGroup, result.Result);
+    }
+
+    // these keys are not defined as "const" in Constants.Security but as "static readonly", so we have to hardcode
+    // them here ("static readonly" can't be used as testcase inputs as they are not constants)
+    [TestCase("44DC260E-B4D4-4DD9-9081-EEC5598F1641", "editor")]
+    [TestCase("9FC2A16F-528C-46D6-A014-75BF4EC2480C", "writer")]
+    public async Task Can_Delete_Non_System_UserGroups(string userGroupKeyAsString, string expectedGroupAlias)
+    {
+        // since we can't use the constants as input, let's make sure we don't get false positives by double checking the group alias
+        var key = Guid.Parse(userGroupKeyAsString);
+        var userGroup = await UserGroupService.GetAsync(key);
+        Assert.IsNotNull(userGroup);
+        Assert.AreEqual(expectedGroupAlias, userGroup.Alias);
+
+        var result = await UserGroupService.DeleteAsync(key);
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(UserGroupOperationStatus.Success, result.Result);
+    }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

As-is it's not possible for the new backoffice client to figure out if a user group can be deleted or not. The API eventually fails if one attempts to delete one of the "system" groups, but it would be appropriate to remove that option from the UI altogether.

The "system" groups are:

- Administrators
- Sensitive data
- Translators

The "cannot delete system group" rule remains untested in `IUserGroupService` (new service for V14) so I have added tests for this as well.

### Testing this PR

Use the Management API to fetch all user groups. The "system" groups should be tagged as `"isSystemGroup": true`:

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/88d316d7-489d-489a-a8ef-81fe3ffb7d09)
