### PR TITLE
V13 RC: Fix regression for external login providers

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
@@ -145,7 +145,6 @@ public class BackOfficeController : UmbracoController
 
         return await RenderDefaultOrProcessExternalLoginAsync(
             result,
-            () => defaultView,
             () => defaultView);
     }
 
@@ -172,7 +171,6 @@ public class BackOfficeController : UmbracoController
 
         return await RenderDefaultOrProcessExternalLoginAsync(
             result,
-            () => View(viewPath),
             () => View(viewPath));
     }
 
@@ -460,11 +458,9 @@ public class BackOfficeController : UmbracoController
     /// <returns></returns>
     private async Task<IActionResult> RenderDefaultOrProcessExternalLoginAsync(
         AuthenticateResult authenticateResult,
-        Func<IActionResult> defaultResponse,
-        Func<IActionResult> externalSignInResponse)
+        Func<IActionResult> defaultResponse)
     {
         ArgumentNullException.ThrowIfNull(defaultResponse);
-        ArgumentNullException.ThrowIfNull(externalSignInResponse);
 
         ViewData.SetUmbracoPath(_globalSettings.GetUmbracoMvcArea(_hostingEnvironment));
 
@@ -483,8 +479,8 @@ public class BackOfficeController : UmbracoController
 
         if (loginInfo == null || loginInfo.Principal == null)
         {
-            // if the user is not logged in, check if there's any auto login redirects specified
-            if (!authenticateResult.Succeeded)
+            // If the user is not logged in, check if there's any auto login redirects specified
+            if (authenticateResult.Succeeded)
             {
                 return defaultResponse();
             }
@@ -508,7 +504,7 @@ public class BackOfficeController : UmbracoController
         }
 
         // we're just logging in with an external source, not linking accounts
-        return await ExternalSignInAsync(loginInfo, externalSignInResponse);
+        return await ExternalSignInAsync(loginInfo, defaultResponse);
     }
 
     private async Task<IActionResult> ExternalSignInAsync(ExternalLoginInfo loginInfo, Func<IActionResult> response)

--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
@@ -18,7 +18,6 @@ using Umbraco.Cms.Core.Configuration.Grid;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Manifest;
-using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;

--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration.Grid;

--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
@@ -486,11 +486,22 @@ public class BackOfficeController : UmbracoController
             // if the user is not logged in, check if there's any auto login redirects specified
             if (!authenticateResult.Succeeded)
             {
-                var oauthRedirectAuthProvider = _externalLogins.GetAutoLoginProvider();
-                if (!oauthRedirectAuthProvider.IsNullOrWhiteSpace())
-                {
-                    return ExternalLogin(oauthRedirectAuthProvider!);
-                }
+                return defaultResponse();
+            }
+
+            var oauthRedirectAuthProvider = _externalLogins.GetAutoLoginProvider();
+
+            // If there's no auto login provider specified, then we'll render the default view
+            if (oauthRedirectAuthProvider.IsNullOrWhiteSpace())
+            {
+                return defaultResponse();
+            }
+
+            // If the ?logout=true query string is not specified, then we'll redirect to the external login provider
+            // which will then redirect back to the ExternalLoginCallback action
+            if (Request.Query.TryGetValue("logout", out StringValues logout) == false || logout != "true")
+            {
+                return ExternalLogin(oauthRedirectAuthProvider);
             }
 
             return defaultResponse();


### PR DESCRIPTION
### Description

Fixes AB#35485

If you turn on `AutoRedirectLoginToExternalProvider` it will send you in an endless loop, because we now redirect the user when logging out. This PR adds a check for the parameter `?logout=true` in the BackOfficeController to prevent this scenario. It also refactors the controller to reduce nesting and improve the general understanding of how external login providers work.