### PR TITLE
Implement dashboard name

### DIFF
--- a/src/Umbraco.Core/Dashboards/IDashboardSlim.cs
+++ b/src/Umbraco.Core/Dashboards/IDashboardSlim.cs
@@ -14,6 +14,12 @@ public interface IDashboardSlim
     string? Alias { get; }
 
     /// <summary>
+    ///     Gets the name of the dashboard.
+    /// </summary>
+    [DataMember(Name = "name")]
+    string? Name => null;
+
+    /// <summary>
     ///     Gets the view used to render the dashboard.
     /// </summary>
     [DataMember(Name = "view")]

--- a/src/Umbraco.Core/Services/DashboardService.cs
+++ b/src/Umbraco.Core/Services/DashboardService.cs
@@ -49,7 +49,7 @@ public class DashboardService : IDashboardService
             tabs.Add(new Tab<IDashboard>
             {
                 Id = tabId++,
-                Label = label == $"[{label}]"
+                Label = !string.IsNullOrEmpty(label) && label.StartsWith("[") && label.EndsWith("]")
                     ? !string.IsNullOrEmpty(dashboard.Name)
                         ? dashboard.Name
                         : label

--- a/src/Umbraco.Core/Services/DashboardService.cs
+++ b/src/Umbraco.Core/Services/DashboardService.cs
@@ -49,11 +49,11 @@ public class DashboardService : IDashboardService
             tabs.Add(new Tab<IDashboard>
             {
                 Id = tabId++,
-                Label = !string.IsNullOrEmpty(label)
-                    ? label
-                    : !string.IsNullOrEmpty(dashboard.Name)
+                Label = label == $"[{label}]"
+                    ? !string.IsNullOrEmpty(dashboard.Name)
                         ? dashboard.Name
-                        : dashboard.Alias,
+                        : label
+                    : label,
                 Alias = dashboard.Alias,
                 Properties = dashboards,
             });

--- a/src/Umbraco.Core/Services/DashboardService.cs
+++ b/src/Umbraco.Core/Services/DashboardService.cs
@@ -43,11 +43,17 @@ public class DashboardService : IDashboardService
                 throw new NotSupportedException("Legacy UserControl (.ascx) dashboards are no longer supported.");
             }
 
+            var label = _localizedText.Localize("dashboardTabs", dashboard.Alias);
+
             var dashboards = new List<IDashboard> { dashboard };
             tabs.Add(new Tab<IDashboard>
             {
                 Id = tabId++,
-                Label = _localizedText.Localize("dashboardTabs", dashboard.Alias),
+                Label = !string.IsNullOrEmpty(label)
+                    ? label
+                    : !string.IsNullOrEmpty(dashboard.Name)
+                        ? dashboard.Name
+                        : dashboard.Alias,
                 Alias = dashboard.Alias,
                 Properties = dashboards,
             });

--- a/src/Umbraco.Web.UI.Client/src/views/common/dashboard.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dashboard.controller.js
@@ -9,21 +9,25 @@
  */
 
 function DashboardController($scope, $q, $routeParams, $location, dashboardResource, localizationService) {
-    const DASHBOARD_QUERY_PARAM = 'dashboard';
 
-    $scope.page = {};
-    $scope.page.nameLocked = true;
-    $scope.page.loading = true;
+    const DASHBOARD_QUERY_PARAM = 'dashboard';
+    const promises = [];
+
+    const vm = this;
+
+    vm.page = {};
+    vm.page.nameLocked = true;
+    vm.page.loading = true;
+
+    vm.changeTab = changeTab;
 
     $scope.dashboard = {};
 
-    var promises = [];
-
-    promises.push(localizationService.localize("sections_" + $routeParams.section).then(function (name) {
+    promises.push(localizationService.localize("sections_" + $routeParams.section).then(name => {
     	$scope.dashboard.name = name;
     }));
 
-    promises.push(dashboardResource.getDashboard($routeParams.section).then(function (tabs) {
+    promises.push(dashboardResource.getDashboard($routeParams.section).then(tabs => {
         $scope.dashboard.tabs = tabs;
 
         if ($scope.dashboard.tabs && $scope.dashboard.tabs.length > 0) {
@@ -31,20 +35,20 @@ function DashboardController($scope, $q, $routeParams, $location, dashboardResou
         }
     }));
 
-    $q.all(promises).then(function () {
-        $scope.page.loading = false;
+    $q.all(promises).then(() => {
+        vm.page.loading = false;
     });
 
-    $scope.changeTab = function (tab) {
+    function changeTab(tab) {
         if ($scope.dashboard.tabs && $scope.dashboard.tabs.length > 0) {
-            $scope.dashboard.tabs.forEach(function (tab) {
+            $scope.dashboard.tabs.forEach(tab => {
                 tab.active = false;
             });
         }
 
         tab.active = true;
         $location.search(DASHBOARD_QUERY_PARAM, tab.alias);
-    };
+    }
 
     function initActiveTab() {
         // Check the query parameter for a dashboard alias

--- a/src/Umbraco.Web.UI.Client/src/views/common/dashboard.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/dashboard.html
@@ -1,16 +1,16 @@
-<div ng-controller="Umbraco.DashboardController">
+<div ng-controller="Umbraco.DashboardController as vm">
 
     <ng-form name="dashboardForm" val-form-manager>
 
-        <umb-load-indicator ng-show="page.loading"></umb-load-indicator>
+        <umb-load-indicator ng-show="vm.page.loading"></umb-load-indicator>
 
-        <div class="umb-dashboard" ng-if="!page.loading" data-element='dashboard'>
+        <div class="umb-dashboard" ng-if="!vm.page.loading" data-element='dashboard'>
 
             <div class="umb-dashboard__header" ng-show="dashboard.tabs.length > 1">
                 <umb-tabs-nav
                     ng-if="dashboard.tabs"
                     tabs="dashboard.tabs"
-                    on-tab-change="changeTab(tab)">
+                    on-tab-change="vm.changeTab(tab)">
                 </umb-tabs-nav>
             </div>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR add the option to set a dashboard name without need to add localization.
The `Name` property act as fallback, so it won't affect current implementation of `IDashboard` where it still use translation if prevent and fallback to `Name` prooperty, but if not implemented, null or empty value is shown the default localized value, which is `[alias]`.

It also makes it a bit more consistent with other concepts in core, e.g. ContentApp where a name can be set without translation:
https://github.com/umbraco/Umbraco-CMS/blob/c6d01178c06a519423b3c37fea7bbdd0e536319f/src/Umbraco.Core/Models/ContentEditing/ContentApp.cs#L18

### Test notes

Extract following folder to `Umbraco.Web.UI` project:
[Dashboards.zip](https://github.com/umbraco/Umbraco-CMS/files/13527278/Dashboards.zip)

Furthermore extract this folder to `App_Plugins`:
[Our.Umbraco.Dashboards.zip](https://github.com/umbraco/Umbraco-CMS/files/13527388/Our.Umbraco.Dashboards.zip)

With no localization of `dashboardTabs_{alias}` and `Name` property set on implementation of `IDashboard`:

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/2b9068cc-b758-4a06-a21a-eab5717f72be)

When comment out `Name` property in `OutdatedContentDashboard` (like if developers haven't implemented it) and no translation of `dashboardTabs_{alias}`:

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/b76bcaa8-1502-47c9-9f26-d3830f4499e2)

With translation and with or without implementation of `Name` property:

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/2a0d31e3-b852-4c53-b54a-df5f4ab08fbd)
