### PR TITLE
V14 QA Authorization integration test, DRY base class

### DIFF
--- a/src/Umbraco.Core/ExpressionHelper.cs
+++ b/src/Umbraco.Core/ExpressionHelper.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Persistence;
 
 namespace Umbraco.Cms.Core;
@@ -152,7 +153,7 @@ public static class ExpressionHelper
         }
 
         var rVal = new Dictionary<string, object?>();
-        var parameters = body.Method.GetParameters().Select(x => x.Name).Where(x => x is not null).ToArray();
+        var parameters = body.Method.GetParameters().Select(x => x.GetCustomAttribute<FromQueryAttribute>()?.Name ?? x.Name).Where(x => x is not null).ToArray();
         var i = 0;
         foreach (Expression argument in body.Arguments)
         {

--- a/tests/Umbraco.Tests.Integration/ManagementApi/AuditLog/ByKeyAuditLogControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/AuditLog/ByKeyAuditLogControllerTests.cs
@@ -6,55 +6,39 @@ using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Tests.Integration.ManagementApi.AuditLog;
 
-
 [TestFixture]
-public class ByKeyAuditLogControllerTests : ManagementApiBaseTest<ByKeyAuditLogController>
+public class ByKeyAuditLogControllerTests : ManagementApiUserGroupTestBase<ByKeyAuditLogController>
 {
     protected override Expression<Func<ByKeyAuditLogController, object>> MethodSelector =>
         x => x.ByKey(Constants.Security.SuperUserKey, Direction.Ascending, null, 0, 100);
 
-    protected override List<HttpStatusCode> AuthenticatedStatusCodes { get; } = new()
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
     {
-        HttpStatusCode.OK
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
     };
 
-    [Test]
-    public virtual async Task As_Admin_I_Have_Access()
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
     {
-        var response = await AccessAsAdmin();
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+    };
 
-        AssertStatusCode(response, true);
-    }
-
-    [Test]
-    public virtual async Task As_Editor_I_Have_Access()
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
     {
-        var response = await AccessAsEditor();
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden,
+    };
 
-        AssertStatusCode(response, true);
-    }
-
-    [Test]
-    public virtual async Task As_Sensitive_Data_I_Have_No_Access()
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
     {
-        var response = await AccessAsSensitiveData();
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden,
+    };
 
-        AssertStatusCode(response, false);
-    }
-
-    [Test]
-    public virtual async Task As_Translator_I_Have_No_Access()
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
     {
-        var response = await AccessAsTranslator();
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+    };
 
-        AssertStatusCode(response, false);
-    }
-
-    [Test]
-    public virtual async Task As_Writer_I_Have_Access()
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
     {
-        var response = await AccessAsWriter();
-
-        AssertStatusCode(response, true);
-    }
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized,
+    };
 }

--- a/tests/Umbraco.Tests.Integration/ManagementApi/AuditLog/ByKeyAuditLogControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/AuditLog/ByKeyAuditLogControllerTests.cs
@@ -14,31 +14,31 @@ public class ByKeyAuditLogControllerTests : ManagementApiUserGroupTestBase<ByKey
 
     protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden,
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden
     };
 
     protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden,
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden
     };
 
     protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized,
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized
     };
 }

--- a/tests/Umbraco.Tests.Integration/ManagementApi/AuditLog/ByKeyAuditLogControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/AuditLog/ByKeyAuditLogControllerTests.cs
@@ -14,31 +14,31 @@ public class ByKeyAuditLogControllerTests : ManagementApiUserGroupTestBase<ByKey
 
     protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden
+        ExpectedStatusCode = HttpStatusCode.Forbidden
     };
 
     protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden
+        ExpectedStatusCode = HttpStatusCode.Forbidden
     };
 
     protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized
+        ExpectedStatusCode = HttpStatusCode.Unauthorized
     };
 }

--- a/tests/Umbraco.Tests.Integration/ManagementApi/AuditLog/ByTypeAuditLogControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/AuditLog/ByTypeAuditLogControllerTests.cs
@@ -14,31 +14,31 @@ public class ByTypeAuditLogControllerTests : ManagementApiUserGroupTestBase<ByTy
 
     protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized,
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized
     };
 }

--- a/tests/Umbraco.Tests.Integration/ManagementApi/AuditLog/ByTypeAuditLogControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/AuditLog/ByTypeAuditLogControllerTests.cs
@@ -2,73 +2,43 @@ using System.Linq.Expressions;
 using System.Net;
 using NUnit.Framework;
 using Umbraco.Cms.Api.Management.Controllers.AuditLog;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Tests.Integration.ManagementApi.AuditLog;
 
 [TestFixture]
-public class ByTypeAuditLogControllerTests : ManagementApiTest<ByTypeAuditLogController>
+public class ByTypeAuditLogControllerTests : ManagementApiUserGroupTestBase<ByTypeAuditLogController>
 {
     protected override Expression<Func<ByTypeAuditLogController, object>> MethodSelector =>
         x => x.ByType(AuditType.New, null, 0, 100);
 
-    [Test]
-    public virtual async Task As_Admin_I_Have_Access()
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
     {
-        await AuthenticateClientAsync(Client, "admin@umbraco.com", "1234567890", Constants.Security.AdminGroupKey);
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+    };
 
-        var response = await Client.GetAsync(Url);
-
-        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
-
-    [Test]
-    public virtual async Task As_Editor_I_Have_Access()
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
     {
-        await AuthenticateClientAsync(Client, "editor@umbraco.com", "1234567890", Constants.Security.EditorGroupKey);
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+    };
 
-        var response = await Client.GetAsync(Url);
-
-        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
-
-    [Test]
-    public virtual async Task As_Sensitive_Data_I_Have_Access()
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
     {
-        await AuthenticateClientAsync(Client, "sensitiveData@umbraco.com", "1234567890", Constants.Security.SensitiveDataGroupKey);
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+    };
 
-        var response = await Client.GetAsync(Url);
-
-        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
-
-    [Test]
-    public virtual async Task As_Translator_I_Have_Access()
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
     {
-        await AuthenticateClientAsync(Client, "translator@umbraco.com", "1234567890", Constants.Security.TranslatorGroupKey);
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+    };
 
-        var response = await Client.GetAsync(Url);
-
-        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
-
-    [Test]
-    public virtual async Task As_Writer_I_Have_Access()
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
     {
-        await AuthenticateClientAsync(Client, "writer@umbraco.com", "1234567890", Constants.Security.WriterGroupKey);
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+    };
 
-        var response = await Client.GetAsync(Url);
-
-        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
-
-
-    [Test]
-    public virtual async Task Unauthorized_When_No_Token_Is_Provided()
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
     {
-        var response = await Client.GetAsync(Url);
-
-        Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized,
+    };
 }

--- a/tests/Umbraco.Tests.Integration/ManagementApi/AuditLog/ByTypeAuditLogControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/AuditLog/ByTypeAuditLogControllerTests.cs
@@ -14,31 +14,31 @@ public class ByTypeAuditLogControllerTests : ManagementApiUserGroupTestBase<ByTy
 
     protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized
+        ExpectedStatusCode = HttpStatusCode.Unauthorized
     };
 }

--- a/tests/Umbraco.Tests.Integration/ManagementApi/AuditLog/CurrentUserAuditLogControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/AuditLog/CurrentUserAuditLogControllerTests.cs
@@ -7,67 +7,38 @@ using Umbraco.Cms.Core;
 namespace Umbraco.Cms.Tests.Integration.ManagementApi.AuditLog;
 
 [TestFixture]
-public class CurrentUserAuditLogControllerTests : ManagementApiTest<CurrentUserAuditLogController>
+public class CurrentUserAuditLogControllerTests : ManagementApiUserGroupTestBase<CurrentUserAuditLogController>
 {
     protected override Expression<Func<CurrentUserAuditLogController, object>> MethodSelector =>
         x => x.CurrentUser(Direction.Ascending, null, 0, 100);
 
-    [Test]
-    public virtual async Task As_Admin_I_Have_Access()
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
     {
-        await AuthenticateClientAsync(Client, "admin@umbraco.com", "1234567890", Constants.Security.AdminGroupKey);
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+    };
 
-        var response = await Client.GetAsync(Url);
-
-        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
-
-    [Test]
-    public virtual async Task As_Editor_I_Have_Access()
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
     {
-        await AuthenticateClientAsync(Client, "editor@umbraco.com", "1234567890", Constants.Security.EditorGroupKey);
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+    };
 
-        var response = await Client.GetAsync(Url);
-
-        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
-
-    [Test]
-    public virtual async Task As_Sensitive_Data_I_Have_Access()
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
     {
-        await AuthenticateClientAsync(Client, "sensitiveData@umbraco.com", "1234567890", Constants.Security.SensitiveDataGroupKey);
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+    };
 
-        var response = await Client.GetAsync(Url);
-
-        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
-
-    [Test]
-    public virtual async Task As_Translator_I_Have_Access()
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
     {
-        await AuthenticateClientAsync(Client, "translator@umbraco.com", "1234567890", Constants.Security.TranslatorGroupKey);
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+    };
 
-        var response = await Client.GetAsync(Url);
-
-        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
-
-    [Test]
-    public virtual async Task As_Writer_I_Have_Access()
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
     {
-        await AuthenticateClientAsync(Client, "writer@umbraco.com", "1234567890", Constants.Security.WriterGroupKey);
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+    };
 
-        var response = await Client.GetAsync(Url);
-
-        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
-
-
-    [Test]
-    public virtual async Task Unauthorized_When_No_Token_Is_Provided()
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
     {
-        var response = await Client.GetAsync(Url);
-
-        Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized,
+    };
 }

--- a/tests/Umbraco.Tests.Integration/ManagementApi/AuditLog/CurrentUserAuditLogControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/AuditLog/CurrentUserAuditLogControllerTests.cs
@@ -14,31 +14,31 @@ public class CurrentUserAuditLogControllerTests : ManagementApiUserGroupTestBase
 
     protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized
+        ExpectedStatusCode = HttpStatusCode.Unauthorized
     };
 }

--- a/tests/Umbraco.Tests.Integration/ManagementApi/AuditLog/CurrentUserAuditLogControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/AuditLog/CurrentUserAuditLogControllerTests.cs
@@ -14,31 +14,31 @@ public class CurrentUserAuditLogControllerTests : ManagementApiUserGroupTestBase
 
     protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized,
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized
     };
 }

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Culture/AllCultureControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Culture/AllCultureControllerTests.cs
@@ -13,31 +13,31 @@ public class AllCultureControllerTests : ManagementApiUserGroupTestBase<AllCultu
 
     protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized
+        ExpectedStatusCode = HttpStatusCode.Unauthorized
     };
 }

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Culture/AllCultureControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Culture/AllCultureControllerTests.cs
@@ -2,7 +2,6 @@ using System.Linq.Expressions;
 using System.Net;
 using NUnit.Framework;
 using Umbraco.Cms.Api.Management.Controllers.Culture;
-using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Tests.Integration.ManagementApi.Culture;
 
@@ -14,31 +13,31 @@ public class AllCultureControllerTests : ManagementApiUserGroupTestBase<AllCultu
 
     protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized,
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized
     };
 }

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Culture/AllCultureControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Culture/AllCultureControllerTests.cs
@@ -7,67 +7,38 @@ using Umbraco.Cms.Core;
 namespace Umbraco.Cms.Tests.Integration.ManagementApi.Culture;
 
 [TestFixture]
-public class AllCultureControllerTests : ManagementApiTest<AllCultureController>
+public class AllCultureControllerTests : ManagementApiUserGroupTestBase<AllCultureController>
 {
     protected override Expression<Func<AllCultureController, object>> MethodSelector =>
         x => x.GetAll(0, 100);
 
-    [Test]
-    public virtual async Task As_Admin_I_Have_Access()
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
     {
-        await AuthenticateClientAsync(Client, "admin@umbraco.com", "1234567890", Constants.Security.AdminGroupKey);
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+    };
 
-        var response = await Client.GetAsync(Url);
-
-        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
-
-    [Test]
-    public virtual async Task As_Editor_I_Have_Access()
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
     {
-        await AuthenticateClientAsync(Client, "editor@umbraco.com", "1234567890", Constants.Security.EditorGroupKey);
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+    };
 
-        var response = await Client.GetAsync(Url);
-
-        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
-
-    [Test]
-    public virtual async Task As_Sensitive_Data_I_Have_Access()
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
     {
-        await AuthenticateClientAsync(Client, "sensitiveData@umbraco.com", "1234567890", Constants.Security.SensitiveDataGroupKey);
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+    };
 
-        var response = await Client.GetAsync(Url);
-
-        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
-
-    [Test]
-    public virtual async Task As_Translator_I_Have_Access()
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
     {
-        await AuthenticateClientAsync(Client, "translator@umbraco.com", "1234567890", Constants.Security.TranslatorGroupKey);
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+    };
 
-        var response = await Client.GetAsync(Url);
-
-        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
-
-    [Test]
-    public virtual async Task As_Writer_I_Have_Access()
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
     {
-        await AuthenticateClientAsync(Client, "writer@umbraco.com", "1234567890", Constants.Security.WriterGroupKey);
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+    };
 
-        var response = await Client.GetAsync(Url);
-
-        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
-
-
-    [Test]
-    public virtual async Task Unauthorized_When_No_Token_Is_Provided()
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
     {
-        var response = await Client.GetAsync(Url);
-
-        Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized,
+    };
 }

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Folder/ByKeyDataTypeFolderControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Folder/ByKeyDataTypeFolderControllerTests.cs
@@ -23,31 +23,31 @@ public class ByKeyDataTypeFolderControllerTests : ManagementApiUserGroupTestBase
 
     protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden,
+        ExpectedStatusCode = HttpStatusCode.Forbidden,
     };
 
     protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden
+        ExpectedStatusCode = HttpStatusCode.Forbidden
     };
 
     protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized
+        ExpectedStatusCode = HttpStatusCode.Unauthorized
     };
 }

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Folder/ByKeyDataTypeFolderControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Folder/ByKeyDataTypeFolderControllerTests.cs
@@ -23,12 +23,12 @@ public class ByKeyDataTypeFolderControllerTests : ManagementApiUserGroupTestBase
 
     protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
@@ -38,16 +38,16 @@ public class ByKeyDataTypeFolderControllerTests : ManagementApiUserGroupTestBase
 
     protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden,
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden
     };
 
     protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized,
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized
     };
 }

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Folder/CreateDataTypeFolderControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Folder/CreateDataTypeFolderControllerTests.cs
@@ -4,7 +4,6 @@ using System.Net.Http.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Api.Management.Controllers.DataType.Folder;
 using Umbraco.Cms.Api.Management.ViewModels.Folder;
-using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Tests.Integration.ManagementApi.DataType.Folder;
 
@@ -16,36 +15,36 @@ public class CreateDataTypeFolderControllerTests : ManagementApiUserGroupTestBas
 
     protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.Created,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.Created
     };
 
     protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.Created,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.Created
     };
 
     protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden,
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden
     };
 
     protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden,
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden
     };
 
     protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.Created,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.Created
     };
 
     protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized,
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized
     };
 
     [Test]
-    public override async Task As_Unauthorized_I_Dont_Have_Access()
+    public override async Task As_Unauthorized_I_Have_Specified_Access()
     {
         CreateFolderRequestModel createFolderModel =
             new() { Id = Guid.NewGuid(), ParentId = null, Name = "TestFolderName" };

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Folder/CreateDataTypeFolderControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Folder/CreateDataTypeFolderControllerTests.cs
@@ -15,49 +15,36 @@ public class CreateDataTypeFolderControllerTests : ManagementApiUserGroupTestBas
 
     protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.Created
+        ExpectedStatusCode = HttpStatusCode.Created
     };
 
     protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.Created
+        ExpectedStatusCode = HttpStatusCode.Created
     };
 
     protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden
+        ExpectedStatusCode = HttpStatusCode.Forbidden
     };
 
     protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden
+        ExpectedStatusCode = HttpStatusCode.Forbidden
     };
 
     protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.Created
+        ExpectedStatusCode = HttpStatusCode.Created
     };
 
     protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized
+        ExpectedStatusCode = HttpStatusCode.Unauthorized
     };
 
-    [Test]
-    public override async Task As_Unauthorized_I_Have_Specified_Access()
+    protected override async Task<HttpResponseMessage> ClientRequest()
     {
-        CreateFolderRequestModel createFolderModel =
-            new() { Id = Guid.NewGuid(), ParentId = null, Name = "TestFolderName" };
-
-        var response = await Client.PostAsync(Url, JsonContent.Create(createFolderModel));
-
-        Assert.AreEqual(UnauthorizedUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
-
-    protected override async Task<HttpResponseMessage> AuthorizedRequest(Guid userGroupKey)
-    {
-        await AuthenticateClientAsync(Client, UserEmail, UserPassword, userGroupKey);
-
         CreateFolderRequestModel createFolderModel =
             new() { Id = Guid.NewGuid(), ParentId = null, Name = "TestFolderName" };
 

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Folder/DeleteDataTypeFolderControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Folder/DeleteDataTypeFolderControllerTests.cs
@@ -23,46 +23,33 @@ public class DeleteDataTypeFolderControllerTests : ManagementApiUserGroupTestBas
 
     protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden
+        ExpectedStatusCode = HttpStatusCode.Forbidden
     };
 
     protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden
+        ExpectedStatusCode = HttpStatusCode.Forbidden
     };
 
     protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized
+        ExpectedStatusCode = HttpStatusCode.Unauthorized
     };
 
-    [Test]
-    public override async Task As_Unauthorized_I_Have_Specified_Access()
-    {
-        var response = await Client.DeleteAsync(Url);
-
-        Assert.AreEqual(UnauthorizedUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
-
-    protected override async Task<HttpResponseMessage> AuthorizedRequest(Guid userGroupKey)
-    {
-        await AuthenticateClientAsync(Client, UserEmail, UserPassword, userGroupKey);
-
-        return await Client.DeleteAsync(Url);
-    }
+    protected override async Task<HttpResponseMessage> ClientRequest() => await Client.DeleteAsync(Url);
 }

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Folder/DeleteDataTypeFolderControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Folder/DeleteDataTypeFolderControllerTests.cs
@@ -17,43 +17,42 @@ public class DeleteDataTypeFolderControllerTests : ManagementApiUserGroupTestBas
     protected override Expression<Func<DeleteDataTypeFolderController, object>> MethodSelector =>
         x => x.Delete(_folderId);
 
-
     [SetUp]
     public void Setup() =>
         DataTypeContainerService.CreateAsync(_folderId, "FolderName", null, Constants.Security.SuperUserKey);
 
     protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden,
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden
     };
 
     protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden,
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden
     };
 
     protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized,
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized
     };
 
     [Test]
-    public override async Task As_Unauthorized_I_Dont_Have_Access()
+    public override async Task As_Unauthorized_I_Have_Specified_Access()
     {
         var response = await Client.DeleteAsync(Url);
 

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Folder/UpdateDataTypeFolderControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Folder/UpdateDataTypeFolderControllerTests.cs
@@ -24,36 +24,36 @@ public class UpdateDataTypeFolderControllerTests : ManagementApiUserGroupTestBas
 
     protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden,
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden
     };
 
     protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden,
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden
     };
 
     protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized,
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized
     };
 
     [Test]
-    public override async Task As_Unauthorized_I_Dont_Have_Access()
+    public override async Task As_Unauthorized_I_Have_Specified_Access()
     {
         UpdateFolderResponseModel updateFolderModel = new() { Name = "UpdatedName" };
 

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Folder/UpdateDataTypeFolderControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Folder/UpdateDataTypeFolderControllerTests.cs
@@ -24,48 +24,36 @@ public class UpdateDataTypeFolderControllerTests : ManagementApiUserGroupTestBas
 
     protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden
+        ExpectedStatusCode = HttpStatusCode.Forbidden
     };
 
     protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden
+        ExpectedStatusCode = HttpStatusCode.Forbidden
     };
 
     protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized
+        ExpectedStatusCode = HttpStatusCode.Unauthorized
     };
 
-    [Test]
-    public override async Task As_Unauthorized_I_Have_Specified_Access()
+    protected override async Task<HttpResponseMessage> ClientRequest()
     {
-        UpdateFolderResponseModel updateFolderModel = new() { Name = "UpdatedName" };
-
-        var response = await Client.PutAsync(Url, JsonContent.Create(updateFolderModel));
-
-        Assert.AreEqual(UnauthorizedUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
-
-    protected override async Task<HttpResponseMessage> AuthorizedRequest(Guid userGroupKey)
-    {
-        await AuthenticateClientAsync(Client, UserEmail, UserPassword, userGroupKey);
-
         UpdateFolderResponseModel updateFolderModel = new() { Name = "UpdatedName" };
 
         return await Client.PutAsync(Url, JsonContent.Create(updateFolderModel));

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Language/AllLanguageControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Language/AllLanguageControllerTests.cs
@@ -1,0 +1,40 @@
+﻿using System.Linq.Expressions;
+using System.Net;
+using Umbraco.Cms.Api.Management.Controllers.Language;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.Language;
+
+public class AllLanguageControllerTests: ManagementApiUserGroupTestBase<AllLanguageController>
+{
+    protected override Expression<Func<AllLanguageController, object>> MethodSelector => x => x.All(0, 100);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.OK
+    };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.OK
+    };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.OK
+    };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.OK
+    };
+
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.OK
+    };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Unauthorized
+    };
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Language/ByIsoCodeLanguageControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Language/ByIsoCodeLanguageControllerTests.cs
@@ -1,0 +1,53 @@
+﻿using System.Linq.Expressions;
+using System.Net;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.Language;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.Language;
+
+public class ByIsoCodeLanguageControllerTests : ManagementApiUserGroupTestBase<ByIsoCodeLanguageController>
+{
+    private ILanguageService LanguageService => GetRequiredService<ILanguageService>();
+
+    private const string IsoCode = "da";
+
+    private readonly ILanguage _languageResponseModel = new Core.Models.Language(IsoCode, "Danish");
+
+    [SetUp]
+    public void Setup() => LanguageService.CreateAsync(_languageResponseModel, Constants.Security.SuperUserKey);
+
+    protected override Expression<Func<ByIsoCodeLanguageController, object>> MethodSelector => x => x.ByIsoCode(IsoCode);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.OK
+    };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.NotFound
+    };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.NotFound
+    };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.NotFound
+    };
+
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.NotFound
+    };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Unauthorized
+    };
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Language/CreateLanguageControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Language/CreateLanguageControllerTests.cs
@@ -1,0 +1,49 @@
+﻿using System.Linq.Expressions;
+using System.Net;
+using System.Net.Http.Json;
+using Umbraco.Cms.Api.Management.Controllers.Language;
+using Umbraco.Cms.Api.Management.ViewModels.Language;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.Language;
+
+public class CreateLanguageControllerTests : ManagementApiUserGroupTestBase<CreateLanguageController>
+{
+    protected override Expression<Func<CreateLanguageController, object>> MethodSelector => x => x.Create(null);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Created
+    };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Unauthorized
+    };
+
+    protected override async Task<HttpResponseMessage> ClientRequest()
+    {
+        CreateLanguageRequestModel createLanguageModel = new() { IsoCode = "da-DK", Name = "Danish", IsDefault = false, IsMandatory = false };
+
+        return await Client.PostAsync(Url, JsonContent.Create(createLanguageModel));
+    }
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Language/DeleteLanguageControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Language/DeleteLanguageControllerTests.cs
@@ -1,0 +1,55 @@
+﻿using System.Linq.Expressions;
+using System.Net;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.Language;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.Language;
+
+public class DeleteLanguageControllerTests : ManagementApiUserGroupTestBase<DeleteLanguageController>
+{
+    private ILanguageService LanguageService => GetRequiredService<ILanguageService>();
+
+    private const string IsoCode = "da";
+
+    private readonly ILanguage _languageResponseModel = new Core.Models.Language(IsoCode, "Danish");
+
+    protected override Expression<Func<DeleteLanguageController, object>> MethodSelector => x => x.Delete(IsoCode);
+
+    [SetUp]
+    public void Setup() => LanguageService.CreateAsync(_languageResponseModel, Constants.Security.SuperUserKey);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.OK
+    };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Unauthorized
+    };
+
+    protected override async Task<HttpResponseMessage> ClientRequest() => await Client.DeleteAsync(Url);
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Language/Item/ItemsLanguageEntityControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Language/Item/ItemsLanguageEntityControllerTests.cs
@@ -1,0 +1,57 @@
+﻿using System.Linq.Expressions;
+using System.Net;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.Language.Item;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.Language.Item;
+
+public class ItemsLanguageEntityControllerTests: ManagementApiUserGroupTestBase<ItemsLanguageEntityController>
+{
+    private ILanguageService LanguageService => GetRequiredService<ILanguageService>();
+
+    private const string IsoCode = "da";
+
+    private readonly HashSet<string> _isoCode = new() { IsoCode };
+
+    private readonly ILanguage _languageResponseModel = new Core.Models.Language(IsoCode, "Danish");
+
+    protected override Expression<Func<ItemsLanguageEntityController, object>> MethodSelector => x => x.Items(_isoCode);
+
+    [SetUp]
+    public void Setup() => LanguageService.CreateAsync(_languageResponseModel, Constants.Security.SuperUserKey);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.OK
+    };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Unauthorized
+    };
+
+    protected override async Task<HttpResponseMessage> ClientRequest() => await Client.GetAsync(Url);
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Language/UpdateLanguageControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Language/UpdateLanguageControllerTests.cs
@@ -1,0 +1,62 @@
+﻿using System.Linq.Expressions;
+using System.Net;
+using System.Net.Http.Json;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.Language;
+using Umbraco.Cms.Api.Management.ViewModels.Language;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.Language;
+
+public class UpdateLanguageControllerTests : ManagementApiUserGroupTestBase<UpdateLanguageController>
+{
+    private ILanguageService LanguageService => GetRequiredService<ILanguageService>();
+
+    private const string IsoCode = "da";
+
+    private readonly ILanguage _languageResponseModel = new Core.Models.Language(IsoCode, "Danish");
+
+    protected override Expression<Func<UpdateLanguageController, object>> MethodSelector => x => x.Update(IsoCode, null);
+
+    [SetUp]
+    public void Setup() => LanguageService.CreateAsync(_languageResponseModel, Constants.Security.SuperUserKey);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.OK
+    };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Unauthorized
+    };
+
+    protected override async Task<HttpResponseMessage> ClientRequest()
+    {
+        UpdateLanguageRequestModel updateLanguageModel = new() { IsMandatory = true };
+
+        return await Client.PutAsync(Url, JsonContent.Create(updateLanguageModel));
+    }
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/ManagementApiUserGroupTestBase.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/ManagementApiUserGroupTestBase.cs
@@ -46,28 +46,8 @@ public class ManagementApiUserGroupTestBase<T> : ManagementApiTest<T> where T : 
 
     // Admin
     [Test]
-    public virtual async Task As_Admin_I_Have_Access()
+    public virtual async Task As_Admin_I_Have_Specified_Access()
     {
-        if (AdminUserGroupAssertionModel.Allowed is false)
-        {
-            Assert.Ignore();
-            return;
-        }
-
-        var response = await AuthorizedRequest(Constants.Security.AdminGroupKey);
-
-        Assert.AreEqual(AdminUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
-
-    [Test]
-    public virtual async Task As_Admin_I_Dont_Have_Access()
-    {
-        if (AdminUserGroupAssertionModel.Allowed)
-        {
-            Assert.Ignore();
-            return;
-        }
-
         var response = await AuthorizedRequest(Constants.Security.AdminGroupKey);
 
         Assert.AreEqual(AdminUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
@@ -75,28 +55,8 @@ public class ManagementApiUserGroupTestBase<T> : ManagementApiTest<T> where T : 
 
     // Editor
     [Test]
-    public virtual async Task As_Editor_I_Have_Access()
+    public virtual async Task As_Editor_I_Have_Specified_Access()
     {
-        if (EditorUserGroupAssertionModel.Allowed is false)
-        {
-            Assert.Ignore();
-            return;
-        }
-
-        var response = await AuthorizedRequest(Constants.Security.EditorGroupKey);
-
-        Assert.AreEqual(EditorUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
-
-    [Test]
-    public virtual async Task As_Editor_I_Have_Dont_Access()
-    {
-        if (EditorUserGroupAssertionModel.Allowed)
-        {
-            Assert.Ignore();
-            return;
-        }
-
         var response = await AuthorizedRequest(Constants.Security.EditorGroupKey);
 
         Assert.AreEqual(EditorUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
@@ -104,28 +64,8 @@ public class ManagementApiUserGroupTestBase<T> : ManagementApiTest<T> where T : 
 
     // SensitiveData
     [Test]
-    public virtual async Task As_Sensitive_Data_I_Have_Access()
+    public virtual async Task As_Sensitive_Data_I_Have_Specified_Access()
     {
-        if (SensitiveDataUserGroupAssertionModel.Allowed is false)
-        {
-            Assert.Ignore();
-            return;
-        }
-
-        var response = await AuthorizedRequest(Constants.Security.SensitiveDataGroupKey);
-
-        Assert.AreEqual(SensitiveDataUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
-
-    [Test]
-    public virtual async Task As_Sensitive_Data_I_Dont_Have_Access()
-    {
-        if (SensitiveDataUserGroupAssertionModel.Allowed)
-        {
-            Assert.Ignore();
-            return;
-        }
-
         var response = await AuthorizedRequest(Constants.Security.SensitiveDataGroupKey);
 
         Assert.AreEqual(SensitiveDataUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
@@ -133,58 +73,17 @@ public class ManagementApiUserGroupTestBase<T> : ManagementApiTest<T> where T : 
 
     // Translator
     [Test]
-    public virtual async Task As_Translator_I_Have_Access()
+    public virtual async Task As_Translator_I_Have_Specified_Access()
     {
-        if (TranslatorUserGroupAssertionModel.Allowed is false)
-        {
-            Assert.Ignore();
-            return;
-        }
-
-        var response = await AuthorizedRequest(Constants.Security.TranslatorGroupKey);
-
-        Assert.AreEqual(TranslatorUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
-
-    [Test]
-    public virtual async Task As_Translator_I_Dont_Have_Access()
-    {
-        if (TranslatorUserGroupAssertionModel.Allowed)
-        {
-            Assert.Ignore();
-            return;
-        }
-
         var response = await AuthorizedRequest(Constants.Security.TranslatorGroupKey);
 
         Assert.AreEqual(TranslatorUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
     }
 
     // Writer
-
     [Test]
-    public virtual async Task As_Writer_I_Have_Access()
+    public virtual async Task As_Writer_I_Have_Specified_Access()
     {
-        if (WriterUserGroupAssertionModel.Allowed is false)
-        {
-            Assert.Ignore();
-            return;
-        }
-
-        var response = await AuthorizedRequest(Constants.Security.WriterGroupKey);
-
-        Assert.AreEqual(WriterUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
-
-    [Test]
-    public virtual async Task As_Writer_I_Dont_Have_Access()
-    {
-        if (WriterUserGroupAssertionModel.Allowed)
-        {
-            Assert.Ignore();
-            return;
-        }
-
         var response = await AuthorizedRequest(Constants.Security.WriterGroupKey);
 
         Assert.AreEqual(WriterUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
@@ -192,28 +91,8 @@ public class ManagementApiUserGroupTestBase<T> : ManagementApiTest<T> where T : 
 
     // Unauthorized
     [Test]
-    public virtual async Task As_Unauthorized_I_Have_Access()
+    public virtual async Task As_Unauthorized_I_Have_Specified_Access()
     {
-        if (UnauthorizedUserGroupAssertionModel.Allowed is false)
-        {
-            Assert.Ignore();
-            return;
-        }
-
-        var response = await Client.GetAsync(Url);
-
-        Assert.AreEqual(UnauthorizedUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
-    }
-
-    [Test]
-    public virtual async Task As_Unauthorized_I_Dont_Have_Access()
-    {
-        if (UnauthorizedUserGroupAssertionModel.Allowed)
-        {
-            Assert.Ignore();
-            return;
-        }
-
         var response = await Client.GetAsync(Url);
 
         Assert.AreEqual(UnauthorizedUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/ManagementApiUserGroupTestBase.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/ManagementApiUserGroupTestBase.cs
@@ -13,32 +13,32 @@ public class ManagementApiUserGroupTestBase<T> : ManagementApiTest<T> where T : 
 
     protected virtual UserGroupAssertionModel AdminUserGroupAssertionModel => new()
     {
-        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected virtual UserGroupAssertionModel EditorUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden,
+        ExpectedStatusCode = HttpStatusCode.Forbidden
     };
 
     protected virtual UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden,
+        ExpectedStatusCode = HttpStatusCode.Forbidden
     };
 
     protected virtual UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden,
+        ExpectedStatusCode = HttpStatusCode.Forbidden
     };
 
     protected virtual UserGroupAssertionModel WriterUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden,
+        ExpectedStatusCode = HttpStatusCode.Forbidden
     };
 
     protected virtual UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
     {
-        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized,
+        ExpectedStatusCode = HttpStatusCode.Unauthorized
     };
 
     protected const string UserEmail = "test@umbraco.com";
@@ -93,15 +93,19 @@ public class ManagementApiUserGroupTestBase<T> : ManagementApiTest<T> where T : 
     [Test]
     public virtual async Task As_Unauthorized_I_Have_Specified_Access()
     {
-        var response = await Client.GetAsync(Url);
+        var response = await ClientRequest();
 
         Assert.AreEqual(UnauthorizedUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
     }
 
     protected virtual async Task<HttpResponseMessage> AuthorizedRequest(Guid userGroupKey)
     {
-        await AuthenticateClientAsync(Client, UserEmail, UserPassword, userGroupKey);
+        await AuthenticateUser(userGroupKey);
 
-        return await Client.GetAsync(Url);
+        return await ClientRequest();
     }
+
+    protected virtual async Task AuthenticateUser(Guid userGroupKey) => await AuthenticateClientAsync(Client, UserEmail, UserPassword, userGroupKey);
+
+    protected virtual async Task<HttpResponseMessage> ClientRequest() => await Client.GetAsync(Url);
 }

--- a/tests/Umbraco.Tests.Integration/ManagementApi/ManagementApiUserGroupTestBase.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/ManagementApiUserGroupTestBase.cs
@@ -1,0 +1,228 @@
+﻿using System.Linq.Expressions;
+using System.Net;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers;
+using Umbraco.Cms.Core;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi;
+
+[TestFixture]
+public class ManagementApiUserGroupTestBase<T> : ManagementApiTest<T> where T : ManagementApiControllerBase
+{
+    protected override Expression<Func<T, object>> MethodSelector { get; }
+
+    protected virtual UserGroupAssertionModel AdminUserGroupAssertionModel => new()
+    {
+        Allowed = true, ExpectedStatusCode = HttpStatusCode.OK,
+    };
+
+    protected virtual UserGroupAssertionModel EditorUserGroupAssertionModel => new()
+    {
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden,
+    };
+
+    protected virtual UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
+    {
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden,
+    };
+
+    protected virtual UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
+    {
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden,
+    };
+
+    protected virtual UserGroupAssertionModel WriterUserGroupAssertionModel => new()
+    {
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Forbidden,
+    };
+
+    protected virtual UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
+    {
+        Allowed = false, ExpectedStatusCode = HttpStatusCode.Unauthorized,
+    };
+
+    protected const string UserEmail = "test@umbraco.com";
+    protected const string UserPassword = "1234567890";
+
+    // Admin
+    [Test]
+    public virtual async Task As_Admin_I_Have_Access()
+    {
+        if (AdminUserGroupAssertionModel.Allowed is false)
+        {
+            Assert.Ignore();
+            return;
+        }
+
+        var response = await AuthorizedRequest(Constants.Security.AdminGroupKey);
+
+        Assert.AreEqual(AdminUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
+    }
+
+    [Test]
+    public virtual async Task As_Admin_I_Dont_Have_Access()
+    {
+        if (AdminUserGroupAssertionModel.Allowed)
+        {
+            Assert.Ignore();
+            return;
+        }
+
+        var response = await AuthorizedRequest(Constants.Security.AdminGroupKey);
+
+        Assert.AreEqual(AdminUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
+    }
+
+    // Editor
+    [Test]
+    public virtual async Task As_Editor_I_Have_Access()
+    {
+        if (EditorUserGroupAssertionModel.Allowed is false)
+        {
+            Assert.Ignore();
+            return;
+        }
+
+        var response = await AuthorizedRequest(Constants.Security.EditorGroupKey);
+
+        Assert.AreEqual(EditorUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
+    }
+
+    [Test]
+    public virtual async Task As_Editor_I_Have_Dont_Access()
+    {
+        if (EditorUserGroupAssertionModel.Allowed)
+        {
+            Assert.Ignore();
+            return;
+        }
+
+        var response = await AuthorizedRequest(Constants.Security.EditorGroupKey);
+
+        Assert.AreEqual(EditorUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
+    }
+
+    // SensitiveData
+    [Test]
+    public virtual async Task As_Sensitive_Data_I_Have_Access()
+    {
+        if (SensitiveDataUserGroupAssertionModel.Allowed is false)
+        {
+            Assert.Ignore();
+            return;
+        }
+
+        var response = await AuthorizedRequest(Constants.Security.SensitiveDataGroupKey);
+
+        Assert.AreEqual(SensitiveDataUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
+    }
+
+    [Test]
+    public virtual async Task As_Sensitive_Data_I_Dont_Have_Access()
+    {
+        if (SensitiveDataUserGroupAssertionModel.Allowed)
+        {
+            Assert.Ignore();
+            return;
+        }
+
+        var response = await AuthorizedRequest(Constants.Security.SensitiveDataGroupKey);
+
+        Assert.AreEqual(SensitiveDataUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
+    }
+
+    // Translator
+    [Test]
+    public virtual async Task As_Translator_I_Have_Access()
+    {
+        if (TranslatorUserGroupAssertionModel.Allowed is false)
+        {
+            Assert.Ignore();
+            return;
+        }
+
+        var response = await AuthorizedRequest(Constants.Security.TranslatorGroupKey);
+
+        Assert.AreEqual(TranslatorUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
+    }
+
+    [Test]
+    public virtual async Task As_Translator_I_Dont_Have_Access()
+    {
+        if (TranslatorUserGroupAssertionModel.Allowed)
+        {
+            Assert.Ignore();
+            return;
+        }
+
+        var response = await AuthorizedRequest(Constants.Security.TranslatorGroupKey);
+
+        Assert.AreEqual(TranslatorUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
+    }
+
+    // Writer
+
+    [Test]
+    public virtual async Task As_Writer_I_Have_Access()
+    {
+        if (WriterUserGroupAssertionModel.Allowed is false)
+        {
+            Assert.Ignore();
+            return;
+        }
+
+        var response = await AuthorizedRequest(Constants.Security.WriterGroupKey);
+
+        Assert.AreEqual(WriterUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
+    }
+
+    [Test]
+    public virtual async Task As_Writer_I_Dont_Have_Access()
+    {
+        if (WriterUserGroupAssertionModel.Allowed)
+        {
+            Assert.Ignore();
+            return;
+        }
+
+        var response = await AuthorizedRequest(Constants.Security.WriterGroupKey);
+
+        Assert.AreEqual(WriterUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
+    }
+
+    // Unauthorized
+    [Test]
+    public virtual async Task As_Unauthorized_I_Have_Access()
+    {
+        if (UnauthorizedUserGroupAssertionModel.Allowed is false)
+        {
+            Assert.Ignore();
+            return;
+        }
+
+        var response = await Client.GetAsync(Url);
+
+        Assert.AreEqual(UnauthorizedUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
+    }
+
+    [Test]
+    public virtual async Task As_Unauthorized_I_Dont_Have_Access()
+    {
+        if (UnauthorizedUserGroupAssertionModel.Allowed)
+        {
+            Assert.Ignore();
+            return;
+        }
+
+        var response = await Client.GetAsync(Url);
+
+        Assert.AreEqual(UnauthorizedUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode, await response.Content.ReadAsStringAsync());
+    }
+
+    protected virtual async Task<HttpResponseMessage> AuthorizedRequest(Guid userGroupKey)
+    {
+        await AuthenticateClientAsync(Client, UserEmail, UserPassword, userGroupKey);
+
+        return await Client.GetAsync(Url);
+    }
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/UserGroupAssertionModel.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/UserGroupAssertionModel.cs
@@ -1,0 +1,10 @@
+﻿using System.Net;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi;
+
+public class UserGroupAssertionModel
+{
+    public bool Allowed { get; set; }
+
+    public HttpStatusCode ExpectedStatusCode { get; set; }
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/UserGroupAssertionModel.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/UserGroupAssertionModel.cs
@@ -4,7 +4,5 @@ namespace Umbraco.Cms.Tests.Integration.ManagementApi;
 
 public class UserGroupAssertionModel
 {
-    public bool Allowed { get; set; }
-
     public HttpStatusCode ExpectedStatusCode { get; set; }
 }


### PR DESCRIPTION
I've created the ManagementApiUserGroupTestBase Class. 
This allows us to specify if the UserGroup is Allowed or not and which StatusCode is expected for each test. All the tests in the base class are virtual, so they can be overwritten if additional setup for the specific test is needed. 

For each User Group in the test base, there are two tests: 'Have_Access' and 'Dont_Have_Access.' Only one of these tests should run for a particular User Group and endpoint. We determine which test to run by setting the 'Allowed' property to true or false. If 'Allowed' is true, the 'Have_Access' test is executed.

In each base test, we assert the response, excluding the Unauthorized tests. The response is obtained from the 'AuthorizedRequest()' method in the base class. This method authenticates a user with a user group key and returns an HttpResponse message. Since the method is virtual, it can be easily overridden, minimizing code duplication and enhancing maintainability.

Please let me know what you think about this approach 😄 