### PR TITLE
Fix #14270 - ImageCropperValue.GetCropUrl(alias, imageUrlGenerator) always returns null - v10

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/ImageCropperValue.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/ImageCropperValue.cs
@@ -98,7 +98,7 @@ public class ImageCropperValue : IHtmlEncodedString, IEquatable<ImageCropperValu
         }
 
         ImageUrlGenerationOptions options =
-            GetCropBaseOptions(null, crop, useFocalPoint || string.IsNullOrWhiteSpace(alias));
+            GetCropBaseOptions(Src, crop, useFocalPoint || string.IsNullOrWhiteSpace(alias));
 
         if (crop is not null && useCropDimensions)
         {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/ImageCropperTest.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/ImageCropperTest.cs
@@ -202,7 +202,7 @@ public class ImageCropperTest
     {
         var cropDataSet = CropperJson1.DeserializeImageCropperValue();
         var urlString = cropDataSet.GetCropUrl("thumb", new TestImageUrlGenerator());
-        Assert.AreEqual("?c=0.58729977382575338,0.055768992440203169,0,0.32457553600198386&w=100&h=100", urlString);
+        Assert.AreEqual(MediaPath + "?c=0.58729977382575338,0.055768992440203169,0,0.32457553600198386&w=100&h=100", urlString);
     }
 
     /// <summary>


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes (https://github.com/umbraco/Umbraco-CMS/issues/14270)

### Description
I have copied the changes from this PR (https://github.com/umbraco/Umbraco-CMS/pull/14308) and want them added to v10 as well.