### PR TITLE
Fix console errors in content type editor with single block mode

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/umbBlockListPropertyEditor.component.js
@@ -256,7 +256,7 @@
 
             updateClipboard(true);
 
-            if (vm.singleBlockMode && vm.layout.length == 0) {
+            if (vm.singleBlockMode && vm.layout.length == 0 && vm.availableBlockTypes?.length > 0) {
                 var wasAdded = false;
                 var blockType = vm.availableBlockTypes[0];
 
@@ -306,12 +306,13 @@
          */
         function ensureCultureData(content) {
 
-            if (!content) return;
+            if (!content || !vm.umbVariantContent) return;
 
             if (vm.umbVariantContent.editor.content.language) {
                 // set the scaffolded content's language to the language of the current editor
                 content.language = vm.umbVariantContent.editor.content.language;
             }
+
             // currently we only ever deal with invariant content for blocks so there's only one
             content.variants[0].tabs.forEach(tab => {
                 tab.properties.forEach(prop => {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/15332

### Description
When opening content type editor from content node via infinite editing or directly from setttings section a few console errors happened due to missing `umbVariantContent` in the context and `vm.availableBlockTypes` returning empty array and this `vm.availableBlockTypes[0]` returned undefined.
