### PR TITLE
Change `WebhookEventCollectionBuilder` to set collection

### DIFF
--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
@@ -11,91 +11,119 @@ using Umbraco.Cms.Core.Webhooks;
 namespace Umbraco.Cms.Core.DependencyInjection;
 
 /// <summary>
-///     Contains extensions methods for <see cref="IUmbracoBuilder" /> used for registering content apps.
+/// Contains extensions methods for <see cref="IUmbracoBuilder" />.
 /// </summary>
 public static partial class UmbracoBuilderExtensions
 {
     /// <summary>
-    ///     Register a component.
+    /// Register a component.
     /// </summary>
     /// <typeparam name="T">The type of the component.</typeparam>
     /// <param name="builder">The builder.</param>
+    /// <returns>
+    /// The builder.
+    /// </returns>
     public static IUmbracoBuilder AddComponent<T>(this IUmbracoBuilder builder)
-        where T : class, IComponent
+        where T : IComponent
     {
         builder.Components().Append<T>();
+
         return builder;
     }
 
     /// <summary>
-    ///     Register a content app.
+    /// Register a content app.
     /// </summary>
     /// <typeparam name="T">The type of the content app.</typeparam>
     /// <param name="builder">The builder.</param>
+    /// <returns>
+    /// The builder.
+    /// </returns>
     public static IUmbracoBuilder AddContentApp<T>(this IUmbracoBuilder builder)
-        where T : class, IContentAppFactory
+        where T : IContentAppFactory
     {
         builder.ContentApps().Append<T>();
+
         return builder;
     }
 
     /// <summary>
-    ///     Register a content finder.
+    /// Register a content finder.
     /// </summary>
     /// <typeparam name="T">The type of the content finder.</typeparam>
     /// <param name="builder">The builder.</param>
+    /// <returns>
+    /// The builder.
+    /// </returns>
     public static IUmbracoBuilder AddContentFinder<T>(this IUmbracoBuilder builder)
-        where T : class, IContentFinder
+        where T : IContentFinder
     {
         builder.ContentFinders().Append<T>();
+
         return builder;
     }
 
     /// <summary>
-    ///     Register a dashboard.
+    /// Register a dashboard.
     /// </summary>
     /// <typeparam name="T">The type of the dashboard.</typeparam>
     /// <param name="builder">The builder.</param>
+    /// <returns>
+    /// The builder.
+    /// </returns>
     public static IUmbracoBuilder AddDashboard<T>(this IUmbracoBuilder builder)
-        where T : class, IDashboard
+        where T : IDashboard
     {
         builder.Dashboards().Add<T>();
+
         return builder;
     }
 
     /// <summary>
-    /// Register a manifest filter
+    /// Register a manifest filter.
     /// </summary>
     /// <typeparam name="T">The type of the manifest filter.</typeparam>
     /// <param name="builder">The Builder.</param>
+    /// <returns>
+    /// The builder.
+    /// </returns>
     public static IUmbracoBuilder AddManifestFilter<T>(this IUmbracoBuilder builder)
-        where T : class, IManifestFilter
+        where T : IManifestFilter
     {
         builder.ManifestFilters().Append<T>();
+
         return builder;
     }
 
     /// <summary>
-    ///     Register a media url provider.
+    /// Register a media URL provider.
     /// </summary>
-    /// <typeparam name="T">The type of the media url provider.</typeparam>
+    /// <typeparam name="T">The type of the media URL provider.</typeparam>
     /// <param name="builder">The builder.</param>
+    /// <returns>
+    /// The builder.
+    /// </returns>
     public static IUmbracoBuilder AddMediaUrlProvider<T>(this IUmbracoBuilder builder)
-        where T : class, IMediaUrlProvider
+        where T : IMediaUrlProvider
     {
         builder.MediaUrlProviders().Append<T>();
+
         return builder;
     }
 
     /// <summary>
-    ///     Register a embed provider.
+    /// Register a embed provider.
     /// </summary>
     /// <typeparam name="T">The type of the embed provider.</typeparam>
     /// <param name="builder">The builder.</param>
+    /// <returns>
+    /// The builder.
+    /// </returns>
     public static IUmbracoBuilder AddEmbedProvider<T>(this IUmbracoBuilder builder)
-        where T : class, IEmbedProvider
+        where T : IEmbedProvider
     {
         builder.EmbedProviders().Append<T>();
+
         return builder;
     }
 
@@ -104,46 +132,62 @@ public static partial class UmbracoBuilderExtensions
     /// </summary>
     /// <typeparam name="T">The type of the section.</typeparam>
     /// <param name="builder">The builder.</param>
+    /// <returns>
+    /// The builder.
+    /// </returns>
     public static IUmbracoBuilder AddSection<T>(this IUmbracoBuilder builder)
-        where T : class, ISection
+        where T : ISection
     {
         builder.Sections().Append<T>();
+
         return builder;
     }
 
     /// <summary>
-    ///     Register a url provider.
+    /// Register a URL provider.
     /// </summary>
-    /// <typeparam name="T">The type of the url provider.</typeparam>
+    /// <typeparam name="T">The type of the URL provider.</typeparam>
     /// <param name="builder">The Builder.</param>
+    /// <returns>
+    /// The builder.
+    /// </returns>
     public static IUmbracoBuilder AddUrlProvider<T>(this IUmbracoBuilder builder)
-        where T : class, IUrlProvider
+        where T : IUrlProvider
     {
         builder.UrlProviders().Append<T>();
+
         return builder;
     }
 
     /// <summary>
-    /// Add an IMapDefinition to the MapDefinitionCollectionBuilder
+    /// Add a map definition.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="builder"></param>
-    /// <returns></returns>
-    public static IUmbracoBuilder AddMapDefinition<T>(this IUmbracoBuilder builder) where T : IMapDefinition
+    /// <typeparam name="T">The type of map definition.</typeparam>
+    /// <param name="builder">The builder.</param>
+    /// <returns>
+    /// The builder.
+    /// </returns>
+    public static IUmbracoBuilder AddMapDefinition<T>(this IUmbracoBuilder builder)
+        where T : IMapDefinition
     {
-        builder.WithCollectionBuilder<MapDefinitionCollectionBuilder>().Add<T>();
+        builder.MapDefinitions().Add<T>();
+
         return builder;
     }
 
     /// <summary>
-    /// Add an IWebhookEvent to the WebhookEventCollectionBuilder.
+    /// Add a webhook event.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="builder"></param>
-    /// <returns></returns>
-    public static IUmbracoBuilder AddWebhookEvent<T>(this IUmbracoBuilder builder) where T : IWebhookEvent
+    /// <typeparam name="T">The type of webhook event.</typeparam>
+    /// <param name="builder">The builder.</param>
+    /// <returns>
+    /// The builder.
+    /// </returns>
+    public static IUmbracoBuilder AddWebhookEvent<T>(this IUmbracoBuilder builder)
+        where T : IWebhookEvent
     {
-        builder.WebhookEvents().Append<T>();
+        builder.WebhookEvents().Add<T>();
+
         return builder;
     }
 }

--- a/src/Umbraco.Core/Webhooks/WebhookEventCollectionBuilder.cs
+++ b/src/Umbraco.Core/Webhooks/WebhookEventCollectionBuilder.cs
@@ -7,7 +7,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Webhooks;
 
-public class WebhookEventCollectionBuilder : OrderedCollectionBuilderBase<WebhookEventCollectionBuilder, WebhookEventCollection, IWebhookEvent>
+public class WebhookEventCollectionBuilder : SetCollectionBuilderBase<WebhookEventCollectionBuilder, WebhookEventCollection, IWebhookEvent>
 {
     protected override WebhookEventCollectionBuilder This => this;
 

--- a/src/Umbraco.Core/Webhooks/WebhookEventCollectionBuilderCmsContentExtensions.cs
+++ b/src/Umbraco.Core/Webhooks/WebhookEventCollectionBuilderCmsContentExtensions.cs
@@ -18,15 +18,15 @@ public static class WebhookEventCollectionBuilderCmsContentExtensions
     public static WebhookEventCollectionBuilderCmsContent AddDefault(this WebhookEventCollectionBuilderCmsContent builder)
     {
         builder.Builder
-           .Append<ContentCopiedWebhookEvent>()
-           .Append<ContentDeletedWebhookEvent>()
-           .Append<ContentEmptiedRecycleBinWebhookEvent>()
-           .Append<ContentMovedToRecycleBinWebhookEvent>()
-           .Append<ContentMovedWebhookEvent>()
-           .Append<ContentPublishedWebhookEvent>()
-           .Append<ContentSavedWebhookEvent>()
-           .Append<ContentSortedWebhookEvent>()
-           .Append<ContentUnpublishedWebhookEvent>();
+           .Add<ContentCopiedWebhookEvent>()
+           .Add<ContentDeletedWebhookEvent>()
+           .Add<ContentEmptiedRecycleBinWebhookEvent>()
+           .Add<ContentMovedToRecycleBinWebhookEvent>()
+           .Add<ContentMovedWebhookEvent>()
+           .Add<ContentPublishedWebhookEvent>()
+           .Add<ContentSavedWebhookEvent>()
+           .Add<ContentSortedWebhookEvent>()
+           .Add<ContentUnpublishedWebhookEvent>();
 
         return builder;
     }
@@ -41,8 +41,8 @@ public static class WebhookEventCollectionBuilderCmsContentExtensions
     public static WebhookEventCollectionBuilderCmsContent AddBlueprint(this WebhookEventCollectionBuilderCmsContent builder)
     {
         builder.Builder
-           .Append<ContentDeletedBlueprintWebhookEvent>()
-           .Append<ContentSavedBlueprintWebhookEvent>();
+           .Add<ContentDeletedBlueprintWebhookEvent>()
+           .Add<ContentSavedBlueprintWebhookEvent>();
 
         return builder;
     }
@@ -57,8 +57,8 @@ public static class WebhookEventCollectionBuilderCmsContentExtensions
     public static WebhookEventCollectionBuilderCmsContent AddVersion(this WebhookEventCollectionBuilderCmsContent builder)
     {
         builder.Builder
-           .Append<ContentDeletedVersionsWebhookEvent>()
-           .Append<ContentRolledBackWebhookEvent>();
+           .Add<ContentDeletedVersionsWebhookEvent>()
+           .Add<ContentRolledBackWebhookEvent>();
 
         return builder;
     }

--- a/src/Umbraco.Core/Webhooks/WebhookEventCollectionBuilderCmsContentTypeExtensions.cs
+++ b/src/Umbraco.Core/Webhooks/WebhookEventCollectionBuilderCmsContentTypeExtensions.cs
@@ -18,10 +18,10 @@ public static class WebhookEventCollectionBuilderCmsContentTypeExtensions
     public static WebhookEventCollectionBuilderCmsContentType AddDocumentType(this WebhookEventCollectionBuilderCmsContentType builder)
     {
         builder.Builder
-            .Append<DocumentTypeChangedWebhookEvent>()
-            .Append<DocumentTypeDeletedWebhookEvent>()
-            .Append<DocumentTypeMovedWebhookEvent>()
-            .Append<DocumentTypeSavedWebhookEvent>();
+            .Add<DocumentTypeChangedWebhookEvent>()
+            .Add<DocumentTypeDeletedWebhookEvent>()
+            .Add<DocumentTypeMovedWebhookEvent>()
+            .Add<DocumentTypeSavedWebhookEvent>();
 
         return builder;
     }
@@ -36,10 +36,10 @@ public static class WebhookEventCollectionBuilderCmsContentTypeExtensions
     public static WebhookEventCollectionBuilderCmsContentType AddMediaType(this WebhookEventCollectionBuilderCmsContentType builder)
     {
         builder.Builder
-            .Append<MediaTypeChangedWebhookEvent>()
-            .Append<MediaTypeDeletedWebhookEvent>()
-            .Append<MediaTypeMovedWebhookEvent>()
-            .Append<MediaTypeSavedWebhookEvent>();
+            .Add<MediaTypeChangedWebhookEvent>()
+            .Add<MediaTypeDeletedWebhookEvent>()
+            .Add<MediaTypeMovedWebhookEvent>()
+            .Add<MediaTypeSavedWebhookEvent>();
 
         return builder;
     }
@@ -55,10 +55,10 @@ public static class WebhookEventCollectionBuilderCmsContentTypeExtensions
     public static WebhookEventCollectionBuilderCmsContentType AddMemberType(this WebhookEventCollectionBuilderCmsContentType builder)
     {
         builder.Builder
-            .Append<MemberTypeChangedWebhookEvent>()
-            .Append<MemberTypeDeletedWebhookEvent>()
-            .Append<MemberTypeMovedWebhookEvent>()
-            .Append<MemberTypeSavedWebhookEvent>();
+            .Add<MemberTypeChangedWebhookEvent>()
+            .Add<MemberTypeDeletedWebhookEvent>()
+            .Add<MemberTypeMovedWebhookEvent>()
+            .Add<MemberTypeSavedWebhookEvent>();
 
         return builder;
     }

--- a/src/Umbraco.Core/Webhooks/WebhookEventCollectionBuilderCmsExtensions.cs
+++ b/src/Umbraco.Core/Webhooks/WebhookEventCollectionBuilderCmsExtensions.cs
@@ -189,7 +189,7 @@ public static class WebhookEventCollectionBuilderCmsExtensions
     public static WebhookEventCollectionBuilderCms AddHealthCheck(this WebhookEventCollectionBuilderCms builder)
     {
         builder.Builder
-            .Append<HealthCheckCompletedWebhookEvent>();
+            .Add<HealthCheckCompletedWebhookEvent>();
 
         return builder;
     }

--- a/src/Umbraco.Core/Webhooks/WebhookEventCollectionBuilderCmsExtensions.cs
+++ b/src/Umbraco.Core/Webhooks/WebhookEventCollectionBuilderCmsExtensions.cs
@@ -22,11 +22,11 @@ public static class WebhookEventCollectionBuilderCmsExtensions
     public static WebhookEventCollectionBuilderCms AddDefault(this WebhookEventCollectionBuilderCms builder)
     {
         builder.Builder
-            .Append<ContentDeletedWebhookEvent>()
-            .Append<ContentPublishedWebhookEvent>()
-            .Append<ContentUnpublishedWebhookEvent>()
-            .Append<MediaDeletedWebhookEvent>()
-            .Append<MediaSavedWebhookEvent>();
+            .Add<ContentDeletedWebhookEvent>()
+            .Add<ContentPublishedWebhookEvent>()
+            .Add<ContentUnpublishedWebhookEvent>()
+            .Add<MediaDeletedWebhookEvent>()
+            .Add<MediaSavedWebhookEvent>();
 
         return builder;
     }
@@ -108,9 +108,9 @@ public static class WebhookEventCollectionBuilderCmsExtensions
     public static WebhookEventCollectionBuilderCms AddDataType(this WebhookEventCollectionBuilderCms builder)
     {
         builder.Builder
-            .Append<DataTypeDeletedWebhookEvent>()
-            .Append<DataTypeMovedWebhookEvent>()
-            .Append<DataTypeSavedWebhookEvent>();
+            .Add<DataTypeDeletedWebhookEvent>()
+            .Add<DataTypeMovedWebhookEvent>()
+            .Add<DataTypeSavedWebhookEvent>();
 
         return builder;
     }
@@ -125,8 +125,8 @@ public static class WebhookEventCollectionBuilderCmsExtensions
     public static WebhookEventCollectionBuilderCms AddDictionary(this WebhookEventCollectionBuilderCms builder)
     {
         builder.Builder
-            .Append<DictionaryItemDeletedWebhookEvent>()
-            .Append<DictionaryItemSavedWebhookEvent>();
+            .Add<DictionaryItemDeletedWebhookEvent>()
+            .Add<DictionaryItemSavedWebhookEvent>();
 
         return builder;
     }
@@ -141,8 +141,8 @@ public static class WebhookEventCollectionBuilderCmsExtensions
     public static WebhookEventCollectionBuilderCms AddDomain(this WebhookEventCollectionBuilderCms builder)
     {
         builder.Builder
-            .Append<DomainDeletedWebhookEvent>()
-            .Append<DomainSavedWebhookEvent>();
+            .Add<DomainDeletedWebhookEvent>()
+            .Add<DomainSavedWebhookEvent>();
 
         return builder;
     }
@@ -189,8 +189,8 @@ public static class WebhookEventCollectionBuilderCmsExtensions
     public static WebhookEventCollectionBuilderCms AddLanguage(this WebhookEventCollectionBuilderCms builder)
     {
         builder.Builder
-            .Append<LanguageDeletedWebhookEvent>()
-            .Append<LanguageSavedWebhookEvent>();
+            .Add<LanguageDeletedWebhookEvent>()
+            .Add<LanguageSavedWebhookEvent>();
 
         return builder;
     }
@@ -205,11 +205,11 @@ public static class WebhookEventCollectionBuilderCmsExtensions
     public static WebhookEventCollectionBuilderCms AddMedia(this WebhookEventCollectionBuilderCms builder)
     {
         builder.Builder
-            .Append<MediaDeletedWebhookEvent>()
-            .Append<MediaSavedWebhookEvent>()
-            .Append<MediaEmptiedRecycleBinWebhookEvent>()
-            .Append<MediaMovedWebhookEvent>()
-            .Append<MediaMovedToRecycleBinWebhookEvent>();
+            .Add<MediaDeletedWebhookEvent>()
+            .Add<MediaSavedWebhookEvent>()
+            .Add<MediaEmptiedRecycleBinWebhookEvent>()
+            .Add<MediaMovedWebhookEvent>()
+            .Add<MediaMovedToRecycleBinWebhookEvent>();
 
         return builder;
     }
@@ -260,7 +260,7 @@ public static class WebhookEventCollectionBuilderCmsExtensions
     public static WebhookEventCollectionBuilderCms AddPackage(this WebhookEventCollectionBuilderCms builder)
     {
         builder.Builder
-            .Append<ImportedPackageWebhookEvent>();
+            .Add<ImportedPackageWebhookEvent>();
 
         return builder;
     }
@@ -275,8 +275,8 @@ public static class WebhookEventCollectionBuilderCmsExtensions
     public static WebhookEventCollectionBuilderCms AddPublicAccess(this WebhookEventCollectionBuilderCms builder)
     {
         builder.Builder
-            .Append<PublicAccessEntryDeletedWebhookEvent>()
-            .Append<PublicAccessEntrySavedWebhookEvent>();
+            .Add<PublicAccessEntryDeletedWebhookEvent>()
+            .Add<PublicAccessEntrySavedWebhookEvent>();
 
         return builder;
     }
@@ -291,8 +291,8 @@ public static class WebhookEventCollectionBuilderCmsExtensions
     public static WebhookEventCollectionBuilderCms AddRelation(this WebhookEventCollectionBuilderCms builder)
     {
         builder.Builder
-            .Append<RelationDeletedWebhookEvent>()
-            .Append<RelationSavedWebhookEvent>();
+            .Add<RelationDeletedWebhookEvent>()
+            .Add<RelationSavedWebhookEvent>();
 
         return builder;
     }
@@ -307,8 +307,8 @@ public static class WebhookEventCollectionBuilderCmsExtensions
     public static WebhookEventCollectionBuilderCms AddRelationType(this WebhookEventCollectionBuilderCms builder)
     {
         builder.Builder
-            .Append<RelationTypeDeletedWebhookEvent>()
-            .Append<RelationTypeSavedWebhookEvent>();
+            .Add<RelationTypeDeletedWebhookEvent>()
+            .Add<RelationTypeSavedWebhookEvent>();
 
         return builder;
     }

--- a/src/Umbraco.Core/Webhooks/WebhookEventCollectionBuilderCmsFileExtensions.cs
+++ b/src/Umbraco.Core/Webhooks/WebhookEventCollectionBuilderCmsFileExtensions.cs
@@ -18,8 +18,8 @@ public static class WebhookEventCollectionBuilderCmsFileExtensions
     public static WebhookEventCollectionBuilderCmsFile AddPartialView(this WebhookEventCollectionBuilderCmsFile builder)
     {
         builder.Builder
-            .Append<PartialViewDeletedWebhookEvent>()
-            .Append<PartialViewSavedWebhookEvent>();
+            .Add<PartialViewDeletedWebhookEvent>()
+            .Add<PartialViewSavedWebhookEvent>();
 
         return builder;
     }
@@ -34,8 +34,8 @@ public static class WebhookEventCollectionBuilderCmsFileExtensions
     public static WebhookEventCollectionBuilderCmsFile AddScript(this WebhookEventCollectionBuilderCmsFile builder)
     {
         builder.Builder
-            .Append<ScriptDeletedWebhookEvent>()
-            .Append<ScriptSavedWebhookEvent>();
+            .Add<ScriptDeletedWebhookEvent>()
+            .Add<ScriptSavedWebhookEvent>();
 
         return builder;
     }
@@ -50,8 +50,8 @@ public static class WebhookEventCollectionBuilderCmsFileExtensions
     public static WebhookEventCollectionBuilderCmsFile AddStylesheet(this WebhookEventCollectionBuilderCmsFile builder)
     {
         builder.Builder
-            .Append<StylesheetDeletedWebhookEvent>()
-            .Append<StylesheetSavedWebhookEvent>();
+            .Add<StylesheetDeletedWebhookEvent>()
+            .Add<StylesheetSavedWebhookEvent>();
 
         return builder;
     }
@@ -66,8 +66,8 @@ public static class WebhookEventCollectionBuilderCmsFileExtensions
     public static WebhookEventCollectionBuilderCmsFile AddTemplate(this WebhookEventCollectionBuilderCmsFile builder)
     {
         builder.Builder
-            .Append<TemplateDeletedWebhookEvent>()
-            .Append<TemplateSavedWebhookEvent>();
+            .Add<TemplateDeletedWebhookEvent>()
+            .Add<TemplateSavedWebhookEvent>();
 
         return builder;
     }

--- a/src/Umbraco.Core/Webhooks/WebhookEventCollectionBuilderCmsMemberExtensions.cs
+++ b/src/Umbraco.Core/Webhooks/WebhookEventCollectionBuilderCmsMemberExtensions.cs
@@ -18,9 +18,9 @@ public static class WebhookEventCollectionBuilderCmsMemberExtensions
     public static WebhookEventCollectionBuilderCmsMember AddDefault(this WebhookEventCollectionBuilderCmsMember builder)
     {
         builder.Builder
-            .Append<ExportedMemberWebhookEvent>()
-            .Append<MemberDeletedWebhookEvent>()
-            .Append<MemberSavedWebhookEvent>();
+            .Add<ExportedMemberWebhookEvent>()
+            .Add<MemberDeletedWebhookEvent>()
+            .Add<MemberSavedWebhookEvent>();
 
         return builder;
     }
@@ -35,8 +35,8 @@ public static class WebhookEventCollectionBuilderCmsMemberExtensions
     public static WebhookEventCollectionBuilderCmsMember AddRoles(this WebhookEventCollectionBuilderCmsMember builder)
     {
         builder.Builder
-            .Append<AssignedMemberRolesWebhookEvent>()
-            .Append<RemovedMemberRolesWebhookEvent>();
+            .Add<AssignedMemberRolesWebhookEvent>()
+            .Add<RemovedMemberRolesWebhookEvent>();
 
         return builder;
     }
@@ -51,8 +51,8 @@ public static class WebhookEventCollectionBuilderCmsMemberExtensions
     public static WebhookEventCollectionBuilderCmsMember AddGroup(this WebhookEventCollectionBuilderCmsMember builder)
     {
         builder.Builder
-            .Append<MemberGroupDeletedWebhookEvent>()
-            .Append<MemberGroupSavedWebhookEvent>();
+            .Add<MemberGroupDeletedWebhookEvent>()
+            .Add<MemberGroupSavedWebhookEvent>();
 
         return builder;
     }

--- a/src/Umbraco.Core/Webhooks/WebhookEventCollectionBuilderCmsUserExtensions.cs
+++ b/src/Umbraco.Core/Webhooks/WebhookEventCollectionBuilderCmsUserExtensions.cs
@@ -18,8 +18,8 @@ public static class WebhookEventCollectionBuilderCmsUserExtensions
     public static WebhookEventCollectionBuilderCmsUser AddDefault(this WebhookEventCollectionBuilderCmsUser builder)
     {
         builder.Builder
-            .Append<UserDeletedWebhookEvent>()
-            .Append<UserSavedWebhookEvent>();
+            .Add<UserDeletedWebhookEvent>()
+            .Add<UserSavedWebhookEvent>();
 
         return builder;
     }
@@ -34,13 +34,13 @@ public static class WebhookEventCollectionBuilderCmsUserExtensions
     public static WebhookEventCollectionBuilderCmsUser AddLogin(this WebhookEventCollectionBuilderCmsUser builder)
     {
         builder.Builder
-            .Append<UserLockedWebhookEvent>()
-            .Append<UserLoginFailedWebhookEvent>()
-            .Append<UserLoginRequiresVerificationWebhookEvent>()
-            .Append<UserLoginSuccessWebhookEvent>()
-            .Append<UserLogoutSuccessWebhookEvent>()
-            .Append<UserTwoFactorRequestedWebhookEvent>()
-            .Append<UserUnlockedWebhookEvent>();
+            .Add<UserLockedWebhookEvent>()
+            .Add<UserLoginFailedWebhookEvent>()
+            .Add<UserLoginRequiresVerificationWebhookEvent>()
+            .Add<UserLoginSuccessWebhookEvent>()
+            .Add<UserLogoutSuccessWebhookEvent>()
+            .Add<UserTwoFactorRequestedWebhookEvent>()
+            .Add<UserUnlockedWebhookEvent>();
 
         return builder;
     }
@@ -55,9 +55,9 @@ public static class WebhookEventCollectionBuilderCmsUserExtensions
     public static WebhookEventCollectionBuilderCmsUser AddPassword(this WebhookEventCollectionBuilderCmsUser builder)
     {
         builder.Builder
-            .Append<UserForgotPasswordRequestedWebhookEvent>()
-            .Append<UserPasswordChangedWebhookEvent>()
-            .Append<UserPasswordResetWebhookEvent>();
+            .Add<UserForgotPasswordRequestedWebhookEvent>()
+            .Add<UserPasswordChangedWebhookEvent>()
+            .Add<UserPasswordResetWebhookEvent>();
 
         return builder;
     }
@@ -72,9 +72,9 @@ public static class WebhookEventCollectionBuilderCmsUserExtensions
     public static WebhookEventCollectionBuilderCmsUser AddGroup(this WebhookEventCollectionBuilderCmsUser builder)
     {
         builder.Builder
-            .Append<AssignedUserGroupPermissionsWebhookEvent>()
-            .Append<UserGroupDeletedWebhookEvent>()
-            .Append<UserGroupSavedWebhookEvent>();
+            .Add<AssignedUserGroupPermissionsWebhookEvent>()
+            .Add<UserGroupDeletedWebhookEvent>()
+            .Add<UserGroupSavedWebhookEvent>();
 
         return builder;
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
As discussed in https://github.com/umbraco/Umbraco-CMS/pull/15345#discussion_r1413634361, the UI for webhook events now contains a search bar and already orders them by `eventName`, so there's no reason for registering them in any specific order.

Although changing the base class from `OrderedCollectionBuilderBase` to `SetCollectionBuilderBase` is a simple change, it does mean you have to use `Add<T>()` instead of `Append<T>()` to add registrations, which does mean it's a breaking change. I don't think it warrants adding a similar method that simply forwards `Append<T>() => Add<T>()`, as we've only released it in RCs and should keep the final release as clean as possible.