### PR TITLE
Ensure the toggles return booleans and not integers.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/umbdataformatter.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/umbdataformatter.service.js
@@ -295,13 +295,13 @@
                             saveModel.memberGroups = _.keys(_.pick(prop.value, value => value === true));
                             break;
                         case '_umb_approved':
-                            saveModel.isApproved = prop.value;
+                            saveModel.isApproved = prop.value == true;
                             break;
                         case '_umb_lockedOut':
-                            saveModel.isLockedOut = prop.value;
+                            saveModel.isLockedOut = prop.value == true;
                             break;
                         case '_umb_twoFactorEnabled':
-                            saveModel.isTwoFactorEnabled = prop.value;
+                            saveModel.isTwoFactorEnabled = prop.value == true;
                             break;
                     }
                   }


### PR DESCRIPTION
### Prerequisites

Fixes #15341

### Description
Ensure the client sends booleans and not integers when using toggles on the members
