### PR TITLE
Fixing PR #15318 which updated an interface, which is breaking

### DIFF
--- a/src/Umbraco.Core/Deploy/IFileTypeCollection.cs
+++ b/src/Umbraco.Core/Deploy/IFileTypeCollection.cs
@@ -27,7 +27,18 @@ public interface IFileTypeCollection
     /// <returns>
     ///   <c>true</c> if the file type associated with the specified entity type was found; otherwise, <c>false</c>.
     /// </returns>
-    bool TryGetValue(string entityType, [NotNullWhen(true)] out IFileType? fileType) => throw new NotImplementedException();
+    bool TryGetValue(string entityType, [NotNullWhen(true)] out IFileType? fileType)
+    {
+        // TODO (V14): Remove default implementation
+        if (Contains(entityType))
+        {
+            fileType = this[entityType];
+            return true;
+        }
+
+        fileType = null;
+        return false;
+    }
 
     /// <summary>
     /// Determines whether this collection contains a file type for the specified entity type.
@@ -44,5 +55,5 @@ public interface IFileTypeCollection
     /// <returns>
     /// The entity types.
     /// </returns>
-    ICollection<string> GetEntityTypes() => throw new NotImplementedException();
+    ICollection<string> GetEntityTypes() => Array.Empty<string>(); // TODO (V14): Remove default implementation
 }

--- a/src/Umbraco.Core/Deploy/IFileTypeCollection.cs
+++ b/src/Umbraco.Core/Deploy/IFileTypeCollection.cs
@@ -27,7 +27,7 @@ public interface IFileTypeCollection
     /// <returns>
     ///   <c>true</c> if the file type associated with the specified entity type was found; otherwise, <c>false</c>.
     /// </returns>
-    bool TryGetValue(string entityType, [NotNullWhen(true)] out IFileType? fileType);
+    bool TryGetValue(string entityType, [NotNullWhen(true)] out IFileType? fileType) => throw new NotImplementedException();
 
     /// <summary>
     /// Determines whether this collection contains a file type for the specified entity type.
@@ -44,5 +44,5 @@ public interface IFileTypeCollection
     /// <returns>
     /// The entity types.
     /// </returns>
-    ICollection<string> GetEntityTypes();
+    ICollection<string> GetEntityTypes() => throw new NotImplementedException();
 }


### PR DESCRIPTION
While technically a breaking change, it was not expected this interface was in use by anyone. However, to be safe, this fixes the breaking change by providing a default implementation. 
