### PR TITLE
Management API: Allow specifying root access for user groups

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Factories/UserGroupPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/UserGroupPresentationFactory.cs
@@ -31,7 +31,10 @@ public class UserGroupPresentationFactory : IUserGroupPresentationFactory
     public async Task<UserGroupResponseModel> CreateAsync(IUserGroup userGroup)
     {
         Guid? contentStartNodeKey = GetKeyFromId(userGroup.StartContentId, UmbracoObjectTypes.Document);
+        var contentRootAccess = contentStartNodeKey is null && userGroup.StartContentId == Constants.System.Root;
         Guid? mediaStartNodeKey = GetKeyFromId(userGroup.StartMediaId, UmbracoObjectTypes.Media);
+        var mediaRootAccess = mediaStartNodeKey is null && userGroup.StartMediaId == Constants.System.Root;
+
         Attempt<IEnumerable<string>, UserGroupOperationStatus> languageIsoCodesMappingAttempt = await MapLanguageIdsToIsoCodeAsync(userGroup.AllowedLanguages);
 
         // We've gotten this data from the database, so the mapping should not fail
@@ -45,7 +48,9 @@ public class UserGroupPresentationFactory : IUserGroupPresentationFactory
             Name = userGroup.Name ?? string.Empty,
             Id = userGroup.Key,
             DocumentStartNodeId = contentStartNodeKey,
+            DocumentRootAccess = contentRootAccess,
             MediaStartNodeId = mediaStartNodeKey,
+            MediaRootAccess = mediaRootAccess,
             Icon = userGroup.Icon,
             Languages = languageIsoCodesMappingAttempt.Result,
             HasAccessToAllLanguages = userGroup.HasAccessToAllLanguages,
@@ -219,6 +224,10 @@ public class UserGroupPresentationFactory : IUserGroupPresentationFactory
 
             target.StartContentId = contentId;
         }
+        else if (source.DocumentRootAccess)
+        {
+            target.StartContentId = Constants.System.Root;
+        }
         else
         {
             target.StartContentId = null;
@@ -234,6 +243,10 @@ public class UserGroupPresentationFactory : IUserGroupPresentationFactory
             }
 
             target.StartMediaId = mediaId;
+        }
+        else if (source.MediaRootAccess)
+        {
+            target.StartMediaId = Constants.System.Root;
         }
         else
         {

--- a/src/Umbraco.Cms.Api.Management/ViewModels/UserGroup/UserGroupBase.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/UserGroup/UserGroupBase.cs
@@ -44,12 +44,28 @@ public class UserGroupBase
     public Guid? DocumentStartNodeId { get; init; }
 
     /// <summary>
+    /// If the group should have access to the document root.
+    /// <remarks>
+    /// This will be ignored if an explicit start node has been specified in <see cref="DocumentStartNodeId"/>.
+    /// </remarks>
+    /// </summary>
+    public bool DocumentRootAccess { get; init; }
+
+    /// <summary>
     /// The Id of the media that should act as root node for the user group
     /// <remarks>
     /// This can be overwritten by a different user group if a user is a member of multiple groups
     /// </remarks>
     /// </summary>
     public Guid? MediaStartNodeId { get; init; }
+
+    /// <summary>
+    /// If the group should have access to the media root.
+    /// <remarks>
+    /// This will be ignored if an explicit start node has been specified in <see cref="MediaStartNodeId"/>.
+    /// </remarks>
+    /// </summary>
+    public bool MediaRootAccess { get; init; }
 
     /// <summary>
     /// Ad-hoc list of permissions provided, and maintained by the front-end. The server has no concept of what these mean.

--- a/src/Umbraco.Core/Services/UserGroupService.cs
+++ b/src/Umbraco.Core/Services/UserGroupService.cs
@@ -399,12 +399,14 @@ internal sealed class UserGroupService : RepositoryService, IUserGroupService
     private UserGroupOperationStatus ValidateStartNodesExists(IUserGroup userGroup)
     {
         if (userGroup.StartContentId is not null
-        && _entityService.Exists(userGroup.StartContentId.Value, UmbracoObjectTypes.Document) is false)
+            && userGroup.StartContentId is not Constants.System.Root
+            && _entityService.Exists(userGroup.StartContentId.Value, UmbracoObjectTypes.Document) is false)
         {
             return UserGroupOperationStatus.DocumentStartNodeKeyNotFound;
         }
 
         if (userGroup.StartMediaId is not null
+            && userGroup.StartMediaId is not Constants.System.Root
             && _entityService.Exists(userGroup.StartMediaId.Value, UmbracoObjectTypes.Media) is false)
         {
             return UserGroupOperationStatus.MediaStartNodeKeyNotFound;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR adds the ability to explicitly specify content and media root access when creating/editing user groups via the Management API.

The current backoffice API uses integer IDs when specifying user group start nodes. Thus it's possible to pass the `Constants.System.Root` constant for root access.

The Management API on the other hand uses GUID keys. As no constant exists for "system root key" (rightfully so!), and because a `null` value for start node means "no start node defined", we need to add extra request model properties to explicitly define root access for content and media (`DocumentRootAccess` and `MediaRootAccess` respectively).

These properties do _not_ take precedence over any specified start nodes; if the API request specifies both a start node key (not `null`) _and_ root access (`true`), the specified start node will be set as root for the user group.

### Testing this PR

Use Swagger to verify that you can:

1. Create a new user group with and without root access.
2. Add and remove root access to content and media individually on existing user groups.

Also verify that when passing in _both_ a valid start node key and `true` for root access, the start node key "wins" and root access is not permitted.
