### PR TITLE
Use named HttpClients

### DIFF
--- a/src/Umbraco.Core/Constants-HttpClients.cs
+++ b/src/Umbraco.Core/Constants-HttpClients.cs
@@ -14,5 +14,10 @@ public static partial class Constants
         ///     Name for http client which ignores certificate errors.
         /// </summary>
         public const string IgnoreCertificateErrors = "Umbraco:HttpClients:IgnoreCertificateErrors";
+
+        /// <summary>
+        ///     Name for http client which sends webhook requests.
+        /// </summary>
+        public const string WebhookFiring = "Umbraco:HttpClients:WebhookFiring";
     }
 }

--- a/src/Umbraco.Core/Constants-HttpClients.cs
+++ b/src/Umbraco.Core/Constants-HttpClients.cs
@@ -19,5 +19,13 @@ public static partial class Constants
         ///     Name for http client which sends webhook requests.
         /// </summary>
         public const string WebhookFiring = "Umbraco:HttpClients:WebhookFiring";
+
+        public static class Headers
+        {
+            /// <summary>
+            ///     User agent name for the product name.
+            /// </summary>
+            public const string UserAgentProductName = "Umbraco-Cms";
+        }
     }
 }

--- a/src/Umbraco.Core/Media/EmbedProviders/OEmbedProviderBase.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/OEmbedProviderBase.cs
@@ -55,7 +55,7 @@ public abstract class OEmbedProviderBase : IEmbedProvider
         if (_httpClient == null)
         {
             _httpClient = new HttpClient();
-            _httpClient.DefaultRequestHeaders.UserAgent.TryParseAdd("Umbraco-CMS");
+            _httpClient.DefaultRequestHeaders.UserAgent.TryParseAdd(Constants.HttpClients.Headers.UserAgentProductName);
         }
 
         using (var request = new HttpRequestMessage(HttpMethod.Get, url))

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookFiring.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookFiring.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Scoping;
-using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Infrastructure.BackgroundJobs.Jobs;

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookFiring.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookFiring.cs
@@ -93,24 +93,25 @@ public class WebhookFiring : IRecurringBackgroundJob
 
         var request = new HttpRequestMessage(HttpMethod.Post, webhook.Url)
         {
-            Version = httpClient.DefaultRequestVersion, VersionPolicy = httpClient.DefaultVersionPolicy,
+            Version = httpClient.DefaultRequestVersion,
+            VersionPolicy = httpClient.DefaultVersionPolicy,
         };
 
-        // Add headers
-        request.Headers.TryAddWithoutValidation("Umb-Webhook-Event", eventName);
-
-        foreach (KeyValuePair<string, string> header in webhook.Headers)
-        {
-            request.Headers.TryAddWithoutValidation(header.Key, header.Value);
-        }
-
-        // Set content
-        request.Content = new StringContent(serializedObject ?? string.Empty, Encoding.UTF8, MediaTypeNames.Application.Json);
-
-        // Send request
         HttpResponseMessage? response = null;
         try
         {
+            // Add headers
+            request.Headers.Add("Umb-Webhook-Event", eventName);
+
+            foreach (KeyValuePair<string, string> header in webhook.Headers)
+            {
+                request.Headers.Add(header.Key, header.Value);
+            }
+
+            // Set content
+            request.Content = new StringContent(serializedObject ?? string.Empty, Encoding.UTF8, MediaTypeNames.Application.Json);
+
+            // Send request
             response = await httpClient.SendAsync(request, cancellationToken);
         }
         catch (Exception ex)

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookFiring.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookFiring.cs
@@ -102,6 +102,7 @@ public class WebhookFiring : IRecurringBackgroundJob
             // Add headers
             request.Headers.Add("Umb-Webhook-Event", eventName);
             request.Headers.Add("Umb-Webhook-RetryCount", retryCount.ToString());
+            request.Headers.Add("Umb-Webhook-Date", date.ToString("R"));
 
             foreach (KeyValuePair<string, string> header in webhook.Headers)
             {

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookFiring.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookFiring.cs
@@ -102,7 +102,7 @@ public class WebhookFiring : IRecurringBackgroundJob
             // Add headers
             request.Headers.Add("Umb-Webhook-Event", eventName);
             request.Headers.Add("Umb-Webhook-RetryCount", retryCount.ToString());
-            request.Headers.Add("Umb-Webhook-Date", date.ToString("R"));
+            request.Headers.Add("Umb-Webhook-Date", DateTime.Now.ToString("R"));
 
             foreach (KeyValuePair<string, string> header in webhook.Headers)
             {

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookFiring.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookFiring.cs
@@ -71,8 +71,7 @@ public class WebhookFiring : IRecurringBackgroundJob
                         return;
                     }
 
-                    HttpResponseMessage? response = await SendRequestAsync(webhook, request.EventAlias, request.RequestObject, request.RetryCount, CancellationToken.None);
-
+                    using HttpResponseMessage? response = await SendRequestAsync(webhook, request.EventAlias, request.RequestObject, request.RetryCount, CancellationToken.None);
                     if ((response?.IsSuccessStatusCode ?? false) || request.RetryCount >= _webhookSettings.MaximumRetries)
                     {
                         await _webhookRequestService.DeleteAsync(request);

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookFiring.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookFiring.cs
@@ -101,6 +101,7 @@ public class WebhookFiring : IRecurringBackgroundJob
         {
             // Add headers
             request.Headers.Add("Umb-Webhook-Event", eventName);
+            request.Headers.Add("Umb-Webhook-Retry-Count", retryCount.ToString());
 
             foreach (KeyValuePair<string, string> header in webhook.Headers)
             {
@@ -115,7 +116,7 @@ public class WebhookFiring : IRecurringBackgroundJob
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error while sending webhook request for webhook {WebhookKey}.", webhook);
+            _logger.LogError(ex, "Error while sending webhook request for webhook {WebhookKey}.", webhook.Key);
         }
 
         var webhookResponseModel = new WebhookResponseModel

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Net.Http.Headers;
 using System.Reflection;
 using Dazinator.Extensions.FileProviders.GlobPatternFilter;
 using Microsoft.AspNetCore.Builder;
@@ -22,6 +23,7 @@ using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Blocks;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Diagnostics;
@@ -260,7 +262,11 @@ public static partial class UmbracoBuilderExtensions
                 ServerCertificateCustomValidationCallback =
                     HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
             });
-        builder.Services.AddHttpClient(Constants.HttpClients.WebhookFiring);
+        builder.Services.AddHttpClient(Constants.HttpClients.WebhookFiring, (services, client) =>
+        {
+            var productVersion = services.GetRequiredService<IUmbracoVersion>().SemanticVersion.ToSemanticStringWithoutBuild();
+            client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Umbraco", productVersion));
+        });
         return builder;
     }
 

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -265,7 +265,7 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddHttpClient(Constants.HttpClients.WebhookFiring, (services, client) =>
         {
             var productVersion = services.GetRequiredService<IUmbracoVersion>().SemanticVersion.ToSemanticStringWithoutBuild();
-            client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Umbraco-CMS", productVersion));
+            client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(Constants.HttpClients.Headers.UserAgentProductName, productVersion));
         });
         return builder;
     }

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -265,7 +265,7 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddHttpClient(Constants.HttpClients.WebhookFiring, (services, client) =>
         {
             var productVersion = services.GetRequiredService<IUmbracoVersion>().SemanticVersion.ToSemanticStringWithoutBuild();
-            client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Umbraco", productVersion));
+            client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Umbraco-CMS", productVersion));
         });
         return builder;
     }

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Serilog.Extensions.Logging;
@@ -261,6 +260,7 @@ public static partial class UmbracoBuilderExtensions
                 ServerCertificateCustomValidationCallback =
                     HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
             });
+        builder.Services.AddHttpClient<IRecurringBackgroundJob, WebhookFiring>();
         return builder;
     }
 

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -260,7 +260,7 @@ public static partial class UmbracoBuilderExtensions
                 ServerCertificateCustomValidationCallback =
                     HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
             });
-        builder.Services.AddHttpClient<IRecurringBackgroundJob, WebhookFiring>();
+        builder.Services.AddHttpClient(Constants.HttpClients.WebhookFiring);
         return builder;
     }
 


### PR DESCRIPTION
# Notes
- Adds a named `IHttpClient` client for Webhook firing.
- Uses the `IHttpClientFactory` to then create a HttpClient, instead of just newing it up.
- This means that users of umbraco can now overwrite the named HttpClient with their configuration. 

# How to test
- Create a Document type with allow as root set to true.
- Create a webhook (getting url from webhook.site or other testing environment)
- Set the Content is published event.
- Create some content.
- Assert your endpoint gets called.

- We can assert that you can overwrite configuration, with the test composer down below:

# You can then overwrite our named client like:

``` 
using System.Diagnostics;
using Umbraco.Cms.Core;
using Umbraco.Cms.Core.Composing;

namespace Umbraco.Cms.Web.UI;

public class MyComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.AddComponent<HttpClientComponent>();

        builder.Services.AddHttpClient(Constants.HttpClients.WebhookFiring, client =>
        {
            client.DefaultRequestHeaders.UserAgent.ParseAdd("Umbraco");
        });

        builder.Services.AddHttpClient(Constants.HttpClients.WebhookFiring, client =>
        {
            client.DefaultRequestHeaders.Referrer = new Uri("http://example.com/");
        });
    }

    private class HttpClientComponent(IHttpClientFactory httpClientFactory) : IComponent
    {
        public void Initialize()
        {
            var client = httpClientFactory.CreateClient(Constants.HttpClients.WebhookFiring);

            Debug.Assert(client.DefaultRequestHeaders.UserAgent.Count > 0, "User agent must be set!");
            Debug.Assert(client.DefaultRequestHeaders.Referrer != null, "Referrer should be set!");
            Debugger.Break();
        }

        public void Terminate()
        { }
    }
}

```