### PR TITLE
Add localization keys for webhooks edit view

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -2011,6 +2011,14 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="types">Types</key>
     <key alias="webhookKey">Webhook key</key>
     <key alias="retryCount">Retry count</key>
+    <key alias="urlDescription">The url to call when the webhook is triggered.</key>
+    <key alias="eventDescription">The events for which the webhook should be triggered.</key>
+    <key alias="contentTypeDescription">Only trigger the webhook for a specific content type.</key>
+    <key alias="enabledDescription">Is the webhook enabled?</key>
+    <key alias="headersDescription">Custom headers to include in the webhook request.</key>
+    <key alias="contentType">Content Type</key>
+    <key alias="headers">Headers</key>
+    <key alias="selectEventFirst">Please select an event first.</key>
   </area>
   <area alias="languages">
     <key alias="addLanguage">Add language</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -2032,6 +2032,14 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="types">Types</key>
     <key alias="webhookKey">Webhook key</key>
     <key alias="retryCount">Retry count</key>
+    <key alias="urlDescription">The url to call when the webhook is triggered.</key>
+    <key alias="eventDescription">The events for which the webhook should be triggered.</key>
+    <key alias="contentTypeDescription">Only trigger the webhook for a specific content type.</key>
+    <key alias="enabledDescription">Is the webhook enabled?</key>
+    <key alias="headersDescription">Custom headers to include in the webhook request.</key>
+    <key alias="contentType">Content Type</key>
+    <key alias="headers">Headers</key>
+    <key alias="selectEventFirst">Please select an event first.</key>
   </area>
   <area alias="languages">
     <key alias="addLanguage">Add language</key>

--- a/src/Umbraco.Web.UI.Client/src/views/webhooks/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/webhooks/edit.controller.js
@@ -33,12 +33,18 @@
                 "treeHeaders_webhooks",
                 "webhooks_addWebhook",
                 "defaultdialogs_confirmSure",
-                "defaultdialogs_editWebhook"
+                "defaultdialogs_editWebhook",
+                "webhooks_selectEventFirst",
+                "general_name",
+                "general_value"
             ]).then(function (values) {
                 vm.labels.webhooks = values[0];
                 vm.labels.addWebhook = values[1];
                 vm.labels.areYouSure = values[2];
                 vm.labels.editWebhook = values[3];
+                vm.labels.selectEventFirst = values[4];
+                vm.labels.headerName = values[5];
+                vm.labels.headerValue = values[6];
 
                 if ($routeParams.create) {
                   vm.isNew = true;

--- a/src/Umbraco.Web.UI.Client/src/views/webhooks/edit.html
+++ b/src/Umbraco.Web.UI.Client/src/views/webhooks/edit.html
@@ -26,8 +26,8 @@
                         <umb-box-content>
 
                           <umb-control-group
-                                label="Url"
-                                description="The url to call when the webhook is triggered."
+                                label="@webhooks_url"
+                                description="@webhooks_urlDescription"
                                 alias="webhookUrl"
                                 required="true">
 
@@ -45,8 +45,8 @@
                           </umb-control-group>
 
                           <umb-control-group
-                              label="Events"
-                              description="The events for which the webhook should be triggered."
+                              label="@webhooks_events"
+                              description="@webhooks_eventDescription"
                               alias="webhookEvents"
                               required="true">
 
@@ -70,8 +70,8 @@
                           </umb-control-group>
 
                           <umb-control-group
-                              label="Content Type"
-                              description="Only trigger the webhook for a specific content type."
+                              label="@webhooks_contentType"
+                              description="@webhooks_contentTypeDescription"
                               alias="webhookContentType">
 
                             <umb-node-preview
@@ -94,13 +94,13 @@
                                 <localize key="general_add">Add</localize>
                               </span>
                               <span ng-if="!vm.webhook.events || vm.webhook.events.length === 0">
-                                Please select an event first.
+                                  {{vm.labels.selectEventFirst}}
                               </span>
                             </button>
 
                           </umb-control-group>
 
-                          <umb-control-group label="Enabled" description="Is the webhook enabled?" alias="webhookEnabled">
+                          <umb-control-group label="@webhooks_enabled" description="@webhooks_enabledDescription" alias="webhookEnabled">
                             <umb-toggle
                                 checked="vm.webhook.enabled"
                                 on-click="vm.webhook.enabled = !vm.webhook.enabled">
@@ -108,16 +108,16 @@
                           </umb-control-group>
 
                           <umb-control-group
-                              label="Headers"
-                              description="Custom headers to include in the webhook request."
+                              label="@webhooks_headers"
+                              description="@webhooks_headersDescription"
                               alias="webhookHeaders">
 
                             <div class="umb-property-editor--limit-width">
                               <table class="table table-hover">
                                 <thead>
                                   <tr>
-                                    <th>Name</th>
-                                    <th>Value</th>
+                                    <th>{{vm.labels.headerName}}</th>
+                                    <th>{{vm.labels.headerValue}}</th>
                                   </tr>
                                 </thead>
                                 <tbody>


### PR DESCRIPTION
Add localization keys for webhooks edit view. Add keys for:

- [x] Control Group Labels
- [x] Control Group Descriptions
- [x] Table headers
- [x] Button text

![image](https://github.com/umbraco/Umbraco-CMS/assets/7831614/b943fbc7-b04b-4676-983f-2f09b9b7a3b3)
