### PR TITLE
V13: Log retrycount and properly log request headers

### DIFF
--- a/src/Umbraco.Core/Services/WebhookLogFactory.cs
+++ b/src/Umbraco.Core/Services/WebhookLogFactory.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net;
+using System.Text;
 using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Webhooks;
 
 namespace Umbraco.Cms.Core.Services;
 
@@ -15,20 +15,38 @@ public class WebhookLogFactory : IWebhookLogFactory
             Key = Guid.NewGuid(),
             Url = webhook.Url,
             WebhookKey = webhook.Key,
+            RetryCount = responseModel.RetryCount,
         };
 
         if (responseModel.HttpResponseMessage is not null)
         {
-            log.RequestBody = await responseModel.HttpResponseMessage!.RequestMessage!.Content!.ReadAsStringAsync(cancellationToken);
+            if (responseModel.HttpResponseMessage.RequestMessage?.Content is not null)
+            {
+                log.RequestBody = await responseModel.HttpResponseMessage.RequestMessage.Content.ReadAsStringAsync(cancellationToken);
+                log.RequestHeaders = CalculateHeaders(responseModel.HttpResponseMessage);
+            }
+
             log.ResponseBody = await responseModel.HttpResponseMessage.Content.ReadAsStringAsync(cancellationToken);
-            log.StatusCode = MapStatusCodeToMessage(responseModel.HttpResponseMessage.StatusCode);
-            log.RetryCount = responseModel.RetryCount;
             log.ResponseHeaders = responseModel.HttpResponseMessage.Headers.ToString();
-            log.RequestHeaders = responseModel.HttpResponseMessage.RequestMessage.Headers.ToString();
+            log.StatusCode = MapStatusCodeToMessage(responseModel.HttpResponseMessage.StatusCode);
         }
 
         return log;
     }
 
     private string MapStatusCodeToMessage(HttpStatusCode statusCode) => $"{statusCode.ToString()} ({(int)statusCode})";
+
+    private string CalculateHeaders(HttpResponseMessage responseMessage)
+    {
+        IEnumerable<KeyValuePair<string, IEnumerable<string>>> headers = responseMessage.RequestMessage!.Headers.Concat(responseMessage.RequestMessage.Content!.Headers);
+
+        var result = new StringBuilder();
+
+        foreach (KeyValuePair<string, IEnumerable<string>> header in headers)
+        {
+            result.AppendLine($"{header.Key}: {string.Join(", ", header.Value)}\n");
+        }
+
+        return result.ToString();
+    }
 }


### PR DESCRIPTION
# Notes
- Retry count was not logged properly when an error occurred, this has been changed to log retry count every time.
- Request headers was not logged correctly:
![image](https://github.com/umbraco/Umbraco-CMS/assets/70372949/bf0a24f5-c0db-44b0-9557-8973cb908e56)
- This should now log request headers correctly👍 

# How to test
- Create a doc type with allowed as root set to true
- Create a webhook, with URL set to a given endpoint (use webhook.site or other for testing)
- Also add "Content is published" event to webhook.
- Create some content with the doc type you created in step 1.
- Look in your webhook logs, this should now display the request headers 🙌 

- stop solution
- insert `throw new Exception();` in `WebhookFiring` L102 (just after the try clause)
- Run solution
- Publish the content again.
- Look in your webhooklogs again, this should now have retry count logged 👍 