### PR TITLE
V13: Link to error when Webhook request exceptions happen

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/webhooks/overlays/details.html
+++ b/src/Umbraco.Web.UI.Client/src/views/webhooks/overlays/details.html
@@ -46,6 +46,7 @@
 
         </umb-box>
 
+      <div ng-if="model.log.statusCode === 'OK (200)'">
         <umb-box>
           <umb-box-header title="Request"></umb-box-header>
           <umb-box-content class="block-form">
@@ -61,6 +62,18 @@
             <umb-code-snippet language="'TEXT'" wrap="true">{{vm.formatData(model.log.responseBody) | json}}</umb-code-snippet>
           </umb-box-content>
         </umb-box>
+      </div>
+      <div ng-if="model.log.statusCode !== 'OK (200)'">
+        <umb-box>
+          <umb-box-header title="Request failed"></umb-box-header>
+          <umb-box-content class="block-form">
+            <a href="/umbraco#/settings/logViewer/search?lq=WebhookKey%3D'{{model.log.webhookKey}}'">
+              The webhook request has failed, please look at the logs for a more detailed description of the error.
+            </a>
+          </umb-box-content>
+        </umb-box>
+      </div>
+
 
     </umb-editor-container>
 


### PR DESCRIPTION
# Notes
- Before when exceptions would happen, the webhook logs would not be helpful.
- This PR remedies that by instead removing all the Reponse/Request information when an exception has occurred, and instead links the user to the logs to inspect 👍 

# How to test
- Manually throw an exception when webhookfiring, by putting in ` throw new Exception();` on L102 in `WebhookFiring.cs`
- Run umbraco
- Create a doc type with allow as root set.
- Create a webhook with Content Published event.
- Create some content with the doc type you just created.
- Navigate to the webhook logs (this might take up to 10 seconds)
- Click on your webhook request that just failed (should be the latest one)
- This should now display a helpful message and link you to the logs  👍 