### PR TITLE
Disable transitive package version pinning

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,17 +2,14 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
-  
   <!-- Global packages (private, build-time packages for all projects) -->
   <ItemGroup>
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" />
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507" />
-    <GlobalPackageReference Include="Umbraco.Code" Version="2.0.0" />
+    <GlobalPackageReference Include="Umbraco.Code" Version="2.1.0" />
     <GlobalPackageReference Include="Umbraco.GitVersioning.Extensions" Version="0.2.0" />
   </ItemGroup>
-  
   <!-- Microsoft packages -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.0" />
@@ -37,16 +34,14 @@
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
     <PackageVersion Include="System.Runtime.Caching" Version="8.0.0" />
   </ItemGroup>
-  
   <!-- Umbraco packages -->
   <ItemGroup>
     <PackageVersion Include="Umbraco.JsonSchema.Extensions" Version="0.3.0" />
     <PackageVersion Include="Umbraco.CSharpTest.Net.Collections" Version="15.0.0" />
   </ItemGroup>
-  
   <!-- Third-party packages -->
   <ItemGroup>
-    <PackageVersion Include="Asp.Versioning.Mvc" Version="7.1.0" />
+    <PackageVersion Include="Asp.Versioning.Mvc" Version="7.1.1" />
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="7.1.0" />
     <PackageVersion Include="Dazinator.Extensions.FileProviders" Version="2.0.0" />
     <PackageVersion Include="Examine" Version="3.1.0" />
@@ -82,15 +77,5 @@
     <PackageVersion Include="Smidge.InMemory" Version="4.3.0" />
     <PackageVersion Include="Smidge.Nuglify" Version="4.3.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-  </ItemGroup>
-  
-  <!-- Transitive pinned versions -->
-  <ItemGroup>
-    <!-- NPoco.SqlServer brings in a vulnerable version of Azure.Identity -->
-    <PackageVersion Include="Azure.Identity" Version="1.10.4" />
-    <!-- Umbraco.Code depends on an outdated Microsoft.CodeAnalysis.CSharp.Workspaces version-->
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
-    <!-- Dazinator.Extensions.FileProviders brings in a vulnerable version of System.Net.Http -->
-    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -78,4 +78,11 @@
     <PackageVersion Include="Smidge.Nuglify" Version="4.3.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
+  <!-- Transitive pinned versions -->
+  <ItemGroup>
+    <!-- Both Microsoft.EntityFrameworkCore.SqlServer and NPoco.SqlServer bring in a vulnerable version of Azure.Identity -->
+    <PackageVersion Include="Azure.Identity" Version="1.10.4" />
+    <!-- Dazinator.Extensions.FileProviders brings in a vulnerable version of System.Net.Http -->
+    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+  </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -78,11 +78,15 @@
     <PackageVersion Include="Smidge.Nuglify" Version="4.3.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
-  <!-- Transitive pinned versions -->
+  <!-- Transitive pinned versions (only required because our direct dependencies have vulnerable versions of transitive dependencies) -->
   <ItemGroup>
     <!-- Both Microsoft.EntityFrameworkCore.SqlServer and NPoco.SqlServer bring in a vulnerable version of Azure.Identity -->
     <PackageVersion Include="Azure.Identity" Version="1.10.4" />
     <!-- Dazinator.Extensions.FileProviders brings in a vulnerable version of System.Net.Http -->
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <!-- Examine brings in a vulnerable version of System.Security.Cryptography.Xml -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.0" />
+    <!-- Both Dazinator.Extensions.FileProviders and MiniProfiler.AspNetCore.Mvc bring in a vulnerable version of System.Text.RegularExpressions -->
+    <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/src/Umbraco.Cms.Persistence.EFCore.SqlServer/Umbraco.Cms.Persistence.EFCore.SqlServer.csproj
+++ b/src/Umbraco.Cms.Persistence.EFCore.SqlServer/Umbraco.Cms.Persistence.EFCore.SqlServer.csproj
@@ -5,6 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Take top-level depedendency on Azure.Identity, because Microsoft.EntityFrameworkCore.SqlServer depends on a vulnerable version -->
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
   </ItemGroup>
 

--- a/src/Umbraco.Cms.Persistence.EFCore/Umbraco.Cms.Persistence.EFCore.csproj
+++ b/src/Umbraco.Cms.Persistence.EFCore/Umbraco.Cms.Persistence.EFCore.csproj
@@ -5,6 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Take top-level depedendency on Azure.Identity, because Microsoft.EntityFrameworkCore.SqlServer depends on a vulnerable version -->
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="OpenIddict.EntityFrameworkCore" />

--- a/src/Umbraco.Cms.Persistence.SqlServer/Umbraco.Cms.Persistence.SqlServer.csproj
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Umbraco.Cms.Persistence.SqlServer.csproj
@@ -5,6 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Take top-level depedendency on Azure.Identity, because NPoco.SqlServer depends on a vulnerable version -->
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="NPoco.SqlServer" />
   </ItemGroup>
 

--- a/src/Umbraco.Examine.Lucene/Umbraco.Examine.Lucene.csproj
+++ b/src/Umbraco.Examine.Lucene/Umbraco.Examine.Lucene.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Examine" />
+    <!-- Take top-level depedendency on System.Security.Cryptography.Xml, because Examine depends on a vulnerable version -->
+    <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
+++ b/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
@@ -22,6 +22,8 @@
     <PackageReference Include="Smidge.Nuglify" />
     <!-- Take top-level depedendency on System.Net.Http, because Dazinator.Extensions.FileProviders depends on a vulnerable version -->
     <PackageReference Include="System.Net.Http" />
+    <!-- Take top-level depedendency on System.Text.RegularExpressions, because both Dazinator.Extensions.FileProviders and MiniProfiler.AspNetCore.Mvc depend on a vulnerable version -->
+    <PackageReference Include="System.Text.RegularExpressions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
+++ b/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
@@ -20,6 +20,8 @@
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Smidge.InMemory" />
     <PackageReference Include="Smidge.Nuglify" />
+    <!-- Take top-level depedendency on System.Net.Http, because Dazinator.Extensions.FileProviders depends on a vulnerable version -->
+    <PackageReference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -4,7 +4,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
   <ItemGroup>
     <!-- Microsoft packages -->
-    <PackageVersion Include="BenchmarkDotNet" Version="0.13.10" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.11" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Although PR https://github.com/umbraco/Umbraco-CMS/pull/15362 generally improved the Central Package Management setup and ensured we don't depend on any outdated, vulnerable dependencies, it also resulted in having all transitive dependencies listed as direct dependencies.

The main reason for enabling `CentralPackageTransitivePinningEnabled` was to fix a dependency version conflict caused by Umbraco.Code. This PR instead references an updated version that uses the latest Microsoft.CodeAnalysis.CSharp.Workspaces version 4.8 (so it aligns with Microsoft.CodeAnalysis.CSharp that's used by the CMS).

Since Umbraco.Code 2.1.0 isn't released to NuGet yet, I've added a separate commit that adds the prereleases feed, so we can first test out the fix. Once released to NuGet, that commit can be reverted/reset 😄 

Testing steps: besides producing a successful build, ensure the NuGet artifacts have the expected dependencies now,