### PR TITLE
Remove date header from webhook request and use constants

### DIFF
--- a/src/Umbraco.Core/Constants-WebhookEvents.cs
+++ b/src/Umbraco.Core/Constants-WebhookEvents.cs
@@ -1,84 +1,96 @@
-﻿namespace Umbraco.Cms.Core;
+namespace Umbraco.Cms.Core;
 
 public static partial class Constants
 {
     public static class WebhookEvents
     {
-        public static class Aliases
+        public static class HeaderNames
         {
+            /// <summary>
+            /// Gets the <c>Umb-Webhook-Event</c> HTTP header name.
+            /// </summary>
+            public const string EventName = "Umb-Webhook-Event";
 
             /// <summary>
-            ///     Webhook event alias for content versions deleted
+            /// Gets the <c>Umb-Webhook-RetryCount</c> HTTP header name.
+            /// </summary>
+            public const string RetryCount = "Umb-Webhook-RetryCount";
+        }
+
+        public static class Aliases
+        {
+            /// <summary>
+            /// Webhook event alias for content versions deleted.
             /// </summary>
             public const string ContentDeletedVersions = "Umbraco.ContentDeletedVersions";
 
             /// <summary>
-            ///     Webhook event alias for content blueprint saved
+            /// Webhook event alias for content blueprint saved.
             /// </summary>
             public const string ContentSavedBlueprint = "Umbraco.ContentSavedBlueprint";
 
             /// <summary>
-            ///     Webhook event alias for content blueprint deleted
+            /// Webhook event alias for content blueprint deleted.
             /// </summary>
             public const string ContentDeletedBlueprint = "Umbraco.ContentDeletedBlueprint";
 
             /// <summary>
-            ///     Webhook event alias for content moved into the recycle bin.
+            /// Webhook event alias for content moved into the recycle bin.
             /// </summary>
             public const string ContentMovedToRecycleBin = "Umbraco.ContentMovedToRecycleBin";
 
             /// <summary>
-            ///     Webhook event alias for content sorted.
+            /// Webhook event alias for content sorted.
             /// </summary>
             public const string ContentSorted = "Umbraco.ContentSorted";
 
             /// <summary>
-            ///     Webhook event alias for content moved.
+            /// Webhook event alias for content moved.
             /// </summary>
             public const string ContentMoved = "Umbraco.ContentMoved";
 
             /// <summary>
-            ///     Webhook event alias for content copied.
+            /// Webhook event alias for content copied.
             /// </summary>
             public const string ContentCopied = "Umbraco.ContentCopied";
 
             /// <summary>
-            ///     Webhook event alias for content emptied recycle bin.
+            /// Webhook event alias for content emptied recycle bin.
             /// </summary>
             public const string ContentEmptiedRecycleBin = "Umbraco.ContentEmptiedRecycleBin";
 
             /// <summary>
-            ///     Webhook event alias for content rolled back.
+            /// Webhook event alias for content rolled back.
             /// </summary>
             public const string ContentRolledBack = "Umbraco.ContentRolledBack";
 
             /// <summary>
-            ///     Webhook event alias for content saved.
+            /// Webhook event alias for content saved.
             /// </summary>
             public const string ContentSaved = "Umbraco.ContentSaved";
 
             /// <summary>
-            ///     Webhook event alias for content publish.
+            /// Webhook event alias for content publish.
             /// </summary>
             public const string ContentPublish = "Umbraco.ContentPublish";
 
             /// <summary>
-            ///     Webhook event alias for content delete.
+            /// Webhook event alias for content delete.
             /// </summary>
             public const string ContentDelete = "Umbraco.ContentDelete";
 
             /// <summary>
-            ///     Webhook event alias for content unpublish.
+            /// Webhook event alias for content unpublish.
             /// </summary>
             public const string ContentUnpublish = "Umbraco.ContentUnpublish";
 
             /// <summary>
-            ///     Webhook event alias for media delete.
+            /// Webhook event alias for media delete.
             /// </summary>
             public const string MediaDelete = "Umbraco.MediaDelete";
 
             /// <summary>
-            ///     Webhook event alias for media save.
+            /// Webhook event alias for media save.
             /// </summary>
             public const string MediaSave = "Umbraco.MediaSave";
         }
@@ -86,22 +98,22 @@ public static partial class Constants
         public static class Types
         {
             /// <summary>
-            ///     Webhook event type for content.
+            /// Webhook event type for content.
             /// </summary>
             public const string Content = "Content";
 
             /// <summary>
-            ///     Webhook event type for content media.
+            /// Webhook event type for content media.
             /// </summary>
             public const string Media = "Media";
 
             /// <summary>
-            ///     Webhook event type for content member.
+            /// Webhook event type for content member.
             /// </summary>
             public const string Member = "Member";
 
             /// <summary>
-            ///     Webhook event type for others, this is the default category if you have not chosen one.
+            /// Webhook event type for others, this is the default category if you have not chosen one.
             /// </summary>
             public const string Other = "Other";
         }

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookFiring.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookFiring.cs
@@ -1,4 +1,4 @@
-﻿using System.Net.Mime;
+using System.Net.Mime;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -101,8 +101,8 @@ public class WebhookFiring : IRecurringBackgroundJob
         try
         {
             // Add headers
-            request.Headers.Add("Umb-Webhook-Event", eventName);
-            request.Headers.Add("Umb-Webhook-RetryCount", retryCount.ToString());
+            request.Headers.Add(Constants.WebhookEvents.HeaderNames.EventName, eventName);
+            request.Headers.Add(Constants.WebhookEvents.HeaderNames.RetryCount, retryCount.ToString());
 
             foreach (KeyValuePair<string, string> header in webhook.Headers)
             {

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookFiring.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/WebhookFiring.cs
@@ -103,7 +103,6 @@ public class WebhookFiring : IRecurringBackgroundJob
             // Add headers
             request.Headers.Add("Umb-Webhook-Event", eventName);
             request.Headers.Add("Umb-Webhook-RetryCount", retryCount.ToString());
-            request.Headers.Add("Umb-Webhook-Date", DateTime.Now.ToString("R"));
 
             foreach (KeyValuePair<string, string> header in webhook.Headers)
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
As mentioned in https://github.com/umbraco/Umbraco-CMS/pull/15375#discussion_r1420066349, providing the current date/time in a header doesn't add any real value. The date/time that would be of interest is when the event was raised and the `WebhookRequest` was created (as they're 'fired' some time later in a background thread), but that's not stored in the database yet. So lets ensure we don't sent this header yet! Besides that, I've also moved the header names into constants 👍🏻

For testing, I believe a code review should suffice, as there's no big changes!