### PR TITLE
PropertyEditor(UI)Alias name refactor

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Factories/DataTypePresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DataTypePresentationFactory.cs
@@ -32,7 +32,7 @@ public class DataTypePresentationFactory : IDataTypePresentationFactory
     /// <inheritdoc />
     public async Task<Attempt<IDataType, DataTypeOperationStatus>> CreateAsync(CreateDataTypeRequestModel requestModel)
     {
-        if (!_propertyEditorCollection.TryGet(requestModel.PropertyEditorAlias, out IDataEditor? editor))
+        if (!_propertyEditorCollection.TryGet(requestModel.EditorAlias, out IDataEditor? editor))
         {
             return Attempt.FailWithStatus<IDataType, DataTypeOperationStatus>(DataTypeOperationStatus.PropertyEditorNotFound, new DataType(new VoidEditor(_dataValueEditorFactory), _configurationEditorJsonSerializer));
         }
@@ -47,7 +47,7 @@ public class DataTypePresentationFactory : IDataTypePresentationFactory
         var dataType = new DataType(editor, _configurationEditorJsonSerializer)
         {
             Name = requestModel.Name,
-            EditorUiAlias = requestModel.PropertyEditorUiAlias,
+            EditorUiAlias = requestModel.EditorUiAlias,
             DatabaseType = GetEditorValueStorageType(editor),
             ConfigurationData = MapConfigurationData(requestModel, editor),
             ParentId = parentAttempt.Result,
@@ -86,7 +86,7 @@ public class DataTypePresentationFactory : IDataTypePresentationFactory
 
     public Task<Attempt<IDataType, DataTypeOperationStatus>> CreateAsync(UpdateDataTypeRequestModel requestModel, IDataType current)
     {
-        if (!_propertyEditorCollection.TryGet(requestModel.PropertyEditorAlias, out IDataEditor? editor))
+        if (!_propertyEditorCollection.TryGet(requestModel.EditorAlias, out IDataEditor? editor))
         {
             return Task.FromResult(Attempt.FailWithStatus<IDataType, DataTypeOperationStatus>(DataTypeOperationStatus.PropertyEditorNotFound, new DataType(new VoidEditor(_dataValueEditorFactory), _configurationEditorJsonSerializer) ));
         }
@@ -95,7 +95,7 @@ public class DataTypePresentationFactory : IDataTypePresentationFactory
 
         dataType.Name = requestModel.Name;
         dataType.Editor = editor;
-        dataType.EditorUiAlias = requestModel.PropertyEditorUiAlias;
+        dataType.EditorUiAlias = requestModel.EditorUiAlias;
         dataType.DatabaseType = GetEditorValueStorageType(editor);
         dataType.ConfigurationData = MapConfigurationData(requestModel, editor);
 

--- a/src/Umbraco.Cms.Api.Management/Mapping/DataType/DataTypeViewModelMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/DataType/DataTypeViewModelMapDefinition.cs
@@ -30,8 +30,8 @@ public class DataTypeViewModelMapDefinition : IMapDefinition
         target.Id = source.Key;
         target.ParentId = _dataTypeService.GetContainer(source.ParentId)?.Key;
         target.Name = source.Name ?? string.Empty;
-        target.PropertyEditorAlias = source.EditorAlias;
-        target.PropertyEditorUiAlias = source.EditorUiAlias;
+        target.EditorAlias = source.EditorAlias;
+        target.EditorUiAlias = source.EditorUiAlias;
 
         IConfigurationEditor? configurationEditor = source.Editor?.GetConfigurationEditor();
         IDictionary<string, object> configuration = configurationEditor?.ToConfigurationEditor(source.ConfigurationData)

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -19572,10 +19572,10 @@
           "name": {
             "type": "string"
           },
-          "propertyEditorAlias": {
+          "editorAlias": {
             "type": "string"
           },
-          "propertyEditorUiAlias": {
+          "editorUiAlias": {
             "type": "string",
             "nullable": true
           },

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DataTypeModelBase.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DataTypeModelBase.cs
@@ -4,9 +4,9 @@ public abstract class DataTypeModelBase
 {
     public string Name { get; set; } = string.Empty;
 
-    public string PropertyEditorAlias { get; set; } = string.Empty;
+    public string EditorAlias { get; set; } = string.Empty;
 
-    public string? PropertyEditorUiAlias { get; set; }
+    public string? EditorUiAlias { get; set; }
 
     public IEnumerable<DataTypePropertyPresentationModel> Values { get; set; } = null!;
 }


### PR DESCRIPTION
### Description
Simple renaming of propertyEditorAlias properties on Management api models to better align with the new way of doing things.