### PR TITLE
Added fix for <umb-button-group /> label issues

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbbuttongroup.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbbuttongroup.directive.js
@@ -93,7 +93,7 @@ Use this directive to render a button with a dropdown of alternative actions.
 
   function ButtonGroupDirective() {
 
-    function controller($scope) {
+    function controller($scope, localizationService) {
       $scope.toggleStyle = null;
       $scope.blockElement = false;
 
@@ -121,6 +121,31 @@ Use this directive to render a button with a dropdown of alternative actions.
           }
         }
       }
+
+      // As the <localize /> directive doesn't support Angular expressions as fallback, we instead listen for changes
+      // to the label key of the default button, and if detected, we update the button label with the localized value
+      // received from the localization service
+      $scope.$watch("defaultButton.labelKey", function () {
+        if (!$scope.defaultButton.labelKey) return;
+        localizationService.localize($scope.defaultButton.labelKey).then(value => {
+          if (value && value.indexOf("[") === 0) return;
+          $scope.defaultButton.label = value;
+        });
+      });
+
+      // In a similar way, we must listen for changes to the sub buttons (or their label keys), and if detected, update
+      // the label with the localized value received from the localization service
+      $scope.$watch("defaultButton.subButtons", function () {
+        if (!Array.isArray($scope.subButtons)) return;
+        $scope.subButtons.forEach(function (sub) {
+          if (!sub.labelKey) return;
+          localizationService.localize(sub.labelKey).then(value => {
+            if (value && value.indexOf("[") === 0) return;
+            sub.label = value;
+          });
+        });
+      }, true);
+
     }
 
     function link(scope) {

--- a/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button-group.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button-group.html
@@ -8,7 +8,7 @@
       href-target="{{defaultButton.hrefTarget}}"
       button-style="{{buttonStyle}}"
       state="state"
-      label="{{defaultButton.labelKey}}"
+      label="{{defaultButton.label}}"
       label-key="{{defaultButton.labelKey}}"
       shortcut="{{defaultButton.hotKey}}"
       shortcut-when-hidden="{{defaultButton.hotKeyWhenHidden}}"
@@ -29,7 +29,7 @@
       ng-disabled="disabled">
          <span class="caret">
             <span class="sr-only">
-               <localize key="{{labelKey}}">{{label}}</localize>
+               {{defaultButton.label}}
             </span>
          </span>
    </button>
@@ -48,8 +48,7 @@
             hotkey="{{subButton.hotKey}}"
             hotkey-when-hidden="{{subButton.hotKeyWhenHidden}}"
             ng-disabled="disabled">
-               <localize ng-if="subButton.labelKey" key="{{subButton.labelKey}}">{{subButton.labelKey}}</localize>
-               <span ng-if="subButton.label">{{subButton.label}}</span>
+               <span>{{subButton.label}}</span>
                <span ng-if="subButton.addEllipsis === 'true'">...</span>
          </button>
       </umb-dropdown-item>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

As requested by @nul800sebastiaan, this PR targets the `release/13.0` branch. My changes should however fix the issue both Umbraco 12.3 and 13.0.

### Description

For Umbraco 12.3, @madsrasmussen made some changes to the `<umb-button-group />` directive which adds support for labels on sub buttons. Previously a label was only supported on the default button: https://github.com/umbraco/Umbraco-CMS/commit/cb4d8e34ce9e2b124a2b1c74b4a4309ae456d64f

In my [**Skybrud Redirects Import**](https://github.com/skybrud/Skybrud.Umbraco.Redirects.Import) package I had specified both a label and a label key for the sub buttons (as this worked on the default button). But with the changes to the `<umb-button-group />` directive, both the label and the localized label associated with the label key are now shown.

![image](https://github.com/umbraco/Umbraco-CMS/assets/3634580/d239933c-6b13-4338-a989-5c0997013852)

This PR drops the use of the `<localize />` directive as this doesn't support a fallback value based on an Angular expression. Instead the `<umb-button-group />` directive will instead now use a watcher and the `localizationService` to resolve the localized label from the label key (if specified).

As trying to fix this, I also discovered two other issues:

- The value passed to the `label` parameter of the default button was `{{defaultButton.labelKey}}`, but as there is a separate `label-key` parameter, the passed value should be `{{defaultButton.label}}` instead.

- The screen reader text for the caret button was `<localize key="{{labelKey}}">{{label}}</localize>`. As far as I can tell, neither `labelKey` and `label` exists in the root of the scope, but instead lives as properties on the `defaultButton` object, and as described above, the `<localize />` directive doesn't support Angular expressions as fallback, the fallback text would essential end up being `{{label}}` (not evaluated). 

### Fallback values

It's also worth mentioning that normally if a label key is passed to `localizationService`, but the label key isn't found, the resolved value will be the label key wrapped in square brackets. This will then overwrite the label (the fallback value). I've therefore added some checks for `if (value && value.indexOf("[") === 0) return;` so that the resolved value is ignored if it starts with an open square bracket character. This applies to the caret button as well as the sub buttons, but not the default button as this is instead handled by the `<umb-button />` directive.

Since we've already handled the localization inside the `<umb-button-group />` directive, removing [this line](https://github.com/umbraco/Umbraco-CMS/blob/release-13.0.0-rc4/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button-group.html#L12) should fix this as the `defaultButton.label` will contain the localized value. I haven't changed this for my PR, but I'd be happy to do so it makes sense to include here as well 😉 

### Testing

For testing this, I've set up a small dashboard with a two button groups. The files for the dashboard are:

- `/App_Plugins/MyDashboard/Default.html`

    ```html
    <div ng-controller="myDashboard.controller as vm">
    
      <div style="padding: 50px 150px;">
        <umb-button-group
          ng-repeat="bg in vm.buttonGroups"
          button-style="{{bg.buttonStyle}}"
          default-button="bg.defaultButton"
          sub-buttons="bg.subButtons"
          direction="down"
          float="right">
        </umb-button-group>
      </div>
    
      <pre>{{vm | json}}</pre>
    </div>
    ```

- `/App_Plugins/MyDashboard/package.manifest`

    ```json
    {
        "dashboards": [
            {
                "alias": "myDashboard",
                "sections": [ "content" ],
                "view": "/App_Plugins/MyDashboard/Default.html"
            }
        ],
        "javascript": [
            "/App_Plugins/MyDashboard/Controller.js"
        ]
    }
    ```

- `/App_Plugins/MyDashboard/Controller.js`

    ```js
    angular.module("umbraco").controller("myDashboard.controller", function ($scope) {
    
      const vm = this;
    
      vm.buttonGroups = [
        {
          alias: "add",
          buttonStyle: "success",
          defaultButton: {
            labelKey: "redirects_addNewRedirect",
            label: "Add",
            handler: function () {
    
    
            }
          },
          subButtons: []
        },
        {
          buttonStyle: "success",
          defaultButton: {
            labelKey: "redirects_nonExisting",
            label: "Fallback",
            handler: function () {
    
    
            }
          },
        }
      ];
    
      vm.buttonGroups[0].subButtons.push({
        label: "Import",
        labelKey: "redirects_import",
        handler: function () {
    
    
        }
      });
    
      vm.buttonGroups[0].subButtons.push({
        label: "Export",
        labelKey: "redirects_import",
        handler: function () {
    
    
        }
      });
    
      vm.buttonGroups[0].subButtons.push({
        label: "Fallback",
        labelKey: "redirects_nonExisting",
        handler: function () {
    
    
        }
      });
    
    });
    ```

- `/App_Plugins/MyDashboard/Lang/en-US.xml`

    ```xml
    <?xml version="1.0" encoding="utf-8" standalone="yes"?>
    
    <language alias="en" intName="English (US)" localName="English (US)" lcid="" culture="en-US">
      <area alias="redirects">
        <key alias="addNewRedirect">Add new redirect</key>
        <key alias="import">Import</key>
      </area>
    </language>
    ```

The test should show the following:

![image](https://github.com/umbraco/Umbraco-CMS/assets/3634580/c4492358-8c5d-48da-a739-0a28bfd83adf)

- First sub button has an initial label of **Import**, which is overwritten by the resolved value from the label key (also **Import**).

- Second sub button has an initial label of **Export**, but to test the changes, I've specified the label key as `redirects_import`, the the resolved label is now **Import** (so that we can see that the label key does in fact overwrite the label).

- Third sub button has an initial label of **Fallback**. As no translation exists for `redirects_nonExisting`, the initial label is still shown (opposed to **[redirects_nonExisting]**). 

- The second of the two primary buttons also has `redirects_nonExisting` as it's label key, but as the localization is handled by the `<umb-button />` directive, and not `<umb-button-group />`, the rendered label is **[redirects_nonExisting]**. As described earlier, removing [this line](https://github.com/umbraco/Umbraco-CMS/blob/release-13.0.0-rc4/src/Umbraco.Web.UI.Client/src/views/components/buttons/umb-button-group.html#L12) should ensure that the rendered label is instead **Fallback**.













