### PR TITLE
V13: Regression with global window.uui export

### DIFF
--- a/src/Umbraco.Cms.StaticAssets/Umbraco.Cms.StaticAssets.csproj
+++ b/src/Umbraco.Cms.StaticAssets/Umbraco.Cms.StaticAssets.csproj
@@ -23,10 +23,10 @@
   </Target>
 
   <Target Name="BuildBelle">
-    <Exec WorkingDirectory="$(ProjectDir)..\Umbraco.Web.UI.Client\" Command="npm ci --no-fund --no-audit --prefer-offline" />
-    <Exec WorkingDirectory="$(ProjectDir)..\Umbraco.Web.UI.Client\" Command="npm run build:skip-tests" />
     <Exec WorkingDirectory="$(ProjectDir)..\Umbraco.Web.UI.Login\" Command="npm ci --no-fund --no-audit --prefer-offline" />
     <Exec WorkingDirectory="$(ProjectDir)..\Umbraco.Web.UI.Login\" Command="npm run build" />
+    <Exec WorkingDirectory="$(ProjectDir)..\Umbraco.Web.UI.Client\" Command="npm ci --no-fund --no-audit --prefer-offline" />
+    <Exec WorkingDirectory="$(ProjectDir)..\Umbraco.Web.UI.Client\" Command="npm run build:skip-tests" />
   </Target>
 
   <Target Name="CleanBellePreconditions" AfterTargets="Clean" Condition="'$(UmbracoBuild)' == ''">

--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoBackOffice/Default.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoBackOffice/Default.cshtml
@@ -122,8 +122,6 @@
         }
     </script>
 
-    <script type="module" src="~/umbraco/login/external.js" asp-append-version="true"></script>
-    <script type="module" src="~/umbraco/login/index.js" asp-append-version="true"></script>
     <script src="@WebPath.Combine(backOfficePath.TrimStart("~"), "/lib/lazyload-js/LazyLoad.min.js")"></script>
     <script src="@Url.GetUrlWithCacheBust("Application", "BackOffice", null!, hostingEnvironment, umbracoVersion, runtimeMinifier)"></script>
 

--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoBackOffice/Default.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoBackOffice/Default.cshtml
@@ -37,10 +37,6 @@
     <title ng-bind="$root.locationTitle">Umbraco</title>
 
     @Html.Raw(await runtimeMinifier.RenderCssHereAsync(BackOfficeWebAssets.UmbracoInitCssBundleName))
-
-    <link rel="stylesheet" href="~/umbraco/login/style.css" asp-append-version="true" />
-    <script type="module" src="~/umbraco/login/external.js" asp-append-version="true"></script>
-    <script type="module" src="~/umbraco/login/index.js" asp-append-version="true"></script>
 </head>
 <body ng-class="{'touch':touchDevice, 'emptySection':emptySection, 'umb-drawer-is-visible':drawer.show, 'umb-tour-is-visible': tour.show, 'tabbing-active':tabbingActive}" ng-controller="Umbraco.MainController" id="umbracoMainPageBody">
     <noscript>
@@ -126,6 +122,8 @@
         }
     </script>
 
+    <script type="module" src="~/umbraco/login/external.js" asp-append-version="true"></script>
+    <script type="module" src="~/umbraco/login/index.js" asp-append-version="true"></script>
     <script src="@WebPath.Combine(backOfficePath.TrimStart("~"), "/lib/lazyload-js/LazyLoad.min.js")"></script>
     <script src="@Url.GetUrlWithCacheBust("Application", "BackOffice", null!, hostingEnvironment, umbracoVersion, runtimeMinifier)"></script>
 

--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoLogin/Index.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoLogin/Index.cshtml
@@ -49,10 +49,7 @@
 
     @Html.Raw(await RuntimeMinifier.RenderCssHereAsync(BackOfficeWebAssets.UmbracoNonOptimizedPackageCssBundleName))
     @Html.Raw(await RuntimeMinifier.RenderCssHereAsync(BackOfficeWebAssets.UmbracoCssBundleName))
-
-    <link rel="stylesheet" href="~/umbraco/login/style.css" asp-append-version="true"/>
-    <script type="module" src="~/umbraco/login/external.js" asp-append-version="true"></script>
-    <script type="module" src="~/umbraco/login/index.js" asp-append-version="true"></script>
+    <link rel="stylesheet" href="~/umbraco/lib/umbraco-ui/uui-css/dist/uui-css.css" asp-append-version="true"/>
     <style>
       body {
         margin: 0;
@@ -111,6 +108,9 @@
         }
     </umb-auth>
 </umb-backoffice-icon-registry>
+
+<script src="~/umbraco/lib/umbraco-ui/uui/dist/uui.min.js" asp-append-version="true"></script>
+<script src="~/umbraco/login/login.iife.js" asp-append-version="true"></script>
 
 @if (isDebug)
 {

--- a/src/Umbraco.Infrastructure/WebAssets/BackOfficeWebAssets.cs
+++ b/src/Umbraco.Infrastructure/WebAssets/BackOfficeWebAssets.cs
@@ -59,6 +59,8 @@ public class BackOfficeWebAssets
             BundlingOptions.NotOptimizedAndComposite,
             FormatPaths(
                 "assets/css/umbraco.min.css",
+                "lib/umbraco-ui/uui-css/dist/custom-properties.css",
+                "lib/umbraco-ui/uui-css/dist/uui-text.css",
                 "lib/bootstrap-social/bootstrap-social.css",
                 "lib/font-awesome/css/font-awesome.min.css"));
 

--- a/src/Umbraco.Infrastructure/WebAssets/JsInitialize.js
+++ b/src/Umbraco.Infrastructure/WebAssets/JsInitialize.js
@@ -35,6 +35,10 @@
     'lib/umbraco/NamespaceManager.js',
     'lib/umbraco/LegacySpeechBubble.js',
 
+    'lib/umbraco-ui/uui/dist/uui.min.js',
+
+    'login/login.iife.js',
+
     'js/utilities.min.js',
 
     'js/app.min.js',

--- a/src/Umbraco.Web.UI.Client/gulp/tasks/dependencies.js
+++ b/src/Umbraco.Web.UI.Client/gulp/tasks/dependencies.js
@@ -282,6 +282,16 @@ function dependencies() {
             ],
             "base": "./node_modules/wicg-inert"
         },
+        {
+          "name": "umbraco-ui",
+          "src": [
+            "./node_modules/@umbraco-ui/uui/dist/uui.min.js",
+            "./node_modules/@umbraco-ui/uui/dist/uui.min.js.map",
+            "./node_modules/@umbraco-ui/uui-css/dist/custom-properties.css",
+            "./node_modules/@umbraco-ui/uui-css/dist/uui-text.css"
+          ],
+          "base": "./node_modules/@umbraco-ui"
+        },
     ];
 
     // add streams for node modules

--- a/src/Umbraco.Web.UI.Client/gulp/tasks/dependencies.js
+++ b/src/Umbraco.Web.UI.Client/gulp/tasks/dependencies.js
@@ -288,7 +288,13 @@ function dependencies() {
             "./node_modules/@umbraco-ui/uui/dist/uui.min.js",
             "./node_modules/@umbraco-ui/uui/dist/uui.min.js.map",
             "./node_modules/@umbraco-ui/uui-css/dist/custom-properties.css",
-            "./node_modules/@umbraco-ui/uui-css/dist/uui-text.css"
+            "./node_modules/@umbraco-ui/uui-css/dist/uui-text.css",
+            "./node_modules/@umbraco-ui/uui-css/dist/uui-css.css",
+            "./node_modules/@umbraco-ui/uui-css/assets/fonts/lato/LatoLatin-Black.woff2",
+            "./node_modules/@umbraco-ui/uui-css/assets/fonts/lato/LatoLatin-Light.woff2",
+            "./node_modules/@umbraco-ui/uui-css/assets/fonts/lato/LatoLatin-Regular.woff2",
+            "./node_modules/@umbraco-ui/uui-css/assets/fonts/lato/LatoLatin-Italic.woff2",
+            "./node_modules/@umbraco-ui/uui-css/assets/fonts/lato/LatoLatin-Bold.woff2"
           ],
           "base": "./node_modules/@umbraco-ui"
         },

--- a/src/Umbraco.Web.UI.Login/index.html
+++ b/src/Umbraco.Web.UI.Login/index.html
@@ -9,6 +9,7 @@
   <meta name="robots" content="noindex, nofollow"/>
   <meta name="pinterest" content="nopin"/>
   <title>Umbraco</title>
+  <link rel="stylesheet" href="/node_modules/@umbraco-ui/uui-css/dist/uui-css.css"/>
   <script type="module">
     import {startMockServiceWorker} from './src/mocks/index.ts';
 
@@ -16,7 +17,6 @@
       await startMockServiceWorker();
     }
   </script>
-  <script type="module" src="/src/external.ts"></script>
   <script type="module" src="/src/index.ts"></script>
 </head>
 <body class="uui-font uui-text" style="margin: 0; padding: 0; overflow: hidden">

--- a/src/Umbraco.Web.UI.Login/package-lock.json
+++ b/src/Umbraco.Web.UI.Login/package-lock.json
@@ -6,13 +6,13 @@
 		"": {
 			"name": "login",
 			"dependencies": {
-				"@umbraco-ui/uui": "^1.5.0",
-				"@umbraco-ui/uui-css": "^1.5.0",
 				"lit": "^2.8.0",
 				"msw": "^1.3.2",
 				"rxjs": "^7.8.1"
 			},
 			"devDependencies": {
+				"@umbraco-ui/uui": "1.5.0",
+				"@umbraco-ui/uui-css": "1.5.0",
 				"typescript": "^5.2.2",
 				"vite": "^4.5.0"
 			},
@@ -474,6 +474,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui/-/uui-1.5.0.tgz",
 			"integrity": "sha512-V9pAdCsiaBy+Vq23sZd9JJCk+TX6xMsclJtTUWhwCq8/YUh6KNERbdoVfMYGUZ1yyJ/g+yddQsWlYOxHNp8msw==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-action-bar": "1.5.0",
 				"@umbraco-ui/uui-avatar": "1.5.0",
@@ -562,6 +563,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-action-bar/-/uui-action-bar-1.5.0.tgz",
 			"integrity": "sha512-2B4ONNRTEtoKjnBo8mtvQo2Y9WW7LDSx6q85UuA+YEWfMOgZ0hr0lFepPg+qq/q90/8ZIoItoxRo16UFrPVaHQ==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-button-group": "1.5.0"
@@ -571,6 +573,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar/-/uui-avatar-1.5.0.tgz",
 			"integrity": "sha512-Iw4MQ2IMfJq590ydA6d2WXJ3gC7wO1vpA6tZj3T772B81LBZR31ftoMn3ho4cpavV5Nv4LvBnGhc2YajbsVn5A==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -579,6 +582,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar-group/-/uui-avatar-group-1.5.0.tgz",
 			"integrity": "sha512-hlmqOGLQIN8uJMoLgT+RPHFWIxi8Ridhp/MrKgEjuNF6sTu4bCQyN28XuC9JD+4vBcSjU4a893QGvckalQxZiA==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-avatar": "1.5.0",
 				"@umbraco-ui/uui-base": "1.5.0"
@@ -588,6 +592,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-badge/-/uui-badge-1.5.0.tgz",
 			"integrity": "sha512-6azqqcqRzVHXYz/JfAody6kDZQG3hiBTiCS8EEYY9GcFNqh8BvFLX4yK9R6zz5BVrjgT3qkmPpE2iIpqV6J58A==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -596,6 +601,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-base/-/uui-base-1.5.0.tgz",
 			"integrity": "sha512-HzKRvbf/aPA1y8l9ZLTvF5Up7W6jX8UwqVUr1B8lwckI6tgxOEFPqLya+U4papqZDh4wz/lysXSDESeVfUy8cw==",
+			"dev": true,
 			"dependencies": {
 				"lit": "^2.3.1"
 			}
@@ -604,6 +610,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-boolean-input/-/uui-boolean-input-1.5.0.tgz",
 			"integrity": "sha512-uhIPzi7n3Z4Li3n688Q8v3725apwasZvPntm7kMdtssXay6hUHOcor+hkpPavGXRVxZGg+9gIYRM6sQWp853cA==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -612,6 +619,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-box/-/uui-box-1.5.0.tgz",
 			"integrity": "sha512-uTHBvwzS9pRu0MVfN74+bux6lK0m1AmY/7xor9ez9/uzDyIK096D9jSLTQkfDyngIhqnV6kFLbG7PqcfQURFJQ==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-css": "1.4.0"
@@ -621,6 +629,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-css/-/uui-css-1.4.0.tgz",
 			"integrity": "sha512-HBCFPuXJijeZbjnjdqmg3oqOGB3RmpQKT/s/Uy0TSJfaQGfz0e73o2eRghYHWF2rdqHw6brKFrZTZHBVvCE/xA==",
+			"dev": true,
 			"dependencies": {
 				"lit": "^2.2.2"
 			}
@@ -629,6 +638,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-breadcrumbs/-/uui-breadcrumbs-1.5.0.tgz",
 			"integrity": "sha512-mXuzt5o4NZ1E/HVTLYq+TklX9VQSH5zce+Ef1t2EgUE3EFQH0fwcdCRBC9SpklueNj46ngGHmVhyfv8ekne1Wg==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -637,6 +647,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button/-/uui-button-1.5.0.tgz",
 			"integrity": "sha512-ujicvfqUAN0JtBcgj8OG1YcyDaArTBdP5LvNsyYB8s0dePgcws71XzJ1mbHbXhuA386ioNue04yGDL+gSFlJ/A==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-icon-registry-essential": "1.5.0"
@@ -646,6 +657,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-group/-/uui-button-group-1.5.0.tgz",
 			"integrity": "sha512-8yhFdfg7p1B8MM2fIxIlc0Mmhnx46scdGhqeRhvaQ2/dcdpVTI1j1hI2JyOM18TUhJeot4olLqwatlXxlFFT+A==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -654,6 +666,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-inline-create/-/uui-button-inline-create-1.5.0.tgz",
 			"integrity": "sha512-J60vRf7nzQyRYKj+qYhMQR6LrQH6PyTrxyqyfDOVGzcWKzsTuRahxuVOIOzrs489cznwRYwL11jtK32MlrSjGQ==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -662,6 +675,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card/-/uui-card-1.5.0.tgz",
 			"integrity": "sha512-RgpnQca3rpjMG/3DAmmrExI7gmNNHBNYwfjRqgCd/3QkBwRrtT/+jdppVsGRxxW5xAN90sJ/eLP7i3F5EfWlSA==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -670,6 +684,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-content-node/-/uui-card-content-node-1.5.0.tgz",
 			"integrity": "sha512-aYGeTsppWT0KS9orrqkl9DF2v5l3gSGhBJZqIPiHVBOzczYIcgLWJbdAkaCgpwh1Zacbv3tnB/76965fd4EwPw==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-card": "1.5.0",
@@ -680,6 +695,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-media/-/uui-card-media-1.5.0.tgz",
 			"integrity": "sha512-0KktT0IExh06W7QP1FMNqU+tpUL1qDwWeeA19PbZPXwHg15hbSW15a+Hc4aiwqlHYHOPT2gxXoiVc7jqWlMcSQ==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-card": "1.5.0",
@@ -691,6 +707,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-user/-/uui-card-user-1.5.0.tgz",
 			"integrity": "sha512-xJjfkRHkt2xim1o+IvEPQiTpIQR+Z9+69096ssuGb3EkxyyUsDmH3aZZH6/+LKdtKR+7mPZVJub9TTWB4VRnwQ==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-avatar": "1.5.0",
 				"@umbraco-ui/uui-base": "1.5.0",
@@ -701,6 +718,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-caret/-/uui-caret-1.5.0.tgz",
 			"integrity": "sha512-4Apw4TMALEydo5o31gsIyICuPVyKvG/oySNup+5psU3apS0JDQ1RXCgGVDFoFxt5xzM+iJ6/J8ZOOILMVNFM6Q==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -709,6 +727,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-checkbox/-/uui-checkbox-1.5.0.tgz",
 			"integrity": "sha512-Kve+XAIkSFG9kowbZI1MpDEKihpMTtD9q36pcHiVENqxL1+Tydy60yjy3tHV8o6uamJ8qjR6ZlvLttRwLId9tQ==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-boolean-input": "1.5.0",
@@ -719,6 +738,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-area/-/uui-color-area-1.5.0.tgz",
 			"integrity": "sha512-FF6PrUCBo2nOg5iLbD+iB8aa3Vh+skIfqjFsPD80qLE0sKQ/53juZCnCbvvp7Z0YmIqwBlWP7xGEzJBGfS6OlA==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"colord": "^2.9.3"
@@ -728,6 +748,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-picker/-/uui-color-picker-1.5.0.tgz",
 			"integrity": "sha512-y/IwXhtaQJWNjwnZtYTvv47+bsmUYJzFLtXqxGckcUmyJQvoZ6DDxslTSv1B9J3QTXU0zpakqpxPszlNNHUygw==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"colord": "^2.9.3"
@@ -737,6 +758,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-slider/-/uui-color-slider-1.5.0.tgz",
 			"integrity": "sha512-nkUpUxfD7VlayBHirM56xKqi1h0Opg7Q2suzxEC4KLDVLO1+L0KzsDORn1tfeantSG0PahBMbuve1XOoOwCrAA==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -745,6 +767,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatch/-/uui-color-swatch-1.5.0.tgz",
 			"integrity": "sha512-UDqlGmJIMGyn7C23q33v8dkJoISmIAL0XZNTiPkEhwGjKRlxkbexmGd4L4vFt+nhJDRrN86JoZ64BRTHVN8V7A==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-icon-registry-essential": "1.5.0",
@@ -755,6 +778,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatches/-/uui-color-swatches-1.5.0.tgz",
 			"integrity": "sha512-SvTKINbckKvqkkS4XnQfpELkW2x47CUa4PsnXqioXNIWP5sBJb9Kydiu0N1+lV57fAkteqNp+YY8mFxn3a6iPA==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-color-swatch": "1.5.0"
@@ -764,6 +788,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox/-/uui-combobox-1.5.0.tgz",
 			"integrity": "sha512-SoK4+yR0dJViXZinZ7iqowl6tvWPTTPSOBVE7FfOqOAgFoccOE/nQqjeNjSM0co80OKXqHUsh+kX/HwLjdyNEA==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-button": "1.5.0",
@@ -776,6 +801,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox-list/-/uui-combobox-list-1.5.0.tgz",
 			"integrity": "sha512-5cVlhnst3p6eEHFqn6O8LMswx3wdwpzlfAghleQJW+ZUIVo7ZPXznZz7+6yvnVWxnI7+xxFebHgC0KFxGMUVvg==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -784,6 +810,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-css/-/uui-css-1.5.0.tgz",
 			"integrity": "sha512-jBSJg8KTWDG7DOVzz7A+UpMxMNHtddcLgt9k25vC4H+84xl+TN51RFTqF8C0JCZdWFK0eKWYlJsGqVrDfoVCcg==",
+			"dev": true,
 			"dependencies": {
 				"lit": "^2.2.2"
 			}
@@ -792,6 +819,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog/-/uui-dialog-1.5.0.tgz",
 			"integrity": "sha512-m6J5i+eiLdNApryIY1KW/4kyunAuTpkcWBjQmxyESmlDIqRGdW0lqaahQvcZSZHto03jleUdH5wYTLNgKIb/rw==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-css": "1.4.0"
@@ -801,6 +829,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog-layout/-/uui-dialog-layout-1.5.0.tgz",
 			"integrity": "sha512-vfZ3FMzYccGBVvSSXvCeoHYX+VU8QppXtFR2OGDZwU0b8BOKtfKTP/2VLPEWCG4vJYKPmqZESo3N9bZXWDkWSg==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -809,6 +838,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-css/-/uui-css-1.4.0.tgz",
 			"integrity": "sha512-HBCFPuXJijeZbjnjdqmg3oqOGB3RmpQKT/s/Uy0TSJfaQGfz0e73o2eRghYHWF2rdqHw6brKFrZTZHBVvCE/xA==",
+			"dev": true,
 			"dependencies": {
 				"lit": "^2.2.2"
 			}
@@ -817,6 +847,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-dropzone/-/uui-file-dropzone-1.5.0.tgz",
 			"integrity": "sha512-3rkTWidY4k2fyktRxfsMVTSvF+EIguv9p1Fga7v4DCNkplCp6OyJnwWby5F//+NvTHphaGchxZirOWMLgLyDog==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-symbol-file-dropzone": "1.5.0"
@@ -826,6 +857,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-preview/-/uui-file-preview-1.5.0.tgz",
 			"integrity": "sha512-Re+R8uZSD3t3jUgZvzG/DfQtihss7aw+rG41IAjmRO9wBZuUAsowfgCd2OJnuOYJXeaqOYYl+QQr7pmR2a/HNQ==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-symbol-file": "1.5.0",
@@ -837,6 +869,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form/-/uui-form-1.5.0.tgz",
 			"integrity": "sha512-rbXFZzAg93/fzvNkxHavUr62DnSeWuVghd9CK9lhe6A9ER9cfjOcGn/INTYK3HHPBalay9IOq+WV1xxC5H6zyg==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -845,6 +878,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-layout-item/-/uui-form-layout-item-1.5.0.tgz",
 			"integrity": "sha512-owla3DWo1deVUEG0JzC7pE70h6Ll6lmbR+B+utbMdEgM6shEMdokpPioeCaXb8v7On9Whz+zJGAGBAYl/oyjug==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-form-validation-message": "1.5.0"
@@ -854,6 +888,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-validation-message/-/uui-form-validation-message-1.5.0.tgz",
 			"integrity": "sha512-wuWCzttkUlEctqdJi9qzSzT8h10WvoK3+5usYB9V8NpdPYzOmbXU5RDYpoTWS0nPO56C6rlRlt3TH1khIQtPJA==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -862,6 +897,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon/-/uui-icon-1.5.0.tgz",
 			"integrity": "sha512-8Sz6PaYTC8KDCKj5ed+xnlnuh9/NOs0tQGPOma1bnVxGJN8LNjl+cJSLp+iU1m3Qq50H0TG+0K/dS3WUExjbZw==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -870,6 +906,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry/-/uui-icon-registry-1.5.0.tgz",
 			"integrity": "sha512-ei+HnaCKFjcCYjHYC0hqncY2vDfbgRkWhftOnrhqVZPJkE4omWDmVsLSGg/vm88ar1QleDmVj+CAa4J9T+uVeg==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-icon": "1.5.0"
@@ -879,6 +916,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry-essential/-/uui-icon-registry-essential-1.5.0.tgz",
 			"integrity": "sha512-nxNEQDI4SNBXnI2/Ov60vcdzKFyRCInwZDFNAKyt31F1yTNM0EM0ne5yV4AqM6YPOKVoWzqFcLz2rx64X+oLvQ==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-icon-registry": "1.5.0"
@@ -888,6 +926,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input/-/uui-input-1.5.0.tgz",
 			"integrity": "sha512-TlbSIRh2Z7xJxW0GEPENd369W1hHgr9Y8IIRE5RDllXzZc8yho4QXPJSDFQTiHMf41LIkOTfIkrQst5047FiXg==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -896,6 +935,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-file/-/uui-input-file-1.5.0.tgz",
 			"integrity": "sha512-8h/qGED5KE7sb/YE7dHapZxcWXGm0qCPJft8AGOu/ZK/WdOUV1WHynLjV4yGVZgY9PVZGc+GQTzvdgwxxpltQw==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-action-bar": "1.5.0",
 				"@umbraco-ui/uui-base": "1.5.0",
@@ -909,6 +949,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-lock/-/uui-input-lock-1.5.0.tgz",
 			"integrity": "sha512-KBhZLLD+5qyibbcp0AiJo7V4e/+GiKouGz/rCk6/3vxEKpe8CtWekcHhjrdlsHcOluQeBcb1Pdqng0wC9UTO5Q==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-button": "1.5.0",
@@ -920,6 +961,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-password/-/uui-input-password-1.5.0.tgz",
 			"integrity": "sha512-8wvQ/10jfufU0QWhK3gBVo5V/fzk4AuX8wPuieKZDY9Jnwkr7ugZ11DOJtaV3Az/4a0nrfF3TQ2gbBC7zHx2JA==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-icon-registry-essential": "1.5.0",
@@ -930,6 +972,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-keyboard-shortcut/-/uui-keyboard-shortcut-1.5.0.tgz",
 			"integrity": "sha512-KVTMHl6X0T4cUA3bUgM06xzwCN3VD5W3tZloF0i6e3PTHhkyCE5tKD/2Hizm56OGb+ifaI/oN3L1m7vEPC8IHw==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -938,6 +981,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-label/-/uui-label-1.5.0.tgz",
 			"integrity": "sha512-Sc6XuMEyivBEQDfMOA6JT7nW5H4/eD6dzUtUNabOwzCG5GUpvTMfRccpdjmzOvl9VCGNWtE9ikqCBZWexWA6YA==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -946,6 +990,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader/-/uui-loader-1.5.0.tgz",
 			"integrity": "sha512-lhl1KqRbM5NTp08fvxgzOsbHFz04z8/WjaOar6lqNnL0R+CcFtVWQrv69Opht9Sj1NdHESmHEVnX0yodod2LhQ==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -954,6 +999,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-bar/-/uui-loader-bar-1.5.0.tgz",
 			"integrity": "sha512-qUcVXi4i+ClozPc0Vfw7g90CLAQVj04F71xtatxDY5nhSWDEMEI6b/pXtN/B9TklkqfgE1mf/gRziFrpbVjLhA==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -962,6 +1008,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-circle/-/uui-loader-circle-1.5.0.tgz",
 			"integrity": "sha512-059/DJDYbgOmr/LPXbiDaTkBcInmzUUu/YDtQt/SkZPCO33uuB7TDc+++cMgFYskdXBpqesNvVfZOUd4P6zJyA==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -970,6 +1017,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-menu-item/-/uui-menu-item-1.5.0.tgz",
 			"integrity": "sha512-rmKuTz0Xgf0LyQRqs3tr2Z4O6oaNCd7UmI8kEbluk4yKpk5MU38BlFY9p39fpiEVUuzjcg9pBjrEyxrC/H9xjA==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-loader-bar": "1.5.0",
@@ -980,6 +1028,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-modal/-/uui-modal-1.5.0.tgz",
 			"integrity": "sha512-q9g4rA8OYCPlOmZMES/O17NiAu18wtMxNHMuT6dADP2tuULE+TKT6A8vqC7aq8JkWOTAXRAFvTjTmcvm6L2pvg==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -988,6 +1037,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-pagination/-/uui-pagination-1.5.0.tgz",
 			"integrity": "sha512-I3gCWbyLRFvi5fAlezQZarvj7FuEZ7NVZbbKJxqEhbo1bwOxDMXlDNxIIrxSg3R8YAuDNP9Pbdw+rnQwupuOMQ==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-button": "1.5.0",
@@ -998,6 +1048,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover/-/uui-popover-1.5.0.tgz",
 			"integrity": "sha512-Ab8UL4UGxTUn6hYbTqPrMtyGpQr3Xw1E/PVKG3+j+UrNw1Ro5piKgh0TahwxLnrsXWOPXfy53oaXNYsMGenndA==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -1006,6 +1057,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover-container/-/uui-popover-container-1.5.0.tgz",
 			"integrity": "sha512-issjf86TwvwLA6sJOs5pLRMFY+WBc4oeTZiJMz5mhZ5C5UoRmU65L6RP/0UnzZ4ZGY2Gpdh2YatNnZ7hVMg5ig==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -1014,6 +1066,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-progress-bar/-/uui-progress-bar-1.5.0.tgz",
 			"integrity": "sha512-B/v7VsBBwo19Y+4NBRllt7Ls+WLQfx6vY57rfO8MQG7zxGznxpTSIYvd3wxdRuDsFQeVwwoYjF1/YBJ7iWUnEQ==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -1022,6 +1075,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-radio/-/uui-radio-1.5.0.tgz",
 			"integrity": "sha512-3e52VZHcgHB/17eLTmiZwdm7ENgfX6AF4Dw+8H2x8jdRjyvt8lbykCq+6xewAZFsLAu7vTOEKtd2RhQFI2+hwg==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -1030,6 +1084,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-range-slider/-/uui-range-slider-1.5.0.tgz",
 			"integrity": "sha512-oHmIoF+KrHDWiOKonIWq7n94C6CzStBXrleS6iwCgWY++ayaHKCPlCuQIYp3BmGjnMQn8Ou0r2x/RuBPuraLVQ==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -1038,6 +1093,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref/-/uui-ref-1.5.0.tgz",
 			"integrity": "sha512-wba/OP6b/mG5kp4bUgBBcBAAy3RWTbokVyjb52FR7nyqNMnIE/UBdgi0XeBx4j6lZeEbr5k5ZOGQ1knEHbPWyQ==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -1046,6 +1102,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-list/-/uui-ref-list-1.5.0.tgz",
 			"integrity": "sha512-sxs3hC97zDuFaV8mvXLAbqqtWk0kqDdHY9ORt9CxacdT36nQS58Sw60/plCryqoyp7P2cUZVtlEeff53OKOTCQ==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -1054,6 +1111,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node/-/uui-ref-node-1.5.0.tgz",
 			"integrity": "sha512-bjmMgrIW+/4bmUXwMwFFaPrg2MeTxXssb6EpbBItJ+s0QhTEcTNyAD/DK3RlSMRE5VPO11sRwgCr06aIhklx0Q==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-icon": "1.5.0",
@@ -1064,6 +1122,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-data-type/-/uui-ref-node-data-type-1.5.0.tgz",
 			"integrity": "sha512-k14MI3cRELOmAwmtFeBzgCFw4+uin0JSqf85ZaqNkXSAmg+4I0ayUI6PGz+Jw66yGHvw3YNeUMKPmLO8l6M79A==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-ref-node": "1.5.0"
@@ -1073,6 +1132,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-document-type/-/uui-ref-node-document-type-1.5.0.tgz",
 			"integrity": "sha512-ouytDUaSls7Hsd0WaDy4wgfKMLpxlxx16WWyHlzX5lMyhkR+S3olyNZcgDRtz9xIQV+dVE3iDsUeQcNAigCdaw==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-ref-node": "1.5.0"
@@ -1082,6 +1142,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-form/-/uui-ref-node-form-1.5.0.tgz",
 			"integrity": "sha512-D86A1+ScVGTer2kci6Y9X4ZAhCnm4kxUi7bCFH7dn7oi/Fq8fhs3PBuA7mr1FrZgrPvXVdW+Qa7ldxxU58NIWA==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-ref-node": "1.5.0"
@@ -1091,6 +1152,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-member/-/uui-ref-node-member-1.5.0.tgz",
 			"integrity": "sha512-/UPmUNk6KP2unKnJKjr1qGkdPlFGTRj3K7H/mczCY7IbtzEccdEswWJCdUy/doIkAKbDdaqKe3/9HBoA3JtWPw==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-ref-node": "1.5.0"
@@ -1100,6 +1162,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-package/-/uui-ref-node-package-1.5.0.tgz",
 			"integrity": "sha512-XkET8XKb3XxmjlIDrmtwm9o0QsaG81bcpUBEBA/wUC0OcJNrjTKyv6ciAVDP7HaW6XpN8XwsRbqdcrYwM8lXDQ==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-ref-node": "1.5.0"
@@ -1109,6 +1172,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-user/-/uui-ref-node-user-1.5.0.tgz",
 			"integrity": "sha512-9TrIr1JWw3cIkWfQrdv9iLRIqm/dd10d6uZEWaGJ/MuxyCywqMg/LSApV/NLapB4HXhIG4pGCiXvUa8OVW99ew==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-ref-node": "1.5.0"
@@ -1118,6 +1182,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-scroll-container/-/uui-scroll-container-1.5.0.tgz",
 			"integrity": "sha512-Xj5jnmCEDyRENmWtuPI1QYEMzrmi/9/LaajkPEIZEYVu2owI940F0viS5X+X/FvKehSxoSt9ainCwkLphgzNiw==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -1126,6 +1191,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-select/-/uui-select-1.5.0.tgz",
 			"integrity": "sha512-lcMiIM6WxF5YraIXAqSpujx3OJzq6Snfik0BUypTWbUZdKVQTgLPh3A6We9PdD6K64AX2Zk4eH8yhQ+5GNImzQ==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -1134,6 +1200,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-slider/-/uui-slider-1.5.0.tgz",
 			"integrity": "sha512-Mp6xz7C7GbAuQ1Totd2WLzvS56ekx4l31mAvUvor0GqrUF/hHxwfrGZOAWoBqoTdKQAFKbZVSM782a+cwNv3hg==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -1142,6 +1209,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-expand/-/uui-symbol-expand-1.5.0.tgz",
 			"integrity": "sha512-ZCuGAJT2qFs4wQ6Z+g/qV3obv/SbriMnaIOGy6XTTAuMlh2+aNAwm33Je0wYKCTwHNUmnl427wTMEkQcMziD4g==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -1150,6 +1218,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file/-/uui-symbol-file-1.5.0.tgz",
 			"integrity": "sha512-ClB/lT/ebyUBmPqExB2ZinMOo/bCMEgjGxjkXy2THX4lOLUqvjDNEKLq99MAREKSh/mmGq7iB3Z/hd9/EDu75Q==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -1158,6 +1227,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-dropzone/-/uui-symbol-file-dropzone-1.5.0.tgz",
 			"integrity": "sha512-0YL88rFFI5SOzzORtm1VtMihN4if7r0CIRe5Q3Sv0WwHjrMfIM08DeONCgN2j+ZoKgnTvt9KpE1OGigshouRug==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -1166,6 +1236,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-thumbnail/-/uui-symbol-file-thumbnail-1.5.0.tgz",
 			"integrity": "sha512-/qkf6AdAIsRmUfsBdtFkFk5wPWw6JvSVHvgk/UvZulHHb2F8TamPSJfb6voh86Vq8DzVIcy3ZbqatxH7LZBY1g==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -1174,6 +1245,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-folder/-/uui-symbol-folder-1.5.0.tgz",
 			"integrity": "sha512-Sxt4n5IBT+XIqu2nJxP4RnhourwC+1X5bD40YgUBmqZJ9KV//tox4zo2elU19WCeRZFkklZGfn2smLY1FD0OGg==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -1182,6 +1254,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-lock/-/uui-symbol-lock-1.5.0.tgz",
 			"integrity": "sha512-EH7tEPCB+PTyjWbW+bdekk4M5hcjvYYpCKTnl3Pdpzh0mrxHPt9xa8908JB0tG8n0m0EcP+L7k8pthUmkgpK7A==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -1190,6 +1263,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-more/-/uui-symbol-more-1.5.0.tgz",
 			"integrity": "sha512-EuhU4kle4swMFZnsguWPz77rOtrk0IQcXuEA60fjzFGJCwsg7yyu9Ns209IEUsYh5ktstj8pXKT8+ZDila5umg==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -1198,6 +1272,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-sort/-/uui-symbol-sort-1.5.0.tgz",
 			"integrity": "sha512-/cifoZXuZbDmuZFPD0rr95Gpuy18DnboOYb/Ir6G3PANJ0fWOhzykHUrdx18ItLzhhwfE3dcZk4EWcGrEkfnfg==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -1206,6 +1281,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-table/-/uui-table-1.5.0.tgz",
 			"integrity": "sha512-tjhpEzBYCQdgieoXcIgcOjROrScF0Ifutz/6gmpcdrXYbgZ+YkWX7dSLAeQj3fzGebaPbNYzGOmGZA9/opZ1rg==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -1214,6 +1290,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tabs/-/uui-tabs-1.5.0.tgz",
 			"integrity": "sha512-0D5NLufis9Tzc5Vr+fl8Z0wABHyz1Tep76Qnx0nXyYzAZvdNq2IxThHbGqA1cb+FjVJSKdfp6ONfiPc/SIVAzA==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-button": "1.5.0",
@@ -1225,6 +1302,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tag/-/uui-tag-1.5.0.tgz",
 			"integrity": "sha512-OZGitHjdn4coj1x7F7zfeIx5M9NhGd8+CqpD915V9Qm8YlTQxFLq1M8tqjIxaYAB5EcHXuyzRpSUCrt/WUvipA==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -1233,6 +1311,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-textarea/-/uui-textarea-1.5.0.tgz",
 			"integrity": "sha512-+zDqbYKYfaiG0IXEaQatUaWsD4umtkTtbCMnqVPMhxwneVoE9d69ejat2zLFUI/ERm3nKMyq/NRfxzXJgzlDng==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -1241,6 +1320,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification/-/uui-toast-notification-1.5.0.tgz",
 			"integrity": "sha512-cFjz4/uZudR3yuSqK5gqzAio55ZOOxQAOc8bC5keS0HXL84JcDwrEP4/Nz7X/uUNUqauYZG/iBUirAvqfv7Osw==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-button": "1.5.0",
@@ -1253,6 +1333,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-container/-/uui-toast-notification-container-1.5.0.tgz",
 			"integrity": "sha512-AB4kwgocUeDwkxiCYNH0AOMEtExDS6sEq9sk2i8AGDAEjprAB3m0HM9AlrA+T0V1GtSuv+Q1DEuCyxnVbuK0WQ==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-toast-notification": "1.5.0"
@@ -1262,6 +1343,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-layout/-/uui-toast-notification-layout-1.5.0.tgz",
 			"integrity": "sha512-rM7cGCdMolhsndfZT9zGAPI9P3bl1lNpjDhWI124Mgx+KS8t2Q2h9O+7FGqFnjCTJOQES1pdQ+enl2NxCuEkNg==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-css": "1.4.0"
@@ -1271,6 +1353,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-css/-/uui-css-1.4.0.tgz",
 			"integrity": "sha512-HBCFPuXJijeZbjnjdqmg3oqOGB3RmpQKT/s/Uy0TSJfaQGfz0e73o2eRghYHWF2rdqHw6brKFrZTZHBVvCE/xA==",
+			"dev": true,
 			"dependencies": {
 				"lit": "^2.2.2"
 			}
@@ -1279,6 +1362,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-css/-/uui-css-1.4.0.tgz",
 			"integrity": "sha512-HBCFPuXJijeZbjnjdqmg3oqOGB3RmpQKT/s/Uy0TSJfaQGfz0e73o2eRghYHWF2rdqHw6brKFrZTZHBVvCE/xA==",
+			"dev": true,
 			"dependencies": {
 				"lit": "^2.2.2"
 			}
@@ -1287,6 +1371,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toggle/-/uui-toggle-1.5.0.tgz",
 			"integrity": "sha512-vsJSpBSmlrLzspCa1dGQGYXfc6RwTGTzSlNQdnzzP7qefVRP4GlOaqYV0TJhHMcYdbai+iEkrLznzJQvM9JFLA==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0",
 				"@umbraco-ui/uui-boolean-input": "1.5.0"
@@ -1296,6 +1381,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-visually-hidden/-/uui-visually-hidden-1.5.0.tgz",
 			"integrity": "sha512-3Imqxp8+hvirakPogqzvRlU+uhshpGRdrEMU7phCS5VGzDEl8NL1BhxR31EQAw7DspwbD5non3ZwbTwLYydfCg==",
+			"dev": true,
 			"dependencies": {
 				"@umbraco-ui/uui-base": "1.5.0"
 			}
@@ -1583,7 +1669,8 @@
 		"node_modules/colord": {
 			"version": "2.9.3",
 			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
-			"integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw=="
+			"integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+			"dev": true
 		},
 		"node_modules/cookie": {
 			"version": "0.4.2",

--- a/src/Umbraco.Web.UI.Login/package.json
+++ b/src/Umbraco.Web.UI.Login/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "login",
 	"private": true,
-	"type": "module",
 	"scripts": {
 		"dev": "vite",
 		"build": "tsc && vite build",
@@ -13,13 +12,13 @@
       "npm": ">=10.1"
     },
 	"dependencies": {
-		"@umbraco-ui/uui": "^1.5.0",
-		"@umbraco-ui/uui-css": "^1.5.0",
 		"lit": "^2.8.0",
 		"msw": "^1.3.2",
 		"rxjs": "^7.8.1"
 	},
 	"devDependencies": {
+    "@umbraco-ui/uui": "1.5.0",
+    "@umbraco-ui/uui-css": "1.5.0",
 		"typescript": "^5.2.2",
 		"vite": "^4.5.0"
 	},

--- a/src/Umbraco.Web.UI.Login/src/external.ts
+++ b/src/Umbraco.Web.UI.Login/src/external.ts
@@ -1,9 +1,0 @@
-/**
- * These are the public exports for the login UI.
- * They are used by the Umbraco backoffice mainly to show external login providers.
- */
-import '@umbraco-ui/uui-css/dist/uui-css.css';
-import '@umbraco-ui/uui';
-import './external/icon.registry.js';
-import './external/custom-view.element.js';
-import './external/localization/localize.element.js';

--- a/src/Umbraco.Web.UI.Login/src/index.ts
+++ b/src/Umbraco.Web.UI.Login/src/index.ts
@@ -15,5 +15,8 @@ import './components/external-login-provider.element.js';
 import './components/layouts/new-password-layout.element.js';
 import './components/layouts/confirmation-layout.element.js';
 import './components/layouts/error-layout.element.js';
-
 import './components/login-input.element.js';
+
+import './external/icon.registry.js';
+import './external/custom-view.element.js';
+import './external/localization/localize.element.js';

--- a/src/Umbraco.Web.UI.Login/vite.config.ts
+++ b/src/Umbraco.Web.UI.Login/vite.config.ts
@@ -4,14 +4,16 @@ import { defineConfig } from 'vite';
 export default defineConfig({
 	build: {
 		lib: {
-			entry: ['src/index.ts', 'src/external.ts'],
-			formats: ['es'],
+			entry: 'src/index.ts',
+      formats: ['iife'],
+      name: 'umblogin',
+      fileName: 'login'
 		},
     rollupOptions: {
+      external: [/^@umbraco/],
       output: {
-        manualChunks: {
-          'uui': ['@umbraco-ui/uui'],
-          'vendor': ['lit', 'rxjs'],
+        globals: {
+          '@umbraco-ui/uui': 'uui',
         },
       }
     },


### PR DESCRIPTION
### Description

Fixes #15397 

This PR fixes a regression where the UI library was no longer exported to `window.uui`, because we tried to use the es version of the library. However, since this is expected to be present inside the backoffice, we have reverted to the UMD version of the library.

This affects the login screen, which not only has its own Index.cshtml file, where it can load itself as it pleases, but also has to work inside the backoffice, where only CommonJS is supported. Therefore we will build the login assets in IIFE mode where we can replace imports from `@umbraco-ui/uui` dynamically with `window.uui` in the build process.
