### PR TITLE
Add `RemoveDefault()` extension method to fluent API for CMS webhook events

### DIFF
--- a/src/Umbraco.Core/Webhooks/WebhookEventCollectionBuilderCmsExtensions.cs
+++ b/src/Umbraco.Core/Webhooks/WebhookEventCollectionBuilderCmsExtensions.cs
@@ -32,6 +32,25 @@ public static class WebhookEventCollectionBuilderCmsExtensions
     }
 
     /// <summary>
+    /// Removes the default webhook events.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <returns>
+    /// The builder.
+    /// </returns>
+    public static WebhookEventCollectionBuilderCms RemoveDefault(this WebhookEventCollectionBuilderCms builder)
+    {
+        builder.Builder
+            .Remove<ContentDeletedWebhookEvent>()
+            .Remove<ContentPublishedWebhookEvent>()
+            .Remove<ContentUnpublishedWebhookEvent>()
+            .Remove<MediaDeletedWebhookEvent>()
+            .Remove<MediaSavedWebhookEvent>();
+
+        return builder;
+    }
+
+    /// <summary>
     /// Adds all available content (including blueprint and version) webhook events.
     /// </summary>
     /// <param name="builder">The builder.</param>

--- a/src/Umbraco.Core/Webhooks/WebhookEventCollectionBuilderCmsExtensions.cs
+++ b/src/Umbraco.Core/Webhooks/WebhookEventCollectionBuilderCmsExtensions.cs
@@ -9,6 +9,15 @@ namespace Umbraco.Cms.Core.DependencyInjection;
 /// </summary>
 public static class WebhookEventCollectionBuilderCmsExtensions
 {
+    private static readonly Type[] _defaultTypes =
+    [
+        typeof(ContentDeletedWebhookEvent),
+        typeof(ContentPublishedWebhookEvent),
+        typeof(ContentUnpublishedWebhookEvent),
+        typeof(MediaDeletedWebhookEvent),
+        typeof(MediaSavedWebhookEvent),
+    ];
+
     /// <summary>
     /// Adds the default webhook events.
     /// </summary>
@@ -21,12 +30,7 @@ public static class WebhookEventCollectionBuilderCmsExtensions
     /// </remarks>
     public static WebhookEventCollectionBuilderCms AddDefault(this WebhookEventCollectionBuilderCms builder)
     {
-        builder.Builder
-            .Add<ContentDeletedWebhookEvent>()
-            .Add<ContentPublishedWebhookEvent>()
-            .Add<ContentUnpublishedWebhookEvent>()
-            .Add<MediaDeletedWebhookEvent>()
-            .Add<MediaSavedWebhookEvent>();
+        builder.Builder.Add(_defaultTypes);
 
         return builder;
     }
@@ -40,12 +44,10 @@ public static class WebhookEventCollectionBuilderCmsExtensions
     /// </returns>
     public static WebhookEventCollectionBuilderCms RemoveDefault(this WebhookEventCollectionBuilderCms builder)
     {
-        builder.Builder
-            .Remove<ContentDeletedWebhookEvent>()
-            .Remove<ContentPublishedWebhookEvent>()
-            .Remove<ContentUnpublishedWebhookEvent>()
-            .Remove<MediaDeletedWebhookEvent>()
-            .Remove<MediaSavedWebhookEvent>();
+        foreach (Type type in _defaultTypes)
+        {
+            builder.Builder.Remove(type);
+        }
 
         return builder;
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
PR https://github.com/umbraco/Umbraco-CMS/pull/15345 added a fluent API for adding webhook events, but because the CMS adds a subset of events by default, you had to first clear all events to make sure you only end up with the configured ones. However, if other packages (like Deploy) also add events by default, those will also be cleared.

To address this, I've added a `RemoveDefault()` extension method, so the following example ensures all CMS default events are removed and only the content ones are added, without affecting other custom/non-CMS events:

```c#
using Umbraco.Cms.Core.Composing;

public class WebhookComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
        => builder.WebhookEvents()
            .AddCms(cmsBuilder => cmsBuilder.RemoveDefault().AddContent());
}
```