### PR TITLE
Add webhooks extension methods

### DIFF
--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
@@ -8,6 +8,7 @@ using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Sections;
 using Umbraco.Cms.Core.Webhooks;
+using static Umbraco.Cms.Core.DependencyInjection.WebhookEventCollectionBuilderExtensions;
 
 namespace Umbraco.Cms.Core.DependencyInjection;
 
@@ -193,6 +194,17 @@ public static partial class UmbracoBuilderExtensions
     }
 
     /// <summary>
+    /// Adds all available CMS webhook events.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <returns>The builder.</returns>
+    public static IUmbracoBuilder AddAllCmsWebhookEvents(this IUmbracoBuilder builder)
+    {
+        builder.WebhookEvents().AddCms();
+        return builder;
+    }
+
+    /// <summary>
     /// Add an IDynamicRootQueryStep to the DynamicRootQueryStepCollectionBuilder.
     /// </summary>
     /// <typeparam name="T"></typeparam>
@@ -201,6 +213,18 @@ public static partial class UmbracoBuilderExtensions
     public static IUmbracoBuilder AddDynamicRootStep<T>(this IUmbracoBuilder builder) where T : IDynamicRootQueryStep
     {
         builder.DynamicRootSteps().Append<T>();
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds CMS webhook events specified in the <paramref name="cmsBuilder" /> action.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="cmsBuilder">The CMS builder.</param>
+    /// <returns>The builder.</returns>
+    public static IUmbracoBuilder ConfigureCmsWebhookEvents(this IUmbracoBuilder builder, Action<WebhookEventCollectionBuilderCms> cmsBuilder)
+    {
+        builder.WebhookEvents().AddCms(cmsBuilder);
         return builder;
     }
 }

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
@@ -8,7 +8,6 @@ using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Sections;
 using Umbraco.Cms.Core.Webhooks;
-using static Umbraco.Cms.Core.DependencyInjection.WebhookEventCollectionBuilderExtensions;
 
 namespace Umbraco.Cms.Core.DependencyInjection;
 
@@ -222,7 +221,7 @@ public static partial class UmbracoBuilderExtensions
     /// <param name="builder">The builder.</param>
     /// <param name="cmsBuilder">The CMS builder.</param>
     /// <returns>The builder.</returns>
-    public static IUmbracoBuilder ConfigureCmsWebhookEvents(this IUmbracoBuilder builder, Action<WebhookEventCollectionBuilderCms> cmsBuilder)
+    public static IUmbracoBuilder ConfigureCmsWebhookEvents(this IUmbracoBuilder builder, Action<WebhookEventCollectionBuilderExtensions.WebhookEventCollectionBuilderCms> cmsBuilder)
     {
         builder.WebhookEvents().AddCms(cmsBuilder);
         return builder;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Add two `IUmbracoBuilder` extension methods to the `UmbracoBuilder.CollectionBuilders.cs` class. 

**AddAllCmsWebhookEvents**
This method allows for easy registration of all CMS WebhookEvents from the `Startup.cs`/`Program.cs` class. See the code example below:

```csharp
WebApplicationBuilder builder = WebApplication.CreateBuilder(args);

builder.CreateUmbracoBuilder()
    .AddBackOffice()
    .AddWebsite()
    .AddDeliveryApi()
    .AddComposers()
    .AddAllCmsWebhookEvents()
    .Build();

WebApplication app = builder.Build();
```

**ConfigureCmsWebhookEvents**
This method can be used to configure `WebhookEvents` in the `Startup.cs`/`Program.cs` class, for example:

```csharp
WebApplicationBuilder builder = WebApplication.CreateBuilder(args);

builder.CreateUmbracoBuilder()
    .AddBackOffice()
    .AddWebsite()
    .AddDeliveryApi()
    .AddComposers()
    .ConfigureCmsWebhookEvents(cmsBuilder => cmsBuilder.AddLanguage())
    .Build();

WebApplication app = builder.Build();
```

When https://github.com/umbraco/Umbraco-CMS/pull/15424 is merged the default events can be deleted like so: 

```csharp
builder.CreateUmbracoBuilder()
    .AddBackOffice()
    .AddWebsite()
    .AddDeliveryApi()
    .AddComposers()
    .ConfigureCmsWebhookEvents(cmsBuilder => cmsBuilder.RemoveDefault().AddLanguage())
    .Build();
```