### PR TITLE
V14/feature/apply usergroup to users

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/CreateUserGroupController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/CreateUserGroupController.cs
@@ -49,7 +49,7 @@ public class CreateUserGroupController : UserGroupControllerBase
 
         IUserGroup group = userGroupCreationAttempt.Result;
 
-        Attempt<IUserGroup, UserGroupOperationStatus> result = await _userGroupService.CreateAsync(group, CurrentUserKey(_backOfficeSecurityAccessor));
+        Attempt<IUserGroup, UserGroupOperationStatus> result = await _userGroupService.CreateAsync(group, CurrentUserKey(_backOfficeSecurityAccessor), createUserGroupRequestModel.GroupUsers);
         return result.Success
             ? CreatedAtAction<ByKeyUserGroupController>(controller => nameof(controller.ByKey), group.Key)
             : UserGroupOperationStatusResult(result.Status);

--- a/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/UpdateUserGroupController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/UpdateUserGroupController.cs
@@ -32,7 +32,7 @@ public class UpdateUserGroupController : UserGroupControllerBase
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> Update(Guid id, UpdateUserGroupRequestModel dataTypeRequestModel)
+    public async Task<IActionResult> Update(Guid id, UpdateUserGroupRequestModel updateUserGroupRequestModel)
     {
         IUserGroup? existingUserGroup = await _userGroupService.GetAsync(id);
 
@@ -41,14 +41,14 @@ public class UpdateUserGroupController : UserGroupControllerBase
             return UserGroupOperationStatusResult(UserGroupOperationStatus.NotFound);
         }
 
-        Attempt<IUserGroup, UserGroupOperationStatus> userGroupUpdateAttempt = await _userGroupPresentationFactory.UpdateAsync(existingUserGroup, dataTypeRequestModel);
+        Attempt<IUserGroup, UserGroupOperationStatus> userGroupUpdateAttempt = await _userGroupPresentationFactory.UpdateAsync(existingUserGroup, updateUserGroupRequestModel);
         if (userGroupUpdateAttempt.Success is false)
         {
             return UserGroupOperationStatusResult(userGroupUpdateAttempt.Status);
         }
 
         IUserGroup userGroup = userGroupUpdateAttempt.Result;
-        Attempt<IUserGroup, UserGroupOperationStatus> result = await _userGroupService.UpdateAsync(userGroup, CurrentUserKey(_backOfficeSecurityAccessor));
+        Attempt<IUserGroup, UserGroupOperationStatus> result = await _userGroupService.UpdateAsync(userGroup, CurrentUserKey(_backOfficeSecurityAccessor), updateUserGroupRequestModel.GroupUsers);
 
         return result.Success
             ? Ok()

--- a/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/UpdateUserGroupController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/UpdateUserGroupController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.UserGroup;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
@@ -41,14 +42,17 @@ public class UpdateUserGroupController : UserGroupControllerBase
             return UserGroupOperationStatusResult(UserGroupOperationStatus.NotFound);
         }
 
-        Attempt<IUserGroup, UserGroupOperationStatus> userGroupUpdateAttempt = await _userGroupPresentationFactory.UpdateAsync(existingUserGroup, updateUserGroupRequestModel);
+        Attempt<IUserGroup, UserGroupOperationStatus> userGroupUpdateAttempt =
+            await _userGroupPresentationFactory.UpdateAsync(existingUserGroup, updateUserGroupRequestModel);
         if (userGroupUpdateAttempt.Success is false)
         {
             return UserGroupOperationStatusResult(userGroupUpdateAttempt.Status);
         }
 
         IUserGroup userGroup = userGroupUpdateAttempt.Result;
-        Attempt<IUserGroup, UserGroupOperationStatus> result = await _userGroupService.UpdateAsync(userGroup, CurrentUserKey(_backOfficeSecurityAccessor), updateUserGroupRequestModel.GroupUsers);
+        Attempt<IUserGroup, UserGroupOperationStatus> result = await _userGroupService.UpdateAsync(
+                new UserGroupUpdateModel(userGroup, updateUserGroupRequestModel.GroupUsers),
+                CurrentUserKey(_backOfficeSecurityAccessor));
 
         return result.Success
             ? Ok()

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -1,3 +1,4 @@
+
 {
   "openapi": "3.0.1",
   "info": {
@@ -19450,7 +19451,7 @@
         "type": "object",
         "allOf": [
           {
-            "$ref": "#/components/schemas/UserGroupBaseModel"
+            "$ref": "#/components/schemas/UserGroupUpsertBaseModel"
           }
         ],
         "additionalProperties": false
@@ -23921,7 +23922,7 @@
         "type": "object",
         "allOf": [
           {
-            "$ref": "#/components/schemas/UserGroupBaseModel"
+            "$ref": "#/components/schemas/UserGroupUpsertBaseModel"
           }
         ],
         "additionalProperties": false
@@ -24080,6 +24081,25 @@
           },
           "isSystemGroup": {
             "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UserGroupUpsertBaseModel": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/UserGroupBaseModel"
+          }
+        ],
+        "properties": {
+          "groupUsers": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "nullable": true
           }
         },
         "additionalProperties": false

--- a/src/Umbraco.Cms.Api.Management/ViewModels/UserGroup/CreateUserGroupRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/UserGroup/CreateUserGroupRequestModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace Umbraco.Cms.Api.Management.ViewModels.UserGroup;
 
-public class CreateUserGroupRequestModel : UserGroupBase
+public class CreateUserGroupRequestModel : UserGroupUpsertBase
 {
 
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/UserGroup/UpdateUserGroupRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/UserGroup/UpdateUserGroupRequestModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace Umbraco.Cms.Api.Management.ViewModels.UserGroup;
 
-public class UpdateUserGroupRequestModel : UserGroupBase
+public class UpdateUserGroupRequestModel : UserGroupUpsertBase
 {
 
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/UserGroup/UserGroupUpsertBase.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/UserGroup/UserGroupUpsertBase.cs
@@ -1,0 +1,9 @@
+namespace Umbraco.Cms.Api.Management.ViewModels.UserGroup;
+
+public class UserGroupUpsertBase : UserGroupBase
+{
+    /// <summary>
+    /// The list of users that should be part of this UserGroup after the operation has concluded
+    /// </summary>
+    public Guid[]? GroupUsers { get; init; }
+}

--- a/src/Umbraco.Core/Models/UserGroupUpdateModel.cs
+++ b/src/Umbraco.Core/Models/UserGroupUpdateModel.cs
@@ -1,0 +1,22 @@
+using Umbraco.Cms.Core.Models.Membership;
+
+namespace Umbraco.Cms.Core.Models;
+
+public class UserGroupUpdateModel
+{
+    /// <summary>
+    /// the usergroup to update
+    /// </summary>
+    public IUserGroup UserGroup { get; init; }
+
+    /// <summary>
+    /// the list of users to explicitly assign to the group
+    /// </summary>
+    public Guid[]? GroupUserKeys { get; init; }
+
+    public UserGroupUpdateModel(IUserGroup userGroup, Guid[]? groupUserKeys)
+    {
+        UserGroup = userGroup;
+        GroupUserKeys = groupUserKeys;
+    }
+}

--- a/src/Umbraco.Core/Services/IUserGroupService.cs
+++ b/src/Umbraco.Core/Services/IUserGroupService.cs
@@ -77,7 +77,8 @@ public interface IUserGroupService
     /// <param name="userGroup">The user group to update.</param>
     /// <param name="userKey">The ID of the user responsible for updating the group.</param>
     /// <returns>An attempt indicating if the operation was a success as well as a more detailed <see cref="UserGroupOperationStatus"/>.</returns>
-    Task<Attempt<IUserGroup, UserGroupOperationStatus>> UpdateAsync(IUserGroup userGroup, Guid userKey);
+    /// <param name="groupUserKeys">The exact list of users that should be part of this group. If null, no changes will be made to the assignments.</param>
+    Task<Attempt<IUserGroup, UserGroupOperationStatus>> UpdateAsync(IUserGroup userGroup, Guid userKey, Guid[]? groupUserKeys);
 
     /// <summary>
     ///     Deletes a UserGroup

--- a/src/Umbraco.Core/Services/IUserGroupService.cs
+++ b/src/Umbraco.Core/Services/IUserGroupService.cs
@@ -77,8 +77,7 @@ public interface IUserGroupService
     /// <param name="userGroup">The user group to update.</param>
     /// <param name="userKey">The ID of the user responsible for updating the group.</param>
     /// <returns>An attempt indicating if the operation was a success as well as a more detailed <see cref="UserGroupOperationStatus"/>.</returns>
-    /// <param name="groupUserKeys">The exact list of users that should be part of this group. If null, no changes will be made to the assignments.</param>
-    Task<Attempt<IUserGroup, UserGroupOperationStatus>> UpdateAsync(IUserGroup userGroup, Guid userKey, Guid[]? groupUserKeys = null);
+    Task<Attempt<IUserGroup, UserGroupOperationStatus>> UpdateAsync(IUserGroup userGroup, Guid userKey);
 
     /// <summary>
     ///     Deletes a UserGroup
@@ -96,4 +95,14 @@ public interface IUserGroupService
     /// <param name="userKeys">The user whose groups we want to alter.</param>
     /// <returns>An attempt indicating if the operation was a success as well as a more detailed <see cref="UserGroupOperationStatus"/>.</returns>
     Task UpdateUserGroupsOnUsers(ISet<Guid> userGroupKeys, ISet<Guid> userKeys);
+
+    /// <summary>
+    /// Updates the UserGroup and assigns the explicit list of users as its members
+    /// </summary>
+    /// <param name="updateModel">the update model</param>
+    /// <param name="userKey">the user performing the action</param>
+    /// <returns></returns>
+    Task<Attempt<IUserGroup, UserGroupOperationStatus>> UpdateAsync(
+        UserGroupUpdateModel updateModel,
+        Guid userKey);
 }

--- a/src/Umbraco.Core/Services/IUserGroupService.cs
+++ b/src/Umbraco.Core/Services/IUserGroupService.cs
@@ -78,7 +78,7 @@ public interface IUserGroupService
     /// <param name="userKey">The ID of the user responsible for updating the group.</param>
     /// <returns>An attempt indicating if the operation was a success as well as a more detailed <see cref="UserGroupOperationStatus"/>.</returns>
     /// <param name="groupUserKeys">The exact list of users that should be part of this group. If null, no changes will be made to the assignments.</param>
-    Task<Attempt<IUserGroup, UserGroupOperationStatus>> UpdateAsync(IUserGroup userGroup, Guid userKey, Guid[]? groupUserKeys);
+    Task<Attempt<IUserGroup, UserGroupOperationStatus>> UpdateAsync(IUserGroup userGroup, Guid userKey, Guid[]? groupUserKeys = null);
 
     /// <summary>
     ///     Deletes a UserGroup

--- a/src/Umbraco.Core/Services/UserGroupService.cs
+++ b/src/Umbraco.Core/Services/UserGroupService.cs
@@ -309,6 +309,7 @@ internal sealed class UserGroupService : RepositoryService, IUserGroupService
         if (performUpdateResult != null)
         {
             // something went wrong, return the attempt
+            scope.Complete();
             return performUpdateResult.Value;
         }
 
@@ -334,6 +335,7 @@ internal sealed class UserGroupService : RepositoryService, IUserGroupService
         if (performUpdateResult != null)
         {
             // something went wrong, return the attempt
+            scope.Complete();
             return performUpdateResult.Value;
         }
 
@@ -376,7 +378,6 @@ internal sealed class UserGroupService : RepositoryService, IUserGroupService
         var savingNotification = new UserGroupSavingNotification(userGroup, eventMessages);
         if (await scope.Notifications.PublishCancelableAsync(savingNotification))
         {
-            scope.Complete();
             return Attempt.FailWithStatus(UserGroupOperationStatus.CancelledByNotification, userGroup);
         }
 

--- a/src/Umbraco.Core/Services/UserGroupService.cs
+++ b/src/Umbraco.Core/Services/UserGroupService.cs
@@ -301,7 +301,7 @@ internal sealed class UserGroupService : RepositoryService, IUserGroupService
     public async Task<Attempt<IUserGroup, UserGroupOperationStatus>> UpdateAsync(
         IUserGroup userGroup,
         Guid userKey,
-        Guid[]? groupUserKeys)
+        Guid[]? groupUserKeys = null)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope();
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserGroupService/UserGroupServiceCreateTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserGroupService/UserGroupServiceCreateTests.cs
@@ -1,0 +1,89 @@
+﻿using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Services.UserGroupService;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+public class UserGroupServiceCreateTests : UmbracoIntegrationTest
+{
+    private IUserGroupService UserGroupService => GetRequiredService<IUserGroupService>();
+
+    private IUserService UserService => GetRequiredService<IUserService>();
+
+    [Test]
+    public async Task Create_UserGroup_With_Users_Adds_Group_To_User_UserGroups()
+    {
+
+        var editorGroupAlias = "editor";
+        var testGroupAlias = "testGroup";
+
+        // get the editor group
+        var editorUserGroup = await UserGroupService.GetAsync(editorGroupAlias);
+        var newUserGroupKeys = new HashSet<Guid>() { editorUserGroup!.Key };
+
+        // create 3 new users
+        var create1Result = await UserService.CreateAsync(
+            Constants.Security.SuperUserKey,
+            new UserCreateModel
+            {
+                Email = "user1@test.test",
+                Name = "user1@test.test",
+                UserGroupKeys = newUserGroupKeys,
+                UserName = "user1@test.test",
+            },
+            approveUser: true);
+
+        var create2Result = await UserService.CreateAsync(
+            Constants.Security.SuperUserKey,
+            new UserCreateModel
+            {
+                Email = "user2@test.test",
+                Name = "user2@test.test",
+                UserGroupKeys = newUserGroupKeys,
+                UserName = "user2@test.test",
+            },
+            approveUser: true);
+
+        var create3Result = await UserService.CreateAsync(
+            Constants.Security.SuperUserKey,
+            new UserCreateModel
+            {
+                Email = "user3@test.test",
+                Name = "user3@test.test",
+                UserGroupKeys = newUserGroupKeys,
+                UserName = "user3@test.test",
+            },
+            approveUser: true);
+
+        // create a new group with first member
+        await UserGroupService.CreateAsync(
+            new UserGroup(ShortStringHelper) { Name = "Test Group", Alias = testGroupAlias },
+            Constants.Security.SuperUserKey,
+            new[] { create1Result.Result.CreatedUser!.Key });
+
+        // check only the first member is added to the usergroup and retains its other groups
+        var user1 = await UserService.GetAsync(create1Result.Result.CreatedUser.Key);
+        var user2 = await UserService.GetAsync(create2Result.Result.CreatedUser!.Key);
+        var user3 = await UserService.GetAsync(create3Result.Result.CreatedUser!.Key);
+
+        Assert.AreEqual(user1!.Groups.Count(), 2);
+        Assert.AreEqual(user2!.Groups.Count(), 1);
+        Assert.AreEqual(user3!.Groups.Count(), 1);
+
+        Assert.IsTrue(user1.Groups.Count(g =>
+            g.Alias.Equals(editorGroupAlias, StringComparison.InvariantCultureIgnoreCase)) == 1);
+        Assert.IsTrue(user2.Groups.Count(g =>
+            g.Alias.Equals(editorGroupAlias, StringComparison.InvariantCultureIgnoreCase)) == 1);
+        Assert.IsTrue(user3.Groups.Count(g =>
+            g.Alias.Equals(editorGroupAlias, StringComparison.InvariantCultureIgnoreCase)) == 1);
+
+        Assert.IsTrue(
+            user1.Groups.Count(g => g.Alias.Equals(testGroupAlias, StringComparison.InvariantCultureIgnoreCase)) == 1);
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserGroupService/UserGroupServiceEditTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserGroupService/UserGroupServiceEditTests.cs
@@ -1,0 +1,203 @@
+﻿using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Services.UserGroupService;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+public class UserGroupServiceEditTests : UmbracoIntegrationTest
+{
+    private IUserGroupService UserGroupService => GetRequiredService<IUserGroupService>();
+
+    private IUserService UserService => GetRequiredService<IUserService>();
+
+    [Test]
+    public async Task Edit_UserGroup_WithUsers_AddsGroup_To_UserUserGroups_Removes_FromOthers()
+    {
+        var editorGroupAlias = "editor";
+        var testGroupAlias = "testGroup";
+
+        // get the editor group
+        var editorUserGroup = await UserGroupService.GetAsync(editorGroupAlias);
+        var newUserGroupKeys = new HashSet<Guid>() { editorUserGroup!.Key };
+
+        // create 3 new users
+        var create1Result = await CreateTestMember(newUserGroupKeys, "user1@test.test");
+        var create2Result = await CreateTestMember(newUserGroupKeys, "user2@test.test");
+        var create3Result = await CreateTestMember(newUserGroupKeys, "user3@test.test");
+
+        // create a new group with first user
+        var userGroupCreateResult = await UserGroupService.CreateAsync(
+            new UserGroup(ShortStringHelper) { Name = "Test Group", Alias = testGroupAlias },
+            Constants.Security.SuperUserKey,
+            new[] { create1Result.Result.CreatedUser!.Key });
+
+        // Add the group to the second user
+        var user2ToEdit = await UserService.GetAsync(create2Result.Result.CreatedUser!.Key);
+        user2ToEdit!.AddGroup(userGroupCreateResult.Result.ToReadOnlyGroup());
+        UserService.Save(user2ToEdit);
+
+        // update the userGroup and set the assigned users to user3
+        userGroupCreateResult.Result.Name = "Updated Test Group";
+        await UserGroupService.UpdateAsync(
+            userGroupCreateResult.Result,
+            Constants.Security.SuperUserKey,
+            new[] { create3Result.Result.CreatedUser!.Key });
+
+        // check only the first member is added to the userGroup and retains its other groups
+        var user1 = await UserService.GetAsync(create1Result.Result.CreatedUser.Key);
+        var user2 = await UserService.GetAsync(create2Result.Result.CreatedUser.Key);
+        var user3 = await UserService.GetAsync(create3Result.Result.CreatedUser!.Key);
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(1, user1!.Groups.Count());
+            Assert.AreEqual(1, user2!.Groups.Count());
+            Assert.AreEqual(2, user3!.Groups.Count());
+
+            Assert.IsTrue(user1.Groups.Count(g =>
+                g.Alias.Equals(editorGroupAlias, StringComparison.InvariantCultureIgnoreCase)) == 1);
+            Assert.IsTrue(user2.Groups.Count(g =>
+                g.Alias.Equals(editorGroupAlias, StringComparison.InvariantCultureIgnoreCase)) == 1);
+            Assert.IsTrue(user3.Groups.Count(g =>
+                g.Alias.Equals(editorGroupAlias, StringComparison.InvariantCultureIgnoreCase)) == 1);
+
+            Assert.IsTrue(
+                user3.Groups.Count(g => g.Alias.Equals(testGroupAlias, StringComparison.InvariantCultureIgnoreCase)) ==
+                1);
+        });
+    }
+
+    [Test]
+    public async Task Edit_UserGroup_With_EmptyUsers_Removes_FromAll()
+    {
+        var editorGroupAlias = "editor";
+        var testGroupAlias = "testGroup";
+
+        // get the editor group
+        var editorUserGroup = await UserGroupService.GetAsync(editorGroupAlias);
+        var newUserGroupKeys = new HashSet<Guid>() { editorUserGroup!.Key };
+
+        // create 3 new users
+        var create1Result = await CreateTestMember(newUserGroupKeys, "user1@test.test");
+        var create2Result = await CreateTestMember(newUserGroupKeys, "user2@test.test");
+        var create3Result = await CreateTestMember(newUserGroupKeys, "user3@test.test");
+
+        // create a new group with first user
+        var userGroupCreateResult = await UserGroupService.CreateAsync(
+            new UserGroup(ShortStringHelper) { Name = "Test Group", Alias = testGroupAlias },
+            Constants.Security.SuperUserKey,
+            new[] { create1Result.Result.CreatedUser!.Key });
+
+        // Add the group to the second user
+        var user2ToEdit = await UserService.GetAsync(create2Result.Result.CreatedUser!.Key);
+        user2ToEdit!.AddGroup(userGroupCreateResult.Result.ToReadOnlyGroup());
+        UserService.Save(user2ToEdit);
+
+        // update the userGroup and clear the assignment list
+        userGroupCreateResult.Result.Name = "Updated Test Group";
+        await UserGroupService.UpdateAsync(
+            userGroupCreateResult.Result,
+            Constants.Security.SuperUserKey,
+            Array.Empty<Guid>());
+
+        // check no user has the group assigned
+        var user1 = await UserService.GetAsync(create1Result.Result.CreatedUser.Key);
+        var user2 = await UserService.GetAsync(create2Result.Result.CreatedUser.Key);
+        var user3 = await UserService.GetAsync(create3Result.Result.CreatedUser!.Key);
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(1, user1!.Groups.Count());
+            Assert.AreEqual(1, user2!.Groups.Count());
+            Assert.AreEqual(1, user3!.Groups.Count());
+
+            Assert.IsTrue(user1.Groups.Count(g =>
+                g.Alias.Equals(editorGroupAlias, StringComparison.InvariantCultureIgnoreCase)) == 1);
+            Assert.IsTrue(user2.Groups.Count(g =>
+                g.Alias.Equals(editorGroupAlias, StringComparison.InvariantCultureIgnoreCase)) == 1);
+            Assert.IsTrue(user3.Groups.Count(g =>
+                g.Alias.Equals(editorGroupAlias, StringComparison.InvariantCultureIgnoreCase)) == 1);
+        });
+    }
+
+    [Test]
+    public async Task Edit_UserGroup_With_NullUsers_DoesNotAlter_GroupsOnUsers()
+    {
+        var editorGroupAlias = "editor";
+        var testGroupAlias = "testGroup";
+
+        // get the editor group
+        var editorUserGroup = await UserGroupService.GetAsync(editorGroupAlias);
+        var newUserGroupKeys = new HashSet<Guid>() { editorUserGroup!.Key };
+
+        // create 3 new users
+        var create1Result = await CreateTestMember(newUserGroupKeys, "user1@test.test");
+        var create2Result = await CreateTestMember(newUserGroupKeys, "user2@test.test");
+        var create3Result = await CreateTestMember(newUserGroupKeys, "user3@test.test");
+
+        // create a new group with first user
+        var userGroupCreateResult = await UserGroupService.CreateAsync(
+            new UserGroup(ShortStringHelper) { Name = "Test Group", Alias = testGroupAlias },
+            Constants.Security.SuperUserKey,
+            new[] { create1Result.Result.CreatedUser!.Key });
+
+        // Add the group to the second
+        var user2ToEdit = await UserService.GetAsync(create2Result.Result.CreatedUser!.Key);
+        user2ToEdit!.AddGroup(userGroupCreateResult.Result.ToReadOnlyGroup());
+        UserService.Save(user2ToEdit);
+
+        // update the userGroup without supplying a new list of users
+        userGroupCreateResult.Result.Name = "Updated Test Group";
+        await UserGroupService.UpdateAsync(
+            userGroupCreateResult.Result,
+            Constants.Security.SuperUserKey);
+
+        // check no usergroup changes occured
+        var user1 = await UserService.GetAsync(create1Result.Result.CreatedUser.Key);
+        var user2 = await UserService.GetAsync(create2Result.Result.CreatedUser.Key);
+        var user3 = await UserService.GetAsync(create3Result.Result.CreatedUser!.Key);
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(2, user1!.Groups.Count());
+            Assert.AreEqual(2, user2!.Groups.Count());
+            Assert.AreEqual(1, user3!.Groups.Count());
+
+            Assert.IsTrue(user1.Groups.Count(g =>
+                g.Alias.Equals(editorGroupAlias, StringComparison.InvariantCultureIgnoreCase)) == 1);
+            Assert.IsTrue(user2.Groups.Count(g =>
+                g.Alias.Equals(editorGroupAlias, StringComparison.InvariantCultureIgnoreCase)) == 1);
+            Assert.IsTrue(user3.Groups.Count(g =>
+                g.Alias.Equals(editorGroupAlias, StringComparison.InvariantCultureIgnoreCase)) == 1);
+
+            Assert.IsTrue(
+                user1.Groups.Count(g => g.Alias.Equals(testGroupAlias, StringComparison.InvariantCultureIgnoreCase)) ==
+                1);
+            Assert.IsTrue(
+                user2.Groups.Count(g => g.Alias.Equals(testGroupAlias, StringComparison.InvariantCultureIgnoreCase)) ==
+                1);
+        });
+    }
+
+    private async Task<Attempt<UserCreationResult, UserOperationStatus>> CreateTestMember(HashSet<Guid> initialGroups,
+        string emailNameUserName)
+    {
+        return await UserService.CreateAsync(
+            Constants.Security.SuperUserKey,
+            new UserCreateModel
+            {
+                Email = emailNameUserName,
+                Name = emailNameUserName,
+                UserGroupKeys = initialGroups,
+                UserName = emailNameUserName,
+            },
+            approveUser: true);
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserGroupService/UserGroupServiceEditTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserGroupService/UserGroupServiceEditTests.cs
@@ -46,9 +46,10 @@ public class UserGroupServiceEditTests : UmbracoIntegrationTest
         // update the userGroup and set the assigned users to user3
         userGroupCreateResult.Result.Name = "Updated Test Group";
         await UserGroupService.UpdateAsync(
+            new UserGroupUpdateModel(
             userGroupCreateResult.Result,
-            Constants.Security.SuperUserKey,
-            new[] { create3Result.Result.CreatedUser!.Key });
+            new[] { create3Result.Result.CreatedUser!.Key }),
+            Constants.Security.SuperUserKey);
 
         // check only the first member is added to the userGroup and retains its other groups
         var user1 = await UserService.GetAsync(create1Result.Result.CreatedUser.Key);
@@ -103,9 +104,10 @@ public class UserGroupServiceEditTests : UmbracoIntegrationTest
         // update the userGroup and clear the assignment list
         userGroupCreateResult.Result.Name = "Updated Test Group";
         await UserGroupService.UpdateAsync(
-            userGroupCreateResult.Result,
-            Constants.Security.SuperUserKey,
-            Array.Empty<Guid>());
+            new UserGroupUpdateModel(
+                userGroupCreateResult.Result,
+                Array.Empty<Guid>()),
+            Constants.Security.SuperUserKey);
 
         // check no user has the group assigned
         var user1 = await UserService.GetAsync(create1Result.Result.CreatedUser.Key);
@@ -124,6 +126,67 @@ public class UserGroupServiceEditTests : UmbracoIntegrationTest
                 g.Alias.Equals(editorGroupAlias, StringComparison.InvariantCultureIgnoreCase)) == 1);
             Assert.IsTrue(user3.Groups.Count(g =>
                 g.Alias.Equals(editorGroupAlias, StringComparison.InvariantCultureIgnoreCase)) == 1);
+        });
+    }
+
+    [Test]
+    public async Task Edit_UserGroup_With_NullUsers_DoesNotAlter_GroupsOnUsers_WithoutModel()
+    {
+        var editorGroupAlias = "editor";
+        var testGroupAlias = "testGroup";
+
+        // get the editor group
+        var editorUserGroup = await UserGroupService.GetAsync(editorGroupAlias);
+        var newUserGroupKeys = new HashSet<Guid>() { editorUserGroup!.Key };
+
+        // create 3 new users
+        var create1Result = await CreateTestMember(newUserGroupKeys, "user1@test.test");
+        var create2Result = await CreateTestMember(newUserGroupKeys, "user2@test.test");
+        var create3Result = await CreateTestMember(newUserGroupKeys, "user3@test.test");
+
+        // create a new group with first user
+        var userGroupCreateResult = await UserGroupService.CreateAsync(
+            new UserGroup(ShortStringHelper) { Name = "Test Group", Alias = testGroupAlias },
+            Constants.Security.SuperUserKey,
+            new[] { create1Result.Result.CreatedUser!.Key });
+
+        // Add the group to the second
+        var user2ToEdit = await UserService.GetAsync(create2Result.Result.CreatedUser!.Key);
+        user2ToEdit!.AddGroup(userGroupCreateResult.Result.ToReadOnlyGroup());
+        UserService.Save(user2ToEdit);
+
+        // update the userGroup without supplying a new list of users
+        userGroupCreateResult.Result.Name = "Updated Test Group";
+        await UserGroupService.UpdateAsync(
+            new UserGroupUpdateModel(
+                userGroupCreateResult.Result,
+                null),
+            Constants.Security.SuperUserKey);
+
+        // check no usergroup changes occured
+        var user1 = await UserService.GetAsync(create1Result.Result.CreatedUser.Key);
+        var user2 = await UserService.GetAsync(create2Result.Result.CreatedUser.Key);
+        var user3 = await UserService.GetAsync(create3Result.Result.CreatedUser!.Key);
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(2, user1!.Groups.Count());
+            Assert.AreEqual(2, user2!.Groups.Count());
+            Assert.AreEqual(1, user3!.Groups.Count());
+
+            Assert.IsTrue(user1.Groups.Count(g =>
+                g.Alias.Equals(editorGroupAlias, StringComparison.InvariantCultureIgnoreCase)) == 1);
+            Assert.IsTrue(user2.Groups.Count(g =>
+                g.Alias.Equals(editorGroupAlias, StringComparison.InvariantCultureIgnoreCase)) == 1);
+            Assert.IsTrue(user3.Groups.Count(g =>
+                g.Alias.Equals(editorGroupAlias, StringComparison.InvariantCultureIgnoreCase)) == 1);
+
+            Assert.IsTrue(
+                user1.Groups.Count(g => g.Alias.Equals(testGroupAlias, StringComparison.InvariantCultureIgnoreCase)) ==
+                1);
+            Assert.IsTrue(
+                user2.Groups.Count(g => g.Alias.Equals(testGroupAlias, StringComparison.InvariantCultureIgnoreCase)) ==
+                1);
         });
     }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserGroupService/UserGroupServiceValidationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserGroupService/UserGroupServiceValidationTests.cs
@@ -7,15 +7,13 @@ using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
 
-namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Services;
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Services.UserGroupService;
 
 [TestFixture]
 [UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
 public class UserGroupServiceValidationTests : UmbracoIntegrationTest
 {
     private IUserGroupService UserGroupService => GetRequiredService<IUserGroupService>();
-
-    private IShortStringHelper ShortStringHelper => GetRequiredService<IShortStringHelper>();
 
     [Test]
     public async Task Cannot_create_user_group_with_name_equals_null()


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below
- [x] I have added integration tests to new service layer functionality
- [ ] [n/a] I have added unit tests to new isolated code
- [x] I have listed breaking changes if any

### Description
Added a way to assign users to usergroups when creating or updating a usergroup. This way you do not need to fetch all the users who have the group, remove them and resave the users.

### Breaking changes
None, all changes to signatures were done on new v14 services/models/controllers

### Testing
Create new users/groups trough the management api and verify whether the assignments get updated accordingly. Check the integration tests for possible scenarios

