### PR TITLE
V10: Loosen permissions

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/LanguageController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/LanguageController.cs
@@ -18,7 +18,6 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers;
 ///     Backoffice controller supporting the dashboard for language administration.
 /// </summary>
 [PluginController(Constants.Web.Mvc.BackOfficeApiArea)]
-[Authorize(Policy = AuthorizationPolicies.SectionAccessSettings)]
 public class LanguageController : UmbracoAuthorizedJsonController
 {
     private readonly ILocalizationService _localizationService;
@@ -43,6 +42,7 @@ public class LanguageController : UmbracoAuthorizedJsonController
     /// </summary>
     /// <returns></returns>
     [HttpGet]
+    [Authorize(Policy = AuthorizationPolicies.TreeAccessLanguages)]
     public IDictionary<string, string> GetAllCultures()
         => CultureInfo.GetCultures(CultureTypes.AllCultures).DistinctBy(x => x.Name).OrderBy(x => x.EnglishName)
             .ToDictionary(x => x.Name, x => x.EnglishName);
@@ -52,6 +52,7 @@ public class LanguageController : UmbracoAuthorizedJsonController
     /// </summary>
     /// <returns></returns>
     [HttpGet]
+    [Authorize(Policy = AuthorizationPolicies.SectionAccessContent)]
     public IEnumerable<Language>? GetAllLanguages()
     {
         IEnumerable<ILanguage> allLanguages = _localizationService.GetAllLanguages();
@@ -60,6 +61,7 @@ public class LanguageController : UmbracoAuthorizedJsonController
     }
 
     [HttpGet]
+    [Authorize(Policy = AuthorizationPolicies.TreeAccessLanguages)]
     public ActionResult<Language?> GetLanguage(int id)
     {
         ILanguage? lang = _localizationService.GetLanguageById(id);

--- a/src/Umbraco.Web.BackOffice/Controllers/StylesheetController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/StylesheetController.cs
@@ -14,6 +14,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers;
 ///     The API controller used for retrieving available stylesheets
 /// </summary>
 [PluginController(Constants.Web.Mvc.BackOfficeApiArea)]
+// This is a bit wierd, but if you have access to the content section, you can load a rich text editor, and thus need to get the rules.
 [Authorize(Policy = AuthorizationPolicies.SectionAccessContent)]
 public class StylesheetController : UmbracoAuthorizedJsonController
 {

--- a/src/Umbraco.Web.BackOffice/Controllers/StylesheetController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/StylesheetController.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers;
 ///     The API controller used for retrieving available stylesheets
 /// </summary>
 [PluginController(Constants.Web.Mvc.BackOfficeApiArea)]
-[Authorize(Policy = AuthorizationPolicies.SectionAccessSettings)]
+[Authorize(Policy = AuthorizationPolicies.SectionAccessContent)]
 public class StylesheetController : UmbracoAuthorizedJsonController
 {
     private readonly IFileService _fileService;


### PR DESCRIPTION
In a security fix we did, we tightened some of our endpoints, a little too tightly. 
This resulted in editors not being able to load rich text editors if it had stylesheets.
And not being able to load multilingual contents

# How to test
- Add a richtext stylesheet
- Create a content type with a rich text editor
- Choose the stylesheet
- Create some content
- Login as editor and you should be able to load the content, and edit the rich text editor.


- Add another language to your site
- For you content type, allow vary by culture
- Now login with you editor, you should be able to load the content.