### PR TITLE
Remove content section access policy from GetAllLanguages endpoint.

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/LanguageController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/LanguageController.cs
@@ -43,7 +43,6 @@ public class LanguageController : UmbracoAuthorizedJsonController
     /// </summary>
     /// <returns></returns>
     [HttpGet]
-    [Authorize(Policy = AuthorizationPolicies.SectionAccessContent)]
     public IEnumerable<Language>? GetAllLanguages()
     {
         IEnumerable<ILanguage> allLanguages = _localizationService.GetAllLanguages();


### PR DESCRIPTION
Following on from #15437, the permissions are still too restrictive. 
Users in groups without access to the content section are not able to load any section tree, because they are not authorise to get all languages.

Fixes #15435

The problem:
![image](https://github.com/umbraco/Umbraco-CMS/assets/13795754/49c45407-efb2-4142-8933-da23ccfb099d)


### How to test
* Set up a group with access to settings, but not content
* Set up a user in that group
* Log in to that user
* You are able to view the settings tree

