### PR TITLE
13: Add old databasemodel to ChangeLogStatusCode migration

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_0_0/ChangeLogStatusCode.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_0_0/ChangeLogStatusCode.cs
@@ -99,7 +99,5 @@ public class ChangeLogStatusCode : MigrationBase
         [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
         [NullSetting(NullSetting = NullSettings.NotNull)]
         public string ResponseBody { get; set; } = string.Empty;
-
-        [Column(Name = "exceptionOccured")] public bool ExceptionOccured { get; set; }
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_0_0/ChangeLogStatusCode.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_0_0/ChangeLogStatusCode.cs
@@ -2,7 +2,7 @@
 using NPoco;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Infrastructure.Persistence;
-using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+using Umbraco.Cms.Infrastructure.Persistence.DatabaseAnnotations;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_13_0_0;
@@ -21,18 +21,18 @@ public class ChangeLogStatusCode : MigrationBase
         }
 
         Sql<ISqlContext> fetchQuery = Database.SqlContext.Sql()
-            .Select<WebhookLogDto>()
-            .From<WebhookLogDto>();
+            .Select<WebhookLogDtoOld>()
+            .From<WebhookLogDtoOld>();
 
         // Use a custom SQL query to prevent selecting explicit columns (sortOrder doesn't exist yet)
-        List<WebhookLogDto> webhookLogDtos = Database.Fetch<WebhookLogDto>(fetchQuery);
+        List<WebhookLogDtoOld> webhookLogDtos = Database.Fetch<WebhookLogDtoOld>(fetchQuery);
 
         Sql<ISqlContext> deleteQuery = Database.SqlContext.Sql()
-            .Delete<WebhookLogDto>();
+            .Delete<WebhookLogDtoOld>();
 
         Database.Execute(deleteQuery);
 
-        foreach (WebhookLogDto webhookLogDto in webhookLogDtos)
+        foreach (WebhookLogDtoOld webhookLogDto in webhookLogDtos)
         {
             if (Enum.TryParse(webhookLogDto.StatusCode, out HttpStatusCode statusCode))
             {
@@ -41,5 +41,65 @@ public class ChangeLogStatusCode : MigrationBase
         }
 
         Database.InsertBatch(webhookLogDtos);
+    }
+
+    [TableName(Constants.DatabaseSchema.Tables.WebhookLog)]
+    [PrimaryKey("id")]
+    [ExplicitColumns]
+    private class WebhookLogDtoOld
+    {
+        [Column("id")]
+        [PrimaryKeyColumn(AutoIncrement = true)]
+        public int Id { get; set; }
+
+        [Column("webhookKey")] public Guid WebhookKey { get; set; }
+
+        [Column(Name = "key")]
+        [NullSetting(NullSetting = NullSettings.NotNull)]
+        public Guid Key { get; set; }
+
+        [Column(Name = "statusCode")]
+        [NullSetting(NullSetting = NullSettings.NotNull)]
+        public string StatusCode { get; set; } = string.Empty;
+
+        [Column(Name = "date")]
+        [Index(IndexTypes.NonClustered, Name = "IX_" + Constants.DatabaseSchema.Tables.WebhookLog + "_date")]
+        [NullSetting(NullSetting = NullSettings.NotNull)]
+        public DateTime Date { get; set; }
+
+        [Column(Name = "url")]
+        [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
+        [NullSetting(NullSetting = NullSettings.NotNull)]
+        public string Url { get; set; } = string.Empty;
+
+        [Column(Name = "eventAlias")]
+        [NullSetting(NullSetting = NullSettings.NotNull)]
+        public string EventAlias { get; set; } = string.Empty;
+
+        [Column(Name = "retryCount")]
+        [NullSetting(NullSetting = NullSettings.NotNull)]
+        public int RetryCount { get; set; }
+
+        [Column(Name = "requestHeaders")]
+        [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
+        [NullSetting(NullSetting = NullSettings.NotNull)]
+        public string RequestHeaders { get; set; } = string.Empty;
+
+        [Column(Name = "requestBody")]
+        [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
+        [NullSetting(NullSetting = NullSettings.NotNull)]
+        public string RequestBody { get; set; } = string.Empty;
+
+        [Column(Name = "responseHeaders")]
+        [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
+        [NullSetting(NullSetting = NullSettings.NotNull)]
+        public string ResponseHeaders { get; set; } = string.Empty;
+
+        [Column(Name = "responseBody")]
+        [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
+        [NullSetting(NullSetting = NullSettings.NotNull)]
+        public string ResponseBody { get; set; } = string.Empty;
+
+        [Column(Name = "exceptionOccured")] public bool ExceptionOccured { get; set; }
     }
 }


### PR DESCRIPTION
# Notes
- `ChangeLogStatusCode` was using the current `WebhookLogDto` model, and thus makes it no longer idempotent.
- This was causing errors when migrating from rc2 -> final as the database model had changed. (Note this is not a problem if you upgrade from rc2 -> rc3 -> final.

# How to test
- Create a 13-rc2 database, (check out the `release-13.0.0-rc2` tag, then install)
- Change to this branch
- Run the upgrader