### PR TITLE
V14: Tighten permissions for folder controllers

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DataTypeFolderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DataTypeFolderControllerBase.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Cms.Api.Management.Controllers.DataType.Folder;
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.DataType}/folder")]
 [ApiExplorerSettings(GroupName = "Data Type")]
-[Authorize(Policy = "New" + AuthorizationPolicies.TreeAccessDocumentsOrDocumentTypes)]
+[Authorize(Policy = "New" + AuthorizationPolicies.TreeAccessDocumentTypes)]
 public abstract class DataTypeFolderControllerBase : FolderManagementControllerBase<IDataType>
 {
     protected DataTypeFolderControllerBase(

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Folder/DocumentTypeFolderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Folder/DocumentTypeFolderControllerBase.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Cms.Api.Management.Controllers.DocumentType.Folder;
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.DocumentType}/folder")]
 [ApiExplorerSettings(GroupName = "Document Type")]
-[Authorize(Policy = "New" + AuthorizationPolicies.TreeAccessDocumentsOrDocumentTypes)]
+[Authorize(Policy = "New" + AuthorizationPolicies.TreeAccessDocumentTypes)]
 public abstract class DocumentTypeFolderControllerBase : FolderManagementControllerBase<IContentType>
 {
     protected DocumentTypeFolderControllerBase(

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Folder/MediaTypeFolderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Folder/MediaTypeFolderControllerBase.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Cms.Api.Management.Controllers.MediaType.Folder;
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.MediaType}/folder")]
 [ApiExplorerSettings(GroupName = "Media Type")]
-[Authorize(Policy = "New" + AuthorizationPolicies.TreeAccessMediaOrMediaTypes)]
+[Authorize(Policy = "New" + AuthorizationPolicies.TreeAccessMediaTypes)]
 public abstract class MediaTypeFolderControllerBase : FolderManagementControllerBase<IMediaType>
 {
     protected MediaTypeFolderControllerBase(

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeAuthPolicyBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeAuthPolicyBuilderExtensions.cs
@@ -86,7 +86,6 @@ internal static class BackOfficeAuthPolicyBuilderExtensions
         AddPolicy(AuthorizationPolicies.TreeAccessDocumentTypes, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Settings);
         AddPolicy(AuthorizationPolicies.TreeAccessLanguages, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Settings);
         AddPolicy(AuthorizationPolicies.TreeAccessMediaTypes, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Settings);
-        AddPolicy(AuthorizationPolicies.TreeAccessMediaOrMediaTypes, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Media, Constants.Applications.Settings);
         AddPolicy(AuthorizationPolicies.TreeAccessMemberGroups, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Members);
         AddPolicy(AuthorizationPolicies.TreeAccessMemberTypes, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Settings);
         AddPolicy(AuthorizationPolicies.TreeAccessPartialViews, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Settings);


### PR DESCRIPTION
## Details
- Setting the correct policies for folder controller base classes

## Test
- User groups with no access to Settings section shouldn't be able to create/delete folders - Editors for example