### PR TITLE
Make "create folder" return HTTP 201 Created for file system folders

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Folder/CreatePartialViewFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Folder/CreatePartialViewFolderController.cs
@@ -2,23 +2,32 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Folder;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Mapping;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PartialView.Folder;
 
 [ApiVersion("1.0")]
 public class CreatePartialViewFolderController : PartialViewFolderControllerBase
 {
-    public CreatePartialViewFolderController(
-        IUmbracoMapper mapper,
-        IPartialViewFolderService partialViewFolderService)
+    public CreatePartialViewFolderController(IUmbracoMapper mapper, IPartialViewFolderService partialViewFolderService)
         : base(mapper, partialViewFolderService)
     {
     }
 
     [HttpPost]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    public Task<IActionResult> Create(CreatePathFolderRequestModel model) => CreateAsync(model);
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Create(CreatePathFolderRequestModel model)
+    {
+        Attempt<PathContainer?, PartialViewFolderOperationStatus> result = await CreateAsync(model);
+        return result.Success
+            ? CreatedAtAction<ByPathPartialViewFolderController>(controller => nameof(controller.ByPath), new { path = result.Result!.Path })
+            : OperationStatusResult(result.Status);
+    }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Folder/DeletePartialViewFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Folder/DeletePartialViewFolderController.cs
@@ -19,5 +19,7 @@ public class DeletePartialViewFolderController : PartialViewFolderControllerBase
     [HttpDelete]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public Task<IActionResult> Delete(string path) => DeleteAsync(path);
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/PathFolderManagementControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PathFolderManagementControllerBase.cs
@@ -30,18 +30,11 @@ public abstract class PathFolderManagementControllerBase<TStatus> : ManagementAp
         return Ok(viewModel);
     }
 
-    protected async Task<IActionResult> CreateAsync(CreatePathFolderRequestModel requestModel)
+    protected async Task<Attempt<PathContainer?, TStatus>> CreateAsync(CreatePathFolderRequestModel requestModel)
     {
         PathContainer folderModel = Mapper.Map<PathContainer>(requestModel)!;
 
-        Attempt<PathContainer?, TStatus> attempt = await CreateContainerAsync(folderModel);
-        if (attempt.Success is false)
-        {
-            return OperationStatusResult(attempt.Status);
-        }
-
-        PathFolderResponseModel? viewModel = Mapper.Map<PathFolderResponseModel>(attempt.Result);
-        return Ok(viewModel);
+        return await CreateContainerAsync(folderModel);
     }
 
     protected async Task<IActionResult> DeleteAsync(string path)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/Folder/CreateScriptFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/Folder/CreateScriptFolderController.cs
@@ -2,23 +2,32 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Folder;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Mapping;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Script.Folder;
 
 [ApiVersion("1.0")]
 public class CreateScriptFolderController : ScriptFolderControllerBase
 {
-    public CreateScriptFolderController(
-        IUmbracoMapper mapper,
-        IScriptFolderService scriptFolderService)
+    public CreateScriptFolderController(IUmbracoMapper mapper, IScriptFolderService scriptFolderService)
         : base(mapper, scriptFolderService)
     {
     }
 
     [HttpPost]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    public Task<IActionResult> Create(CreatePathFolderRequestModel model) => CreateAsync(model);
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Create(CreatePathFolderRequestModel model)
+    {
+        Attempt<PathContainer?, ScriptFolderOperationStatus> result = await CreateAsync(model);
+        return result.Success
+            ? CreatedAtAction<ByPathScriptFolderController>(controller => nameof(controller.ByPath), new { path = result.Result!.Path })
+            : OperationStatusResult(result.Status);
+    }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/Folder/DeleteScriptFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/Folder/DeleteScriptFolderController.cs
@@ -17,5 +17,7 @@ public class DeleteScriptFolderController : ScriptFolderControllerBase
     [HttpDelete]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public Task<IActionResult> Delete(string path) => DeleteAsync(path);
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Folder/CreateStylesheetFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Folder/CreateStylesheetFolderController.cs
@@ -2,21 +2,33 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Folder;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Mapping;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet.Folder;
 
 [ApiVersion("1.0")]
 public class CreateStylesheetFolderController : StylesheetFolderControllerBase
 {
-    public CreateStylesheetFolderController(IUmbracoMapper mapper, IStylesheetFolderService stylesheetFolderService) : base(mapper, stylesheetFolderService)
+    public CreateStylesheetFolderController(IUmbracoMapper mapper, IStylesheetFolderService stylesheetFolderService)
+        : base(mapper, stylesheetFolderService)
     {
     }
 
 
     [HttpPost]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    public Task<IActionResult> Create(CreatePathFolderRequestModel model) => CreateAsync(model);
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Create(CreatePathFolderRequestModel model)
+    {
+        Attempt<PathContainer?, StylesheetFolderOperationStatus> result = await CreateAsync(model);
+        return result.Success
+            ? CreatedAtAction<ByPathStylesheetFolderController>(controller => nameof(controller.ByPath), new { path = result.Result!.Path })
+            : OperationStatusResult(result.Status);
+    }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Folder/DeleteStylesheetFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Folder/DeleteStylesheetFolderController.cs
@@ -9,12 +9,15 @@ namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet.Folder;
 [ApiVersion("1.0")]
 public class DeleteStylesheetFolderController : StylesheetFolderControllerBase
 {
-    public DeleteStylesheetFolderController(IUmbracoMapper mapper, IStylesheetFolderService stylesheetFolderService) : base(mapper, stylesheetFolderService)
+    public DeleteStylesheetFolderController(IUmbracoMapper mapper, IStylesheetFolderService stylesheetFolderService)
+        : base(mapper, stylesheetFolderService)
     {
     }
 
     [HttpDelete]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public Task<IActionResult> Delete(string path) => DeleteAsync(path);
 }

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -10836,8 +10836,58 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "Success"
+          "201": {
+            "description": "Created",
+            "headers": {
+              "Location": {
+                "description": "Location of the newly created resource",
+                "schema": {
+                  "type": "string",
+                  "description": "Location of the newly created resource",
+                  "format": "uri"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           },
           "401": {
             "description": "The resource is protected and requires an authentication token"
@@ -10866,6 +10916,46 @@
         "responses": {
           "200": {
             "description": "Success"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           },
           "401": {
             "description": "The resource is protected and requires an authentication token"
@@ -12646,8 +12736,58 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "Success"
+          "201": {
+            "description": "Created",
+            "headers": {
+              "Location": {
+                "description": "Location of the newly created resource",
+                "schema": {
+                  "type": "string",
+                  "description": "Location of the newly created resource",
+                  "format": "uri"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           },
           "401": {
             "description": "The resource is protected and requires an authentication token"
@@ -12676,6 +12816,46 @@
         "responses": {
           "200": {
             "description": "Success"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           },
           "401": {
             "description": "The resource is protected and requires an authentication token"
@@ -14037,8 +14217,58 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "Success"
+          "201": {
+            "description": "Created",
+            "headers": {
+              "Location": {
+                "description": "Location of the newly created resource",
+                "schema": {
+                  "type": "string",
+                  "description": "Location of the newly created resource",
+                  "format": "uri"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           },
           "401": {
             "description": "The resource is protected and requires an authentication token"
@@ -14067,6 +14297,46 @@
         "responses": {
           "200": {
             "description": "Success"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           },
           "401": {
             "description": "The resource is protected and requires an authentication token"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The file system folder management endpoints do not follow the rest of the API standard of returning HTTP 201 Created when creating new resources. This PR fixes it.

While I was there, I added the missing response types (HTTP 404, HTTP 400) for all file system "create" and "delete" folder endpoints.

### Testing this PR

Use Swagger 😄 

1. Verify that the "create folder" endpoints for Partial Views, Stylesheets and Scripts return 201 when folder creation is successful.
2. Verify that the 201 response code is documented in Swagger for all the file system "create folder" endpoints.
3. Verify that 400 and 404 errors are documented in Swagger for all the file system "create folder" and "delete folder" endpoints.

