### PR TITLE
Use SQLite in-memory database and configure database optimizations for E2E tests

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -419,7 +419,7 @@ stages:
         displayName: E2E Tests (SQLite)
         variables:
           # Connection string
-          CONNECTIONSTRINGS__UMBRACODBDSN: Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True
+          CONNECTIONSTRINGS__UMBRACODBDSN: Data Source=Umbraco;Mode=Memory;Cache=Shared;Foreign Keys=True;Pooling=True
           CONNECTIONSTRINGS__UMBRACODBDSN_PROVIDERNAME: Microsoft.Data.Sqlite
         strategy:
           matrix:
@@ -474,9 +474,10 @@ stages:
               $cmsVersion = "$(Build.BuildNumber)" -replace "\+",".g"
               dotnet new nugetconfig
               dotnet nuget add source ./nupkg --name Local
-              dotnet new --install Umbraco.Templates::$cmsVersion
+              dotnet new install Umbraco.Templates::$cmsVersion
               dotnet new umbraco --name UmbracoProject --version $cmsVersion --exclude-gitignore --no-restore --no-update-check
               dotnet restore UmbracoProject
+              cp $(Build.SourcesDirectory)/tests/Umbraco.Tests.AcceptanceTest.UmbracoProject/*.cs UmbracoProject
               dotnet build UmbracoProject --configuration $(buildConfiguration) --no-restore
               dotnet dev-certs https
             displayName: Build application

--- a/tests/Umbraco.Tests.AcceptanceTest.UmbracoProject/SQLiteMemoryComposer.cs
+++ b/tests/Umbraco.Tests.AcceptanceTest.UmbracoProject/SQLiteMemoryComposer.cs
@@ -1,0 +1,37 @@
+using Microsoft.Data.Sqlite;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Extensions;
+
+internal sealed class SQLiteMemoryComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        var connectionString = builder.Config.GetUmbracoConnectionString(out var providerName);
+        if (!string.IsNullOrEmpty(connectionString) &&
+            Constants.ProviderNames.SQLLite.InvariantEquals(providerName) &&
+            connectionString.InvariantContains("Mode=Memory"))
+        {
+            // Open new SQLite connection to ensure in-memory database is persisted for the whole application duration
+            var connection = new SqliteConnection(connectionString);
+            connection.Open();
+
+            // And ensure connection is kept open (by keeping a reference) and gets gracefully closed/disposed when application stops
+            builder.Services.AddHostedService(_ => new SQLiteMemoryHostedService(connection));
+        }
+    }
+
+    private sealed class SQLiteMemoryHostedService : IHostedService, IAsyncDisposable
+    {
+        private readonly SqliteConnection _connection;
+
+        public SQLiteMemoryHostedService(SqliteConnection connection) => _connection = connection;
+
+        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public async Task StopAsync(CancellationToken cancellationToken) => await _connection.CloseAsync();
+
+        public async ValueTask DisposeAsync() => await _connection.DisposeAsync();
+    }
+}

--- a/tests/Umbraco.Tests.AcceptanceTest.UmbracoProject/SqlServerDelayedDurabilityComposer.cs
+++ b/tests/Umbraco.Tests.AcceptanceTest.UmbracoProject/SqlServerDelayedDurabilityComposer.cs
@@ -1,0 +1,39 @@
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Extensions;
+
+internal sealed class SqlServerDelayedDurabilityComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        var connectionString = builder.Config.GetUmbracoConnectionString(out var providerName);
+        if (!string.IsNullOrEmpty(connectionString) &&
+            Constants.ProviderNames.SQLServer.InvariantEquals(providerName))
+        {
+            builder.AddNotificationAsyncHandler<UnattendedInstallNotification, SqlServerDelayedDurabilityInstallNotification>();
+        }
+    }
+
+    private sealed class SqlServerDelayedDurabilityInstallNotification : INotificationAsyncHandler<UnattendedInstallNotification>
+    {
+        private readonly IOptions<ConnectionStrings> _connectionStrings;
+
+        public SqlServerDelayedDurabilityInstallNotification(IOptions<ConnectionStrings> connectionStrings) => _connectionStrings = connectionStrings;
+
+        public async Task HandleAsync(UnattendedInstallNotification notification, CancellationToken cancellationToken)
+        {
+            using var connection = new SqlConnection(_connectionStrings.Value.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            // Disable waiting on log IO to finish when commiting a transaction (we can tolerate some data loss)
+            var command = new SqlCommand("ALTER DATABASE CURRENT SET DELAYED_DURABILITY = FORCED;", connection);
+            await command.ExecuteNonQueryAsync(cancellationToken);
+        }
+    }
+}

--- a/tests/Umbraco.Tests.AcceptanceTest.UmbracoProject/Umbraco.Tests.AcceptanceTest.UmbracoProject.csproj
+++ b/tests/Umbraco.Tests.AcceptanceTest.UmbracoProject/Umbraco.Tests.AcceptanceTest.UmbracoProject.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Umbraco.Cms\Umbraco.Cms.csproj" />
+  </ItemGroup>
+</Project>

--- a/umbraco.sln
+++ b/umbraco.sln
@@ -133,8 +133,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		global.json = global.json
 		icon.png = icon.png
 		LICENSE.md = LICENSE.md
-		umbraco.sln.DotSettings = umbraco.sln.DotSettings
 		nuget.config = nuget.config
+		umbraco.sln.DotSettings = umbraco.sln.DotSettings
 		version.json = version.json
 	EndProjectSection
 EndProject
@@ -184,6 +184,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Umbraco.Cms.Persistence.EFCore.Sqlite", "src\Umbraco.Cms.Persistence.EFCore.Sqlite\Umbraco.Cms.Persistence.EFCore.Sqlite.csproj", "{8B4771F0-8EC2-4761-BBCE-DDE073DB3B7A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Umbraco.Cms.Persistence.EFCore.SqlServer", "src\Umbraco.Cms.Persistence.EFCore.SqlServer\Umbraco.Cms.Persistence.EFCore.SqlServer.csproj", "{9276C3F0-0DC9-46C9-BF32-9EE79D92AE02}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Umbraco.Tests.AcceptanceTest.UmbracoProject", "tests\Umbraco.Tests.AcceptanceTest.UmbracoProject\Umbraco.Tests.AcceptanceTest.UmbracoProject.csproj", "{A13FF0A0-69FA-468A-9F79-565401D5C341}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -358,6 +360,12 @@ Global
 		{9276C3F0-0DC9-46C9-BF32-9EE79D92AE02}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9276C3F0-0DC9-46C9-BF32-9EE79D92AE02}.SkipTests|Any CPU.ActiveCfg = Debug|Any CPU
 		{9276C3F0-0DC9-46C9-BF32-9EE79D92AE02}.SkipTests|Any CPU.Build.0 = Debug|Any CPU
+		{A13FF0A0-69FA-468A-9F79-565401D5C341}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A13FF0A0-69FA-468A-9F79-565401D5C341}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A13FF0A0-69FA-468A-9F79-565401D5C341}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A13FF0A0-69FA-468A-9F79-565401D5C341}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A13FF0A0-69FA-468A-9F79-565401D5C341}.SkipTests|Any CPU.ActiveCfg = Debug|Any CPU
+		{A13FF0A0-69FA-468A-9F79-565401D5C341}.SkipTests|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -376,6 +384,7 @@ Global
 		{2B47AD9F-FFF1-448A-88F1-D4F568811738} = {F2BF84D9-0A14-40AF-A0F3-B9BBBBC16A44}
 		{25AECCB5-B187-4406-844B-91B8FF0FCB37} = {2B47AD9F-FFF1-448A-88F1-D4F568811738}
 		{EA628ABD-624E-4AF3-B548-6710D4D66531} = {2B47AD9F-FFF1-448A-88F1-D4F568811738}
+		{A13FF0A0-69FA-468A-9F79-565401D5C341} = {B5BD12C1-A454-435E-8A46-FF4A364C0382}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7A0F2E34-D2AF-4DAB-86A0-7D7764B3D0EC}


### PR DESCRIPTION
This builds on top of PR https://github.com/umbraco/Umbraco-CMS/pull/14042 and configures the E2E Acceptance Test build to use a SQLite in-memory database and optimizes the SQL Server database to [force delayed durability](https://learn.microsoft.com/en-us/sql/relational-databases/logs/control-transaction-durability?view=sql-server-ver16#delayed-transaction-durability) (which should improve throughput by minimizing log I/O).