### PR TITLE
Add red class to remove button in dynamic query steps

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.html
@@ -139,7 +139,7 @@
               </div>
             </div>
             <div class="umb-node-preview__actions">
-              <button type="button" class="umb-node-preview__action" ng-click="removeQueryStep(queryStep)"><localize key="general_remove">Remove</localize></button>
+              <button type="button" class="umb-node-preview__action umb-node-preview__action--red" ng-click="removeQueryStep(queryStep)"><localize key="general_remove">Remove</localize></button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Added the `umb-node-preview__action--red` to remove button, to make it consistent with other remove buttons in `<umb-node-preview>`.
We could probably just use the component here instead, but for now I have added the class.