### PR TITLE
Add handling of failed publish.

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
@@ -2061,7 +2061,7 @@ public class ContentController : ContentControllerBase
         var languageCount = _allLangs.Value.Count();
 
         // If there is no culture specified or the cultures specified are equal to the total amount of languages, publish the content in all cultures.
-        if (model.Cultures == null || !model.Cultures.Any() || model.Cultures.Length == languageCount)
+        if (model.Cultures == null || !model.Cultures.Any())
         {
             return PostPublishById(model.Id);
         }
@@ -2322,7 +2322,7 @@ public class ContentController : ContentControllerBase
         }
 
         var languageCount = _allLangs.Value.Count();
-        if (model.Cultures?.Length == 0 || model.Cultures?.Length == languageCount)
+        if (model.Cultures?.Length == 0)
         {
             //this means that the entire content item will be unpublished
             PublishResult unpublishResult = _contentService.Unpublish(foundContent, userId: _backofficeSecurityAccessor.BackOfficeSecurity?.GetUserId().Result ?? -1);
@@ -2786,6 +2786,7 @@ public class ContentController : ContentControllerBase
                 case PublishResultType.FailedPublishIsTrashed:
                 case PublishResultType.FailedPublishContentInvalid:
                 case PublishResultType.FailedPublishMandatoryCultureMissing:
+                case PublishResultType.FailedPublishNothingToPublish:
                     //the rest that we are looking for each belong in their own group
                     return x.Result;
                 default:
@@ -2927,6 +2928,11 @@ public class ContentController : ContentControllerBase
                     display.AddWarningNotification(
                         _localizedTextService.Localize(null, "publish"),
                         "publish/contentPublishedFailedByCulture");
+                    break;
+                case PublishResultType.FailedPublishNothingToPublish:
+                    display.AddWarningNotification(
+                         _localizedTextService.Localize(null, "publish"),
+                        $"Nothing to publish for some languages. Ensure selected languages have a page created.");
                     break;
                 default:
                     throw new IndexOutOfRangeException($"PublishedResultType \"{status.Key}\" was not expected.");


### PR DESCRIPTION
When publishing, if the selected page does not yet have a page created, handle the FailedPublishNothingToPublish error so that the user is not presented with an exception. A warning is shown to the user that some languages failed to publish due to nothing to publish and to check that a page has been created for selected languages. Additionally fixed a validation issue where publish would always succeed if all languages were selected.

Issue: 15352

### Prerequisites

- [X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [15352](https://github.com/umbraco/Umbraco-CMS/issues/15352)

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

This pull request contains the following changes:

- Handle the FailedPublishNothingtoPublish publish result in ContentController.cs. A warning now appears when the user attempts to publish a language for which no page has been created. See below image for warning text contents.

![nothing_to_publish_warning](https://github.com/umbraco/Umbraco-CMS/assets/50598649/112da5fb-26ed-4fcf-8c09-ebec7c6b165f)

- Removed conditions to always publish successfully if all languages are selected.

Steps to test (taken from main issue body):

1. Create a page with List view enabled.
2. Enable several languages in the settings section.
3. Create a child page and set "Allow vary by culture" to true. This page should be created in only one language.
4. Go back to the List view page.
5. Select the created page.
6. Click "Publish" in top-right.
7. Select a language for which a page has not been created.
8. Click "Publish" in the popup.
9. Observe that a warning message appears informing the user that a publish was attempted for a page that has not been created.
10. Repeat 7. but select all languages.
11. Observe warning message from 9.

<!-- Thanks for contributing to Umbraco CMS! -->
