### PR TITLE
V14: add the cors policy as first item on the pipeline filter

### DIFF
--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeCorsPolicyBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeCorsPolicyBuilderExtensions.cs
@@ -29,7 +29,8 @@ internal static class BackOfficeCorsPolicyBuilderExtensions
 
         builder.Services.AddCors(options =>
         {
-            options.AddPolicy(name: policyName,
+            options.AddPolicy(
+                name: policyName,
                 policy =>
                 {
                     policy
@@ -42,9 +43,9 @@ internal static class BackOfficeCorsPolicyBuilderExtensions
 
         builder.Services.Configure<UmbracoPipelineOptions>(options =>
         {
-            options.AddFilter(new UmbracoPipelineFilter("UmbracoManagementApiCustomHostCorsPolicy")
+            options.PipelineFilters.Insert(0, new UmbracoPipelineFilter("UmbracoManagementApiCustomHostCorsPolicy")
             {
-                PostRouting = app => app.UseCors(policyName)
+                PrePipeline = app => app.UseCors(policyName),
             });
         });
 


### PR DESCRIPTION
This ensures that any assets loaded as "modules" also get the right Access-Control-Allow-* headers, i.e. any javascript modules loaded from the App_Plugins/ folder will be subject to this.
