### PR TITLE
V10: Add new content blueprint requirement

### DIFF
--- a/src/Umbraco.Web.BackOffice/Authorization/ContentBlueprintHandler.cs
+++ b/src/Umbraco.Web.BackOffice/Authorization/ContentBlueprintHandler.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Web.BackOffice.Authorization;
+
+/// <summary>
+///     Ensures authorization have permission to create content blueprints.
+/// </summary>
+public class ContentBlueprintHandler : MustSatisfyRequirementAuthorizationHandler<ContentBlueprintRequirement>
+{
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurity;
+    private readonly IUserService _userService;
+
+    public ContentBlueprintHandler(IBackOfficeSecurityAccessor backOfficeSecurity, IUserService userService)
+    {
+        _backOfficeSecurity = backOfficeSecurity;
+        _userService = userService;
+    }
+
+    protected override Task<bool> IsAuthorized(AuthorizationHandlerContext context, ContentBlueprintRequirement requirement)
+    {
+        IUser? user = _backOfficeSecurity.BackOfficeSecurity?.CurrentUser;
+        if (user is null)
+        {
+            return Task.FromResult(false);
+        }
+
+        // Check if a given user group has permission to create a content template
+        foreach (IReadOnlyUserGroup userGroup in user.Groups)
+        {
+            if (userGroup.Permissions is null)
+            {
+                continue;
+            }
+
+            if (userGroup.Permissions.Any(x => x.Contains(ActionCreateBlueprintFromContent.ActionLetter)))
+            {
+                return Task.FromResult(true);
+            }
+        }
+
+        // If the user groups did not have permissions, we have to also
+        // check granular permissions, as you could potentially have permission there.
+        EntityPermissionCollection permissions = _userService.GetPermissions(user);
+        return Task.FromResult(permissions.GetAllPermissions().Any(x => x.Contains(ActionCreateBlueprintFromContent.ActionLetter)));
+    }
+}

--- a/src/Umbraco.Web.BackOffice/Authorization/ContentBlueprintRequirement.cs
+++ b/src/Umbraco.Web.BackOffice/Authorization/ContentBlueprintRequirement.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace Umbraco.Cms.Web.BackOffice.Authorization;
+
+/// <summary>
+///     An authorization requirement for <see cref="ContentBlueprintHandler" />
+/// </summary>
+public class ContentBlueprintRequirement : IAuthorizationRequirement
+{
+}

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
@@ -822,9 +822,10 @@ public class ContentController : ContentControllerBase
     ///     Saves content
     /// </summary>
     [FileUploadCleanupFilter]
-    [ContentSaveValidation]
-    public async Task<ActionResult<ContentItemDisplay<ContentVariantDisplay>?>?> PostSaveBlueprint(
-        [ModelBinder(typeof(BlueprintItemBinder))] ContentItemSave contentItem)
+    // We have to use a Tree authorization policy here, as "ContentBlueprints"
+    // is a tree in the backoffice.
+    [Authorize(Policy = AuthorizationPolicies.TreeAccessContentBlueprint)]
+    public async Task<ActionResult<ContentItemDisplay<ContentVariantDisplay>?>?> PostSaveBlueprint([ModelBinder(typeof(BlueprintItemBinder))] ContentItemSave contentItem)
     {
         ActionResult<ContentItemDisplay<ContentVariantDisplay>?> contentItemDisplay = await PostSaveInternal(
             contentItem,

--- a/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilder.BackOfficeAuth.cs
+++ b/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilder.BackOfficeAuth.cs
@@ -104,6 +104,7 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddSingleton<IAuthorizationHandler, MediaPermissionsResourceHandler>();
         builder.Services.AddSingleton<IAuthorizationHandler, MediaPermissionsQueryStringHandler>();
         builder.Services.AddSingleton<IAuthorizationHandler, DenyLocalLoginHandler>();
+        builder.Services.AddSingleton<IAuthorizationHandler, ContentBlueprintHandler>();
 
         builder.Services.AddAuthorization(o => CreatePolicies(o, backOfficeAuthenticationScheme));
     }
@@ -235,6 +236,12 @@ public static partial class UmbracoBuilderExtensions
             policy.AuthenticationSchemes.Add(backOfficeAuthenticationScheme);
             policy.Requirements.Add(new SectionRequirement(
                 Constants.Applications.Content, Constants.Applications.Media, Constants.Applications.Members));
+        });
+
+        options.AddPolicy(AuthorizationPolicies.TreeAccessContentBlueprint, policy =>
+        {
+            policy.AuthenticationSchemes.Add(backOfficeAuthenticationScheme);
+            policy.Requirements.Add(new ContentBlueprintRequirement());
         });
 
         options.AddPolicy(AuthorizationPolicies.SectionAccessMedia, policy =>

--- a/src/Umbraco.Web.BackOffice/Filters/ContentSaveValidationAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/ContentSaveValidationAttribute.cs
@@ -278,6 +278,7 @@ internal sealed class ContentSaveValidationAttribute : TypeFilterAttribute
 
             if (!authorizationResult.Succeeded)
             {
+                // THIS LINE MAKES US FORBIDDEN, WHICH MAKES SENSE
                 actionContext.Result = new ForbidResult();
                 return false;
             }

--- a/src/Umbraco.Web.Common/Authorization/AuthorizationPolicies.cs
+++ b/src/Umbraco.Web.Common/Authorization/AuthorizationPolicies.cs
@@ -59,6 +59,7 @@ public static class AuthorizationPolicies
     public const string TreeAccessMemberGroups = nameof(TreeAccessMemberGroups);
     public const string TreeAccessDocumentTypes = nameof(TreeAccessDocumentTypes);
     public const string TreeAccessMemberTypes = nameof(TreeAccessMemberTypes);
+    public const string TreeAccessContentBlueprint = nameof(TreeAccessContentBlueprint);
 
     // Custom access based on multiple trees
     public const string TreeAccessDocumentsOrDocumentTypes = nameof(TreeAccessDocumentsOrDocumentTypes);


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/15460

# Notes
- Add new `TreeAccessContentBlueprint` policy
- Adds new `ContentBlueprintRequirement` for the policy.
- Adds new `ContentBlueprintHandler`, with logic to check if a given user has permission to create a Blueprint.

# How to test
- Create a document type with `allow as root` set to true
- Create a content with the document type, called "Root"
- Go to user groups, edit the `Editor` group, and set the start node to "Root".
- Add a user assigned to the `Editor` user group.
- Login with the user
- Create a content template.
