### PR TITLE
Add policies for content template handling

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
@@ -766,6 +766,7 @@ public class ContentController : ContentControllerBase
     /// <param name="contentId">The content id to copy</param>
     /// <param name="name">The name of the blueprint</param>
     /// <returns></returns>
+    [Authorize(Policy = AuthorizationPolicies.ContentPermissionCreateBlueprintFromId)]
     [HttpPost]
     public ActionResult<SimpleNotificationModel> CreateBlueprintFromContent(
         [FromQuery] int contentId,
@@ -821,8 +822,9 @@ public class ContentController : ContentControllerBase
     /// <summary>
     ///     Saves content
     /// </summary>
+    [Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentTypes)]
     [FileUploadCleanupFilter]
-    [ContentSaveValidation]
+    [ContentSaveValidation(skipUserAccessValidation:true)] // skip user access validation because we "only" require Settings access to create new blueprints from scratch
     public async Task<ActionResult<ContentItemDisplay<ContentVariantDisplay>?>?> PostSaveBlueprint(
         [ModelBinder(typeof(BlueprintItemBinder))] ContentItemSave contentItem)
     {
@@ -2012,6 +2014,7 @@ public class ContentController : ContentControllerBase
         return Ok();
     }
 
+    [Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentTypes)]
     [HttpDelete]
     [HttpPost]
     public IActionResult DeleteBlueprint(int id)

--- a/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilder.BackOfficeAuth.cs
+++ b/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilder.BackOfficeAuth.cs
@@ -179,6 +179,13 @@ public static partial class UmbracoBuilderExtensions
             policy.Requirements.Add(new ContentPermissionsQueryStringRequirement(ActionDelete.ActionLetter));
         });
 
+        options.AddPolicy(AuthorizationPolicies.ContentPermissionCreateBlueprintFromId, policy =>
+        {
+            policy.AuthenticationSchemes.Add(backOfficeAuthenticationScheme);
+            policy.Requirements.Add(
+                new ContentPermissionsQueryStringRequirement(ActionCreateBlueprintFromContent.ActionLetter, "contentId"));
+        });
+
         options.AddPolicy(AuthorizationPolicies.BackOfficeAccess, policy =>
         {
             policy.AuthenticationSchemes.Add(backOfficeAuthenticationScheme);

--- a/src/Umbraco.Web.BackOffice/Filters/ContentSaveValidationAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/ContentSaveValidationAttribute.cs
@@ -20,9 +20,12 @@ namespace Umbraco.Cms.Web.BackOffice.Filters;
 /// </summary>
 internal sealed class ContentSaveValidationAttribute : TypeFilterAttribute
 {
-    public ContentSaveValidationAttribute() : base(typeof(ContentSaveValidationFilter)) =>
+    public ContentSaveValidationAttribute(bool skipUserAccessValidation = false)
+        : base(typeof(ContentSaveValidationFilter))
+    {
         Order = -3000; // More important than ModelStateInvalidFilter.FilterOrder
-
+        Arguments = new object[] { skipUserAccessValidation };
+    }
 
     private sealed class ContentSaveValidationFilter : IAsyncActionFilter
     {
@@ -32,6 +35,7 @@ internal sealed class ContentSaveValidationAttribute : TypeFilterAttribute
         private readonly ILocalizationService _localizationService;
         private readonly ILoggerFactory _loggerFactory;
         private readonly IPropertyValidationService _propertyValidationService;
+        private readonly bool _skipUserAccessValidation;
 
 
         public ContentSaveValidationFilter(
@@ -40,7 +44,8 @@ internal sealed class ContentSaveValidationAttribute : TypeFilterAttribute
             IPropertyValidationService propertyValidationService,
             IAuthorizationService authorizationService,
             IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
-            ILocalizationService localizationService)
+            ILocalizationService localizationService,
+            bool skipUserAccessValidation)
         {
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             _contentService = contentService ?? throw new ArgumentNullException(nameof(contentService));
@@ -49,6 +54,7 @@ internal sealed class ContentSaveValidationAttribute : TypeFilterAttribute
             _authorizationService = authorizationService;
             _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
             _localizationService = localizationService;
+            _skipUserAccessValidation = skipUserAccessValidation;
         }
 
         public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
@@ -88,7 +94,7 @@ internal sealed class ContentSaveValidationAttribute : TypeFilterAttribute
                 return;
             }
 
-            if (!await ValidateUserAccessAsync(model, context))
+            if (_skipUserAccessValidation is false && await ValidateUserAccessAsync(model, context) is false)
             {
                 return;
             }

--- a/src/Umbraco.Web.Common/Authorization/AuthorizationPolicies.cs
+++ b/src/Umbraco.Web.Common/Authorization/AuthorizationPolicies.cs
@@ -22,6 +22,7 @@ public static class AuthorizationPolicies
     public const string ContentPermissionProtectById = nameof(ContentPermissionProtectById);
     public const string ContentPermissionBrowseById = nameof(ContentPermissionBrowseById);
     public const string ContentPermissionDeleteById = nameof(ContentPermissionDeleteById);
+    public const string ContentPermissionCreateBlueprintFromId = nameof(ContentPermissionCreateBlueprintFromId);
 
     public const string MediaPermissionByResource = nameof(MediaPermissionByResource);
     public const string MediaPermissionPathById = nameof(MediaPermissionPathById);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This adds explicit access policy checks for content template handling (create and delete).

1. When creating content templates from the content tree, the newly introduced `AuthorizationPolicies.ContentPermissionCreateBlueprintFromId` policy must be fulfilled (user must have "Create content template" permission within the scope of the content targeted as a blueprint).
2. When creating or deleting content templates from the settings section, the `AuthorizationPolicies.TreeAccessDocumentTypes` must be fulfilled (user must have access to content types).

Besides added security, this also ensures that uses without access to the content root is still allowed to create content templates, provided they fulfil the access requirements outlined above.

### Testing this PR

- Admin users should be able to create content templates as per usual, both from the content tree and from the settings section.
- Users with settings access and _without_ content root access should be able to create content templates from the settings section.
- It should _not_ be possible to create content templates from the content tree if the "Create content template" permission is not set in the context of the source content item.
   - This is a little tricky to test, because the "Create content template..." menu item is hidden if one does not have access to it; you'll need to:
      1. Log in with a test user (non-admin) - use an incognito browser for this.
      2. Open the "Create content tempate..." dialog from the content tree (but DO NOT submit it yet).
      3. In another browser window, log in with an admin user and revoke the "Create content template" permissions from the test user.
      4. Submit the "Create content template..." dialog in the incognito browser. This should yield an error like this: 
![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/79b42907-88e3-494c-b9ca-8d9b6008ac01)
