### PR TITLE
Correct aliases for ContentDeletedWebhook and ContentUnpublishedWebhook

### DIFF
--- a/src/Umbraco.Core/Webhooks/Events/Content/ContentDeletedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/Content/ContentDeletedWebhookEvent.cs
@@ -23,7 +23,7 @@ public class ContentDeletedWebhookEvent : WebhookEventContentBase<ContentDeleted
     {
     }
 
-    public override string Alias => Constants.WebhookEvents.Aliases.ContentUnpublish;
+    public override string Alias => Constants.WebhookEvents.Aliases.ContentDelete;
 
     protected override IEnumerable<IContent> GetEntitiesFromNotification(ContentDeletedNotification notification) =>
         notification.DeletedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/Content/ContentUnpublishedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/Content/ContentUnpublishedWebhookEvent.cs
@@ -23,7 +23,7 @@ public class ContentUnpublishedWebhookEvent : WebhookEventContentBase<ContentUnp
     {
     }
 
-    public override string Alias => Constants.WebhookEvents.Aliases.ContentDelete;
+    public override string Alias => Constants.WebhookEvents.Aliases.ContentUnpublish;
 
     protected override IEnumerable<IContent> GetEntitiesFromNotification(ContentUnpublishedNotification notification) => notification.UnpublishedEntities;
 


### PR DESCRIPTION
### Description
The aliases for the `ContentDeletedWebhook` and the `ContentUnpublishedWebhook` were wrong.

Fixes:  https://github.com/umbraco/Umbraco-CMS/issues/15486
