### PR TITLE
Use constants for all webhook event aliases

### DIFF
--- a/src/Umbraco.Core/Constants-WebhookEvents.cs
+++ b/src/Umbraco.Core/Constants-WebhookEvents.cs
@@ -1,4 +1,4 @@
-﻿namespace Umbraco.Cms.Core;
+namespace Umbraco.Cms.Core;
 
 public static partial class Constants
 {
@@ -81,6 +81,316 @@ public static partial class Constants
             ///     Webhook event alias for media save.
             /// </summary>
             public const string MediaSave = "Umbraco.MediaSave";
+
+            /// <summary>
+            ///     Webhook event alias for document type changed.
+            /// </summary>
+            public const string DocumentTypeChanged = "documentTypeChanged";
+
+            /// <summary>
+            ///     Webhook event alias for document type deleted.
+            /// </summary>
+            public const string DocumentTypeDeleted = "documentTypeDeleted";
+
+            /// <summary>
+            ///     Webhook event alias for document type moved.
+            /// </summary>
+            public const string DocumentTypeMoved = "documentTypeMoved";
+
+            /// <summary>
+            ///     Webhook event alias for document type saved.
+            /// </summary>
+            public const string DocumentTypeSaved = "documentTypeSaved";
+
+            /// <summary>
+            ///     Webhook event alias for media type changed.
+            /// </summary>
+            public const string MediaTypeChanged = "mediaTypeChanged";
+
+            /// <summary>
+            ///     Webhook event alias for media type deleted.
+            /// </summary>
+            public const string MediaTypeDeleted = "mediaTypeDeleted";
+
+            /// <summary>
+            ///     Webhook event alias for media type moved.
+            /// </summary>
+            public const string MediaTypeMoved = "mediaTypeMoved";
+
+            /// <summary>
+            ///     Webhook event alias for media type saved.
+            /// </summary>
+            public const string MediaTypeSaved = "mediaTypeSaved";
+
+            /// <summary>
+            ///     Webhook event alias for member type changed.
+            /// </summary>
+            public const string MemberTypeChanged = "memberTypeChanged";
+
+            /// <summary>
+            ///     Webhook event alias for member type deleted.
+            /// </summary>
+            public const string MemberTypeDeleted = "memberTypeDeleted";
+
+            /// <summary>
+            ///     Webhook event alias for member type moved.
+            /// </summary>
+            public const string MemberTypeMoved = "memberTypeMoved";
+
+            /// <summary>
+            ///     Webhook event alias for member type saved.
+            /// </summary>
+            public const string MemberTypeSaved = "memberTypeSaved";
+
+            /// <summary>
+            ///     Webhook event alias for data type deleted.
+            /// </summary>
+            public const string DataTypeDeleted = "dataTypeDeleted";
+
+            /// <summary>
+            ///     Webhook event alias for data type moved.
+            /// </summary>
+            public const string DataTypeMoved = "dataTypeMoved";
+
+            /// <summary>
+            ///     Webhook event alias for data type saved.
+            /// </summary>
+            public const string DataTypeSaved = "dataTypeSaved";
+
+            /// <summary>
+            ///     Webhook event alias for dictionary item deleted.
+            /// </summary>
+            public const string DictionaryItemDeleted = "dictionaryItemDeleted";
+
+            /// <summary>
+            ///     Webhook event alias for dictionary item saved.
+            /// </summary>
+            public const string DictionaryItemSaved = "dictionaryItemSaved";
+
+            /// <summary>
+            ///     Webhook event alias for domain deleted.
+            /// </summary>
+            public const string DomainDeleted = "domainDeleted";
+
+            /// <summary>
+            ///     Webhook event alias for domain saved.
+            /// </summary>
+            public const string DomainSaved = "domainSaved";
+
+            /// <summary>
+            ///     Webhook event alias for partial view deleted.
+            /// </summary>
+            public const string PartialViewDeleted = "partialViewDeleted";
+
+            /// <summary>
+            ///     Webhook event alias for partial view saved.
+            /// </summary>
+            public const string PartialViewSaved = "partialViewSaved";
+
+            /// <summary>
+            ///     Webhook event alias for script deleted.
+            /// </summary>
+            public const string ScriptDeleted = "scriptDeleted";
+
+            /// <summary>
+            ///     Webhook event alias for script saved.
+            /// </summary>
+            public const string ScriptSaved = "scriptSaved";
+
+            /// <summary>
+            ///     Webhook event alias for stylesheet deleted.
+            /// </summary>
+            public const string StylesheetDeleted = "stylesheetDeleted";
+
+            /// <summary>
+            ///     Webhook event alias for stylesheet saved.
+            /// </summary>
+            public const string StylesheetSaved = "stylesheetSaved";
+
+            /// <summary>
+            ///     Webhook event alias for template deleted.
+            /// </summary>
+            public const string TemplateDeleted = "templateDeleted";
+
+            /// <summary>
+            ///     Webhook event alias for template saved.
+            /// </summary>
+            public const string TemplateSaved = "templateSaved";
+
+            /// <summary>
+            ///     Webhook event alias for health check completed.
+            /// </summary>
+            public const string HealthCheckCompleted = "healthCheckCompleted";
+
+            /// <summary>
+            ///     Webhook event alias for language deleted.
+            /// </summary>
+            public const string LanguageDeleted = "languageDeleted";
+
+            /// <summary>
+            ///     Webhook event alias for language saved.
+            /// </summary>
+            public const string LanguageSaved = "languageSaved";
+
+            /// <summary>
+            ///     Webhook event alias for media emptied recycle bin.
+            /// </summary>
+            public const string MediaEmptiedRecycleBin = "mediaEmptiedRecycleBin";
+
+            /// <summary>
+            ///     Webhook event alias for media moved to recycle bin.
+            /// </summary>
+            public const string MediaMovedToRecycleBin = "mediaMovedToRecycleBin";
+
+            /// <summary>
+            ///     Webhook event alias for media moved.
+            /// </summary>
+            public const string MediaMoved = "mediaMoved";
+
+            /// <summary>
+            ///     Webhook event alias for assigned member roles.
+            /// </summary>
+            public const string AssignedMemberRoles = "assignedMemberRoles";
+
+            /// <summary>
+            ///     Webhook event alias for exported member.
+            /// </summary>
+            public const string ExportedMember = "exportedMember";
+
+            /// <summary>
+            ///     Webhook event alias for member deleted.
+            /// </summary>
+            public const string MemberDeleted = "memberDeleted";
+
+            /// <summary>
+            ///     Webhook event alias for member group deleted.
+            /// </summary>
+            public const string MemberGroupDeleted = "memberGroupDeleted";
+
+            /// <summary>
+            ///     Webhook event alias for member group saved.
+            /// </summary>
+            public const string MemberGroupSaved = "memberGroupSaved";
+
+            /// <summary>
+            ///     Webhook event alias for member saved.
+            /// </summary>
+            public const string MemberSaved = "memberSaved";
+
+            /// <summary>
+            ///     Webhook event alias for removed member roles.
+            /// </summary>
+            public const string RemovedMemberRoles = "removedMemberRoles";
+
+            /// <summary>
+            ///     Webhook event alias for package imported.
+            /// </summary>
+            public const string PackageImported = "packageImported";
+
+            /// <summary>
+            ///     Webhook event alias for public access entry deleted.
+            /// </summary>
+            public const string PublicAccessEntryDeleted = "publicAccessEntryDeleted";
+
+            /// <summary>
+            ///     Webhook event alias for public access entry saved.
+            /// </summary>
+            public const string PublicAccessEntrySaved = "publicAccessEntrySaved";
+
+            /// <summary>
+            ///     Webhook event alias for relation deleted.
+            /// </summary>
+            public const string RelationDeleted = "relationDeleted";
+
+            /// <summary>
+            ///     Webhook event alias for relation saved.
+            /// </summary>
+            public const string RelationSaved = "relationSaved";
+
+            /// <summary>
+            ///     Webhook event alias for relation type deleted.
+            /// </summary>
+            public const string RelationTypeDeleted = "relationTypeDeleted";
+
+            /// <summary>
+            ///     Webhook event alias for relation type saved.
+            /// </summary>
+            public const string RelationTypeSaved = "relationTypeSaved";
+
+            /// <summary>
+            ///    Webhook event alias for assigned user group permissions;
+            /// </summary>
+            public const string AssignedUserGroupPermissions = "assignedUserGroupPermissions";
+
+            /// <summary>
+            ///     Webhook event alias for user deleted.
+            /// </summary>
+            public const string UserDeleted = "userDeleted";
+
+            /// <summary>
+            ///     Webhook event alias for user forgot password requested.
+            /// </summary>
+            public const string UserForgotPasswordRequested = "userForgotPasswordRequested";
+
+            /// <summary>
+            ///     Webhook event alias for user group deleted.
+            /// </summary>
+            public const string UserGroupDeleted = "UserGroupDeleted";
+
+            /// <summary>
+            ///     Webhook event alias for user group saved.
+            /// </summary>
+            public const string UserGroupSaved = "userGroupSaved";
+
+            /// <summary>
+            ///     Webhook event alias for user locked.
+            /// </summary>
+            public const string UserLocked = "userLocked";
+
+            /// <summary>
+            ///     Webhook event alias for user login failed.
+            /// </summary>
+            public const string UserLoginFailed = "userLoginFailed";
+
+            /// <summary>
+            ///     Webhook event alias for user login requires verification.
+            /// </summary>
+            public const string UserLoginRequiresVerification = "userLoginRequiresVerification";
+
+            /// <summary>
+            ///     Webhook event alias for user login success.
+            /// </summary>
+            public const string UserLoginSuccess = "userLoginSuccess";
+
+            /// <summary>
+            ///     Webhook event alias for user logout success.
+            /// </summary>
+            public const string UserLogoutSuccess = "userLogoutSuccess";
+
+            /// <summary>
+            ///     Webhook event alias for user password changed.
+            /// </summary>
+            public const string UserPasswordChanged = "userPasswordChanged";
+
+            /// <summary>
+            ///     Webhook event alias for user password reset.
+            /// </summary>
+            public const string UserPasswordReset = "userPasswordReset";
+
+            /// <summary>
+            ///     Webhook event alias for user saved.
+            /// </summary>
+            public const string UserSaved = "userSaved";
+
+            /// <summary>
+            ///     Webhook event alias for user two factor requested.
+            /// </summary>
+            public const string UserTwoFactorRequested = "userTwoFactorRequested";
+
+            /// <summary>
+            ///     Webhook event alias for user unlocked.
+            /// </summary>
+            public const string UserUnlocked = "userUnlocked";
         }
 
         public static class Types

--- a/src/Umbraco.Core/Webhooks/Events/ContentType/DocumentTypeChangedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/ContentType/DocumentTypeChangedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class DocumentTypeChangedWebhookEvent : WebhookEventBase<ContentTypeChang
     {
     }
 
-    public override string Alias => "documentTypeChanged";
+    public override string Alias => Constants.WebhookEvents.Aliases.DocumentTypeChanged;
 
     public override object? ConvertNotificationToRequestPayload(ContentTypeChangedNotification notification)
         => notification.Changes;

--- a/src/Umbraco.Core/Webhooks/Events/ContentType/DocumentTypeDeletedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/ContentType/DocumentTypeDeletedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class DocumentTypeDeletedWebhookEvent : WebhookEventBase<ContentTypeDelet
     {
     }
 
-    public override string Alias => "documentTypeDeleted";
+    public override string Alias => Constants.WebhookEvents.Aliases.DocumentTypeDeleted;
 
     public override object? ConvertNotificationToRequestPayload(ContentTypeDeletedNotification notification)
         => notification.DeletedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/ContentType/DocumentTypeMovedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/ContentType/DocumentTypeMovedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class DocumentTypeMovedWebhookEvent : WebhookEventBase<ContentTypeMovedNo
     {
     }
 
-    public override string Alias => "documentTypeMoved";
+    public override string Alias => Constants.WebhookEvents.Aliases.DocumentTypeMoved;
 
     public override object? ConvertNotificationToRequestPayload(ContentTypeMovedNotification notification)
         => notification.MoveInfoCollection;

--- a/src/Umbraco.Core/Webhooks/Events/ContentType/DocumentTypeSavedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/ContentType/DocumentTypeSavedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class DocumentTypeSavedWebhookEvent : WebhookEventBase<ContentTypeSavedNo
     {
     }
 
-    public override string Alias => "documentTypeSaved";
+    public override string Alias => Constants.WebhookEvents.Aliases.DocumentTypeSaved;
 
     public override object? ConvertNotificationToRequestPayload(ContentTypeSavedNotification notification)
         => notification.SavedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/ContentType/MediaTypeChangedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/ContentType/MediaTypeChangedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class MediaTypeChangedWebhookEvent : WebhookEventBase<MediaTypeChangedNot
     {
     }
 
-    public override string Alias => "mediaTypeChanged";
+    public override string Alias => Constants.WebhookEvents.Aliases.MediaTypeChanged;
 
     public override object? ConvertNotificationToRequestPayload(MediaTypeChangedNotification notification)
         => notification.Changes;

--- a/src/Umbraco.Core/Webhooks/Events/ContentType/MediaTypeDeletedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/ContentType/MediaTypeDeletedWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,7 +18,7 @@ public class MediaTypeDeletedWebhookEvent : WebhookEventBase<MediaTypeDeletedNot
     {
     }
 
-    public override string Alias => "mediaTypeDeleted";
+    public override string Alias => Constants.WebhookEvents.Aliases.MediaTypeDeleted;
 
     public override object? ConvertNotificationToRequestPayload(MediaTypeDeletedNotification notification)
         => notification.DeletedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/ContentType/MediaTypeMovedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/ContentType/MediaTypeMovedWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,7 +18,7 @@ public class MediaTypeMovedWebhookEvent : WebhookEventBase<MediaTypeMovedNotific
     {
     }
 
-    public override string Alias => "mediaTypeMoved";
+    public override string Alias => Constants.WebhookEvents.Aliases.MediaTypeMoved;
 
     public override object? ConvertNotificationToRequestPayload(MediaTypeMovedNotification notification)
         => notification.MoveInfoCollection;

--- a/src/Umbraco.Core/Webhooks/Events/ContentType/MediaTypeSavedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/ContentType/MediaTypeSavedWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,7 +18,7 @@ public class MediaTypeSavedWebhookEvent : WebhookEventBase<MediaTypeSavedNotific
     {
     }
 
-    public override string Alias => "mediaTypeSaved";
+    public override string Alias => Constants.WebhookEvents.Aliases.MediaTypeSaved;
 
     public override object? ConvertNotificationToRequestPayload(MediaTypeSavedNotification notification)
         => notification.SavedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/ContentType/MemberTypeChangedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/ContentType/MemberTypeChangedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class MemberTypeChangedWebhookEvent : WebhookEventBase<MemberTypeChangedN
     {
     }
 
-    public override string Alias => "memberTypeChanged";
+    public override string Alias => Constants.WebhookEvents.Aliases.MemberTypeChanged;
 
     public override object? ConvertNotificationToRequestPayload(MemberTypeChangedNotification notification)
         => notification.Changes;

--- a/src/Umbraco.Core/Webhooks/Events/ContentType/MemberTypeDeletedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/ContentType/MemberTypeDeletedWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,7 +18,7 @@ public class MemberTypeDeletedWebhookEvent : WebhookEventBase<MemberTypeDeletedN
     {
     }
 
-    public override string Alias => "memberTypeDeleted";
+    public override string Alias => Constants.WebhookEvents.Aliases.MemberTypeDeleted;
 
     public override object? ConvertNotificationToRequestPayload(MemberTypeDeletedNotification notification)
         => notification.DeletedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/ContentType/MemberTypeMovedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/ContentType/MemberTypeMovedWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,7 +18,7 @@ public class MemberTypeMovedWebhookEvent : WebhookEventBase<MemberTypeMovedNotif
     {
     }
 
-    public override string Alias => "memberTypeMoved";
+    public override string Alias => Constants.WebhookEvents.Aliases.MemberTypeMoved;
 
     public override object? ConvertNotificationToRequestPayload(MemberTypeMovedNotification notification)
         => notification.MoveInfoCollection;

--- a/src/Umbraco.Core/Webhooks/Events/ContentType/MemberTypeSavedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/ContentType/MemberTypeSavedWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,7 +18,7 @@ public class MemberTypeSavedWebhookEvent : WebhookEventBase<MemberTypeSavedNotif
     {
     }
 
-    public override string Alias => "memberTypeSaved";
+    public override string Alias => Constants.WebhookEvents.Aliases.MemberTypeSaved;
 
     public override object? ConvertNotificationToRequestPayload(MemberTypeSavedNotification notification) =>
         notification.SavedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/DataType/DataTypeDeletedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/DataType/DataTypeDeletedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class DataTypeDeletedWebhookEvent : WebhookEventBase<DataTypeSavedNotific
     {
     }
 
-    public override string Alias => "dataTypeDeleted";
+    public override string Alias => Constants.WebhookEvents.Aliases.DataTypeDeleted;
 
     public override object? ConvertNotificationToRequestPayload(DataTypeSavedNotification notification)
         => notification.SavedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/DataType/DataTypeMovedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/DataType/DataTypeMovedWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,7 +18,7 @@ public class DataTypeMovedWebhookEvent : WebhookEventBase<DataTypeMovedNotificat
     {
     }
 
-    public override string Alias => "dataTypeMoved";
+    public override string Alias => Constants.WebhookEvents.Aliases.DataTypeMoved;
 
     public override object? ConvertNotificationToRequestPayload(DataTypeMovedNotification notification)
         => notification.MoveInfoCollection;

--- a/src/Umbraco.Core/Webhooks/Events/DataType/DataTypeSavedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/DataType/DataTypeSavedWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,7 +18,7 @@ public class DataTypeSavedWebhookEvent : WebhookEventBase<DataTypeSavedNotificat
     {
     }
 
-    public override string Alias => "dataTypeSaved";
+    public override string Alias => Constants.WebhookEvents.Aliases.DataTypeSaved;
 
     public override object? ConvertNotificationToRequestPayload(DataTypeSavedNotification notification)
         => notification.SavedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/Dictionary/DictionaryItemDeletedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/Dictionary/DictionaryItemDeletedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class DictionaryItemDeletedWebhookEvent : WebhookEventBase<DictionaryItem
     {
     }
 
-    public override string Alias => "dictionaryItemDeleted";
+    public override string Alias => Constants.WebhookEvents.Aliases.DictionaryItemDeleted;
 
     public override object? ConvertNotificationToRequestPayload(DictionaryItemDeletedNotification notification)
         => notification.DeletedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/Dictionary/DictionaryItemSavedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/Dictionary/DictionaryItemSavedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class DictionaryItemSavedWebhookEvent : WebhookEventBase<DictionaryItemSa
     {
     }
 
-    public override string Alias => "dictionaryItemSaved";
+    public override string Alias => Constants.WebhookEvents.Aliases.DictionaryItemSaved;
 
     public override object? ConvertNotificationToRequestPayload(DictionaryItemSavedNotification notification)
         => notification.SavedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/Domain/DomainDeletedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/Domain/DomainDeletedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class DomainDeletedWebhookEvent : WebhookEventBase<DomainDeletedNotificat
     {
     }
 
-    public override string Alias => "domainDeleted";
+    public override string Alias => Constants.WebhookEvents.Aliases.DomainDeleted;
 
     public override object? ConvertNotificationToRequestPayload(DomainDeletedNotification notification)
         => notification.DeletedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/Domain/DomainSavedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/Domain/DomainSavedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class DomainSavedWebhookEvent : WebhookEventBase<DomainSavedNotification>
     {
     }
 
-    public override string Alias => "domainSaved";
+    public override string Alias => Constants.WebhookEvents.Aliases.DocumentTypeSaved;
 
     public override object? ConvertNotificationToRequestPayload(DomainSavedNotification notification)
         => notification.SavedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/Domain/DomainSavedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/Domain/DomainSavedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class DomainSavedWebhookEvent : WebhookEventBase<DomainSavedNotification>
     {
     }
 
-    public override string Alias => Constants.WebhookEvents.Aliases.DocumentTypeSaved;
+    public override string Alias => Constants.WebhookEvents.Aliases.DomainSaved;
 
     public override object? ConvertNotificationToRequestPayload(DomainSavedNotification notification)
         => notification.SavedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/File/PartialViewDeletedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/File/PartialViewDeletedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class PartialViewDeletedWebhookEvent : WebhookEventBase<PartialViewDelete
     {
     }
 
-    public override string Alias => "partialViewDeleted";
+    public override string Alias => Constants.WebhookEvents.Aliases.PartialViewDeleted;
 
     public override object? ConvertNotificationToRequestPayload(PartialViewDeletedNotification notification)
         => notification.DeletedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/File/PartialViewSavedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/File/PartialViewSavedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class PartialViewSavedWebhookEvent : WebhookEventBase<PartialViewSavedNot
     {
     }
 
-    public override string Alias => "partialViewSaved";
+    public override string Alias => Constants.WebhookEvents.Aliases.PartialViewSaved;
 
     public override object? ConvertNotificationToRequestPayload(PartialViewSavedNotification notification) =>
         notification.SavedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/File/ScriptDeletedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/File/ScriptDeletedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class ScriptDeletedWebhookEvent : WebhookEventBase<ScriptDeletedNotificat
     {
     }
 
-    public override string Alias => "scriptDeleted";
+    public override string Alias => Constants.WebhookEvents.Aliases.ScriptDeleted;
 
     public override object? ConvertNotificationToRequestPayload(ScriptDeletedNotification notification)
         => notification.DeletedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/File/ScriptSavedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/File/ScriptSavedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class ScriptSavedWebhookEvent : WebhookEventBase<ScriptDeletedNotificatio
     {
     }
 
-    public override string Alias => "scriptSaved";
+    public override string Alias => Constants.WebhookEvents.Aliases.ScriptSaved;
 
     public override object? ConvertNotificationToRequestPayload(ScriptDeletedNotification notification)
         => notification.DeletedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/File/StylesheetDeletedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/File/StylesheetDeletedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class StylesheetDeletedWebhookEvent : WebhookEventBase<StylesheetDeletedN
     {
     }
 
-    public override string Alias => "stylesheetDeleted";
+    public override string Alias => Constants.WebhookEvents.Aliases.StylesheetDeleted;
 
     public override object? ConvertNotificationToRequestPayload(StylesheetDeletedNotification notification) =>
         notification.DeletedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/File/StylesheetSavedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/File/StylesheetSavedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class StylesheetSavedWebhookEvent : WebhookEventBase<StylesheetSavedNotif
     {
     }
 
-    public override string Alias => "stylesheetSaved";
+    public override string Alias => Constants.WebhookEvents.Aliases.StylesheetSaved;
 
     public override object? ConvertNotificationToRequestPayload(StylesheetSavedNotification notification)
         => notification.SavedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/File/TemplateDeletedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/File/TemplateDeletedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class TemplateDeletedWebhookEvent : WebhookEventBase<TemplateDeletedNotif
     {
     }
 
-    public override string Alias => "templateDeleted";
+    public override string Alias => Constants.WebhookEvents.Aliases.TemplateDeleted;
 
     public override object? ConvertNotificationToRequestPayload(TemplateDeletedNotification notification) =>
         notification.DeletedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/File/TemplateSavedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/File/TemplateSavedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class TemplateSavedWebhookEvent : WebhookEventBase<TemplateSavedNotificat
     {
     }
 
-    public override string Alias => "templateSaved";
+    public override string Alias => Constants.WebhookEvents.Aliases.TemplateSaved;
 
     public override object? ConvertNotificationToRequestPayload(TemplateSavedNotification notification)
     {

--- a/src/Umbraco.Core/Webhooks/Events/HealthCheck/HealthCheckCompletedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/HealthCheck/HealthCheckCompletedWebhookEvent.cs
@@ -13,7 +13,7 @@ public class HealthCheckCompletedWebhookEvent : WebhookEventBase<HealthCheckComp
     {
     }
 
-    public override string Alias => "healthCheckCompleted";
+    public override string Alias => Constants.WebhookEvents.Aliases.HealthCheckCompleted;
 
     public override object? ConvertNotificationToRequestPayload(HealthCheckCompletedNotification notification) => notification.HealthCheckResults;
 }

--- a/src/Umbraco.Core/Webhooks/Events/Language/LanguageDeletedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/Language/LanguageDeletedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class LanguageDeletedWebhookEvent : WebhookEventBase<LanguageDeletedNotif
     {
     }
 
-    public override string Alias => "languageDeleted";
+    public override string Alias => Constants.WebhookEvents.Aliases.LanguageDeleted;
 
     public override object? ConvertNotificationToRequestPayload(LanguageDeletedNotification notification)
         => notification.DeletedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/Language/LanguageSavedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/Language/LanguageSavedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class LanguageSavedWebhookEvent : WebhookEventBase<LanguageSavedNotificat
     {
     }
 
-    public override string Alias => "languageSaved";
+    public override string Alias => Constants.WebhookEvents.Aliases.LanguageSaved;
 
     public override object? ConvertNotificationToRequestPayload(LanguageSavedNotification notification)
         => notification.SavedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/Media/MediaEmptiedRecycleBinWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/Media/MediaEmptiedRecycleBinWebhookEvent.cs
@@ -23,7 +23,7 @@ public class MediaEmptiedRecycleBinWebhookEvent : WebhookEventContentBase<MediaE
     {
     }
 
-    public override string Alias => "mediaEmptiedRecycleBin";
+    public override string Alias => Constants.WebhookEvents.Aliases.MediaEmptiedRecycleBin;
 
     protected override IEnumerable<IMedia> GetEntitiesFromNotification(MediaEmptiedRecycleBinNotification notification) => notification.DeletedEntities;
 

--- a/src/Umbraco.Core/Webhooks/Events/Media/MediaMovedToRecycleBinWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/Media/MediaMovedToRecycleBinWebhookEvent.cs
@@ -23,7 +23,7 @@ public class MediaMovedToRecycleBinWebhookEvent : WebhookEventContentBase<MediaM
     {
     }
 
-    public override string Alias => "mediaMovedToRecycleBin";
+    public override string Alias => Constants.WebhookEvents.Aliases.MediaMovedToRecycleBin;
 
     protected override IEnumerable<IMedia> GetEntitiesFromNotification(MediaMovedToRecycleBinNotification notification) => notification.MoveInfoCollection.Select(x => x.Entity);
 

--- a/src/Umbraco.Core/Webhooks/Events/Media/MediaMovedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/Media/MediaMovedWebhookEvent.cs
@@ -23,7 +23,7 @@ public class MediaMovedWebhookEvent : WebhookEventContentBase<MediaMovedNotifica
     {
     }
 
-    public override string Alias => "mediaMoved";
+    public override string Alias => Constants.WebhookEvents.Aliases.MediaMoved;
 
     protected override IEnumerable<IMedia> GetEntitiesFromNotification(MediaMovedNotification notification) => notification.MoveInfoCollection.Select(x => x.Entity);
 

--- a/src/Umbraco.Core/Webhooks/Events/Member/AssignedMemberRolesWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/Member/AssignedMemberRolesWebhookEvent.cs
@@ -18,5 +18,5 @@ public class AssignedMemberRolesWebhookEvent : WebhookEventBase<AssignedMemberRo
     {
     }
 
-    public override string Alias => "assignedMemberRoles";
+    public override string Alias => Constants.WebhookEvents.Aliases.AssignedMemberRoles;
 }

--- a/src/Umbraco.Core/Webhooks/Events/Member/ExportedMemberWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/Member/ExportedMemberWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,7 +18,7 @@ public class ExportedMemberWebhookEvent : WebhookEventBase<ExportedMemberNotific
     {
     }
 
-    public override string Alias => "exportedMember";
+    public override string Alias => Constants.WebhookEvents.Aliases.ExportedMember;
 
     public override object? ConvertNotificationToRequestPayload(ExportedMemberNotification notification)
     {

--- a/src/Umbraco.Core/Webhooks/Events/Member/MemberDeletedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/Member/MemberDeletedWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,7 +18,7 @@ public class MemberDeletedWebhookEvent : WebhookEventBase<MemberDeletedNotificat
     {
     }
 
-    public override string Alias => "memberDeleted";
+    public override string Alias => Constants.WebhookEvents.Aliases.MemberDeleted;
 
     public override object? ConvertNotificationToRequestPayload(MemberDeletedNotification notification)
     {

--- a/src/Umbraco.Core/Webhooks/Events/Member/MemberGroupDeletedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/Member/MemberGroupDeletedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class MemberGroupDeletedWebhookEvent : WebhookEventBase<MemberGroupDelete
     {
     }
 
-    public override string Alias => "memberGroupDeleted";
+    public override string Alias => Constants.WebhookEvents.Aliases.MemberGroupDeleted;
 
     public override object? ConvertNotificationToRequestPayload(MemberGroupDeletedNotification notification)
         => notification.DeletedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/Member/MemberGroupSavedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/Member/MemberGroupSavedWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,7 +18,7 @@ public class MemberGroupSavedWebhookEvent : WebhookEventBase<MemberGroupSavedNot
     {
     }
 
-    public override string Alias => "memberGroupSaved";
+    public override string Alias => Constants.WebhookEvents.Aliases.MemberGroupSaved;
 
     public override object? ConvertNotificationToRequestPayload(MemberGroupSavedNotification notification)
         => notification.SavedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/Member/MemberSavedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/Member/MemberSavedWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,7 +18,7 @@ public class MemberSavedWebhookEvent : WebhookEventBase<MemberSavedNotification>
     {
     }
 
-    public override string Alias => "memberSaved";
+    public override string Alias => Constants.WebhookEvents.Aliases.MemberSaved;
 
     public override object? ConvertNotificationToRequestPayload(MemberSavedNotification notification)
     {

--- a/src/Umbraco.Core/Webhooks/Events/Member/RemovedMemberRolesWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/Member/RemovedMemberRolesWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,5 +18,5 @@ public class RemovedMemberRolesWebhookEvent : WebhookEventBase<RemovedMemberRole
     {
     }
 
-    public override string Alias => "removedMemberRoles";
+    public override string Alias => Constants.WebhookEvents.Aliases.RemovedMemberRoles;
 }

--- a/src/Umbraco.Core/Webhooks/Events/Package/ImportedPackageWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/Package/ImportedPackageWebhookEvent.cs
@@ -18,5 +18,5 @@ public class ImportedPackageWebhookEvent : WebhookEventBase<ImportedPackageNotif
     {
     }
 
-    public override string Alias => "packageImported";
+    public override string Alias => Constants.WebhookEvents.Aliases.PackageImported;
 }

--- a/src/Umbraco.Core/Webhooks/Events/PublicAccess/PublicAccessEntryDeletedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/PublicAccess/PublicAccessEntryDeletedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class PublicAccessEntryDeletedWebhookEvent : WebhookEventBase<PublicAcces
     {
     }
 
-    public override string Alias => "publicAccessEntryDeleted";
+    public override string Alias => Constants.WebhookEvents.Aliases.PublicAccessEntryDeleted;
 
     public override object? ConvertNotificationToRequestPayload(PublicAccessEntryDeletedNotification notification) => notification.DeletedEntities;
 }

--- a/src/Umbraco.Core/Webhooks/Events/PublicAccess/PublicAccessEntrySavedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/PublicAccess/PublicAccessEntrySavedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class PublicAccessEntrySavedWebhookEvent : WebhookEventBase<PublicAccessE
     {
     }
 
-    public override string Alias => "publicAccessEntrySaved";
+    public override string Alias => Constants.WebhookEvents.Aliases.PublicAccessEntrySaved;
 
     public override object? ConvertNotificationToRequestPayload(PublicAccessEntrySavedNotification notification)
         => notification.SavedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/Relation/RelationDeletedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/Relation/RelationDeletedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class RelationDeletedWebhookEvent : WebhookEventBase<RelationDeletedNotif
     {
     }
 
-    public override string Alias => "relationDeleted";
+    public override string Alias => Constants.WebhookEvents.Aliases.RelationDeleted;
 
     public override object? ConvertNotificationToRequestPayload(RelationDeletedNotification notification)
         => notification.DeletedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/Relation/RelationSavedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/Relation/RelationSavedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class RelationSavedWebhookEvent : WebhookEventBase<RelationSavedNotificat
     {
     }
 
-    public override string Alias => "relationSaved";
+    public override string Alias => Constants.WebhookEvents.Aliases.RelationSaved;
 
     public override object? ConvertNotificationToRequestPayload(RelationSavedNotification notification)
         => notification.SavedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/RelationType/RelationTypeDeletedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/RelationType/RelationTypeDeletedWebhookEvent.cs
@@ -19,7 +19,7 @@ public class RelationTypeDeletedWebhookEvent : WebhookEventBase<RelationTypeDele
     }
 
 
-    public override string Alias => "relationTypeDeleted";
+    public override string Alias => Constants.WebhookEvents.Aliases.RelationTypeDeleted;
 
     public override object? ConvertNotificationToRequestPayload(RelationTypeDeletedNotification notification)
         => notification.DeletedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/RelationType/RelationTypeSavedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/RelationType/RelationTypeSavedWebhookEvent.cs
@@ -18,7 +18,7 @@ public class RelationTypeSavedWebhookEvent : WebhookEventBase<RelationTypeSavedN
     {
     }
 
-    public override string Alias => "relationTypeSaved";
+    public override string Alias => Constants.WebhookEvents.Aliases.RelationTypeSaved;
 
     public override object? ConvertNotificationToRequestPayload(RelationTypeSavedNotification notification)
         => notification.SavedEntities;

--- a/src/Umbraco.Core/Webhooks/Events/User/AssignedUserGroupPermissionsWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/User/AssignedUserGroupPermissionsWebhookEvent.cs
@@ -18,7 +18,7 @@ public class AssignedUserGroupPermissionsWebhookEvent : WebhookEventBase<Assigne
     {
     }
 
-    public override string Alias => "assignedUserGroupPermissions";
+    public override string Alias => Constants.WebhookEvents.Aliases.AssignedUserGroupPermissions;
 
     public override object? ConvertNotificationToRequestPayload(AssignedUserGroupPermissionsNotification notification)
         => notification.EntityPermissions;

--- a/src/Umbraco.Core/Webhooks/Events/User/UserDeletedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/User/UserDeletedWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,7 +18,7 @@ public class UserDeletedWebhookEvent : WebhookEventBase<UserDeletedNotification>
     {
     }
 
-    public override string Alias => "userDeleted";
+    public override string Alias => Constants.WebhookEvents.Aliases.UserDeleted;
 
     public override object? ConvertNotificationToRequestPayload(UserDeletedNotification notification)
     {

--- a/src/Umbraco.Core/Webhooks/Events/User/UserForgotPasswordRequestedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/User/UserForgotPasswordRequestedWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,6 +18,6 @@ public class UserForgotPasswordRequestedWebhookEvent : WebhookEventBase<UserForg
     {
     }
 
-    public override string Alias => "userForgotPasswordRequested";
+    public override string Alias => Constants.WebhookEvents.Aliases.UserForgotPasswordRequested;
 
 }

--- a/src/Umbraco.Core/Webhooks/Events/User/UserGroupDeletedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/User/UserGroupDeletedWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,7 +18,7 @@ public class UserGroupDeletedWebhookEvent : WebhookEventBase<UserGroupDeletedNot
     {
     }
 
-    public override string Alias => "userGroupDeleted";
+    public override string Alias => Constants.WebhookEvents.Aliases.UserGroupDeleted;
 
     public override object? ConvertNotificationToRequestPayload(UserGroupDeletedNotification notification) => notification.DeletedEntities;
 }

--- a/src/Umbraco.Core/Webhooks/Events/User/UserGroupSavedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/User/UserGroupSavedWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,7 +18,7 @@ public class UserGroupSavedWebhookEvent : WebhookEventBase<UserGroupSavedNotific
     {
     }
 
-    public override string Alias => "userGroupSaved";
+    public override string Alias => Constants.WebhookEvents.Aliases.UserGroupSaved;
 
     public override object? ConvertNotificationToRequestPayload(UserGroupSavedNotification notification) => notification.SavedEntities;
 }

--- a/src/Umbraco.Core/Webhooks/Events/User/UserLockedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/User/UserLockedWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,5 +18,5 @@ public class UserLockedWebhookEvent : WebhookEventBase<UserLockedNotification>
     {
     }
 
-    public override string Alias => "userLocked";
+    public override string Alias => Constants.WebhookEvents.Aliases.UserLocked;
 }

--- a/src/Umbraco.Core/Webhooks/Events/User/UserLoginFailedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/User/UserLoginFailedWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,5 +18,5 @@ public class UserLoginFailedWebhookEvent : WebhookEventBase<UserLoginFailedNotif
     {
     }
 
-    public override string Alias => "userLoginFailed";
+    public override string Alias => Constants.WebhookEvents.Aliases.UserLoginFailed;
 }

--- a/src/Umbraco.Core/Webhooks/Events/User/UserLoginRequiresVerificationWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/User/UserLoginRequiresVerificationWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,6 +18,6 @@ public class UserLoginRequiresVerificationWebhookEvent : WebhookEventBase<UserLo
     {
     }
 
-    public override string Alias => "userLoginRequiresVerification";
+    public override string Alias => Constants.WebhookEvents.Aliases.UserLoginRequiresVerification;
 
 }

--- a/src/Umbraco.Core/Webhooks/Events/User/UserLoginSuccessWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/User/UserLoginSuccessWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,5 +18,5 @@ public class UserLoginSuccessWebhookEvent : WebhookEventBase<UserLoginSuccessNot
     {
     }
 
-    public override string Alias => "userLoginSuccess";
+    public override string Alias => Constants.WebhookEvents.Aliases.UserLoginSuccess;
 }

--- a/src/Umbraco.Core/Webhooks/Events/User/UserLogoutSuccessWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/User/UserLogoutSuccessWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,5 +18,5 @@ public class UserLogoutSuccessWebhookEvent : WebhookEventBase<UserLogoutSuccessN
     {
     }
 
-    public override string Alias => "userLogoutSuccess";
+    public override string Alias => Constants.WebhookEvents.Aliases.UserLogoutSuccess;
 }

--- a/src/Umbraco.Core/Webhooks/Events/User/UserPasswordChangedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/User/UserPasswordChangedWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,6 +18,6 @@ public class UserPasswordChangedWebhookEvent : WebhookEventBase<UserPasswordChan
     {
     }
 
-    public override string Alias => "userPasswordChanged";
+    public override string Alias => Constants.WebhookEvents.Aliases.UserPasswordChanged;
 
 }

--- a/src/Umbraco.Core/Webhooks/Events/User/UserPasswordResetWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/User/UserPasswordResetWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,5 +18,5 @@ public class UserPasswordResetWebhookEvent : WebhookEventBase<UserPasswordResetN
     {
     }
 
-    public override string Alias => "userPasswordReset";
+    public override string Alias => Constants.WebhookEvents.Aliases.UserPasswordReset;
 }

--- a/src/Umbraco.Core/Webhooks/Events/User/UserSavedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/User/UserSavedWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,7 +18,7 @@ public class UserSavedWebhookEvent : WebhookEventBase<UserSavedNotification>
     {
     }
 
-    public override string Alias => "userSaved";
+    public override string Alias => Constants.WebhookEvents.Aliases.UserSaved;
 
     public override object? ConvertNotificationToRequestPayload(UserSavedNotification notification)
     {

--- a/src/Umbraco.Core/Webhooks/Events/User/UserTwoFactorRequestedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/User/UserTwoFactorRequestedWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,6 +18,6 @@ public class UserTwoFactorRequestedWebhookEvent : WebhookEventBase<UserTwoFactor
     {
     }
 
-    public override string Alias => "userTwoFactorRequested";
+    public override string Alias => Constants.WebhookEvents.Aliases.UserTwoFactorRequested;
 
 }

--- a/src/Umbraco.Core/Webhooks/Events/User/UserUnlockedWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/User/UserUnlockedWebhookEvent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -18,5 +18,5 @@ public class UserUnlockedWebhookEvent : WebhookEventBase<UserUnlockedNotificatio
     {
     }
 
-    public override string Alias => "userUnlocked";
+    public override string Alias => Constants.WebhookEvents.Aliases.UserUnlocked;
 }


### PR DESCRIPTION
Use constants for all webhook event aliases. I think it would have been nicer to use `Umbraco` as a prefix everywhere, but unfortunately this will now cause a breaking change.
