### PR TITLE
Decouple Lucene from Content Delivery API

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Delivery/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -15,6 +15,7 @@ using Umbraco.Cms.Api.Delivery.Rendering;
 using Umbraco.Cms.Api.Delivery.Routing;
 using Umbraco.Cms.Api.Delivery.Security;
 using Umbraco.Cms.Api.Delivery.Services;
+using Umbraco.Cms.Api.Delivery.Services.QueryBuilders;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DeliveryApi;
@@ -55,6 +56,7 @@ public static class UmbracoBuilderExtensions
         builder.Services.AddSingleton<IApiAccessService, ApiAccessService>();
         builder.Services.AddSingleton<IApiContentQueryService, ApiContentQueryService>();
         builder.Services.AddSingleton<IApiContentQueryProvider, ApiContentQueryProvider>();
+        builder.Services.AddSingleton<IApiContentQueryFactory, ApiContentQueryFactory>();
         builder.Services.AddSingleton<IApiMediaQueryService, ApiMediaQueryService>();
         builder.Services.AddTransient<IMemberApplicationManager, MemberApplicationManager>();
         builder.Services.AddTransient<IRequestMemberAccessService, RequestMemberAccessService>();

--- a/src/Umbraco.Cms.Api.Delivery/Services/ApiContentQueryProvider.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/ApiContentQueryProvider.cs
@@ -1,4 +1,4 @@
-﻿using Examine;
+using Examine;
 using Examine.Search;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -27,6 +27,7 @@ internal sealed class ApiContentQueryProvider : IApiContentQueryProvider
     public ApiContentQueryProvider(
         IExamineManager examineManager,
         ContentIndexHandlerCollection indexHandlers,
+        IApiContentQueryFactory apiContentQueryFactory,
         IOptions<DeliveryApiSettings> deliveryApiSettings,
         ILogger<ApiContentQueryProvider> logger)
     {
@@ -41,7 +42,7 @@ internal sealed class ApiContentQueryProvider : IApiContentQueryProvider
 
         // for the time being we're going to keep these as internal implementation details.
         // perhaps later on it will make sense to expose them through the DI.
-        _selectorBuilder = new ApiContentQuerySelectorBuilder(deliveryApiSettings.Value);
+        _selectorBuilder = new ApiContentQuerySelectorBuilder(deliveryApiSettings.Value, apiContentQueryFactory);
         _filterBuilder = new ApiContentQueryFilterBuilder(fieldTypes, _logger);
         _sortBuilder = new ApiContentQuerySortBuilder(fieldTypes, _logger);
 

--- a/src/Umbraco.Cms.Api.Delivery/Services/QueryBuilders/ApiContentQueryFactory.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/QueryBuilders/ApiContentQueryFactory.cs
@@ -1,0 +1,26 @@
+using Examine;
+using Examine.Lucene.Providers;
+using Examine.Lucene.Search;
+using Examine.Search;
+using Umbraco.Cms.Infrastructure.Examine;
+
+namespace Umbraco.Cms.Api.Delivery.Services.QueryBuilders
+{
+    internal sealed class ApiContentQueryFactory : IApiContentQueryFactory
+    {
+        /// <inheritdoc/>
+        public IQuery CreateApiContentQuery(IIndex index)
+        {
+            // Needed for enabling leading wildcards searches
+            BaseLuceneSearcher searcher = index.Searcher as BaseLuceneSearcher ?? throw new InvalidOperationException($"Index searcher must be of type {nameof(BaseLuceneSearcher)}.");
+
+            IQuery query = searcher.CreateQuery(
+                IndexTypes.Content,
+                BooleanOperation.And,
+                searcher.LuceneAnalyzer,
+                new LuceneSearchOptions { AllowLeadingWildcard = true });
+
+            return query;
+        }
+    }
+}

--- a/src/Umbraco.Cms.Api.Delivery/Services/QueryBuilders/ApiContentQuerySelectorBuilder.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/QueryBuilders/ApiContentQuerySelectorBuilder.cs
@@ -1,6 +1,4 @@
 using Examine;
-using Examine.Lucene.Providers;
-using Examine.Lucene.Search;
 using Examine.Search;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DeliveryApi;
@@ -30,9 +28,6 @@ internal sealed class ApiContentQuerySelectorBuilder
 
     public IBooleanOperation Build(SelectorOption selectorOption, IIndex index, string culture, ProtectedAccess protectedAccess, bool preview)
     {
-        // Needed for enabling leading wildcards searches
-        BaseLuceneSearcher searcher = index.Searcher as BaseLuceneSearcher ?? throw new InvalidOperationException($"Index searcher must be of type {nameof(BaseLuceneSearcher)}.");
-
         IQuery query = _queryFactory.CreateApiContentQuery(index);
 
         IBooleanOperation selectorOperation = selectorOption.Values.Length == 1

--- a/src/Umbraco.Cms.Api.Delivery/Services/QueryBuilders/IApiContentQueryFactory.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/QueryBuilders/IApiContentQueryFactory.cs
@@ -1,0 +1,18 @@
+using Examine;
+using Examine.Search;
+
+namespace Umbraco.Cms.Api.Delivery.Services.QueryBuilders
+{
+    /// <summary>
+    /// Used to create an <see cref="IQuery"/> instance for content items for the content delivery api.
+    /// </summary>
+    public interface IApiContentQueryFactory
+    {
+        /// <summary>
+        /// Creates an <see cref="IQuery"/> for content items for the content delivery api.
+        /// </summary>
+        /// <param name="index">The <see cref="IIndex"/>.</param>
+        /// <returns>An <see cref="IQuery"/> instance.</returns>
+        IQuery CreateApiContentQuery(IIndex index);
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Currently the Content Delivery API is tightly coupled to Lucene. That means that any other Examine implementation cannot work currently with the Content Delivery API without re-writing the entire `IApiContentQueryProvider` which is a substantial amount of code. 

This change introduces the `IApiContentQueryFactory` which is responsible for creating the IQuery used to as the entry point Examine query for the content delivery API. 

This means that implementations like ExamineX can work without copying/rewriting the whole IApiContentQueryProvider which is a substantial amount of code that is very opinionated.

### Testing

All tests should pass
