### PR TITLE
Ensure artifact dependency keeps correct mode, ordering and checksum values

### DIFF
--- a/src/Umbraco.Core/Deploy/ArtifactDependency.cs
+++ b/src/Umbraco.Core/Deploy/ArtifactDependency.cs
@@ -34,7 +34,7 @@ public class ArtifactDependency
     /// <value>
     ///   <c>true</c> if the dependency is included when building a dependency tree and gets deployed in the correct order; otherwise, <c>false</c>.
     /// </value>
-    public bool Ordering { get; }
+    public bool Ordering { get; internal set; }
 
     /// <summary>
     /// Gets the dependency mode.
@@ -42,7 +42,7 @@ public class ArtifactDependency
     /// <value>
     /// The dependency mode.
     /// </value>
-    public ArtifactDependencyMode Mode { get; }
+    public ArtifactDependencyMode Mode { get; internal set; }
 
     /// <summary>
     /// Gets or sets the checksum.

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Deploy/ArtifactBaseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Deploy/ArtifactBaseTests.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
@@ -47,6 +45,71 @@ public class ArtifactBaseTests
         Assert.AreEqual(
             "umb://template-file/TestPage.cshtml,umb://template/d4651496fad24c1290a53ea4d55d945b",
             string.Join(",", artifact.Dependencies.Select(x => x.Udi.ToString())));
+    }
+
+    [Test]
+    public void Dependencies_Correctly_Updates_Mode()
+    {
+        var udi = Udi.Create(Constants.UdiEntityType.AnyGuid, Guid.NewGuid());
+
+        var dependencies = new ArtifactDependencyCollection
+        {
+            // Keep Match
+            new ArtifactDependency(udi, false, ArtifactDependencyMode.Match),
+            new ArtifactDependency(udi, false, ArtifactDependencyMode.Exist),
+        };
+
+        Assert.AreEqual(1, dependencies.Count);
+        var dependency = dependencies.First();
+        Assert.AreEqual(udi, dependency.Udi);
+        Assert.AreEqual(false, dependency.Ordering);
+        Assert.AreEqual(ArtifactDependencyMode.Match, dependency.Mode);
+        Assert.AreEqual(null, dependency.Checksum);
+    }
+
+    [Test]
+    public void Dependencies_Correctly_Updates_Ordering()
+    {
+        var udi = Udi.Create(Constants.UdiEntityType.AnyGuid, Guid.NewGuid());
+
+        var dependencies = new ArtifactDependencyCollection
+        {
+            // Keep ordering (regardless of mode)
+            new ArtifactDependency(udi, false, ArtifactDependencyMode.Match),
+            new ArtifactDependency(udi, false, ArtifactDependencyMode.Exist),
+            new ArtifactDependency(udi, true, ArtifactDependencyMode.Match),
+            new ArtifactDependency(udi, true, ArtifactDependencyMode.Exist),
+            new ArtifactDependency(udi, false, ArtifactDependencyMode.Match),
+            new ArtifactDependency(udi, false, ArtifactDependencyMode.Exist),
+        };
+
+        Assert.AreEqual(1, dependencies.Count);
+        var dependency = dependencies.First();
+        Assert.AreEqual(udi, dependency.Udi);
+        Assert.AreEqual(true, dependency.Ordering);
+        Assert.AreEqual(ArtifactDependencyMode.Match, dependency.Mode);
+        Assert.AreEqual(null, dependency.Checksum);
+    }
+
+    [Test]
+    public void Dependencies_Correctly_Updates_Checksum()
+    {
+        var udi = Udi.Create(Constants.UdiEntityType.AnyGuid, Guid.NewGuid());
+
+        var dependencies = new ArtifactDependencyCollection
+        {
+            // Keep checksum
+            new ArtifactDependency(udi, true, ArtifactDependencyMode.Match, "123"),
+            new ArtifactDependency(udi, true, ArtifactDependencyMode.Match, string.Empty),
+            new ArtifactDependency(udi, true, ArtifactDependencyMode.Match),
+        };
+
+        Assert.AreEqual(1, dependencies.Count);
+        var dependency = dependencies.First();
+        Assert.AreEqual(udi, dependency.Udi);
+        Assert.AreEqual(true, dependency.Ordering);
+        Assert.AreEqual(ArtifactDependencyMode.Match, dependency.Mode);
+        Assert.AreEqual("123", dependency.Checksum);
     }
 
     private class TestArtifact : ArtifactBase<GuidUdi>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
PR https://github.com/umbraco/Umbraco-CMS/pull/15318 causes a regression in adding artifact dependencies to `ArtifactDependencyCollection` for the same UDI, but with a different ordering flag set. Instead of not adding the artifact when the dependency mode was the same, the logic was changed to only prevent downgrading it from `ArtifactDependencyMode.Match` to `ArtifactDependencyMode.Exist`. So dependencies with the same mode would override an already added one and thereby potentially reset the ordering flag.

Deploy actually relied on this implementation detail, because a dependency to the parent content node would first be added using `new ArtifactDependency(art.Parent, true, ArtifactDependencyMode.Exist)` (with ordering enabled), before any dependencies/references within the content were added later. As long as the mode wasn't upgraded to `Match` (which wouldn't make sense for referenced content), the ordering flag from the first added dependency would still be used. However, because this isn't the case anymore, if the content references the parent node and adds a dependency using `new ArtifactDependency(udi, false, ArtifactDependencyMode.Exist)` (with ordering disabled), Deploy won't ensure the parent gets processed before any of it's children and you can get a `ProcessArtifactException` with a message saying it can't find the parent 😢 

To properly fix this, I've ensured both the `Ordering` and `Mode` properties can be internally set and existing dependencies are updated to only 'upgrade' the values (exist to match and non-ordering to ordering). I've also added new tests to verify this.