### PR TITLE
Use `<umb-node-preview>` component and resolve data in controller

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.html
+++ b/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.html
@@ -1,4 +1,4 @@
-<div ng-controller="Umbraco.PrevalueEditors.TreeSourceController" class="umb-property-editor umb-contentpicker">
+<div ng-controller="Umbraco.PrevalueEditors.TreeSourceController as vm" class="umb-property-editor umb-contentpicker">
 
 	<select ng-model="model.value.type" class="umb-property-editor" ng-change="clear()">
 		<option value="content">Content</option>
@@ -7,17 +7,18 @@
 	</select>
 
   <h5 ng-if="node"><localize key="contentPicker_configurationStartNodeTitle">Root node</localize></h5>
+
   <umb-node-preview
-		ng-if="node"
-    class="mt1"
-		icon="node.icon"
-		name="node.name"
-		published="node.published"
-		description="node.path"
-		allow-remove="true"
-		allow-edit="true"
-		on-remove="clear()"
-		on-edit="openContentPicker()">
+		  ng-if="node"
+      class="mt1"
+		  icon="node.icon"
+		  name="node.name"
+		  published="node.published"
+		  description="node.path"
+		  allow-remove="true"
+		  allow-edit="true"
+		  on-remove="clear()"
+		  on-edit="openContentPicker()">
 	</umb-node-preview>
 
     <div ng-if="!node && model.value.type === 'content'" class="mt2">
@@ -93,7 +94,7 @@
 
         <h5><localize key="dynamicRoot_configurationTitle">Dynamic Root Query</localize></h5>
 
-        <!-- origin -->
+        <!-- Origin -->
         <div class="umb-node-preview" single>
           <div class="flex">
             <umb-icon class="umb-node-preview__icon" icon="{{dynamicRootOriginIcon}}"></umb-icon>
@@ -112,13 +113,29 @@
           </div>
         </div>
 
-        <!-- list of query steps -->
-        <div ui-sortable="sortableOptionsForQuerySteps" ng-model="model.value.dynamicRoot.querySteps">
+        <!-- List of query steps -->
+        <div ui-sortable="sortableOptionsForQuerySteps" ng-model="vm.querySteps" ng-if="vm.querySteps">
+          <umb-node-preview
+              ng-repeat="queryStep in vm.querySteps"
+              single
+              class="mt1"
+              icon="queryStep.icon"
+              name="queryStep.name"
+              description="queryStep.description"
+              allow-edit="false"
+              allow-remove="true"
+              on-remove="removeQueryStep(queryStep)">
+          </umb-node-preview>
+        </div>
+
+        <!--<div ui-sortable="sortableOptionsForQuerySteps" ng-model="model.value.dynamicRoot.querySteps">
           <div class="umb-node-preview" single ng-repeat="queryStep in model.value.dynamicRoot.querySteps track by $index">
             <div class="flex">
-              <umb-icon class="umb-node-preview__icon" icon="{{getIconForQueryStepAlias(queryStep.alias)}}"></umb-icon>
+              <umb-icon class="umb-node-preview__icon" icon="{{getIconForQueryStep(queryStep)}}"></umb-icon>
               <div class="umb-node-preview__content">
                 <div class="umb-node-preview__name">
+                  {{getNameForQueryStep(queryStep)}}
+
                   <localize ng-if="queryStep.alias === 'NearestAncestorOrSelf' ||
                   queryStep.alias === 'FurthestAncestorOrSelf' ||
                   queryStep.alias === 'NearestDescendantOrSelf' ||
@@ -128,9 +145,9 @@
                   queryStep.alias !== 'NearestDescendantOrSelf' &&
                   queryStep.alias !== 'FurthestDescendantOrSelf'">{{queryStep.alias}}</span>
                 </div>
-                <div class="umb-node-preview__description" ng-if="queryStep.anyOfDocTypeKeys && queryStep.anyOfDocTypeKeys.length > 0">
+                <div class="umb-node-preview__description" ng-if="queryStep.anyOfDocTypeKeys && queryStep.anyOfDocTypeKeys.length > 0">-->
                   <!-- todo: Maybe get the name to display here. -->
-                  <localize key="dynamicRoot_queryStepTypes">of type: </localize>
+                  <!--<localize key="dynamicRoot_queryStepTypes">of type: </localize>
 
                   <span ng-repeat="key in queryStep.anyOfDocTypeKeys track by $index">
                     {{ key | umbCmsJoinArray:', '}}
@@ -139,18 +156,17 @@
               </div>
             </div>
             <div class="umb-node-preview__actions">
-              <button type="button" class="umb-node-preview__action" ng-click="removeQueryStep(queryStep)"><localize key="general_remove">Remove</localize></button>
+              <button type="button" class="umb-node-preview__action umb-node-preview__action--red" ng-click="removeQueryStep(queryStep)"><localize key="general_remove">Remove</localize></button>
             </div>
           </div>
-        </div>
+        </div>-->
 
         <button
           type="button"
-          class="umb-node-preview-add"
+          class="umb-node-preview-add mt1"
           ng-click="appendDynamicQueryStep()">
           <localize key="dynamicRoot_addQueryStep">Add query step</localize>
         </button>
-
 
         <ul class="unstyled list-icons mt3">
           <li>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR makes the view cleaner and resolve data in controller instead for stored query steps.
https://github.com/umbraco/Umbraco-CMS/pull/15035

It also re-use `<umb-node-preview>` component instead of the hardcoded markup.
Regarding query steps, it probably shouldn't use `single` attribute, but I think it have visually impact on the UI.
