### PR TITLE
V14: User token revocation and session sign-out

### DIFF
--- a/src/Umbraco.Cms.Api.Common/DependencyInjection/UmbracoBuilderAuthExtensions.cs
+++ b/src/Umbraco.Cms.Api.Common/DependencyInjection/UmbracoBuilderAuthExtensions.cs
@@ -40,8 +40,8 @@ public static class UmbracoBuilderAuthExtensions
                         Paths.MemberApi.LogoutEndpoint.TrimStart(Constants.CharArrays.ForwardSlash),
                         Paths.BackOfficeApi.LogoutEndpoint.TrimStart(Constants.CharArrays.ForwardSlash))
                     .SetRevocationEndpointUris(
-                        Paths.BackOfficeApi.RevokeEndpoint.TrimStart(Constants.CharArrays.ForwardSlash),
-                        Paths.MemberApi.RevokeEndpoint.TrimStart(Constants.CharArrays.ForwardSlash));
+                        Paths.MemberApi.RevokeEndpoint.TrimStart(Constants.CharArrays.ForwardSlash),
+                        Paths.BackOfficeApi.RevokeEndpoint.TrimStart(Constants.CharArrays.ForwardSlash));
 
                 // Enable authorization code flow with PKCE
                 options

--- a/src/Umbraco.Cms.Api.Management/Security/BackOfficeApplicationManager.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/BackOfficeApplicationManager.cs
@@ -104,6 +104,12 @@ public class BackOfficeApplicationManager : OpenIdDictApplicationManagerBase, IB
                 CallbackUrlFor(_backOfficeHost ?? backOfficeUrl, _authorizeCallbackPathName ?? "/umbraco")
             },
             Type = OpenIddictConstants.ClientTypes.Public,
+            PostLogoutRedirectUris =
+            {
+                CallbackUrlFor(_backOfficeHost ?? backOfficeUrl, _authorizeCallbackPathName ?? "/umbraco/login"),
+                // FIXME: remove when we no longer use Umbraco.Web.UI project
+                CallbackUrlFor(_backOfficeHost ?? backOfficeUrl, _authorizeCallbackPathName ?? "/umbraco")
+            },
             Permissions =
             {
                 OpenIddictConstants.Permissions.Endpoints.Authorization,

--- a/src/Umbraco.Cms.Api.Management/Security/BackOfficeApplicationManager.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/BackOfficeApplicationManager.cs
@@ -108,11 +108,13 @@ public class BackOfficeApplicationManager : OpenIdDictApplicationManagerBase, IB
             {
                 OpenIddictConstants.Permissions.Endpoints.Authorization,
                 OpenIddictConstants.Permissions.Endpoints.Token,
+                OpenIddictConstants.Permissions.Endpoints.Logout,
+                OpenIddictConstants.Permissions.Endpoints.Revocation,
                 OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode,
                 OpenIddictConstants.Permissions.GrantTypes.RefreshToken,
                 OpenIddictConstants.Permissions.ResponseTypes.Code
             }
         };
 
-    private static Uri CallbackUrlFor(Uri url, string relativePath) => new Uri( $"{url.GetLeftPart(UriPartial.Authority)}/{relativePath.TrimStart(Constants.CharArrays.ForwardSlash)}");
+    private static Uri CallbackUrlFor(Uri url, string relativePath) => new Uri($"{url.GetLeftPart(UriPartial.Authority)}/{relativePath.TrimStart(Constants.CharArrays.ForwardSlash)}");
 }


### PR DESCRIPTION
## Details
- Added support for token revocation and session sign-out for backoffice auth.

## Test
> [!NOTE]  
> Both **Umbraco.Web.UI** and **Umbraco.Web.UI.New** projects can be used for testing.

> Revoke a token (Postman):
- Get a token (_through `/umbraco/management/api/v1/security/back-office/authorize` and then `/umbraco/management/api/v1/security/back-office/token`_);
- Verify that you can use it in a Management API endpoint;
- Call the revocation endpoint with that token:
```http
POST /umbraco/management/api/v1/security/back-office/revoke
     client_id=umbraco-back-office
     token={token to revoke}
Content-Type: application/x-www-form-urlencoded
```
- Verify that it returns 200 OK;
- Verify that you can no longer use the revoked token.
</br>

> Terminate a session (browser):
- Login to Umbraco;
- Verify that the `NewUmbracoBackOffice` cookie is there;
- Visit the following link:
  - If running on **Umbraco.Web.UI** - `https://localhost:44331/umbraco/management/api/v1/security/back-office/signout?post_logout_redirect_uri=https://localhost:44331/umbraco`;
  - If running on **Umbraco.Web.UI.New** - `https://localhost:44339/umbraco/management/api/v1/security/back-office/signout?post_logout_redirect_uri=https://localhost:44339/umbraco/login`.
- Verify that you are redirected to the login page and that the `NewUmbracoBackOffice` cookie is no longer present.