### PR TITLE
Fixes #15512 to allow curly braces in anchors

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -1184,7 +1184,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
           if (currentTarget.url.indexOf("localLink:") > 0) {
             // if the current link has an anchor, it needs to be considered when getting the udi/id
             // if an anchor exists, reduce the substring max by its length plus two to offset the removed prefix and trailing curly brace
-            var linkId = currentTarget.url.substring(currentTarget.url.indexOf(":") + 1, currentTarget.url.lastIndexOf("}"));
+            var linkId = currentTarget.url.substring(currentTarget.url.indexOf(":") + 1, currentTarget.url.indexOf("}"));
 
             //we need to check if this is an INT or a UDI
             var parsedIntId = parseInt(linkId, 10);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes the issues described here: https://github.com/umbraco/Umbraco-CMS/issues/15512

### Description

The PR changes the way that `createLink` inside `tinymce.service.js` parses a locallink. The old implementation used `lastIndexOf` which made it impossible to use `}` as part of the anchor/query string (see the issue).

I've replaced this with simply using `indexOf` to get the frist occurrence of `}` which will be the closing curly brace for the locallink-placeholder.

Examples:
| Value | Before | After |
|------|------|-------|
| `/{localLink:umb://document/dd2b2f19a23f41fb891e22567cf9eda1}` | ✅ | ✅ |
| `/{localLink:1061}` | ✅ | ✅ |
| `/{localLink:umb://document/dd2b2f19a23f41fb891e22567cf9eda1}?key=value` | ✅ | ✅ |
| `/{localLink:umb://document/dd2b2f19a23f41fb891e22567cf9eda1}?key={{value}}` | ⛔ | ✅ |

It similar code is used in Bellissima it might be a good idea to make sure that this fix is included there as well.

Also: I looked around and it seems that `tinymce.service.js` is the only javascript that parses locallinks, I wanted to add a unit test but to be able to do that I would have to move the code somewhere that can be easily testable. I looked at `utilities.js`, `udi.service.js` and `udiParser.service.js` but none of them felt right so I decided to skip the unit test.

I would be happy to update the PR if I can get directions on where to extract the parsing code.
