### PR TITLE
Implement temporary file configuration endpoint

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/TemporaryFile/ConfigurationTemporaryFileController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/TemporaryFile/ConfigurationTemporaryFileController.cs
@@ -1,0 +1,26 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.ViewModels.TemporaryFile;
+
+namespace Umbraco.Cms.Api.Management.Controllers.TemporaryFile;
+
+[ApiVersion("1.0")]
+public class ConfigurationTemporaryFileController : TemporaryFileControllerBase
+{
+    private readonly ITemporaryFileConfigurationPresentationFactory _temporaryFileConfigurationPresentationFactory;
+
+    public ConfigurationTemporaryFileController(
+        ITemporaryFileConfigurationPresentationFactory temporaryFileConfigurationPresentationFactory) =>
+        _temporaryFileConfigurationPresentationFactory = temporaryFileConfigurationPresentationFactory;
+
+    [HttpGet("configuration")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public Task<IActionResult> Configuration()
+    {
+        TemporaryFileConfigurationResponseModel responseModel = _temporaryFileConfigurationPresentationFactory.Create();
+        return Task.FromResult<IActionResult>(Ok(responseModel));
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/TemporaryFileUploadsBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/TemporaryFileUploadsBuilderExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Umbraco.Cms.Api.Management.Mapping.TemporaryFile;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.Mapping.TemporaryFile;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Mapping;
 
@@ -10,6 +12,7 @@ internal static class TTemporaryFileBuilderExtensions
     {
         builder.WithCollectionBuilder<MapDefinitionCollectionBuilder>()
             .Add<TemporaryFileViewModelsMapDefinition>();
+        builder.Services.AddTransient<ITemporaryFileConfigurationPresentationFactory, TemporaryFileConfigurationPresentationFactory>();
 
         return builder;
     }

--- a/src/Umbraco.Cms.Api.Management/Factories/ITemporaryFileConfigurationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/ITemporaryFileConfigurationPresentationFactory.cs
@@ -1,0 +1,8 @@
+﻿using Umbraco.Cms.Api.Management.ViewModels.TemporaryFile;
+
+namespace Umbraco.Cms.Api.Management.Factories;
+
+public interface ITemporaryFileConfigurationPresentationFactory
+{
+    TemporaryFileConfigurationResponseModel Create();
+}

--- a/src/Umbraco.Cms.Api.Management/Factories/TemporaryFileConfigurationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/TemporaryFileConfigurationPresentationFactory.cs
@@ -24,8 +24,6 @@ public class TemporaryFileConfigurationPresentationFactory : ITemporaryFileConfi
             ImageFileTypes = _imageUrlGenerator.SupportedImageFileTypes.ToArray(),
             DisallowedUploadedFilesExtensions = _contentSettings.DisallowedUploadedFileExtensions,
             AllowedUploadedFileExtensions = _contentSettings.AllowedUploadedFileExtensions,
-            MaxFileSize = GetMaxRequestLength(),
+            MaxFileSize = _runtimeSettings.MaxRequestLength,
         };
-
-    private string GetMaxRequestLength() => _runtimeSettings.MaxRequestLength.HasValue ? _runtimeSettings.MaxRequestLength.Value.ToString() : string.Empty;
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/TemporaryFileConfigurationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/TemporaryFileConfigurationPresentationFactory.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.Extensions.Options;
+using Umbraco.Cms.Api.Management.ViewModels.TemporaryFile;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Media;
+
+namespace Umbraco.Cms.Api.Management.Factories;
+
+public class TemporaryFileConfigurationPresentationFactory : ITemporaryFileConfigurationPresentationFactory
+{
+    private readonly RuntimeSettings _runtimeSettings;
+    private readonly IImageUrlGenerator _imageUrlGenerator;
+    private readonly ContentSettings _contentSettings;
+
+    public TemporaryFileConfigurationPresentationFactory(IOptionsSnapshot<ContentSettings> contentSettings, IOptionsSnapshot<RuntimeSettings> runtimeSettings, IImageUrlGenerator imageUrlGenerator)
+    {
+        _runtimeSettings = runtimeSettings.Value;
+        _imageUrlGenerator = imageUrlGenerator;
+        _contentSettings = contentSettings.Value;
+    }
+
+    public TemporaryFileConfigurationResponseModel Create() =>
+        new()
+        {
+            ImageFileTypes = _imageUrlGenerator.SupportedImageFileTypes.ToArray(),
+            DisallowedUploadedFilesExtensions = _contentSettings.DisallowedUploadedFileExtensions,
+            AllowedUploadedFileExtensions = _contentSettings.AllowedUploadedFileExtensions,
+            MaxFileSize = _runtimeSettings.MaxRequestLength ?? 0,
+        };
+}

--- a/src/Umbraco.Cms.Api.Management/Factories/TemporaryFileConfigurationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/TemporaryFileConfigurationPresentationFactory.cs
@@ -24,6 +24,8 @@ public class TemporaryFileConfigurationPresentationFactory : ITemporaryFileConfi
             ImageFileTypes = _imageUrlGenerator.SupportedImageFileTypes.ToArray(),
             DisallowedUploadedFilesExtensions = _contentSettings.DisallowedUploadedFileExtensions,
             AllowedUploadedFileExtensions = _contentSettings.AllowedUploadedFileExtensions,
-            MaxFileSize = _runtimeSettings.MaxRequestLength ?? 0,
+            MaxFileSize = GetMaxRequestLength(),
         };
+
+    private string GetMaxRequestLength() => _runtimeSettings.MaxRequestLength.HasValue ? _runtimeSettings.MaxRequestLength.Value.ToString() : string.Empty;
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/TemporaryFile/TemporaryFileConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/TemporaryFile/TemporaryFileConfigurationResponseModel.cs
@@ -8,5 +8,5 @@ public class TemporaryFileConfigurationResponseModel
 
     public string[] AllowedUploadedFileExtensions { get; set; } = Array.Empty<string>();
 
-    public int MaxFileSize { get; set; }
+    public string MaxFileSize { get; set; } = string.Empty;
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/TemporaryFile/TemporaryFileConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/TemporaryFile/TemporaryFileConfigurationResponseModel.cs
@@ -1,0 +1,12 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.TemporaryFile;
+
+public class TemporaryFileConfigurationResponseModel
+{
+    public string[] ImageFileTypes { get; set; } = Array.Empty<string>();
+
+    public string[] DisallowedUploadedFilesExtensions { get; set; } = Array.Empty<string>();
+
+    public string[] AllowedUploadedFileExtensions { get; set; } = Array.Empty<string>();
+
+    public int MaxFileSize { get; set; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/TemporaryFile/TemporaryFileConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/TemporaryFile/TemporaryFileConfigurationResponseModel.cs
@@ -8,5 +8,5 @@ public class TemporaryFileConfigurationResponseModel
 
     public string[] AllowedUploadedFileExtensions { get; set; } = Array.Empty<string>();
 
-    public string MaxFileSize { get; set; } = string.Empty;
+    public int? MaxFileSize { get; set; }
 }


### PR DESCRIPTION
# Notes
- Implemented `temporaryfile/configuration` endpoint
- Implemented that will get the different configurations from settings & construct the response model.

# How to test
- Using swagger, test out the `temporaryfile/configuration` endpoint
- It should return something akin to:

```
   "imageFileTypes": "png,jpg,jpeg,jfif,gif,bm,bmp,dip,ppm,pbm,pgm,tga,vda,icb,vst,tiff,tif,webp",
    "disallowedUploadFiles": "ashx,aspx,ascx,config,cshtml,vbhtml,asmx,air,axd,xamlx",
    "allowedUploadFiles": "",
    "maxFileSize": null,
```
