### PR TITLE
v14: Implement current user configuration endpoint

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/User/Current/ConfigurationCurrentUserController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/Current/ConfigurationCurrentUserController.cs
@@ -1,12 +1,15 @@
 ﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.User.Current;
+using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User.Current;
 
 [ApiVersion("1.0")]
+[Authorize(Policy = "New" + AuthorizationPolicies.BackOfficeAccess)]
 public class ConfigurationCurrentUserController : CurrentUserControllerBase
 {
     private readonly IUserPresentationFactory _userPresentationFactory;

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/Current/ConfigurationCurrentUserController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/Current/ConfigurationCurrentUserController.cs
@@ -1,0 +1,24 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.ViewModels.User.Current;
+
+namespace Umbraco.Cms.Api.Management.Controllers.User.Current;
+
+[ApiVersion("1.0")]
+public class ConfigurationCurrentUserController : CurrentUserControllerBase
+{
+    private readonly IUserPresentationFactory _userPresentationFactory;
+
+    public ConfigurationCurrentUserController(IUserPresentationFactory userPresentationFactory) => _userPresentationFactory = userPresentationFactory;
+
+    [MapToApiVersion("1.0")]
+    [HttpGet("configuration")]
+    [ProducesResponseType(typeof(CurrenUserConfigurationResponseModel), StatusCodes.Status200OK)]
+    public async Task<IActionResult> Configuration()
+    {
+        CurrenUserConfigurationResponseModel model = await _userPresentationFactory.CreateCurrentUserConfigurationModelAsync();
+        return Ok(model);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Factories/IUserPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IUserPresentationFactory.cs
@@ -18,4 +18,6 @@ public interface IUserPresentationFactory
     Task<CurrentUserResponseModel> CreateCurrentUserResponseModelAsync(IUser user);
 
     Task<UserResendInviteModel> CreateResendInviteModelAsync(ResendInviteUserRequestModel requestModel);
+
+    Task<CurrenUserConfigurationResponseModel> CreateCurrentUserConfigurationModelAsync();
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/Current/CurrenUserConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/Current/CurrenUserConfigurationResponseModel.cs
@@ -1,0 +1,19 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.User.Current;
+
+public class CurrenUserConfigurationResponseModel
+{
+    public bool KeepUserLoggedIn { get; set; }
+
+    public bool UserNameIsEmail { get; set; }
+
+    public int MinimumPasswordLength { get; set; }
+
+    public int MinimumPasswordNonAlphaNum { get; set; }
+
+    public bool RequireDigit { get; set; }
+
+    public bool RequireLowercase { get; set; }
+
+    public bool RequireUppercase { get; set; }
+
+}


### PR DESCRIPTION
# Notes
- Implemented current user configuration endpoint `user/current/configuration`
- Implemented method in UserPresentationFactory that takes the settings and creates the ConfigurationResponseModel.

# How to test
- Using swagger, call the `user/current/configuration` endpoint
- Response should look something like:
```
{
  "keepUserLoggedIn": false,
  "userNameIsEmail": true,
  "minimumPasswordLength": 10,
  "minimumPasswordNonAlphaNum": 0,
  "requireDigit": false,
  "requireLowercase": false,
  "requireUppercase": false
}
```