### PR TITLE
Idea: Add a HasValue check to a generated Modelsbuilder Model

### DIFF
--- a/src/Umbraco.Infrastructure/ModelsBuilder/Building/TextBuilder.cs
+++ b/src/Umbraco.Infrastructure/ModelsBuilder/Building/TextBuilder.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Microsoft.Extensions.Primitives;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 
@@ -297,6 +298,14 @@ public class TextBuilder : Builder
         sb.Append(
             "\t\t\t=> PublishedModelUtility.GetModelPropertyType(GetModelContentType(publishedSnapshotAccessor), selector);\n");
         sb.Append("#pragma warning restore 0109\n\n");
+        sb.Append("#nullable enable\n");
+        sb.AppendFormat("\t\tpublic bool HasValue(IPublishedSnapshotAccessor publishedSnapshotAccessor, Expression<Func<{0}, string>> selector, string? culture = null, string? segment = null, Fallback fallback = default) \n", type.ClrName);
+        sb.Append("\t\t{\n");
+        sb.Append("\t\t\t\tvar propertyType = GetModelPropertyType(publishedSnapshotAccessor, selector);\n");
+        sb.Append("\t\t\t\treturn propertyType!=null ? this.HasValue(propertyType.Alias,culture,segment,fallback) : false;\n");
+        sb.Append("\t\t}\n");
+        sb.Append("#nullable disable\n\n");
+
         sb.Append("\t\tprivate IPublishedValueFallback _publishedValueFallback;");
 
         // write the ctor


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this will fix it for sure.

### Description

Hi, I've been fiddling around with this over the festive period, but I'm not really sure what people think, nor whether any changes to Modelsbuilder are wise or welcomed, or whether this has been thought about before, and rejecting as a thing - but here is the thing that has been idling in my brain, when I'm reviewing code, I'm regularly seeing different approaches in templates to writing out markup depending on whether a field has been populated in Umbraco, you know

```
if (Model.HasValue("subTitle")){
<h2>@(Model.Value<string>("subTitle"))</h2>
```

which is very readable but uses 'stringly typed models'

or when using Modelsbuilder either

```
if (Model.HasValue("subTitle")){
<h2>@Model.SubTitle</h2>
}
```
(which defeats the purpose of using modelsbuilder somewhat)
or

```
if (!string.IsNullOrWhiteSpace(Model.SubTitle)){
<h2>@Model.SubTitle</h2>
}
```

which is ugly and for an RTE field becomes

```
if (!string.IsNullOrWhiteSpace(Model.BodyText.ToString()){
<div class="body">
@Model.BodyText
</div>
}
```

(and this is actually the official recommended approach in the docs, but is is simple?) 

also ToString() will blow up if Model.BodyText is null so you end up advising

```
if (!string.IsNullOrWhiteSpace(Model.BodyText?.ToString()){
<div class="body">
@Model.BodyText
</div>
}
```

There is however a Modelsbuilder 'way' to get an alias of a Modelsbuilder model though...

....so you could have....

```
if (Model.HasValue(HomePage.GetModelPropertyType(_snapshotAccessor, f=>f.SubTitle)){
@Model.SubTitle
}
```

This gives you intellisense on the property name, but is still verbose (particularly with the injection of snapshot accessor, it convolutes it more)

None of these approaches is 'super readable' - 'super friendly' (except perhaps the first stringly typed example :-P)

But it is this which got me tinkering with Modelsbuilder to see what else might be possible and to see if anything is betterer than these existing alternate options...

What I have in this PR, is the addition of a HasValue method to every generated Modelsbuilder Model that takes in the same function expression that one would use with GetModelPropertyType and also all the other overloads for the generic Model.HasValue helper... (this might be a terrible idea?) anyway it allows you to then write:

```
if (Model.HasValue(_snapshotAccessor, f=>f.SubTitle)){
<h2>@Model.SubTitle</h2>
}
```

and also

```
if (Model.HasValue(_snapshotAccessor,f=>f.Title,"en-GB", fallback: Fallback.ToAncestors)){
<h2>@Model.SubTitle</h2>
}
```

to allow you to check a specific culture or whether there is a fallback value... (this is after all just a wrapper around the existing Model.HasValue for IPublishedContent)

I'm thinking this might be more readable and friendly than `!string.IsNullOrWhiteSpace`...

(and also one of the main reasons to use Modelsbuilder is to avoid typos and yet that missing off of the ! at the start of a logic test IS the top typo I seem to encounter)

...  but I'm not sure if it's super efficient to be getting these alias in this way and I'm still abit uneasy about the injection of _stanpshotAccessor, but I had fun noodling around with it over the festive period, and has scratched the itch, but I'd be interested to hear if anyone thinks this is worth persuing further as an idea.

For example, we could change the constructor for all modelsbuilder models to have IPublishedSnapshotAccessor injected into the constructor (this might be bit of a breaking change for people who manually create their own models? possibly only in a major version hop perhaps?) 

But then we could have

```
if (Model.HasValue(f=>f.SubTitle)){
<h2>@Model.SubTitle</h2>
}
```

Which I think from a 'new developer to Umbraco' perspective or 'typing with intellisense in VS' perspective or from a 'quickly reading through the code at a later date to find the issue' perspective - would be the best Modelsbuilder equivalent of the IPublishedContent approach to test for whether a property has a value... but if so - why haven't we done this before?

If it's a performance issue around getting the alias in this way then we could generate 'anything into the models' so we could also have a separate method for each and every property that already knows it's alias, and would allow for:

```
if (Model.HasSubTitleValue()){
<h2>@Model.SubTitle</h2>
}
```

or maybe there is some other neater way to do this! (extension method?) - anyway just getting closure by creating the PR, and having thunk my thunks on it, sorry it has turned into a blog post, but I can't remember my login for my blog so I suspect this is why I've done this instead!

But it would be great if I didn't have to keep looking at all these variations in technical reviews and site healthchecks and there was just one readable and friendly way to check for HasValue for Modelsbuilder that everyone just used, I am after all - only really thinking of myself.

### Testing

Pull down this PR's branch, install Umbraco, generate Modelsbuilder models, then in your homepage.cshtml template view inject PublishedSnapshotAccessor and check for the value of the 'title' property eg

```
@using Umbraco.Cms.Web.Common.PublishedModels;
@inject IPublishedSnapshotAccessor _snapshotAccessor;
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<ContentModels.Homepage>
@{
    Layout = null;
}
@if (Model.HasValue(_snapshotAccessor,f=>f.Title)){
<h1>@Model.Title</h1>
}

```


Thanks for considering this contribution to Umbraco CMS! 
