### PR TITLE
V14: User configuration endpoint

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/User/ConfigurationUserController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/ConfigurationUserController.cs
@@ -1,0 +1,23 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.ViewModels.User;
+using Umbraco.Cms.Web.Common.Authorization;
+
+namespace Umbraco.Cms.Api.Management.Controllers.User;
+
+[ApiVersion("1.0")]
+[Authorize(Policy = "New" + AuthorizationPolicies.RequireAdminAccess)]
+public class ConfigurationUserController : UserControllerBase
+{
+    private readonly IUserPresentationFactory _userPresentationFactory;
+
+    public ConfigurationUserController(IUserPresentationFactory userPresentationFactory) => _userPresentationFactory = userPresentationFactory;
+
+    [HttpGet("configuration")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(UserConfigurationResponseModel), StatusCodes.Status200OK)]
+    public async Task<IActionResult> Configuration() => Ok(await _userPresentationFactory.CreateUserConfigurationModelAsync());
+}

--- a/src/Umbraco.Cms.Api.Management/Factories/IUserPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IUserPresentationFactory.cs
@@ -18,4 +18,6 @@ public interface IUserPresentationFactory
     Task<CurrentUserResponseModel> CreateCurrentUserResponseModelAsync(IUser user);
 
     Task<UserResendInviteModel> CreateResendInviteModelAsync(ResendInviteUserRequestModel requestModel);
+
+    Task<UserConfigurationResponseModel> CreateUserConfigurationModelAsync();
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/UserConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/UserConfigurationResponseModel.cs
@@ -1,0 +1,16 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.User;
+
+public class UserConfigurationResponseModel
+{
+    public bool ShowUserInvite { get; set; }
+
+    public int MinimumPasswordLength { get; set; }
+
+    public bool MinimumPasswordNonAlphaNum { get; set; }
+
+    public bool RequireDigit { get; set; }
+
+    public bool RequireLowercase { get; set; }
+
+    public bool RequireUppercase { get; set; }
+}


### PR DESCRIPTION
# Notes
- Added `user/configuration` endpoint
- Added new `UserConfigurationResponseModel`

# How to test
- Call the `user/configuration` endpoint using swagger.

It should look something like: 
        "showUserInvite": true,
        "minimumPasswordLength": 10,
        "minimumPasswordNonAlphaNum": true,
        + other password configs