### PR TITLE
Run the same cleanup with scaffolding content as when copying.

### DIFF
--- a/src/Umbraco.Core/Notifications/ContentScaffoldedNotification.cs
+++ b/src/Umbraco.Core/Notifications/ContentScaffoldedNotification.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Core.Notifications;
+
+/// <summary>
+/// Notification that is send out when a Content item has been scaffolded from an original item and basic cleaning has been performed
+/// </summary>
+public sealed class ContentScaffoldedNotification : ScaffoldedNotification<IContent>
+{
+    public ContentScaffoldedNotification(IContent original, IContent scaffold, int parentId, EventMessages messages)
+        : base(original, scaffold, parentId, messages)
+    {
+    }
+}

--- a/src/Umbraco.Core/Notifications/ScaffoldedNotification.cs
+++ b/src/Umbraco.Core/Notifications/ScaffoldedNotification.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Umbraco.Cms.Core.Events;
+
+namespace Umbraco.Cms.Core.Notifications;
+
+public abstract class ScaffoldedNotification<T> : CancelableObjectNotification<T>
+    where T : class
+{
+    protected ScaffoldedNotification(T original, T scaffold, int parentId, EventMessages messages)
+        : base(original, messages)
+    {
+        Scaffold = scaffold;
+        ParentId = parentId;
+    }
+
+    public T Original => Target;
+
+    public T Scaffold { get; }
+
+    public int ParentId { get; }
+}

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -358,10 +358,13 @@ public static partial class UmbracoBuilderExtensions
         builder
             .AddNotificationHandler<ContentSavingNotification, BlockListPropertyNotificationHandler>()
             .AddNotificationHandler<ContentCopyingNotification, BlockListPropertyNotificationHandler>()
+            .AddNotificationHandler<ContentScaffoldedNotification, BlockListPropertyNotificationHandler>()
             .AddNotificationHandler<ContentSavingNotification, BlockGridPropertyNotificationHandler>()
             .AddNotificationHandler<ContentCopyingNotification, BlockGridPropertyNotificationHandler>()
+            .AddNotificationHandler<ContentScaffoldedNotification, BlockGridPropertyNotificationHandler>()
             .AddNotificationHandler<ContentSavingNotification, NestedContentPropertyHandler>()
             .AddNotificationHandler<ContentCopyingNotification, NestedContentPropertyHandler>()
+            .AddNotificationHandler<ContentScaffoldedNotification, NestedContentPropertyHandler>()
             .AddNotificationHandler<ContentCopiedNotification, FileUploadPropertyEditor>()
             .AddNotificationHandler<ContentDeletedNotification, FileUploadPropertyEditor>()
             .AddNotificationHandler<MediaDeletedNotification, FileUploadPropertyEditor>()

--- a/src/Umbraco.Infrastructure/PropertyEditors/ComplexPropertyEditorContentNotificationHandler.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ComplexPropertyEditorContentNotificationHandler.cs
@@ -10,9 +10,16 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
+/// <summary>
+/// Handles nested Udi keys when
+/// - saving: Empty keys get generated
+/// - copy: keys get replaced by new ones while keeping references intact
+/// - scaffolding: keys get replaced by new ones while keeping references intact
+/// </summary>
 public abstract class ComplexPropertyEditorContentNotificationHandler :
     INotificationHandler<ContentSavingNotification>,
-    INotificationHandler<ContentCopyingNotification>
+    INotificationHandler<ContentCopyingNotification>,
+    INotificationHandler<ContentScaffoldedNotification>
 {
     protected abstract string EditorAlias { get; }
 
@@ -29,6 +36,12 @@ public abstract class ComplexPropertyEditorContentNotificationHandler :
             IEnumerable<IProperty> props = entity.GetPropertiesByEditor(EditorAlias);
             UpdatePropertyValues(props, true);
         }
+    }
+
+    public void Handle(ContentScaffoldedNotification notification)
+    {
+        IEnumerable<IProperty> props = notification.Scaffold.GetPropertiesByEditor(EditorAlias);
+        UpdatePropertyValues(props, false);
     }
 
     protected abstract string FormatPropertyValue(string rawJson, bool onlyMissingKeys);

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
@@ -628,7 +628,7 @@ public class ContentController : ContentControllerBase
         using (ICoreScope scope = _scopeProvider.CreateCoreScope())
         {
             IContent? blueprint = _contentService.GetBlueprintById(blueprintId);
-            if (blueprint == null)
+            if (blueprint is null)
             {
                 return NotFound();
             }


### PR DESCRIPTION


### Prerequisites

- [x] I have added steps to test this contribution in the description below

Issue: https://github.com/umbraco/Umbraco-CMS/issues/14870

### Description
- Added a new ContentScaffoldedNotification
- Published the notification when a new scaffold has been created from a blueprint (content template)
- Linked up the ComplextPEContent handler to do the same cleanup for the new notification as when copying.
- registered handlers to the event for blocklist, blockgrid and nested content


### Testing
See reproduction steps in linked issue https://github.com/umbraco/Umbraco-CMS/issues/13698
