### PR TITLE
Remove clean xss from datatype name and alias.

### DIFF
--- a/src/Umbraco.Web.BackOffice/Filters/DataTypeValidateAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/DataTypeValidateAttribute.cs
@@ -43,14 +43,6 @@ internal sealed class DataTypeValidateAttribute : TypeFilterAttribute
         public void OnActionExecuting(ActionExecutingContext context)
         {
             var dataType = (DataTypeSave?)context.ActionArguments["dataType"];
-            if (dataType is not null)
-            {
-                dataType.Name = dataType.Name?.CleanForXss('[', ']', '(', ')', ':');
-                dataType.Alias = dataType.Alias == null
-                    ? dataType.Name!
-                    : dataType.Alias.CleanForXss('[', ']', '(', ')', ':');
-            }
-
             // get the property editor, ensuring that it exits
             if (!_propertyEditorCollection.TryGet(dataType?.EditorAlias, out IDataEditor? propertyEditor))
             {

--- a/src/Umbraco.Web.BackOffice/Filters/DataTypeValidateAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/DataTypeValidateAttribute.cs
@@ -42,9 +42,10 @@ internal sealed class DataTypeValidateAttribute : TypeFilterAttribute
 
         public void OnActionExecuting(ActionExecutingContext context)
         {
-            var dataType = (DataTypeSave?)context.ActionArguments["dataType"]; if (dataType is not null)
+            var dataType = (DataTypeSave?)context.ActionArguments["dataType"];
+            if (dataType is not null)
             {
-                dataType.Name = dataType.Name?.CleanForXss('[', ']', '(', ')', ':', '/', '\');
+                dataType.Name = dataType.Name?.CleanForXss('[', ']', '(', ')', ':', '/', '\\');
                 dataType.Alias = dataType.Alias == null
                     ? dataType.Name!
                     : dataType.Alias.CleanForXss('[', ']', '(', ')', ':');

--- a/src/Umbraco.Web.BackOffice/Filters/DataTypeValidateAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/DataTypeValidateAttribute.cs
@@ -42,7 +42,14 @@ internal sealed class DataTypeValidateAttribute : TypeFilterAttribute
 
         public void OnActionExecuting(ActionExecutingContext context)
         {
-            var dataType = (DataTypeSave?)context.ActionArguments["dataType"];
+            var dataType = (DataTypeSave?)context.ActionArguments["dataType"]; if (dataType is not null)
+            {
+                dataType.Name = dataType.Name?.CleanForXss('[', ']', '(', ')', ':', '/', '\');
+                dataType.Alias = dataType.Alias == null
+                    ? dataType.Name!
+                    : dataType.Alias.CleanForXss('[', ']', '(', ')', ':');
+            }
+
             // get the property editor, ensuring that it exits
             if (!_propertyEditorCollection.TryGet(dataType?.EditorAlias, out IDataEditor? propertyEditor))
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/15529

### Description
as this bug descript it https://github.com/umbraco/Umbraco-CMS/issues/15529 create a new data type or edit an exiting one. Change name to something containing a / or : 

What happens is, the / or : is replaced with a whitespace so "True / false" -> "True   False" <- 3 whitespace.

When saving the datatype it runs a cleanForXss method witch replace / or : and other special chars with a whitespace.
I have removed the cleanforxss, to allow using the special chars to create names for the datatype.

Idon´t belive it makes a securtiy risk do to the fact that the rest of umbraco don´t do the same validation for the name property or alias. So in Doctype /: you name it is allowed, also due to the fact that the Datatype controller is behind the authizition.
