### PR TITLE
V14: Copy and move endpoints for content and media types

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/MoveDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/MoveDataTypeController.cs
@@ -22,7 +22,7 @@ public class MoveDataTypeController : DataTypeControllerBase
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
-    [HttpPost("{id:guid}/move")]
+    [HttpPut("{id:guid}/move")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/MoveDictionaryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/MoveDictionaryController.cs
@@ -22,7 +22,7 @@ public class MoveDictionaryController : DictionaryControllerBase
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
-    [HttpPost("{id:guid}/move")]
+    [HttpPut("{id:guid}/move")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/CopyDocumentTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/CopyDocumentTypeController.cs
@@ -1,0 +1,38 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.DocumentType;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Api.Management.Controllers.DocumentType;
+
+[ApiVersion("1.0")]
+public class CopyDocumentTypeController : DocumentTypeControllerBase
+{
+    private readonly IContentTypeService _contentTypeService;
+
+    public CopyDocumentTypeController(IContentTypeService contentTypeService)
+        => _contentTypeService = contentTypeService;
+
+    [HttpPost("{id:guid}/copy")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Copy(Guid id, CopyDocumentTypeRequestModel copyDocumentTypeRequestModel)
+    {
+        IContentType? source = await _contentTypeService.GetAsync(id);
+        if (source is null)
+        {
+            return OperationStatusResult(ContentTypeOperationStatus.NotFound);
+        }
+
+        Attempt<IContentType, ContentTypeStructureOperationStatus> result = await _contentTypeService.CopyAsync(source, copyDocumentTypeRequestModel.TargetId);
+
+        return result.Success
+            ? CreatedAtAction<ByKeyDocumentTypeController>(controller => nameof(controller.ByKey), result.Result!.Key)
+            : StructureOperationStatusResult(result.Status);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/CopyDocumentTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/CopyDocumentTypeController.cs
@@ -24,13 +24,7 @@ public class CopyDocumentTypeController : DocumentTypeControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Copy(Guid id, CopyDocumentTypeRequestModel copyDocumentTypeRequestModel)
     {
-        IContentType? source = await _contentTypeService.GetAsync(id);
-        if (source is null)
-        {
-            return OperationStatusResult(ContentTypeOperationStatus.NotFound);
-        }
-
-        Attempt<IContentType, ContentTypeStructureOperationStatus> result = await _contentTypeService.CopyAsync(source, copyDocumentTypeRequestModel.TargetId);
+        Attempt<IContentType?, ContentTypeStructureOperationStatus> result = await _contentTypeService.CopyAsync(id, copyDocumentTypeRequestModel.TargetId);
 
         return result.Success
             ? CreatedAtAction<ByKeyDocumentTypeController>(controller => nameof(controller.ByKey), result.Result!.Key)

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/CopyDocumentTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/CopyDocumentTypeController.cs
@@ -20,6 +20,7 @@ public class CopyDocumentTypeController : DocumentTypeControllerBase
     [HttpPost("{id:guid}/copy")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Copy(Guid id, CopyDocumentTypeRequestModel copyDocumentTypeRequestModel)
     {

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/DocumentTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/DocumentTypeControllerBase.cs
@@ -92,6 +92,10 @@ public abstract class DocumentTypeControllerBase : ManagementApiControllerBase
             ContentTypeStructureOperationStatus.NotAllowedByPath => new BadRequestObjectResult(new ProblemDetailsBuilder()
                 .WithTitle("Not allowed by path")
                 .WithDetail($"The {type} type operation cannot be performed due to not allowed path (i.e. a child of itself)")),
+            ContentTypeStructureOperationStatus.NotFound => new NotFoundObjectResult(new ProblemDetailsBuilder()
+                .WithTitle("Not Found")
+                .WithDetail($"The specified {type} type was not found")
+                .Build()),
             _ => new ObjectResult("Unknown content type structure operation status") { StatusCode = StatusCodes.Status500InternalServerError }
         };
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/DocumentTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/DocumentTypeControllerBase.cs
@@ -18,6 +18,9 @@ public abstract class DocumentTypeControllerBase : ManagementApiControllerBase
     protected IActionResult OperationStatusResult(ContentTypeOperationStatus status)
         => ContentTypeOperationStatusResult(status, "document");
 
+    protected IActionResult StructureOperationStatusResult(ContentTypeStructureOperationStatus status)
+        => ContentTypeStructureOperationStatusResult(status, "document");
+
     internal static IActionResult ContentTypeOperationStatusResult(ContentTypeOperationStatus status, string type) =>
         status switch
         {
@@ -72,5 +75,23 @@ public abstract class DocumentTypeControllerBase : ManagementApiControllerBase
                     .WithDetail("One or more property type aliases are already in use, all property type aliases must be unique.")
                     .Build()),
             _ => new ObjectResult("Unknown content type operation status") { StatusCode = StatusCodes.Status500InternalServerError },
+        };
+
+    public static IActionResult ContentTypeStructureOperationStatusResult(ContentTypeStructureOperationStatus status, string type) =>
+        status switch
+        {
+            ContentTypeStructureOperationStatus.Success => new OkResult(),
+            ContentTypeStructureOperationStatus.CancelledByNotification => new BadRequestObjectResult(new ProblemDetailsBuilder()
+                .WithTitle("Cancelled by notification")
+                .WithDetail($"A notification handler prevented the {type} type operation")
+                .Build()),
+            ContentTypeStructureOperationStatus.ContainerNotFound => new NotFoundObjectResult(new ProblemDetailsBuilder()
+                .WithTitle("Container not found")
+                .WithDetail("The specified container was not found")
+                .Build()),
+            ContentTypeStructureOperationStatus.NotAllowedByPath => new BadRequestObjectResult(new ProblemDetailsBuilder()
+                .WithTitle("Not allowed by path")
+                .WithDetail($"The {type} type operation cannot be performed due to not allowed path (i.e. a child of itself)")),
+            _ => new ObjectResult("Unknown content type structure operation status") { StatusCode = StatusCodes.Status500InternalServerError }
         };
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/MoveDocumentTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/MoveDocumentTypeController.cs
@@ -24,13 +24,7 @@ public class MoveDocumentTypeController : DocumentTypeControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Move(Guid id, MoveDocumentTypeRequestModel moveDocumentTypeRequestModel)
     {
-        IContentType? source = await _contentTypeService.GetAsync(id);
-        if (source is null)
-        {
-            return OperationStatusResult(ContentTypeOperationStatus.NotFound);
-        }
-
-        Attempt<IContentType, ContentTypeStructureOperationStatus> result = await _contentTypeService.MoveAsync(source, moveDocumentTypeRequestModel.TargetId);
+        Attempt<IContentType?, ContentTypeStructureOperationStatus> result = await _contentTypeService.MoveAsync(id, moveDocumentTypeRequestModel.TargetId);
 
         return result.Success
             ? Ok()

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/MoveDocumentTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/MoveDocumentTypeController.cs
@@ -1,0 +1,38 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.DocumentType;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Api.Management.Controllers.DocumentType;
+
+[ApiVersion("1.0")]
+public class MoveDocumentTypeController : DocumentTypeControllerBase
+{
+    private readonly IContentTypeService _contentTypeService;
+
+    public MoveDocumentTypeController(IContentTypeService contentTypeService)
+        => _contentTypeService = contentTypeService;
+
+    [HttpPost("{id:guid}/move")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Move(Guid id, MoveDocumentTypeRequestModel moveDocumentTypeRequestModel)
+    {
+        IContentType? source = await _contentTypeService.GetAsync(id);
+        if (source is null)
+        {
+            return OperationStatusResult(ContentTypeOperationStatus.NotFound);
+        }
+
+        Attempt<IContentType, ContentTypeStructureOperationStatus> result = await _contentTypeService.MoveAsync(source, moveDocumentTypeRequestModel.TargetId);
+
+        return result.Success
+            ? Ok()
+            : StructureOperationStatusResult(result.Status);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/MoveDocumentTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/MoveDocumentTypeController.cs
@@ -17,7 +17,7 @@ public class MoveDocumentTypeController : DocumentTypeControllerBase
     public MoveDocumentTypeController(IContentTypeService contentTypeService)
         => _contentTypeService = contentTypeService;
 
-    [HttpPost("{id:guid}/move")]
+    [HttpPut("{id:guid}/move")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/MoveDocumentTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/MoveDocumentTypeController.cs
@@ -20,6 +20,7 @@ public class MoveDocumentTypeController : DocumentTypeControllerBase
     [HttpPost("{id:guid}/move")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Move(Guid id, MoveDocumentTypeRequestModel moveDocumentTypeRequestModel)
     {

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/CopyMediaTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/CopyMediaTypeController.cs
@@ -2,6 +2,7 @@ using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.MediaType;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
@@ -23,16 +24,10 @@ public class CopyMediaTypeController : MediaTypeControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Copy(Guid id, CopyMediaTypeRequestModel copyMediaTypeRequestModel)
     {
-        IMediaType? source = await _mediaTypeService.GetAsync(id);
-        if (source is null)
-        {
-            return OperationStatusResult(ContentTypeOperationStatus.NotFound);
-        }
-
-        var result = await _mediaTypeService.CopyAsync(source, copyMediaTypeRequestModel.TargetId);
+        Attempt<IMediaType?, ContentTypeStructureOperationStatus> result = await _mediaTypeService.CopyAsync(id, copyMediaTypeRequestModel.TargetId);
 
         return result.Success
-            ? CreatedAtAction<ByKeyMediaTypeController>(controller => nameof(controller.ByKey), result.Result.Key)
+            ? CreatedAtAction<ByKeyMediaTypeController>(controller => nameof(controller.ByKey), result.Result!.Key)
             : StructureOperationStatusResult(result.Status);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/CopyMediaTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/CopyMediaTypeController.cs
@@ -19,6 +19,7 @@ public class CopyMediaTypeController : MediaTypeControllerBase
     [HttpPost("{id:guid}/copy")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Copy(Guid id, CopyMediaTypeRequestModel copyMediaTypeRequestModel)
     {

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/CopyMediaTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/CopyMediaTypeController.cs
@@ -1,0 +1,37 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.MediaType;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Api.Management.Controllers.MediaType;
+
+[ApiVersion("1.0")]
+public class CopyMediaTypeController : MediaTypeControllerBase
+{
+    private readonly IMediaTypeService _mediaTypeService;
+
+    public CopyMediaTypeController(IMediaTypeService mediaTypeService)
+        => _mediaTypeService = mediaTypeService;
+
+    [HttpPost("{id:guid}/copy")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Copy(Guid id, CopyMediaTypeRequestModel copyMediaTypeRequestModel)
+    {
+        IMediaType? source = await _mediaTypeService.GetAsync(id);
+        if (source is null)
+        {
+            return OperationStatusResult(ContentTypeOperationStatus.NotFound);
+        }
+
+        var result = await _mediaTypeService.CopyAsync(source, copyMediaTypeRequestModel.TargetId);
+
+        return result.Success
+            ? CreatedAtAction<ByKeyMediaTypeController>(controller => nameof(controller.ByKey), result.Result.Key)
+            : StructureOperationStatusResult(result.Status);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/MediaTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/MediaTypeControllerBase.cs
@@ -16,4 +16,7 @@ public abstract class MediaTypeControllerBase : ManagementApiControllerBase
 {
     protected IActionResult OperationStatusResult(ContentTypeOperationStatus status)
         => DocumentTypeControllerBase.ContentTypeOperationStatusResult(status, "media");
+
+    protected IActionResult StructureOperationStatusResult(ContentTypeStructureOperationStatus status)
+        => DocumentTypeControllerBase.ContentTypeStructureOperationStatusResult(status, "media");
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/MoveMediaTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/MoveMediaTypeController.cs
@@ -17,7 +17,7 @@ public class MoveMediaTypeController : MediaTypeControllerBase
     public MoveMediaTypeController(IMediaTypeService mediaTypeService)
         => _mediaTypeService = mediaTypeService;
 
-    [HttpPost("{id:guid}/move")]
+    [HttpPut("{id:guid}/move")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/MoveMediaTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/MoveMediaTypeController.cs
@@ -24,13 +24,7 @@ public class MoveMediaTypeController : MediaTypeControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Move(Guid id, MoveMediaTypeRequestModel moveMediaTypeRequestModel)
     {
-        IMediaType? source = await _mediaTypeService.GetAsync(id);
-        if (source is null)
-        {
-            return OperationStatusResult(ContentTypeOperationStatus.NotFound);
-        }
-
-        Attempt<IMediaType, ContentTypeStructureOperationStatus> result = await _mediaTypeService.MoveAsync(source, moveMediaTypeRequestModel.TargetId);
+        Attempt<IMediaType?, ContentTypeStructureOperationStatus> result = await _mediaTypeService.MoveAsync(id, moveMediaTypeRequestModel.TargetId);
 
         return result.Success
             ? Ok()

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/MoveMediaTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/MoveMediaTypeController.cs
@@ -1,0 +1,38 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.MediaType;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Api.Management.Controllers.MediaType;
+
+[ApiVersion("1.0")]
+public class MoveMediaTypeController : MediaTypeControllerBase
+{
+    private readonly IMediaTypeService _mediaTypeService;
+
+    public MoveMediaTypeController(IMediaTypeService mediaTypeService)
+        => _mediaTypeService = mediaTypeService;
+
+    [HttpPost("{id:guid}/move")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Move(Guid id, MoveMediaTypeRequestModel moveMediaTypeRequestModel)
+    {
+        IMediaType? source = await _mediaTypeService.GetAsync(id);
+        if (source is null)
+        {
+            return OperationStatusResult(ContentTypeOperationStatus.NotFound);
+        }
+
+        Attempt<IMediaType, ContentTypeStructureOperationStatus> result = await _mediaTypeService.MoveAsync(source, moveMediaTypeRequestModel.TargetId);
+
+        return result.Success
+            ? Ok()
+            : StructureOperationStatusResult(result.Status);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/MoveMediaTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/MoveMediaTypeController.cs
@@ -20,6 +20,7 @@ public class MoveMediaTypeController : MediaTypeControllerBase
     [HttpPost("{id:guid}/move")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Move(Guid id, MoveMediaTypeRequestModel moveMediaTypeRequestModel)
     {

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -3048,6 +3048,26 @@
               }
             }
           },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -3130,6 +3150,26 @@
         "responses": {
           "200": {
             "description": "Success"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
@@ -8146,6 +8186,26 @@
               }
             }
           },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -8228,6 +8288,26 @@
         "responses": {
           "200": {
             "description": "Success"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
@@ -11641,6 +11721,46 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/preview": {
+      "delete": {
+        "tags": [
+          "Preview"
+        ],
+        "operationId": "DeletePreview",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Preview"
+        ],
+        "operationId": "PostPreview",
+        "responses": {
+          "200": {
+            "description": "Success"
           },
           "401": {
             "description": "The resource is protected and requires an authentication token"
@@ -16410,6 +16530,27 @@
               }
             }
           },
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/temporaryfile/configuration": {
+      "get": {
+        "tags": [
+          "Temporary File"
+        ],
+        "operationId": "GetTemporaryfileConfiguration",
+        "responses": {
           "200": {
             "description": "Success"
           },

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -2986,6 +2986,182 @@
         ]
       }
     },
+    "/umbraco/management/api/v1/document-type/{id}/copy": {
+      "post": {
+        "tags": [
+          "Document Type"
+        ],
+        "operationId": "PostDocumentTypeByIdCopy",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CopyDocumentTypeRequestModel"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CopyDocumentTypeRequestModel"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CopyDocumentTypeRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "Location": {
+                "description": "Location of the newly created resource",
+                "schema": {
+                  "type": "string",
+                  "description": "Location of the newly created resource",
+                  "format": "uri"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/document-type/{id}/move": {
+      "post": {
+        "tags": [
+          "Document Type"
+        ],
+        "operationId": "PostDocumentTypeByIdMove",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/MoveDocumentTypeRequestModel"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/MoveDocumentTypeRequestModel"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/MoveDocumentTypeRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
     "/umbraco/management/api/v1/document-type/folder": {
       "post": {
         "tags": [
@@ -7876,6 +8052,182 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/media-type/{id}/copy": {
+      "post": {
+        "tags": [
+          "Media Type"
+        ],
+        "operationId": "PostMediaTypeByIdCopy",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CopyMediaTypeRequestModel"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CopyMediaTypeRequestModel"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CopyMediaTypeRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "Location": {
+                "description": "Location of the newly created resource",
+                "schema": {
+                  "type": "string",
+                  "description": "Location of the newly created resource",
+                  "format": "uri"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/media-type/{id}/move": {
+      "post": {
+        "tags": [
+          "Media Type"
+        ],
+        "operationId": "PostMediaTypeByIdMove",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/MoveMediaTypeRequestModel"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/MoveMediaTypeRequestModel"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/MoveMediaTypeRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
           },
           "404": {
             "description": "Not Found",
@@ -13502,6 +13854,56 @@
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/ProblemDetailsBuilderModel"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/server/configuration": {
+      "get": {
+        "tags": [
+          "Server"
+        ],
+        "operationId": "GetServerConfiguration",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ServerConfigurationResponseModel"
+                    }
+                  ]
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ServerConfigurationResponseModel"
+                    }
+                  ]
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ServerConfigurationResponseModel"
                     }
                   ]
                 }
@@ -19415,6 +19817,28 @@
         },
         "additionalProperties": false
       },
+      "CopyDocumentTypeRequestModel": {
+        "type": "object",
+        "properties": {
+          "targetId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CopyMediaTypeRequestModel": {
+        "type": "object",
+        "properties": {
+          "targetId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "CreateContentForDocumentRequestModel": {
         "required": [
           "values",
@@ -19981,6 +20405,13 @@
             "$ref": "#/components/schemas/TemplateModelBaseModel"
           }
         ],
+        "properties": {
+          "key": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
         "additionalProperties": false
       },
       "CreateTextFileViewModelBaseModel": {
@@ -21933,7 +22364,29 @@
         },
         "additionalProperties": false
       },
+      "MoveDocumentTypeRequestModel": {
+        "type": "object",
+        "properties": {
+          "targetId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "MoveMediaRequestModel": {
+        "type": "object",
+        "properties": {
+          "targetId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "MoveMediaTypeRequestModel": {
         "type": "object",
         "properties": {
           "targetId": {
@@ -23971,6 +24424,18 @@
           },
           "data": {
             "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ServerConfigurationResponseModel": {
+        "required": [
+          "allowPasswordReset"
+        ],
+        "type": "object",
+        "properties": {
+          "allowPasswordReset": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -810,11 +810,11 @@
       }
     },
     "/umbraco/management/api/v1/data-type/{id}/move": {
-      "post": {
+      "put": {
         "tags": [
           "Data Type"
         ],
-        "operationId": "PostDataTypeByIdMove",
+        "operationId": "PutDataTypeByIdMove",
         "parameters": [
           {
             "name": "id",
@@ -2120,11 +2120,11 @@
       }
     },
     "/umbraco/management/api/v1/dictionary/{id}/move": {
-      "post": {
+      "put": {
         "tags": [
           "Dictionary"
         ],
-        "operationId": "PostDictionaryByIdMove",
+        "operationId": "PutDictionaryByIdMove",
         "parameters": [
           {
             "name": "id",

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -3100,11 +3100,11 @@
       }
     },
     "/umbraco/management/api/v1/document-type/{id}/move": {
-      "post": {
+      "put": {
         "tags": [
           "Document Type"
         ],
-        "operationId": "PostDocumentTypeByIdMove",
+        "operationId": "PutDocumentTypeByIdMove",
         "parameters": [
           {
             "name": "id",
@@ -8238,11 +8238,11 @@
       }
     },
     "/umbraco/management/api/v1/media-type/{id}/move": {
-      "post": {
+      "put": {
         "tags": [
           "Media Type"
         ],
-        "operationId": "PostMediaTypeByIdMove",
+        "operationId": "PutMediaTypeByIdMove",
         "parameters": [
           {
             "name": "id",

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/CopyDocumentTypeRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/CopyDocumentTypeRequestModel.cs
@@ -1,0 +1,6 @@
+namespace Umbraco.Cms.Api.Management.ViewModels.DocumentType;
+
+public class CopyDocumentTypeRequestModel
+{
+    public Guid? TargetId { get; set; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/MoveDocumentTypeRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/MoveDocumentTypeRequestModel.cs
@@ -1,0 +1,6 @@
+namespace Umbraco.Cms.Api.Management.ViewModels.DocumentType;
+
+public class MoveDocumentTypeRequestModel
+{
+    public Guid? TargetId { get; set; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/MediaType/CopyMediaTypeRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/MediaType/CopyMediaTypeRequestModel.cs
@@ -1,0 +1,6 @@
+namespace Umbraco.Cms.Api.Management.ViewModels.MediaType;
+
+public class CopyMediaTypeRequestModel
+{
+    public Guid? TargetId { get; set; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/MediaType/MoveMediaTypeRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/MediaType/MoveMediaTypeRequestModel.cs
@@ -1,0 +1,6 @@
+namespace Umbraco.Cms.Api.Management.ViewModels.MediaType;
+
+public class MoveMediaTypeRequestModel
+{
+    public Guid? TargetId { get; set; }
+}

--- a/src/Umbraco.Core/Services/IContentTypeServiceBase.cs
+++ b/src/Umbraco.Core/Services/IContentTypeServiceBase.cs
@@ -136,7 +136,7 @@ public interface IContentTypeBaseService<TItem> : IContentTypeBaseService, IServ
     [Obsolete("Please use CopyAsync. Will be removed in V15.")]
     TItem Copy(TItem original, string alias, string name, TItem parent);
 
-    Task<Attempt<TItem, ContentTypeStructureOperationStatus>> CopyAsync(TItem toCopy, Guid? containerKey);
+    Task<Attempt<TItem?, ContentTypeStructureOperationStatus>> CopyAsync(Guid key, Guid? containerKey);
 
-    Task<Attempt<TItem, ContentTypeStructureOperationStatus>> MoveAsync(TItem toMove, Guid? containerKey);
+    Task<Attempt<TItem?, ContentTypeStructureOperationStatus>> MoveAsync(Guid key, Guid? containerKey);
 }

--- a/src/Umbraco.Core/Services/IContentTypeServiceBase.cs
+++ b/src/Umbraco.Core/Services/IContentTypeServiceBase.cs
@@ -124,11 +124,19 @@ public interface IContentTypeBaseService<TItem> : IContentTypeBaseService, IServ
 
     Attempt<OperationResult<OperationResultType, EntityContainer>?> RenameContainer(int id, string name, int userId = Constants.Security.SuperUserId);
 
+    [Obsolete("Please use MoveAsync. Will be removed in V16.")]
     Attempt<OperationResult<MoveOperationStatusType>?> Move(TItem moving, int containerId);
 
+    [Obsolete("Please use CopyAsync. Will be removed in V16.")]
     Attempt<OperationResult<MoveOperationStatusType, TItem>?> Copy(TItem copying, int containerId);
 
+    [Obsolete("Please use CopyAsync. Will be removed in V15.")]
     TItem Copy(TItem original, string alias, string name, int parentId = -1);
 
+    [Obsolete("Please use CopyAsync. Will be removed in V15.")]
     TItem Copy(TItem original, string alias, string name, TItem parent);
+
+    Task<Attempt<TItem, ContentTypeStructureOperationStatus>> CopyAsync(TItem toCopy, Guid? containerKey);
+
+    Task<Attempt<TItem, ContentTypeStructureOperationStatus>> MoveAsync(TItem toMove, Guid? containerKey);
 }

--- a/src/Umbraco.Core/Services/OperationStatus/ContentTypeStructureOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/ContentTypeStructureOperationStatus.cs
@@ -1,0 +1,9 @@
+namespace Umbraco.Cms.Core.Services.OperationStatus;
+
+public enum ContentTypeStructureOperationStatus
+{
+    Success,
+    CancelledByNotification,
+    ContainerNotFound,
+    NotAllowedByPath
+}

--- a/src/Umbraco.Core/Services/OperationStatus/ContentTypeStructureOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/ContentTypeStructureOperationStatus.cs
@@ -5,5 +5,6 @@ public enum ContentTypeStructureOperationStatus
     Success,
     CancelledByNotification,
     ContainerNotFound,
-    NotAllowedByPath
+    NotAllowedByPath,
+    NotFound
 }


### PR DESCRIPTION
## Details
- Created endpoints for copying and moving content and media types;
  - The functionality is similar to how it works in the current (old) backoffice;
  - The implementation is shared between content and media types.

## Test
- Verify that you can copy and move content/media types to folders or root (`"targetId":null`). 