### PR TITLE
Fix: No Blocks Mode for RTE when required context for Blocks is not present

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -1439,6 +1439,10 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
 
       function initBlocks() {
 
+        if(!args.blockEditorApi) {
+          return;
+        }
+
         const blockEls = args.editor.contentDocument.querySelectorAll('umb-rte-block, umb-rte-block-inline');
         for (var blockEl of blockEls) {
           if(!blockEl._isInitializedUmbBlock) {

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -1743,19 +1743,21 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
       });
 
 
-      //Create the insert block plugin
-      self.createBlockPicker(args.editor, args.blockEditorApi, function (currentTarget, userData, imgDomElement) {
-        args.blockEditorApi.showCreateDialog(0, false, (newBlock) => {
-          // TODO: Handle if its an array:
-          if(Utilities.isArray(newBlock)) {
-            newBlock.forEach(block => {
-              self.insertBlockInEditor(args.editor, block.layout.contentUdi, block.config.displayInline);
-            });
-          } else {
-            self.insertBlockInEditor(args.editor, newBlock.layout.contentUdi, newBlock.config.displayInline);
-          }
+      if(args.blockEditorApi) {
+        //Create the insert block plugin
+        self.createBlockPicker(args.editor, args.blockEditorApi, function (currentTarget, userData, imgDomElement) {
+          args.blockEditorApi.showCreateDialog(0, false, (newBlock) => {
+            // TODO: Handle if its an array:
+            if(Utilities.isArray(newBlock)) {
+              newBlock.forEach(block => {
+                self.insertBlockInEditor(args.editor, block.layout.contentUdi, block.config.displayInline);
+              });
+            } else {
+              self.insertBlockInEditor(args.editor, newBlock.layout.contentUdi, newBlock.config.displayInline);
+            }
+          });
         });
-      });
+      }
 
       //Create the embedded plugin
       self.createInsertEmbeddedMedia(args.editor, function (activeElement, modify) {


### PR DESCRIPTION
To continue supporting Rich Text Editor Property Editor implemented via `<umb-property>` without any further Backoffice implementations in its surroundings, this PR introduces a No Blocks Mode that will be active when the requirements for Blocks aren't meet.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/15474