### PR TITLE
V14: Add security related configurations

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/ConfigurationSecurityController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/ConfigurationSecurityController.cs
@@ -15,7 +15,8 @@ public class ConfigurationSecurityController : SecurityControllerBase
 {
     private readonly IPasswordConfigurationPresentationFactory _passwordConfigurationPresentationFactory;
 
-    public ConfigurationSecurityController(IPasswordConfigurationPresentationFactory passwordConfigurationPresentationFactory) => _passwordConfigurationPresentationFactory = passwordConfigurationPresentationFactory;
+    public ConfigurationSecurityController(IPasswordConfigurationPresentationFactory passwordConfigurationPresentationFactory)
+        => _passwordConfigurationPresentationFactory = passwordConfigurationPresentationFactory;
 
     [HttpGet("configuration")]
     [MapToApiVersion("1.0")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/ConfigurationSecurityController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/ConfigurationSecurityController.cs
@@ -8,6 +8,7 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Security;
 
+[ApiVersion("1.0")]
 [Authorize(Policy = "New" + AuthorizationPolicies.DenyLocalLoginIfConfigured)]
 // FIXME: Add requiring password reset token policy when its implemented
 public class ConfigurationSecurityController : SecurityControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/ConfigurationSecurityController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/ConfigurationSecurityController.cs
@@ -1,0 +1,31 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.ViewModels.Security;
+using Umbraco.Cms.Web.Common.Authorization;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Security;
+
+[Authorize(Policy = "New" + AuthorizationPolicies.DenyLocalLoginIfConfigured)]
+// FIXME: Add requiring password reset token policy when its implemented
+public class ConfigurationSecurityController : SecurityControllerBase
+{
+    private readonly IPasswordConfigurationPresentationFactory _passwordConfigurationPresentationFactory;
+
+    public ConfigurationSecurityController(IPasswordConfigurationPresentationFactory passwordConfigurationPresentationFactory) => _passwordConfigurationPresentationFactory = passwordConfigurationPresentationFactory;
+
+    [HttpGet("configuration")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(SecurityConfigurationResponseModel), StatusCodes.Status200OK)]
+    public async Task<IActionResult> Configuration()
+    {
+        var viewModel = new SecurityConfigurationResponseModel
+        {
+            PasswordConfiguration = _passwordConfigurationPresentationFactory.CreatePasswordConfigurationResponseModel(),
+        };
+
+        return await Task.FromResult(Ok(viewModel));
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/ResetPasswordController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/ResetPasswordController.cs
@@ -11,11 +11,13 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 namespace Umbraco.Cms.Api.Management.Controllers.Security;
 
 [ApiVersion("1.0")]
+// FIXME: Add requiring password reset token policy when its implemented
 public class ResetPasswordController : SecurityControllerBase
 {
     private readonly IUserService _userService;
 
     public ResetPasswordController(IUserService userService) => _userService = userService;
+
 
     [HttpPost("forgot-password")]
     [MapToApiVersion("1.0")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/ConfigurationUserController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/ConfigurationUserController.cs
@@ -1,0 +1,23 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.ViewModels.User;
+using Umbraco.Cms.Web.Common.Authorization;
+
+namespace Umbraco.Cms.Api.Management.Controllers.User;
+
+[ApiVersion("1.0")]
+[Authorize(Policy = "New" + AuthorizationPolicies.RequireAdminAccess)]
+public class ConfigurationUserController : UserControllerBase
+{
+    private readonly IUserPresentationFactory _userPresentationFactory;
+
+    public ConfigurationUserController(IUserPresentationFactory userPresentationFactory) => _userPresentationFactory = userPresentationFactory;
+
+    [HttpGet("configuration")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(UserConfigurationResponseModel), StatusCodes.Status200OK)]
+    public async Task<IActionResult> Configuration() => Ok(await _userPresentationFactory.CreateUserConfigurationModelAsync());
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/Current/ConfigurationCurrentUserController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/Current/ConfigurationCurrentUserController.cs
@@ -1,12 +1,15 @@
 ﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.User.Current;
+using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User.Current;
 
 [ApiVersion("1.0")]
+[Authorize(Policy = "New" + AuthorizationPolicies.BackOfficeAccess)]
 public class ConfigurationCurrentUserController : CurrentUserControllerBase
 {
     private readonly IUserPresentationFactory _userPresentationFactory;

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/Current/ConfigurationCurrentUserController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/Current/ConfigurationCurrentUserController.cs
@@ -1,0 +1,24 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.ViewModels.User.Current;
+
+namespace Umbraco.Cms.Api.Management.Controllers.User.Current;
+
+[ApiVersion("1.0")]
+public class ConfigurationCurrentUserController : CurrentUserControllerBase
+{
+    private readonly IUserPresentationFactory _userPresentationFactory;
+
+    public ConfigurationCurrentUserController(IUserPresentationFactory userPresentationFactory) => _userPresentationFactory = userPresentationFactory;
+
+    [MapToApiVersion("1.0")]
+    [HttpGet("configuration")]
+    [ProducesResponseType(typeof(CurrenUserConfigurationResponseModel), StatusCodes.Status200OK)]
+    public async Task<IActionResult> Configuration()
+    {
+        CurrenUserConfigurationResponseModel model = await _userPresentationFactory.CreateCurrentUserConfigurationModelAsync();
+        return Ok(model);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/PasswordBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/PasswordBuilderExtensions.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Core.DependencyInjection;
+
+namespace Umbraco.Cms.Api.Management.DependencyInjection;
+
+public static class PasswordBuilderExtensions
+{
+    internal static IUmbracoBuilder AddPasswordConfiguration(this IUmbracoBuilder builder)
+    {
+        builder.Services.AddTransient<IPasswordConfigurationPresentationFactory, PasswordConfigurationPresentationFactory>();
+        return builder;
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -54,7 +54,8 @@ public static class UmbracoBuilderExtensions
                 .AddStylesheets()
                 .AddServer()
                 .AddCorsPolicy()
-                .AddBackOfficeAuthentication();
+                .AddBackOfficeAuthentication()
+                .AddPasswordConfiguration();
 
             services
                 .ConfigureOptions<ConfigureApiBehaviorOptions>()

--- a/src/Umbraco.Cms.Api.Management/Factories/IPasswordConfigurationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IPasswordConfigurationPresentationFactory.cs
@@ -1,0 +1,8 @@
+﻿using Umbraco.Cms.Api.Management.ViewModels.Security;
+
+namespace Umbraco.Cms.Api.Management.Factories;
+
+public interface IPasswordConfigurationPresentationFactory
+{
+    PasswordConfigurationResponseModel CreatePasswordConfigurationResponseModel();
+}

--- a/src/Umbraco.Cms.Api.Management/Factories/IUserPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IUserPresentationFactory.cs
@@ -18,4 +18,6 @@ public interface IUserPresentationFactory
     Task<CurrentUserResponseModel> CreateCurrentUserResponseModelAsync(IUser user);
 
     Task<UserResendInviteModel> CreateResendInviteModelAsync(ResendInviteUserRequestModel requestModel);
+
+    Task<UserConfigurationResponseModel> CreateUserConfigurationModelAsync();
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/IUserPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IUserPresentationFactory.cs
@@ -20,4 +20,6 @@ public interface IUserPresentationFactory
     Task<UserResendInviteModel> CreateResendInviteModelAsync(ResendInviteUserRequestModel requestModel);
 
     Task<UserConfigurationResponseModel> CreateUserConfigurationModelAsync();
+
+    Task<CurrenUserConfigurationResponseModel> CreateCurrentUserConfigurationModelAsync();
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/PasswordConfigurationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/PasswordConfigurationPresentationFactory.cs
@@ -14,7 +14,7 @@ public class PasswordConfigurationPresentationFactory : IPasswordConfigurationPr
         new()
         {
             MinimumPasswordLength = _userPasswordConfigurationSettings.RequiredLength,
-            MinimumPasswordNonAlphaNum = _userPasswordConfigurationSettings.RequireNonLetterOrDigit,
+            RequireNonLetterOrDigit = _userPasswordConfigurationSettings.RequireNonLetterOrDigit,
             RequireDigit = _userPasswordConfigurationSettings.RequireDigit,
             RequireLowercase = _userPasswordConfigurationSettings.RequireLowercase,
             RequireUppercase = _userPasswordConfigurationSettings.RequireUppercase,

--- a/src/Umbraco.Cms.Api.Management/Factories/PasswordConfigurationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/PasswordConfigurationPresentationFactory.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.Options;
+using Umbraco.Cms.Api.Management.ViewModels.Security;
+using Umbraco.Cms.Core.Configuration.Models;
+
+namespace Umbraco.Cms.Api.Management.Factories;
+
+public class PasswordConfigurationPresentationFactory : IPasswordConfigurationPresentationFactory
+{
+    private readonly UserPasswordConfigurationSettings _userPasswordConfigurationSettings;
+
+    public PasswordConfigurationPresentationFactory(IOptionsSnapshot<UserPasswordConfigurationSettings> userPasswordConfigurationSettings) => _userPasswordConfigurationSettings = userPasswordConfigurationSettings.Value;
+
+    public PasswordConfigurationResponseModel CreatePasswordConfigurationResponseModel() =>
+        new()
+        {
+            MinimumPasswordLength = _userPasswordConfigurationSettings.RequiredLength,
+            MinimumPasswordNonAlphaNum = _userPasswordConfigurationSettings.RequireNonLetterOrDigit,
+            RequireDigit = _userPasswordConfigurationSettings.RequireDigit,
+            RequireLowercase = _userPasswordConfigurationSettings.RequireLowercase,
+            RequireUppercase = _userPasswordConfigurationSettings.RequireUppercase,
+        };
+}

--- a/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
@@ -117,7 +117,7 @@ public class UserPresentationFactory : IUserPresentationFactory
         var model = new CurrenUserConfigurationResponseModel
         {
             KeepUserLoggedIn = _securitySettings.KeepUserLoggedIn,
-            UserNameIsEmail = _securitySettings.UsernameIsEmail,
+            UsernameIsEmail = _securitySettings.UsernameIsEmail,
             PasswordConfiguration = _passwordConfigurationPresentationFactory.CreatePasswordConfigurationResponseModel(),
         };
 
@@ -127,7 +127,7 @@ public class UserPresentationFactory : IUserPresentationFactory
     public Task<UserConfigurationResponseModel> CreateUserConfigurationModelAsync() =>
         Task.FromResult(new UserConfigurationResponseModel
         {
-            ShowUserInvite = _emailSender.CanSendRequiredEmail(),
+            CanInviteUsers = _emailSender.CanSendRequiredEmail(),
             PasswordConfiguration = _passwordConfigurationPresentationFactory.CreatePasswordConfigurationResponseModel(),
         });
 

--- a/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
@@ -1,8 +1,6 @@
-﻿using Microsoft.Extensions.Options;
-using Umbraco.Cms.Api.Management.ViewModels.User;
+﻿using Umbraco.Cms.Api.Management.ViewModels.User;
 using Umbraco.Cms.Api.Management.ViewModels.User.Current;
 using Umbraco.Cms.Core.Cache;
-using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Mail;
 using Umbraco.Cms.Core.Media;
@@ -21,7 +19,7 @@ public class UserPresentationFactory : IUserPresentationFactory
     private readonly IImageUrlGenerator _imageUrlGenerator;
     private readonly IUserGroupPresentationFactory _userGroupPresentationFactory;
     private readonly IEmailSender _emailSender;
-    private readonly UserPasswordConfigurationSettings _userPasswordConfigurationSettings;
+    private readonly IPasswordConfigurationPresentationFactory _passwordConfigurationPresentationFactory;
 
     public UserPresentationFactory(
         IEntityService entityService,
@@ -29,8 +27,8 @@ public class UserPresentationFactory : IUserPresentationFactory
         MediaFileManager mediaFileManager,
         IImageUrlGenerator imageUrlGenerator,
         IUserGroupPresentationFactory userGroupPresentationFactory,
-        IOptionsSnapshot<UserPasswordConfigurationSettings> userPasswordConfigurationSettings,
-        IEmailSender emailSender)
+        IEmailSender emailSender,
+        IPasswordConfigurationPresentationFactory passwordConfigurationPresentationFactory)
     {
         _entityService = entityService;
         _appCaches = appCaches;
@@ -38,7 +36,7 @@ public class UserPresentationFactory : IUserPresentationFactory
         _imageUrlGenerator = imageUrlGenerator;
         _userGroupPresentationFactory = userGroupPresentationFactory;
         _emailSender = emailSender;
-        _userPasswordConfigurationSettings = userPasswordConfigurationSettings.Value;
+        _passwordConfigurationPresentationFactory = passwordConfigurationPresentationFactory;
     }
 
     public UserResponseModel CreateResponseModel(IUser user)
@@ -108,11 +106,7 @@ public class UserPresentationFactory : IUserPresentationFactory
         Task.FromResult(new UserConfigurationResponseModel
         {
             ShowUserInvite = _emailSender.CanSendRequiredEmail(),
-            MinimumPasswordLength = _userPasswordConfigurationSettings.RequiredLength,
-            MinimumPasswordNonAlphaNum = _userPasswordConfigurationSettings.RequireNonLetterOrDigit,
-            RequireDigit = _userPasswordConfigurationSettings.RequireDigit,
-            RequireLowercase = _userPasswordConfigurationSettings.RequireLowercase,
-            RequireUppercase = _userPasswordConfigurationSettings.RequireUppercase,
+            PasswordConfiguration = _passwordConfigurationPresentationFactory.CreatePasswordConfigurationResponseModel(),
         });
 
     public async Task<UserUpdateModel> CreateUpdateModelAsync(Guid existingUserKey, UpdateUserRequestModel updateModel)

--- a/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
@@ -23,7 +23,6 @@ public class UserPresentationFactory : IUserPresentationFactory
     private readonly IEmailSender _emailSender;
     private readonly IPasswordConfigurationPresentationFactory _passwordConfigurationPresentationFactory;
     private readonly SecuritySettings _securitySettings;
-    private readonly UserPasswordConfigurationSettings _userPasswordConfigurationSettings;
 
     public UserPresentationFactory(
         IEntityService entityService,
@@ -32,9 +31,7 @@ public class UserPresentationFactory : IUserPresentationFactory
         IImageUrlGenerator imageUrlGenerator,
         IUserGroupPresentationFactory userGroupPresentationFactory,
         IEmailSender emailSender,
-        IPasswordConfigurationPresentationFactory passwordConfigurationPresentationFactory)
-        IUserGroupPresentationFactory userGroupPresentationFactory,
-        IOptionsSnapshot<UserPasswordConfigurationSettings> userPasswordConfigurationSettings,
+        IPasswordConfigurationPresentationFactory passwordConfigurationPresentationFactory,
         IOptionsSnapshot<SecuritySettings> securitySettings)
     {
         _entityService = entityService;
@@ -45,7 +42,6 @@ public class UserPresentationFactory : IUserPresentationFactory
         _emailSender = emailSender;
         _passwordConfigurationPresentationFactory = passwordConfigurationPresentationFactory;
         _securitySettings = securitySettings.Value;
-        _userPasswordConfigurationSettings = userPasswordConfigurationSettings.Value;
     }
 
     public UserResponseModel CreateResponseModel(IUser user)
@@ -117,11 +113,7 @@ public class UserPresentationFactory : IUserPresentationFactory
         {
             KeepUserLoggedIn = _securitySettings.KeepUserLoggedIn,
             UserNameIsEmail = _securitySettings.UsernameIsEmail,
-            MinimumPasswordLength = _userPasswordConfigurationSettings.RequiredLength,
-            MinimumPasswordNonAlphaNum = _userPasswordConfigurationSettings.RequireNonLetterOrDigit ? 1 : 0,
-            RequireDigit = _userPasswordConfigurationSettings.RequireDigit,
-            RequireLowercase = _userPasswordConfigurationSettings.RequireLowercase,
-            RequireUppercase = _userPasswordConfigurationSettings.RequireUppercase,
+            PasswordConfiguration = _passwordConfigurationPresentationFactory.CreatePasswordConfigurationResponseModel(),
         };
 
         return await Task.FromResult(model);

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Security/PasswordConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Security/PasswordConfigurationResponseModel.cs
@@ -4,7 +4,7 @@ public class PasswordConfigurationResponseModel
 {
     public int MinimumPasswordLength { get; set; }
 
-    public bool MinimumPasswordNonAlphaNum { get; set; }
+    public bool RequireNonLetterOrDigit { get; set; }
 
     public bool RequireDigit { get; set; }
 

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Security/PasswordConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Security/PasswordConfigurationResponseModel.cs
@@ -1,0 +1,14 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Security;
+
+public class PasswordConfigurationResponseModel
+{
+    public int MinimumPasswordLength { get; set; }
+
+    public bool MinimumPasswordNonAlphaNum { get; set; }
+
+    public bool RequireDigit { get; set; }
+
+    public bool RequireLowercase { get; set; }
+
+    public bool RequireUppercase { get; set; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Security/SecurityConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Security/SecurityConfigurationResponseModel.cs
@@ -2,5 +2,5 @@
 
 public class SecurityConfigurationResponseModel
 {
-    public PasswordConfigurationResponseModel PasswordConfiguration { get; set; } = null!;
+    public required PasswordConfigurationResponseModel PasswordConfiguration { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Security/SecurityConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Security/SecurityConfigurationResponseModel.cs
@@ -1,0 +1,6 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Security;
+
+public class SecurityConfigurationResponseModel
+{
+    public PasswordConfigurationResponseModel PasswordConfiguration { get; set; } = null!;
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/Current/CurrenUserConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/Current/CurrenUserConfigurationResponseModel.cs
@@ -6,8 +6,7 @@ public class CurrenUserConfigurationResponseModel
 {
     public bool KeepUserLoggedIn { get; set; }
 
-    public bool UserNameIsEmail { get; set; }
+    public bool UsernameIsEmail { get; set; }
 
-    public PasswordConfigurationResponseModel PasswordConfiguration { get; set; } = null!;
-
+    public required PasswordConfigurationResponseModel PasswordConfiguration { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/Current/CurrenUserConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/Current/CurrenUserConfigurationResponseModel.cs
@@ -1,4 +1,6 @@
-﻿namespace Umbraco.Cms.Api.Management.ViewModels.User.Current;
+﻿using Umbraco.Cms.Api.Management.ViewModels.Security;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.User.Current;
 
 public class CurrenUserConfigurationResponseModel
 {
@@ -6,14 +8,6 @@ public class CurrenUserConfigurationResponseModel
 
     public bool UserNameIsEmail { get; set; }
 
-    public int MinimumPasswordLength { get; set; }
-
-    public int MinimumPasswordNonAlphaNum { get; set; }
-
-    public bool RequireDigit { get; set; }
-
-    public bool RequireLowercase { get; set; }
-
-    public bool RequireUppercase { get; set; }
+    public PasswordConfigurationResponseModel PasswordConfiguration { get; set; } = null!;
 
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/Current/CurrenUserConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/Current/CurrenUserConfigurationResponseModel.cs
@@ -1,0 +1,19 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.User.Current;
+
+public class CurrenUserConfigurationResponseModel
+{
+    public bool KeepUserLoggedIn { get; set; }
+
+    public bool UserNameIsEmail { get; set; }
+
+    public int MinimumPasswordLength { get; set; }
+
+    public int MinimumPasswordNonAlphaNum { get; set; }
+
+    public bool RequireDigit { get; set; }
+
+    public bool RequireLowercase { get; set; }
+
+    public bool RequireUppercase { get; set; }
+
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/UserConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/UserConfigurationResponseModel.cs
@@ -1,0 +1,16 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.User;
+
+public class UserConfigurationResponseModel
+{
+    public bool ShowUserInvite { get; set; }
+
+    public int MinimumPasswordLength { get; set; }
+
+    public bool MinimumPasswordNonAlphaNum { get; set; }
+
+    public bool RequireDigit { get; set; }
+
+    public bool RequireLowercase { get; set; }
+
+    public bool RequireUppercase { get; set; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/UserConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/UserConfigurationResponseModel.cs
@@ -4,7 +4,7 @@ namespace Umbraco.Cms.Api.Management.ViewModels.User;
 
 public class UserConfigurationResponseModel
 {
-    public bool ShowUserInvite { get; set; }
+    public bool CanInviteUsers { get; set; }
 
-    public PasswordConfigurationResponseModel PasswordConfiguration { get; set; } = null!;
+    public required PasswordConfigurationResponseModel PasswordConfiguration { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/UserConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/UserConfigurationResponseModel.cs
@@ -1,16 +1,10 @@
-﻿namespace Umbraco.Cms.Api.Management.ViewModels.User;
+﻿using Umbraco.Cms.Api.Management.ViewModels.Security;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.User;
 
 public class UserConfigurationResponseModel
 {
     public bool ShowUserInvite { get; set; }
 
-    public int MinimumPasswordLength { get; set; }
-
-    public bool MinimumPasswordNonAlphaNum { get; set; }
-
-    public bool RequireDigit { get; set; }
-
-    public bool RequireLowercase { get; set; }
-
-    public bool RequireUppercase { get; set; }
+    public PasswordConfigurationResponseModel PasswordConfiguration { get; set; } = null!;
 }


### PR DESCRIPTION
# Notes
- Adds new `security/configuration` endpoint. This only has password configuration property
- Adds new `user/current/configuration` endpoint. Which has some current user configuration and the password configuration.
- Adds new `user/configuration` endpoint. Which also has some user configuration and password configuration.
- Adds new `PasswordConfigurationPresentationFactory`, which can create the Password configuration for the 3 new endpoints.

# How to test
- use swagger to test the three new endpoints.