### PR TITLE
V13: TinyMCE does not toggle plugin buttons

### DIFF
--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -39,7 +39,7 @@
         "ng-file-upload": "12.2.13",
         "nouislider": "15.7.1",
         "spectrum-colorpicker2": "2.0.10",
-        "tinymce": "6.8.1",
+        "tinymce": "6.8.2",
         "typeahead.js": "0.11.1",
         "underscore": "1.13.6",
         "wicg-inert": "3.1.2"
@@ -16606,9 +16606,9 @@
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "node_modules/tinymce": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.8.1.tgz",
-      "integrity": "sha512-WYPvMXIjBrXM/oBiqGCbT2a8ptiO3TWXm/xxPWDCl8SxRKMW7Rfp0Lk190E9fXmX6uh9lJMRCnmKHzvryz0ftA=="
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.8.2.tgz",
+      "integrity": "sha512-Lho79o2Y1Yn+XdlTEkHTEkEmzwYWTXz7IUsvPwxJF3VTtgHUIAAuBab29kik+f2KED3rZvQavr9D7sHVMJ9x4A=="
     },
     "node_modules/to-absolute-glob": {
       "version": "2.0.2",

--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -51,7 +51,7 @@
     "ng-file-upload": "12.2.13",
     "nouislider": "15.7.1",
     "spectrum-colorpicker2": "2.0.10",
-    "tinymce": "6.8.1",
+    "tinymce": "6.8.2",
     "typeahead.js": "0.11.1",
     "underscore": "1.13.6",
     "wicg-inert": "3.1.2"

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -921,9 +921,15 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
       }
 
       /** Adds the button instance */
-      editor.ui.registry.addButton('umbmacro', {
+      editor.ui.registry.addToggleButton('umbmacro', {
         icon: 'preferences',
         tooltip: 'Insert macro',
+        onSetup: function (api) {
+          const changed = editor.selection.selectorChangedWithUnbind('div.umb-macro-holder', (state) =>
+            api.setActive(state)
+          );
+          return () => changed.unbind();
+        },
 
         /** The insert macro button click event handler */
         onAction: function () {

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -548,7 +548,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
         tooltip: 'Embed',
         onSetup: function (api) {
           const changed = editor.selection.selectorChangedWithUnbind('div[data-embed-url]', (state) =>
-            api.setActive(state),
+            api.setActive(state)
           );
           return () => changed.unbind();
         },
@@ -802,7 +802,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
         tooltip: 'Insert Block',
         onSetup: function (api) {
           const changed = editor.selection.selectorChangedWithUnbind('umb-rte-block[data-content-udi], umb-rte-block-inline[data-content-udi]', (state) =>
-            api.setActive(state),
+            api.setActive(state)
           );
           return () => changed.unbind();
         },
@@ -1235,7 +1235,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
         onAction: createLinkList(showDialog),
         onSetup: function (api) {
           const changed = editor.selection.selectorChangedWithUnbind('a[href]', (state) =>
-            api.setActive(state),
+            api.setActive(state)
           );
           return () => changed.unbind();
         }
@@ -1249,7 +1249,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
         },
         onSetup: function (api) {
           const changed = editor.selection.selectorChangedWithUnbind('a[href]', (state) =>
-            api.setActive(state),
+            api.setActive(state)
           );
           return () => changed.unbind();
         }
@@ -1265,7 +1265,7 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
         onAction: createLinkList(showDialog),
         onSetup: function (api) {
           const changed = editor.selection.selectorChangedWithUnbind('a[href]', (state) =>
-            api.setActive(state),
+            api.setActive(state)
           );
           return () => changed.unbind();
         },


### PR DESCRIPTION
### Description
After the upgrade to TinyMCE 6, they removed the `stateSelector` configuration and replaced it with the more complex `onSetup` method to properly toggle buttons. Also, it is now pertinent that we add buttons to the UI by invoking the `addToggleButton()` rather than the `addButton()` function.

**Before**
```js
        stateSelector: 'img[data-udi]'
```

**After**
```js
        onSetup: function (api) {
          const changed = editor.selection.selectorChangedWithUnbind('img[data-udi]', (state) =>
            api.setActive(state)
          );
          return () => changed.unbind();
        },
```