### PR TITLE
Only update security stamp once per request

### DIFF
--- a/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs
+++ b/src/Umbraco.Web.BackOffice/Security/BackOfficeSignInManager.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
@@ -37,13 +38,43 @@ public class BackOfficeSignInManager : UmbracoSignInManager<BackOfficeIdentityUs
         IAuthenticationSchemeProvider schemes,
         IUserConfirmation<BackOfficeIdentityUser> confirmation,
         IEventAggregator eventAggregator,
-        IOptions<SecuritySettings> securitySettings)
-        : base(userManager, contextAccessor, claimsFactory, optionsAccessor, logger, schemes, confirmation, securitySettings)
+        IOptions<SecuritySettings> securitySettings,
+        IRequestCache requestCache)
+        : base(userManager, contextAccessor, claimsFactory, optionsAccessor, logger, schemes, confirmation, securitySettings, requestCache)
     {
         _userManager = userManager;
         _externalLogins = externalLogins;
         _eventAggregator = eventAggregator;
         _globalSettings = globalSettings.Value;
+    }
+
+    [Obsolete("Use non-obsolete constructor. This is scheduled for removal in V15.")]
+    public BackOfficeSignInManager(
+        BackOfficeUserManager userManager,
+        IHttpContextAccessor contextAccessor,
+        IBackOfficeExternalLoginProviders externalLogins,
+        IUserClaimsPrincipalFactory<BackOfficeIdentityUser> claimsFactory,
+        IOptions<IdentityOptions> optionsAccessor,
+        IOptions<GlobalSettings> globalSettings,
+        ILogger<SignInManager<BackOfficeIdentityUser>> logger,
+        IAuthenticationSchemeProvider schemes,
+        IUserConfirmation<BackOfficeIdentityUser> confirmation,
+        IEventAggregator eventAggregator,
+        IOptions<SecuritySettings> securitySettings)
+        : this(
+            userManager,
+            contextAccessor,
+            externalLogins,
+            claimsFactory,
+            optionsAccessor,
+            globalSettings,
+            logger,
+            schemes,
+            confirmation,
+            eventAggregator,
+            securitySettings,
+            StaticServiceProvider.Instance.GetRequiredService<IRequestCache>())
+    {
     }
 
     [Obsolete("Use non-obsolete constructor. This is scheduled for removal in V14.")]

--- a/src/Umbraco.Web.Common/Security/MemberSignInManager.cs
+++ b/src/Umbraco.Web.Common/Security/MemberSignInManager.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
@@ -32,11 +33,39 @@ public class MemberSignInManager : UmbracoSignInManager<MemberIdentityUser>, IMe
         IUserConfirmation<MemberIdentityUser> confirmation,
         IMemberExternalLoginProviders memberExternalLoginProviders,
         IEventAggregator eventAggregator,
-        IOptions<SecuritySettings> securitySettings)
-        : base(memberManager, contextAccessor, claimsFactory, optionsAccessor, logger, schemes, confirmation, securitySettings)
+        IOptions<SecuritySettings> securitySettings,
+        IRequestCache requestCache)
+        : base(memberManager, contextAccessor, claimsFactory, optionsAccessor, logger, schemes, confirmation, securitySettings, requestCache)
     {
         _memberExternalLoginProviders = memberExternalLoginProviders;
         _eventAggregator = eventAggregator;
+    }
+
+    [Obsolete("Use non-obsolete constructor. This is scheduled for removal in V15.")]
+    public MemberSignInManager(
+        UserManager<MemberIdentityUser> memberManager,
+        IHttpContextAccessor contextAccessor,
+        IUserClaimsPrincipalFactory<MemberIdentityUser> claimsFactory,
+        IOptions<IdentityOptions> optionsAccessor,
+        ILogger<SignInManager<MemberIdentityUser>> logger,
+        IAuthenticationSchemeProvider schemes,
+        IUserConfirmation<MemberIdentityUser> confirmation,
+        IMemberExternalLoginProviders memberExternalLoginProviders,
+        IEventAggregator eventAggregator,
+        IOptions<SecuritySettings> securitySettings)
+        : this(
+            memberManager,
+            contextAccessor,
+            claimsFactory,
+            optionsAccessor,
+            logger,
+            schemes,
+            confirmation,
+            memberExternalLoginProviders,
+            eventAggregator,
+            securitySettings,
+            StaticServiceProvider.Instance.GetRequiredService<IRequestCache>())
+    {
     }
 
     [Obsolete("Use non-obsolete constructor. This is scheduled for removal in V14.")]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/MemberSignInManagerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/MemberSignInManagerTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Net;
@@ -71,7 +72,8 @@ public class MemberSignInManagerTests
             Mock.Of<IUserConfirmation<MemberIdentityUser>>(),
             Mock.Of<IMemberExternalLoginProviders>(),
             Mock.Of<IEventAggregator>(),
-            Mock.Of<IOptions<SecuritySettings>>(x => x.Value == new SecuritySettings()));
+            Mock.Of<IOptions<SecuritySettings>>(x => x.Value == new SecuritySettings()),
+            new DictionaryAppCache());
     }
 
     private static Mock<MemberManager> MockMemberManager()


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/15496

### Description
This ensures the security stamp is only updated once per request.