### PR TITLE
V10: Pass in variation context to published cache

### DIFF
--- a/src/Umbraco.Core/PublishedCache/PublishedCacheBase.cs
+++ b/src/Umbraco.Core/PublishedCache/PublishedCacheBase.cs
@@ -1,6 +1,8 @@
 using System.Xml.XPath;
+using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Xml;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PublishedCache;
@@ -9,10 +11,24 @@ public abstract class PublishedCacheBase : IPublishedCache
 {
     private readonly IVariationContextAccessor? _variationContextAccessor;
 
-    public PublishedCacheBase(IVariationContextAccessor variationContextAccessor) => _variationContextAccessor =
-        variationContextAccessor ?? throw new ArgumentNullException(nameof(variationContextAccessor));
 
-    protected PublishedCacheBase(bool previewDefault) => PreviewDefault = previewDefault;
+    [Obsolete("Use ctor with all parameters. This will be removed in V15")]
+    public PublishedCacheBase(IVariationContextAccessor variationContextAccessor)
+        : this(variationContextAccessor, false)
+    {
+    }
+
+    [Obsolete("Use ctor with all parameters. This will be removed in V15")]
+    protected PublishedCacheBase(bool previewDefault)
+        : this(StaticServiceProvider.Instance.GetRequiredService<IVariationContextAccessor>(), previewDefault)
+    {
+    }
+
+    public PublishedCacheBase(IVariationContextAccessor variationContextAccessor, bool previewDefault)
+    {
+        _variationContextAccessor = variationContextAccessor;
+        PreviewDefault = previewDefault;
+    }
 
     public bool PreviewDefault { get; }
 

--- a/src/Umbraco.PublishedCache.NuCache/ContentCache.cs
+++ b/src/Umbraco.PublishedCache.NuCache/ContentCache.cs
@@ -36,7 +36,7 @@ public class ContentCache : PublishedCacheBase, IPublishedContentCache, INavigab
         IDomainCache domainCache,
         IOptions<GlobalSettings> globalSettings,
         IVariationContextAccessor variationContextAccessor)
-        : base(previewDefault)
+        : base(variationContextAccessor, previewDefault)
     {
         _snapshot = snapshot;
         _snapshotCache = snapshotCache;

--- a/src/Umbraco.PublishedCache.NuCache/MediaCache.cs
+++ b/src/Umbraco.PublishedCache.NuCache/MediaCache.cs
@@ -17,7 +17,7 @@ public class MediaCache : PublishedCacheBase, IPublishedMediaCache, INavigableDa
     #region Constructors
 
     public MediaCache(bool previewDefault, ContentStore.Snapshot snapshot, IVariationContextAccessor variationContextAccessor)
-        : base(previewDefault)
+        : base(variationContextAccessor, previewDefault)
     {
         _snapshot = snapshot;
         _variationContextAccessor = variationContextAccessor;


### PR DESCRIPTION
## Details
- Fixes https://github.com/umbraco/Umbraco-CMS/issues/15473;
  - The reason for the bug was that we were using the wrong ctor which wasn't setting the variation context that is used in the implementation of `GetByContentType()` - this was why it returned different results when the content type varied by culture.

## Test
- Create the following **ProductsController**:
```c#
using Umbraco.Cms.Core.Models.PublishedContent;
using Umbraco.Cms.Core.Web;
using Umbraco.Cms.Web.Common.Controllers;

namespace Umbraco.Cms.Web.UI;

public class ProductsController : UmbracoApiController
{
    private readonly IUmbracoContextFactory _umbracoContextFactory;

    public ProductsController(IUmbracoContextFactory umbracoContextFactory)
        => _umbracoContextFactory = umbracoContextFactory;

    // /umbraco/api/products/test
    public IEnumerable<string> Test()
    {
        using var ctx = _umbracoContextFactory.EnsureUmbracoContext();
        var contentCache = ctx.UmbracoContext.Content;

        if (contentCache is null)
        {
            return Enumerable.Empty<string>();
        }

        IPublishedContentType? contentType = contentCache.GetContentType("product");

        if (contentType is null)
        {
            return Enumerable.Empty<string>();
        }

        var contentItems = contentCache.GetByContentType(contentType);

        return contentItems.Select(x => x.Name).WhereNotNull();
    }
}
```
- Create `Product` document type - allow as root;
- Create `Products` document type - allow as root and add `Product` as a child node;
- In the Content tree, create a few `Product` nodes in the root level, then a `Products` one, also in the root with a few nested `Product` nodes;
- Make sure that the `Product` document type **doesn't** vary by culture;
- Visit `/umbraco/api/products/test` and make sure that you get all nodes of type `Product`;
- Set the `Product` document type to vary by culture;
- The number of items you get from `/umbraco/api/products/test` should be the same.