### PR TITLE
V14: Fix not being able to create scripts in root

### DIFF
--- a/src/Umbraco.Core/Services/FileServiceBase.cs
+++ b/src/Umbraco.Core/Services/FileServiceBase.cs
@@ -39,6 +39,15 @@ public abstract class FileServiceBase<TRepository, TEntity> : RepositoryService,
         return true;
     }
 
+    /// <summary>
+    /// Checks if a path is considered a root path.
+    /// </summary>
+    /// <param name="path">The path to check.</param>
+    /// <returns>True if the path is considered a root path.</returns>
+    protected virtual bool IsRootPath(string? path)
+    // We use "/" here instead of path separator because it's the virtual path used by backoffice, and not an actual FS path.
+        => string.IsNullOrWhiteSpace(path) || path == "/";
+
     /// <inheritdoc />
     public Task<TEntity?> GetAsync(string path)
     {

--- a/src/Umbraco.Core/Services/ScriptService.cs
+++ b/src/Umbraco.Core/Services/ScriptService.cs
@@ -105,13 +105,13 @@ public class ScriptService : FileServiceBase<IScriptRepository, IScript>, IScrip
             return Task.FromResult(ScriptOperationStatus.AlreadyExists);
         }
 
-        if (string.IsNullOrWhiteSpace(createModel.ParentPath) is false &&
-            Repository.FolderExists(createModel.ParentPath) is false)
+        if (IsRootPath(createModel.ParentPath) is false &&
+            Repository.FolderExists(createModel.ParentPath!) is false)
         {
             return Task.FromResult(ScriptOperationStatus.ParentNotFound);
         }
 
-        if(HasValidFileName(createModel.Name) is false)
+        if (HasValidFileName(createModel.Name) is false)
         {
             return Task.FromResult(ScriptOperationStatus.InvalidName);
         }

--- a/src/Umbraco.Core/Services/StylesheetService.cs
+++ b/src/Umbraco.Core/Services/StylesheetService.cs
@@ -102,8 +102,8 @@ public class StylesheetService : FileServiceBase<IStylesheetRepository, IStylesh
             return StylesheetOperationStatus.AlreadyExists;
         }
 
-        if (string.IsNullOrWhiteSpace(createModel.ParentPath) is false
-            && Repository.FolderExists(createModel.ParentPath) is false)
+        if (IsRootPath(createModel.ParentPath) is false
+            && Repository.FolderExists(createModel.ParentPath!) is false)
         {
             return StylesheetOperationStatus.ParentNotFound;
         }


### PR DESCRIPTION
There was an issue where you were unable to create scripts in root from the backoffice, this was because the validation was a bit too strict. 

The scripts and CSS folders have always been created automatically when the first file was created in root, and this behaviour is still there in V14, but only when root was specified with an empty string, this PR also adds "/" as a valid way to specify root. 
 