### PR TITLE
Add custom Examine FileSystemDirectoryFactory using Umbraco SiteName

### DIFF
--- a/src/Umbraco.Examine.Lucene/ConfigurationEnabledDirectoryFactory.cs
+++ b/src/Umbraco.Examine.Lucene/ConfigurationEnabledDirectoryFactory.cs
@@ -54,7 +54,7 @@ public class ConfigurationEnabledDirectoryFactory : DirectoryFactoryBase
             case LuceneDirectoryFactory.SyncedTempFileSystemDirectoryFactory:
                 return _services.GetRequiredService<SyncedFileSystemDirectoryFactory>();
             case LuceneDirectoryFactory.TempFileSystemDirectoryFactory:
-                return _services.GetRequiredService<TempEnvFileSystemDirectoryFactory>();
+                return _services.GetRequiredService<UmbracoTempEnvFileSystemDirectoryFactory>();
             case LuceneDirectoryFactory.Default:
             default:
                 return _services.GetRequiredService<FileSystemDirectoryFactory>();

--- a/src/Umbraco.Examine.Lucene/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Examine.Lucene/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -1,8 +1,10 @@
 using Examine;
 using Examine.Lucene.Directories;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Hosting;
 
 namespace Umbraco.Cms.Infrastructure.Examine.DependencyInjection;
 
@@ -22,8 +24,26 @@ public static class UmbracoBuilderExtensions
 
         services.AddExamine();
 
-        // Create the indexes
-        services
+        services.AddSingleton<UmbracoTempEnvFileSystemDirectoryFactory>();
+        services.RemoveAll<SyncedFileSystemDirectoryFactory>();
+        services.AddSingleton<SyncedFileSystemDirectoryFactory>(
+            s =>
+            {
+                var baseDir = s.GetRequiredService<IApplicationRoot>().ApplicationRoot;
+
+                var tempDir = UmbracoTempEnvFileSystemDirectoryFactory.GetTempPath(
+                    s.GetRequiredService<IApplicationIdentifier>(), s.GetRequiredService<IHostingEnvironment>());
+
+                return ActivatorUtilities.CreateInstance<SyncedFileSystemDirectoryFactory>(
+                    s,
+                    new object[]
+                    {
+                        new DirectoryInfo(tempDir), s.GetRequiredService<IApplicationRoot>().ApplicationRoot
+                    });
+            });
+
+    // Create the indexes
+    services
             .AddExamineLuceneIndex<UmbracoContentIndex, ConfigurationEnabledDirectoryFactory>(Constants.UmbracoIndexes
                 .InternalIndexName)
             .AddExamineLuceneIndex<UmbracoContentIndex, ConfigurationEnabledDirectoryFactory>(Constants.UmbracoIndexes

--- a/src/Umbraco.Examine.Lucene/UmbracoTempEnvFileSystemDirectoryFactory.cs
+++ b/src/Umbraco.Examine.Lucene/UmbracoTempEnvFileSystemDirectoryFactory.cs
@@ -1,0 +1,36 @@
+using Examine;
+using Examine.Lucene.Directories;
+using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
+
+namespace Umbraco.Cms.Infrastructure.Examine
+{
+    /// <summary>
+    /// Custom version of https://github.com/Shazwazza/Examine/blob/release/3.0/src/Examine.Lucene/Directories/TempEnvFileSystemDirectoryFactory.cs that includes the Umbraco SiteName property in the path hash
+    /// </summary>
+    public class UmbracoTempEnvFileSystemDirectoryFactory : FileSystemDirectoryFactory
+    {
+        public UmbracoTempEnvFileSystemDirectoryFactory(
+            IApplicationIdentifier applicationIdentifier,
+            ILockFactory lockFactory,
+            IHostingEnvironment hostingEnvironment)
+            : base(new DirectoryInfo(GetTempPath(applicationIdentifier, hostingEnvironment)), lockFactory)
+        {
+        }
+
+        public static string GetTempPath(IApplicationIdentifier applicationIdentifier, IHostingEnvironment hostingEnvironment)
+        {
+            var hashString = hostingEnvironment.SiteName + "::" + applicationIdentifier.GetApplicationUniqueIdentifier();
+            var appDomainHash = hashString.GenerateHash();
+
+            var cachePath = Path.Combine(
+                Path.GetTempPath(),
+                "ExamineIndexes",
+                //include the appdomain hash is just a safety check, for example if a website is moved from worker A to worker B and then back
+                // to worker A again, in theory the %temp%  folder should already be empty but we really want to make sure that its not
+                // utilizing an old index
+                appDomainHash);
+
+            return cachePath;
+        }
+    }
+}


### PR DESCRIPTION
When Examine is set to use either SyncedTempFileSystemDirectoryFactory or TempFileSystemDirectoryFactory the SiteName property should be used in the hash for the folder name in the same way as LocalTempStorageLocation does (https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Web.Common/AspNetCore/AspNetCoreHostingEnvironment.cs#L136).

This PR implements this change by creating a custom TempEnvFileSystemDirectoryFactory (https://github.com/Shazwazza/Examine/blob/release/3.0/src/Examine.Lucene/Directories/TempEnvFileSystemDirectoryFactory.cs).

This should help with Azure App Slot Swapping indexing locking as the SiteName property can be made sticky to each slot with a different value (as we can do for the published cache already).  It also can be used when debugging locally with multiple launch profiles

