### PR TITLE
Fix/ensured that we not load multiple times same datatypes in each context

### DIFF
--- a/src/Umbraco.Core/Models/IDataValueEditor.cs
+++ b/src/Umbraco.Core/Models/IDataValueEditor.cs
@@ -78,7 +78,10 @@ public interface IDataValueEditor
     /// <summary>
     ///     Converts a property value to a value for the editor.
     /// </summary>
-    object? ToEditor(IProperty property, MapperContext? mapperContext, string? culture, string? segment);
+    object? ToEditor(IProperty property, MapperContext? mapperContext, string? culture, string? segment)
+    {
+        return ToEditor(property, culture, segment);
+    }
 
     // TODO: / deal with this when unplugging the xml cache
     // why property vs propertyType? services should be injected! etc...

--- a/src/Umbraco.Core/Models/IDataValueEditor.cs
+++ b/src/Umbraco.Core/Models/IDataValueEditor.cs
@@ -78,7 +78,7 @@ public interface IDataValueEditor
     /// <summary>
     ///     Converts a property value to a value for the editor.
     /// </summary>
-    object? ToEditor(IProperty property, string? culture, string? segment, MapperContext? mapperContext)
+    object? ToEditor(IProperty property, MapperContext? mapperContext, string? culture, string? segment)
     {
          //todo: remove this when we remove the old ToEditor method
             return ToEditor(property, culture, segment);

--- a/src/Umbraco.Core/Models/IDataValueEditor.cs
+++ b/src/Umbraco.Core/Models/IDataValueEditor.cs
@@ -78,12 +78,7 @@ public interface IDataValueEditor
     /// <summary>
     ///     Converts a property value to a value for the editor.
     /// </summary>
-    object? ToEditor(IProperty property, MapperContext? mapperContext, string? culture, string? segment)
-    {
-         //todo: remove this when we remove the old ToEditor method
-            return ToEditor(property, culture, segment);
-    }
-
+    object? ToEditor(IProperty property, MapperContext? mapperContext, string? culture, string? segment);
 
     // TODO: / deal with this when unplugging the xml cache
     // why property vs propertyType? services should be injected! etc...

--- a/src/Umbraco.Core/Models/IDataValueEditor.cs
+++ b/src/Umbraco.Core/Models/IDataValueEditor.cs
@@ -72,7 +72,7 @@ public interface IDataValueEditor
     /// <summary>
     ///     Converts a property value to a value for the editor.
     /// </summary>
-    [Obsolete("Use ToEditor(IProperty property, MapperContext? context, string? culture, string? segment) instead", true)]
+    [Obsolete("Use ToEditor(IProperty property, string? culture, string? segment, MapperContext context); instead")]
     object? ToEditor(IProperty property, string? culture = null, string? segment = null);
 
     /// <summary>

--- a/src/Umbraco.Core/Models/IDataValueEditor.cs
+++ b/src/Umbraco.Core/Models/IDataValueEditor.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.Xml.Linq;
+using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models.Editors;
 using Umbraco.Cms.Core.PropertyEditors;
 
@@ -63,7 +64,18 @@ public interface IDataValueEditor
     /// <summary>
     ///     Converts a property value to a value for the editor.
     /// </summary>
+    [Obsolete("Use ToEditor(IProperty property, string? culture, string? segment, MapperContext context); instead")]
     object? ToEditor(IProperty property, string? culture = null, string? segment = null);
+
+    /// <summary>
+    ///     Converts a property value to a value for the editor.
+    /// </summary>
+    object? ToEditor(IProperty property, string? culture, string? segment, MapperContext? mapperContext)
+    {
+         //todo: remove this when we remove the old ToEditor method
+            return ToEditor(property, culture, segment);
+    }
+
 
     // TODO: / deal with this when unplugging the xml cache
     // why property vs propertyType? services should be injected! etc...

--- a/src/Umbraco.Core/Models/IDataValueEditor.cs
+++ b/src/Umbraco.Core/Models/IDataValueEditor.cs
@@ -72,7 +72,7 @@ public interface IDataValueEditor
     /// <summary>
     ///     Converts a property value to a value for the editor.
     /// </summary>
-    [Obsolete("Use ToEditor(IProperty property, string? culture, string? segment, MapperContext context); instead")]
+    [Obsolete("Use ToEditor(IProperty property, MapperContext? context, string? culture, string? segment) instead", true)]
     object? ToEditor(IProperty property, string? culture = null, string? segment = null);
 
     /// <summary>

--- a/src/Umbraco.Core/Models/IDataValueEditor.cs
+++ b/src/Umbraco.Core/Models/IDataValueEditor.cs
@@ -60,6 +60,14 @@ public interface IDataValueEditor
     ///     Converts a value posted by the editor to a property value.
     /// </summary>
     object? FromEditor(ContentPropertyData editorValue, object? currentValue);
+    /// <summary>
+    ///     Converts a value posted by the editor to a property value.
+    /// </summary>
+    object? FromEditor(ContentPropertyData editorValue, object? getPropertyValue,
+        Dictionary<int, IDataType?>? dictionary)
+    {
+        return FromEditor(editorValue, getPropertyValue);
+    }
 
     /// <summary>
     ///     Converts a property value to a value for the editor.
@@ -97,4 +105,6 @@ public interface IDataValueEditor
     XNode ConvertDbToXml(IPropertyType propertyType, object value);
 
     string ConvertDbToString(IPropertyType propertyType, object? value);
+
+
 }

--- a/src/Umbraco.Core/Models/Mapping/ContentPropertyBasicMapper.cs
+++ b/src/Umbraco.Core/Models/Mapping/ContentPropertyBasicMapper.cs
@@ -91,6 +91,6 @@ internal class ContentPropertyBasicMapper<TDestination>
         dest.Segment = segment;
 
         // if no 'IncludeProperties' were specified or this property is set to be included - we will map the value and return.
-        dest.Value = editor.GetValueEditor().ToEditor(property, culture, segment);
+        dest.Value = editor.GetValueEditor().ToEditor(property, culture, segment,context);
     }
 }

--- a/src/Umbraco.Core/Models/Mapping/ContentPropertyBasicMapper.cs
+++ b/src/Umbraco.Core/Models/Mapping/ContentPropertyBasicMapper.cs
@@ -91,6 +91,6 @@ internal class ContentPropertyBasicMapper<TDestination>
         dest.Segment = segment;
 
         // if no 'IncludeProperties' were specified or this property is set to be included - we will map the value and return.
-        dest.Value = editor.GetValueEditor().ToEditor(property, culture, segment,context);
+        dest.Value = editor.GetValueEditor().ToEditor(property,context, culture, segment);
     }
 }

--- a/src/Umbraco.Core/Models/Mapping/ContentPropertyDisplayMapper.cs
+++ b/src/Umbraco.Core/Models/Mapping/ContentPropertyDisplayMapper.cs
@@ -35,10 +35,24 @@ internal class ContentPropertyDisplayMapper : ContentPropertyBasicMapper<Content
     public override void Map(IProperty originalProp, ContentPropertyDisplay dest, MapperContext context)
     {
         base.Map(originalProp, dest, context);
+        object? config = null;
+        if (originalProp.PropertyType is not null)
+        {
+            if (!context.Items.ContainsKey($"DataType-{originalProp.PropertyType.DataTypeId}"))
+            {
+                // get the configuration from the property type
+                var item = DataTypeService.GetDataType(originalProp.PropertyType.DataTypeId);
+                config = item?.Configuration;
+                context.Items[$"DataType-{originalProp.PropertyType.DataTypeId}"] = item;
+            }
+            else
+            {
+                // get the configuration from the context
+                config = (context.Items[$"DataType-{originalProp.PropertyType.DataTypeId}"] as IDataType)
+                    ?.Configuration;
+            }
+        }
 
-        var config = originalProp.PropertyType is null
-            ? null
-            : DataTypeService.GetDataType(originalProp.PropertyType.DataTypeId)?.Configuration;
 
         // TODO: IDataValueEditor configuration - general issue
         // GetValueEditor() returns a non-configured IDataValueEditor

--- a/src/Umbraco.Core/Models/Mapping/ContentPropertyDtoMapper.cs
+++ b/src/Umbraco.Core/Models/Mapping/ContentPropertyDtoMapper.cs
@@ -26,7 +26,15 @@ internal class ContentPropertyDtoMapper : ContentPropertyBasicMapper<ContentProp
         dest.ValidationRegExpMessage = property.PropertyType.ValidationRegExpMessage;
         dest.Description = property.PropertyType.Description;
         dest.Label = property.PropertyType.Name;
-        dest.DataType = DataTypeService.GetDataType(property.PropertyType.DataTypeId);
+        if(context.Items.ContainsKey("DataType-" + property.PropertyType.DataTypeId))
+        {
+            dest.DataType = (context.Items["DataType-" + property.PropertyType.DataTypeId] as IDataType);
+        }
+        else
+        {
+            dest.DataType = DataTypeService.GetDataType(property.PropertyType.DataTypeId);
+            context.Items["DataType-" + property.PropertyType.DataTypeId] = dest.DataType;
+        }
         dest.LabelOnTop = property.PropertyType.LabelOnTop;
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
@@ -193,17 +193,10 @@ public class DataValueEditor : IDataValueEditor
     ///     If overridden then the object returned must match the type supplied in the ValueType, otherwise persisting the
     ///     value to the DB will fail when it tries to validate the value type.
     /// </remarks>
+    [Obsolete("Use FromEditor(ContentPropertyData editorValue, object? currentValue, Dictionary<int,IDataType?>? dataTypes) instead")]
     public virtual object? FromEditor(ContentPropertyData editorValue, object? currentValue)
     {
-        Attempt<object?> result = TryConvertValueToCrlType(editorValue.Value);
-        if (result.Success == false)
-        {
-            StaticApplicationLogging.Logger.LogWarning(
-                "The value {EditorValue} cannot be converted to the type {StorageTypeValue}", editorValue.Value, ValueTypes.ToStorageType(ValueType));
-            return null;
-        }
-
-        return result.Result;
+       return FromEditor(editorValue, currentValue,null);
     }
     /// <summary>
     ///     A method to deserialize the string value that has been saved in the content editor to an object to be stored in the
@@ -215,6 +208,7 @@ public class DataValueEditor : IDataValueEditor
     ///     useful for how the value then get's deserialized again to be re-persisted. In most cases it will probably not be
     ///     used.
     /// </param>
+    /// <param name="dataTypes">List of already retrieved datatypes</param>
     /// <returns>The value that gets persisted to the database.</returns>
     /// <remarks>
     ///     By default this will attempt to automatically convert the string value to the value type supplied by ValueType.

--- a/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
@@ -248,9 +248,9 @@ public class DataValueEditor : IDataValueEditor
     [Obsolete("Use ToEditor(IProperty property, string? culture, string? segment, MapperContext context); instead")]
     public virtual object? ToEditor(IProperty property, string? culture = null, string? segment = null)
     {
-        return ToEditor(property, culture, segment, null);
+        return ToEditor(property,null, culture, segment);
     }
-    public virtual object? ToEditor(IProperty property, string? culture = null, string? segment = null, MapperContext? mapperContext = null)
+    public virtual object? ToEditor(IProperty property, MapperContext? mapperContext, string? culture = null, string? segment = null)
     {
         var value = property.GetValue(culture, segment);
         if (value == null)

--- a/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
@@ -4,6 +4,7 @@ using System.Runtime.Serialization;
 using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Editors;
 using Umbraco.Cms.Core.PropertyEditors.Validators;
@@ -217,7 +218,12 @@ public class DataValueEditor : IDataValueEditor
     ///     The object returned will automatically be serialized into JSON notation. For most property editors
     ///     the value returned is probably just a string, but in some cases a JSON structure will be returned.
     /// </remarks>
+    [Obsolete("Use ToEditor(IProperty property, string? culture, string? segment, MapperContext context); instead")]
     public virtual object? ToEditor(IProperty property, string? culture = null, string? segment = null)
+    {
+        return ToEditor(property, culture, segment, null);
+    }
+    public virtual object? ToEditor(IProperty property, string? culture = null, string? segment = null, MapperContext? mapperContext = null)
     {
         var value = property.GetValue(culture, segment);
         if (value == null)
@@ -271,7 +277,6 @@ public class DataValueEditor : IDataValueEditor
                 throw new ArgumentOutOfRangeException("ValueType was out of range.");
         }
     }
-
     // TODO: the methods below should be replaced by proper property value convert ToXPath usage!
 
     /// <summary>

--- a/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
@@ -239,7 +239,7 @@ public class DataValueEditor : IDataValueEditor
     ///     The object returned will automatically be serialized into JSON notation. For most property editors
     ///     the value returned is probably just a string, but in some cases a JSON structure will be returned.
     /// </remarks>
-    [Obsolete("Use ToEditor(IProperty property, string? culture, string? segment, MapperContext context); instead")]
+    [Obsolete("Use ToEditor(IProperty property, MapperContext context, string? culture, string? segment); instead")]
     public virtual object? ToEditor(IProperty property, string? culture = null, string? segment = null)
     {
         return ToEditor(property,null, culture, segment);

--- a/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataValueEditor.cs
@@ -205,7 +205,34 @@ public class DataValueEditor : IDataValueEditor
 
         return result.Result;
     }
+    /// <summary>
+    ///     A method to deserialize the string value that has been saved in the content editor to an object to be stored in the
+    ///     database.
+    /// </summary>
+    /// <param name="editorValue">The value returned by the editor.</param>
+    /// <param name="currentValue">
+    ///     The current value that has been persisted to the database for this editor. This value may be
+    ///     useful for how the value then get's deserialized again to be re-persisted. In most cases it will probably not be
+    ///     used.
+    /// </param>
+    /// <returns>The value that gets persisted to the database.</returns>
+    /// <remarks>
+    ///     By default this will attempt to automatically convert the string value to the value type supplied by ValueType.
+    ///     If overridden then the object returned must match the type supplied in the ValueType, otherwise persisting the
+    ///     value to the DB will fail when it tries to validate the value type.
+    /// </remarks>
+    public virtual object? FromEditor(ContentPropertyData editorValue, object? currentValue, Dictionary<int,IDataType?>? dataTypes)
+    {
+        Attempt<object?> result = TryConvertValueToCrlType(editorValue.Value);
+        if (result.Success == false)
+        {
+            StaticApplicationLogging.Logger.LogWarning(
+                "The value {EditorValue} cannot be converted to the type {StorageTypeValue}", editorValue.Value, ValueTypes.ToStorageType(ValueType));
+            return null;
+        }
 
+        return result.Result;
+    }
     /// <summary>
     ///     A method used to format the database value to a value that can be used by the editor.
     /// </summary>

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyValueEditor.cs
@@ -77,28 +77,7 @@ internal abstract class BlockEditorPropertyValueEditor : BlockValuePropertyValue
     /// <returns></returns>
     public override object ToEditor(IProperty property, string? culture = null, string? segment = null)
     {
-        var val = property.GetValue(culture, segment);
-
-        BlockEditorData? blockEditorData;
-        try
-        {
-            blockEditorData = BlockEditorValues.DeserializeAndClean(val);
-        }
-        catch (JsonSerializationException)
-        {
-            // if this occurs it means the data is invalid, shouldn't happen but has happened if we change the data format.
-            return string.Empty;
-        }
-
-        if (blockEditorData == null)
-        {
-            return string.Empty;
-        }
-
-        MapBlockValueToEditor(property, blockEditorData.BlockValue);
-
-        // return json convertable object
-        return blockEditorData.BlockValue;
+      return ToEditor(property, null,culture, segment);
     }
     // note: there is NO variant support here
 
@@ -109,7 +88,7 @@ internal abstract class BlockEditorPropertyValueEditor : BlockValuePropertyValue
     /// <param name="culture"></param>
     /// <param name="segment"></param>
     /// <returns></returns>
-    public override object ToEditor(IProperty property, string? culture = null, string? segment = null, MapperContext? context = null)
+    public override object ToEditor(IProperty property, MapperContext? context, string? culture = null, string? segment = null)
     {
         var val = property.GetValue(culture, segment);
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyValueEditor.cs
@@ -75,6 +75,7 @@ internal abstract class BlockEditorPropertyValueEditor : BlockValuePropertyValue
     /// <param name="culture"></param>
     /// <param name="segment"></param>
     /// <returns></returns>
+    [Obsolete("Use ToEditor(IProperty property, MapperContext? context, string? culture, string? segment) instead")]
     public override object ToEditor(IProperty property, string? culture = null, string? segment = null)
     {
       return ToEditor(property, null,culture, segment);

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyValueEditor.cs
@@ -123,31 +123,7 @@ internal abstract class BlockEditorPropertyValueEditor : BlockValuePropertyValue
     /// <returns></returns>
     public override object? FromEditor(ContentPropertyData editorValue, object? currentValue)
     {
-        if (editorValue.Value == null || string.IsNullOrWhiteSpace(editorValue.Value.ToString()))
-        {
-            return null;
-        }
-
-        BlockEditorData? blockEditorData;
-        try
-        {
-            blockEditorData = BlockEditorValues.DeserializeAndClean(editorValue.Value);
-        }
-        catch (JsonSerializationException)
-        {
-            // if this occurs it means the data is invalid, shouldn't happen but has happened if we change the data format.
-            return string.Empty;
-        }
-
-        if (blockEditorData == null || blockEditorData.BlockValue.ContentData.Count == 0)
-        {
-            return string.Empty;
-        }
-
-        MapBlockValueFromEditor(blockEditorData.BlockValue, null);
-
-        // return json
-        return JsonConvert.SerializeObject(blockEditorData.BlockValue, Formatting.None);
+      return FromEditor(editorValue, currentValue,null);
     }
     /// <summary>
     ///     Ensure that sub-editor values are translated through their FromEditor methods

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyValueEditor.cs
@@ -164,7 +164,41 @@ internal abstract class BlockEditorPropertyValueEditor : BlockValuePropertyValue
             return string.Empty;
         }
 
-        MapBlockValueFromEditor(blockEditorData.BlockValue);
+        MapBlockValueFromEditor(blockEditorData.BlockValue, null);
+
+        // return json
+        return JsonConvert.SerializeObject(blockEditorData.BlockValue, Formatting.None);
+    }
+    /// <summary>
+    ///     Ensure that sub-editor values are translated through their FromEditor methods
+    /// </summary>
+    /// <param name="editorValue"></param>
+    /// <param name="currentValue"></param>
+    /// <returns></returns>
+    public override object? FromEditor(ContentPropertyData editorValue, object? currentValue,Dictionary<int,IDataType?>? dataTypes)
+    {
+        if (editorValue.Value == null || string.IsNullOrWhiteSpace(editorValue.Value.ToString()))
+        {
+            return null;
+        }
+
+        BlockEditorData? blockEditorData;
+        try
+        {
+            blockEditorData = BlockEditorValues.DeserializeAndClean(editorValue.Value);
+        }
+        catch (JsonSerializationException)
+        {
+            // if this occurs it means the data is invalid, shouldn't happen but has happened if we change the data format.
+            return string.Empty;
+        }
+
+        if (blockEditorData == null || blockEditorData.BlockValue.ContentData.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        MapBlockValueFromEditor(blockEditorData.BlockValue,dataTypes);
 
         // return json
         return JsonConvert.SerializeObject(blockEditorData.BlockValue, Formatting.None);

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyValueEditor.cs
@@ -78,7 +78,7 @@ internal abstract class BlockEditorPropertyValueEditor : BlockValuePropertyValue
     [Obsolete("Use ToEditor(IProperty property, MapperContext? context, string? culture, string? segment) instead")]
     public override object ToEditor(IProperty property, string? culture = null, string? segment = null)
     {
-      return ToEditor(property, null,culture, segment);
+      return this.ToEditor(property, null,culture, segment);
     }
     // note: there is NO variant support here
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
@@ -173,7 +173,7 @@ internal abstract class BlockValuePropertyValueEditorBase : DataValueEditor, IDa
                     valEditors.Add(dataType.Id, valEditor);
                 }
 
-                var convValue = valEditor.ToEditor(tempProp, null, null, mapperContext);
+                var convValue = valEditor.ToEditor(tempProp, mapperContext,null, null);
 
                 // update the raw value since this is what will get serialized out
                 row.RawPropertyValues[prop.Key] = convValue;

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
@@ -103,10 +103,10 @@ internal abstract class BlockValuePropertyValueEditorBase : DataValueEditor, IDa
         return result;
     }
 
-    protected void MapBlockValueFromEditor(BlockValue blockValue)
+    protected void MapBlockValueFromEditor(BlockValue blockValue, Dictionary<int, IDataType?>? dataTypes)
     {
-        MapBlockItemDataFromEditor(blockValue.ContentData);
-        MapBlockItemDataFromEditor(blockValue.SettingsData);
+        MapBlockItemDataFromEditor(blockValue.ContentData,dataTypes);
+        MapBlockItemDataFromEditor(blockValue.SettingsData,dataTypes);
     }
 
     protected void MapBlockValueToEditor(IProperty property, BlockValue blockValue, MapperContext? mapperContext = null)
@@ -181,24 +181,26 @@ internal abstract class BlockValuePropertyValueEditorBase : DataValueEditor, IDa
         }
     }
 
-    private void MapBlockItemDataFromEditor(List<BlockItemData> items)
+    private void MapBlockItemDataFromEditor(List<BlockItemData> items, Dictionary<int, IDataType?>? dataTypes)
     {
-        IDictionary<int, IDataType?> dataTypes = new Dictionary<int, IDataType?>();
-
         foreach (BlockItemData row in items)
         {
             foreach (KeyValuePair<string, BlockItemData.BlockPropertyValue> prop in row.PropertyValues)
             {
                 // Fetch the property types prevalue
                 IDataType? dataType = null;
-                if (dataTypes.ContainsKey(prop.Value.PropertyType.DataTypeId))
+                if (dataTypes?.ContainsKey(prop.Value.PropertyType.DataTypeId) == true)
                 {
                     dataType = dataTypes[prop.Value.PropertyType.DataTypeId];
+                }
+                else if (dataTypes != null)
+                {
+                    dataType = _dataTypeService.GetDataType(prop.Value.PropertyType.DataTypeId);
+                    dataTypes.Add(prop.Value.PropertyType.DataTypeId, dataType);
                 }
                 else
                 {
                     dataType = _dataTypeService.GetDataType(prop.Value.PropertyType.DataTypeId);
-                    dataTypes.Add(prop.Value.PropertyType.DataTypeId, dataType);
                 }
                 var propConfiguration = dataType?.Configuration;
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
@@ -215,7 +215,7 @@ internal abstract class BlockValuePropertyValueEditorBase : DataValueEditor, IDa
                 var contentPropData = new ContentPropertyData(prop.Value.Value, propConfiguration);
 
                 // Get the property editor to do it's conversion
-                var newValue = propEditor.GetValueEditor().FromEditor(contentPropData, prop.Value.Value);
+                var newValue = propEditor.GetValueEditor().FromEditor(contentPropData, prop.Value.Value, dataTypes);
 
                 // update the raw value since this is what will get serialized out
                 row.RawPropertyValues[prop.Key] = newValue;

--- a/src/Umbraco.Infrastructure/PropertyEditors/GridPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/GridPropertyEditor.cs
@@ -193,6 +193,7 @@ namespace Umbraco.Cms.Core.PropertyEditors
             /// <param name="editorValue"></param>
             /// <param name="currentValue"></param>
             /// <returns></returns>
+            [Obsolete("Use FromEditor(ContentPropertyData editorValue, object? currentValue, Dictionary<int,IDataType?>? dataTypes) instead")]
             public override object? FromEditor(ContentPropertyData editorValue, object? currentValue)
             {
                 if (editorValue.Value == null)
@@ -238,7 +239,59 @@ namespace Umbraco.Cms.Core.PropertyEditors
                 // Convert back to raw JSON for persisting
                 return JsonConvert.SerializeObject(grid, Formatting.None);
             }
+            /// <summary>
+            /// Format the data for persistence
+            /// This to ensure if a RTE is used in a Grid cell/control that we parse it for tmp stored images
+            /// to persist to the media library when we go to persist this to the DB
+            /// </summary>
+            /// <param name="editorValue"></param>
+            /// <param name="currentValue"></param>
+            /// <returns></returns>
+            public override object? FromEditor(ContentPropertyData editorValue, object? currentValue, Dictionary<int,IDataType?>? dataTypes)
+            {
+                if (editorValue.Value == null)
+                {
+                    return null;
+                }
 
+                // editorValue.Value is a JSON string of the grid
+                var rawJson = editorValue.Value.ToString();
+                if (rawJson.IsNullOrWhiteSpace())
+                {
+                    return null;
+                }
+
+                var config = editorValue.DataTypeConfiguration as GridConfiguration;
+                GuidUdi? mediaParent = config?.MediaParentId;
+                Guid mediaParentId = mediaParent?.Guid ?? Guid.Empty;
+
+                GridValue? grid = DeserializeGridValue(rawJson!, out var rtes, out _, out _);
+
+                var userId = _backOfficeSecurityAccessor?.BackOfficeSecurity?.CurrentUser?.Id ?? Constants.Security.SuperUserId;
+
+                if (rtes is null)
+                {
+                    return JsonConvert.SerializeObject(grid, Formatting.None);
+                }
+                // Process the rte values
+                foreach (GridValue.GridControl rte in rtes)
+                {
+                    // Parse the HTML
+                    var html = rte.Value?.ToString();
+
+                    if (html is not null)
+                    {
+                        var parseAndSaveBase64Images = _pastedImages.FindAndPersistEmbeddedImages(
+                            html, mediaParentId, userId);
+                        var parseAndSavedTempImages = _pastedImages.FindAndPersistPastedTempImages(parseAndSaveBase64Images, mediaParentId, userId);
+                        var editorValueWithMediaUrlsRemoved = _imageSourceParser.RemoveImageSources(parseAndSavedTempImages);
+                        rte.Value = editorValueWithMediaUrlsRemoved;
+                    }
+                }
+
+                // Convert back to raw JSON for persisting
+                return JsonConvert.SerializeObject(grid, Formatting.None);
+            }
             /// <summary>
             /// Ensures that the rich text editor values are processed within the grid
             /// </summary>

--- a/src/Umbraco.Infrastructure/PropertyEditors/GridPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/GridPropertyEditor.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Media;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Editors;
@@ -245,7 +246,12 @@ namespace Umbraco.Cms.Core.PropertyEditors
             /// <param name="culture"></param>
             /// <param name="segment"></param>
             /// <returns></returns>
+            [Obsolete("Use ToEditor(IProperty property, MapperContext? context, string? culture, string? segment) instead")]
             public override object? ToEditor(IProperty property, string? culture = null, string? segment = null)
+            {
+                return ToEditor(property, null, culture, segment);
+            }
+            public override object? ToEditor(IProperty property, MapperContext? mapperContext, string? culture = null, string? segment = null)
             {
                 var val = property.GetValue(culture, segment)?.ToString();
                 if (val.IsNullOrWhiteSpace())

--- a/src/Umbraco.Infrastructure/PropertyEditors/MediaPicker3PropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MediaPicker3PropertyEditor.cs
@@ -107,7 +107,7 @@ public class MediaPicker3PropertyEditor : DataEditor
 
         public override object ToEditor(IProperty property, string? culture = null, string? segment = null)
         {
-          return ToEditor(property, null, culture, segment);
+          return  this.ToEditor(property, null, culture, segment);
         }
         public override object ToEditor(IProperty property, MapperContext? mapperContext, string? culture = null, string? segment = null)
         {

--- a/src/Umbraco.Infrastructure/PropertyEditors/MediaPicker3PropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MediaPicker3PropertyEditor.cs
@@ -143,7 +143,12 @@ public class MediaPicker3PropertyEditor : DataEditor
 
             return dtos;
         }
+        [Obsolete("Use FromEditor(IProperty property, MapperContext? context, string? culture, string? segment) instead", true)]
         public override object? FromEditor(ContentPropertyData editorValue, object? currentValue)
+        {
+            return FromEditor(editorValue, currentValue, null);
+        }
+        public override object? FromEditor(ContentPropertyData editorValue, object? currentValue, Dictionary<int,IDataType?>? dataTypes)
         {
             if (editorValue.Value is JArray dtos)
             {
@@ -163,7 +168,6 @@ public class MediaPicker3PropertyEditor : DataEditor
 
             return base.FromEditor(editorValue, currentValue);
         }
-
         internal static IEnumerable<MediaWithCropsDto> Deserialize(IJsonSerializer jsonSerializer, object? value)
         {
             var rawJson = value is string str ? str : value?.ToString();

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultiUrlPickerValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultiUrlPickerValueEditor.cs
@@ -209,8 +209,13 @@ public class MultiUrlPickerValueEditor : DataValueEditor, IDataValueReference
     {
       return ToEditor(property, null, culture, segment);
     }
-
+    [Obsolete("Use FromEditor(ContentPropertyData editorValue, object? currentValue, Dictionary<int, IDataType?>? dataTypes) instead")]
     public override object? FromEditor(ContentPropertyData editorValue, object? currentValue)
+    {
+        return FromEditor(editorValue, currentValue, null);
+    }
+
+    public override object? FromEditor(ContentPropertyData editorValue, object? currentValue, Dictionary<int, IDataType?>? dataTypes)
     {
         var value = editorValue.Value?.ToString();
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultiUrlPickerValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultiUrlPickerValueEditor.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Models.Editors;
@@ -124,8 +125,8 @@ public class MultiUrlPickerValueEditor : DataValueEditor, IDataValueReference
             }
         }
     }
-
-    public override object? ToEditor(IProperty property, string? culture = null, string? segment = null)
+    [Obsolete("Use ToEditor(IProperty property, MapperContext? context, string? culture, string? segment) instead", true)]
+    public override object? ToEditor(IProperty property, MapperContext? mapperContext, string? culture = null, string? segment = null)
     {
         var value = property.GetValue(culture, segment)?.ToString();
 
@@ -202,6 +203,11 @@ public class MultiUrlPickerValueEditor : DataValueEditor, IDataValueReference
         }
 
         return base.ToEditor(property, culture, segment);
+    }
+    [Obsolete("Use ToEditor(IProperty property, MapperContext? context, string? culture, string? segment) instead")]
+    public override object? ToEditor(IProperty property, string? culture = null, string? segment = null)
+    {
+      return ToEditor(property, null, culture, segment);
     }
 
     public override object? FromEditor(ContentPropertyData editorValue, object? currentValue)

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultipleTextStringPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultipleTextStringPropertyEditor.cs
@@ -102,6 +102,20 @@ public class MultipleTextStringPropertyEditor : DataEditor
         /// </remarks>
         public override object? FromEditor(ContentPropertyData editorValue, object? currentValue)
         {
+            return FromEditor(editorValue, currentValue, null);
+        }
+        /// <summary>
+        ///     The value passed in from the editor will be an array of simple objects so we'll need to parse them to get the
+        ///     string
+        /// </summary>
+        /// <param name="editorValue"></param>
+        /// <param name="currentValue"></param>
+        /// <returns></returns>
+        /// <remarks>
+        ///     We will also check the pre-values here, if there are more items than what is allowed we'll just trim the end
+        /// </remarks>
+        public override object? FromEditor(ContentPropertyData editorValue, object? currentValue, Dictionary<int,IDataType?>? dataTypes)
+        {
             if (editorValue.Value is not JArray asArray || asArray.HasValues == false)
             {
                 return null;
@@ -128,7 +142,6 @@ public class MultipleTextStringPropertyEditor : DataEditor
 
             return string.Join(NewLine, array);
         }
-
         /// <summary>
         ///     We are actually passing back an array of simple objects instead of an array of strings because in angular a
         ///     primitive (string) value

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultipleTextStringPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultipleTextStringPropertyEditor.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json.Linq;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Exceptions;
 using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Editors;
 using Umbraco.Cms.Core.PropertyEditors.Validators;
@@ -140,12 +141,29 @@ public class MultipleTextStringPropertyEditor : DataEditor
         /// <remarks>
         ///     The legacy property editor saved this data as new line delimited! strange but we have to maintain that.
         /// </remarks>
+        [Obsolete("Use ToEditor(IProperty property, MapperContext? context, string? culture, string? segment) instead")]
         public override object ToEditor(IProperty property, string? culture = null, string? segment = null)
+        {
+           return ToEditor(property, null,culture, segment);
+        }
+        /// <summary>
+        ///     We are actually passing back an array of simple objects instead of an array of strings because in angular a
+        ///     primitive (string) value
+        ///     cannot have 2 way binding, so to get around that each item in the array needs to be an object with a string.
+        /// </summary>
+        /// <param name="property"></param>
+        /// <param name="culture"></param>
+        /// <param name="segment"></param>
+        /// <returns></returns>
+        /// <remarks>
+        ///     The legacy property editor saved this data as new line delimited! strange but we have to maintain that.
+        /// </remarks>
+        public override object ToEditor(IProperty property, MapperContext? mapperContext, string? culture = null, string? segment = null)
         {
             var val = property.GetValue(culture, segment);
 
             return val?.ToString()?.Split(NewLineDelimiters, StringSplitOptions.None).Select(x => JObject.FromObject(new { value = x }))
-                ?? Array.Empty<JObject>();
+                   ?? Array.Empty<JObject>();
         }
     }
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultipleValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultipleValueEditor.cs
@@ -76,7 +76,19 @@ public class MultipleValueEditor : DataValueEditor
     /// <param name="editorValue"></param>
     /// <param name="currentValue"></param>
     /// <returns></returns>
+    [Obsolete("Use FromEditor(ContentPropertyData editorValue, object? currentValue, Dictionary<int,IDataType?>? dataTypes) instead")]
     public override object? FromEditor(ContentPropertyData editorValue, object? currentValue)
+    {
+        return FromEditor(editorValue, currentValue, null);
+    }
+    /// <summary>
+    ///     When multiple values are selected a json array will be posted back so we need to format for storage in
+    ///     the database which is a comma separated string value
+    /// </summary>
+    /// <param name="editorValue"></param>
+    /// <param name="currentValue"></param>
+    /// <returns></returns>
+    public override object? FromEditor(ContentPropertyData editorValue, object? currentValue, Dictionary<int,IDataType?>? dataTypes)
     {
         if (editorValue.Value is not JArray json || json.HasValues == false)
         {

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultipleValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultipleValueEditor.cs
@@ -4,6 +4,7 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Editors;
 using Umbraco.Cms.Core.Serialization;
@@ -37,7 +38,26 @@ public class MultipleValueEditor : DataValueEditor
     /// <param name="culture"></param>
     /// <param name="segment"></param>
     /// <returns></returns>
+    [Obsolete("Use ToEditor(IProperty property, MapperContext? context, string? culture, string? segment) instead")]
     public override object ToEditor(IProperty property, string? culture = null, string? segment = null)
+    {
+        var json = base.ToEditor(property, culture, segment)?.ToString();
+        string[]? result = null;
+        if (json is not null)
+        {
+            result = JsonConvert.DeserializeObject<string[]>(json);
+        }
+
+        return result ?? Array.Empty<string>();
+    }
+    /// <summary>
+    ///     Override so that we can return an array to the editor for multi-select values
+    /// </summary>
+    /// <param name="property"></param>
+    /// <param name="culture"></param>
+    /// <param name="segment"></param>
+    /// <returns></returns>
+    public override object ToEditor(IProperty property, MapperContext? mapperContext, string? culture = null, string? segment = null)
     {
         var json = base.ToEditor(property, culture, segment)?.ToString();
         string[]? result = null;

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultipleValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultipleValueEditor.cs
@@ -41,14 +41,7 @@ public class MultipleValueEditor : DataValueEditor
     [Obsolete("Use ToEditor(IProperty property, MapperContext? context, string? culture, string? segment) instead")]
     public override object ToEditor(IProperty property, string? culture = null, string? segment = null)
     {
-        var json = base.ToEditor(property, culture, segment)?.ToString();
-        string[]? result = null;
-        if (json is not null)
-        {
-            result = JsonConvert.DeserializeObject<string[]>(json);
-        }
-
-        return result ?? Array.Empty<string>();
+        return ToEditor(property, null, culture, segment);
     }
     /// <summary>
     ///     Override so that we can return an array to the editor for multi-select values
@@ -59,7 +52,7 @@ public class MultipleValueEditor : DataValueEditor
     /// <returns></returns>
     public override object ToEditor(IProperty property, MapperContext? mapperContext, string? culture = null, string? segment = null)
     {
-        var json = base.ToEditor(property, culture, segment)?.ToString();
+        var json = base.ToEditor(property,null, culture, segment)?.ToString();
         string[]? result = null;
         if (json is not null)
         {
@@ -79,7 +72,7 @@ public class MultipleValueEditor : DataValueEditor
     [Obsolete("Use FromEditor(ContentPropertyData editorValue, object? currentValue, Dictionary<int,IDataType?>? dataTypes) instead")]
     public override object? FromEditor(ContentPropertyData editorValue, object? currentValue)
     {
-        return FromEditor(editorValue, currentValue, null);
+        return this.FromEditor(editorValue, currentValue, null);
     }
     /// <summary>
     ///     When multiple values are selected a json array will be posted back so we need to format for storage in

--- a/src/Umbraco.Infrastructure/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/NestedContentPropertyEditor.cs
@@ -259,6 +259,7 @@ public class NestedContentPropertyEditor : DataEditor
         /// <param name="culture"></param>
         /// <param name="segment"></param>
         /// <returns></returns>
+        [Obsolete("Use ToEditor(IProperty property, MapperContext? context, string? culture, string? segment) instead")]
         public override object ToEditor(IProperty property, string? culture = null, string? segment = null)
         {
             return ToEditor(property, null, culture, segment);

--- a/src/Umbraco.Infrastructure/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/NestedContentPropertyEditor.cs
@@ -353,48 +353,7 @@ public class NestedContentPropertyEditor : DataEditor
         /// <returns></returns>
         public override object? FromEditor(ContentPropertyData editorValue, object? currentValue)
         {
-            if (editorValue.Value == null || string.IsNullOrWhiteSpace(editorValue.Value.ToString()))
-            {
-                return null;
-            }
-
-            IReadOnlyList<NestedContentValues.NestedContentRowValue> rows =
-                _nestedContentValues.GetPropertyValues(editorValue.Value);
-
-            if (rows.Count == 0)
-            {
-                return null;
-            }
-
-            foreach (NestedContentValues.NestedContentRowValue row in rows.ToList())
-            {
-                foreach (KeyValuePair<string, NestedContentValues.NestedContentPropertyValue> prop in row.PropertyValues
-                             .ToList())
-                {
-                    // Fetch the property types prevalue
-                    var propConfiguration =
-                        _dataTypeService.GetDataType(prop.Value.PropertyType.DataTypeId)?.Configuration;
-
-                    // Lookup the property editor
-                    IDataEditor? propEditor = _propertyEditors[prop.Value.PropertyType.PropertyEditorAlias];
-                    if (propEditor == null)
-                    {
-                        continue;
-                    }
-
-                    // Create a fake content property data object
-                    var contentPropData = new ContentPropertyData(prop.Value.Value, propConfiguration);
-
-                    // Get the property editor to do it's conversion
-                    var newValue = propEditor.GetValueEditor().FromEditor(contentPropData, prop.Value.Value);
-
-                    // update the raw value since this is what will get serialized out
-                    row.RawPropertyValues[prop.Key] = newValue == null ? null : JToken.FromObject(newValue);
-                }
-            }
-
-            // return json
-            return JsonConvert.SerializeObject(rows, Formatting.None);
+           return FromEditor(editorValue,currentValue,  null);
         }
  /// <summary>
         ///     Ensure that sub-editor values are translated through their FromEditor methods

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
@@ -294,6 +294,7 @@ public class RichTextPropertyEditor : DataEditor
         /// <param name="property"></param>
         /// <param name="culture"></param>
         /// <param name="segment"></param>
+        [Obsolete("Use ToEditor(IProperty property, MapperContext? context, string? culture, string? segment) instead")]
         public override object? ToEditor(IProperty property, string? culture = null, string? segment = null)
         {
             return ToEditor(property, null, culture, segment);

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
@@ -328,39 +328,10 @@ public class RichTextPropertyEditor : DataEditor
         /// <param name="editorValue"></param>
         /// <param name="currentValue"></param>
         /// <returns></returns>
+        [Obsolete("Use FromEditor(ContentPropertyData editorValue, object? currentValue, Dictionary<int,IDataType?>? dataTypes) instead")]
         public override object? FromEditor(ContentPropertyData editorValue, object? currentValue)
         {
-            if (TryParseEditorValue(editorValue.Value, out RichTextEditorValue? richTextEditorValue) is false)
-            {
-                return null;
-            }
-
-            var userId = _backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser?.Id ??
-                         Constants.Security.SuperUserId;
-
-            var config = editorValue.DataTypeConfiguration as RichTextConfiguration;
-            GuidUdi? mediaParent = config?.MediaParentId;
-            Guid mediaParentId = mediaParent == null ? Guid.Empty : mediaParent.Guid;
-
-            if (string.IsNullOrWhiteSpace(richTextEditorValue.Markup))
-            {
-                return null;
-            }
-
-            var parseAndSaveBase64Images = _pastedImages.FindAndPersistEmbeddedImages(
-                richTextEditorValue.Markup, mediaParentId, userId);
-            var parseAndSavedTempImages =
-                _pastedImages.FindAndPersistPastedTempImages(parseAndSaveBase64Images, mediaParentId, userId);
-            var editorValueWithMediaUrlsRemoved = _imageSourceParser.RemoveImageSources(parseAndSavedTempImages);
-            var parsed = MacroTagParser.FormatRichTextContentForPersistence(editorValueWithMediaUrlsRemoved);
-            var sanitized = _htmlSanitizer.Sanitize(parsed);
-
-            richTextEditorValue.Markup = sanitized.NullOrWhiteSpaceAsNull() ?? string.Empty;
-
-            RichTextEditorValue cleanedUpRichTextEditorValue = CleanAndMapBlocks(richTextEditorValue, blockValue => MapBlockValueFromEditor(blockValue, null));
-
-            // return json
-            return RichTextPropertyEditorHelper.SerializeRichTextEditorValue(cleanedUpRichTextEditorValue, _jsonSerializer);
+           return FromEditor(editorValue, currentValue, null);
         }
 
         /// <summary>

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
@@ -296,20 +296,7 @@ public class RichTextPropertyEditor : DataEditor
         /// <param name="segment"></param>
         public override object? ToEditor(IProperty property, string? culture = null, string? segment = null)
         {
-            var value = property.GetValue(culture, segment);
-            if (TryParseEditorValue(value, out RichTextEditorValue? richTextEditorValue) is false)
-            {
-                return null;
-            }
-
-            var propertyValueWithMediaResolved = _imageSourceParser.EnsureImageSources(richTextEditorValue.Markup);
-            var parsed = MacroTagParser.FormatRichTextPersistedDataForEditor(
-                propertyValueWithMediaResolved,
-                new Dictionary<string, string>());
-            richTextEditorValue.Markup = parsed;
-
-            // return json convertable object
-            return CleanAndMapBlocks(richTextEditorValue, blockValue => MapBlockValueToEditor(property, blockValue));
+            return ToEditor(property, null, culture, segment);
         }
         /// <summary>
         ///     Format the data for the editor
@@ -317,7 +304,7 @@ public class RichTextPropertyEditor : DataEditor
         /// <param name="property"></param>
         /// <param name="culture"></param>
         /// <param name="segment"></param>
-        public override object? ToEditor(IProperty property, string? culture = null, string? segment = null, MapperContext? mapperContext = null)
+        public override object? ToEditor(IProperty property, MapperContext? mapperContext, string? culture = null, string? segment = null)
         {
             var value = property.GetValue(culture, segment);
             if (TryParseEditorValue(value, out RichTextEditorValue? richTextEditorValue) is false)

--- a/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs
@@ -160,7 +160,13 @@ public class TagsPropertyEditor : DataEditor
         public override IValueRequiredValidator RequiredValidator => new RequiredJsonValueValidator();
 
         /// <inheritdoc />
+        [Obsolete("Use FromEditor(ContentPropertyData editorValue, object? currentValue, Dictionary<int,IDataType?>? dataTypes) instead")]
         public override object? FromEditor(ContentPropertyData editorValue, object? currentValue)
+        {
+            return FromEditor(editorValue, currentValue, null);
+        }
+        /// <inheritdoc />
+        public override object? FromEditor(ContentPropertyData editorValue, object? currentValue, Dictionary<int,IDataType?>? dataTypes)
         {
             var value = editorValue.Value?.ToString();
 
@@ -200,7 +206,6 @@ public class TagsPropertyEditor : DataEditor
 
             return null;
         }
-
         /// <summary>
         ///     Custom validator to validate a required value against an empty json value.
         /// </summary>

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentControllerBase.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentControllerBase.cs
@@ -97,7 +97,7 @@ public abstract class ContentControllerBase : BackOfficeNotificationsController
         {
             return;
         }
-
+        var dictionary = new Dictionary<int, IDataType?>();
         // map the property values
         foreach (ContentPropertyDto propertyDto in dto.Properties)
         {
@@ -140,7 +140,7 @@ public abstract class ContentControllerBase : BackOfficeNotificationsController
             };
 
             // let the editor convert the value that was received, deal with files, etc
-            var value = valueEditor.FromEditor(data, getPropertyValue(contentItem, property));
+            var value = valueEditor.FromEditor(data, getPropertyValue(contentItem, property),dictionary);
 
             // set the value - tags are special
             TagsPropertyEditorAttribute? tagAttribute = propertyDto.PropertyEditor.GetTagAttribute();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This pr address: #14936 and #14842 

### Description
This pr ensuring that we do no load hundrends of times same datatypes in context of loading backoffice and saving content.
Please check this comment: https://github.com/umbraco/Umbraco-CMS/issues/14936#issuecomment-1890398674
Final result:
<img width="560" alt="image" src="https://github.com/umbraco/Umbraco-CMS/assets/2244074/44f99c31-dc46-44ee-ba24-efad6fcdc557">
0 duplicated operation on RuntimeCache / DataTypService.

### Testing
Umbraco Backoffice should not see change in behaviour and saving/publishing also should not be affected. So to test just play around in backoffice and ensured all properties are loading.

for performance testing I prepared this decorators:
https://gist.github.com/bielu/76433f85e21c09ba05b6df9e4bd64e3a
https://gist.github.com/bielu/f7f84550091504916ab07a4341bcdf9e
I register with usage of scrutor:
https://www.nuget.org/packages/Scrutor

via program.cs like this:
```
builder.Services.Decorate<IDataTypeService, DataTypeServiceMiniProfilerDecorator>();
builder.Services.Decorate<IDataTypeRepository, DataRepositoryProfilerDecorator>();
```

