### PR TITLE
Media picker crop image size

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediaentryeditor/mediaentryeditor.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediaentryeditor/mediaentryeditor.controller.js
@@ -103,7 +103,6 @@ angular.module("umbraco")
                 // un-select crop:
                 vm.currentCrop = null;
 
-                //
                 updateMedia();
             }
             

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediaentryeditor/mediaentryeditor.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediaentryeditor/mediaentryeditor.controller.js
@@ -62,7 +62,7 @@ angular.module("umbraco")
 
                 entityResource.getById(vm.mediaEntry.mediaKey, "Media").then(function (mediaEntity) {
                     vm.media = mediaEntity;
-                    vm.imageSrc = mediaHelper.resolveFileFromEntity(mediaEntity, true);
+                    vm.imageSrc = mediaHelper.resolveFileFromEntity(mediaEntity, false);
                     vm.fileSrc = mediaHelper.resolveFileFromEntity(mediaEntity, false);
                     vm.fileExtension = mediaHelper.getFileExtension(vm.fileSrc);
                     vm.loading = false;
@@ -122,13 +122,13 @@ angular.module("umbraco")
             }
 
             function focalPointChanged(left, top) {
-                //update the model focalpoint value
+                // update the model focalpoint value
                 vm.mediaEntry.focalPoint = {
                     left: left,
                     top: top
                 };
 
-                //set form to dirty to track changes
+                // set form to dirty to track changes
                 setDirty();
             }
             

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediaentryeditor/mediaentryeditor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediaentryeditor/mediaentryeditor.html
@@ -1,7 +1,4 @@
-<div
-  class="umb-media-entry-editor"
-  ng-controller="Umbraco.Editors.MediaEntryEditorController as vm"
->
+<div class="umb-media-entry-editor" ng-controller="Umbraco.Editors.MediaEntryEditorController as vm">
   <ng-form name="vm.imageCropperForm" val-form-manager>
     <umb-editor-view umb-tabs ng-if="!page.loading">
       <umb-editor-header
@@ -10,16 +7,13 @@
         name-locked="true"
         hide-alias="true"
         hide-icon="true"
-        hide-description="true"
-      >
+        hide-description="true">
       </umb-editor-header>
 
       <div class="umb-editor-container umb-panel-body umb-scrollable">
         <div ng-if="vm.media.trashed" class="umb-editor--trashed-message">
           <umb-icon icon="icon-trash" class="icon"></umb-icon>
-          <localize key="content_nodeIsInTrash"
-            >This item is in the Recycle Bin</localize
-          >
+          <localize key="content_nodeIsInTrash">This item is in the Recycle Bin</localize>
         </div>
 
         <div class="umb-media-entry-editor__pane">
@@ -27,8 +21,7 @@
             <button
               class="btn-reset umb-outline"
               ng-class="{'--is-active':vm.currentCrop === null}"
-              ng-click="vm.deselectCrop()"
-            >
+              ng-click="vm.deselectCrop()">
               <span class="__text">Media</span>
             </button>
 
@@ -36,16 +29,14 @@
               ng-repeat="crop in vm.mediaEntry.crops track by crop.alias"
               class="btn-reset umb-outline"
               ng-class="{'--is-active':vm.currentCrop.alias === crop.alias, '--is-defined':!!vm.currentCrop.coordinates}"
-              ng-click="vm.selectCrop(crop)"
-            >
+              ng-click="vm.selectCrop(crop)">
               <umb-image-thumbnail
                 center="vm.mediaEntry.focalPoint"
                 crop="crop.coordinates"
                 src="vm.imageSrc"
                 height="{{crop.height}}"
                 width="{{crop.width}}"
-                max-size="75"
-              >
+                max-size="75">
               </umb-image-thumbnail>
               <span class="__text">{{crop.label}}</span>
             </button>
@@ -60,8 +51,7 @@
                 alias="{{vm.currentCrop.alias}}"
                 force-update="{{vm.forceUpdateCrop}}"
                 center="vm.mediaEntry.focalPoint"
-                src="vm.imageSrc"
-              >
+                src="vm.imageSrc">
                 <button class="btn btn-link" ng-click="vm.resetCrop()">
                   <umb-icon icon="icon-wrong"></umb-icon>
                   <localize key="imagecropper_reset">Reset this crop</localize>
@@ -77,8 +67,7 @@
                 center="vm.mediaEntry.focalPoint"
                 disable-focal-point="!vm.model.enableFocalPointSetter"
                 on-value-changed="vm.focalPointChanged(left, top)"
-                on-image-loaded="vm.onImageLoaded(isCroppable, hasDimensions)"
-              >
+                on-image-loaded="vm.onImageLoaded(isCroppable, hasDimensions)">
               </umb-image-gravity>
 
               <umb-media-preview
@@ -88,16 +77,13 @@
                 extension="vm.fileExtension"
                 source="vm.fileSrc"
                 icon="vm.media.icon"
-                name="vm.media.name"
-              >
+                name="vm.media.name">
               </umb-media-preview>
 
               <div class="umb-media-entry-editor__imageholder-actions">
                 <button ng-if="vm.mediaEntry.mediaKey" class="btn btn-link" ng-click="vm.repickMedia()">
                   <umb-icon icon="icon-wrong"></umb-icon>
-                  <localize key="mediaPicker_changeMedia"
-                    >Replace media</localize
-                  >
+                  <localize key="mediaPicker_changeMedia">Replace media</localize>
                 </button>
                 <button ng-if="vm.mediaEntry.mediaKey" class="btn btn-link" ng-click="vm.openMedia()">
                   <umb-icon icon="icon-out"></umb-icon>
@@ -107,12 +93,9 @@
                   type="button"
                   ng-show="vm.model.enableFocalPointSetter && (vm.mediaEntry.focalPoint.left !== 0.5 && vm.mediaEntry.focalPoint.top !== 0.5)"
                   class="btn btn-link"
-                  ng-click="vm.focalPointChanged(0.5, 0.5)"
-                >
+                  ng-click="vm.focalPointChanged(0.5, 0.5)">
                   <umb-icon icon="icon-axis-rotation"></umb-icon>
-                  <localize key="content_resetFocalPoint"
-                    >Reset focal point</localize
-                  >
+                  <localize key="content_resetFocalPoint">Reset focal point</localize>
                 </button>
               </div>
             </div>
@@ -129,8 +112,7 @@
             shortcut="esc"
             button-style="link"
             label="{{vm.closeLabel}}"
-            type="button"
-          >
+            type="button">
           </umb-button>
 
           <umb-button
@@ -138,8 +120,7 @@
             button-style="primary"
             state="vm.saveButtonState"
             label="{{vm.submitLabel}}"
-            type="button"
-          >
+            type="button">
           </umb-button>
         </umb-editor-footer-content-right>
       </umb-editor-footer>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/15548

### Description
This PR ensure a large version of image is returned in Media Picker 3 crop - the original image size, just like Image Cropper does.

Alternatively it would be nice it `mediaHelper.resolveFileFromEntity(mediaEntity, true)` has overload to specific other image sizes of "big thumbnail".