### PR TITLE
Do not log direct query inputs

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Services/ApiMediaQueryService.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/ApiMediaQueryService.cs
@@ -113,7 +113,7 @@ internal sealed class ApiMediaQueryService : IApiMediaQueryService
             if (parts.Length != 2)
             {
                 // invalid filter
-                _logger.LogInformation($"The \"{nameof(filters)}\" query option \"{filter}\" is not valid");
+                _logger.LogInformation("An invalid filter option was encountered. Please ensure that supplied filter options are two-part, separated by ':'.");
                 return null;
             }
 
@@ -127,7 +127,7 @@ internal sealed class ApiMediaQueryService : IApiMediaQueryService
                     break;
                 default:
                     // unknown filter
-                    _logger.LogInformation($"The \"{nameof(filters)}\" query option \"{filter}\" is not supported");
+                    _logger.LogInformation("An unsupported filter option was supplied for the query. Please use only valid filter options. See the documentation for details.");
                     return null;
             }
         }
@@ -143,7 +143,7 @@ internal sealed class ApiMediaQueryService : IApiMediaQueryService
             if (parts.Length != 2)
             {
                 // invalid sort
-                _logger.LogInformation($"The \"{nameof(sorts)}\" query option \"{sort}\" is not valid");
+                _logger.LogInformation("An invalid sort option was encountered. Please ensure that the supplied sort options are two-part, separated by ':'.");
                 return null;
             }
 
@@ -164,7 +164,7 @@ internal sealed class ApiMediaQueryService : IApiMediaQueryService
                     break;
                 default:
                     // unknown sort
-                    _logger.LogInformation($"The \"{nameof(sorts)}\" query option \"{sort}\" is not supported");
+                    _logger.LogInformation("An unsupported sort option was supplied for the query. Please use only valid sort options. See the documentation for details.");
                     return null;
             }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The Delivery API Media Query Service logs direct query inputs. This could theoretically be subject to malicious abuse towards people with log viewer access.

This is theoretically a security vulnerability and was originally reported as a security advisory. But the threat is so very low that we've decided to handle it as a regular fix.

### Testing this PR

See the original security advisory for details to reproduce.

With this PR applied, the log messages look like this:

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/8f5b8382-bb7b-419d-bf69-240bf60d4fa7)
