### PR TITLE
Adds optional class attribute to regex for parsing RTE blocks

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RichTextParsingRegexes.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RichTextParsingRegexes.cs
@@ -4,6 +4,6 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 
 internal static partial class RichTextParsingRegexes
 {
-    [GeneratedRegex("<umb-rte-block(?:-inline)? data-content-udi=\"(?<udi>.[^\"]*)\"><!--Umbraco-Block--><\\/umb-rte-block(?:-inline)?>")]
+    [GeneratedRegex("<umb-rte-block(?:-inline)?(?: class=\"(.[^\"]*)\")? data-content-udi=\"(?<udi>.[^\"]*)\"><!--Umbraco-Block--><\\/umb-rte-block(?:-inline)?>")]
     public static partial Regex BlockRegex();
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #15494

### Description
This adds an optional class attribute in the regex for finding block placeholders in the RTE markup, to make it work with the class attribute added by the rich text editor.


### To test
Create a rich text editor with a block. Insert the block in the rich text editor, make sure the class attribute is added to (or add it manually). Verify that the block actually renders in the frontend.

<!-- Thanks for contributing to Umbraco CMS! -->
