### PR TITLE
"Created at" responses should not have a response body

### DIFF
--- a/src/Umbraco.Cms.Api.Common/Mvc/ActionResults/EmptyCreatedAtActionResult.cs
+++ b/src/Umbraco.Cms.Api.Common/Mvc/ActionResults/EmptyCreatedAtActionResult.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Umbraco.Cms.Api.Common.Mvc.ActionResults;
+
+/// <summary>
+/// A "created at" action result with no response body.
+/// </summary>
+public sealed class EmptyCreatedAtActionResult : ActionResult
+{
+    private readonly string? _actionName;
+    private readonly string? _controllerName;
+    private readonly object? _routeValues;
+
+    public EmptyCreatedAtActionResult(string? actionName, string? controllerName, object? routeValues)
+    {
+        _actionName = actionName;
+        _controllerName = controllerName;
+        _routeValues = routeValues;
+    }
+
+    public override void ExecuteResult(ActionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        HttpRequest request = context.HttpContext.Request;
+        IUrlHelper urlHelper = context.HttpContext.RequestServices.GetRequiredService<IUrlHelperFactory>().GetUrlHelper(context);
+
+        var url = urlHelper.Action(
+            _actionName,
+            _controllerName,
+            _routeValues,
+            request.Scheme,
+            request.Host.ToUriComponent());
+
+        if (string.IsNullOrEmpty(url))
+        {
+            throw new InvalidOperationException("No routes could be found that matched the provided route components");
+        }
+
+        context.HttpContext.Response.StatusCode = StatusCodes.Status201Created;
+        context.HttpContext.Response.Headers.Location = url;
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/ManagementApiControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/ManagementApiControllerBase.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Attributes;
 using Umbraco.Cms.Api.Common.Filters;
+using Umbraco.Cms.Api.Common.Mvc.ActionResults;
 using Umbraco.Cms.Api.Management.DependencyInjection;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Features;
@@ -18,10 +19,10 @@ namespace Umbraco.Cms.Api.Management.Controllers;
 [JsonOptionsName(Constants.JsonOptionsNames.BackOffice)]
 public abstract class ManagementApiControllerBase : Controller, IUmbracoFeature
 {
-    protected CreatedAtActionResult CreatedAtAction<T>(Expression<Func<T, string>> action, Guid id)
+    protected IActionResult CreatedAtAction<T>(Expression<Func<T, string>> action, Guid id)
         => CreatedAtAction(action, new { id = id });
 
-    protected CreatedAtActionResult CreatedAtAction<T>(Expression<Func<T, string>> action, object routeValues)
+    protected IActionResult CreatedAtAction<T>(Expression<Func<T, string>> action, object routeValues)
     {
         if (action.Body is not ConstantExpression constantExpression)
         {
@@ -31,10 +32,10 @@ public abstract class ManagementApiControllerBase : Controller, IUmbracoFeature
         var controllerName = ManagementApiRegexes.ControllerTypeToNameRegex().Replace(typeof(T).Name, string.Empty);
         var actionName = constantExpression.Value?.ToString() ?? throw new ArgumentException("Expression does not have a value.");
 
-        return base.CreatedAtAction(actionName, controllerName, routeValues, null);
+        return new EmptyCreatedAtActionResult(actionName, controllerName, routeValues);
     }
 
-    protected CreatedAtActionResult CreatedAtAction<T>(Expression<Func<T, string>> action, string name)
+    protected IActionResult CreatedAtAction<T>(Expression<Func<T, string>> action, string name)
     {
         if (action.Body is not ConstantExpression constantExpression)
         {
@@ -44,7 +45,7 @@ public abstract class ManagementApiControllerBase : Controller, IUmbracoFeature
         var controllerName = ManagementApiRegexes.ControllerTypeToNameRegex().Replace(typeof(T).Name, string.Empty);
         var actionName = constantExpression.Value?.ToString() ?? throw new ArgumentException("Expression does not have a value.");
 
-        return base.CreatedAtAction(actionName, controllerName, new { name = name }, null);
+        return new EmptyCreatedAtActionResult(actionName, controllerName, new { name = name });
     }
 
     protected static Guid CurrentUserKey(IBackOfficeSecurityAccessor backOfficeSecurityAccessor)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Currently the "Created at" responses from the Management API contain a response body with `"null"`. Turns out the built-in `CreatedAtActionResult` is built upon `ObjectResult`, which outputs `null` values in the response body.

The `"null"` response is messing with the new back-office client.

To work around this, a new `EmptyCreatedAtActionResult` has been added to the `Api.Common`, and this is then used for all "Created at" responses created by Management API base controller.

The `EmptyCreatedAtActionResult` is purposely placed in `Api.Common` and made public (sealed), so it can be reused in other APIs.

### Testing this PR

"Created at" responses are built in different ways depending on the action performed. To test this PR, verify that the following API operations return a HTTP201 status code, and that the response a correct location header:

- Creating a new script.
- Creating a new data type folder.
- Creating a new saved search.
