### PR TITLE
Backport relation tracking fixes and get references from recursive (nested/block) properties

### DIFF
--- a/src/Umbraco.Core/Composing/BuilderCollectionBase.cs
+++ b/src/Umbraco.Core/Composing/BuilderCollectionBase.cs
@@ -3,30 +3,26 @@ using System.Collections;
 namespace Umbraco.Cms.Core.Composing;
 
 /// <summary>
-///     Provides a base class for builder collections.
+/// Provides a base class for builder collections.
 /// </summary>
 /// <typeparam name="TItem">The type of the items.</typeparam>
 public abstract class BuilderCollectionBase<TItem> : IBuilderCollection<TItem>
 {
     private readonly LazyReadOnlyCollection<TItem> _items;
 
-    /// Initializes a new instance of the
-    /// <see cref="BuilderCollectionBase{TItem}" />
-    /// with items.
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BuilderCollectionBase{TItem}" /> with items.
     /// </summary>
     /// <param name="items">The items.</param>
-    public BuilderCollectionBase(Func<IEnumerable<TItem>> items) => _items = new LazyReadOnlyCollection<TItem>(items);
+    public BuilderCollectionBase(Func<IEnumerable<TItem>> items)
+        => _items = new LazyReadOnlyCollection<TItem>(items);
 
     /// <inheritdoc />
     public int Count => _items.Count;
 
-    /// <summary>
-    ///     Gets an enumerator.
-    /// </summary>
+    /// <inheritdoc />
     public IEnumerator<TItem> GetEnumerator() => _items.GetEnumerator();
 
-    /// <summary>
-    ///     Gets an enumerator.
-    /// </summary>
+    /// <inheritdoc />
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/Umbraco.Core/Composing/IBuilderCollection.cs
+++ b/src/Umbraco.Core/Composing/IBuilderCollection.cs
@@ -1,13 +1,16 @@
 namespace Umbraco.Cms.Core.Composing;
 
 /// <summary>
-///     Represents a builder collection, ie an immutable enumeration of items.
+/// Represents a builder collection, ie an immutable enumeration of items.
 /// </summary>
 /// <typeparam name="TItem">The type of the items.</typeparam>
 public interface IBuilderCollection<out TItem> : IEnumerable<TItem>
 {
     /// <summary>
-    ///     Gets the number of items in the collection.
+    /// Gets the number of items in the collection.
     /// </summary>
+    /// <value>
+    /// The count.
+    /// </value>
     int Count { get; }
 }

--- a/src/Umbraco.Core/Models/Editors/UmbracoEntityReference.cs
+++ b/src/Umbraco.Core/Models/Editors/UmbracoEntityReference.cs
@@ -1,49 +1,88 @@
 namespace Umbraco.Cms.Core.Models.Editors;
 
 /// <summary>
-///     Used to track reference to other entities in a property value
+/// Used to track a reference to another entity in a property value.
 /// </summary>
 public struct UmbracoEntityReference : IEquatable<UmbracoEntityReference>
 {
     private static readonly UmbracoEntityReference _empty = new(UnknownTypeUdi.Instance, string.Empty);
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UmbracoEntityReference" /> struct.
+    /// </summary>
+    /// <param name="udi">The UDI.</param>
+    /// <param name="relationTypeAlias">The relation type alias.</param>
     public UmbracoEntityReference(Udi udi, string relationTypeAlias)
     {
         Udi = udi ?? throw new ArgumentNullException(nameof(udi));
         RelationTypeAlias = relationTypeAlias ?? throw new ArgumentNullException(nameof(relationTypeAlias));
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UmbracoEntityReference" /> struct for a document or media item.
+    /// </summary>
+    /// <param name="udi">The UDI.</param>
     public UmbracoEntityReference(Udi udi)
     {
         Udi = udi ?? throw new ArgumentNullException(nameof(udi));
 
         switch (udi.EntityType)
         {
+            case Constants.UdiEntityType.Document:
+                RelationTypeAlias = Constants.Conventions.RelationTypes.RelatedDocumentAlias;
+                break;
             case Constants.UdiEntityType.Media:
                 RelationTypeAlias = Constants.Conventions.RelationTypes.RelatedMediaAlias;
                 break;
             default:
-                RelationTypeAlias = Constants.Conventions.RelationTypes.RelatedDocumentAlias;
+                // No relation type alias convention for this entity type, so leave it empty
+                RelationTypeAlias = string.Empty;
                 break;
         }
     }
 
+    /// <summary>
+    /// Gets the UDI.
+    /// </summary>
+    /// <value>
+    /// The UDI.
+    /// </value>
     public Udi Udi { get; }
 
-    public static UmbracoEntityReference Empty() => _empty;
-
-    public static bool IsEmpty(UmbracoEntityReference reference) => reference == Empty();
-
+    /// <summary>
+    /// Gets the relation type alias.
+    /// </summary>
+    /// <value>
+    /// The relation type alias.
+    /// </value>
     public string RelationTypeAlias { get; }
 
-    public static bool operator ==(UmbracoEntityReference left, UmbracoEntityReference right) => left.Equals(right);
+    /// <summary>
+    /// Gets an empty reference.
+    /// </summary>
+    /// <returns>
+    /// An empty reference.
+    /// </returns>
+    public static UmbracoEntityReference Empty() => _empty;
 
+    /// <summary>
+    /// Determines whether the specified reference is empty.
+    /// </summary>
+    /// <param name="reference">The reference.</param>
+    /// <returns>
+    ///   <c>true</c> if the specified reference is empty; otherwise, <c>false</c>.
+    /// </returns>
+    public static bool IsEmpty(UmbracoEntityReference reference) => reference == Empty();
+
+    /// <inheritdoc />
     public override bool Equals(object? obj) => obj is UmbracoEntityReference reference && Equals(reference);
 
+    /// <inheritdoc />
     public bool Equals(UmbracoEntityReference other) =>
         EqualityComparer<Udi>.Default.Equals(Udi, other.Udi) &&
         RelationTypeAlias == other.RelationTypeAlias;
 
+    /// <inheritdoc />
     public override int GetHashCode()
     {
         var hashCode = -487348478;
@@ -52,5 +91,9 @@ public struct UmbracoEntityReference : IEquatable<UmbracoEntityReference>
         return hashCode;
     }
 
+    /// <inheritdoc />
+    public static bool operator ==(UmbracoEntityReference left, UmbracoEntityReference right) => left.Equals(right);
+
+    /// <inheritdoc />
     public static bool operator !=(UmbracoEntityReference left, UmbracoEntityReference right) => !(left == right);
 }

--- a/src/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollection.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollection.cs
@@ -8,60 +8,119 @@ public class DataValueReferenceFactoryCollection : BuilderCollectionBase<IDataVa
 {
     public DataValueReferenceFactoryCollection(Func<IEnumerable<IDataValueReferenceFactory>> items)
         : base(items)
-    {
-    }
+    { }
 
     // TODO: We could further reduce circular dependencies with PropertyEditorCollection by not having IDataValueReference implemented
     // by property editors and instead just use the already built in IDataValueReferenceFactory and/or refactor that into a more normal collection
-    public IEnumerable<UmbracoEntityReference> GetAllReferences(
-        IPropertyCollection properties,
-        PropertyEditorCollection propertyEditors)
+    public ISet<UmbracoEntityReference> GetAllReferences(IPropertyCollection properties, PropertyEditorCollection propertyEditors)
     {
-        var trackedRelations = new HashSet<UmbracoEntityReference>();
+        var references = new HashSet<UmbracoEntityReference>();
 
-        foreach (IProperty p in properties)
+        foreach (IProperty property in properties)
         {
-            if (!propertyEditors.TryGet(p.PropertyType.PropertyEditorAlias, out IDataEditor? editor))
+            if (!propertyEditors.TryGet(property.PropertyType.PropertyEditorAlias, out IDataEditor? dataEditor))
             {
                 continue;
             }
 
             // TODO: We will need to change this once we support tracking via variants/segments
             // for now, we are tracking values from ALL variants
-            foreach (IPropertyValue propertyVal in p.Values)
+            foreach (IPropertyValue propertyValue in property.Values)
             {
-                var val = propertyVal.EditedValue;
+                object? value = propertyValue.EditedValue;
 
-                IDataValueEditor? valueEditor = editor?.GetValueEditor();
-                if (valueEditor is IDataValueReference reference)
+                if (dataEditor.GetValueEditor() is IDataValueReference dataValueReference)
                 {
-                    IEnumerable<UmbracoEntityReference> refs = reference.GetReferences(val);
-                    foreach (UmbracoEntityReference r in refs)
-                    {
-                        trackedRelations.Add(r);
-                    }
+                    references.UnionWith(dataValueReference.GetReferences(value));
                 }
 
                 // Loop over collection that may be add to existing property editors
                 // implementation of GetReferences in IDataValueReference.
                 // Allows developers to add support for references by a
                 // package /property editor that did not implement IDataValueReference themselves
-                foreach (IDataValueReferenceFactory item in this)
+                foreach (IDataValueReferenceFactory dataValueReferenceFactory in this)
                 {
                     // Check if this value reference is for this datatype/editor
                     // Then call it's GetReferences method - to see if the value stored
-                    // in the dataeditor/property has referecnes to media/content items
-                    if (item.IsForEditor(editor))
+                    // in the dataeditor/property has references to media/content items
+                    if (dataValueReferenceFactory.IsForEditor(dataEditor))
                     {
-                        foreach (UmbracoEntityReference r in item.GetDataValueReference().GetReferences(val))
-                        {
-                            trackedRelations.Add(r);
-                        }
+                        references.UnionWith(dataValueReferenceFactory.GetDataValueReference().GetReferences(value));
                     }
                 }
             }
         }
 
-        return trackedRelations;
+        return references;
+    }
+
+    /// <summary>
+    /// Gets all relation type aliases that are automatically tracked.
+    /// </summary>
+    /// <param name="propertyEditors">The property editors.</param>
+    /// <returns>
+    /// All relation type aliases that are automatically tracked.
+    /// </returns>
+    public ISet<string> GetAutomaticRelationTypesAliases(PropertyEditorCollection propertyEditors)
+    {
+        // Always add default automatic relation types
+        var automaticRelationTypeAliases = new HashSet<string>(Constants.Conventions.RelationTypes.AutomaticRelationTypes);
+
+        // Add relation types for all property editors
+        foreach (IDataEditor dataEditor in propertyEditors)
+        {
+            automaticRelationTypeAliases.UnionWith(GetAutomaticRelationTypesAliases(dataEditor));
+        }
+
+        return automaticRelationTypeAliases;
+    }
+
+    /// <summary>
+    /// Gets the relation type aliases that are automatically tracked for all properties.
+    /// </summary>
+    /// <param name="properties">The properties.</param>
+    /// <param name="propertyEditors">The property editors.</param>
+    /// <returns>
+    /// The relation type aliases that are automatically tracked for all properties.
+    /// </returns>
+    public ISet<string> GetAutomaticRelationTypesAliases(IPropertyCollection properties, PropertyEditorCollection propertyEditors)
+    {
+        // Always add default automatic relation types
+        var automaticRelationTypeAliases = new HashSet<string>(Constants.Conventions.RelationTypes.AutomaticRelationTypes);
+
+        // Only add relation types that are used in the properties
+        foreach (IProperty property in properties)
+        {
+            if (propertyEditors.TryGet(property.PropertyType.PropertyEditorAlias, out IDataEditor? dataEditor))
+            {
+                automaticRelationTypeAliases.UnionWith(GetAutomaticRelationTypesAliases(dataEditor));
+            }
+        }
+
+        return automaticRelationTypeAliases;
+    }
+
+    private IEnumerable<string> GetAutomaticRelationTypesAliases(IDataEditor dataEditor)
+    {
+        if (dataEditor.GetValueEditor() is IDataValueReference dataValueReference)
+        {
+            // Return custom relation types from value editor implementation
+            foreach (var alias in dataValueReference.GetAutomaticRelationTypesAliases())
+            {
+                yield return alias;
+            }
+        }
+
+        foreach (IDataValueReferenceFactory dataValueReferenceFactory in this)
+        {
+            if (dataValueReferenceFactory.IsForEditor(dataEditor))
+            {
+                // Return custom relation types from factory
+                foreach (var alias in dataValueReferenceFactory.GetDataValueReference().GetAutomaticRelationTypesAliases())
+                {
+                    yield return alias;
+                }
+            }
+        }
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollection.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollection.cs
@@ -4,14 +4,30 @@ using Umbraco.Cms.Core.Models.Editors;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
+/// <summary>
+/// Provides a builder collection for <see cref="IDataValueReferenceFactory" /> items.
+/// </summary>
 public class DataValueReferenceFactoryCollection : BuilderCollectionBase<IDataValueReferenceFactory>
 {
+    // TODO: We could further reduce circular dependencies with PropertyEditorCollection by not having IDataValueReference implemented
+    // by property editors and instead just use the already built in IDataValueReferenceFactory and/or refactor that into a more normal collection
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DataValueReferenceFactoryCollection" /> class.
+    /// </summary>
+    /// <param name="items">The items.</param>
     public DataValueReferenceFactoryCollection(Func<IEnumerable<IDataValueReferenceFactory>> items)
         : base(items)
     { }
 
-    // TODO: We could further reduce circular dependencies with PropertyEditorCollection by not having IDataValueReference implemented
-    // by property editors and instead just use the already built in IDataValueReferenceFactory and/or refactor that into a more normal collection
+    /// <summary>
+    /// Gets all unique references from the specified properties.
+    /// </summary>
+    /// <param name="properties">The properties.</param>
+    /// <param name="propertyEditors">The property editors.</param>
+    /// <returns>
+    /// The unique references from the specified properties.
+    /// </returns>
     public ISet<UmbracoEntityReference> GetAllReferences(IPropertyCollection properties, PropertyEditorCollection propertyEditors)
     {
         var references = new HashSet<UmbracoEntityReference>();
@@ -23,35 +39,62 @@ public class DataValueReferenceFactoryCollection : BuilderCollectionBase<IDataVa
                 continue;
             }
 
-            // TODO: We will need to change this once we support tracking via variants/segments
-            // for now, we are tracking values from ALL variants
-            foreach (IPropertyValue propertyValue in property.Values)
-            {
-                object? value = propertyValue.EditedValue;
-
-                if (dataEditor.GetValueEditor() is IDataValueReference dataValueReference)
-                {
-                    references.UnionWith(dataValueReference.GetReferences(value));
-                }
-
-                // Loop over collection that may be add to existing property editors
-                // implementation of GetReferences in IDataValueReference.
-                // Allows developers to add support for references by a
-                // package /property editor that did not implement IDataValueReference themselves
-                foreach (IDataValueReferenceFactory dataValueReferenceFactory in this)
-                {
-                    // Check if this value reference is for this datatype/editor
-                    // Then call it's GetReferences method - to see if the value stored
-                    // in the dataeditor/property has references to media/content items
-                    if (dataValueReferenceFactory.IsForEditor(dataEditor))
-                    {
-                        references.UnionWith(dataValueReferenceFactory.GetDataValueReference().GetReferences(value));
-                    }
-                }
-            }
+            // Only use edited value for now
+            references.UnionWith(GetReferences(dataEditor, property.Values.Select(x => x.EditedValue)));
         }
 
         return references;
+    }
+
+    /// <summary>
+    /// Gets the references.
+    /// </summary>
+    /// <param name="dataEditor">The data editor.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>
+    /// The references.
+    /// </returns>
+    public IEnumerable<UmbracoEntityReference> GetReferences(IDataEditor dataEditor, params object?[] values)
+        => GetReferences(dataEditor, (IEnumerable<object?>)values);
+
+    /// <summary>
+    /// Gets the references.
+    /// </summary>
+    /// <param name="dataEditor">The data editor.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>
+    /// The references.
+    /// </returns>
+    public IEnumerable<UmbracoEntityReference> GetReferences(IDataEditor dataEditor, IEnumerable<object?> values)
+    {
+        // TODO: We will need to change this once we support tracking via variants/segments
+        // for now, we are tracking values from ALL variants
+        if (dataEditor.GetValueEditor() is IDataValueReference dataValueReference)
+        {
+            foreach (UmbracoEntityReference reference in values.SelectMany(dataValueReference.GetReferences))
+            {
+                yield return reference;
+            }
+        }
+
+        // Loop over collection that may be add to existing property editors
+        // implementation of GetReferences in IDataValueReference.
+        // Allows developers to add support for references by a
+        // package /property editor that did not implement IDataValueReference themselves
+        foreach (IDataValueReferenceFactory dataValueReferenceFactory in this)
+        {
+            // Check if this value reference is for this datatype/editor
+            // Then call it's GetReferences method - to see if the value stored
+            // in the dataeditor/property has references to media/content items
+            if (dataValueReferenceFactory.IsForEditor(dataEditor))
+            {
+                IDataValueReference factoryDataValueReference = dataValueReferenceFactory.GetDataValueReference();
+                foreach (UmbracoEntityReference reference in values.SelectMany(factoryDataValueReference.GetReferences))
+                {
+                    yield return reference;
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -61,7 +104,7 @@ public class DataValueReferenceFactoryCollection : BuilderCollectionBase<IDataVa
     /// <returns>
     /// All relation type aliases that are automatically tracked.
     /// </returns>
-    public ISet<string> GetAutomaticRelationTypesAliases(PropertyEditorCollection propertyEditors)
+    public ISet<string> GetAllAutomaticRelationTypesAliases(PropertyEditorCollection propertyEditors)
     {
         // Always add default automatic relation types
         var automaticRelationTypeAliases = new HashSet<string>(Constants.Conventions.RelationTypes.AutomaticRelationTypes);
@@ -76,31 +119,13 @@ public class DataValueReferenceFactoryCollection : BuilderCollectionBase<IDataVa
     }
 
     /// <summary>
-    /// Gets the relation type aliases that are automatically tracked for all properties.
+    /// Gets the automatic relation types aliases.
     /// </summary>
-    /// <param name="properties">The properties.</param>
-    /// <param name="propertyEditors">The property editors.</param>
+    /// <param name="dataEditor">The data editor.</param>
     /// <returns>
-    /// The relation type aliases that are automatically tracked for all properties.
+    /// The automatic relation types aliases.
     /// </returns>
-    public ISet<string> GetAutomaticRelationTypesAliases(IPropertyCollection properties, PropertyEditorCollection propertyEditors)
-    {
-        // Always add default automatic relation types
-        var automaticRelationTypeAliases = new HashSet<string>(Constants.Conventions.RelationTypes.AutomaticRelationTypes);
-
-        // Only add relation types that are used in the properties
-        foreach (IProperty property in properties)
-        {
-            if (propertyEditors.TryGet(property.PropertyType.PropertyEditorAlias, out IDataEditor? dataEditor))
-            {
-                automaticRelationTypeAliases.UnionWith(GetAutomaticRelationTypesAliases(dataEditor));
-            }
-        }
-
-        return automaticRelationTypeAliases;
-    }
-
-    private IEnumerable<string> GetAutomaticRelationTypesAliases(IDataEditor dataEditor)
+    public IEnumerable<string> GetAutomaticRelationTypesAliases(IDataEditor dataEditor)
     {
         if (dataEditor.GetValueEditor() is IDataValueReference dataValueReference)
         {

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -1084,50 +1084,58 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
         {
             // Get all references from our core built in DataEditors/Property Editors
             // Along with seeing if developers want to collect additional references from the DataValueReferenceFactories collection
-            var trackedRelations = _dataValueReferenceFactories.GetAllReferences(entity.Properties, PropertyEditors);
+            ISet<UmbracoEntityReference> references = _dataValueReferenceFactories.GetAllReferences(entity.Properties, PropertyEditors);
 
             // First delete all auto-relations for this entity
-            var relationTypeAliases = _dataValueReferenceFactories.GetAutomaticRelationTypesAliases(entity.Properties, PropertyEditors).ToArray();
-            RelationRepository.DeleteByParent(entity.Id, relationTypeAliases);
+            ISet<string> automaticRelationTypeAliases = _dataValueReferenceFactories.GetAutomaticRelationTypesAliases(entity.Properties, PropertyEditors);
+            RelationRepository.DeleteByParent(entity.Id, automaticRelationTypeAliases.ToArray());
 
-            if (trackedRelations.Count == 0)
+            if (references.Count == 0)
             {
+                // No need to add new references/relations
                 return;
             }
 
-            var udiToGuids = trackedRelations.Select(x => x.Udi as GuidUdi).WhereNotNull().ToDictionary(x => (Udi)x, x => x.Guid);
+            // Lookup node IDs for all GUID based UDIs
+            IEnumerable<Guid> keys = references.Select(x => x.Udi).OfType<GuidUdi>().Select(x => x.Guid);
+            var keysLookup = Database.FetchByGroups<NodeIdKey, Guid>(keys, Constants.Sql.MaxParameterCount, guids =>
+            {
+                return Sql()
+                    .Select<NodeDto>(x => x.NodeId, x => x.UniqueId)
+                    .From<NodeDto>()
+                    .WhereIn<NodeDto>(x => x.UniqueId, guids);
+            }).ToDictionary(x => x.UniqueId, x => x.NodeId);
 
-            // lookup in the DB all INT ids for the GUIDs and chuck into a dictionary
-            var keyToIds = Database.FetchByGroups<NodeIdKey, Guid>(udiToGuids.Values, Constants.Sql.MaxParameterCount, guids => Sql()
-                .Select<NodeDto>(x => x.NodeId, x => x.UniqueId)
-                .From<NodeDto>()
-                .WhereIn<NodeDto>(x => x.UniqueId, guids))
-                .ToDictionary(x => x.UniqueId, x => x.NodeId);
+            // Lookup all relation type IDs
+            var relationTypeLookup = RelationTypeRepository.GetMany(Array.Empty<int>()).ToDictionary(x => x.Alias, x => x.Id);
 
-            var allRelationTypes = RelationTypeRepository.GetMany(Array.Empty<int>()).ToDictionary(x => x.Alias, x => x);
-
-            IEnumerable<ReadOnlyRelation> toSave = trackedRelations.Select(rel =>
+            // Get all valid relations
+            var relations = new List<ReadOnlyRelation>(references.Count);
+            foreach (UmbracoEntityReference reference in references)
+            {
+                if (!automaticRelationTypeAliases.Contains(reference.RelationTypeAlias))
                 {
-                    if (!allRelationTypes.TryGetValue(rel.RelationTypeAlias, out IRelationType? relationType))
-                    {
-                        throw new InvalidOperationException($"The relation type {rel.RelationTypeAlias} does not exist");
-                    }
-
-                    if (!udiToGuids.TryGetValue(rel.Udi, out Guid guid))
-                    {
-                        return null; // This shouldn't happen!
-                    }
-
-                    if (!keyToIds.TryGetValue(guid, out var id))
-                    {
-                        return null; // This shouldn't happen!
-                    }
-
-                    return new ReadOnlyRelation(entity.Id, id, relationType.Id);
-                }).WhereNotNull();
+                    // Returning a reference that doesn't use an automatic relation type is an issue that should be fixed in code
+                    Logger.LogError("The reference to {Udi} uses a relation type {RelationTypeAlias} that is not an automatic relation type.", reference.Udi, reference.RelationTypeAlias);
+                }
+                else if (!relationTypeLookup.TryGetValue(reference.RelationTypeAlias, out int relationTypeId))
+                {
+                    // A non-existent relation type could be caused by an environment issue (e.g. it was manually removed)
+                    Logger.LogWarning("The reference to {Udi} uses a relation type {RelationTypeAlias} that does not exist.", reference.Udi, reference.RelationTypeAlias);
+                }
+                else if (reference.Udi is not GuidUdi udi || !keysLookup.TryGetValue(udi.Guid, out var id))
+                {
+                    // Relations only support references to items that are stored in the NodeDto table (because of foreign key constraints)
+                    Logger.LogInformation("The reference to {Udi} can not be saved as relation, because doesn't have a node ID.", reference.Udi);
+                }
+                else
+                {
+                    relations.Add(new ReadOnlyRelation(entity.Id, id, relationTypeId));
+                }
+            }
 
             // Save bulk relations
-            RelationRepository.SaveBulk(toSave);
+            RelationRepository.SaveBulk(relations);
         }
 
         /// <summary>

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -1087,7 +1087,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
             ISet<UmbracoEntityReference> references = _dataValueReferenceFactories.GetAllReferences(entity.Properties, PropertyEditors);
 
             // First delete all auto-relations for this entity
-            ISet<string> automaticRelationTypeAliases = _dataValueReferenceFactories.GetAutomaticRelationTypesAliases(entity.Properties, PropertyEditors);
+            ISet<string> automaticRelationTypeAliases = _dataValueReferenceFactories.GetAllAutomaticRelationTypesAliases(PropertyEditors);
             RelationRepository.DeleteByParent(entity.Id, automaticRelationTypeAliases.ToArray());
 
             if (references.Count == 0)

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyValueEditor.cs
@@ -17,12 +17,14 @@ internal abstract class BlockEditorPropertyValueEditor : DataValueEditor, IDataV
 {
     private BlockEditorValues? _blockEditorValues;
     private readonly IDataTypeService _dataTypeService;
-    private readonly ILogger<BlockEditorPropertyValueEditor> _logger;
     private readonly PropertyEditorCollection _propertyEditors;
+    private readonly DataValueReferenceFactoryCollection _dataValueReferenceFactories;
+    private readonly ILogger<BlockEditorPropertyValueEditor> _logger;
 
     protected BlockEditorPropertyValueEditor(
         DataEditorAttribute attribute,
         PropertyEditorCollection propertyEditors,
+        DataValueReferenceFactoryCollection dataValueReferenceFactories,
         IDataTypeService dataTypeService,
         ILocalizedTextService textService,
         ILogger<BlockEditorPropertyValueEditor> logger,
@@ -32,6 +34,7 @@ internal abstract class BlockEditorPropertyValueEditor : DataValueEditor, IDataV
         : base(textService, shortStringHelper, jsonSerializer, ioHelper, attribute)
     {
         _propertyEditors = propertyEditors;
+        _dataValueReferenceFactories = dataValueReferenceFactories;
         _dataTypeService = dataTypeService;
         _logger = logger;
     }
@@ -42,73 +45,58 @@ internal abstract class BlockEditorPropertyValueEditor : DataValueEditor, IDataV
         set => _blockEditorValues = value;
     }
 
+    /// <inheritdoc />
     public IEnumerable<UmbracoEntityReference> GetReferences(object? value)
     {
-        var rawJson = value == null ? string.Empty : value is string str ? str : value.ToString();
-
-        var result = new List<UmbracoEntityReference>();
-        BlockEditorData? blockEditorData = BlockEditorValues.DeserializeAndClean(rawJson);
-        if (blockEditorData == null)
+        foreach (BlockItemData.BlockPropertyValue propertyValue in GetAllPropertyValues(value))
         {
-            return Enumerable.Empty<UmbracoEntityReference>();
-        }
-
-        // loop through all content and settings data
-        foreach (BlockItemData row in blockEditorData.BlockValue.ContentData.Concat(blockEditorData.BlockValue.SettingsData))
-        {
-            foreach (KeyValuePair<string, BlockItemData.BlockPropertyValue> prop in row.PropertyValues)
+            if (!_propertyEditors.TryGet(propertyValue.PropertyType.PropertyEditorAlias, out IDataEditor? dataEditor))
             {
-                IDataEditor? propEditor = _propertyEditors[prop.Value.PropertyType.PropertyEditorAlias];
+                continue;
+            }
 
-                IDataValueEditor? valueEditor = propEditor?.GetValueEditor();
-                if (!(valueEditor is IDataValueReference reference))
-                {
-                    continue;
-                }
-
-                var val = prop.Value.Value?.ToString();
-
-                IEnumerable<UmbracoEntityReference> refs = reference.GetReferences(val);
-
-                result.AddRange(refs);
+            foreach (UmbracoEntityReference reference in _dataValueReferenceFactories.GetReferences(dataEditor, propertyValue.Value))
+            {
+                yield return reference;
             }
         }
-
-        return result;
     }
 
     /// <inheritdoc />
     public IEnumerable<ITag> GetTags(object? value, object? dataTypeConfiguration, int? languageId)
     {
+        foreach (BlockItemData.BlockPropertyValue propertyValue in GetAllPropertyValues(value))
+        {
+            if (!_propertyEditors.TryGet(propertyValue.PropertyType.PropertyEditorAlias, out IDataEditor? dataEditor) ||
+                dataEditor.GetValueEditor() is not IDataValueTags dataValueTags)
+            {
+                continue;
+            }
+
+            object? configuration = _dataTypeService.GetDataType(propertyValue.PropertyType.DataTypeKey)?.Configuration;
+            foreach (ITag tag in dataValueTags.GetTags(propertyValue.Value, configuration, languageId))
+            {
+                yield return tag;
+            }
+        }
+    }
+
+    private IEnumerable<BlockItemData.BlockPropertyValue> GetAllPropertyValues(object? value)
+    {
         var rawJson = value == null ? string.Empty : value is string str ? str : value.ToString();
 
         BlockEditorData? blockEditorData = BlockEditorValues.DeserializeAndClean(rawJson);
-        if (blockEditorData == null)
+        if (blockEditorData is null)
         {
-            return Enumerable.Empty<ITag>();
+            yield break;
         }
 
-        var result = new List<ITag>();
-        // loop through all content and settings data
-        foreach (BlockItemData row in blockEditorData.BlockValue.ContentData.Concat(blockEditorData.BlockValue.SettingsData))
+        // Return all property values from the content and settings data
+        IEnumerable<BlockItemData> data = blockEditorData.BlockValue.ContentData.Concat(blockEditorData.BlockValue.SettingsData);
+        foreach (BlockItemData.BlockPropertyValue propertyValue in data.SelectMany(x => x.PropertyValues.Select(x => x.Value)))
         {
-            foreach (KeyValuePair<string, BlockItemData.BlockPropertyValue> prop in row.PropertyValues)
-            {
-                IDataEditor? propEditor = _propertyEditors[prop.Value.PropertyType.PropertyEditorAlias];
-
-                IDataValueEditor? valueEditor = propEditor?.GetValueEditor();
-                if (valueEditor is not IDataValueTags tagsProvider)
-                {
-                    continue;
-                }
-
-                object? configuration = _dataTypeService.GetDataType(prop.Value.PropertyType.DataTypeKey)?.Configuration;
-
-                result.AddRange(tagsProvider.GetTags(prop.Value.Value, configuration, languageId));
-            }
+            yield return propertyValue;
         }
-
-        return result;
     }
 
     #region Convert database // editor
@@ -119,7 +107,6 @@ internal abstract class BlockEditorPropertyValueEditor : DataValueEditor, IDataV
     ///     Ensure that sub-editor values are translated through their ToEditor methods
     /// </summary>
     /// <param name="property"></param>
-    /// <param name="dataTypeService"></param>
     /// <param name="culture"></param>
     /// <param name="segment"></param>
     /// <returns></returns>

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockGridPropertyEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockGridPropertyEditorBase.cs
@@ -50,6 +50,7 @@ public abstract class BlockGridPropertyEditorBase : DataEditor
         public BlockGridEditorPropertyValueEditor(
             DataEditorAttribute attribute,
             PropertyEditorCollection propertyEditors,
+            DataValueReferenceFactoryCollection dataValueReferenceFactories,
             IDataTypeService dataTypeService,
             ILocalizedTextService textService,
             ILogger<BlockEditorPropertyValueEditor> logger,
@@ -58,7 +59,7 @@ public abstract class BlockGridPropertyEditorBase : DataEditor
             IIOHelper ioHelper,
             IContentTypeService contentTypeService,
             IPropertyValidationService propertyValidationService)
-            : base(attribute, propertyEditors, dataTypeService, textService, logger, shortStringHelper, jsonSerializer, ioHelper)
+            : base(attribute, propertyEditors, dataValueReferenceFactories, dataTypeService, textService, logger, shortStringHelper, jsonSerializer, ioHelper)
         {
             BlockEditorValues = new BlockEditorValues(new BlockGridEditorDataConverter(jsonSerializer), contentTypeService, logger);
             Validators.Add(new BlockEditorValidator(propertyValidationService, BlockEditorValues, contentTypeService));

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditorBase.cs
@@ -46,6 +46,7 @@ public abstract class BlockListPropertyEditorBase : DataEditor
         public BlockListEditorPropertyValueEditor(
             DataEditorAttribute attribute,
             PropertyEditorCollection propertyEditors,
+            DataValueReferenceFactoryCollection dataValueReferenceFactories,
             IDataTypeService dataTypeService,
             IContentTypeService contentTypeService,
             ILocalizedTextService textService,
@@ -54,7 +55,7 @@ public abstract class BlockListPropertyEditorBase : DataEditor
             IJsonSerializer jsonSerializer,
             IIOHelper ioHelper,
             IPropertyValidationService propertyValidationService) :
-            base(attribute, propertyEditors, dataTypeService, textService, logger, shortStringHelper, jsonSerializer, ioHelper)
+            base(attribute, propertyEditors, dataValueReferenceFactories,dataTypeService, textService, logger, shortStringHelper, jsonSerializer, ioHelper)
         {
             BlockEditorValues = new BlockEditorValues(new BlockListEditorDataConverter(), contentTypeService, logger);
             Validators.Add(new BlockEditorValidator(propertyValidationService, BlockEditorValues, contentTypeService));

--- a/src/Umbraco.Infrastructure/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/NestedContentPropertyEditor.cs
@@ -89,9 +89,10 @@ public class NestedContentPropertyEditor : DataEditor
     internal class NestedContentPropertyValueEditor : DataValueEditor, IDataValueReference, IDataValueTags
     {
         private readonly IDataTypeService _dataTypeService;
+        private readonly PropertyEditorCollection _propertyEditors;
+        private readonly DataValueReferenceFactoryCollection _dataValueReferenceFactories;
         private readonly ILogger<NestedContentPropertyEditor> _logger;
         private readonly NestedContentValues _nestedContentValues;
-        private readonly PropertyEditorCollection _propertyEditors;
 
         public NestedContentPropertyValueEditor(
             IDataTypeService dataTypeService,
@@ -100,16 +101,19 @@ public class NestedContentPropertyEditor : DataEditor
             IShortStringHelper shortStringHelper,
             DataEditorAttribute attribute,
             PropertyEditorCollection propertyEditors,
+            DataValueReferenceFactoryCollection dataValueReferenceFactories,
             ILogger<NestedContentPropertyEditor> logger,
             IJsonSerializer jsonSerializer,
             IIOHelper ioHelper,
             IPropertyValidationService propertyValidationService)
             : base(localizedTextService, shortStringHelper, jsonSerializer, ioHelper, attribute)
         {
-            _propertyEditors = propertyEditors;
             _dataTypeService = dataTypeService;
+            _propertyEditors = propertyEditors;
+            _dataValueReferenceFactories = dataValueReferenceFactories;
             _logger = logger;
             _nestedContentValues = new NestedContentValues(contentTypeService);
+
             Validators.Add(new NestedContentValidator(propertyValidationService, _nestedContentValues, contentTypeService));
         }
 
@@ -137,65 +141,44 @@ public class NestedContentPropertyEditor : DataEditor
             }
         }
 
+        /// <inheritdoc />
         public IEnumerable<UmbracoEntityReference> GetReferences(object? value)
         {
-            var rawJson = value == null ? string.Empty : value is string str ? str : value.ToString();
-
-            var result = new List<UmbracoEntityReference>();
-
-            foreach (NestedContentValues.NestedContentRowValue row in _nestedContentValues.GetPropertyValues(rawJson))
+            foreach (NestedContentValues.NestedContentPropertyValue propertyValue in GetAllPropertyValues(value))
             {
-                foreach (KeyValuePair<string, NestedContentValues.NestedContentPropertyValue> prop in
-                         row.PropertyValues)
+                if (!_propertyEditors.TryGet(propertyValue.PropertyType.PropertyEditorAlias, out IDataEditor? dataEditor))
                 {
-                    IDataEditor? propEditor = _propertyEditors[prop.Value.PropertyType.PropertyEditorAlias];
+                    continue;
+                }
 
-                    IDataValueEditor? valueEditor = propEditor?.GetValueEditor();
-                    if (!(valueEditor is IDataValueReference reference))
-                    {
-                        continue;
-                    }
-
-                    var val = prop.Value.Value?.ToString();
-
-                    IEnumerable<UmbracoEntityReference> refs = reference.GetReferences(val);
-
-                    result.AddRange(refs);
+                foreach (UmbracoEntityReference reference in _dataValueReferenceFactories.GetReferences(dataEditor, propertyValue.Value))
+                {
+                    yield return reference;
                 }
             }
-
-            return result;
         }
 
         /// <inheritdoc />
         public IEnumerable<ITag> GetTags(object? value, object? dataTypeConfiguration, int? languageId)
         {
-            IReadOnlyList<NestedContentValues.NestedContentRowValue> rows =
-                _nestedContentValues.GetPropertyValues(value);
-
-            var result = new List<ITag>();
-
-            foreach (NestedContentValues.NestedContentRowValue row in rows.ToList())
+            foreach (NestedContentValues.NestedContentPropertyValue propertyValue in GetAllPropertyValues(value))
             {
-                foreach (KeyValuePair<string, NestedContentValues.NestedContentPropertyValue> prop in row.PropertyValues
-                             .ToList())
+                if (!_propertyEditors.TryGet(propertyValue.PropertyType.PropertyEditorAlias, out IDataEditor? dataEditor) ||
+                    dataEditor.GetValueEditor() is not IDataValueTags dataValueTags)
                 {
-                    IDataEditor? propEditor = _propertyEditors[prop.Value.PropertyType.PropertyEditorAlias];
+                    continue;
+                }
 
-                    IDataValueEditor? valueEditor = propEditor?.GetValueEditor();
-                    if (valueEditor is not IDataValueTags tagsProvider)
-                    {
-                        continue;
-                    }
-
-                    object? configuration = _dataTypeService.GetDataType(prop.Value.PropertyType.DataTypeKey)?.Configuration;
-
-                    result.AddRange(tagsProvider.GetTags(prop.Value.Value, configuration, languageId));
+                object? configuration = _dataTypeService.GetDataType(propertyValue.PropertyType.DataTypeKey)?.Configuration;
+                foreach (ITag tag in dataValueTags.GetTags(propertyValue.Value, configuration, languageId))
+                {
+                    yield return tag;
                 }
             }
-
-            return result;
         }
+
+        private IEnumerable<NestedContentValues.NestedContentPropertyValue> GetAllPropertyValues(object? value)
+            => _nestedContentValues.GetPropertyValues(value).SelectMany(x => x.PropertyValues.Values);
 
         #region DB to String
 
@@ -422,7 +405,8 @@ public class NestedContentPropertyEditor : DataEditor
                         // set values to null
                         row.PropertyValues[elementTypeProp.Alias] = new NestedContentValues.NestedContentPropertyValue
                         {
-                            PropertyType = elementTypeProp, Value = null,
+                            PropertyType = elementTypeProp,
+                            Value = null,
                         };
                         row.RawPropertyValues[elementTypeProp.Alias] = null;
                     }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueEditorReuseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueEditorReuseTests.cs
@@ -1,4 +1,3 @@
-﻿using System.Linq;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
@@ -15,6 +14,7 @@ public class DataValueEditorReuseTests
 {
     private Mock<IDataValueEditorFactory> _dataValueEditorFactoryMock;
     private PropertyEditorCollection _propertyEditorCollection;
+    private DataValueReferenceFactoryCollection _dataValueReferenceFactories;
 
     [SetUp]
     public void SetUp()
@@ -31,6 +31,7 @@ public class DataValueEditorReuseTests
                 Mock.Of<IIOHelper>()));
 
         _propertyEditorCollection = new PropertyEditorCollection(new DataEditorCollection(Enumerable.Empty<IDataEditor>));
+        _dataValueReferenceFactories = new DataValueReferenceFactoryCollection(Enumerable.Empty<IDataValueReferenceFactory>);
 
         _dataValueEditorFactoryMock
             .Setup(m =>
@@ -38,6 +39,7 @@ public class DataValueEditorReuseTests
             .Returns(() => new BlockListPropertyEditorBase.BlockListEditorPropertyValueEditor(
                 new DataEditorAttribute("a", "b", "c"),
                 _propertyEditorCollection,
+                _dataValueReferenceFactories,
                 Mock.Of<IDataTypeService>(),
                 Mock.Of<IContentTypeService>(),
                 Mock.Of<ILocalizedTextService>(),
@@ -93,7 +95,7 @@ public class DataValueEditorReuseTests
     {
         var blockListPropertyEditor = new BlockListPropertyEditor(
             _dataValueEditorFactoryMock.Object,
-            new PropertyEditorCollection(new DataEditorCollection(Enumerable.Empty<IDataEditor>)),
+            _propertyEditorCollection,
             Mock.Of<IIOHelper>(),
             Mock.Of<IEditorConfigurationParser>(),
             Mock.Of<IBlockValuePropertyIndexValueFactory>());
@@ -114,7 +116,7 @@ public class DataValueEditorReuseTests
     {
         var blockListPropertyEditor = new BlockListPropertyEditor(
             _dataValueEditorFactoryMock.Object,
-            new PropertyEditorCollection(new DataEditorCollection(Enumerable.Empty<IDataEditor>)),
+            _propertyEditorCollection,
             Mock.Of<IIOHelper>(),
             Mock.Of<IEditorConfigurationParser>(),
             Mock.Of<IBlockValuePropertyIndexValueFactory>());

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollectionTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollectionTests.cs
@@ -176,14 +176,11 @@ public class DataValueReferenceFactoryCollectionTests
     {
         var collection = new DataValueReferenceFactoryCollection(Enumerable.Empty<IDataValueReferenceFactory>);
         var propertyEditors = new PropertyEditorCollection(new DataEditorCollection(Enumerable.Empty<IDataEditor>));
-        var properties = new PropertyCollection();
 
-        var resultA = collection.GetAutomaticRelationTypesAliases(propertyEditors).ToArray();
-        var resultB = collection.GetAutomaticRelationTypesAliases(properties, propertyEditors).ToArray();
+        var result = collection.GetAllAutomaticRelationTypesAliases(propertyEditors).ToArray();
 
         var expected = Constants.Conventions.RelationTypes.AutomaticRelationTypes;
-        CollectionAssert.AreEquivalent(expected, resultA, "Result A does not contain the expected relation type aliases.");
-        CollectionAssert.AreEquivalent(expected, resultB, "Result B does not contain the expected relation type aliases.");
+        CollectionAssert.AreEquivalent(expected, result, "Result does not contain the expected relation type aliases.");
     }
 
     [Test]
@@ -194,15 +191,11 @@ public class DataValueReferenceFactoryCollectionTests
         var labelPropertyEditor = new LabelPropertyEditor(DataValueEditorFactory, IOHelper, EditorConfigurationParser);
         var propertyEditors = new PropertyEditorCollection(new DataEditorCollection(() => labelPropertyEditor.Yield()));
         var serializer = new ConfigurationEditorJsonSerializer();
-        var property = new Property(new PropertyType(ShortStringHelper, new DataType(labelPropertyEditor, serializer)));
-        var properties = new PropertyCollection { property, property }; // Duplicate on purpose to test distinct aliases
 
-        var resultA = collection.GetAutomaticRelationTypesAliases(propertyEditors).ToArray();
-        var resultB = collection.GetAutomaticRelationTypesAliases(properties, propertyEditors).ToArray();
+        var result = collection.GetAllAutomaticRelationTypesAliases(propertyEditors).ToArray();
 
         var expected = Constants.Conventions.RelationTypes.AutomaticRelationTypes.Append("umbTest");
-        CollectionAssert.AreEquivalent(expected, resultA, "Result A does not contain the expected relation type aliases.");
-        CollectionAssert.AreEquivalent(expected, resultB, "Result B does not contain the expected relation type aliases.");
+        CollectionAssert.AreEquivalent(expected, result, "Result does not contain the expected relation type aliases.");
     }
 
     private class TestDataValueReferenceFactory : IDataValueReferenceFactory

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollectionTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollectionTests.cs
@@ -1,9 +1,6 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
@@ -174,6 +171,40 @@ public class DataValueReferenceFactoryCollectionTests
         Assert.AreEqual(trackedUdi4, result.ElementAt(1).Udi.ToString());
     }
 
+    [Test]
+    public void GetAutomaticRelationTypesAliases_ContainsDefault()
+    {
+        var collection = new DataValueReferenceFactoryCollection(Enumerable.Empty<IDataValueReferenceFactory>);
+        var propertyEditors = new PropertyEditorCollection(new DataEditorCollection(Enumerable.Empty<IDataEditor>));
+        var properties = new PropertyCollection();
+
+        var resultA = collection.GetAutomaticRelationTypesAliases(propertyEditors).ToArray();
+        var resultB = collection.GetAutomaticRelationTypesAliases(properties, propertyEditors).ToArray();
+
+        var expected = Constants.Conventions.RelationTypes.AutomaticRelationTypes;
+        CollectionAssert.AreEquivalent(expected, resultA, "Result A does not contain the expected relation type aliases.");
+        CollectionAssert.AreEquivalent(expected, resultB, "Result B does not contain the expected relation type aliases.");
+    }
+
+    [Test]
+    public void GetAutomaticRelationTypesAliases_ContainsCustom()
+    {
+        var collection = new DataValueReferenceFactoryCollection(() => new TestDataValueReferenceFactory().Yield());
+
+        var labelPropertyEditor = new LabelPropertyEditor(DataValueEditorFactory, IOHelper, EditorConfigurationParser);
+        var propertyEditors = new PropertyEditorCollection(new DataEditorCollection(() => labelPropertyEditor.Yield()));
+        var serializer = new ConfigurationEditorJsonSerializer();
+        var property = new Property(new PropertyType(ShortStringHelper, new DataType(labelPropertyEditor, serializer)));
+        var properties = new PropertyCollection { property, property }; // Duplicate on purpose to test distinct aliases
+
+        var resultA = collection.GetAutomaticRelationTypesAliases(propertyEditors).ToArray();
+        var resultB = collection.GetAutomaticRelationTypesAliases(properties, propertyEditors).ToArray();
+
+        var expected = Constants.Conventions.RelationTypes.AutomaticRelationTypes.Append("umbTest");
+        CollectionAssert.AreEquivalent(expected, resultA, "Result A does not contain the expected relation type aliases.");
+        CollectionAssert.AreEquivalent(expected, resultB, "Result B does not contain the expected relation type aliases.");
+    }
+
     private class TestDataValueReferenceFactory : IDataValueReferenceFactory
     {
         public IDataValueReference GetDataValueReference() => new TestMediaDataValueReference();
@@ -197,6 +228,12 @@ public class DataValueReferenceFactoryCollectionTests
                     yield return new UmbracoEntityReference(udi);
                 }
             }
+
+            public IEnumerable<string> GetAutomaticRelationTypesAliases() => new[]
+            {
+                "umbTest",
+                "umbTest", // Duplicate on purpose to test distinct aliases
+            };
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco.Forms.Issues/issues/1129 and  https://github.com/umbraco/Umbraco.Forms.Issues/issues/1143, since tracking references using a custom relation type has been added in Forms 12.2 and surfaced issues within the CMS.

### Description
This PR backports https://github.com/umbraco/Umbraco-CMS/pull/15141 and https://github.com/umbraco/Umbraco-CMS/pull/15160 (that both targeted v13) to v10 and should be merged to v12 subsequently, so the automatic relation type aliases are also retrieved from the `IDataValueReferenceFactory`, a SQL parameter overflow bug is fixed and logging of invalid reference relations is improved.

To ensure all relations that are used for reference tracking are deleted before re-inserting them, I've updated the backported code to always get _all_ relation type aliases in `GetAllAutomaticRelationTypesAliases()`. This ensures we don't have to loop over all properties (which might use the same data/property editor anyway) and more importantly: this doesn't require parsing any values/data type configuration when recursive (nested/block) properties are present... Doing this also improves upon the fix/work-around that was added in https://github.com/umbraco/Umbraco-CMS/pull/15447, so that change should be reverted when merging these changes up to v12.

Finally, I've also ensured `UmbracoEntityReference` doesn't default to `Constants.Conventions.RelationTypes.RelatedDocumentAlias` (`umbDocument`) for UDIs/entity types that aren't a document and references from recursive (nested/block) properties are correctly returned as well.

-----------------

Testing this can be done by first creating a new relation type:
- Name: Related Member
- Direction: Parent to child
- Parent: Document
- Child: Member
- Is Dependency: Yes

Then create a document type that uses a Member Picker directly, but also contains a Block List, Block Grid and Nested Content property that allows adding an element type that also has a Member Picker on it. This allows you to test getting references to to members in the recursive (nested/block) properties as well.

Add the following composer to the project to add support for tracking references to members for an existing, built-in property editor:

```c#
using Umbraco.Cms.Core;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Models.Editors;
using Umbraco.Cms.Core.PropertyEditors;

internal class MemberPickerDataValueReferenceComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder) => builder.DataValueReferenceFactories().Append<MemberPickerDataValueReferenceFactory>();

    private class MemberPickerDataValueReferenceFactory : IDataValueReferenceFactory
    {
        public bool IsForEditor(IDataEditor? dataEditor) => dataEditor?.Alias == Constants.PropertyEditors.Aliases.MemberPicker;

        public IDataValueReference GetDataValueReference() => new MemberPickerDataValueReference();

        private class MemberPickerDataValueReference : IDataValueReference
        {
            private const string RelationTypeAlias = "relatedMember";

            public IEnumerable<UmbracoEntityReference> GetReferences(object? value)
            {
                if (value is string stringValue &&
                    UdiParser.TryParse(stringValue, out Udi? udi))
                {
                    yield return new UmbracoEntityReference(udi, RelationTypeAlias);
                }
            }

            public IEnumerable<string> GetAutomaticRelationTypesAliases() => RelationTypeAlias.Yield();
        }
    }
}
```

Next up: create a couple members, add a new content page using the previously created document type and select the members.

![Selected members](https://github.com/umbraco/Umbraco-CMS/assets/1051287/a6ba134d-424b-42c0-b674-41cfcc056977)

After saving this page, the relations should be visible when going to the relation type (below Settings):

![Relations](https://github.com/umbraco/Umbraco-CMS/assets/1051287/711b568c-598c-46ca-bda4-edc3f7f0b314)

Removing the selected members from the page should also clean up the relations again.