### PR TITLE
V13: Rich text editor does not show its toolbar on grid layout rte's

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/grid/grid.rte.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/grid/grid.rte.directive.js
@@ -36,7 +36,6 @@ angular.module("umbraco.directives")
 
                 //stores a reference to the editor
                 let tinyMceEditor = null;
-                const umbPanelBody = document.querySelector(".umb-panel-body");
 
                 const assetPromises = [];
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/grid/grid.rte.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/grid/grid.rte.directive.js
@@ -72,7 +72,7 @@ angular.module("umbraco.directives")
 
                     //create a baseline Config to extend upon
                     let baseLineConfigObj = {
-                        maxImageSize: editorConfig.maxImageSize,
+                        maxImageSize: editorConfig.maxImageSize
                     };
 
                     baseLineConfigObj.setup = function (editor) {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/grid/grid.rte.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/grid/grid.rte.directive.js
@@ -12,22 +12,18 @@ angular.module("umbraco.directives")
             replace: true,
             link: function (scope, element, attrs) {
 
-                // TODO: A lot of the code below should be shared between the grid rte and the normal rte
-
                 scope.isLoading = true;
-
-                var promises = [];
 
                 //To id the html textarea we need to use the datetime ticks because we can have multiple rte's per a single property alias
                 // because now we have to support having 2x (maybe more at some stage) content editors being displayed at once. This is because
                 // we have this mini content editor panel that can be launched with MNTP.
                 scope.textAreaHtmlId = scope.uniqueId + "_" + String.CreateGuid();
 
-                var editorConfig = scope.configuration ? scope.configuration : null;
+                let editorConfig = scope.configuration ? scope.configuration : null;
                 if (!editorConfig || Utilities.isString(editorConfig)) {
                     editorConfig = tinyMceService.defaultPrevalues();
                     //for the grid by default, we don't want to include the macro or the block-picker toolbar
-                    editorConfig.toolbar = _.without(editorConfig, "umbmacro", "umbblockpicker");
+                    editorConfig.toolbar = _.without(editorConfig.toolbar, "umbmacro", "umbblockpicker");
                 }
 
                 //ensure the grid's global config is being passed up to the RTE, these 2 properties need to be in this format
@@ -39,45 +35,50 @@ angular.module("umbraco.directives")
                 scope.dataTypeKey = scope.datatypeKey; //Yes - this casing is rediculous, but it's because the var starts with `data` so it can't be `data-type-id` :/
 
                 //stores a reference to the editor
-                var tinyMceEditor = null;
+                let tinyMceEditor = null;
+
+                const assetPromises = [];
 
                 //queue file loading
                 tinyMceAssets.forEach(function (tinyJsAsset) {
-                    promises.push(assetsService.loadJs(tinyJsAsset, scope));
+                  assetPromises.push(assetsService.loadJs(tinyJsAsset, scope));
                 });
-                promises.push(tinyMceService.getTinyMceEditorConfig({
-                    htmlId: scope.textAreaHtmlId,
-                    stylesheets: editorConfig.stylesheets,
-                    toolbar: editorConfig.toolbar,
-                    mode: editorConfig.mode
-                }));
 
-                $q.all(promises).then(function (result) {
+                //wait for assets to load before proceeding
+                $q.all(assetPromises)
+                  .then(function () {
+                    return tinyMceService.getTinyMceEditorConfig({
+                      htmlId: scope.textAreaHtmlId,
+                      stylesheets: editorConfig.stylesheets,
+                      toolbar: editorConfig.toolbar,
+                      mode: editorConfig.mode
+                    })
+                  })
 
-                    var standardConfig = result[promises.length - 1];
+                  // Handle additional assets loading depending on the configuration before initializing the editor
+                  .then(function (tinyMceConfig) {
+                    // Load the plugins.min.js file from the TinyMCE Cloud if a Cloud Api Key is specified
+                    if (tinyMceConfig.cloudApiKey) {
+                      return assetsService.loadJs(`https://cdn.tiny.cloud/1/${tinyMceConfig.cloudApiKey}/tinymce/${tinymce.majorVersion}.${tinymce.minorVersion}/plugins.min.js`)
+                        .then(() => tinyMceConfig);
+                    }
+
+                    return tinyMceConfig;
+                  })
+
+                  //wait for config to be ready after assets have loaded
+                  .then(function (standardConfig) {
 
                     //create a baseline Config to extend upon
-                    var baseLineConfigObj = {
+                    let baseLineConfigObj = {
                         maxImageSize: editorConfig.maxImageSize,
-                        toolbar_sticky: true
+                        toolbar_sticky: true,
                     };
-
-                    Utilities.extend(baseLineConfigObj, standardConfig);
 
                     baseLineConfigObj.setup = function (editor) {
 
                         //set the reference
                         tinyMceEditor = editor;
-
-                        //initialize the standard editor functionality for Umbraco
-                        tinyMceService.initializeEditor({
-                            editor: editor,
-                            toolbar: editorConfig.toolbar,
-                            model: scope,
-                            // Form is found in the scope of the grid controller above us, not in our isolated scope
-                            // https://github.com/umbraco/Umbraco-CMS/issues/7461
-                            currentForm: angularHelper.getCurrentForm(scope.$parent)
-                        });
 
                         //custom initialization for this editor within the grid
                         editor.on('init', function (e) {
@@ -96,47 +97,51 @@ angular.module("umbraco.directives")
                             }, 400);
 
                         });
+
+                        //initialize the standard editor functionality for Umbraco
+                        tinyMceService.initializeEditor({
+                          editor: editor,
+                          toolbar: editorConfig.toolbar,
+                          model: scope,
+                          // Form is found in the scope of the grid controller above us, not in our isolated scope
+                          // https://github.com/umbraco/Umbraco-CMS/issues/7461
+                          currentForm: angularHelper.getCurrentForm(scope.$parent)
+                        });
                     };
 
-                    /** Loads in the editor */
-                    function loadTinyMce() {
+                    Utilities.extend(baseLineConfigObj, standardConfig);
 
-                        //we need to add a timeout here, to force a redraw so TinyMCE can find
-                        //the elements needed
-                        $timeout(function () {
-                            tinymce.init(baseLineConfigObj);
-                        }, 150, false);
+                    //we need to add a timeout here, to force a redraw so TinyMCE can find
+                    //the elements needed
+                    $timeout(function () {
+                      tinymce.init(baseLineConfigObj);
+                    }, 150);
+                });
+
+                const tabShownListener = eventsService.on("app.tabChange", function (e, args) {
+
+                  const tabId = String(args.id);
+                  const myTabId = element.closest(".umb-tab-pane").attr("rel");
+
+                  if (tabId === myTabId) {
+                    //the tab has been shown, trigger the mceAutoResize (as it could have timed out before the tab was shown)
+                    if (tinyMceEditor !== undefined && tinyMceEditor != null) {
+                      tinyMceEditor.execCommand('mceAutoResize', false, null, null);
                     }
+                  }
+                });
 
-                    loadTinyMce();
+                //when the element is disposed we need to unsubscribe!
+                // NOTE: this is very important otherwise if this is part of a modal, the listener still exists because the dom
+                // element might still be there even after the modal has been hidden.
+                scope.$on('$destroy', function () {
+                  eventsService.unsubscribe(tabShownListener);
 
-                    // TODO: This should probably be in place for all RTE, not just for the grid, which means
-                    // this code can live in tinyMceService.initializeEditor
-                    var tabShownListener = eventsService.on("app.tabChange", function (e, args) {
-
-                        var tabId = args.id;
-                        var myTabId = element.closest(".umb-tab-pane").attr("rel");
-
-                        if (String(tabId) === myTabId) {
-                            //the tab has been shown, trigger the mceAutoResize (as it could have timed out before the tab was shown)
-                            if (tinyMceEditor !== undefined && tinyMceEditor != null) {
-                                tinyMceEditor.execCommand('mceAutoResize', false, null, null);
-                            }
-                        }
-
-                    });
-
-                    //when the element is disposed we need to unsubscribe!
-                    // NOTE: this is very important otherwise if this is part of a modal, the listener still exists because the dom
-                    // element might still be there even after the modal has been hidden.
-                    scope.$on('$destroy', function () {
-                        eventsService.unsubscribe(tabShownListener);
-                        //ensure we unbind this in case the blur doesn't fire above
-                        if (tinyMceEditor !== undefined && tinyMceEditor != null) {
-                            tinyMceEditor.destroy()
-                        }
-                    });
-
+                  //ensure we unbind this in case the blur doesn't fire above
+                  if (tinyMceEditor) {
+                    tinyMceEditor.destroy();
+                    tinyMceEditor = null;
+                  }
                 });
 
             }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/grid/grid.rte.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/grid/grid.rte.directive.js
@@ -98,22 +98,6 @@ angular.module("umbraco.directives")
 
                         });
 
-                        //when we leave the editor (maybe)
-                        editor.on('blur', function (e) {
-                          angularHelper.safeApply(scope, function () {
-                            unpinToolbar();
-                            umbPanelBody.removeEventListener("scroll", pinToolbar);
-                          });
-                        });
-
-                        // Focus on editor
-                        editor.on('focus', function (e) {
-                          angularHelper.safeApply(scope, function () {
-                            pinToolbar();
-                            umbPanelBody.addEventListener("scroll", pinToolbar, { passive: true });
-                          });
-                        });
-
                         //initialize the standard editor functionality for Umbraco
                         tinyMceService.initializeEditor({
                           editor: editor,
@@ -151,7 +135,6 @@ angular.module("umbraco.directives")
                 // NOTE: this is very important otherwise if this is part of a modal, the listener still exists because the dom
                 // element might still be there even after the modal has been hidden.
                 scope.$on('$destroy', function () {
-                  umbPanelBody.removeEventListener("scroll", pinToolbar)
                   eventsService.unsubscribe(tabShownListener);
 
                   //ensure we unbind this in case the blur doesn't fire above
@@ -160,58 +143,6 @@ angular.module("umbraco.directives")
                     tinyMceEditor = null;
                   }
                 });
-
-                const pinToolbar = () => {
-                  //we can't pin the toolbar if this doesn't exist (i.e. when in distraction free mode)
-                  if (!tinyMceEditor.container) {
-                    return;
-                  }
-
-                  const tinyMce = tinyMceEditor.container;
-                  const toolbar = tinyMce.querySelector(".tox-editor-header");
-                  const toolbarHeight = toolbar.offsetHeight;
-                  const tinyMceRect = tinyMce.getBoundingClientRect();
-                  const tinyMceTop = tinyMceRect.top;
-                  const tinyMceBottom = tinyMceRect.bottom;
-                  const tinyMceWidth = tinyMceRect.width;
-
-                  const tinyMceEditArea = tinyMce.querySelector(".tox-edit-area");
-
-                  // set height of mce to 177px if it is less than 177px to
-                  // allow the content to be shown with a pinned toolbar
-                  // (only relevant when the content is less than 177px)
-                  if (tinyMce.offsetHeight < 177) {
-                    tinyMce.style.height = "177px";
-                  }
-
-                  // set padding in top of mce so the content does not "jump" up
-                  tinyMceEditArea.style.paddingTop = toolbarHeight + "px";
-
-                  if (tinyMceTop < 177 && ((177 + toolbarHeight) < tinyMceBottom)) {
-                    toolbar.style.position = "fixed";
-                    toolbar.style.top = "177px";
-                    toolbar.style.left = "auto";
-                    toolbar.style.right = "auto";
-                    toolbar.style.width = tinyMceWidth + "px";
-                  } else {
-                    toolbar.style.position = "absolute";
-                    toolbar.style.left = "";
-                    toolbar.style.right = "";
-                    toolbar.style.top = "";
-                    toolbar.style.width = tinyMceWidth + "px";
-                  }
-
-                }
-
-                const unpinToolbar = () => {
-                  const tinyMce = tinyMceEditor.container;
-                  const toolbar = tinyMce.querySelector(".tox-editor-header");
-                  const tinyMceEditArea = tinyMce.querySelector(".tox-edit-area");
-                  // reset padding in top of mce so the content does not "jump" up
-                  tinyMceEditArea.style.paddingTop = "0";
-                  toolbar.style.position = "static";
-                }
-
             }
         };
     });

--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -781,6 +781,11 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
         });
       });
 
+      // Do not add any further controls if the block editor is not available
+      if (!blockEditorApi) {
+        return;
+      }
+
       editor.ui.registry.addButton('umbblockpicker', {
         icon: 'visualblocks',
         tooltip: 'Insert Block',
@@ -1438,6 +1443,10 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
       }
 
       function initBlocks() {
+
+        if(!args.blockEditorApi) {
+          return;
+        }
 
         const blockEls = args.editor.contentDocument.querySelectorAll('umb-rte-block, umb-rte-block-inline');
         for (var blockEl of blockEls) {

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/rte.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/editors/rte.html
@@ -4,8 +4,8 @@
 		configuration="model.config.rte"
 		value="control.value"
 		unique-id="control.$uniqueId"
-        datatype-key="{{model.dataTypeKey}}"
-        ignore-user-start-nodes="{{model.config.ignoreUserStartNodes}}">
+    datatype-key="{{model.dataTypeKey}}"
+    ignore-user-start-nodes="{{model.config.ignoreUserStartNodes}}">
 	</grid-rte>
 
 </div>


### PR DESCRIPTION
### Description

Fixes #15515
Fixes #15581

Potentially fixes #14911

This has been a problem probably since Umbraco 11, where we upgraded TinyMCE from v4 to v6. A lot of functionality was lost or replaced with built-in configuration including the sticky toolbar. The grid layout uses the option `toolbar_sticky` from TinyMCE, but at some point, it stopped showing the toolbar in certain scenarios where multiple rich text editors are shown in a grid layout on the same page.

The code for `rte.component.js` and `grid.rte.directive.js` has now been aligned so the behavior of the rich text editor should be the same whether shown on a page or in a grid layout editor. However, blocks are not supported in the grid layout editor so that is still disabled. This PR fixes a small typo where the `umbblockpicker` was not properly removed from the toolbar.

In the same vein, I have removed the TODOs about combining the "extra" code for rich text editors into the existing TinyMceService the reason is that we are going to remove the grid layout entirely in the new backoffice, and so the code will be removed anyway.


