### PR TITLE
Add management api delete document endpoints

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/DeleteDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/DeleteDocumentController.cs
@@ -1,0 +1,57 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Security.Authorization.Content;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Web.Common.Authorization;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Document;
+
+[ApiVersion("1.0")]
+public class DeleteDocumentController : DocumentControllerBase
+{
+    private readonly IAuthorizationService _authorizationService;
+    private readonly IContentEditingService _contentEditingService;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+
+    public DeleteDocumentController(
+        IAuthorizationService authorizationService,
+        IContentEditingService contentEditingService,
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+    {
+        _authorizationService = authorizationService;
+        _contentEditingService = contentEditingService;
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+    }
+
+    [HttpDelete("{id:guid}")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Delete(Guid id)
+    {
+        AuthorizationResult authorizationResult  = await _authorizationService.AuthorizeResourceAsync(
+            User,
+            ContentPermissionResource.WithKeys(ActionDelete.ActionLetter, id),
+            AuthorizationPolicies.ContentPermissionByResource);
+
+        if (!authorizationResult.Succeeded)
+        {
+            return Forbidden();
+        }
+
+        Attempt<IContent?, ContentEditingOperationStatus> result = await _contentEditingService.DeleteAsync(id, CurrentUserKey(_backOfficeSecurityAccessor));
+
+        return result.Success
+            ? Ok()
+            : ContentEditingOperationStatusResult(result.Status);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/RecycleBin/DeleteDocumentRecycleBinController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/RecycleBin/DeleteDocumentRecycleBinController.cs
@@ -1,0 +1,59 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Security.Authorization.Content;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Web.Common.Authorization;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Document.RecycleBin;
+
+[ApiVersion("1.0")]
+public class DeleteDocumentRecycleBinController : DocumentRecycleBinControllerBase
+{
+    private readonly IAuthorizationService _authorizationService;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+    private readonly IContentEditingService _contentEditingService;
+
+    public DeleteDocumentRecycleBinController(
+        IEntityService entityService,
+        IAuthorizationService authorizationService,
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
+        IContentEditingService contentEditingService)
+        : base(entityService)
+    {
+        _authorizationService = authorizationService;
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+        _contentEditingService = contentEditingService;
+    }
+
+    [HttpDelete("{id:guid}")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Delete(Guid id)
+    {
+        AuthorizationResult authorizationResult  = await _authorizationService.AuthorizeResourceAsync(
+            User,
+            ContentPermissionResource.WithKeys(ActionDelete.ActionLetter, id),
+            AuthorizationPolicies.ContentPermissionByResource);
+
+        if (!authorizationResult.Succeeded)
+        {
+            return Forbidden();
+        }
+
+        Attempt<IContent?, ContentEditingOperationStatus> result = await _contentEditingService.DeleteFromRecycleBinAsync(id, CurrentUserKey(_backOfficeSecurityAccessor));
+
+        return result.Success
+            ? Ok()
+            : ContentEditingOperationStatusResult(result.Status);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/RecycleBin/DocumentRecycleBinControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/RecycleBin/DocumentRecycleBinControllerBase.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
@@ -9,6 +10,7 @@ using Umbraco.Cms.Api.Management.Controllers.RecycleBin;
 using Umbraco.Cms.Api.Management.Filters;
 using Umbraco.Cms.Api.Management.ViewModels.RecycleBin;
 using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document.RecycleBin;
@@ -40,4 +42,30 @@ public class DocumentRecycleBinControllerBase : RecycleBinControllerBase<Recycle
 
         return responseModel;
     }
+
+    protected IActionResult ContentEditingOperationStatusResult(ContentEditingOperationStatus status) =>
+        status switch
+        {
+            ContentEditingOperationStatus.CancelledByNotification => BadRequest(new ProblemDetailsBuilder()
+                .WithTitle("Cancelled by notification")
+                .WithDetail("A notification handler prevented the content operation.")
+                .Build()),
+            ContentEditingOperationStatus.NotFound => NotFound(new ProblemDetailsBuilder()
+                .WithTitle("The content could not be found")
+                .Build()),
+            ContentEditingOperationStatus.NotAllowed => BadRequest(new ProblemDetailsBuilder()
+                .WithTitle("Operation not permitted")
+                .WithDetail("The attempted operation was not permitted, likely due to a permission/configuration mismatch with the operation.")
+                .Build()),
+            ContentEditingOperationStatus.NotInTrash => BadRequest(new ProblemDetailsBuilder()
+                .WithTitle("Content is not in the recycle bin")
+                .WithDetail("The attempted operation requires the targeted content to be in the recycle bin.")
+                .Build()),
+            ContentEditingOperationStatus.Unknown => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+                .WithTitle("Unknown error. Please see the log for more details.")
+                .Build()),
+            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+                .WithTitle("Unknown content operation status.")
+                .Build()),
+        };
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/RecycleBin/DocumentRecycleBinControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/RecycleBin/DocumentRecycleBinControllerBase.cs
@@ -42,30 +42,4 @@ public class DocumentRecycleBinControllerBase : RecycleBinControllerBase<Recycle
 
         return responseModel;
     }
-
-    protected IActionResult ContentEditingOperationStatusResult(ContentEditingOperationStatus status) =>
-        status switch
-        {
-            ContentEditingOperationStatus.CancelledByNotification => BadRequest(new ProblemDetailsBuilder()
-                .WithTitle("Cancelled by notification")
-                .WithDetail("A notification handler prevented the content operation.")
-                .Build()),
-            ContentEditingOperationStatus.NotFound => NotFound(new ProblemDetailsBuilder()
-                .WithTitle("The content could not be found")
-                .Build()),
-            ContentEditingOperationStatus.NotAllowed => BadRequest(new ProblemDetailsBuilder()
-                .WithTitle("Operation not permitted")
-                .WithDetail("The attempted operation was not permitted, likely due to a permission/configuration mismatch with the operation.")
-                .Build()),
-            ContentEditingOperationStatus.NotInTrash => BadRequest(new ProblemDetailsBuilder()
-                .WithTitle("Content is not in the recycle bin")
-                .WithDetail("The attempted operation requires the targeted content to be in the recycle bin.")
-                .Build()),
-            ContentEditingOperationStatus.Unknown => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
-                .WithTitle("Unknown error. Please see the log for more details.")
-                .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
-                .WithTitle("Unknown content operation status.")
-                .Build()),
-        };
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/RecycleBin/RecycleBinControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RecycleBin/RecycleBinControllerBase.cs
@@ -1,13 +1,10 @@
-﻿using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Common.Builders;
+﻿using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Api.Management.Services.Paging;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.ViewModels.RecycleBin;
-using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.RecycleBin;
 
@@ -79,32 +76,6 @@ public abstract class RecycleBinControllerBase<TItem> : ManagementApiControllerB
 
         return viewModel;
     }
-
-    protected IActionResult ContentEditingOperationStatusResult(ContentEditingOperationStatus status) =>
-        status switch
-        {
-            ContentEditingOperationStatus.CancelledByNotification => BadRequest(new ProblemDetailsBuilder()
-                .WithTitle("Cancelled by notification")
-                .WithDetail("A notification handler prevented the content operation.")
-                .Build()),
-            ContentEditingOperationStatus.NotFound => NotFound(new ProblemDetailsBuilder()
-                    .WithTitle("The content could not be found")
-                    .Build()),
-            ContentEditingOperationStatus.NotAllowed => BadRequest(new ProblemDetailsBuilder()
-                .WithTitle("Operation not permitted")
-                .WithDetail("The attempted operation was not permitted, likely due to a permission/configuration mismatch with the operation.")
-                .Build()),
-            ContentEditingOperationStatus.NotInTrash => BadRequest(new ProblemDetailsBuilder()
-                .WithTitle("Content is not in the recycle bin")
-                .WithDetail("The attempted operation requires the targeted content to be in the recycle bin.")
-                .Build()),
-            ContentEditingOperationStatus.Unknown => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
-                .WithTitle("Unknown error. Please see the log for more details.")
-                .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
-                .WithTitle("Unknown content operation status.")
-                .Build()),
-        };
 
     private IEntitySlim[] GetPagedRootEntities(long pageNumber, int pageSize, out long totalItems)
     {

--- a/src/Umbraco.Cms.Api.Management/Controllers/RecycleBin/RecycleBinControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RecycleBin/RecycleBinControllerBase.cs
@@ -4,11 +4,12 @@ using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Api.Management.Services.Paging;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
+using Umbraco.Cms.Api.Management.Content;
 using Umbraco.Cms.Api.Management.ViewModels.RecycleBin;
 
 namespace Umbraco.Cms.Api.Management.Controllers.RecycleBin;
 
-public abstract class RecycleBinControllerBase<TItem> : ManagementApiControllerBase
+public abstract class RecycleBinControllerBase<TItem> : ContentControllerBase
     where TItem : RecycleBinItemResponseModel, new()
 {
     private readonly IEntityService _entityService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/RecycleBin/RecycleBinControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RecycleBin/RecycleBinControllerBase.cs
@@ -1,10 +1,13 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Api.Management.Services.Paging;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.ViewModels.RecycleBin;
+using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.RecycleBin;
 
@@ -76,6 +79,32 @@ public abstract class RecycleBinControllerBase<TItem> : ManagementApiControllerB
 
         return viewModel;
     }
+
+    protected IActionResult ContentEditingOperationStatusResult(ContentEditingOperationStatus status) =>
+        status switch
+        {
+            ContentEditingOperationStatus.CancelledByNotification => BadRequest(new ProblemDetailsBuilder()
+                .WithTitle("Cancelled by notification")
+                .WithDetail("A notification handler prevented the content operation.")
+                .Build()),
+            ContentEditingOperationStatus.NotFound => NotFound(new ProblemDetailsBuilder()
+                    .WithTitle("The content could not be found")
+                    .Build()),
+            ContentEditingOperationStatus.NotAllowed => BadRequest(new ProblemDetailsBuilder()
+                .WithTitle("Operation not permitted")
+                .WithDetail("The attempted operation was not permitted, likely due to a permission/configuration mismatch with the operation.")
+                .Build()),
+            ContentEditingOperationStatus.NotInTrash => BadRequest(new ProblemDetailsBuilder()
+                .WithTitle("Content is not in the recycle bin")
+                .WithDetail("The attempted operation requires the targeted content to be in the recycle bin.")
+                .Build()),
+            ContentEditingOperationStatus.Unknown => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+                .WithTitle("Unknown error. Please see the log for more details.")
+                .Build()),
+            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+                .WithTitle("Unknown content operation status.")
+                .Build()),
+        };
 
     private IEntitySlim[] GetPagedRootEntities(long pageNumber, int pageSize, out long totalItems)
     {

--- a/src/Umbraco.Cms.Api.Management/Umbraco.Cms.Api.Management.csproj
+++ b/src/Umbraco.Cms.Api.Management/Umbraco.Cms.Api.Management.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="JsonPatch.Net" />
-    <PackageReference Include="Swashbuckle.AspNetCore"  />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Umbraco.Core/Services/ContentEditingService.cs
+++ b/src/Umbraco.Core/Services/ContentEditingService.cs
@@ -80,8 +80,11 @@ internal sealed class ContentEditingService
     public async Task<Attempt<IContent?, ContentEditingOperationStatus>> MoveToRecycleBinAsync(Guid key, Guid userKey)
         => await HandleMoveToRecycleBinAsync(key, userKey);
 
+    public async Task<Attempt<IContent?, ContentEditingOperationStatus>> DeleteFromRecycleBinAsync(Guid key, Guid userKey)
+        => await HandleDeleteAsync(key, userKey, true);
+
     public async Task<Attempt<IContent?, ContentEditingOperationStatus>> DeleteAsync(Guid key, Guid userKey)
-        => await HandleDeleteAsync(key, userKey);
+        => await HandleDeleteAsync(key, userKey, false);
 
     public async Task<Attempt<IContent?, ContentEditingOperationStatus>> MoveAsync(Guid key, Guid? parentKey, Guid userKey)
         => await HandleMoveAsync(key, parentKey, userKey);

--- a/src/Umbraco.Core/Services/ContentEditingServiceBase.cs
+++ b/src/Umbraco.Core/Services/ContentEditingServiceBase.cs
@@ -103,13 +103,13 @@ internal abstract class ContentEditingServiceBase<TContent, TContentType, TConte
     }
 
     protected async Task<Attempt<TContent?, ContentEditingOperationStatus>> HandleMoveToRecycleBinAsync(Guid key, Guid userKey)
-        => await HandleDeletionAsync(key, userKey, false, MoveToRecycleBin);
+        => await HandleDeletionAsync(key, userKey, ContentTrashStatusRequirement.MustBeNotTrashed, MoveToRecycleBin);
 
-    protected async Task<Attempt<TContent?, ContentEditingOperationStatus>> HandleDeleteAsync(Guid key, Guid userKey)
-        => await HandleDeletionAsync(key, userKey, true, Delete);
+    protected async Task<Attempt<TContent?, ContentEditingOperationStatus>> HandleDeleteAsync(Guid key, Guid userKey, bool mustBeTrashed = true)
+        => await HandleDeletionAsync(key, userKey, mustBeTrashed ? ContentTrashStatusRequirement.MustBeTrashed : ContentTrashStatusRequirement.Irrelevant, Delete);
 
     // helper method to perform move-to-recycle-bin and delete for content as they are very much handled in the same way
-    private async Task<Attempt<TContent?, ContentEditingOperationStatus>> HandleDeletionAsync(Guid key, Guid userKey, bool mustBeTrashed, Func<TContent, int, OperationResult?> performDelete)
+    private async Task<Attempt<TContent?, ContentEditingOperationStatus>> HandleDeletionAsync(Guid key, Guid userKey, ContentTrashStatusRequirement trashStatusRequirement, Func<TContent, int, OperationResult?> performDelete)
     {
         using ICoreScope scope = CoreScopeProvider.CreateCoreScope();
         TContent? content = ContentService.GetById(key);
@@ -118,9 +118,10 @@ internal abstract class ContentEditingServiceBase<TContent, TContentType, TConte
             return await Task.FromResult(Attempt.FailWithStatus(ContentEditingOperationStatus.NotFound, content));
         }
 
-        if (content.Trashed != mustBeTrashed)
+        if ((trashStatusRequirement is ContentTrashStatusRequirement.MustBeTrashed && content.Trashed is false)
+            || (trashStatusRequirement is ContentTrashStatusRequirement.MustBeNotTrashed && content.Trashed is true))
         {
-            ContentEditingOperationStatus status = mustBeTrashed
+            ContentEditingOperationStatus status = trashStatusRequirement is ContentTrashStatusRequirement.MustBeTrashed
                 ? ContentEditingOperationStatus.NotInTrash
                 : ContentEditingOperationStatus.InTrash;
             return await Task.FromResult(Attempt.FailWithStatus<TContent?, ContentEditingOperationStatus>(status, content));
@@ -470,4 +471,11 @@ internal abstract class ContentEditingServiceBase<TContent, TContentType, TConte
 
     private static Dictionary<string, IPropertyType> GetPropertyTypesByAlias(TContentType contentType)
         => contentType.CompositionPropertyTypes.ToDictionary(pt => pt.Alias);
+
+    private enum ContentTrashStatusRequirement
+    {
+        Irrelevant,
+        MustBeTrashed,
+        MustBeNotTrashed
+    }
 }

--- a/src/Umbraco.Core/Services/IContentEditingService.cs
+++ b/src/Umbraco.Core/Services/IContentEditingService.cs
@@ -14,11 +14,19 @@ public interface IContentEditingService
 
     Task<Attempt<IContent?, ContentEditingOperationStatus>> MoveToRecycleBinAsync(Guid key, Guid userKey);
 
-    Task<Attempt<IContent?, ContentEditingOperationStatus>> DeleteAsync(Guid key, Guid userKey);
+    /// <summary>
+    /// Deletes a Content Item if it is in the recycle bin.
+    /// </summary>
+    Task<Attempt<IContent?, ContentEditingOperationStatus>> DeleteFromRecycleBinAsync(Guid key, Guid userKey);
 
     Task<Attempt<IContent?, ContentEditingOperationStatus>> MoveAsync(Guid key, Guid? parentKey, Guid userKey);
 
     Task<Attempt<IContent?, ContentEditingOperationStatus>> CopyAsync(Guid key, Guid? parentKey, bool relateToOriginal, bool includeDescendants, Guid userKey);
 
     Task<ContentEditingOperationStatus> SortAsync(Guid? parentKey, IEnumerable<SortingModel> sortingModels, Guid userKey);
+
+    /// <summary>
+    /// Deletes a Content Item whether it is in the recycle bin or not.
+    /// </summary>
+    Task<Attempt<IContent?, ContentEditingOperationStatus>> DeleteAsync(Guid key, Guid userKey);
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.DeleteFromRecycleBin.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.DeleteFromRecycleBin.cs
@@ -8,7 +8,7 @@ public partial class ContentEditingServiceTests
 {
     [TestCase(true)]
     [TestCase(false)]
-    public async Task Can_Delete_FromRecycleBin(bool variant)
+    public async Task Can_DeleteFromRecycleBin_If_InsideRecycleBin(bool variant)
     {
         var content = await (variant ? CreateVariantContent() : CreateInvariantContent());
         await ContentEditingService.MoveToRecycleBinAsync(content.Key, Constants.Security.SuperUserKey);
@@ -22,26 +22,26 @@ public partial class ContentEditingServiceTests
         Assert.IsNull(content);
     }
 
+    [Test]
+    public async Task Cannot_Delete_FromRecycleBin_Non_Existing()
+    {
+        var result = await ContentEditingService.DeleteFromRecycleBinAsync(Guid.NewGuid(), Constants.Security.SuperUserKey);
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(ContentEditingOperationStatus.NotFound, result.Status);
+    }
+
     [TestCase(true)]
     [TestCase(false)]
-    public async Task Can_Delete_FromOutsideOfRecycleBin(bool variant)
+    public async Task Cannot_Delete_FromRecycleBin_If_Not_In_Recycle_Bin(bool variant)
     {
         var content = await (variant ? CreateVariantContent() : CreateInvariantContent());
 
-        var result = await ContentEditingService.DeleteAsync(content.Key, Constants.Security.SuperUserKey);
-        Assert.IsTrue(result.Success);
-        Assert.AreEqual(ContentEditingOperationStatus.Success, result.Status);
-
-        // re-get and verify deletion
-        content = await ContentEditingService.GetAsync(content.Key);
-        Assert.IsNull(content);
-    }
-
-    [Test]
-    public async Task Cannot_Delete_Non_Existing()
-    {
-        var result = await ContentEditingService.DeleteAsync(Guid.NewGuid(), Constants.Security.SuperUserKey);
+        var result = await ContentEditingService.DeleteFromRecycleBinAsync(content.Key, Constants.Security.SuperUserKey);
         Assert.IsFalse(result.Success);
-        Assert.AreEqual(ContentEditingOperationStatus.NotFound, result.Status);
+        Assert.AreEqual(ContentEditingOperationStatus.NotInTrash, result.Status);
+
+        // re-get and verify that deletion did not happen
+        content = await ContentEditingService.GetAsync(content.Key);
+        Assert.IsNotNull(content);
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.MoveToRecyleBin.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.MoveToRecyleBin.cs
@@ -25,7 +25,7 @@ public partial class ContentEditingServiceTests
     [Test]
     public async Task Cannot_Move_Non_Existing_To_Recycle_Bin()
     {
-        var result = await ContentEditingService.DeleteAsync(Guid.NewGuid(), Constants.Security.SuperUserKey);
+        var result = await ContentEditingService.MoveToRecycleBinAsync(Guid.NewGuid(), Constants.Security.SuperUserKey);
         Assert.IsFalse(result.Success);
         Assert.AreEqual(ContentEditingOperationStatus.NotFound, result.Status);
     }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
@@ -58,7 +58,7 @@
     <Compile Update="Umbraco.Infrastructure\Services\ContentEditingServiceTests.Copy.cs">
       <DependentUpon>ContentEditingServiceTests.cs</DependentUpon>
     </Compile>
-    <Compile Update="Umbraco.Infrastructure\Services\ContentEditingServiceTests.Delete.cs">
+    <Compile Update="Umbraco.Infrastructure\Services\ContentEditingServiceTests.DeleteFromRecycleBin.cs">
       <DependentUpon>ContentEditingServiceTests.cs</DependentUpon>
     </Compile>
     <Compile Update="Umbraco.Infrastructure\Services\ContentEditingServiceTests.Get.cs">
@@ -114,6 +114,9 @@
     </Compile>
     <Compile Update="Umbraco.Core\Services\MediaTypeEditingServiceTests.Update.cs">
       <DependentUpon>MediaTypeEditingServiceTests.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Umbraco.Infrastructure\Services\ContentEditingServiceTests.MoveToRecyleBin.cs">
+      <DependentUpon>ContentEditingServiceTests.cs</DependentUpon>
     </Compile>
   </ItemGroup>
 


### PR DESCRIPTION
### Description
This PR adds missing endpoints for deleting documents from anywhere and from the recycle bin specifically.

### Testing example payloads
Create document type
```
{
  "alias": "testDocType",
  "name": "testDocType",
  "description": "testDocType",
  "icon": "umb:wand",
  "allowedAsRoot": true,
  "variesByCulture": false,
  "variesBySegment": false,
  "isElement": false,
  "properties": [
    {
      "id": "7A9B8D0F-EC59-440F-A47A-79C9C4E65D25",
      "sortOrder": 0,
      "alias": "testProperty",
      "name": "testProperty",
      "description": "testProperty",
      "dataTypeId": "0cc0eba1-9960-42c9-bf9b-60e150b429ae",
      "variesByCulture": false,
      "variesBySegment": false
    }
  ]
}
```
create document (use ID from location header in previous request)
```
{
  "values": [
    {
      "culture": null,
      "segment": null,
      "alias": "testProperty",
      "value": "testValue"
    }
  ],
  "variants": [
    {
      "culture": null,
      "segment": null,
      "name": "testDocument"
    }
  ],
  "parentId": null,
  "contentTypeId": "THETYPEIDHERE"
}
```

### Testing
- [x] delete document that does not exist => fail
- [x] delete document from bin that does not exist => fail
- [x] move document to bin that does not exist => fail
- create a document
  - [x] delete it from the bin => fail
  - [x] move it to bin => success
  - [x] move it to bin => fail
  - [x] delete it from bin => success
  - [x] delete it from bin => fail
  - [x] fetch the document => fail
- create a document
  - [x] delete it => success
  - [x] fetch the document => fail
- create a document
  - [x] move it to bin => success
  - [x] delete it (trough the document endpoint, not recycle bin) => success
  - [x] fetch the document => fail