### PR TITLE
V14/feature/empty recycle bin endpoints

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/RecycleBin/EmptyDocumentRecycleBinController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/RecycleBin/EmptyDocumentRecycleBinController.cs
@@ -1,0 +1,56 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Security.Authorization.Content;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Web.Common.Authorization;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Document.RecycleBin;
+
+[ApiVersion("1.0")]
+public class EmptyDocumentRecycleBinController : DocumentRecycleBinControllerBase
+{
+    private readonly IAuthorizationService _authorizationService;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+    private readonly IContentService _contentService;
+    private readonly IUserIdKeyResolver _userIdKeyResolver;
+
+    public EmptyDocumentRecycleBinController(
+        IEntityService entityService,
+        IAuthorizationService authorizationService,
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
+        IContentService contentService,
+        IUserIdKeyResolver userIdKeyResolver)
+        : base(entityService)
+    {
+        _authorizationService = authorizationService;
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+        _contentService = contentService;
+        _userIdKeyResolver = userIdKeyResolver;
+    }
+
+    [HttpDelete]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> EmptyRecycleBin()
+    {
+        AuthorizationResult authorizationResult  = await _authorizationService.AuthorizeResourceAsync(
+            User,
+            ContentPermissionResource.RecycleBin(ActionDelete.ActionLetter),
+            AuthorizationPolicies.ContentPermissionByResource);
+
+        if (authorizationResult.Succeeded is false)
+        {
+            return Forbidden();
+        }
+
+        OperationResult result = _contentService.EmptyRecycleBin(await _userIdKeyResolver.GetAsync(CurrentUserKey(_backOfficeSecurityAccessor)));
+        return result.Success
+            ? Ok()
+            : OperationStatusResult(result);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/RecycleBin/EmptyDocumentRecycleBinController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/RecycleBin/EmptyDocumentRecycleBinController.cs
@@ -17,20 +17,17 @@ public class EmptyDocumentRecycleBinController : DocumentRecycleBinControllerBas
     private readonly IAuthorizationService _authorizationService;
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
     private readonly IContentService _contentService;
-    private readonly IUserIdKeyResolver _userIdKeyResolver;
 
     public EmptyDocumentRecycleBinController(
         IEntityService entityService,
         IAuthorizationService authorizationService,
         IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
-        IContentService contentService,
-        IUserIdKeyResolver userIdKeyResolver)
+        IContentService contentService)
         : base(entityService)
     {
         _authorizationService = authorizationService;
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
         _contentService = contentService;
-        _userIdKeyResolver = userIdKeyResolver;
     }
 
     [HttpDelete]
@@ -48,7 +45,7 @@ public class EmptyDocumentRecycleBinController : DocumentRecycleBinControllerBas
             return Forbidden();
         }
 
-        OperationResult result = _contentService.EmptyRecycleBin(await _userIdKeyResolver.GetAsync(CurrentUserKey(_backOfficeSecurityAccessor)));
+        OperationResult result = await _contentService.EmptyRecycleBinAsync(CurrentUserKey(_backOfficeSecurityAccessor));
         return result.Success
             ? Ok()
             : OperationStatusResult(result);

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/RecycleBin/EmptyMediaRecycleBinController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/RecycleBin/EmptyMediaRecycleBinController.cs
@@ -1,0 +1,53 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Controllers.Media.RecycleBin;
+using Umbraco.Cms.Api.Management.Security.Authorization.Media;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Web.Common.Authorization;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Document.RecycleBin;
+
+[ApiVersion("1.0")]
+public class EmptyMediaRecycleBinController : MediaRecycleBinControllerBase
+{
+    private readonly IAuthorizationService _authorizationService;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+    private readonly IMediaService _mediaService;
+
+    public EmptyMediaRecycleBinController(
+        IEntityService entityService,
+        IAuthorizationService authorizationService,
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
+        IMediaService mediaService)
+        : base(entityService)
+    {
+        _authorizationService = authorizationService;
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+        _mediaService = mediaService;
+    }
+
+    [HttpDelete]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> EmptyRecycleBin()
+    {
+        AuthorizationResult authorizationResult  = await _authorizationService.AuthorizeResourceAsync(
+            User,
+            MediaPermissionResource.RecycleBin(),
+            AuthorizationPolicies.MediaPermissionByResource);
+
+        if (authorizationResult.Succeeded is false)
+        {
+            return Forbidden();
+        }
+
+        OperationResult result = await _mediaService.EmptyRecycleBinAsync(CurrentUserKey(_backOfficeSecurityAccessor));
+        return result.Success
+            ? Ok()
+            : OperationStatusResult(result);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/RecycleBin/RecycleBinControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RecycleBin/RecycleBinControllerBase.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Services;
@@ -77,6 +79,17 @@ public abstract class RecycleBinControllerBase<TItem> : ManagementApiControllerB
         return viewModel;
     }
 
+    protected IActionResult OperationStatusResult(OperationResult result) =>
+        result.Result switch
+        {
+            OperationResultType.FailedCancelledByEvent => BadRequest(new ProblemDetailsBuilder()
+                .WithTitle("Cancelled by notification")
+                .WithDetail("A notification handler prevented the operation.")
+                .Build()),
+            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+                .WithTitle("Unknown operation status.")
+                .Build()),
+        };
     private IEntitySlim[] GetPagedRootEntities(long pageNumber, int pageSize, out long totalItems)
     {
         IEntitySlim[] rootEntities = _entityService

--- a/src/Umbraco.Cms.Api.Management/Umbraco.Cms.Api.Management.csproj
+++ b/src/Umbraco.Cms.Api.Management/Umbraco.Cms.Api.Management.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="JsonPatch.Net" />
-    <PackageReference Include="Swashbuckle.AspNetCore"  />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -32,6 +32,7 @@ public class ContentService : RepositoryService, IContentService
     private readonly Lazy<IPropertyValidationService> _propertyValidationService;
     private readonly IShortStringHelper _shortStringHelper;
     private readonly ICultureImpactFactory _cultureImpactFactory;
+    private readonly IUserIdKeyResolver _userIdKeyResolver;
     private IQuery<IContent>? _queryNotTrashed;
 
     #region Constructors
@@ -48,7 +49,8 @@ public class ContentService : RepositoryService, IContentService
     ILanguageRepository languageRepository,
     Lazy<IPropertyValidationService> propertyValidationService,
     IShortStringHelper shortStringHelper,
-    ICultureImpactFactory cultureImpactFactory)
+    ICultureImpactFactory cultureImpactFactory,
+    IUserIdKeyResolver userIdKeyResolver)
     : base(provider, loggerFactory, eventMessagesFactory)
     {
         _documentRepository = documentRepository;
@@ -60,10 +62,11 @@ public class ContentService : RepositoryService, IContentService
         _propertyValidationService = propertyValidationService;
         _shortStringHelper = shortStringHelper;
         _cultureImpactFactory = cultureImpactFactory;
+        _userIdKeyResolver = userIdKeyResolver;
         _logger = loggerFactory.CreateLogger<ContentService>();
     }
 
-    [Obsolete("Use constructor that takes ICultureImpactService as a parameter, scheduled for removal in V12")]
+    [Obsolete("Use constructor that takes IUserIdKeyResolver as a parameter, scheduled for removal in V15")]
     public ContentService(
         ICoreScopeProvider provider,
         ILoggerFactory loggerFactory,
@@ -75,7 +78,8 @@ public class ContentService : RepositoryService, IContentService
         IDocumentBlueprintRepository documentBlueprintRepository,
         ILanguageRepository languageRepository,
         Lazy<IPropertyValidationService> propertyValidationService,
-        IShortStringHelper shortStringHelper)
+        IShortStringHelper shortStringHelper,
+        ICultureImpactFactory cultureImpactFactory)
         : this(
             provider,
             loggerFactory,
@@ -88,7 +92,8 @@ public class ContentService : RepositoryService, IContentService
             languageRepository,
             propertyValidationService,
             shortStringHelper,
-            StaticServiceProvider.Instance.GetRequiredService<ICultureImpactFactory>())
+            cultureImpactFactory,
+            StaticServiceProvider.Instance.GetRequiredService<IUserIdKeyResolver>())
     {
     }
 
@@ -2519,6 +2524,9 @@ public class ContentService : RepositoryService, IContentService
         content.WriterId = userId;
         _documentRepository.Save(content);
     }
+
+    public async Task<OperationResult> EmptyRecycleBinAsync(Guid userId)
+        => EmptyRecycleBin(await _userIdKeyResolver.GetAsync(userId));
 
     /// <summary>
     ///     Empties the Recycle Bin by deleting all <see cref="IContent" /> that resides in the bin

--- a/src/Umbraco.Core/Services/IContentService.cs
+++ b/src/Umbraco.Core/Services/IContentService.cs
@@ -165,7 +165,7 @@ public interface IContentService : IContentServiceBase<IContent>
     /// </summary>
     /// <returns>An Enumerable list of <see cref="IContent" /> objects</returns>
     /// <remarks>
-    ///     The content returned from this method may be culture variant, in which case you can use 
+    ///     The content returned from this method may be culture variant, in which case you can use
     ///     <see cref="Umbraco.Extensions.ContentExtensions.GetStatus(IContent, ContentScheduleCollection, string?)" /> to get the status for a specific culture.
     /// </remarks>
     IEnumerable<IContent> GetContentForExpiration(DateTime date);
@@ -175,7 +175,7 @@ public interface IContentService : IContentServiceBase<IContent>
     /// </summary>
     /// <returns>An Enumerable list of <see cref="IContent" /> objects</returns>
     /// <remarks>
-    ///     The content returned from this method may be culture variant, in which case you can use 
+    ///     The content returned from this method may be culture variant, in which case you can use
     ///     <see cref="Umbraco.Extensions.ContentExtensions.GetStatus(IContent, ContentScheduleCollection, string?)" /> to get the status for a specific culture.
     /// </remarks>
     IEnumerable<IContent> GetContentForRelease(DateTime date);
@@ -521,4 +521,6 @@ public interface IContentService : IContentServiceBase<IContent>
     IContent CreateAndSave(string name, IContent parent, string contentTypeAlias, int userId = Constants.Security.SuperUserId);
 
     #endregion
+
+    Task<OperationResult> EmptyRecycleBinAsync(Guid userId);
 }

--- a/src/Umbraco.Core/Services/IMediaService.cs
+++ b/src/Umbraco.Core/Services/IMediaService.cs
@@ -381,4 +381,6 @@ public interface IMediaService : IContentServiceBase<IMedia>
     /// <param name="filepath">The filesystem path to the media.</param>
     /// <returns>The size of the media.</returns>
     long GetMediaFileSize(string filepath);
+
+    Task<OperationResult> EmptyRecycleBinAsync(Guid userId);
 }

--- a/src/Umbraco.Core/Services/MediaService.cs
+++ b/src/Umbraco.Core/Services/MediaService.cs
@@ -1,5 +1,7 @@
 using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
@@ -25,6 +27,7 @@ namespace Umbraco.Cms.Core.Services
         private readonly IAuditRepository _auditRepository;
         private readonly IEntityRepository _entityRepository;
         private readonly IShortStringHelper _shortStringHelper;
+        private readonly IUserIdKeyResolver _userIdKeyResolver;
 
         private readonly MediaFileManager _mediaFileManager;
 
@@ -39,7 +42,8 @@ namespace Umbraco.Cms.Core.Services
             IAuditRepository auditRepository,
             IMediaTypeRepository mediaTypeRepository,
             IEntityRepository entityRepository,
-            IShortStringHelper shortStringHelper)
+            IShortStringHelper shortStringHelper,
+            IUserIdKeyResolver userIdKeyResolver)
             : base(provider, loggerFactory, eventMessagesFactory)
         {
             _mediaFileManager = mediaFileManager;
@@ -48,6 +52,33 @@ namespace Umbraco.Cms.Core.Services
             _mediaTypeRepository = mediaTypeRepository;
             _entityRepository = entityRepository;
             _shortStringHelper = shortStringHelper;
+            _userIdKeyResolver = userIdKeyResolver;
+        }
+
+        [Obsolete("Use constructor that takes IUserIdKeyResolver as a parameter, scheduled for removal in V15")]
+        public MediaService(
+            ICoreScopeProvider provider,
+            MediaFileManager mediaFileManager,
+            ILoggerFactory loggerFactory,
+            IEventMessagesFactory eventMessagesFactory,
+            IMediaRepository mediaRepository,
+            IAuditRepository auditRepository,
+            IMediaTypeRepository mediaTypeRepository,
+            IEntityRepository entityRepository,
+            IShortStringHelper shortStringHelper)
+            : this(
+                provider,
+                mediaFileManager,
+                loggerFactory,
+                eventMessagesFactory,
+                mediaRepository,
+                auditRepository,
+                mediaTypeRepository,
+                entityRepository,
+                shortStringHelper,
+                StaticServiceProvider.Instance.GetRequiredService<IUserIdKeyResolver>()
+                )
+        {
         }
 
         #endregion
@@ -1088,6 +1119,9 @@ namespace Umbraco.Cms.Core.Services
 
             _mediaRepository.Save(media);
         }
+
+        public async Task<OperationResult> EmptyRecycleBinAsync(Guid userId)
+            => EmptyRecycleBin(await _userIdKeyResolver.GetAsync(userId));
 
         /// <summary>
         /// Empties the Recycle Bin by deleting all <see cref="IMedia"/> that resides in the bin


### PR DESCRIPTION
### Description
This PR adds the missing endpoints to empty the recycle bin for documents and media items

### Testing example payloads
Create document type
```
{
  "alias": "testDocType",
  "name": "testDocType",
  "description": "testDocType",
  "icon": "umb:wand",
  "allowedAsRoot": true,
  "variesByCulture": false,
  "variesBySegment": false,
  "isElement": false,
  "properties": [
    {
      "id": "7A9B8D0F-EC59-440F-A47A-79C9C4E65D25",
      "sortOrder": 0,
      "alias": "testProperty",
      "name": "testProperty",
      "description": "testProperty",
      "dataTypeId": "0cc0eba1-9960-42c9-bf9b-60e150b429ae",
      "variesByCulture": false,
      "variesBySegment": false
    }
  ]
}
```
create document (use ID from location header in previous request)
```
{
  "values": [
    {
      "culture": null,
      "segment": null,
      "alias": "testProperty",
      "value": "testValue"
    }
  ],
  "variants": [
    {
      "culture": null,
      "segment": null,
      "name": "testDocument"
    }
  ],
  "parentId": null,
  "contentTypeId": "THETYPEIDHERE"
}
```
create minimal media item from standard media type
```
{
  "variants": [
    {
      "culture": null,
      "segment": null,
      "name": "testImage"
    }
  ],
  "contentTypeId": "cc07b313-0843-4aa8-bbda-871c8da728c8"
}
```

### Testing
- [ ] empty document recycle bin with no items in it => success
- [ ] empty document recycle bin with no items in it => success
- create a document
  - move it to the bin
  - check item is in the bin
  - [ ] empty document recycle bin => success
  - [ ] get items in document recycle bin => empty
 - create a media item
  - move it to the bin
  - check item is in the bin
  - [ ] empty media recycle bin => success
  - [ ] get items in media recycle bin => empty