### PR TITLE
Updates DeliveryApiConfiguration to include link to new media delivery api article 

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Configuration/DeliveryApiConfiguration.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Configuration/DeliveryApiConfiguration.cs
@@ -8,6 +8,5 @@ internal static class DeliveryApiConfiguration
 
     internal const string ApiDocumentationContentArticleLink = "https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api";
 
-    // TODO: update this when the Media article is out
-    internal const string ApiDocumentationMediaArticleLink = "https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api";
+    internal const string ApiDocumentationMediaArticleLink = "https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api";
 }


### PR DESCRIPTION
### Prerequisites

See details in PR https://github.com/umbraco/Umbraco-CMS/issues/15610 

### Description

The `DeliveryApiConfiguration.cs` file had the incorrect link, with a TODO intending to correct it. I removed the TODO, and added the correct link. 
