### PR TITLE
V13 RC: Document types throw an error when inserting a block capable editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -367,7 +367,6 @@
              * @name load
              * @methodOf umbraco.services.blockEditorModelObject
              * @description Load the scaffolding models for the given configuration, these are needed to provide useful models for each block.
-             * @param {Object} blockObject BlockObject to receive data values from.
              * @returns {Promise} A Promise object which resolves when all scaffold models are loaded.
              */
             load: function () {
@@ -398,9 +397,15 @@
                 scaffoldKeys = scaffoldKeys.filter((value, index, self) => self.indexOf(value) === index);
 
                 if(scaffoldKeys.length > 0) {
-                  var currentPage = editorState.getCurrent();
-                  var currentPageId = currentPage ? (currentPage.id > 0 ? currentPage.id : currentPage.parentId) : null || -20;
+                  // We need to know if we are in the document type editor or content editor.
+                  // If we are in the document type editor, we need to use -20 as the current page id.
+                  // If we are in the content editor, we need to use the current page id or parent id if the current page is new.
+                  // We can recognize a content editor context by checking if the current editor state has a contentTypeKey.
+                  const currentEditorState = editorState.getCurrent();
+                  const currentPageId = currentEditorState.contentTypeKey ? currentEditorState.id || currentEditorState.parentId || -20 : -20;
 
+                  // Load all scaffolds for the block types.
+                  // The currentPageId is used to determine the access level for the current user.
                   tasks.push(contentResource.getScaffoldByKeys(currentPageId, scaffoldKeys).then(scaffolds => {
                       Object.values(scaffolds).forEach(scaffold => {
                           // self.scaffolds might not exists anymore, this happens if this instance has been destroyed before the load is complete.


### PR DESCRIPTION
### Description

Fixes #15588

A minor regression was introduced with #15063 where the `editorState` held an actual id when used in the Document Type Editor as well, but since this is not real content, the request to GetEmptyByKeys would throw an error whenever you insert any block capable editor on a document type (e.g. rich text editor, block list, and block grid).

This has been fixed by checking if we are inside a content editor context or editing a document type by checking for the presence of the property `contentTypeKey` on `editorState.getCurrent()`, which should only be present when editing actual content, which has an actual id representing content in the database.