### PR TITLE
Fix for issue 15598

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/JsonPropertyIndexValueFactoryBase.cs
+++ b/src/Umbraco.Core/PropertyEditors/JsonPropertyIndexValueFactoryBase.cs
@@ -40,7 +40,7 @@ public abstract class JsonPropertyIndexValueFactoryBase<TSerialized> : IProperty
 
     }
 
-    public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(
+    public virtual IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(
         IProperty property,
         string? culture,
         string? segment,

--- a/src/Umbraco.Core/PropertyEditors/TagPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Core/PropertyEditors/TagPropertyIndexValueFactory.cs
@@ -1,20 +1,26 @@
+using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Web.Common.DependencyInjection;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
 public class TagPropertyIndexValueFactory : JsonPropertyIndexValueFactoryBase<string[]>, ITagPropertyIndexValueFactory
 {
+    private IndexingSettings _indexingSettings;
+
     public TagPropertyIndexValueFactory(
         IJsonSerializer jsonSerializer,
         IOptionsMonitor<IndexingSettings> indexingSettings)
         : base(jsonSerializer, indexingSettings)
     {
         ForceExplicitlyIndexEachNestedProperty = true;
+        _indexingSettings = indexingSettings.CurrentValue;
+        indexingSettings.OnChange(newValue => _indexingSettings = newValue);
     }
 
     [Obsolete("Use non-obsolete constructor. This will be removed in Umbraco 14.")]
@@ -44,5 +50,41 @@ public class TagPropertyIndexValueFactory : JsonPropertyIndexValueFactoryBase<st
         bool published)
     {
         yield return new KeyValuePair<string, IEnumerable<object?>>(property.Alias, deserializedPropertyValue);
+    }
+
+    public override IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(
+        IProperty property,
+        string? culture,
+        string? segment,
+        bool published,
+        IEnumerable<string> availableCultures,
+        IDictionary<Guid, IContentType> contentTypeDictionary)
+    {
+        IEnumerable<KeyValuePair<string, IEnumerable<object?>>> jsonValues = base.GetIndexValues(property, culture, segment, published, availableCultures, contentTypeDictionary);
+        if (jsonValues?.Any() is true)
+        {
+            return jsonValues;
+        }
+
+        var result = new List<KeyValuePair<string, IEnumerable<object?>>>();
+
+        var propertyValue = property.GetValue(culture, segment, published);
+
+        // If there is a value, it's a string and it's not empty/white space
+        if (propertyValue is string rawValue && !string.IsNullOrWhiteSpace(rawValue))
+        {
+            var values = rawValue.Split(',', StringSplitOptions.RemoveEmptyEntries);
+
+            result.AddRange(Handle(values, property, culture, segment, published, availableCultures, contentTypeDictionary));
+        }
+
+        IEnumerable<KeyValuePair<string, IEnumerable<object?>>> summary = HandleResume(result, property, culture, segment, published);
+        if (_indexingSettings.ExplicitlyIndexEachNestedProperty || ForceExplicitlyIndexEachNestedProperty)
+        {
+            result.AddRange(summary);
+            return result;
+        }
+
+        return summary;
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

https://github.com/umbraco/Umbraco-CMS/issues/15598

### Description
The problem that causes the issue above is that the `TagPropertyIndexValueFactory` uses the JSON base class which tries to detect JSON in the property value. However, since the tags are stored as CSV, it isn't valid JSON and therefore no values get added to the value set. I've changed the `TagPropertyIndexValueFactory` to first try the usual JSON values, if that comes back empty, it will then try to get values as if they were stored as CSV.

To test, set the default Tags property editor to be stored as CSV and then add a property to any document type that uses said property editor. Add some values and save. Check the ExternalIndex and you should now see that the tags property is indexed.