### PR TITLE
Fixing #14088 (Info tab alias url incorrect).

### DIFF
--- a/src/Umbraco.Core/Routing/AliasUrlProvider.cs
+++ b/src/Umbraco.Core/Routing/AliasUrlProvider.cs
@@ -144,7 +144,7 @@ public class AliasUrlProvider : IUrlProvider
                 foreach (var alias in aliases.Distinct())
                 {
                     var path = "/" + alias;
-                    var uri = new Uri(CombinePaths(domainUri.Uri.GetLeftPart(UriPartial.Path), path));
+                    var uri = new Uri(CombinePaths(domainUri.Uri.GetLeftPart(UriPartial.Authority), path));
                     yield return UrlInfo.Url(
                         _uriUtility.UriFromUmbraco(uri, _requestConfig).ToString(),
                         domainUri.Culture);


### PR DESCRIPTION


### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #14088.

### Description

Match content finder functionality in the url provider for `umbracoUrlAlias`, specifically when domains with paths are specified (e.g. `/en`). This allows the Info tab in the back office to show the correct url when an alias is specified with an `umbracoUrlAlias` field, as well as returning correct urls when the various url providers are queried in dotnet.

To test, add a domain to the root node that contains a path, e.g. `/en`. Add a text field with the alias `umbracoUrlAlias` to a document type for content under the root node. Add a value to the content, e.g. `aliased-url`, and save and publish. The resulting aliased url shown in the Info tab for the content should contain the domain root and **not** the domain path, e.g. it should be `https://localhost:44331/aliased-url` and not `https://localhost:44331/en/aliased-url`. When clicked in the Info tab or browsed to directly, the aliased url should open the associated content page.