### PR TITLE
Get references from macro parameters using IDataValueReferenceFactory

### DIFF
--- a/src/Umbraco.Infrastructure/Templates/HtmlMacroParameterParser.cs
+++ b/src/Umbraco.Infrastructure/Templates/HtmlMacroParameterParser.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Umbraco.Cms.Core;
@@ -6,6 +7,7 @@ using Umbraco.Cms.Core.Models.Editors;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Macros;
+using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Templates;
@@ -15,12 +17,23 @@ public sealed class HtmlMacroParameterParser : IHtmlMacroParameterParser
     private readonly ILogger<HtmlMacroParameterParser> _logger;
     private readonly IMacroService _macroService;
     private readonly ParameterEditorCollection _parameterEditors;
+    private readonly DataValueReferenceFactoryCollection _dataValueReferenceFactories;
 
+    [Obsolete("Use the non-obsolete overload instead, scheduled for removal in v14")]
     public HtmlMacroParameterParser(IMacroService macroService, ILogger<HtmlMacroParameterParser> logger, ParameterEditorCollection parameterEditors)
+        : this(
+            macroService,
+            logger,
+            parameterEditors,
+            StaticServiceProvider.Instance.GetRequiredService<DataValueReferenceFactoryCollection>())
+    { }
+
+    public HtmlMacroParameterParser(IMacroService macroService, ILogger<HtmlMacroParameterParser> logger, ParameterEditorCollection parameterEditors, DataValueReferenceFactoryCollection dataValueReferenceFactories)
     {
         _macroService = macroService;
         _logger = logger;
         _parameterEditors = parameterEditors;
+        _dataValueReferenceFactories = dataValueReferenceFactories;
     }
 
     /// <summary>
@@ -41,6 +54,7 @@ public sealed class HtmlMacroParameterParser : IHtmlMacroParameterParser
             (macroAlias, macroAttributes) => foundMacros.Add(new Tuple<string?, Dictionary<string, string>>(
                 macroAlias,
                 new Dictionary<string, string>(macroAttributes, StringComparer.OrdinalIgnoreCase))));
+
         foreach (UmbracoEntityReference umbracoEntityReference in GetUmbracoEntityReferencesFromMacros(foundMacros))
         {
             yield return umbracoEntityReference;
@@ -52,8 +66,7 @@ public sealed class HtmlMacroParameterParser : IHtmlMacroParameterParser
     /// </summary>
     /// <param name="macroGridControls"></param>
     /// <returns></returns>
-    public IEnumerable<UmbracoEntityReference> FindUmbracoEntityReferencesFromGridControlMacros(
-        IEnumerable<GridValue.GridControl> macroGridControls)
+    public IEnumerable<UmbracoEntityReference> FindUmbracoEntityReferencesFromGridControlMacros(IEnumerable<GridValue.GridControl> macroGridControls)
     {
         var foundMacros = new List<Tuple<string?, Dictionary<string, string>>>();
 
@@ -65,8 +78,7 @@ public sealed class HtmlMacroParameterParser : IHtmlMacroParameterParser
             // Collect any macro parameters that contain the media udi format
             if (gridMacro is not null && gridMacro.MacroParameters is not null && gridMacro.MacroParameters.Any())
             {
-                foundMacros.Add(
-                    new Tuple<string?, Dictionary<string, string>>(gridMacro.MacroAlias, gridMacro.MacroParameters));
+                foundMacros.Add(new Tuple<string?, Dictionary<string, string>>(gridMacro.MacroAlias, gridMacro.MacroParameters));
             }
         }
 
@@ -101,14 +113,12 @@ public sealed class HtmlMacroParameterParser : IHtmlMacroParameterParser
                 continue;
             }
 
-            foundMacroUmbracoEntityReferences.Add(
-                new UmbracoEntityReference(Udi.Create(Constants.UdiEntityType.Macro, macroConfig.Key)));
+            foundMacroUmbracoEntityReferences.Add(new UmbracoEntityReference(Udi.Create(Constants.UdiEntityType.Macro, macroConfig.Key)));
 
             // Only do this if the macros actually have parameters
             if (macroConfig.Properties.Keys.Any(f => f != "macroAlias"))
             {
-                foreach (UmbracoEntityReference umbracoEntityReference in GetUmbracoEntityReferencesFromMacroParameters(
-                             macro.Item2, macroConfig, _parameterEditors))
+                foreach (UmbracoEntityReference umbracoEntityReference in GetUmbracoEntityReferencesFromMacroParameters(macro.Item2, macroConfig, _parameterEditors))
                 {
                     yield return umbracoEntityReference;
                 }
@@ -130,41 +140,23 @@ public sealed class HtmlMacroParameterParser : IHtmlMacroParameterParser
     ///     look up the corresponding property editor for a macro parameter
     /// </param>
     /// <returns></returns>
-    private IEnumerable<UmbracoEntityReference> GetUmbracoEntityReferencesFromMacroParameters(
-        Dictionary<string, string> macroParameters, IMacro macroConfig, ParameterEditorCollection parameterEditors)
+    private IEnumerable<UmbracoEntityReference> GetUmbracoEntityReferencesFromMacroParameters(Dictionary<string, string> macroParameters, IMacro macroConfig, ParameterEditorCollection parameterEditors)
     {
-        var foundUmbracoEntityReferences = new List<UmbracoEntityReference>();
         foreach (IMacroProperty parameter in macroConfig.Properties)
         {
             if (macroParameters.TryGetValue(parameter.Alias, out var parameterValue))
             {
                 var parameterEditorAlias = parameter.EditorAlias;
-
-                // Lookup propertyEditor from the registered ParameterEditors with the implmementation to avoid looking up for each parameter
-                IDataEditor? parameterEditor = parameterEditors.FirstOrDefault(f =>
-                    string.Equals(f.Alias, parameterEditorAlias, StringComparison.OrdinalIgnoreCase));
+                IDataEditor? parameterEditor = parameterEditors.FirstOrDefault(f => string.Equals(f.Alias, parameterEditorAlias, StringComparison.OrdinalIgnoreCase));
                 if (parameterEditor is not null)
                 {
-                    // Get the ParameterValueEditor for this PropertyEditor (where the GetReferences method is implemented) - cast as IDataValueReference to determine if 'it is' implemented for the editor
-                    if (parameterEditor.GetValueEditor() is IDataValueReference parameterValueEditor)
+                    foreach (UmbracoEntityReference entityReference in _dataValueReferenceFactories.GetReferences(parameterEditor, parameterValue))
                     {
-                        foreach (UmbracoEntityReference entityReference in parameterValueEditor.GetReferences(
-                                     parameterValue))
-                        {
-                            foundUmbracoEntityReferences.Add(entityReference);
-                        }
-                    }
-                    else
-                    {
-                        _logger.LogInformation(
-                            "{0} doesn't have a ValueEditor that implements IDataValueReference",
-                            parameterEditor.Alias);
+                        yield return entityReference;
                     }
                 }
             }
         }
-
-        return foundUmbracoEntityReferences;
     }
 
     // Poco class to deserialise the Json for a Macro Control


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
When @bergmania was merging https://github.com/umbraco/Umbraco-CMS/pull/15593 up to the latest versions, he noticed that the changes didn't affect parsing references from macros. Although the `RichTextPropertyValueEditor` and `GridPropertyValueEditor` already used `IHtmlMacroParameterParser` to get references from the macro parameter editors, this implementation didn't use the `IDataValueReferenceFactory` (and relied on value editor implementing `IDataValueReference` directly). After applying this PR, the factories will also be used when getting references, ensuring full compatibility.

To test this, first create a macro that uses e.g. the Multiple Media Picker as parameter. Add this macro to a RTE or (legacy) Grid editor property, pick some media items and save/publish the page. Even before this PR, the reference to the page should be listed on the media item(s).

Now add the following composer to add a data value reference factory and check whether the `GetReferences()` method is called when saving the page. If you change the media UDI/GUID to one that isn't already selected, the relation to that media item should also be visible when this PR is applied:

```c#
using Umbraco.Cms.Core;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Models.Editors;
using Umbraco.Cms.Core.PropertyEditors;

internal class MultipleMediaPickerPickerDataValueReferenceComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder) => builder.DataValueReferenceFactories().Append<MultipleMediaPickerDataValueReferenceFactory>();

    private class MultipleMediaPickerDataValueReferenceFactory : IDataValueReferenceFactory
    {
        public bool IsForEditor(IDataEditor? dataEditor) => dataEditor?.Alias == Constants.PropertyEditors.Aliases.MultipleMediaPicker;

        public IDataValueReference GetDataValueReference() => new MultipleMediaPickerDataValueReference();

        private class MultipleMediaPickerDataValueReference : IDataValueReference
        {
            public IEnumerable<UmbracoEntityReference> GetReferences(object? value)
            {
                // Return static reference for testing
                yield return new UmbracoEntityReference(Udi.Create(Constants.UdiEntityType.Media, new Guid("4de39248-0fdd-4f1f-bf15-07935b1be83d")));
            }
        }
    }
}
```