### PR TITLE
Made some internal classes public

### DIFF
--- a/src/Umbraco.Web/Editors/Binders/BlueprintItemBinder.cs
+++ b/src/Umbraco.Web/Editors/Binders/BlueprintItemBinder.cs
@@ -5,7 +5,7 @@ using Umbraco.Web.Models.ContentEditing;
 
 namespace Umbraco.Web.Editors.Binders
 {
-    internal class BlueprintItemBinder : ContentItemBinder
+    public class BlueprintItemBinder : ContentItemBinder
     {
         public BlueprintItemBinder()
         {

--- a/src/Umbraco.Web/Editors/Binders/ContentItemBinder.cs
+++ b/src/Umbraco.Web/Editors/Binders/ContentItemBinder.cs
@@ -15,7 +15,7 @@ namespace Umbraco.Web.Editors.Binders
     /// <summary>
     /// The model binder for <see cref="T:Umbraco.Web.Models.ContentEditing.ContentItemSave" />
     /// </summary>
-    internal class ContentItemBinder : IModelBinder
+    public class ContentItemBinder : IModelBinder
     {
         public ContentItemBinder() : this(Current.Services)
         {

--- a/src/Umbraco.Web/Editors/Filters/ContentSaveValidationAttribute.cs
+++ b/src/Umbraco.Web/Editors/Filters/ContentSaveValidationAttribute.cs
@@ -23,7 +23,7 @@ namespace Umbraco.Web.Editors.Filters
     /// <summary>
     /// Validates the incoming <see cref="ContentItemSave"/> model along with if the user is allowed to perform the operation
     /// </summary>
-    internal sealed class ContentSaveValidationAttribute : ActionFilterAttribute
+    public sealed class ContentSaveValidationAttribute : ActionFilterAttribute
     {
         private readonly ILogger _logger;
         private readonly IUmbracoContextAccessor _umbracoContextAccessor;

--- a/src/Umbraco.Web/WebApi/Filters/FileUploadCleanupFilterAttribute.cs
+++ b/src/Umbraco.Web/WebApi/Filters/FileUploadCleanupFilterAttribute.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Web.WebApi.Filters
     /// <summary>
     /// Checks if the parameter is IHaveUploadedFiles and then deletes any temporary saved files from file uploads associated with the request
     /// </summary>
-    internal sealed class FileUploadCleanupFilterAttribute : ActionFilterAttribute
+    public sealed class FileUploadCleanupFilterAttribute : ActionFilterAttribute
     {
         private readonly bool _incomingModel;
 


### PR DESCRIPTION
Made some internal classes public, so its possible to bypass security for packages like DTGE.
Related: https://github.com/umbraco/Umbraco-CMS/issues/15572

Fixes: https://github.com/umbraco/Umbraco-CMS/discussions/15560

### Example
```cs
using Umbraco.Core;
using Umbraco.Core.Cache;
using Umbraco.Core.Configuration;
using Umbraco.Core.Logging;
using Umbraco.Core.Persistence;
using Umbraco.Core.PropertyEditors;
using Umbraco.Core.Scoping;
using Umbraco.Core.Services;
using Umbraco.Web;
using Umbraco.Web.Editors;
using Umbraco.Web.Models.ContentEditing;
using Umbraco.Web.WebApi.Filters;
using Umbraco.Web.Editors.Filters;
using Umbraco.Web.Editors.Binders;
using System.Web.Http.ModelBinding;

namespace ClassLibrary2
{

    [Umbraco.Web.Mvc.PluginController("dtge")]
    [UmbracoApplicationAuthorize(Constants.Applications.Content)]
    public class WhateverController : BackOfficeNotificationsController
    {
        private ContentController _contentController;

        public WhateverController(PropertyEditorCollection propertyEditors, IGlobalSettings globalSettings,
     IUmbracoContextAccessor umbracoContextAccessor, ISqlContext sqlContext, ServiceContext services,
     AppCaches appCaches, IProfilingLogger logger, IRuntimeState runtimeState, UmbracoHelper umbracoHelper,
     IScopeProvider scopeProvider)
     : base(globalSettings, umbracoContextAccessor, sqlContext, services, appCaches, logger, runtimeState, umbracoHelper)
        {
            _contentController = new ContentController(propertyEditors, globalSettings, umbracoContextAccessor, sqlContext, services, appCaches,logger,runtimeState,umbracoHelper,scopeProvider);
        }


        [FileUploadCleanupFilter]
        [ContentSaveValidation(skipUserAccessValidation: true)]
        public ContentItemDisplay PostSaveBlueprint([ModelBinder(typeof(BlueprintItemBinder))] ContentItemSave contentItem)
        {
            return _contentController.PostSaveBlueprint(contentItem);
        }
    }
}

```