### PR TITLE
#15568 fixed by adding IRichTextEditorIntermediateValue

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/IRichTextEditorIntermediateValue.cs
+++ b/src/Umbraco.Core/PropertyEditors/IRichTextEditorIntermediateValue.cs
@@ -1,0 +1,13 @@
+using Umbraco.Cms.Core.Models.Blocks;
+
+namespace Umbraco.Cms.Core.PropertyEditors;
+
+/// <summary>
+/// Models Intermediate Value for Rich Text Editors Property Value Converter.
+/// </summary>
+public interface IRichTextEditorIntermediateValue
+{
+    public string Markup { get; }
+
+    public RichTextBlockModel? RichTextBlockModel { get; }
+}

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RteMacroRenderingValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RteMacroRenderingValueConverter.cs
@@ -156,7 +156,7 @@ public class RteMacroRenderingValueConverter : SimpleTinyMceValueConverter, IDel
 
     public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding)
     {
-        if (inter is not RichTextEditorIntermediateValue richTextEditorIntermediateValue
+        if (inter is not IRichTextEditorIntermediateValue richTextEditorIntermediateValue
             || richTextEditorIntermediateValue.Markup.IsNullOrWhiteSpace())
         {
             // different return types for the JSON configuration forces us to have different return values for empty properties
@@ -201,7 +201,7 @@ public class RteMacroRenderingValueConverter : SimpleTinyMceValueConverter, IDel
 
     private string? Convert(object? source, bool preview)
     {
-        if (source is not RichTextEditorIntermediateValue intermediateValue)
+        if (source is not IRichTextEditorIntermediateValue intermediateValue)
         {
             return null;
         }
@@ -291,7 +291,7 @@ public class RteMacroRenderingValueConverter : SimpleTinyMceValueConverter, IDel
         return RichTextParsingRegexes.BlockRegex().Replace(source, RenderBlock);
     }
 
-    private RichTextModel CreateRichTextModel(RichTextEditorIntermediateValue richTextEditorIntermediateValue)
+    private RichTextModel CreateRichTextModel(IRichTextEditorIntermediateValue richTextEditorIntermediateValue)
     {
         var markup = _apiRichTextMarkupParser.Parse(richTextEditorIntermediateValue.Markup);
 
@@ -308,7 +308,7 @@ public class RteMacroRenderingValueConverter : SimpleTinyMceValueConverter, IDel
         };
     }
 
-    private class RichTextEditorIntermediateValue
+    private class RichTextEditorIntermediateValue : IRichTextEditorIntermediateValue
     {
         public required string Markup { get; set; }
 


### PR DESCRIPTION
Fixes this issue by adding a interface for the internal intermediate value-class for the Rich Text Editor PVC.

https://github.com/umbraco/Umbraco-CMS/discussions/15568#discussioncomment-8256627

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
Adds the interface `IRichTextEditorIntermediateValue` so that sub-classes to `RteMacroRenderingValueConverter` can provide values for the methods in the base class.

