### PR TITLE
Move the ContentControllerBase to the correct location

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Content/ContentControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Content/ContentControllerBase.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Management.Controllers;
 using Umbraco.Cms.Api.Management.ViewModels.Content;
 using Umbraco.Cms.Api.Management.ViewModels.Document;
 using Umbraco.Cms.Core.Models.ContentEditing;
@@ -9,7 +8,7 @@ using Umbraco.Cms.Core.Models.ContentPublishing;
 using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Extensions;
 
-namespace Umbraco.Cms.Api.Management.Content;
+namespace Umbraco.Cms.Api.Management.Controllers.Content;
 
 public class ContentControllerBase : ManagementApiControllerBase
 {

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/DocumentControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/DocumentControllerBase.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Management.Content;
+using Umbraco.Cms.Api.Management.Controllers.Content;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Api.Management.ViewModels.Content;
 using Umbraco.Cms.Api.Management.ViewModels.Document;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/MediaControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/MediaControllerBase.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
-using Umbraco.Cms.Api.Management.Content;
+using Umbraco.Cms.Api.Management.Controllers.Content;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Api.Management.ViewModels.Content;
 using Umbraco.Cms.Api.Management.ViewModels.Media;

--- a/src/Umbraco.Cms.Api.Management/Controllers/RecycleBin/RecycleBinControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RecycleBin/RecycleBinControllerBase.cs
@@ -2,7 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
-using Umbraco.Cms.Api.Management.Content;
+using Umbraco.Cms.Api.Management.Controllers.Content;
 using Umbraco.Cms.Api.Management.Services.Paging;
 using Umbraco.Cms.Api.Management.ViewModels.Item;
 using Umbraco.Cms.Api.Management.ViewModels.RecycleBin;


### PR DESCRIPTION
### Description

For whatever reason, `ContentControllerBase` is located outside the `Controllers` namespace in the API 😆 this PR cleans it up.