### PR TITLE
Align presentation model factory naming

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/ByKeyMediaController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/ByKeyMediaController.cs
@@ -18,16 +18,16 @@ public class ByKeyMediaController : MediaControllerBase
 {
     private readonly IAuthorizationService _authorizationService;
     private readonly IMediaEditingService _mediaEditingService;
-    private readonly IMediaPresentationModelFactory _mediaPresentationModelFactory;
+    private readonly IMediaPresentationFactory _mediaPresentationFactory;
 
     public ByKeyMediaController(
         IAuthorizationService authorizationService,
         IMediaEditingService mediaEditingService,
-        IMediaPresentationModelFactory mediaPresentationModelFactory)
+        IMediaPresentationFactory mediaPresentationFactory)
     {
         _authorizationService = authorizationService;
         _mediaEditingService = mediaEditingService;
-        _mediaPresentationModelFactory = mediaPresentationModelFactory;
+        _mediaPresentationFactory = mediaPresentationFactory;
     }
 
     [HttpGet("{id:guid}")]
@@ -52,7 +52,7 @@ public class ByKeyMediaController : MediaControllerBase
             return MediaNotFound();
         }
 
-        MediaResponseModel model = await _mediaPresentationModelFactory.CreateResponseModelAsync(media);
+        MediaResponseModel model = await _mediaPresentationFactory.CreateResponseModelAsync(media);
         return Ok(model);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/ItemMediaItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/ItemMediaItemController.cs
@@ -14,12 +14,12 @@ namespace Umbraco.Cms.Api.Management.Controllers.Media.Item;
 public class ItemMediaItemController : MediaItemControllerBase
 {
     private readonly IEntityService _entityService;
-    private readonly IMediaPresentationModelFactory _mediaPresentationModelFactory;
+    private readonly IMediaPresentationFactory _mediaPresentationFactory;
 
-    public ItemMediaItemController(IEntityService entityService, IMediaPresentationModelFactory mediaPresentationModelFactory)
+    public ItemMediaItemController(IEntityService entityService, IMediaPresentationFactory mediaPresentationFactory)
     {
         _entityService = entityService;
-        _mediaPresentationModelFactory = mediaPresentationModelFactory;
+        _mediaPresentationFactory = mediaPresentationFactory;
     }
 
     [HttpGet("item")]
@@ -31,7 +31,7 @@ public class ItemMediaItemController : MediaItemControllerBase
             .GetAll(UmbracoObjectTypes.Media, ids.ToArray())
             .OfType<IMediaEntitySlim>();
 
-        IEnumerable<MediaItemResponseModel> responseModels = media.Select(_mediaPresentationModelFactory.CreateItemResponseModel);
+        IEnumerable<MediaItemResponseModel> responseModels = media.Select(_mediaPresentationFactory.CreateItemResponseModel);
         return await Task.FromResult(Ok(responseModels));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/RecycleBin/ChildrenMediaRecycleBinController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/RecycleBin/ChildrenMediaRecycleBinController.cs
@@ -11,8 +11,8 @@ namespace Umbraco.Cms.Api.Management.Controllers.Media.RecycleBin;
 [ApiVersion("1.0")]
 public class ChildrenMediaRecycleBinController : MediaRecycleBinControllerBase
 {
-    public ChildrenMediaRecycleBinController(IEntityService entityService, IMediaPresentationModelFactory mediaPresentationModelFactory)
-        : base(entityService, mediaPresentationModelFactory)
+    public ChildrenMediaRecycleBinController(IEntityService entityService, IMediaPresentationFactory mediaPresentationFactory)
+        : base(entityService, mediaPresentationFactory)
     {
     }
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/RecycleBin/EmptyMediaRecycleBinController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/RecycleBin/EmptyMediaRecycleBinController.cs
@@ -24,8 +24,8 @@ public class EmptyMediaRecycleBinController : MediaRecycleBinControllerBase
         IAuthorizationService authorizationService,
         IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
         IMediaService mediaService,
-        IMediaPresentationModelFactory mediaPresentationModelFactory)
-        : base(entityService, mediaPresentationModelFactory)
+        IMediaPresentationFactory mediaPresentationFactory)
+        : base(entityService, mediaPresentationFactory)
     {
         _authorizationService = authorizationService;
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/RecycleBin/MediaRecycleBinControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/RecycleBin/MediaRecycleBinControllerBase.cs
@@ -22,11 +22,11 @@ namespace Umbraco.Cms.Api.Management.Controllers.Media.RecycleBin;
 [Authorize(Policy = "New" + AuthorizationPolicies.SectionAccessMedia)]
 public class MediaRecycleBinControllerBase : RecycleBinControllerBase<MediaRecycleBinItemResponseModel>
 {
-    private readonly IMediaPresentationModelFactory _mediaPresentationModelFactory;
+    private readonly IMediaPresentationFactory _mediaPresentationFactory;
 
-    public MediaRecycleBinControllerBase(IEntityService entityService, IMediaPresentationModelFactory mediaPresentationModelFactory)
+    public MediaRecycleBinControllerBase(IEntityService entityService, IMediaPresentationFactory mediaPresentationFactory)
         : base(entityService)
-        => _mediaPresentationModelFactory = mediaPresentationModelFactory;
+        => _mediaPresentationFactory = mediaPresentationFactory;
 
     protected override UmbracoObjectTypes ItemObjectType => UmbracoObjectTypes.Media;
 
@@ -38,8 +38,8 @@ public class MediaRecycleBinControllerBase : RecycleBinControllerBase<MediaRecyc
 
         if (entity is IMediaEntitySlim mediaEntitySlim)
         {
-            responseModel.Variants = _mediaPresentationModelFactory.CreateVariantsItemResponseModels(mediaEntitySlim);
-            responseModel.MediaType = _mediaPresentationModelFactory.CreateMediaTypeReferenceResponseModel(mediaEntitySlim);
+            responseModel.Variants = _mediaPresentationFactory.CreateVariantsItemResponseModels(mediaEntitySlim);
+            responseModel.MediaType = _mediaPresentationFactory.CreateMediaTypeReferenceResponseModel(mediaEntitySlim);
         }
 
         return responseModel;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/RecycleBin/RootMediaRecycleBinController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/RecycleBin/RootMediaRecycleBinController.cs
@@ -11,8 +11,8 @@ namespace Umbraco.Cms.Api.Management.Controllers.Media.RecycleBin;
 [ApiVersion("1.0")]
 public class RootMediaRecycleBinController : MediaRecycleBinControllerBase
 {
-    public RootMediaRecycleBinController(IEntityService entityService, IMediaPresentationModelFactory mediaPresentationModelFactory)
-        : base(entityService, mediaPresentationModelFactory)
+    public RootMediaRecycleBinController(IEntityService entityService, IMediaPresentationFactory mediaPresentationFactory)
+        : base(entityService, mediaPresentationFactory)
     {
     }
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Tree/ChildrenMediaTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Tree/ChildrenMediaTreeController.cs
@@ -20,8 +20,8 @@ public class ChildrenMediaTreeController : MediaTreeControllerBase
         IDataTypeService dataTypeService,
         AppCaches appCaches,
         IBackOfficeSecurityAccessor backofficeSecurityAccessor,
-        IMediaPresentationModelFactory mediaPresentationModelFactory)
-        : base(entityService, userStartNodeEntitiesService, dataTypeService, appCaches, backofficeSecurityAccessor, mediaPresentationModelFactory)
+        IMediaPresentationFactory mediaPresentationFactory)
+        : base(entityService, userStartNodeEntitiesService, dataTypeService, appCaches, backofficeSecurityAccessor, mediaPresentationFactory)
     {
     }
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Tree/MediaTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Tree/MediaTreeControllerBase.cs
@@ -23,7 +23,7 @@ public class MediaTreeControllerBase : UserStartNodeTreeControllerBase<MediaTree
 {
     private readonly AppCaches _appCaches;
     private readonly IBackOfficeSecurityAccessor _backofficeSecurityAccessor;
-    private readonly IMediaPresentationModelFactory _mediaPresentationModelFactory;
+    private readonly IMediaPresentationFactory _mediaPresentationFactory;
 
     public MediaTreeControllerBase(
         IEntityService entityService,
@@ -31,12 +31,12 @@ public class MediaTreeControllerBase : UserStartNodeTreeControllerBase<MediaTree
         IDataTypeService dataTypeService,
         AppCaches appCaches,
         IBackOfficeSecurityAccessor backofficeSecurityAccessor,
-        IMediaPresentationModelFactory mediaPresentationModelFactory)
+        IMediaPresentationFactory mediaPresentationFactory)
         : base(entityService, userStartNodeEntitiesService, dataTypeService)
     {
         _appCaches = appCaches;
         _backofficeSecurityAccessor = backofficeSecurityAccessor;
-        _mediaPresentationModelFactory = mediaPresentationModelFactory;
+        _mediaPresentationFactory = mediaPresentationFactory;
     }
 
     protected override UmbracoObjectTypes ItemObjectType => UmbracoObjectTypes.Media;
@@ -52,8 +52,8 @@ public class MediaTreeControllerBase : UserStartNodeTreeControllerBase<MediaTree
             responseModel.IsTrashed = entity.Trashed;
             responseModel.Id = entity.Key;
 
-            responseModel.Variants = _mediaPresentationModelFactory.CreateVariantsItemResponseModels(mediaEntitySlim);
-            responseModel.MediaType = _mediaPresentationModelFactory.CreateMediaTypeReferenceResponseModel(mediaEntitySlim);
+            responseModel.Variants = _mediaPresentationFactory.CreateVariantsItemResponseModels(mediaEntitySlim);
+            responseModel.MediaType = _mediaPresentationFactory.CreateMediaTypeReferenceResponseModel(mediaEntitySlim);
         }
 
         return responseModel;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Tree/RootMediaTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Tree/RootMediaTreeController.cs
@@ -20,8 +20,8 @@ public class RootMediaTreeController : MediaTreeControllerBase
         IDataTypeService dataTypeService,
         AppCaches appCaches,
         IBackOfficeSecurityAccessor backofficeSecurityAccessor,
-        IMediaPresentationModelFactory mediaPresentationModelFactory)
-        : base(entityService, userStartNodeEntitiesService, dataTypeService, appCaches, backofficeSecurityAccessor, mediaPresentationModelFactory)
+        IMediaPresentationFactory mediaPresentationFactory)
+        : base(entityService, userStartNodeEntitiesService, dataTypeService, appCaches, backofficeSecurityAccessor, mediaPresentationFactory)
     {
     }
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Item/ItemPartialViewItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Item/ItemPartialViewItemController.cs
@@ -10,10 +10,10 @@ namespace Umbraco.Cms.Api.Management.Controllers.PartialView.Item;
 [ApiVersion("1.0")]
 public class ItemPartialViewItemController : PartialViewItemControllerBase
 {
-    private readonly IFileItemPresentationModelFactory _fileItemPresentationModelFactory;
+    private readonly IFileItemPresentationFactory _fileItemPresentationFactory;
 
-    public ItemPartialViewItemController(IFileItemPresentationModelFactory fileItemPresentationModelFactory)
-        => _fileItemPresentationModelFactory = fileItemPresentationModelFactory;
+    public ItemPartialViewItemController(IFileItemPresentationFactory fileItemPresentationFactory)
+        => _fileItemPresentationFactory = fileItemPresentationFactory;
 
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
@@ -21,7 +21,7 @@ public class ItemPartialViewItemController : PartialViewItemControllerBase
     public async Task<IActionResult> Item([FromQuery(Name = "path")] HashSet<string> paths)
     {
         paths = paths.Select(path => path.VirtualPathToSystemPath()).ToHashSet();
-        IEnumerable<PartialViewItemResponseModel> responseModels = _fileItemPresentationModelFactory.CreatePartialViewItemResponseModels(paths);
+        IEnumerable<PartialViewItemResponseModel> responseModels = _fileItemPresentationFactory.CreatePartialViewItemResponseModels(paths);
         return await Task.FromResult(Ok(responseModels));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/Item/ItemScriptItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/Item/ItemScriptItemController.cs
@@ -10,10 +10,10 @@ namespace Umbraco.Cms.Api.Management.Controllers.Script.Item;
 [ApiVersion("1.0")]
 public class ItemScriptItemController : ScriptItemControllerBase
 {
-    private readonly IFileItemPresentationModelFactory _fileItemPresentationModelFactory;
+    private readonly IFileItemPresentationFactory _fileItemPresentationFactory;
 
-    public ItemScriptItemController(IFileItemPresentationModelFactory fileItemPresentationModelFactory)
-        => _fileItemPresentationModelFactory = fileItemPresentationModelFactory;
+    public ItemScriptItemController(IFileItemPresentationFactory fileItemPresentationFactory)
+        => _fileItemPresentationFactory = fileItemPresentationFactory;
 
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
@@ -21,7 +21,7 @@ public class ItemScriptItemController : ScriptItemControllerBase
     public async Task<IActionResult> Item([FromQuery(Name = "path")] HashSet<string> paths)
     {
         paths = paths.Select(path => path.VirtualPathToSystemPath()).ToHashSet();
-        IEnumerable<ScriptItemResponseModel> responseModels = _fileItemPresentationModelFactory.CreateScriptItemResponseModels(paths);
+        IEnumerable<ScriptItemResponseModel> responseModels = _fileItemPresentationFactory.CreateScriptItemResponseModels(paths);
         return await Task.FromResult(Ok(responseModels));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Item/ItemStaticFileItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Item/ItemStaticFileItemController.cs
@@ -10,10 +10,10 @@ namespace Umbraco.Cms.Api.Management.Controllers.StaticFile.Item;
 [ApiVersion("1.0")]
 public class ItemStaticFileItemController : StaticFileItemControllerBase
 {
-    private readonly IFileItemPresentationModelFactory _fileItemPresentationModelFactory;
+    private readonly IFileItemPresentationFactory _fileItemPresentationFactory;
 
-    public ItemStaticFileItemController(IFileItemPresentationModelFactory fileItemPresentationModelFactory)
-        => _fileItemPresentationModelFactory = fileItemPresentationModelFactory;
+    public ItemStaticFileItemController(IFileItemPresentationFactory fileItemPresentationFactory)
+        => _fileItemPresentationFactory = fileItemPresentationFactory;
 
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
@@ -21,7 +21,7 @@ public class ItemStaticFileItemController : StaticFileItemControllerBase
     public async Task<IActionResult> Item([FromQuery(Name = "path")] HashSet<string> paths)
     {
         paths = paths.Select(path => path.VirtualPathToSystemPath()).ToHashSet();
-        IEnumerable<StaticFileItemResponseModel> responseModels = _fileItemPresentationModelFactory.CreateStaticFileItemResponseModels(paths);
+        IEnumerable<StaticFileItemResponseModel> responseModels = _fileItemPresentationFactory.CreateStaticFileItemResponseModels(paths);
         return await Task.FromResult(Ok(responseModels));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Item/ItemStylesheetItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Item/ItemStylesheetItemController.cs
@@ -10,10 +10,10 @@ namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet.Item;
 [ApiVersion("1.0")]
 public class ItemStylesheetItemController : StylesheetItemControllerBase
 {
-    private readonly IFileItemPresentationModelFactory _fileItemPresentationModelFactory;
+    private readonly IFileItemPresentationFactory _fileItemPresentationFactory;
 
-    public ItemStylesheetItemController(IFileItemPresentationModelFactory fileItemPresentationModelFactory)
-        => _fileItemPresentationModelFactory = fileItemPresentationModelFactory;
+    public ItemStylesheetItemController(IFileItemPresentationFactory fileItemPresentationFactory)
+        => _fileItemPresentationFactory = fileItemPresentationFactory;
 
     [HttpGet("item")]
     [MapToApiVersion("1.0")]
@@ -21,7 +21,7 @@ public class ItemStylesheetItemController : StylesheetItemControllerBase
     public async Task<IActionResult> Item([FromQuery(Name = "path")] HashSet<string> paths)
     {
         paths = paths.Select(path => path.VirtualPathToSystemPath()).ToHashSet();
-        IEnumerable<StylesheetItemResponseModel> responseModels = _fileItemPresentationModelFactory.CreateStylesheetItemResponseModels(paths);
+        IEnumerable<StylesheetItemResponseModel> responseModels = _fileItemPresentationFactory.CreateStylesheetItemResponseModels(paths);
         return await Task.FromResult(Ok(responseModels));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/EntityBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/EntityBuilderExtensions.cs
@@ -12,7 +12,7 @@ internal static class EntityBuilderExtensions
     {
         builder.WithCollectionBuilder<MapDefinitionCollectionBuilder>()
             .Add<ItemTypeMapDefinition>();
-        builder.Services.AddUnique<IFileItemPresentationModelFactory, FileItemPresentationModelFactory>();
+        builder.Services.AddUnique<IFileItemPresentationFactory, FileItemPresentationFactory>();
 
         return builder;
     }

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/MediaBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/MediaBuilderExtensions.cs
@@ -12,7 +12,7 @@ internal static class MediaBuilderExtensions
 {
     internal static IUmbracoBuilder AddMedia(this IUmbracoBuilder builder)
     {
-        builder.Services.AddTransient<IMediaPresentationModelFactory, MediaPresentationModelFactory>();
+        builder.Services.AddTransient<IMediaPresentationFactory, MediaPresentationFactory>();
         builder.Services.AddTransient<IMediaEditingPresentationFactory, MediaEditingPresentationFactory>();
         builder.Services.AddTransient<IUrlAssembler, DefaultUrlAssembler>();
         builder.Services.AddScoped<IAbsoluteUrlBuilder, DefaultAbsoluteUrlBuilder>();

--- a/src/Umbraco.Cms.Api.Management/Factories/FileItemPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/FileItemPresentationFactory.cs
@@ -9,12 +9,12 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Factories;
 
-public class FileItemPresentationModelFactory : IFileItemPresentationModelFactory
+public class FileItemPresentationFactory : IFileItemPresentationFactory
 {
     private readonly FileSystems _fileSystems;
     private readonly IPhysicalFileSystem _physicalFileSystem;
 
-    public FileItemPresentationModelFactory(FileSystems fileSystems, IPhysicalFileSystem physicalFileSystem)
+    public FileItemPresentationFactory(FileSystems fileSystems, IPhysicalFileSystem physicalFileSystem)
     {
         _fileSystems = fileSystems;
         _physicalFileSystem = physicalFileSystem;

--- a/src/Umbraco.Cms.Api.Management/Factories/IFileItemPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IFileItemPresentationFactory.cs
@@ -2,11 +2,10 @@
 using Umbraco.Cms.Api.Management.ViewModels.Script.Item;
 using Umbraco.Cms.Api.Management.ViewModels.StaticFile.Item;
 using Umbraco.Cms.Api.Management.ViewModels.Stylesheet.Item;
-using Umbraco.Cms.Core.IO;
 
 namespace Umbraco.Cms.Api.Management.Factories;
 
-public interface IFileItemPresentationModelFactory
+public interface IFileItemPresentationFactory
 {
     IEnumerable<PartialViewItemResponseModel> CreatePartialViewItemResponseModels(IEnumerable<string> path);
 

--- a/src/Umbraco.Cms.Api.Management/Factories/IMediaPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IMediaPresentationFactory.cs
@@ -7,7 +7,7 @@ using Umbraco.Cms.Core.Models.Entities;
 
 namespace Umbraco.Cms.Api.Management.Factories;
 
-public interface IMediaPresentationModelFactory
+public interface IMediaPresentationFactory
 {
     Task<MediaResponseModel> CreateResponseModelAsync(IMedia media);
 

--- a/src/Umbraco.Cms.Api.Management/Factories/MediaPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/MediaPresentationFactory.cs
@@ -14,8 +14,8 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Factories;
 
-internal sealed class MediaPresentationModelFactory
-    : ContentPresentationFactoryBase<IMediaType, IMediaTypeService>, IMediaPresentationModelFactory
+internal sealed class MediaPresentationFactory
+    : ContentPresentationFactoryBase<IMediaType, IMediaTypeService>, IMediaPresentationFactory
 {
     private readonly IUmbracoMapper _umbracoMapper;
     private readonly ContentSettings _contentSettings;
@@ -23,7 +23,7 @@ internal sealed class MediaPresentationModelFactory
     private readonly IAbsoluteUrlBuilder _absoluteUrlBuilder;
     private readonly IMediaTypeService _mediaTypeService;
 
-    public MediaPresentationModelFactory(
+    public MediaPresentationFactory(
         IUmbracoMapper umbracoMapper,
         IOptions<ContentSettings> contentSettings,
         MediaUrlGeneratorCollection mediaUrlGenerators,


### PR DESCRIPTION
### Description

We have a little inconsistency in our naming of presentation factories:

- `PresentationModelFactory` (e.g. `MediaPresentationModelFactory`)
- `PresentationFactory` (e.g. `DocumentPresentationFactory`)

`PresentationFactory` is most widely adopted, so this PR renames the `PresentationModelFactory` ones to align.