### PR TITLE
Update nouislider options for image cropper.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/imaging/umbimagecrop.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/imaging/umbimagecrop.directive.js
@@ -50,19 +50,11 @@ angular.module("umbraco.directives")
 
                     scope.sliderOptions = {
                         "start": scope.dimensions.scale.current,
-                        "step": 0.001,
+                        "step": 0.01,
                         "tooltips": [false],
-                        "format": {
-                            to: function (value) {
-                                return parseFloat(parseFloat(value).toFixed(3));
-                            },
-                            from: function (value) {
-                                return parseFloat(parseFloat(value).toFixed(3));
-                            }
-                        },
                         "range": {
-                            "min": scope.dimensions.scale.min,
-                            "max": scope.dimensions.scale.max
+                            "min": 0,
+                            "max": 100
                         }
                     };
 


### PR DESCRIPTION
Previous slider min and max values caused home and end keys to behave incorrectly. Min is now 0 to reflect 0% zoom and max is now 100 to reflect max zoom. Additionally, adjusted step to 0.01 to avoid slow adjustments when using arrow keys or page up / page down keys.

Issue: #15578

### Prerequisites

- [X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [15578](https://github.com/umbraco/Umbraco-CMS/issues/15578)

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

1. Create new document type.
2. Add image cropper property to document.
3. Open the image cropper settings and use crops defined below.

![image](https://github.com/umbraco/Umbraco-CMS/assets/50598649/3ba6963b-d2ea-44d3-8114-93709883e160)

4. Add new media picker property to document.
5. Open media picker settings and provide image crops defined below.

![image](https://github.com/umbraco/Umbraco-CMS/assets/50598649/502355fd-a1ee-4754-9b00-fb4bf0b4a13d)

6. Use document type to create new document.
7. Upload desired image.
8. Click "Square" crop.
9. Drag slider using mouse and verify that moving right zooms in and moving left zooms out.
10. Verify that the right arrow key zooms in and the left arrow key zooms out.
11. Verify that the page up key zooms in and the page down key zooms out.
12. Verify that the end key moves the slider to the end.
13. Verify that the home key moves the slider to the beginning.
14. Repeat 9-13 for the other image cropper defined crops.
15. Upload image to media picker.
16. Click image name.
17. In right side bar, click "C1".
18. Verify slider functionality as in 9-13.
19. Repeat 18 for the other media picker defined crops.

<!-- Thanks for contributing to Umbraco CMS! -->
