### PR TITLE
Allow methods that call GetCropUrl to be verified in unit tests.

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/ImageCropperTemplateCoreExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/ImageCropperTemplateCoreExtensions.cs
@@ -520,7 +520,7 @@ public static class ImageCropperTemplateCoreExtensions
             throw new ArgumentNullException(nameof(mediaItem));
         }
 
-        if (mediaItem.HasProperty(propertyAlias) == false || mediaItem.HasValue(propertyAlias) == false)
+        if (mediaItem.HasProperty(propertyAlias) == false || mediaItem.HasValue(publishedValueFallback, propertyAlias) == false)
         {
             return null;
         }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description

I was looking to create a unit test around a method that calls into GetCropUrl.  I found I could do it, but only with the small update in this PR.  The extension method here is using the "friendly" extension methods that use service location, but it doesn't need to do so as the parameter it needs is passed in already.

To test I think visual inspection will suffice, but otherwise confirm rendering a media item's crop works [as per the docs](https://docs.umbraco.com/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/image-cropper).