### PR TITLE
Refactor GetChildren method on Content Controller and introduce GetChildrenForSort

### DIFF
--- a/src/Umbraco.Core/Models/ContentEditing/GetChildrenFilter.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/GetChildrenFilter.cs
@@ -1,0 +1,54 @@
+namespace Umbraco.Cms.Core.Models.ContentEditing
+{
+    /// <summary>
+    /// Represents a filter for fetching child content items with optional sorting and pagination.
+    /// </summary>
+    public class GetChildrenFilter
+    {
+        /// <summary>
+        /// The unique identifier for the parent content item whose children are to be retrieved.
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// A comma-separated list of property aliases to include in the response. Null or empty to include all.
+        /// </summary>
+        public string? IncludeProperties { get; set; }
+
+        /// <summary>
+        /// The page number for pagination, starting at 1. A value of 0 indicates no pagination.
+        /// </summary>
+        public int PageNumber { get; set; } = 0;
+
+        /// <summary>
+        /// The number of items per page for pagination. A value of 0 indicates no pagination.
+        /// </summary>
+        public int PageSize { get; set; } = 0;
+
+        /// <summary>
+        /// The property name by which to order the child items. Defaults to "SortOrder".
+        /// </summary>
+        public string OrderBy { get; set; } = "SortOrder";
+
+        /// <summary>
+        /// The direction in which to order the child items (Ascending or Descending).
+        /// </summary>
+        public Direction OrderDirection { get; set; } = Direction.Ascending;
+
+        /// <summary>
+        /// Indicates whether the ordering should be applied to system fields. True to use system fields.
+        /// </summary>
+        public bool OrderBySystemField { get; set; } = true;
+
+        /// <summary>
+        /// A filter string to apply when retrieving child items. Could be used to match names, IDs, or other properties.
+        /// </summary>
+        public string Filter { get; set; } = "";
+
+        /// <summary>
+        /// The culture code (ISO) to filter content by language. Empty string indicates no culture filtering.
+        /// Note: Originally named CultureName, but it actually expects a culture ISO code.
+        /// </summary>
+        public string CultureName { get; set; } = "";  // TODO: it's not a NAME it's the ISO CODE
+    }
+}

--- a/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
@@ -794,7 +794,8 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
          * @param {String} options.filter if provided, query will only return those with names matching the filter
          * @param {String} options.orderDirection can be `Ascending` or `Descending` - Default: `Ascending`
          * @param {String} options.orderBy property to order items by, default: `SortOrder`
-          * @param {String} options.cultureName if provided, the results will be for this specific culture/variant
+         * @param {String} options.cultureName if provided, the results will be for this specific culture/variant
+         * @param {Boolean} options.isSortRequest if provided, the results will be for this specific culture/variant
          * @returns {Promise} resourcePromise object containing an array of content items.
          *
          */
@@ -839,11 +840,13 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
                 return false;
             }
 
+            let apiEndpoint = options.isSortRequest ? "GetChildrenForSort" : "GetChildren";
+
             return umbRequestHelper.resourcePromise(
                 $http.get(
                     umbRequestHelper.getApiUrl(
                         "contentApiBaseUrl",
-                        "GetChildren",
+                        apiEndpoint,
                         {
                             id: parentId,
                             includeProperties: _.pluck(options.includeProperties, 'alias').join(","),

--- a/src/Umbraco.Web.UI.Client/src/views/content/content.sort.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.sort.controller.js
@@ -32,7 +32,7 @@
 
         function onInit() {
             vm.loading = true;
-            contentResource.getChildren(id, { cultureName: $routeParams.cculture ? $routeParams.cculture : $routeParams.mculture })
+            contentResource.getChildren(id, { cultureName: $routeParams.cculture ? $routeParams.cculture : $routeParams.mculture, isSortRequest: true })
                 .then(function(data){
                     vm.children = data.items;
                     vm.loading = false;


### PR DESCRIPTION
I've just pushed some updates that hopefully tackle the issue discussed here https://github.com/umbraco/Umbraco-CMS/issues/15608

This is a draft PR, so consider this a potential option for a fix. There maybe other options we can explore, so any feedback would be welcome :)

----

Introduced the `GetChildrenFilter` class for parameter encapsulation to enable a DRY approach.

This change facilitates the introduction of a new `GetChildrenForSort` method, allowing precise control over the **ActionLetter** in the `FilterAllowedOutgoingContent`.

Added the `GetChildrenFilter` to 'Umbraco.Cms.Core.Models.ContentEditing' as there seemed to be president with `GetAvailableCompositionsFilter`

### Prerequisites

- [ x] I have added steps to test this contribution in the description below

### Description

For reference: please see videos of the original bug here: https://github.com/umbraco/Umbraco-CMS/issues/15608

On a fresh install setup a new editor user and create a simple multi root node structure:

![image](https://github.com/umbraco/Umbraco-CMS/assets/550193/e664dd5d-f303-4f68-af98-a99a7f09b6e7)

For the created user setup a new group:
- Content start node to be on of the root nodes
- Restrict the permission so **only** Sort is enabled in the Structure settings.

![image](https://github.com/umbraco/Umbraco-CMS/assets/550193/afeb020e-e306-463e-bda7-fbb31ffc4f38)

![image](https://github.com/umbraco/Umbraco-CMS/assets/550193/5b962647-d3d2-4d8f-b761-6626ef28d23e)

Set 'Granular permissions' for the start node as:

![image](https://github.com/umbraco/Umbraco-CMS/assets/550193/aa80705f-b853-4343-b677-b7992d81d1c4)

![image](https://github.com/umbraco/Umbraco-CMS/assets/550193/1cbe135b-c959-435e-b5b9-dd286d09ec77)

Assign this group to the created editor user.

Sign in as the editor user.

The Content should be restricted as expected.

The user should now be able to sort the nodes

