### PR TITLE
 UriUtilityCore not handling QueryString and Anchors correctly.

### DIFF
--- a/src/Umbraco.Core/UriUtilityCore.cs
+++ b/src/Umbraco.Core/UriUtilityCore.cs
@@ -4,8 +4,6 @@ namespace Umbraco.Cms.Core;
 
 public static class UriUtilityCore
 {
-    #region Uri string utilities
-
     public static bool HasScheme(string uri) => uri.IndexOf("://", StringComparison.InvariantCulture) > 0;
 
     public static string StartWithScheme(string uri) => StartWithScheme(uri, null);
@@ -15,16 +13,15 @@ public static class UriUtilityCore
 
     public static string EndPathWithSlash(string uri)
     {
-        var pos1 = Math.Max(0, uri.IndexOf('?'));
-        var pos2 = Math.Max(0, uri.IndexOf('#'));
-        var pos = Math.Min(pos1, pos2);
+        ReadOnlySpan<char> uriSpan = uri.AsSpan();
+        var pos = IndexOfPathEnd(uriSpan);
 
-        var path = pos > 0 ? uri.Substring(0, pos) : uri;
+        var path = (pos > 0 ? uriSpan[..pos] : uriSpan).ToString();
         path = path.EnsureEndsWith('/');
 
         if (pos > 0)
         {
-            path += uri.Substring(pos);
+            return string.Concat(path, uriSpan[pos..]);
         }
 
         return path;
@@ -32,20 +29,27 @@ public static class UriUtilityCore
 
     public static string TrimPathEndSlash(string uri)
     {
-        var pos1 = Math.Max(0, uri.IndexOf('?'));
-        var pos2 = Math.Max(0, uri.IndexOf('#'));
-        var pos = Math.Min(pos1, pos2);
+        ReadOnlySpan<char> uriSpan = uri.AsSpan();
+        var pos = IndexOfPathEnd(uriSpan);
 
-        var path = pos > 0 ? uri[..pos] : uri;
+        var path = (pos > 0 ? uriSpan[..pos] : uriSpan).ToString();
         path = path.TrimEnd(Constants.CharArrays.ForwardSlash);
 
         if (pos > 0)
         {
-            path += uri.Substring(pos);
+            return string.Concat(path, uriSpan[pos..]);
         }
 
         return path;
     }
 
-    #endregion
+    private static int IndexOfPathEnd(ReadOnlySpan<char> uri)
+    {
+        var pos1 = Math.Max(0, uri.IndexOf('?'));
+        var pos2 = Math.Max(0, uri.IndexOf('#'));
+        return pos1 == 0 && pos2 == 0 ? 0
+            : pos1 == 0 ? pos2
+            : pos2 == 0 ? pos1
+            : Math.Min(pos1, pos2);
+    }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/CoreThings/UriUtilityCoreTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/CoreThings/UriUtilityCoreTests.cs
@@ -1,0 +1,33 @@
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.CoreThings;
+
+[TestFixture]
+public class UriUtilityCoreTests
+{
+    [TestCase("/en", "/en")]
+    [TestCase("/en#anchor", "/en#anchor")]
+    [TestCase("/en/", "/en")]
+    [TestCase("/en/#anchor", "/en#anchor")]
+    [TestCase("/en/?abc=123", "/en?abc=123")]
+    [TestCase("/en/#abc?abc=123", "/en#abc?abc=123")]
+    public void TrimPathEndSlash(string uri, string expected)
+    {
+        var result = UriUtilityCore.TrimPathEndSlash(uri);
+        Assert.AreEqual(expected, result);
+    }
+
+
+    [TestCase("/en/", "/en/")]
+    [TestCase("/en#anchor", "/en/#anchor")]
+    [TestCase("/en", "/en/")]
+    [TestCase("/en/#anchor", "/en/#anchor")]
+    [TestCase("/en?abc=123", "/en/?abc=123")]
+    [TestCase("/en#abc?abc=123", "/en/#abc?abc=123")]
+    public void EndPathWithSlash(string uri, string expected)
+    {
+        var result = UriUtilityCore.EndPathWithSlash(uri);
+        Assert.AreEqual(expected, result);
+    }
+}


### PR DESCRIPTION

### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
EndPathWithSlash and TrimPathEndSlash,  `pos` calculation if one of them is 0 they pos will always be 0. Changing this to Max doesnt work for the case where both are greater than 0.


<!-- Thanks for contributing to Umbraco CMS! -->
