### PR TITLE
Fix certificate health check so that it validates multiple times

### DIFF
--- a/src/Umbraco.Core/HealthChecks/Checks/Security/HttpsCheck.cs
+++ b/src/Umbraco.Core/HealthChecks/Checks/Security/HttpsCheck.cs
@@ -25,7 +25,6 @@ public class HttpsCheck : HealthCheck
     private const int NumberOfDaysForExpiryWarning = 14;
     private const string HttpPropertyKeyCertificateDaysToExpiry = "CertificateDaysToExpiry";
 
-    private static HttpClient? _httpClient;
     private readonly IOptionsMonitor<GlobalSettings> _globalSettings;
     private readonly IHostingEnvironment _hostingEnvironment;
 
@@ -46,12 +45,6 @@ public class HttpsCheck : HealthCheck
         _globalSettings = globalSettings;
         _hostingEnvironment = hostingEnvironment;
     }
-
-    private static HttpClient _httpClientEnsureInitialized => _httpClient ??= new HttpClient(new HttpClientHandler
-    {
-        ServerCertificateCustomValidationCallback = ServerCertificateCustomValidation,
-    });
-
     /// <inheritdoc />
     public override async Task<IEnumerable<HealthCheckStatus>> GetStatus() =>
         await Task.WhenAll(
@@ -72,8 +65,7 @@ public class HttpsCheck : HealthCheck
     {
         if (certificate is not null)
         {
-            requestMessage.Properties[HttpPropertyKeyCertificateDaysToExpiry] =
-                (int)Math.Floor((certificate.NotAfter - DateTime.Now).TotalDays);
+            requestMessage.Options.Set(new HttpRequestOptionsKey<int?>(HttpPropertyKeyCertificateDaysToExpiry), (int?)Math.Floor((certificate.NotAfter - DateTime.Now).TotalDays));
         }
 
         return sslErrors == SslPolicyErrors.None;
@@ -92,17 +84,22 @@ public class HttpsCheck : HealthCheck
 
         try
         {
-            using HttpResponseMessage response = await _httpClientEnsureInitialized.SendAsync(request);
+            using var httpClient = new HttpClient(new HttpClientHandler
+            {
+                ServerCertificateCustomValidationCallback = ServerCertificateCustomValidation,
+            });
+
+            using HttpResponseMessage response = await httpClient.SendAsync(request);
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
                 // Got a valid response, check now if the certificate is expiring within the specified amount of days
                 int? daysToExpiry = 0;
-                if (request.Properties.TryGetValue(
-                    HttpPropertyKeyCertificateDaysToExpiry,
-                    out var certificateDaysToExpiry))
+                if (response.RequestMessage != null && response.RequestMessage.Options.TryGetValue(
+                        new HttpRequestOptionsKey<int?>(HttpPropertyKeyCertificateDaysToExpiry),
+                        out var certificateDaysToExpiry))
                 {
-                    daysToExpiry = (int?)certificateDaysToExpiry;
+                    daysToExpiry = certificateDaysToExpiry;
                 }
 
                 if (daysToExpiry <= 0)


### PR DESCRIPTION
When running the Security health checks for a second time the certificate check will fail with "Your website's SSL certificate has expired" - https://github.com/umbraco/Umbraco.Cloud.Issues/issues/665

This PR fixes the issue and also switches the deprecated use of `request.Properties` to `request.Options`