### PR TITLE
added the slash to the list of acceptable characters in a data type name

### DIFF
--- a/src/Umbraco.Web.BackOffice/Filters/DataTypeValidateAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/DataTypeValidateAttribute.cs
@@ -45,7 +45,7 @@ internal sealed class DataTypeValidateAttribute : TypeFilterAttribute
             var dataType = (DataTypeSave?)context.ActionArguments["dataType"];
             if (dataType is not null)
             {
-                dataType.Name = dataType.Name?.CleanForXss('[', ']', '(', ')', ':');
+                dataType.Name = dataType.Name?.CleanForXss('[', ']', '(', ')', ':', '/');
                 dataType.Alias = dataType.Alias == null
                     ? dataType.Name!
                     : dataType.Alias.CleanForXss('[', ']', '(', ')', ':');


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes #15529 

### Description

This was a simple issue to replicate, you just add a forward slash into the name of a data type and press save and see the slash is removed.

On investigation I found the slash was being removed in the DataTypeValidateAttribute

The forward slash was being removed as a potential XSS character as part of a generic set of characters to remove.

There are some characters which have been added to the exception list for data type names such as `[` and `]`

The fix for this was to add the forward slash as one of those exceptions.

Now it saves the data type without any issues.
