### PR TITLE
Enable reuse of BackOfficeSecurityRequirementsOperationFilter for custom APIs

### DIFF
--- a/src/Umbraco.Cms.Api.Management/OpenApi/BackOfficeSecurityRequirementsOperationFilter.cs
+++ b/src/Umbraco.Cms.Api.Management/OpenApi/BackOfficeSecurityRequirementsOperationFilter.cs
@@ -1,56 +1,8 @@
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
-using Microsoft.OpenApi.Models;
-using Swashbuckle.AspNetCore.SwaggerGen;
 using Umbraco.Cms.Api.Management.DependencyInjection;
-using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.OpenApi;
 
-internal class BackOfficeSecurityRequirementsOperationFilter : IOperationFilter
+internal class BackOfficeSecurityRequirementsOperationFilter : BackOfficeSecurityRequirementsOperationFilterBase
 {
-    public void Apply(OpenApiOperation operation, OperationFilterContext context)
-    {
-        if (context.MethodInfo.HasMapToApiAttribute(ManagementApiConfiguration.ApiName) == false)
-        {
-            return;
-        }
-
-        if (!context.MethodInfo.GetCustomAttributes(true).Any(x => x is AllowAnonymousAttribute) &&
-            !(context.MethodInfo.DeclaringType?.GetCustomAttributes(true).Any(x => x is AllowAnonymousAttribute) ?? false))
-        {
-            operation.Responses.Add(StatusCodes.Status401Unauthorized.ToString(), new OpenApiResponse
-            {
-                Description = "The resource is protected and requires an authentication token"
-            });
-
-            operation.Security = new List<OpenApiSecurityRequirement>
-            {
-                new OpenApiSecurityRequirement
-                {
-                    {
-                        new OpenApiSecurityScheme
-                        {
-                            Reference = new OpenApiReference
-                            {
-                                Type = ReferenceType.SecurityScheme,
-                                Id = ManagementApiConfiguration.ApiSecurityName
-                            }
-                        }, new string[] { }
-                    }
-                }
-            };
-        }
-
-
-        // If method/controller has an explicit AuthorizeAttribute or the controller ctor injects IAuthorizationService, then we know Forbid result is possible.
-        if (context.MethodInfo.GetCustomAttributes(false).Any(x => x is AuthorizeAttribute
-            || context.MethodInfo.DeclaringType?.GetConstructors().Any(x => x.GetParameters().Any(x => x.ParameterType == typeof(IAuthorizationService))) is true))
-        {
-            operation.Responses.Add(StatusCodes.Status403Forbidden.ToString(), new OpenApiResponse
-            {
-                Description = "The authenticated user do not have access to this resource"
-            });
-        }
-    }
+    protected override string ApiName => ManagementApiConfiguration.ApiName;
 }

--- a/src/Umbraco.Cms.Api.Management/OpenApi/BackOfficeSecurityRequirementsOperationFilterBase.cs
+++ b/src/Umbraco.Cms.Api.Management/OpenApi/BackOfficeSecurityRequirementsOperationFilterBase.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using Umbraco.Cms.Api.Management.DependencyInjection;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.OpenApi;
+
+public abstract class BackOfficeSecurityRequirementsOperationFilterBase : IOperationFilter
+{
+    protected abstract string ApiName { get; }
+
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        if (context.MethodInfo.HasMapToApiAttribute(ApiName) == false)
+        {
+            return;
+        }
+
+        if (!context.MethodInfo.GetCustomAttributes(true).Any(x => x is AllowAnonymousAttribute) &&
+            !(context.MethodInfo.DeclaringType?.GetCustomAttributes(true).Any(x => x is AllowAnonymousAttribute) ?? false))
+        {
+            operation.Responses.Add(StatusCodes.Status401Unauthorized.ToString(), new OpenApiResponse
+            {
+                Description = "The resource is protected and requires an authentication token"
+            });
+
+            operation.Security = new List<OpenApiSecurityRequirement>
+            {
+                new OpenApiSecurityRequirement
+                {
+                    {
+                        new OpenApiSecurityScheme
+                        {
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.SecurityScheme,
+                                Id = ManagementApiConfiguration.ApiSecurityName
+                            }
+                        }, new string[] { }
+                    }
+                }
+            };
+        }
+
+
+        // If method/controller has an explicit AuthorizeAttribute or the controller ctor injects IAuthorizationService, then we know Forbid result is possible.
+        if (context.MethodInfo.GetCustomAttributes(false).Any(x => x is AuthorizeAttribute
+                                                                   || context.MethodInfo.DeclaringType?.GetConstructors().Any(x => x.GetParameters().Any(x => x.ParameterType == typeof(IAuthorizationService))) is true))
+        {
+            operation.Responses.Add(StatusCodes.Status403Forbidden.ToString(), new OpenApiResponse
+            {
+                Description = "The authenticated user do not have access to this resource"
+            });
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The `BackOfficeSecurityRequirementsOperationFilter` enables back-office authentication for Swagger UI. It is currently both internal and hardcoded to be applied only to controllers within the Management API group (`"management"`).

If one would like to use back-office out for Swagger UI with a custom API, but also use a custom group instead of `"management"`, one has to clone-and-own the entire implementation. That seems a little silly, so this PR introduces an abstract base class that can be reused for custom APIs.

### Testing this PR

Using the code snippet below, the custom API within the `"my-api-v1"` group should be able to use back-office auth with Swagger UI:

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/597ca47c-966e-41d9-a1e8-184c9297efb8)

#### Code snippet

```csharp
using Asp.Versioning;
using Microsoft.AspNetCore.Authorization;
using Microsoft.AspNetCore.Mvc;
using Microsoft.Extensions.Options;
using Microsoft.OpenApi.Models;
using Swashbuckle.AspNetCore.SwaggerGen;
using Umbraco.Cms.Api.Common.Attributes;
using Umbraco.Cms.Api.Common.Filters;
using Umbraco.Cms.Api.Management.OpenApi;
using Umbraco.Cms.Core;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Models.Membership;
using Umbraco.Cms.Core.Security;
using Umbraco.Cms.Web.Common.Authorization;

namespace Umbraco.Cms.Web.UI.New.Custom;


public class MyBackOfficeSecurityRequirementsOperationFilter : BackOfficeSecurityRequirementsOperationFilterBase
{
    protected override string ApiName => "my-api-v1";
}

public class MyConfigureSwaggerGenOptions : IConfigureOptions<SwaggerGenOptions>
{
    public void Configure(SwaggerGenOptions options)
    {
        options.SwaggerDoc("my-api-v1", new OpenApiInfo { Title = "My API v1", Version = "1.0" });
        options.OperationFilter<MyBackOfficeSecurityRequirementsOperationFilter>();
    }
}

public class MyComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
        => builder.Services.ConfigureOptions<MyConfigureSwaggerGenOptions>();
}

[ApiController]
[ApiVersion("1.0")]
[MapToApi("my-api-v1")]
[Authorize(Policy = "New" + AuthorizationPolicies.BackOfficeAccess)]
[JsonOptionsName(Constants.JsonOptionsNames.BackOffice)]
[Route("api/v{version:apiVersion}/my")]
public class MyApiController : Controller
{
    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;

    public MyApiController(IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
        => _backOfficeSecurityAccessor = backOfficeSecurityAccessor;

    [HttpGet("say-hello")]
    [MapToApiVersion("1.0")]
    [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
    public IActionResult SayHello()
    {
        IUser currentUser = _backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser
                            ?? throw new InvalidOperationException("No backoffice user found");
        return Ok($"Hello, {currentUser.Name}");
    }
}
```