### PR TITLE
Output "operationStatus" for error scenarios whenever possible

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/DataTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/DataTypeControllerBase.cs
@@ -16,42 +16,44 @@ namespace Umbraco.Cms.Api.Management.Controllers.DataType;
 public abstract class DataTypeControllerBase : ManagementApiControllerBase
 {
     protected IActionResult DataTypeOperationStatusResult(DataTypeOperationStatus status) =>
-        status switch
+        OperationStatusResult(status, problemDetailsBuilder => status switch
         {
-            DataTypeOperationStatus.InvalidConfiguration => BadRequest(new ProblemDetailsBuilder()
+            DataTypeOperationStatus.InvalidConfiguration => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid data type configuration")
                 .WithDetail("The supplied data type configuration was not valid. Please see the log for more details.")
                 .Build()),
-            DataTypeOperationStatus.NotFound => DataTypeNotFound(),
-            DataTypeOperationStatus.InvalidName => BadRequest(new ProblemDetailsBuilder()
+            DataTypeOperationStatus.NotFound => DataTypeNotFound(problemDetailsBuilder),
+            DataTypeOperationStatus.InvalidName => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid data type name")
                 .WithDetail("The data type name must be non-empty and no longer than 255 characters.")
                 .Build()),
-            DataTypeOperationStatus.ParentNotContainer => BadRequest(new ProblemDetailsBuilder()
+            DataTypeOperationStatus.ParentNotContainer => BadRequest(problemDetailsBuilder
                 .WithTitle("parent id is not a container")
                 .WithDetail("The parent id does not represent a container.")
                 .Build()),
-            DataTypeOperationStatus.DuplicateKey => BadRequest(new ProblemDetailsBuilder()
+            DataTypeOperationStatus.DuplicateKey => BadRequest(problemDetailsBuilder
                 .WithTitle("The id is already used")
                 .WithDetail("The data type id must be unique.")
                 .Build()),
-            DataTypeOperationStatus.CancelledByNotification => BadRequest(new ProblemDetailsBuilder()
+            DataTypeOperationStatus.CancelledByNotification => BadRequest(problemDetailsBuilder
                 .WithTitle("Cancelled by notification")
                 .WithDetail("A notification handler prevented the data type operation.")
                 .Build()),
-            DataTypeOperationStatus.PropertyEditorNotFound => NotFound(
-                new ProblemDetailsBuilder()
-                    .WithTitle("The targeted property editor was not found.")
-                    .Build()),
-            DataTypeOperationStatus.ParentNotFound => NotFound(new ProblemDetailsBuilder()
-                    .WithTitle("The targeted parent for the data type operation was not found.")
-                    .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+            DataTypeOperationStatus.PropertyEditorNotFound => NotFound(problemDetailsBuilder
+                .WithTitle("The targeted property editor was not found.")
+                .Build()),
+            DataTypeOperationStatus.ParentNotFound => NotFound(problemDetailsBuilder
+                .WithTitle("The targeted parent for the data type operation was not found.")
+                .Build()),
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown data type operation status.")
                 .Build()),
-        };
+        });
 
-    protected IActionResult DataTypeNotFound() => NotFound(new ProblemDetailsBuilder()
-        .WithTitle("The data type could not be found")
-        .Build());
+    protected IActionResult DataTypeNotFound() => OperationStatusResult(DataTypeOperationStatus.NotFound, DataTypeNotFound);
+
+    private IActionResult DataTypeNotFound(ProblemDetailsBuilder problemDetailsBuilder)
+        => NotFound(problemDetailsBuilder
+            .WithTitle("The data type could not be found")
+            .Build());
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/ByKeyDictionaryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/ByKeyDictionaryController.cs
@@ -29,7 +29,7 @@ public class ByKeyDictionaryController : DictionaryControllerBase
         IDictionaryItem? dictionary = await _dictionaryItemService.GetAsync(id);
         if (dictionary == null)
         {
-            return DictionaryNotFound();
+            return DictionaryItemNotFound();
         }
 
         return Ok(await _dictionaryPresentationFactory.CreateDictionaryItemViewModelAsync(dictionary));

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/DictionaryControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/DictionaryControllerBase.cs
@@ -15,31 +15,33 @@ namespace Umbraco.Cms.Api.Management.Controllers.Dictionary;
 public abstract class DictionaryControllerBase : ManagementApiControllerBase
 {
     protected IActionResult DictionaryItemOperationStatusResult(DictionaryItemOperationStatus status) =>
-        status switch
+        OperationStatusResult(status, problemDetailsBuilder => status switch
         {
-            DictionaryItemOperationStatus.DuplicateItemKey => Conflict(new ProblemDetailsBuilder()
+            DictionaryItemOperationStatus.DuplicateItemKey => Conflict(problemDetailsBuilder
                 .WithTitle("Duplicate dictionary item name detected")
                 .WithDetail("Another dictionary item exists with the same name. Dictionary item names must be unique.")
                 .Build()),
-            DictionaryItemOperationStatus.ItemNotFound => DictionaryNotFound(),
-            DictionaryItemOperationStatus.ParentNotFound => NotFound(new ProblemDetailsBuilder()
-                    .WithTitle("The dictionary item parent could not be found")
-                    .Build()),
-            DictionaryItemOperationStatus.CancelledByNotification => BadRequest(new ProblemDetailsBuilder()
+            DictionaryItemOperationStatus.ItemNotFound => DictionaryItemNotFound(problemDetailsBuilder),
+            DictionaryItemOperationStatus.ParentNotFound => NotFound(problemDetailsBuilder
+                .WithTitle("The dictionary item parent could not be found")
+                .Build()),
+            DictionaryItemOperationStatus.CancelledByNotification => BadRequest(problemDetailsBuilder
                 .WithTitle("Cancelled by notification")
                 .WithDetail("A notification handler prevented the dictionary item operation.")
                 .Build()),
-            DictionaryItemOperationStatus.InvalidParent => BadRequest(new ProblemDetailsBuilder()
+            DictionaryItemOperationStatus.InvalidParent => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid parent")
                 .WithDetail("The targeted parent dictionary item is not valid for this dictionary item operation.")
                 .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown dictionary operation status.")
                 .Build()),
-        };
+        });
 
+    protected IActionResult DictionaryItemNotFound() => OperationStatusResult(DictionaryItemOperationStatus.ItemNotFound, DictionaryItemNotFound);
 
-    protected IActionResult DictionaryNotFound() => NotFound(new ProblemDetailsBuilder()
-        .WithTitle("The dictionary item could not be found")
-        .Build());
+    private IActionResult DictionaryItemNotFound(ProblemDetailsBuilder problemDetailsBuilder)
+        => NotFound(problemDetailsBuilder
+            .WithTitle("The dictionary item could not be found")
+            .Build());
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/ExportDictionaryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/ExportDictionaryController.cs
@@ -31,7 +31,7 @@ public class ExportDictionaryController : DictionaryControllerBase
         IDictionaryItem? dictionaryItem = await _dictionaryItemService.GetAsync(id);
         if (dictionaryItem is null)
         {
-            return DictionaryNotFound();
+            return DictionaryItemNotFound();
         }
 
         XElement xml = _entityXmlSerializer.Serialize(dictionaryItem, includeChildren);

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/ImportDictionaryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/ImportDictionaryController.cs
@@ -38,26 +38,27 @@ public class ImportDictionaryController : DictionaryControllerBase
                 importDictionaryRequestModel.Parent?.Id,
                 CurrentUserKey(_backOfficeSecurityAccessor));
 
-        return result.Status switch
-        {
-            DictionaryImportOperationStatus.Success => CreatedAtId<ByKeyDictionaryController>(controller => nameof(controller.ByKey), result.Result!.Key),
-            DictionaryImportOperationStatus.ParentNotFound => NotFound(new ProblemDetailsBuilder()
+        return result.Success
+            ? CreatedAtId<ByKeyDictionaryController>(controller => nameof(controller.ByKey), result.Result!.Key)
+            : OperationStatusResult(result.Status, problemDetailsBuilder => result.Status switch
+            {
+                DictionaryImportOperationStatus.ParentNotFound => NotFound(problemDetailsBuilder
                     .WithTitle("The parent dictionary item could not be found.")
                     .Build()),
-            DictionaryImportOperationStatus.TemporaryFileNotFound => NotFound(new ProblemDetailsBuilder()
+                DictionaryImportOperationStatus.TemporaryFileNotFound => NotFound(problemDetailsBuilder
                     .WithTitle("The temporary file with specified id could not be found.")
                     .Build()),
-            DictionaryImportOperationStatus.InvalidFileType => BadRequest(new ProblemDetailsBuilder()
-                .WithTitle("Invalid file type")
-                .WithDetail("The dictionary import only supports UDT files.")
-                .Build()),
-            DictionaryImportOperationStatus.InvalidFileContent => BadRequest(new ProblemDetailsBuilder()
-                .WithTitle("Invalid file content")
-                .WithDetail("The uploaded file could not be read as a valid UDT file.")
-                .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
-                .WithTitle("Unknown dictionary import operation status.")
-                .Build()),
-        };
+                DictionaryImportOperationStatus.InvalidFileType => BadRequest(problemDetailsBuilder
+                    .WithTitle("Invalid file type")
+                    .WithDetail("The dictionary import only supports UDT files.")
+                    .Build()),
+                DictionaryImportOperationStatus.InvalidFileContent => BadRequest(problemDetailsBuilder
+                    .WithTitle("Invalid file content")
+                    .WithDetail("The uploaded file could not be read as a valid UDT file.")
+                    .Build()),
+                _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
+                    .WithTitle("Unknown dictionary import operation status.")
+                    .Build()),
+            });
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/MoveDictionaryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/MoveDictionaryController.cs
@@ -32,7 +32,7 @@ public class MoveDictionaryController : DictionaryControllerBase
         IDictionaryItem? source = await _dictionaryItemService.GetAsync(id);
         if (source == null)
         {
-            return DictionaryNotFound();
+            return DictionaryItemNotFound();
         }
 
         Attempt<IDictionaryItem, DictionaryItemOperationStatus> result = await _dictionaryItemService.MoveAsync(

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/UpdateDictionaryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/UpdateDictionaryController.cs
@@ -45,7 +45,7 @@ public class UpdateDictionaryController : DictionaryControllerBase
         IDictionaryItem? current = await _dictionaryItemService.GetAsync(id);
         if (current == null)
         {
-            return DictionaryNotFound();
+            return DictionaryItemNotFound();
         }
 
         AuthorizationResult authorizationResult  = await _authorizationService.AuthorizeResourceAsync(

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/UpdateDomainsController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/UpdateDomainsController.cs
@@ -32,27 +32,29 @@ public class UpdateDomainsController : DocumentControllerBase
 
         Attempt<IEnumerable<IDomain>, DomainOperationStatus> result = await _domainService.UpdateDomainsAsync(id, domainsUpdateModel);
 
-        return result.Status switch
-        {
-            DomainOperationStatus.Success => Ok(),
-            DomainOperationStatus.CancelledByNotification => BadRequest(new ProblemDetailsBuilder()
-                .WithTitle("Cancelled by notification")
-                .WithDetail("A notification handler prevented the domain update operation.")
-                .Build()),
-            DomainOperationStatus.ContentNotFound => NotFound(new ProblemDetailsBuilder()
+        return result.Success
+            ? Ok()
+            : OperationStatusResult(result.Status, problemDetailsBuilder => result.Status switch
+            {
+                DomainOperationStatus.Success => Ok(),
+                DomainOperationStatus.CancelledByNotification => BadRequest(problemDetailsBuilder
+                    .WithTitle("Cancelled by notification")
+                    .WithDetail("A notification handler prevented the domain update operation.")
+                    .Build()),
+                DomainOperationStatus.ContentNotFound => NotFound(problemDetailsBuilder
                     .WithTitle("The targeted content item was not found.")
                     .Build()),
-            DomainOperationStatus.LanguageNotFound => BadRequest(new ProblemDetailsBuilder()
-                .WithTitle("Invalid language specified")
-                .WithDetail("One or more of the specified language ISO codes could not be found.")
-                .Build()),
-            DomainOperationStatus.DuplicateDomainName => Conflict(new ProblemDetailsBuilder()
-                .WithTitle("Duplicate domain name detected")
-                .WithDetail("One or more of the specified domain names were duplicates, possibly of assignments to other content items.")
-                .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
-                .WithTitle("Unknown domain update operation status.")
-                .Build()),
-        };
+                DomainOperationStatus.LanguageNotFound => BadRequest(problemDetailsBuilder
+                    .WithTitle("Invalid language specified")
+                    .WithDetail("One or more of the specified language ISO codes could not be found.")
+                    .Build()),
+                DomainOperationStatus.DuplicateDomainName => Conflict(problemDetailsBuilder
+                    .WithTitle("Duplicate domain name detected")
+                    .WithDetail("One or more of the specified domain names were duplicates, possibly of assignments to other content items.")
+                    .Build()),
+                _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
+                    .WithTitle("Unknown domain update operation status.")
+                    .Build()),
+            });
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/DocumentTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/DocumentTypeControllerBase.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Services.OperationStatus;
@@ -22,83 +21,83 @@ public abstract class DocumentTypeControllerBase : ManagementApiControllerBase
         => ContentTypeStructureOperationStatusResult(status, "document");
 
     internal static IActionResult ContentTypeOperationStatusResult(ContentTypeOperationStatus status, string type) =>
-        status switch
-        {
-            ContentTypeOperationStatus.Success => new OkResult(),
-            ContentTypeOperationStatus.NotFound => new NotFoundObjectResult(new ProblemDetailsBuilder()
-                .WithTitle("Not Found")
-                .WithDetail($"The specified {type} type was not found")
-                .Build()),
-            ContentTypeOperationStatus.DuplicateAlias => new BadRequestObjectResult(new ProblemDetailsBuilder()
-                .WithTitle("Duplicate alias")
-                .WithDetail($"The specified {type} type alias is already in use")
-                .Build()),
-            ContentTypeOperationStatus.InvalidAlias => new BadRequestObjectResult(new ProblemDetailsBuilder()
-                .WithTitle("Invalid alias")
-                .WithDetail($"The specified {type} type alias is invalid")
-                .Build()),
-            ContentTypeOperationStatus.InvalidPropertyTypeAlias => new BadRequestObjectResult(
-                new ProblemDetailsBuilder()
+        status is ContentTypeOperationStatus.Success
+            ? new OkResult()
+            : OperationStatusResult(status, problemDetailsBuilder => status switch
+            {
+                ContentTypeOperationStatus.NotFound => new NotFoundObjectResult(problemDetailsBuilder
+                    .WithTitle("Not Found")
+                    .WithDetail($"The specified {type} type was not found")
+                    .Build()),
+                ContentTypeOperationStatus.DuplicateAlias => new BadRequestObjectResult(problemDetailsBuilder
+                    .WithTitle("Duplicate alias")
+                    .WithDetail($"The specified {type} type alias is already in use")
+                    .Build()),
+                ContentTypeOperationStatus.InvalidAlias => new BadRequestObjectResult(problemDetailsBuilder
+                    .WithTitle("Invalid alias")
+                    .WithDetail($"The specified {type} type alias is invalid")
+                    .Build()),
+                ContentTypeOperationStatus.InvalidPropertyTypeAlias => new BadRequestObjectResult(problemDetailsBuilder
                     .WithTitle("Invalid property type alias")
                     .WithDetail("One or more property type aliases are invalid")
                     .Build()),
-            ContentTypeOperationStatus.InvalidContainerName => new BadRequestObjectResult(new ProblemDetailsBuilder()
-                .WithTitle("Invalid container name")
-                .WithDetail("One or more container names are invalid")
-                .Build()),
-            ContentTypeOperationStatus.MissingContainer => new BadRequestObjectResult(new ProblemDetailsBuilder()
-                .WithTitle("Missing container")
-                .WithDetail("One or more containers or properties are listed as parents to containers that are not defined.")
-                .Build()),
-            ContentTypeOperationStatus.DuplicateContainer => new BadRequestObjectResult(new ProblemDetailsBuilder()
-                .WithTitle("Duplicate container")
-                .WithDetail("One or more containers (or container keys) are defined multiple times.")
-                .Build()),
-            ContentTypeOperationStatus.DataTypeNotFound => new NotFoundObjectResult(new ProblemDetailsBuilder()
-                .WithTitle("Data Type not found")
-                .WithDetail("One or more of the specified data types were not found")
-                .Build()),
-            ContentTypeOperationStatus.InvalidInheritance => new BadRequestObjectResult(new ProblemDetailsBuilder()
-                .WithTitle("Invalid inheritance")
-                .WithDetail($"The specified {type} type inheritance is invalid")
-                .Build()),
-            ContentTypeOperationStatus.InvalidComposition => new BadRequestObjectResult(new ProblemDetailsBuilder()
-                .WithTitle("Invalid composition")
-                .WithDetail($"The specified {type} type composition is invalid")
-                .Build()),
-            ContentTypeOperationStatus.InvalidParent => new BadRequestObjectResult(new ProblemDetailsBuilder()
-                .WithTitle("Invalid parent")
-                .WithDetail(
-                    "The specified parent is invalid, or cannot be used in combination with the specified composition/inheritance")
-                .Build()),
-            ContentTypeOperationStatus.DuplicatePropertyTypeAlias => new BadRequestObjectResult(
-                new ProblemDetailsBuilder()
-                    .WithTitle("Duplicate property type alias")
-                    .WithDetail("One or more property type aliases are already in use, all property type aliases must be unique.")
+                ContentTypeOperationStatus.InvalidContainerName => new BadRequestObjectResult(problemDetailsBuilder
+                    .WithTitle("Invalid container name")
+                    .WithDetail("One or more container names are invalid")
                     .Build()),
-            _ => new ObjectResult("Unknown content type operation status") { StatusCode = StatusCodes.Status500InternalServerError },
-        };
+                ContentTypeOperationStatus.MissingContainer => new BadRequestObjectResult(problemDetailsBuilder
+                    .WithTitle("Missing container")
+                    .WithDetail("One or more containers or properties are listed as parents to containers that are not defined.")
+                    .Build()),
+                ContentTypeOperationStatus.DuplicateContainer => new BadRequestObjectResult(problemDetailsBuilder
+                    .WithTitle("Duplicate container")
+                    .WithDetail("One or more containers (or container keys) are defined multiple times.")
+                    .Build()),
+                ContentTypeOperationStatus.DataTypeNotFound => new NotFoundObjectResult(problemDetailsBuilder
+                    .WithTitle("Data Type not found")
+                    .WithDetail("One or more of the specified data types were not found")
+                    .Build()),
+                ContentTypeOperationStatus.InvalidInheritance => new BadRequestObjectResult(problemDetailsBuilder
+                    .WithTitle("Invalid inheritance")
+                    .WithDetail($"The specified {type} type inheritance is invalid")
+                    .Build()),
+                ContentTypeOperationStatus.InvalidComposition => new BadRequestObjectResult(problemDetailsBuilder
+                    .WithTitle("Invalid composition")
+                    .WithDetail($"The specified {type} type composition is invalid")
+                    .Build()),
+                ContentTypeOperationStatus.InvalidParent => new BadRequestObjectResult(problemDetailsBuilder
+                    .WithTitle("Invalid parent")
+                    .WithDetail("The specified parent is invalid, or cannot be used in combination with the specified composition/inheritance")
+                    .Build()),
+                ContentTypeOperationStatus.DuplicatePropertyTypeAlias => new BadRequestObjectResult(
+                    problemDetailsBuilder
+                        .WithTitle("Duplicate property type alias")
+                        .WithDetail("One or more property type aliases are already in use, all property type aliases must be unique.")
+                        .Build()),
+                _ => new ObjectResult("Unknown content type operation status") { StatusCode = StatusCodes.Status500InternalServerError },
+            });
 
     public static IActionResult ContentTypeStructureOperationStatusResult(ContentTypeStructureOperationStatus status, string type) =>
-        status switch
-        {
-            ContentTypeStructureOperationStatus.Success => new OkResult(),
-            ContentTypeStructureOperationStatus.CancelledByNotification => new BadRequestObjectResult(new ProblemDetailsBuilder()
-                .WithTitle("Cancelled by notification")
-                .WithDetail($"A notification handler prevented the {type} type operation")
-                .Build()),
-            ContentTypeStructureOperationStatus.ContainerNotFound => new NotFoundObjectResult(new ProblemDetailsBuilder()
-                .WithTitle("Container not found")
-                .WithDetail("The specified container was not found")
-                .Build()),
-            ContentTypeStructureOperationStatus.NotAllowedByPath => new BadRequestObjectResult(new ProblemDetailsBuilder()
-                .WithTitle("Not allowed by path")
-                .WithDetail($"The {type} type operation cannot be performed due to not allowed path (i.e. a child of itself)")
-                .Build()),
-            ContentTypeStructureOperationStatus.NotFound => new NotFoundObjectResult(new ProblemDetailsBuilder()
-                .WithTitle("Not Found")
-                .WithDetail($"The specified {type} type was not found")
-                .Build()),
-            _ => new ObjectResult("Unknown content type structure operation status") { StatusCode = StatusCodes.Status500InternalServerError }
-        };
+        status is ContentTypeStructureOperationStatus.Success
+            ? new OkResult()
+            : OperationStatusResult(status, problemDetailsBuilder => status switch
+            {
+                ContentTypeStructureOperationStatus.CancelledByNotification => new BadRequestObjectResult(problemDetailsBuilder
+                    .WithTitle("Cancelled by notification")
+                    .WithDetail($"A notification handler prevented the {type} type operation")
+                    .Build()),
+                ContentTypeStructureOperationStatus.ContainerNotFound => new NotFoundObjectResult(problemDetailsBuilder
+                    .WithTitle("Container not found")
+                    .WithDetail("The specified container was not found")
+                    .Build()),
+                ContentTypeStructureOperationStatus.NotAllowedByPath => new BadRequestObjectResult(problemDetailsBuilder
+                    .WithTitle("Not allowed by path")
+                    .WithDetail($"The {type} type operation cannot be performed due to not allowed path (i.e. a child of itself)")
+                    .Build()),
+                ContentTypeStructureOperationStatus.NotFound => new NotFoundObjectResult(problemDetailsBuilder
+                    .WithTitle("Not Found")
+                    .WithDetail($"The specified {type} type was not found")
+                    .Build()),
+                _ => new ObjectResult("Unknown content type structure operation status") { StatusCode = StatusCodes.Status500InternalServerError }
+            });
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/FolderManagementControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/FolderManagementControllerBase.cs
@@ -1,7 +1,6 @@
 ﻿using System.Linq.Expressions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.ViewModels;
 using Umbraco.Cms.Api.Management.ViewModels.Folder;
 using Umbraco.Cms.Core;
@@ -30,9 +29,11 @@ public abstract class FolderManagementControllerBase<TTreeEntity> : ManagementAp
         EntityContainer? container = await _treeEntityTypeContainerService.GetAsync(key);
         if (container == null)
         {
-            return NotFound(new ProblemDetailsBuilder()
-                .WithTitle($"Could not find the folder with id: {key}")
-                .Build());
+            return OperationStatusResult(
+                EntityContainerOperationStatus.NotFound,
+                problemDetailsBuilder => NotFound(problemDetailsBuilder
+                    .WithTitle($"Could not find the folder with id: {key}")
+                    .Build()));
         }
 
         EntityContainer? parentContainer = await _treeEntityTypeContainerService.GetParentAsync(container);
@@ -82,32 +83,32 @@ public abstract class FolderManagementControllerBase<TTreeEntity> : ManagementAp
     }
 
     protected IActionResult OperationStatusResult(EntityContainerOperationStatus status)
-        => status switch
+        => OperationStatusResult(status, problemDetailsBuilder => status switch
         {
-            EntityContainerOperationStatus.NotFound => NotFound(new ProblemDetailsBuilder()
+            EntityContainerOperationStatus.NotFound => NotFound(problemDetailsBuilder
                 .WithTitle("The folder could not be found")
                 .Build()),
-            EntityContainerOperationStatus.ParentNotFound => NotFound(new ProblemDetailsBuilder()
+            EntityContainerOperationStatus.ParentNotFound => NotFound(problemDetailsBuilder
                 .WithTitle("The parent folder could not be found")
                 .Build()),
-            EntityContainerOperationStatus.DuplicateName => BadRequest(new ProblemDetailsBuilder()
+            EntityContainerOperationStatus.DuplicateName => BadRequest(problemDetailsBuilder
                 .WithTitle("The name is already used")
                 .WithDetail("The folder name must be unique on this parent.")
                 .Build()),
-            EntityContainerOperationStatus.DuplicateKey => BadRequest(new ProblemDetailsBuilder()
+            EntityContainerOperationStatus.DuplicateKey => BadRequest(problemDetailsBuilder
                 .WithTitle("The id is already used")
                 .WithDetail("The folder id must be unique.")
                 .Build()),
-            EntityContainerOperationStatus.NotEmpty => BadRequest(new ProblemDetailsBuilder()
+            EntityContainerOperationStatus.NotEmpty => BadRequest(problemDetailsBuilder
                 .WithTitle("The folder is not empty")
                 .WithDetail("The folder must be empty to perform this action.")
                 .Build()),
-            EntityContainerOperationStatus.CancelledByNotification => BadRequest(new ProblemDetailsBuilder()
+            EntityContainerOperationStatus.CancelledByNotification => BadRequest(problemDetailsBuilder
                 .WithTitle("Cancelled by notification")
                 .WithDetail("A notification handler prevented the folder operation.")
                 .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown folder operation status.")
                 .Build()),
-        };
+        });
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Install/InstallControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Install/InstallControllerBase.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Api.Management.Filters;
 using Umbraco.Cms.Api.Management.Routing;
@@ -18,31 +17,32 @@ namespace Umbraco.Cms.Api.Management.Controllers.Install;
 public abstract class InstallControllerBase : ManagementApiControllerBase
 {
     protected IActionResult InstallOperationResult(InstallOperationStatus status, InstallationResult? result = null) =>
-        status switch
-        {
-            InstallOperationStatus.Success => Ok(),
-            InstallOperationStatus.UnknownDatabaseProvider => BadRequest(new ProblemDetailsBuilder()
-                .WithTitle("Invalid database configuration")
-                .WithDetail("The database provider is unknown.")
-                .Build()),
-            InstallOperationStatus.MissingConnectionString => BadRequest(new ProblemDetailsBuilder()
-                .WithTitle("Invalid database configuration")
-                .WithDetail("The connection string is missing.")
-                .Build()),
-            InstallOperationStatus.MissingProviderName => BadRequest(new ProblemDetailsBuilder()
-                .WithTitle("Invalid database configuration")
-                .WithDetail("The provider name is missing.")
-                .Build()),
-            InstallOperationStatus.DatabaseConnectionFailed => BadRequest(new ProblemDetailsBuilder()
-                .WithTitle("Invalid database configuration")
-                .WithDetail("Could not connect to the database.")
-                .Build()),
-            InstallOperationStatus.InstallFailed => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
-                .WithTitle("Install failed")
-                .WithDetail(result?.ErrorMessage ?? "An unknown error occurred.")
-                .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
-                .WithTitle("Unknown install operation status.")
-                .Build()),
-        };
+        status is InstallOperationStatus.Success
+            ? Ok()
+            : OperationStatusResult(status, problemDetailsBuilder => status switch
+            {
+                InstallOperationStatus.UnknownDatabaseProvider => BadRequest(problemDetailsBuilder
+                    .WithTitle("Invalid database configuration")
+                    .WithDetail("The database provider is unknown.")
+                    .Build()),
+                InstallOperationStatus.MissingConnectionString => BadRequest(problemDetailsBuilder
+                    .WithTitle("Invalid database configuration")
+                    .WithDetail("The connection string is missing.")
+                    .Build()),
+                InstallOperationStatus.MissingProviderName => BadRequest(problemDetailsBuilder
+                    .WithTitle("Invalid database configuration")
+                    .WithDetail("The provider name is missing.")
+                    .Build()),
+                InstallOperationStatus.DatabaseConnectionFailed => BadRequest(problemDetailsBuilder
+                    .WithTitle("Invalid database configuration")
+                    .WithDetail("Could not connect to the database.")
+                    .Build()),
+                InstallOperationStatus.InstallFailed => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
+                    .WithTitle("Install failed")
+                    .WithDetail(result?.ErrorMessage ?? "An unknown error occurred.")
+                    .Build()),
+                _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
+                    .WithTitle("Unknown install operation status.")
+                    .Build()),
+            });
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Language/LanguageControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Language/LanguageControllerBase.cs
@@ -13,39 +13,41 @@ namespace Umbraco.Cms.Api.Management.Controllers.Language;
 public abstract class LanguageControllerBase : ManagementApiControllerBase
 {
     protected IActionResult LanguageOperationStatusResult(LanguageOperationStatus status) =>
-        status switch
+        OperationStatusResult(status, problemDetailsBuilder => status switch
         {
-            LanguageOperationStatus.InvalidFallback => BadRequest(new ProblemDetailsBuilder()
+            LanguageOperationStatus.InvalidFallback => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid fallback language")
                 .WithDetail("The fallback language could not be applied. This may be caused if the fallback language causes cyclic fallbacks.")
                 .Build()),
-            LanguageOperationStatus.NotFound => LanguageNotFound(),
-            LanguageOperationStatus.MissingDefault => BadRequest(new ProblemDetailsBuilder()
+            LanguageOperationStatus.NotFound => LanguageNotFound(problemDetailsBuilder),
+            LanguageOperationStatus.MissingDefault => BadRequest(problemDetailsBuilder
                 .WithTitle("No default language")
                 .WithDetail("The attempted operation would result in having no default language defined. This is not allowed.")
                 .Build()),
-            LanguageOperationStatus.DuplicateIsoCode => BadRequest(new ProblemDetailsBuilder()
+            LanguageOperationStatus.DuplicateIsoCode => BadRequest(problemDetailsBuilder
                 .WithTitle("Duplicate ISO code")
                 .WithDetail("Another language already exists with the attempted ISO code.")
                 .Build()),
-            LanguageOperationStatus.InvalidIsoCode => BadRequest(new ProblemDetailsBuilder()
+            LanguageOperationStatus.InvalidIsoCode => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid ISO code")
                 .WithDetail("The attempted ISO code does not represent a valid culture.")
                 .Build()),
-            LanguageOperationStatus.InvalidFallbackIsoCode => BadRequest(new ProblemDetailsBuilder()
+            LanguageOperationStatus.InvalidFallbackIsoCode => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid Fallback ISO code")
                 .WithDetail("The attempted fallback ISO code does not represent a valid culture.")
                 .Build()),
-            LanguageOperationStatus.CancelledByNotification => BadRequest(new ProblemDetailsBuilder()
+            LanguageOperationStatus.CancelledByNotification => BadRequest(problemDetailsBuilder
                 .WithTitle("Cancelled by notification")
                 .WithDetail("A notification handler prevented the language operation.")
                 .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown language operation status.")
                 .Build()),
-        };
+        });
 
-    protected IActionResult LanguageNotFound() => NotFound(new ProblemDetailsBuilder()
+    protected IActionResult LanguageNotFound() => OperationStatusResult(LanguageOperationStatus.NotFound, LanguageNotFound);
+
+    private IActionResult LanguageNotFound(ProblemDetailsBuilder problemDetailsBuilder) => NotFound(problemDetailsBuilder
         .WithTitle("The language could not be found")
         .Build());
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/LogViewerControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/LogViewerControllerBase.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Cms.Web.Common.Authorization;
@@ -15,21 +14,22 @@ namespace Umbraco.Cms.Api.Management.Controllers.LogViewer;
 public abstract class LogViewerControllerBase : ManagementApiControllerBase
 {
     protected IActionResult LogViewerOperationStatusResult(LogViewerOperationStatus status) =>
-        status switch
-        {
-            LogViewerOperationStatus.NotFoundLogSearch => NotFound(new ProblemDetailsBuilder()
+        OperationStatusResult(status, problemDetailsBuilder =>
+            status switch
+            {
+                LogViewerOperationStatus.NotFoundLogSearch => NotFound(problemDetailsBuilder
                     .WithTitle("The log search could not be found")
                     .Build()),
-            LogViewerOperationStatus.DuplicateLogSearch => BadRequest(new ProblemDetailsBuilder()
-                .WithTitle("Duplicate log search name")
-                .WithDetail("Another log search already exists with the attempted name.")
-                .Build()),
-            LogViewerOperationStatus.CancelledByLogsSizeValidation => BadRequest(new ProblemDetailsBuilder()
-                .WithTitle("Cancelled due to log file size")
-                .WithDetail("The log file size for the requested date range prevented the operation.")
-                .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
-                .WithTitle("Unknown log viewer operation status.")
-                .Build()),
-        };
+                LogViewerOperationStatus.DuplicateLogSearch => BadRequest(problemDetailsBuilder
+                    .WithTitle("Duplicate log search name")
+                    .WithDetail("Another log search already exists with the attempted name.")
+                    .Build()),
+                LogViewerOperationStatus.CancelledByLogsSizeValidation => BadRequest(problemDetailsBuilder
+                    .WithTitle("Cancelled due to log file size")
+                    .WithDetail("The log file size for the requested date range prevented the operation.")
+                    .Build()),
+                _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
+                    .WithTitle("Unknown log viewer operation status.")
+                    .Build()),
+            });
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/ManagementApiControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/ManagementApiControllerBase.cs
@@ -56,7 +56,7 @@ public abstract class ManagementApiControllerBase : Controller, IUmbracoFeature
     // Duplicate code copied between Management API and Delivery API.
     protected IActionResult Forbidden() => new StatusCodeResult(StatusCodes.Status403Forbidden);
 
-    protected IActionResult OperationStatusResult<TEnum>(TEnum status, Func<ProblemDetailsBuilder, IActionResult> result)
+    protected static IActionResult OperationStatusResult<TEnum>(TEnum status, Func<ProblemDetailsBuilder, IActionResult> result)
         where TEnum : Enum
         => result(new ProblemDetailsBuilder().WithOperationStatus(status));
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/MemberControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/MemberControllerBase.cs
@@ -18,9 +18,7 @@ namespace Umbraco.Cms.Api.Management.Controllers.Member;
 // [Authorize(Policy = "New" + AuthorizationPolicies.SectionAccessMembers)]
 public class MemberControllerBase : ContentControllerBase
 {
-    protected IActionResult MemberNotFound() => NotFound(new ProblemDetailsBuilder()
-        .WithTitle("The requested member could not be found")
-        .Build());
+    protected IActionResult MemberNotFound() => OperationStatusResult(MemberEditingOperationStatus.MemberNotFound, MemberNotFound);
 
     protected IActionResult MemberEditingStatusResult(MemberEditingStatus status)
         => status.MemberEditingOperationStatus is not MemberEditingOperationStatus.Success
@@ -32,9 +30,7 @@ public class MemberControllerBase : ContentControllerBase
     protected IActionResult MemberEditingOperationStatusResult(MemberEditingOperationStatus status)
         => OperationStatusResult(status, problemDetailsBuilder => status switch
         {
-            MemberEditingOperationStatus.MemberNotFound => NotFound(problemDetailsBuilder
-                .WithTitle("The requested member could not be found")
-                .Build()),
+            MemberEditingOperationStatus.MemberNotFound => MemberNotFound(problemDetailsBuilder),
             MemberEditingOperationStatus.MemberTypeNotFound => NotFound(problemDetailsBuilder
                 .WithTitle("The requested member type could not be found")
                 .Build()),
@@ -92,4 +88,8 @@ public class MemberControllerBase : ContentControllerBase
         ContentValidationResult validationResult)
         where TContentModelBase : ContentModelBase<MemberValueModel, MemberVariantRequestModel>
         => ContentEditingOperationStatusResult<TContentModelBase, MemberValueModel, MemberVariantRequestModel>(status, requestModel, validationResult);
+
+    private IActionResult MemberNotFound(ProblemDetailsBuilder problemDetailsBuilder) => NotFound(problemDetailsBuilder
+        .WithTitle("The requested member could not be found")
+        .Build());
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Package/PackageControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Package/PackageControllerBase.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Cms.Web.Common.Authorization;
@@ -15,36 +14,36 @@ namespace Umbraco.Cms.Api.Management.Controllers.Package;
 public abstract class PackageControllerBase : ManagementApiControllerBase
 {
     protected IActionResult PackageOperationStatusResult(PackageOperationStatus status) =>
-        status switch
+        OperationStatusResult(status, problemDetailsBuilder => status switch
         {
-            PackageOperationStatus.NotFound => NotFound(new ProblemDetailsBuilder()
-                    .WithTitle("The package could not be found")
-                    .Build()),
-            PackageOperationStatus.DuplicateItemName => Conflict(new ProblemDetailsBuilder()
+            PackageOperationStatus.NotFound => NotFound(problemDetailsBuilder
+                .WithTitle("The package could not be found")
+                .Build()),
+            PackageOperationStatus.DuplicateItemName => Conflict(problemDetailsBuilder
                 .WithTitle("Duplicate package name")
                 .WithDetail("Another package already exists with the attempted name.")
                 .Build()),
-            PackageOperationStatus.InvalidName => BadRequest(new ProblemDetailsBuilder()
+            PackageOperationStatus.InvalidName => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid package name")
                 .WithDetail("The attempted package name does not represent a valid name for a package.")
                 .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown package operation status.")
                 .Build()),
-        };
+        });
 
     protected IActionResult PackageMigrationOperationStatusResult(PackageMigrationOperationStatus status) =>
-        status switch
+        OperationStatusResult(status, problemDetailsBuilder => status switch
         {
-            PackageMigrationOperationStatus.NotFound => NotFound(new ProblemDetailsBuilder()
-                    .WithTitle("No migration plans were found for that package")
-                    .Build()),
-            PackageMigrationOperationStatus.CancelledByFailedMigration => Conflict(new ProblemDetailsBuilder()
+            PackageMigrationOperationStatus.NotFound => NotFound(problemDetailsBuilder
+                .WithTitle("No migration plans were found for that package")
+                .Build()),
+            PackageMigrationOperationStatus.CancelledByFailedMigration => Conflict(problemDetailsBuilder
                 .WithTitle("Package migration failed")
                 .WithDetail("Check log for full details about the failed migration.")
                 .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown package migration operation status.")
                 .Build()),
-        };
+        });
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Folder/PartialViewFolderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Folder/PartialViewFolderControllerBase.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Services.OperationStatus;
@@ -16,30 +15,30 @@ namespace Umbraco.Cms.Api.Management.Controllers.PartialView.Folder;
 public class PartialViewFolderControllerBase : FileSystemManagementControllerBase
 {
     protected IActionResult OperationStatusResult(PartialViewFolderOperationStatus status) =>
-        status switch
+        OperationStatusResult(status, problemDetailsBuilder => status switch
         {
-            PartialViewFolderOperationStatus.AlreadyExists => BadRequest(new ProblemDetailsBuilder()
+            PartialViewFolderOperationStatus.AlreadyExists => BadRequest(problemDetailsBuilder
                 .WithTitle("Folder already exists")
                 .WithDetail("The folder already exists")
                 .Build()),
-            PartialViewFolderOperationStatus.NotEmpty => BadRequest(new ProblemDetailsBuilder()
+            PartialViewFolderOperationStatus.NotEmpty => BadRequest(problemDetailsBuilder
                 .WithTitle("Not empty")
                 .WithDetail("The folder is not empty and can therefore not be deleted.")
                 .Build()),
-            PartialViewFolderOperationStatus.NotFound => NotFound(new ProblemDetailsBuilder()
+            PartialViewFolderOperationStatus.NotFound => NotFound(problemDetailsBuilder
                 .WithTitle("Not found")
                 .WithDetail("The specified folder was not found.")
                 .Build()),
-            PartialViewFolderOperationStatus.ParentNotFound => NotFound(new ProblemDetailsBuilder()
+            PartialViewFolderOperationStatus.ParentNotFound => NotFound(problemDetailsBuilder
                 .WithTitle("Parent not found")
                 .WithDetail("The parent folder was not found.")
                 .Build()),
-            PartialViewFolderOperationStatus.InvalidName => BadRequest(new ProblemDetailsBuilder()
+            PartialViewFolderOperationStatus.InvalidName => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid name")
                 .WithDetail("The name specified is not a valid name.")
                 .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown partial view folder operation status.")
                 .Build()),
-        };
+        });
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/PartialViewControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/PartialViewControllerBase.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Services.OperationStatus;
@@ -16,38 +15,40 @@ namespace Umbraco.Cms.Api.Management.Controllers.PartialView;
 public class PartialViewControllerBase : FileSystemManagementControllerBase
 {
     protected IActionResult PartialViewOperationStatusResult(PartialViewOperationStatus status) =>
-        status switch
-        {
-            PartialViewOperationStatus.Success => Ok(),
-            PartialViewOperationStatus.AlreadyExists => BadRequest(new ProblemDetailsBuilder()
-                .WithTitle("Partial view already exists")
-                .WithDetail("A partial view with the same path already exists")
-                .Build()),
-            PartialViewOperationStatus.InvalidFileExtension => BadRequest(new ProblemDetailsBuilder()
-                .WithTitle("Invalid file extension")
-                .WithDetail("The file extension is not valid for a partial view.")
-                .Build()),
-            PartialViewOperationStatus.ParentNotFound => NotFound(new ProblemDetailsBuilder()
-                .WithTitle("Parent not found")
-                .WithDetail("The parent folder was not found.")
-                .Build()),
-            PartialViewOperationStatus.PathTooLong => BadRequest(new ProblemDetailsBuilder()
-                .WithTitle("Path too long")
-                .WithDetail("The file path is too long.")
-                .Build()),
-            PartialViewOperationStatus.InvalidName => BadRequest(new ProblemDetailsBuilder()
-                .WithTitle("Invalid name")
-                .WithDetail("The partial view name is invalid.")
-                .Build()),
-            PartialViewOperationStatus.NotFound => PartialViewNotFound(),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
-                .WithTitle("Unknown partial view operation status.")
-                .Build()),
-        };
+        OperationStatusResult(status, problemDetailsBuilder =>
+            status switch
+            {
+                PartialViewOperationStatus.AlreadyExists => BadRequest(problemDetailsBuilder
+                    .WithTitle("Partial view already exists")
+                    .WithDetail("A partial view with the same path already exists")
+                    .Build()),
+                PartialViewOperationStatus.InvalidFileExtension => BadRequest(problemDetailsBuilder
+                    .WithTitle("Invalid file extension")
+                    .WithDetail("The file extension is not valid for a partial view.")
+                    .Build()),
+                PartialViewOperationStatus.ParentNotFound => NotFound(problemDetailsBuilder
+                    .WithTitle("Parent not found")
+                    .WithDetail("The parent folder was not found.")
+                    .Build()),
+                PartialViewOperationStatus.PathTooLong => BadRequest(problemDetailsBuilder
+                    .WithTitle("Path too long")
+                    .WithDetail("The file path is too long.")
+                    .Build()),
+                PartialViewOperationStatus.InvalidName => BadRequest(problemDetailsBuilder
+                    .WithTitle("Invalid name")
+                    .WithDetail("The partial view name is invalid.")
+                    .Build()),
+                PartialViewOperationStatus.NotFound => PartialViewNotFound(),
+                _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
+                    .WithTitle("Unknown partial view operation status.")
+                    .Build()),
+            });
 
-    protected IActionResult PartialViewNotFound() => NotFound(new ProblemDetailsBuilder()
-        .WithTitle("Partial view not found")
-        .WithDetail("The partial view was not found.")
-        .Build());
+    protected IActionResult PartialViewNotFound() => OperationStatusResult(
+        PartialViewOperationStatus.NotFound,
+        problemDetailsBuilder => NotFound(problemDetailsBuilder
+            .WithTitle("Partial view not found")
+            .WithDetail("The partial view was not found.")
+            .Build()));
 
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Profiling/ProfilingControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Profiling/ProfilingControllerBase.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Cms.Web.Common.Authorization;
@@ -14,17 +13,16 @@ namespace Umbraco.Cms.Api.Management.Controllers.Profiling;
 [Authorize(Policy = "New" + AuthorizationPolicies.SectionAccessSettings)]
 public class ProfilingControllerBase : ManagementApiControllerBase
 {
-
-      protected IActionResult WebProfilerOperationStatusResult(WebProfilerOperationStatus status) =>
-        status switch
+    protected IActionResult WebProfilerOperationStatusResult(WebProfilerOperationStatus status) =>
+        OperationStatusResult(status, problemDetailsBuilder => status switch
         {
-            WebProfilerOperationStatus.ExecutingUserNotFound => Unauthorized(new ProblemDetailsBuilder()
+            WebProfilerOperationStatus.ExecutingUserNotFound => Unauthorized(problemDetailsBuilder
                 .WithTitle("Executing user not found")
                 .WithDetail("Executing this action requires a signed in user.")
                 .Build()),
 
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown profiling operation status.")
                 .Build()),
-        };
+        });
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/PropertyType/PropertyTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PropertyType/PropertyTypeControllerBase.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Cms.Web.Common.Authorization;
@@ -15,13 +14,13 @@ namespace Umbraco.Cms.Api.Management.Controllers.PropertyType;
 public abstract class PropertyTypeControllerBase : ManagementApiControllerBase
 {
     protected IActionResult PropertyTypeOperationStatusResult(PropertyTypeOperationStatus status) =>
-        status switch
+        OperationStatusResult(status, problemDetailsBuilder => status switch
         {
-            PropertyTypeOperationStatus.ContentTypeNotFound => NotFound(new ProblemDetailsBuilder()
-                    .WithTitle("The content type was not found.")
-                    .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+            PropertyTypeOperationStatus.ContentTypeNotFound => NotFound(problemDetailsBuilder
+                .WithTitle("The content type was not found.")
+                .Build()),
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown property type operation status.")
                 .Build()),
-        };
+        });
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/RecycleBin/RecycleBinControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RecycleBin/RecycleBinControllerBase.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.Controllers.Content;
 using Umbraco.Cms.Api.Management.Services.Paging;
@@ -84,16 +83,16 @@ public abstract class RecycleBinControllerBase<TItem> : ContentControllerBase
     }
 
     protected IActionResult OperationStatusResult(OperationResult result) =>
-        result.Result switch
+        OperationStatusResult(result.Result, problemDetailsBuilder => result.Result switch
         {
-            OperationResultType.FailedCancelledByEvent => BadRequest(new ProblemDetailsBuilder()
+            OperationResultType.FailedCancelledByEvent => BadRequest(problemDetailsBuilder
                 .WithTitle("Cancelled by notification")
                 .WithDetail("A notification handler prevented the operation.")
                 .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown operation status.")
                 .Build()),
-        };
+        });
 
     private IEntitySlim[] GetPagedRootEntities(long pageNumber, int pageSize, out long totalItems)
     {

--- a/src/Umbraco.Cms.Api.Management/Controllers/Relation/RelationControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Relation/RelationControllerBase.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Cms.Web.Common.Authorization;
@@ -14,16 +14,14 @@ namespace Umbraco.Cms.Api.Management.Controllers.Relation;
 public abstract class RelationControllerBase : ManagementApiControllerBase
 {
     protected IActionResult RelationOperationStatusResult(RelationOperationStatus status) =>
-        status switch
+        OperationStatusResult(status, problemDetailsBuilder => status switch
         {
-            RelationOperationStatus.RelationTypeNotFound => BadRequest(new ProblemDetailsBuilder()
+            RelationOperationStatus.RelationTypeNotFound => BadRequest(problemDetailsBuilder
                 .WithTitle("Relation type not found")
                 .WithDetail("The relation type could not be found.")
                 .Build()),
-        };
-
-    protected IActionResult RelationNotFound() => NotFound(new ProblemDetailsBuilder()
-        .WithTitle("The relation could not be found")
-        .Build());
-
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
+                .WithTitle("Unknown relation operation status.")
+                .Build()),
+        });
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Query/RelationTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Query/RelationTypeControllerBase.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
@@ -14,35 +15,39 @@ namespace Umbraco.Cms.Api.Management.Controllers.RelationType.Query;
 [Authorize(Policy = "New" + AuthorizationPolicies.TreeAccessRelationTypes)]
 public class RelationTypeControllerBase : ManagementApiControllerBase
 {
-        protected IActionResult RelationTypeOperationStatusResult(RelationTypeOperationStatus status) =>
-        status switch
+    protected IActionResult RelationTypeOperationStatusResult(RelationTypeOperationStatus status) =>
+        OperationStatusResult(status, problemDetailsBuilder => status switch
         {
-            RelationTypeOperationStatus.InvalidId => BadRequest(new ProblemDetailsBuilder()
+            RelationTypeOperationStatus.InvalidId => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid id")
                 .WithDetail("Can not assign an Id when creating a relation type")
                 .Build()),
-            RelationTypeOperationStatus.CancelledByNotification => BadRequest(new ProblemDetailsBuilder()
+            RelationTypeOperationStatus.CancelledByNotification => BadRequest(problemDetailsBuilder
                 .WithTitle("Cancelled by notification")
                 .WithDetail("A notification handler prevented the relation type operation.")
                 .Build()),
-            RelationTypeOperationStatus.KeyAlreadyExists => BadRequest(new ProblemDetailsBuilder()
+            RelationTypeOperationStatus.KeyAlreadyExists => BadRequest(problemDetailsBuilder
                 .WithTitle("Key already exists")
                 .WithDetail("An entity with the given key already exists")
                 .Build()),
-            RelationTypeOperationStatus.NotFound => RelationTypeNotFound(),
-            RelationTypeOperationStatus.InvalidChildObjectType => BadRequest(new ProblemDetailsBuilder()
+            RelationTypeOperationStatus.NotFound => RelationTypeNotFound(problemDetailsBuilder),
+            RelationTypeOperationStatus.InvalidChildObjectType => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid child object type")
                 .WithDetail("The child object type is not allowed")
                 .Build()),
-            RelationTypeOperationStatus.InvalidParentObjectType => BadRequest(new ProblemDetailsBuilder()
+            RelationTypeOperationStatus.InvalidParentObjectType => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid parent object type")
                 .WithDetail("The parent object type is not allowed")
                 .Build()),
-        };
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
+                .WithTitle("Unknown relation type operation status.")
+                .Build()),
+        });
 
-        protected IActionResult RelationTypeNotFound() => NotFound(new ProblemDetailsBuilder()
-            .WithTitle("Relation type not found")
-            .WithDetail("A relation type with the given key does not exist")
-            .Build());
+    protected IActionResult RelationTypeNotFound() => OperationStatusResult(RelationTypeOperationStatus.NotFound, RelationTypeNotFound);
 
+    private IActionResult RelationTypeNotFound(ProblemDetailsBuilder problemDetailsBuilder) => NotFound(problemDetailsBuilder
+        .WithTitle("Relation type not found")
+        .WithDetail("A relation type with the given key does not exist")
+        .Build());
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Query/UpdateRelationTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Query/UpdateRelationTypeController.cs
@@ -40,11 +40,7 @@ public class UpdateRelationTypeController : RelationTypeControllerBase
 
         if (persistedRelationType is null)
         {
-            ProblemDetails problemDetails = new ProblemDetailsBuilder()
-                .WithTitle("Could not find relation type")
-                .WithDetail($"Relation type with id {id} could not be found")
-                .Build();
-            return NotFound(problemDetails);
+            return RelationTypeNotFound();
         }
 
         _relationTypePresentationFactory.MapUpdateModelToRelationType(updateRelationTypeSavingViewModel, persistedRelationType);

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/Folder/ScriptFolderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/Folder/ScriptFolderControllerBase.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Services.OperationStatus;
@@ -16,30 +15,30 @@ namespace Umbraco.Cms.Api.Management.Controllers.Script.Folder;
 public class ScriptFolderControllerBase : FileSystemManagementControllerBase
 {
     protected IActionResult OperationStatusResult(ScriptFolderOperationStatus status) =>
-        status switch
+        OperationStatusResult(status, problemDetailsBuilder => status switch
         {
-            ScriptFolderOperationStatus.AlreadyExists => BadRequest(new ProblemDetailsBuilder()
+            ScriptFolderOperationStatus.AlreadyExists => BadRequest(problemDetailsBuilder
                 .WithTitle("Folder already exists")
                 .WithDetail("The folder already exists")
                 .Build()),
-            ScriptFolderOperationStatus.NotEmpty => BadRequest(new ProblemDetailsBuilder()
+            ScriptFolderOperationStatus.NotEmpty => BadRequest(problemDetailsBuilder
                 .WithTitle("Not empty")
                 .WithDetail("The folder is not empty and can therefore not be deleted.")
                 .Build()),
-            ScriptFolderOperationStatus.NotFound => NotFound(new ProblemDetailsBuilder()
+            ScriptFolderOperationStatus.NotFound => NotFound(problemDetailsBuilder
                 .WithTitle("Not found")
                 .WithDetail("The specified folder was not found.")
                 .Build()),
-            ScriptFolderOperationStatus.ParentNotFound => NotFound(new ProblemDetailsBuilder()
+            ScriptFolderOperationStatus.ParentNotFound => NotFound(problemDetailsBuilder
                 .WithTitle("Parent not found")
                 .WithDetail("The parent folder was not found.")
                 .Build()),
-            ScriptFolderOperationStatus.InvalidName => BadRequest(new ProblemDetailsBuilder()
+            ScriptFolderOperationStatus.InvalidName => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid name")
                 .WithDetail("The name specified is not a valid name.")
                 .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown script folder operation status.")
                 .Build()),
-        };
+        });
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/ScriptControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/ScriptControllerBase.cs
@@ -16,42 +16,42 @@ namespace Umbraco.Cms.Api.Management.Controllers.Script;
 public class ScriptControllerBase : FileSystemManagementControllerBase
 {
     protected IActionResult ScriptOperationStatusResult(ScriptOperationStatus status) =>
-        status switch
+        OperationStatusResult(status, problemDetailsBuilder => status switch
         {
-            ScriptOperationStatus.Success => Ok(),
-            ScriptOperationStatus.AlreadyExists => BadRequest(new ProblemDetailsBuilder()
+            ScriptOperationStatus.AlreadyExists => BadRequest(problemDetailsBuilder
                 .WithTitle("Script already exists")
                 .WithDetail("A script with the same path already exists")
                 .Build()),
-            ScriptOperationStatus.CancelledByNotification => BadRequest(new ProblemDetailsBuilder()
+            ScriptOperationStatus.CancelledByNotification => BadRequest(problemDetailsBuilder
                 .WithTitle("Cancelled by notification")
                 .WithDetail("A script notification handler prevented the script operation.")
                 .Build()),
-            ScriptOperationStatus.InvalidFileExtension => BadRequest(new ProblemDetailsBuilder()
+            ScriptOperationStatus.InvalidFileExtension => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid file extension")
                 .WithDetail("The file extension is not valid for a script.")
                 .Build()),
-            ScriptOperationStatus.ParentNotFound => NotFound(new ProblemDetailsBuilder()
+            ScriptOperationStatus.ParentNotFound => NotFound(problemDetailsBuilder
                 .WithTitle("Parent not found")
                 .WithDetail("The parent folder was not found.")
                 .Build()),
-            ScriptOperationStatus.PathTooLong => BadRequest(new ProblemDetailsBuilder()
+            ScriptOperationStatus.PathTooLong => BadRequest(problemDetailsBuilder
                 .WithTitle("Path too long")
                 .WithDetail("The file path is too long.")
                 .Build()),
             ScriptOperationStatus.NotFound => ScriptNotFound(),
-            ScriptOperationStatus.InvalidName => BadRequest(new ProblemDetailsBuilder()
+            ScriptOperationStatus.InvalidName => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid name")
                 .WithDetail("The script name is invalid.")
                 .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown script operation status.")
                 .Build()),
-        };
+        });
 
-    protected IActionResult ScriptNotFound() => NotFound(new ProblemDetailsBuilder()
+    protected IActionResult ScriptNotFound() => OperationStatusResult(ScriptOperationStatus.NotFound, ScriptNotFound);
+
+    private IActionResult ScriptNotFound(ProblemDetailsBuilder problemDetailsBuilder) => NotFound(problemDetailsBuilder
         .WithTitle("The script could not be found")
         .WithDetail("The script was not found.")
         .Build());
-
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/SecurityControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/SecurityControllerBase.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Services.OperationStatus;
@@ -16,23 +15,22 @@ namespace Umbraco.Cms.Api.Management.Controllers.Security;
 public abstract class SecurityControllerBase : ManagementApiControllerBase
 {
     protected IActionResult UserOperationStatusResult(UserOperationStatus status, ErrorMessageResult? errorMessageResult = null) =>
-        status switch
+        OperationStatusResult(status, problemDetailsBuilder => status switch
         {
-            UserOperationStatus.Success => Ok(),
-            UserOperationStatus.UserNotFound => NotFound(new ProblemDetailsBuilder()
+            UserOperationStatus.UserNotFound => NotFound(problemDetailsBuilder
                 .WithTitle("The user was not found")
                 .WithDetail("The specified user was not found.")
                 .Build()),
-            UserOperationStatus.InvalidPasswordResetToken => BadRequest(new ProblemDetailsBuilder()
+            UserOperationStatus.InvalidPasswordResetToken => BadRequest(problemDetailsBuilder
                 .WithTitle("The password reset token was invalid")
                 .WithDetail("The specified password reset token was either used already or wrong.")
                 .Build()),
-            UserOperationStatus.UnknownFailure => BadRequest(new ProblemDetailsBuilder()
+            UserOperationStatus.UnknownFailure => BadRequest(problemDetailsBuilder
                 .WithTitle("Unknown failure")
                 .WithDetail(errorMessageResult?.Error?.ErrorMessage ?? "The error was unknown")
                 .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown user operation status.")
                 .Build()),
-        };
+        });
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Folder/StylesheetFolderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Folder/StylesheetFolderControllerBase.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Services.OperationStatus;
@@ -16,30 +15,30 @@ namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet.Folder;
 public class StylesheetFolderControllerBase : FileSystemManagementControllerBase
 {
     protected IActionResult OperationStatusResult(StylesheetFolderOperationStatus status) =>
-        status switch
+        OperationStatusResult(status, problemDetailsBuilder => status switch
         {
-            StylesheetFolderOperationStatus.AlreadyExists => BadRequest(new ProblemDetailsBuilder()
+            StylesheetFolderOperationStatus.AlreadyExists => BadRequest(problemDetailsBuilder
                 .WithTitle("Folder already exists")
                 .WithDetail("The folder already exists")
                 .Build()),
-            StylesheetFolderOperationStatus.NotEmpty => BadRequest(new ProblemDetailsBuilder()
+            StylesheetFolderOperationStatus.NotEmpty => BadRequest(problemDetailsBuilder
                 .WithTitle("Not empty")
                 .WithDetail("The folder is not empty and can therefore not be deleted.")
                 .Build()),
-            StylesheetFolderOperationStatus.NotFound => NotFound(new ProblemDetailsBuilder()
+            StylesheetFolderOperationStatus.NotFound => NotFound(problemDetailsBuilder
                 .WithTitle("Not found")
                 .WithDetail("The specified folder was not found.")
                 .Build()),
-            StylesheetFolderOperationStatus.ParentNotFound => NotFound(new ProblemDetailsBuilder()
+            StylesheetFolderOperationStatus.ParentNotFound => NotFound(problemDetailsBuilder
                 .WithTitle("Parent not found")
                 .WithDetail("The parent folder was not found.")
                 .Build()),
-            StylesheetFolderOperationStatus.InvalidName => BadRequest(new ProblemDetailsBuilder()
+            StylesheetFolderOperationStatus.InvalidName => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid name")
                 .WithDetail("The name specified is not a valid name.")
                 .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown stylesheet folder operation status.")
                 .Build()),
-        };
+        });
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/StylesheetControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/StylesheetControllerBase.cs
@@ -16,40 +16,41 @@ namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet;
 public class StylesheetControllerBase : FileSystemManagementControllerBase
 {
     protected IActionResult StylesheetOperationStatusResult(StylesheetOperationStatus status) =>
-        status switch
+        OperationStatusResult(status, problemDetailsBuilder => status switch
         {
-            StylesheetOperationStatus.Success => Ok(),
-            StylesheetOperationStatus.AlreadyExists => BadRequest(new ProblemDetailsBuilder()
+            StylesheetOperationStatus.AlreadyExists => BadRequest(problemDetailsBuilder
                 .WithTitle("Stylesheet already exists")
                 .WithDetail("A stylesheet with the same path already exists")
                 .Build()),
-            StylesheetOperationStatus.CancelledByNotification => BadRequest(new ProblemDetailsBuilder()
+            StylesheetOperationStatus.CancelledByNotification => BadRequest(problemDetailsBuilder
                 .WithTitle("Cancelled by notification")
                 .WithDetail("A stylesheet notification handler prevented the stylesheet operation.")
                 .Build()),
-            StylesheetOperationStatus.InvalidFileExtension => BadRequest(new ProblemDetailsBuilder()
+            StylesheetOperationStatus.InvalidFileExtension => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid file extension")
                 .WithDetail("The file extension is not valid for a stylesheet.")
                 .Build()),
-            StylesheetOperationStatus.ParentNotFound => NotFound(new ProblemDetailsBuilder()
+            StylesheetOperationStatus.ParentNotFound => NotFound(problemDetailsBuilder
                 .WithTitle("Parent not found")
                 .WithDetail("The parent folder was not found.")
                 .Build()),
-            StylesheetOperationStatus.PathTooLong => BadRequest(new ProblemDetailsBuilder()
+            StylesheetOperationStatus.PathTooLong => BadRequest(problemDetailsBuilder
                 .WithTitle("Path too long")
                 .WithDetail("The file path is too long.")
                 .Build()),
-            StylesheetOperationStatus.NotFound => StylesheetNotFound(),
-            StylesheetOperationStatus.InvalidName => BadRequest(new ProblemDetailsBuilder()
+            StylesheetOperationStatus.NotFound => StylesheetNotFound(problemDetailsBuilder),
+            StylesheetOperationStatus.InvalidName => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid name")
                 .WithDetail("The stylesheet name is invalid.")
                 .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown stylesheet operation status.")
                 .Build()),
-        };
+        });
 
-    protected IActionResult StylesheetNotFound() => NotFound(new ProblemDetailsBuilder()
+    protected IActionResult StylesheetNotFound() => OperationStatusResult(StylesheetOperationStatus.NotFound, StylesheetNotFound);
+
+    protected IActionResult StylesheetNotFound(ProblemDetailsBuilder problemDetailsBuilder) => NotFound(problemDetailsBuilder
         .WithTitle("Stylesheet not found")
         .WithDetail("The stylesheet was not found.")
         .Build());

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/TemplateControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/TemplateControllerBase.cs
@@ -16,28 +16,30 @@ namespace Umbraco.Cms.Api.Management.Controllers.Template;
 public class TemplateControllerBase : ManagementApiControllerBase
 {
     protected IActionResult TemplateOperationStatusResult(TemplateOperationStatus status) =>
-        status switch
+        OperationStatusResult(status, problemDetailsBuilder => status switch
         {
             TemplateOperationStatus.TemplateNotFound => TemplateNotFound(),
-            TemplateOperationStatus.InvalidAlias => BadRequest(new ProblemDetailsBuilder()
+            TemplateOperationStatus.InvalidAlias => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid alias")
                 .WithDetail("The template alias is not valid.")
                 .Build()),
-            TemplateOperationStatus.CancelledByNotification => BadRequest(new ProblemDetailsBuilder()
+            TemplateOperationStatus.CancelledByNotification => BadRequest(problemDetailsBuilder
                 .WithTitle("Cancelled by notification")
                 .WithDetail("A notification handler prevented the template operation.")
                 .Build()),
-            TemplateOperationStatus.DuplicateAlias => BadRequest(new ProblemDetailsBuilder()
+            TemplateOperationStatus.DuplicateAlias => BadRequest(problemDetailsBuilder
                 .WithTitle("Duplicate alias")
                 .WithDetail("A template with that alias already exists.")
                 .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown template operation status.")
                 .Build()),
-        };
+        });
 
-    protected IActionResult TemplateNotFound() => NotFound(new ProblemDetailsBuilder()
+    protected IActionResult TemplateNotFound()
+        => OperationStatusResult(TemplateOperationStatus.TemplateNotFound, TemplateNotFound);
+
+    protected IActionResult TemplateNotFound(ProblemDetailsBuilder problemDetailsBuilder) => NotFound(problemDetailsBuilder
         .WithTitle("The template could not be found")
         .Build());
-
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/TemporaryFile/TemporaryFileControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/TemporaryFile/TemporaryFileControllerBase.cs
@@ -12,31 +12,28 @@ namespace Umbraco.Cms.Api.Management.Controllers.TemporaryFile;
 public abstract class TemporaryFileControllerBase : ManagementApiControllerBase
 {
     protected IActionResult TemporaryFileStatusResult(TemporaryFileOperationStatus operationStatus) =>
-        operationStatus switch
+        OperationStatusResult(operationStatus, problemDetailsBuilder => operationStatus switch
         {
-            TemporaryFileOperationStatus.FileExtensionNotAllowed => BadRequest(new ProblemDetailsBuilder()
+            TemporaryFileOperationStatus.FileExtensionNotAllowed => BadRequest(problemDetailsBuilder
                 .WithTitle("File extension not allowed")
                 .WithDetail("The file extension is not allowed.")
                 .Build()),
-
-            TemporaryFileOperationStatus.KeyAlreadyUsed => BadRequest(new ProblemDetailsBuilder()
+            TemporaryFileOperationStatus.KeyAlreadyUsed => BadRequest(problemDetailsBuilder
                 .WithTitle("Key already used")
                 .WithDetail("The specified key is already used.")
                 .Build()),
-
-            TemporaryFileOperationStatus.NotFound => NotFound(new ProblemDetailsBuilder()
-                .WithTitle("The temporary file was not found")
-                .Build()),
-            TemporaryFileOperationStatus.UploadBlocked => NotFound(new ProblemDetailsBuilder()
+            TemporaryFileOperationStatus.NotFound => TemporaryFileNotFound(problemDetailsBuilder),
+            TemporaryFileOperationStatus.UploadBlocked => NotFound(problemDetailsBuilder
                 .WithTitle("The temporary file was blocked by a validator")
                 .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown temporary file operation status.")
                 .Build()),
-        };
+        });
 
+    protected IActionResult TemporaryFileNotFound() => OperationStatusResult(TemporaryFileOperationStatus.NotFound, TemporaryFileNotFound);
 
-    protected IActionResult TemporaryFileNotFound() => NotFound(new ProblemDetailsBuilder()
+    private IActionResult TemporaryFileNotFound(ProblemDetailsBuilder problemDetailsBuilder) => NotFound(problemDetailsBuilder
         .WithTitle("The temporary file could not be found")
         .Build());
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Tour/TourControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tour/TourControllerBase.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core.Services.OperationStatus;
 
@@ -12,15 +11,15 @@ namespace Umbraco.Cms.Api.Management.Controllers.Tour;
 public class TourControllerBase : ManagementApiControllerBase
 {
     protected IActionResult TourOperationStatusResult(TourOperationStatus status) =>
-    status switch
-    {
-        TourOperationStatus.Success => Ok(),
-        TourOperationStatus.UserNotFound => NotFound(new ProblemDetailsBuilder()
-            .WithTitle("User not found")
-            .WithDetail("Was not able to find currently logged in user")
-            .Build()),
-        _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
-            .WithTitle("Unknown tour operation status.")
-            .Build()),
-    };
+        OperationStatusResult(status, problemDetailsBuilder => status switch
+        {
+            TourOperationStatus.Success => Ok(),
+            TourOperationStatus.UserNotFound => NotFound(problemDetailsBuilder
+                .WithTitle("User not found")
+                .WithDetail("Was not able to find currently logged in user")
+                .Build()),
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
+                .WithTitle("Unknown tour operation status.")
+                .Build()),
+        });
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Upgrade/UpgradeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Upgrade/UpgradeControllerBase.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Api.Management.Filters;
 using Umbraco.Cms.Api.Management.Routing;
@@ -19,15 +18,17 @@ namespace Umbraco.Cms.Api.Management.Controllers.Upgrade;
 public abstract class UpgradeControllerBase : ManagementApiControllerBase
 {
     protected IActionResult UpgradeOperationResult(UpgradeOperationStatus status, InstallationResult? result = null) =>
-        status switch
-        {
-            UpgradeOperationStatus.Success => Ok(),
-            UpgradeOperationStatus.UpgradeFailed => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
-                .WithTitle("Upgrade failed")
-                .WithDetail(result?.ErrorMessage ?? "An unknown error occurred.")
-                .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
-                .WithTitle("Unknown upgrade operation status.")
-                .Build()),
-        };
+        status is UpgradeOperationStatus.Success
+            ? Ok()
+            : OperationStatusResult(status, problemDetailsBuilder => status switch
+            {
+                UpgradeOperationStatus.UpgradeFailed => StatusCode(StatusCodes.Status500InternalServerError,
+                    problemDetailsBuilder
+                        .WithTitle("Upgrade failed")
+                        .WithDetail(result?.ErrorMessage ?? "An unknown error occurred.")
+                        .Build()),
+                _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
+                    .WithTitle("Unknown upgrade operation status.")
+                    .Build()),
+            });
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/UserOrCurrentUserControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/UserOrCurrentUserControllerBase.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Services.OperationStatus;
 
@@ -11,142 +10,140 @@ namespace Umbraco.Cms.Api.Management.Controllers.User;
 public abstract class UserOrCurrentUserControllerBase : ManagementApiControllerBase
 {
     protected IActionResult UserOperationStatusResult(UserOperationStatus status, ErrorMessageResult? errorMessageResult = null) =>
-        status switch
+        OperationStatusResult(status, problemDetailsBuilder => status switch
         {
-            UserOperationStatus.Success => Ok(),
             UserOperationStatus.MissingUser =>
-                StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+                StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                     .WithTitle("A performing user is required for the operation, but none was found")
                     .Build()),
-            UserOperationStatus.MissingUserGroup => NotFound(new ProblemDetailsBuilder()
+            UserOperationStatus.MissingUserGroup => NotFound(problemDetailsBuilder
                 .WithTitle("Missing User Group")
                 .WithDetail("The specified user group was not found.")
                 .Build()),
-            UserOperationStatus.NoUserGroup => BadRequest(new ProblemDetailsBuilder()
+            UserOperationStatus.NoUserGroup => BadRequest(problemDetailsBuilder
                 .WithTitle("No User Group Specified")
                 .WithDetail("A user group must be specified to create a user")
                 .Build()),
-            UserOperationStatus.UserNameIsNotEmail => BadRequest(new ProblemDetailsBuilder()
+            UserOperationStatus.UserNameIsNotEmail => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid Username")
                 .WithDetail("The username must be the same as the email.")
                 .Build()),
-            UserOperationStatus.EmailCannotBeChanged => BadRequest(new ProblemDetailsBuilder()
+            UserOperationStatus.EmailCannotBeChanged => BadRequest(problemDetailsBuilder
                 .WithTitle("Email Cannot be changed")
                 .WithDetail("Local login is disabled, so the email cannot be changed.")
                 .Build()),
-            UserOperationStatus.DuplicateUserName => BadRequest(new ProblemDetailsBuilder()
+            UserOperationStatus.DuplicateUserName => BadRequest(problemDetailsBuilder
                 .WithTitle("Duplicate Username")
                 .WithDetail("The username is already in use.")
                 .Build()),
-            UserOperationStatus.DuplicateEmail => BadRequest(new ProblemDetailsBuilder()
+            UserOperationStatus.DuplicateEmail => BadRequest(problemDetailsBuilder
                 .WithTitle("Duplicate Email")
                 .WithDetail("The email is already in use.")
                 .Build()),
             UserOperationStatus.Unauthorized => Unauthorized(),
-            UserOperationStatus.CancelledByNotification => BadRequest(new ProblemDetailsBuilder()
+            UserOperationStatus.CancelledByNotification => BadRequest(problemDetailsBuilder
                 .WithTitle("Cancelled by notification")
                 .WithDetail("A notification handler prevented the user operation.")
                 .Build()),
             UserOperationStatus.CannotInvite =>
-                StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+                StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                     .WithTitle("Cannot send user invitation")
                     .Build()),
-            UserOperationStatus.CannotDelete => BadRequest(new ProblemDetailsBuilder()
+            UserOperationStatus.CannotDelete => BadRequest(problemDetailsBuilder
                 .WithTitle("Cannot delete user")
                 .WithDetail("The user cannot be deleted.")
                 .Build()),
-            UserOperationStatus.CannotDisableSelf => BadRequest(new ProblemDetailsBuilder()
+            UserOperationStatus.CannotDisableSelf => BadRequest(problemDetailsBuilder
                 .WithTitle("Cannot disable")
                 .WithDetail("A user cannot disable itself.")
                 .Build()),
-            UserOperationStatus.CannotDeleteSelf => BadRequest(new ProblemDetailsBuilder()
+            UserOperationStatus.CannotDeleteSelf => BadRequest(problemDetailsBuilder
                 .WithTitle("Cannot delete")
                 .WithDetail("A user cannot delete itself.")
                 .Build()),
-            UserOperationStatus.OldPasswordRequired => BadRequest(new ProblemDetailsBuilder()
+            UserOperationStatus.OldPasswordRequired => BadRequest(problemDetailsBuilder
                 .WithTitle("Old password required")
                 .WithDetail("The old password is required to change the password of the specified user.")
                 .Build()),
-            UserOperationStatus.InvalidAvatar => BadRequest(new ProblemDetailsBuilder()
+            UserOperationStatus.InvalidAvatar => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid avatar")
                 .WithDetail("The selected avatar is invalid")
                 .Build()),
-            UserOperationStatus.InvalidEmail => BadRequest(new ProblemDetailsBuilder()
+            UserOperationStatus.InvalidEmail => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid email")
                 .WithDetail("The email is invalid")
                 .Build()),
-            UserOperationStatus.AvatarFileNotFound => BadRequest(new ProblemDetailsBuilder()
+            UserOperationStatus.AvatarFileNotFound => BadRequest(problemDetailsBuilder
                 .WithTitle("Avatar file not found")
                 .WithDetail("The file key did not resolve in to a file")
                 .Build()),
-            UserOperationStatus.ContentStartNodeNotFound => BadRequest(new ProblemDetailsBuilder()
+            UserOperationStatus.ContentStartNodeNotFound => BadRequest(problemDetailsBuilder
                 .WithTitle("Content Start Node not found")
                 .WithDetail("Some of the provided content start nodes was not found.")
                 .Build()),
-            UserOperationStatus.MediaStartNodeNotFound => BadRequest(new ProblemDetailsBuilder()
+            UserOperationStatus.MediaStartNodeNotFound => BadRequest(problemDetailsBuilder
                 .WithTitle("Media Start Node not found")
                 .WithDetail("Some of the provided media start nodes was not found.")
                 .Build()),
-            UserOperationStatus.UserNotFound => NotFound(new ProblemDetailsBuilder()
+            UserOperationStatus.UserNotFound => NotFound(problemDetailsBuilder
                 .WithTitle("The user was not found")
                 .WithDetail("The specified user was not found.")
                 .Build()),
-            UserOperationStatus.CannotDisableInvitedUser => BadRequest(new ProblemDetailsBuilder()
+            UserOperationStatus.CannotDisableInvitedUser => BadRequest(problemDetailsBuilder
                 .WithTitle("Cannot disable invited user")
                 .WithDetail("An invited user cannot be disabled.")
                 .Build()),
-            UserOperationStatus.UnknownFailure => BadRequest(new ProblemDetailsBuilder()
+            UserOperationStatus.UnknownFailure => BadRequest(problemDetailsBuilder
                 .WithTitle("Unknown failure")
                 .WithDetail(errorMessageResult?.Error?.ErrorMessage ?? "The error was unknown")
                 .Build()),
-            UserOperationStatus.InvalidIsoCode => BadRequest(new ProblemDetailsBuilder()
+            UserOperationStatus.InvalidIsoCode => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid ISO code")
                 .WithDetail("The specified ISO code is invalid.")
                 .Build()),
-            UserOperationStatus.InvalidInviteToken => BadRequest(new ProblemDetailsBuilder()
+            UserOperationStatus.InvalidInviteToken => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid verification token")
                 .WithDetail("The specified verification token is invalid.")
                 .Build()),
-            UserOperationStatus.MediaNodeNotFound => NotFound(new ProblemDetailsBuilder()
+            UserOperationStatus.MediaNodeNotFound => NotFound(problemDetailsBuilder
                 .WithTitle("Media node not found")
                 .WithDetail("The specified media node was not found.")
                 .Build()),
-            UserOperationStatus.ContentNodeNotFound => NotFound(new ProblemDetailsBuilder()
+            UserOperationStatus.ContentNodeNotFound => NotFound(problemDetailsBuilder
                 .WithTitle("Content node not found")
                 .WithDetail("The specified content node was not found.")
                 .Build()),
-            UserOperationStatus.NotInInviteState => BadRequest(new ProblemDetailsBuilder()
+            UserOperationStatus.NotInInviteState => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid user state")
                 .WithDetail("The target user is not in the invite state.")
                 .Build()),
             UserOperationStatus.Forbidden => Forbidden(),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown user operation status.")
                 .Build()),
-        };
+        });
 
     protected IActionResult TwoFactorOperationStatusResult(TwoFactorOperationStatus status) =>
-        status switch
+        OperationStatusResult(status, problemDetailsBuilder => status switch
         {
-            TwoFactorOperationStatus.Success => Ok(),
-            TwoFactorOperationStatus.ProviderNameNotFound => NotFound(new ProblemDetailsBuilder()
+            TwoFactorOperationStatus.ProviderNameNotFound => NotFound(problemDetailsBuilder
                 .WithTitle("Missing 2FA provider")
                 .WithDetail("The specified 2fa provider was not found.")
                 .Build()),
-            TwoFactorOperationStatus.ProviderAlreadySetup => BadRequest(new ProblemDetailsBuilder()
+            TwoFactorOperationStatus.ProviderAlreadySetup => BadRequest(problemDetailsBuilder
                 .WithTitle("2FA provider already configured")
                 .WithDetail("The current user already have the provider configured.")
                 .Build()),
-            TwoFactorOperationStatus.InvalidCode => BadRequest(new ProblemDetailsBuilder()
+            TwoFactorOperationStatus.InvalidCode => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid code")
                 .WithDetail("The specified 2fa code was invalid in combination with the provider.")
                 .Build()),
-            TwoFactorOperationStatus.UserNotFound => NotFound(new ProblemDetailsBuilder()
+            TwoFactorOperationStatus.UserNotFound => NotFound(problemDetailsBuilder
                 .WithTitle("User not found")
                 .WithDetail("The specified user id was not found.")
                 .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown two factor operation status.")
                 .Build()),
-        };
+        });
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/UserGroupsControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/UserGroupsControllerBase.cs
@@ -15,83 +15,85 @@ namespace Umbraco.Cms.Api.Management.Controllers.UserGroup;
 public class UserGroupControllerBase : ManagementApiControllerBase
 {
     protected IActionResult UserGroupOperationStatusResult(UserGroupOperationStatus status) =>
-        status switch
+        OperationStatusResult(status, problemDetailsBuilder => status switch
         {
-            UserGroupOperationStatus.NotFound => UserGroupNotFound(),
-            UserGroupOperationStatus.UserNotFound => NotFound(new ProblemDetailsBuilder()
+            UserGroupOperationStatus.NotFound => UserGroupNotFound(problemDetailsBuilder),
+            UserGroupOperationStatus.UserNotFound => NotFound(problemDetailsBuilder
                 .WithTitle("User key not found")
                 .WithDetail("The provided user key do not exist.")
                 .Build()),
-            UserGroupOperationStatus.AlreadyExists => Conflict(new ProblemDetailsBuilder()
+            UserGroupOperationStatus.AlreadyExists => Conflict(problemDetailsBuilder
                 .WithTitle("User group already exists")
                 .WithDetail("The user group exists already.")
                 .Build()),
-            UserGroupOperationStatus.DuplicateAlias => Conflict(new ProblemDetailsBuilder()
+            UserGroupOperationStatus.DuplicateAlias => Conflict(problemDetailsBuilder
                 .WithTitle("Duplicate alias")
                 .WithDetail("A user group already exists with the attempted alias.")
                 .Build()),
-            UserGroupOperationStatus.MissingUser => Unauthorized(new ProblemDetailsBuilder()
+            UserGroupOperationStatus.MissingUser => Unauthorized(problemDetailsBuilder
                 .WithTitle("Missing user")
                 .WithDetail("A performing user was not found when attempting the operation.")
                 .Build()),
-            UserGroupOperationStatus.IsSystemUserGroup => BadRequest(new ProblemDetailsBuilder()
+            UserGroupOperationStatus.IsSystemUserGroup => BadRequest(problemDetailsBuilder
                 .WithTitle("System user group")
                 .WithDetail("The operation is not allowed on a system user group.")
                 .Build()),
-            UserGroupOperationStatus.CancelledByNotification => BadRequest(new ProblemDetailsBuilder()
+            UserGroupOperationStatus.CancelledByNotification => BadRequest(problemDetailsBuilder
                 .WithTitle("Cancelled by notification")
                 .WithDetail("A notification handler prevented the language operation.")
                 .Build()),
-            UserGroupOperationStatus.DocumentStartNodeKeyNotFound => NotFound(new ProblemDetailsBuilder()
+            UserGroupOperationStatus.DocumentStartNodeKeyNotFound => NotFound(problemDetailsBuilder
                 .WithTitle("Document start node key not found")
                 .WithDetail("The assigned document start node does not exists.")
                 .Build()),
-            UserGroupOperationStatus.MediaStartNodeKeyNotFound => NotFound(new ProblemDetailsBuilder()
+            UserGroupOperationStatus.MediaStartNodeKeyNotFound => NotFound(problemDetailsBuilder
                 .WithTitle("Media start node key not found")
                 .WithDetail("The assigned media start node does not exists.")
                 .Build()),
-            UserGroupOperationStatus.LanguageNotFound => NotFound(new ProblemDetailsBuilder()
+            UserGroupOperationStatus.LanguageNotFound => NotFound(problemDetailsBuilder
                 .WithTitle("Language not found")
                 .WithDetail("The specified language cannot be found.")
                 .Build()),
-            UserGroupOperationStatus.NameTooLong => BadRequest(new ProblemDetailsBuilder()
+            UserGroupOperationStatus.NameTooLong => BadRequest(problemDetailsBuilder
                 .WithTitle("Name too long")
                 .WithDetail("User Group name is too long.")
                 .Build()),
-            UserGroupOperationStatus.AliasTooLong => BadRequest(new ProblemDetailsBuilder()
+            UserGroupOperationStatus.AliasTooLong => BadRequest(problemDetailsBuilder
                 .WithTitle("Alias too long")
                 .WithDetail("The user group alias is too long.")
                 .Build()),
-            UserGroupOperationStatus.MissingName => BadRequest(new ProblemDetailsBuilder()
+            UserGroupOperationStatus.MissingName => BadRequest(problemDetailsBuilder
                 .WithTitle("Missing user group name.")
                 .WithDetail("The user group name is required, and cannot be an empty string.")
                 .Build()),
-            UserGroupOperationStatus.UnauthorizedMissingAllowedSectionAccess => Unauthorized(new ProblemDetailsBuilder()
+            UserGroupOperationStatus.UnauthorizedMissingAllowedSectionAccess => Unauthorized(problemDetailsBuilder
                 .WithTitle("Unauthorized section access")
                 .WithDetail("The performing user does not have access to all sections specified as allowed for this user group.")
                 .Build()),
-            UserGroupOperationStatus.UnauthorizedMissingContentStartNodeAccess => Unauthorized(new ProblemDetailsBuilder()
+            UserGroupOperationStatus.UnauthorizedMissingContentStartNodeAccess => Unauthorized(problemDetailsBuilder
                 .WithTitle("Unauthorized content start node access")
                 .WithDetail("The performing user does not have access to the specified content start node item.")
                 .Build()),
-            UserGroupOperationStatus.UnauthorizedMissingMediaStartNodeAccess => Unauthorized(new ProblemDetailsBuilder()
+            UserGroupOperationStatus.UnauthorizedMissingMediaStartNodeAccess => Unauthorized(problemDetailsBuilder
                 .WithTitle("Unauthorized media start node access")
                 .WithDetail("The performing user does not have access to the specified media start node item.")
                 .Build()),
-            UserGroupOperationStatus.UnauthorizedMissingUserGroupAccess => Unauthorized(new ProblemDetailsBuilder()
+            UserGroupOperationStatus.UnauthorizedMissingUserGroupAccess => Unauthorized(problemDetailsBuilder
                 .WithTitle("Unauthorized user group access")
                 .WithDetail("The performing user does not have access to the specified user group(s).")
                 .Build()),
-            UserGroupOperationStatus.UnauthorizedMissingUsersSectionAccess => Unauthorized(new ProblemDetailsBuilder()
+            UserGroupOperationStatus.UnauthorizedMissingUsersSectionAccess => Unauthorized(problemDetailsBuilder
                 .WithTitle("Unauthorized access to Users section")
                 .WithDetail("The performing user does not have access to the Users section.")
                 .Build()),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown user group operation status.")
                 .Build()),
-        };
+        });
 
-    protected IActionResult UserGroupNotFound() => NotFound(new ProblemDetailsBuilder()
+    protected IActionResult UserGroupNotFound() => OperationStatusResult(UserGroupOperationStatus.NotFound, UserGroupNotFound);
+
+    protected IActionResult UserGroupNotFound(ProblemDetailsBuilder problemDetailsBuilder) => NotFound(problemDetailsBuilder
         .WithTitle("The user group could not be found")
         .Build());
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR ensures that non-success responses from the Management API include the "operationStatus" in the responding problem details.

### Testing this PR

TBD