### PR TITLE
V14 QA Decreased retry of failing test from 5 to 3.

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/playwright.config.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/playwright.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 5 : 2,
+  retries: process.env.CI ? 3 : 2,
   // We don't want to run parallel, as tests might differ in state
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */


### PR DESCRIPTION
Decreased the number of times we try to retry running a failing test. The tests are running slower which results in the pipeline timing out. And there is no real reason to retry a test more than 2-3 times