### PR TITLE
V13: The login screen does not display external login errors

### DIFF
--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoBackOffice/Default.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoBackOffice/Default.cshtml
@@ -16,7 +16,6 @@
 @inject IOptions<GlobalSettings> globalSettings
 @inject IRuntimeMinifier runtimeMinifier
 @inject IProfilerHtml profilerHtml
-@inject IBackOfficeExternalLoginProviders externalLogins
 @{
     bool.TryParse(Context.Request.Query["umbDebug"], out bool isDebug);
     var backOfficePath = globalSettings.Value.GetBackOfficePath(hostingEnvironment);
@@ -114,8 +113,6 @@
 
     <script>
         document.angularReady = function(app) {
-            @await Html.AngularValueExternalLoginInfoScriptAsync(externalLogins, ViewData.GetExternalSignInProviderErrors()!)
-            @Html.AngularValueResetPasswordCodeInfoScript(ViewData[ViewDataExtensions.TokenPasswordResetCode]!)
             @await Html.AngularValueTinyMceAssetsAsync(runtimeMinifier)
             //required for the noscript trick
             document.getElementById("mainwrapper").style.display = "inherit";

--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoLogin/Index.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoLogin/Index.cshtml
@@ -32,6 +32,7 @@
     var disableLocalLogin = ExternalLogins.HasDenyLocalLogin();
     var externalLoginsUrl = LinkGenerator.GetPathByAction(nameof(BackOfficeController.ExternalLogin), ControllerExtensions.GetControllerName<BackOfficeController>(), new { area = Constants.Web.Mvc.BackOfficeArea });
     var externalLoginProviders = await ExternalLogins.GetBackOfficeProvidersAsync();
+    var externalSignInErrors = ViewData.GetExternalSignInProviderErrors();
 }
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 
@@ -105,6 +106,15 @@
                 button-color="@provider.ExternalLoginProvider.Options.ButtonColor.ToString().ToLowerInvariant()"
                 custom-view="@provider.ExternalLoginProvider.Options.CustomBackOfficeView">
             </umb-external-login-provider>
+        }
+        @if (externalSignInErrors?.Errors?.Count() > 0)
+        {
+            <div slot="subheadline" style="color:var(--uui-color-danger-standalone)">
+                @foreach (var error in externalSignInErrors.Errors)
+                {
+                    <div>@error</div>
+                }
+            </div>
         }
     </umb-auth>
 </umb-backoffice-icon-registry>

--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
@@ -473,7 +473,7 @@ public class BackOfficeController : UmbracoController
                 _httpContextAccessor.HttpContext,
                 ViewDataExtensions.TokenExternalSignInError,
                 _jsonSerializer) ||
-            ViewData.FromTempData(TempData, ViewDataExtensions.TokenExternalSignInError) || ViewData.FromTempData(TempData, ViewDataExtensions.TokenPasswordResetCode))
+            ViewData.FromTempData(TempData, ViewDataExtensions.TokenExternalSignInError))
         {
             // Return early to let the client side handle the messaging
             return defaultResponse();

--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
@@ -426,7 +426,8 @@ public class BackOfficeController : UmbracoController
         if (user == null)
         {
             // ... this should really not happen
-            return RedirectToLogin(new { flow = "external-login", status = "localUserNotFound" });
+            TempData[ViewDataExtensions.TokenExternalSignInError] = new[] { "Local user does not exist" };
+            return RedirectToLogin(new { flow = "external-login", status = "localUserNotFound", logout = "true"});
         }
 
         ExternalLoginInfo? info =
@@ -435,7 +436,9 @@ public class BackOfficeController : UmbracoController
         if (info == null)
         {
             // Add error and redirect for it to be displayed
-            return RedirectToLogin(new { flow = "external-login", status = "externalLoginInfoNotFound" });
+            TempData[ViewDataExtensions.TokenExternalSignInError] =
+                new[] { "An error occurred, could not get external login info" };
+            return RedirectToLogin(new { flow = "external-login", status = "externalLoginInfoNotFound", logout = "true"});
         }
 
         IdentityResult addLoginResult = await _userManager.AddLoginAsync(user, info);
@@ -448,7 +451,8 @@ public class BackOfficeController : UmbracoController
         }
 
         // Add errors and redirect for it to be displayed
-        return RedirectToLogin(new { flow = "external-login", status = "failed" });
+        TempData[ViewDataExtensions.TokenExternalSignInError] = addLoginResult.Errors;
+        return RedirectToLogin(new { flow = "external-login", status = "failed", logout = "true" });
     }
 
     /// <summary>
@@ -471,6 +475,7 @@ public class BackOfficeController : UmbracoController
                 _jsonSerializer) ||
             ViewData.FromTempData(TempData, ViewDataExtensions.TokenExternalSignInError) || ViewData.FromTempData(TempData, ViewDataExtensions.TokenPasswordResetCode))
         {
+            // Return early to let the client side handle the messaging
             return defaultResponse();
         }
 

--- a/src/Umbraco.Web.Common/Extensions/ViewDataExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/ViewDataExtensions.cs
@@ -122,9 +122,11 @@ public static class ViewDataExtensions
         this ViewDataDictionary viewData,
         BackOfficeExternalLoginProviderErrors errors) => viewData[TokenExternalSignInError] = errors;
 
+    [Obsolete("This is deprecated and will be removed in V15")]
     public static string? GetPasswordResetCode(this ViewDataDictionary viewData) =>
         (string?)viewData[TokenPasswordResetCode];
 
+    [Obsolete("This is deprecated and will be removed in V15")]
     public static void SetPasswordResetCode(this ViewDataDictionary viewData, string value) =>
         viewData[TokenPasswordResetCode] = value;
 


### PR DESCRIPTION
### Description

This fixes a regression compared from V12 to V13 where the new login screen UI did not show external login errors that happened on the server side. The is two-fold: `BackOfficeController` needed to have its built-in error messages migrated from V12, and the `UmbracoLogin/Index.cshtml` needed to hook on to those errors and forward them to the login screen UI.

Fixes #15622

### How to test

Set a cookie containing external login errors somewhere, e.g. in the BackOfficeController:

```cs
var someerrormessage = @"{""errors"":[""Some error message""]}";
_httpContextAccessor.Response.Cookies.Append(ViewDataExtensions.TokenExternalSignInError, Convert.ToBase64String(Encoding.UTF8.GetBytes(someerrormessage)), new CookieOptions() { HttpOnly = true, Secure = true });
```

Verify that the error message shows up on the login screen below the welcome message.