### PR TITLE
Add default log level for filtering log levels

### DIFF
--- a/src/Umbraco.Core/Logging/Viewer/LogViewerSourceBase.cs
+++ b/src/Umbraco.Core/Logging/Viewer/LogViewerSourceBase.cs
@@ -98,7 +98,7 @@ namespace Umbraco.Core.Logging.Viewer
         /// <returns></returns>
         public string GetLogLevel()
         {
-            var logLevel = Enum.GetValues(typeof(LogEventLevel)).Cast<LogEventLevel>().Where(Log.Logger.IsEnabled)?.Min() ?? null;
+            var logLevel = Enum.GetValues(typeof(LogEventLevel)).Cast<LogEventLevel>().Where(Log.Logger.IsEnabled).DefaultIfEmpty(LogEventLevel.Information)?.Min() ?? null;
             return logLevel?.ToString() ?? "";
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [#15720]


### Description

"Sequence contains no elements" error message is thrown by .Min() method, which is called in LogViewerSourceBase.GetLogLevel() method. This method is responsible for providing minimum logging level from Serilog config line. It's used only in LogViewerController.

For filtering log levels it uses ILogger interface provided by Serilog, but for some reason sometimes that .Where() clause returns no values and in consequence .Min() method throws exception.
