### PR TITLE
V14: Align routes

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/Filter/FilterMemberFilterController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/Filter/FilterMemberFilterController.cs
@@ -7,18 +7,17 @@ using Umbraco.Cms.Api.Management.ViewModels.Member;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Core.Services.OperationStatus;
 
-namespace Umbraco.Cms.Api.Management.Controllers.Member;
+namespace Umbraco.Cms.Api.Management.Controllers.Member.Filter;
 
 [ApiVersion("1.0")]
-public class FilterMemberController : MemberControllerBase
+public class FilterMemberFilterController : MemberFilterControllerBase
 {
     private readonly IMemberTypeService _memberTypeService;
     private readonly IMemberService _memberService;
     private readonly IMemberPresentationFactory _memberPresentationFactory;
 
-    public FilterMemberController(
+    public FilterMemberFilterController(
         IMemberTypeService memberTypeService,
         IMemberService memberService,
         IMemberPresentationFactory memberPresentationFactory)
@@ -28,10 +27,9 @@ public class FilterMemberController : MemberControllerBase
         _memberPresentationFactory = memberPresentationFactory;
     }
 
-    [HttpGet("filter")]
+    [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<MemberResponseModel>), StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Filter(
         Guid? memberTypeId = null,
@@ -48,7 +46,7 @@ public class FilterMemberController : MemberControllerBase
             IMemberType? memberType = await _memberTypeService.GetAsync(memberTypeId.Value);
             if (memberType == null)
             {
-                return MemberEditingOperationStatusResult(MemberEditingOperationStatus.MemberTypeNotFound);
+                return MemberTypeNotFound();
             }
 
             memberTypeAlias = memberType.Alias;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/Filter/MemberFilterControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/Filter/MemberFilterControllerBase.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Web.Common.Authorization;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Member.Filter;
+
+[ApiController]
+[VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Filter}/{Constants.UdiEntityType.Member}")]
+[ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Member))]
+[Authorize(Policy = "New" + AuthorizationPolicies.SectionAccessForMemberTree)]
+public abstract class MemberFilterControllerBase : ManagementApiControllerBase
+{
+    protected IActionResult MemberTypeNotFound()
+        => OperationStatusResult(ContentEditingOperationStatus.NotFound, problemDetailsBuilder
+            => NotFound(problemDetailsBuilder
+                .WithTitle("The requested member type could not be found")
+                .Build()));
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/TemporaryFile/TemporaryFileControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/TemporaryFile/TemporaryFileControllerBase.cs
@@ -7,7 +7,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 namespace Umbraco.Cms.Api.Management.Controllers.TemporaryFile;
 
 [ApiController]
-[VersionedApiBackOfficeRoute("temporaryfile")]
+[VersionedApiBackOfficeRoute("temporary-file")]
 [ApiExplorerSettings(GroupName = "Temporary File")]
 public abstract class TemporaryFileControllerBase : ManagementApiControllerBase
 {

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/Filter/FilterUserFilterController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/Filter/FilterUserFilterController.cs
@@ -11,16 +11,16 @@ using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 
-namespace Umbraco.Cms.Api.Management.Controllers.User;
+namespace Umbraco.Cms.Api.Management.Controllers.User.Filter;
 
 [ApiVersion("1.0")]
-public class FilterUserController : UserControllerBase
+public class FilterUserFilterController : UserFilterControllerBase
 {
     private readonly IUserService _userService;
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
     private readonly IUserPresentationFactory _userPresentationFactory;
 
-    public FilterUserController(
+    public FilterUserFilterController(
         IUserService userService,
         IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
         IUserPresentationFactory userPresentationFactory)
@@ -41,7 +41,7 @@ public class FilterUserController : UserControllerBase
     /// <param name="userStates">User states to include in the result.</param>
     /// <param name="filter">A string that must be present in the users name or username.</param>
     /// <returns>A paged result of the users matching the query.</returns>
-    [HttpGet("filter")]
+    [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<UserResponseModel>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/Filter/UserFilterControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/Filter/UserFilterControllerBase.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Web.Common.Authorization;
+
+namespace Umbraco.Cms.Api.Management.Controllers.User.Filter;
+
+[ApiController]
+[VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Filter}/user")]
+[Authorize(Policy = "New" + AuthorizationPolicies.SectionAccessUsers)]
+public abstract class UserFilterControllerBase : UserOrCurrentUserControllerBase
+{
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/UserControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/UserControllerBase.cs
@@ -1,12 +1,13 @@
 ﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User;
 
+[ApiController]
 [VersionedApiBackOfficeRoute("user")]
 [Authorize(Policy = "New" + AuthorizationPolicies.SectionAccessUsers)]
 public abstract class UserControllerBase : UserOrCurrentUserControllerBase
 {
-
 }

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -12779,6 +12779,114 @@
         ]
       }
     },
+    "/umbraco/management/api/v1/filter/member": {
+      "get": {
+        "tags": [
+          "Member"
+        ],
+        "operationId": "GetFilterMember",
+        "parameters": [
+          {
+            "name": "memberTypeId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "username"
+            }
+          },
+          {
+            "name": "orderDirection",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/DirectionModel"
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedMemberResponseModel"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedMemberResponseModel"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedMemberResponseModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
     "/umbraco/management/api/v1/item/member": {
       "get": {
         "tags": [
@@ -13264,134 +13372,6 @@
         "responses": {
           "200": {
             "description": "Success"
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "The resource is protected and requires an authentication token"
-          }
-        },
-        "security": [
-          {
-            "Backoffice User": [ ]
-          }
-        ]
-      }
-    },
-    "/umbraco/management/api/v1/member/filter": {
-      "get": {
-        "tags": [
-          "Member"
-        ],
-        "operationId": "GetMemberFilter",
-        "parameters": [
-          {
-            "name": "memberTypeId",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "orderBy",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "default": "username"
-            }
-          },
-          {
-            "name": "orderDirection",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/DirectionModel"
-            }
-          },
-          {
-            "name": "filter",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "skip",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
-          },
-          {
-            "name": "take",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 100
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PagedMemberResponseModel"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PagedMemberResponseModel"
-                }
-              },
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/PagedMemberResponseModel"
-                }
-              }
-            }
           },
           "400": {
             "description": "Bad Request",
@@ -20478,12 +20458,12 @@
         ]
       }
     },
-    "/umbraco/management/api/v1/temporaryfile": {
+    "/umbraco/management/api/v1/temporary-file": {
       "post": {
         "tags": [
           "Temporary File"
         ],
-        "operationId": "PostTemporaryfile",
+        "operationId": "PostTemporaryFile",
         "requestBody": {
           "content": {
             "multipart/form-data": {
@@ -20563,12 +20543,12 @@
         ]
       }
     },
-    "/umbraco/management/api/v1/temporaryfile/{id}": {
+    "/umbraco/management/api/v1/temporary-file/{id}": {
       "get": {
         "tags": [
           "Temporary File"
         ],
-        "operationId": "GetTemporaryfileById",
+        "operationId": "GetTemporaryFileById",
         "parameters": [
           {
             "name": "id",
@@ -20667,7 +20647,7 @@
         "tags": [
           "Temporary File"
         ],
-        "operationId": "DeleteTemporaryfileById",
+        "operationId": "DeleteTemporaryFileById",
         "parameters": [
           {
             "name": "id",
@@ -20734,12 +20714,12 @@
         ]
       }
     },
-    "/umbraco/management/api/v1/temporaryfile/configuration": {
+    "/umbraco/management/api/v1/temporary-file/configuration": {
       "get": {
         "tags": [
           "Temporary File"
         ],
-        "operationId": "GetTemporaryfileConfiguration",
+        "operationId": "GetTemporaryFileConfiguration",
         "responses": {
           "200": {
             "description": "Success"
@@ -21884,6 +21864,149 @@
           },
           "403": {
             "description": "The authenticated user do not have access to this resource"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/filter/user": {
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "operationId": "GetFilterUser",
+        "parameters": [
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/UserOrderModel"
+            }
+          },
+          {
+            "name": "orderDirection",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/DirectionModel"
+            }
+          },
+          {
+            "name": "userGroupIds",
+            "in": "query",
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          },
+          {
+            "name": "userStates",
+            "in": "query",
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/UserStateModel"
+              }
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedUserResponseModel"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedUserResponseModel"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedUserResponseModel"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
           }
         },
         "security": [
@@ -23775,149 +23898,6 @@
           },
           "403": {
             "description": "The authenticated user do not have access to this resource"
-          }
-        },
-        "security": [
-          {
-            "Backoffice User": [ ]
-          }
-        ]
-      }
-    },
-    "/umbraco/management/api/v1/user/filter": {
-      "get": {
-        "tags": [
-          "User"
-        ],
-        "operationId": "GetUserFilter",
-        "parameters": [
-          {
-            "name": "skip",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
-          },
-          {
-            "name": "take",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 100
-            }
-          },
-          {
-            "name": "orderBy",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/UserOrderModel"
-            }
-          },
-          {
-            "name": "orderDirection",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/DirectionModel"
-            }
-          },
-          {
-            "name": "userGroupIds",
-            "in": "query",
-            "schema": {
-              "uniqueItems": true,
-              "type": "array",
-              "items": {
-                "type": "string",
-                "format": "uuid"
-              }
-            }
-          },
-          {
-            "name": "userStates",
-            "in": "query",
-            "schema": {
-              "uniqueItems": true,
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/UserStateModel"
-              }
-            }
-          },
-          {
-            "name": "filter",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "default": ""
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PagedUserResponseModel"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PagedUserResponseModel"
-                }
-              },
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/PagedUserResponseModel"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "The resource is protected and requires an authentication token"
           }
         },
         "security": [

--- a/src/Umbraco.Core/Constants-Web.cs
+++ b/src/Umbraco.Core/Constants-Web.cs
@@ -75,6 +75,7 @@ public static partial class Constants
             public const string RecycleBin = "recycle-bin";
             public const string Item = "item";
             public const string Collection = "collection";
+            public const string Filter = "filter";
         }
 
         public static class AttributeRouting


### PR DESCRIPTION
## Details
- Fixing the routes for Temporary file APIs;
- Changing the route of user and member filter endpoints - `"filter"` is now treated as a viewport (same as `"item"`).

## Test
- Add a few members and users and verify the /filter endpoints still work.