### PR TITLE
Add CultureInfo.InvariantCulture argument to nodeId.ToString() in Che…

### DIFF
--- a/src/Umbraco.Core/Security/ContentPermissions.cs
+++ b/src/Umbraco.Core/Security/ContentPermissions.cs
@@ -200,7 +200,7 @@ public class ContentPermissions
 
         // get the implicit/inherited permissions for the user for this path
         // if there is no entity for this id, than just use the id as the path (i.e. -1 or -20)
-        return CheckPermissionsPath(entity?.Path ?? nodeId.ToString(), user, permissionsToCheck)
+        return CheckPermissionsPath(entity?.Path ?? nodeId.ToString(CultureInfo.InvariantCulture), user, permissionsToCheck)
             ? ContentAccess.Granted
             : ContentAccess.Denied;
     }
@@ -259,7 +259,7 @@ public class ContentPermissions
 
         // get the implicit/inherited permissions for the user for this path
         // if there is no content item for this id, than just use the id as the path (i.e. -1 or -20)
-        return CheckPermissionsPath(contentItem?.Path ?? nodeId.ToString(), user, permissionsToCheck)
+        return CheckPermissionsPath(contentItem?.Path ?? nodeId.ToString(CultureInfo.InvariantCulture), user, permissionsToCheck)
             ? ContentAccess.Granted
             : ContentAccess.Denied;
     }


### PR DESCRIPTION
Problem: Unable to save or publish a new root node in Umbraco backoffice. The save icon would become active for a moment and then return to its default state without giving the user any error or success message while the new node did not get saved or published.

How to test/replicate issue: Log in to the backoffice and set the user's language to "Norwegian Bokmål" and then attempt to save or publish a new content node on the root level.

Cause: The permissions check would fail due to a string conversion of the nodeId of "-1". In certain system cultures like nb-NO, the conversion of -1 would result in "−1" ("-" vs "−"). 

![image](https://github.com/umbraco/Umbraco-CMS/assets/35521784/2fa51418-0d80-4aa0-a52f-16e01170b293)

This would cause the int.TryParse to return false in the GetIdsFromPathReversed() method in StringExtensions.cs, returning and empty array and fail the permissions check for the user.

Solution: Pass in CultureInfo.InvariantCulture as an argument in the ToString() conversion of nodeId in CheckPermissionsPath() method to ensure that the converted Id always will have a valid negative sign regardless of system culture.

![image](https://github.com/umbraco/Umbraco-CMS/assets/35521784/3e1ce5c1-12c8-42ec-88a9-223336d85a09)



