### PR TITLE
Ensure that data types required by the core cannot be deleted.

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/DataTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/DataTypeControllerBase.cs
@@ -46,6 +46,10 @@ public abstract class DataTypeControllerBase : ManagementApiControllerBase
             DataTypeOperationStatus.ParentNotFound => NotFound(new ProblemDetailsBuilder()
                     .WithTitle("The targeted parent for the data type operation was not found.")
                     .Build()),
+            DataTypeOperationStatus.NonDeletable => BadRequest(new ProblemDetailsBuilder()
+                .WithTitle("The data type is non-deletable")
+                .WithDetail("The specified data type is required by the system and cannot be deleted.")
+                .Build()),
             _ => StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetailsBuilder()
                 .WithTitle("Unknown data type operation status.")
                 .Build()),

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Tree/DataTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Tree/DataTypeTreeControllerBase.cs
@@ -8,6 +8,7 @@ using Umbraco.Cms.Api.Management.Controllers.Tree;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Api.Management.ViewModels.DataType.Item;
 using Umbraco.Cms.Web.Common.Authorization;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType.Tree;
 
@@ -39,6 +40,7 @@ public class DataTypeTreeControllerBase : FolderTreeControllerBase<DataTypeTreeI
             if (dataTypes.TryGetValue(entity.Id, out IDataType? dataType))
             {
                 responseModel.EditorUiAlias = dataType.EditorUiAlias;
+                responseModel.IsDeletable = dataType.IsDeletableDataType();
             }
 
             return responseModel;

--- a/src/Umbraco.Cms.Api.Management/Mapping/DataType/DataTypeViewModelMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/DataType/DataTypeViewModelMapDefinition.cs
@@ -4,6 +4,7 @@ using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Mapping.DataType;
 
@@ -26,6 +27,7 @@ public class DataTypeViewModelMapDefinition : IMapDefinition
         target.Name = source.Name ?? string.Empty;
         target.EditorAlias = source.EditorAlias;
         target.EditorUiAlias = source.EditorUiAlias;
+        target.IsDeletable = source.IsDeletableDataType();
 
         IConfigurationEditor? configurationEditor = source.Editor?.GetConfigurationEditor();
         IDictionary<string, object> configuration = configurationEditor?.ToConfigurationEditor(source.ConfigurationData)

--- a/src/Umbraco.Cms.Api.Management/Mapping/Item/ItemTypeMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Item/ItemTypeMapDefinition.cs
@@ -14,6 +14,7 @@ using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Mapping.Item;
 
@@ -47,6 +48,7 @@ public class ItemTypeMapDefinition : IMapDefinition
         target.Name = source.Name ?? string.Empty;
         target.Id = source.Key;
         target.EditorUiAlias = source.EditorUiAlias;
+        target.IsDeletable = source.IsDeletableDataType();
     }
 
     // Umbraco.Code.MapAll

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -26229,6 +26229,9 @@
         "type": "string"
       },
       "DataTypeItemResponseModel": {
+        "required": [
+          "isDeletable"
+        ],
         "type": "object",
         "allOf": [
           {
@@ -26239,6 +26242,9 @@
           "editorUiAlias": {
             "type": "string",
             "nullable": true
+          },
+          "isDeletable": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false
@@ -26337,7 +26343,8 @@
       },
       "DataTypeResponseModel": {
         "required": [
-          "id"
+          "id",
+          "isDeletable"
         ],
         "type": "object",
         "allOf": [
@@ -26357,11 +26364,17 @@
               }
             ],
             "nullable": true
+          },
+          "isDeletable": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false
       },
       "DataTypeTreeItemResponseModel": {
+        "required": [
+          "isDeletable"
+        ],
         "type": "object",
         "allOf": [
           {
@@ -26372,6 +26385,9 @@
           "editorUiAlias": {
             "type": "string",
             "nullable": true
+          },
+          "isDeletable": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DataTypeResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DataTypeResponseModel.cs
@@ -5,4 +5,6 @@ public class DataTypeResponseModel : DataTypeModelBase
     public Guid Id { get; set; }
 
     public ReferenceByIdModel? Parent { get; set; }
+
+    public bool IsDeletable { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DataType/Item/DataTypeItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DataType/Item/DataTypeItemResponseModel.cs
@@ -5,4 +5,6 @@ namespace Umbraco.Cms.Api.Management.ViewModels.DataType.Item;
 public class DataTypeItemResponseModel : NamedItemResponseModelBase
 {
     public string? EditorUiAlias { get; set; }
+
+    public bool IsDeletable { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DataType/Item/DataTypeTreeItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DataType/Item/DataTypeTreeItemResponseModel.cs
@@ -5,4 +5,6 @@ namespace Umbraco.Cms.Api.Management.ViewModels.DataType.Item;
 public class DataTypeTreeItemResponseModel : FolderTreeItemResponseModel
 {
     public string? EditorUiAlias { get; set; }
+
+    public bool IsDeletable { get; set; }
 }

--- a/src/Umbraco.Core/Models/DataTypeExtensions.cs
+++ b/src/Umbraco.Core/Models/DataTypeExtensions.cs
@@ -42,8 +42,23 @@ public static class DataTypeExtensions
         Constants.DataTypes.Guids.LabelDecimalGuid,
         Constants.DataTypes.Guids.LabelDateTimeGuid,
         Constants.DataTypes.Guids.LabelBigIntGuid,
+        Constants.DataTypes.Guids.LabelIntGuid,
         Constants.DataTypes.Guids.LabelTimeGuid,
         Constants.DataTypes.Guids.LabelDateTimeGuid,
+    };
+
+    private static readonly ISet<Guid> IdsOfNonDeletableDataTypes = new HashSet<Guid>
+    {
+        // these data types are required by PublishedContentType when creating system properties for members
+        // (e.g. username, last login date, approval status)
+        Constants.DataTypes.Guids.CheckboxGuid,
+        Constants.DataTypes.Guids.TextstringGuid,
+        Constants.DataTypes.Guids.LabelDateTimeGuid,
+
+        // these data types are required for default list view handling
+        Constants.DataTypes.Guids.ListViewContentGuid,
+        Constants.DataTypes.Guids.ListViewMediaGuid,
+        Constants.DataTypes.Guids.ListViewMembersGuid,
     };
 
     /// <summary>
@@ -75,14 +90,26 @@ public static class DataTypeExtensions
     }
 
     /// <summary>
-    ///     Returns true if this date type is build-in/default.
+    ///     Returns true if this data type is build-in/default.
     /// </summary>
     /// <param name="dataType">The data type definition.</param>
     /// <returns></returns>
     public static bool IsBuildInDataType(this IDataType dataType) => IsBuildInDataType(dataType.Key);
 
     /// <summary>
-    ///     Returns true if this date type is build-in/default.
+    ///     Returns true if this data type is build-in/default.
     /// </summary>
     public static bool IsBuildInDataType(Guid key) => IdsOfBuildInDataTypes.Contains(key);
+
+    /// <summary>
+    ///     Returns true if this data type can be deleted.
+    /// </summary>
+    /// <param name="dataType">The data type definition.</param>
+    /// <returns></returns>
+    public static bool IsDeletableDataType(this IDataType dataType) => IsDeletableDataType(dataType.Key);
+
+    /// <summary>
+    ///     Returns true if this data type can be deleted.
+    /// </summary>
+    public static bool IsDeletableDataType(Guid key) => IdsOfNonDeletableDataTypes.Contains(key) is false;
 }

--- a/src/Umbraco.Core/Services/DataTypeService.cs
+++ b/src/Umbraco.Core/Services/DataTypeService.cs
@@ -590,6 +590,12 @@ namespace Umbraco.Cms.Core.Services.Implement
                 return Attempt.FailWithStatus(DataTypeOperationStatus.NotFound, dataType);
             }
 
+            if (dataType.IsDeletableDataType() is false)
+            {
+                scope.Complete();
+                return Attempt.FailWithStatus<IDataType?, DataTypeOperationStatus>(DataTypeOperationStatus.NonDeletable, dataType);
+            }
+
             var deletingDataTypeNotification = new DataTypeDeletingNotification(dataType, eventMessages);
             if (await scope.Notifications.PublishCancelableAsync(deletingDataTypeNotification))
             {

--- a/src/Umbraco.Core/Services/OperationStatus/DataTypeOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/DataTypeOperationStatus.cs
@@ -11,5 +11,6 @@ public enum DataTypeOperationStatus
     NotFound,
     ParentNotFound,
     ParentNotContainer,
-    PropertyEditorNotFound
+    PropertyEditorNotFound,
+    NonDeletable
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/DataTypeServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/DataTypeServiceTests.cs
@@ -139,15 +139,20 @@ public class DataTypeServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
-    public async Task DataTypeService_Can_Delete_Textfield_DataType_And_Clear_Usages()
+    public async Task DataTypeService_Can_Delete_DataType_And_Clear_Usages()
     {
         // Arrange
-        var dataTypeDefinitions = await DataTypeService.GetByEditorAliasAsync(Constants.PropertyEditors.Aliases.TextBox);
+        var dataTypeDefinitions = await DataTypeService.GetByEditorAliasAsync(Constants.PropertyEditors.Aliases.RichText);
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
         var doctype =
             ContentTypeBuilder.CreateSimpleContentType("umbTextpage", "Textpage", defaultTemplateId: template.Id);
         ContentTypeService.Save(doctype);
+
+        // validate the assumptions used for assertions later in this test
+        var contentType = ContentTypeService.Get(doctype.Id);
+        Assert.AreEqual(3, contentType.PropertyTypes.Count());
+        Assert.IsNotNull(contentType.PropertyTypes.SingleOrDefault(pt => pt.PropertyEditorAlias is Constants.PropertyEditors.Aliases.RichText));
 
         // Act
         var definition = dataTypeDefinitions.First();
@@ -164,9 +169,9 @@ public class DataTypeServiceTests : UmbracoIntegrationTest
         Assert.That(deletedDefinition, Is.Null);
 
         // Further assertions against the ContentType that contains PropertyTypes based on the TextField
-        var contentType = ContentTypeService.Get(doctype.Id);
+        contentType = ContentTypeService.Get(doctype.Id);
         Assert.That(contentType.Alias, Is.EqualTo("umbTextpage"));
-        Assert.That(contentType.PropertyTypes.Count(), Is.EqualTo(1));
+        Assert.That(contentType.PropertyTypes.Count(), Is.EqualTo(2));
     }
 
     [Test]
@@ -425,5 +430,21 @@ public class DataTypeServiceTests : UmbracoIntegrationTest
         dataType = await DataTypeService.GetAsync(dataType.Key);
         Assert.IsNotNull(dataType);
         Assert.AreEqual(Constants.System.Root, dataType.ParentId);
+    }
+
+    [TestCase(Constants.DataTypes.Guids.LabelDateTime)]
+    [TestCase(Constants.DataTypes.Guids.Textstring)]
+    [TestCase(Constants.DataTypes.Guids.Checkbox)]
+    [TestCase(Constants.DataTypes.Guids.ListViewContent)]
+    [TestCase(Constants.DataTypes.Guids.ListViewMedia)]
+    [TestCase(Constants.DataTypes.Guids.ListViewMembers)]
+    public async Task Cannot_Delete_NonDeletable_DataType(string dataTypeKey)
+    {
+        var dataType = await DataTypeService.GetAsync(Guid.Parse(dataTypeKey));
+        Assert.IsNotNull(dataType);
+
+        var result = await DataTypeService.DeleteAsync(dataType.Key, Constants.Security.SuperUserKey);
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(DataTypeOperationStatus.NonDeletable, result.Status);
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The core cannot handle if certain of the default data types are deleted. Until we can remove this dependency, the following default data types may not be deleted:

- The checkbox (Toggle)
- The textbox
- The date/time label
- The content, media and member list views

### Testing this PR

Use Swagger to try deleting any of the above mentioned data types through the Management API. It should fail.

It should still be possible to delete other data types (including default ones).