### PR TITLE
V14: Align cultures & segments casing

### DIFF
--- a/src/Umbraco.Core/Models/ContentCultureInfosCollection.cs
+++ b/src/Umbraco.Core/Models/ContentCultureInfosCollection.cs
@@ -48,8 +48,6 @@ public class ContentCultureInfosCollection : ObservableDictionary<string, Conten
                 nameof(culture));
         }
 
-        culture = culture.ToLowerInvariant();
-
         if (TryGetValue(culture, out ContentCultureInfos item))
         {
             item.Name = name;

--- a/src/Umbraco.Core/Models/Property.cs
+++ b/src/Umbraco.Core/Models/Property.cs
@@ -567,8 +567,6 @@ public class Property : EntityBase, IProperty
     {
         // TODO: Either we allow change tracking at this class level, or we add some special change tracking collections to the Property
         // class to deal with change tracking which variants have changed
-        private string? _culture;
-        private string? _segment;
 
         /// <summary>
         ///     Gets or sets the culture of the property.
@@ -577,18 +575,14 @@ public class Property : EntityBase, IProperty
         ///     The culture is either null (invariant) or a non-empty string. If the property is
         ///     set with an empty or whitespace value, its value is converted to null.
         /// </remarks>
-        public string? Culture
-        {
-            get => _culture;
-            set => _culture = value.IsNullOrWhiteSpace() ? null : value!.ToLowerInvariant();
-        }
+        public string? Culture { get; set; }
 
         public object DeepClone() => Clone();
 
         public bool Equals(PropertyValue? other) =>
             other != null &&
-            _culture == other._culture &&
-            _segment == other._segment &&
+            Culture == other.Culture &&
+            Segment == other.Segment &&
             EqualityComparer<object>.Default.Equals(EditedValue, other.EditedValue) &&
             EqualityComparer<object>.Default.Equals(PublishedValue, other.PublishedValue);
 
@@ -599,11 +593,7 @@ public class Property : EntityBase, IProperty
         ///     The segment is either null (neutral) or a non-empty string. If the property is
         ///     set with an empty or whitespace value, its value is converted to null.
         /// </remarks>
-        public string? Segment
-        {
-            get => _segment;
-            set => _segment = value?.ToLowerInvariant();
-        }
+        public string? Segment { get; set; }
 
         /// <summary>
         ///     Gets or sets the edited value of the property.
@@ -621,8 +611,8 @@ public class Property : EntityBase, IProperty
         public IPropertyValue Clone()
             => new PropertyValue
             {
-                _culture = _culture,
-                _segment = _segment,
+                Culture = Culture,
+                Segment = Segment,
                 PublishedValue = PublishedValue,
                 EditedValue = EditedValue,
             };
@@ -632,14 +622,14 @@ public class Property : EntityBase, IProperty
         public override int GetHashCode()
         {
             var hashCode = 1885328050;
-            if (_culture is not null)
+            if (Culture is not null)
             {
-                hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(_culture);
+                hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(Culture);
             }
 
-            if (_segment is not null)
+            if (Segment is not null)
             {
-                hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(_segment);
+                hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(Segment);
             }
 
             if (EditedValue is not null)

--- a/src/Umbraco.Infrastructure/Examine/DeliveryApiContentIndexValueSetBuilder.cs
+++ b/src/Umbraco.Infrastructure/Examine/DeliveryApiContentIndexValueSetBuilder.cs
@@ -76,7 +76,7 @@ internal sealed class DeliveryApiContentIndexValueSetBuilder : IDeliveryApiConte
 
             foreach (var culture in availableCultures)
             {
-                var indexCulture = culture ?? "none";
+                var indexCulture = culture?.ToLowerInvariant() ?? "none";
                 var isPublished = publishedCultures.Contains(culture);
 
                 // required index values go here

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentServiceTests.cs
@@ -3544,7 +3544,7 @@ public class ContentServiceTests : UmbracoIntegrationTestWithContent
         // verify saved state
         content = ContentService.GetById(content.Key)!;
         Assert.AreEqual(1, content.PublishedCultures.Count());
-        Assert.AreEqual(langEn.IsoCode.ToLowerInvariant(), content.PublishedCultures.First());
+        Assert.AreEqual(langEn.IsoCode, content.PublishedCultures.First());
     }
 
     private void AssertPerCulture<T>(IContent item, Func<IContent, string, T> getter,


### PR DESCRIPTION
## Details
- When calling GET `/umbraco/management/api/v1/document/{id}`, the cultures casing in the response wasn't the same: 
<code>{
  "urls": [
    {
      <b>"culture": "da-DK",</b>
      "url": "/da/"
    },
    {
     <b> "culture": "en-US",</b>
      "url": "/en/"
    }
    ...
  ],
  ...
  "id": "e1cd7d17-63d8-4b92-859c-b93cd0a2d475",
  "values": [
    {
      "$type": "DocumentValueModel",
      <b>"culture": "en-us",</b>
      "segment": null,
      "alias": "description",
      "value": "Home page text."
    },
...
</code>


- This PR removes `ToLowerInvariant()` from culture and segment which was the underlying issue;
  - And we make sure that the values in the indexes are unchanged (so people don't have to rebuild their indexes);
    - We will keep the value there to lowercase - this was already the case for External and Internal indexes; now we handle that in the DeliveryAPI one as well instead of storing the value as it is. 

## Test
- Build a simple multilingual site on v13;
- Import the DB to a project on `v14/dev`;
- Call `/umbraco/management/api/v1/document/{id}`;
- Verify that the value of each `culture` field in the `values` collection is all lowercase;
  - This is not the case in `urls` collection or in the response from any other endpoint;
- Switch to this branch;
- Verify that the culture casing is now aligned in the GET `/umbraco/management/api/v1/document/{id}`;

> Delivery API tests
- Verify that the Delivery API index data is unchanged;
  - Verify that the data from GET `/umbraco/delivery/api/v1/content` is the same;
  - Verify that the Accept-Language header works as before.