### PR TITLE
Add ancestor endpoints and remove explicit parent context

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Tree/AncestorsDataTypeTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Tree/AncestorsDataTypeTreeController.cs
@@ -1,0 +1,22 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.DataType.Item;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.DataType.Tree;
+
+[ApiVersion("1.0")]
+public class AncestorsDataTypeTreeController : DataTypeTreeControllerBase
+{
+    public AncestorsDataTypeTreeController(IEntityService entityService, IDataTypeService dataTypeService)
+        : base(entityService, dataTypeService)
+    {
+    }
+
+    [HttpGet("ancestors")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(IEnumerable<DataTypeTreeItemResponseModel>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IEnumerable<DataTypeTreeItemResponseModel>>> Ancestors(Guid descendantId)
+        => await GetAncestors(descendantId);
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/AncestorsDictionaryTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/AncestorsDictionaryTreeController.cs
@@ -1,0 +1,22 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Dictionary.Tree;
+
+[ApiVersion("1.0")]
+public class AncestorsDictionaryTreeController : DictionaryTreeControllerBase
+{
+    public AncestorsDictionaryTreeController(IEntityService entityService, IDictionaryItemService dictionaryItemService)
+        : base(entityService, dictionaryItemService)
+    {
+    }
+
+    [HttpGet("ancestors")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(IEnumerable<NamedEntityTreeItemResponseModel>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IEnumerable<NamedEntityTreeItemResponseModel>>> Ancestors(Guid descendantId)
+        => await GetAncestors(descendantId);
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/ChildrenDictionaryTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/ChildrenDictionaryTreeController.cs
@@ -29,6 +29,6 @@ public class ChildrenDictionaryTreeController : DictionaryTreeControllerBase
 
         PagedModel<IDictionaryItem> paginatedItems = await DictionaryItemService.GetPagedAsync(parentId, skip, take);
 
-        return Ok(PagedViewModel(await MapTreeItemViewModels(parentId, paginatedItems.Items), paginatedItems.Total));
+        return Ok(PagedViewModel(await MapTreeItemViewModels(paginatedItems.Items), paginatedItems.Total));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/DictionaryTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/DictionaryTreeControllerBase.cs
@@ -28,26 +28,47 @@ public class DictionaryTreeControllerBase : NamedEntityTreeControllerBase<NamedE
 
     protected IDictionaryItemService DictionaryItemService { get; }
 
-    protected async Task<IEnumerable<NamedEntityTreeItemResponseModel>> MapTreeItemViewModels(Guid? parentKey, IEnumerable<IDictionaryItem> dictionaryItems)
+    protected async Task<IEnumerable<NamedEntityTreeItemResponseModel>> MapTreeItemViewModels(IEnumerable<IDictionaryItem> dictionaryItems)
+        => await Task.WhenAll(dictionaryItems.Select(CreateEntityTreeItemViewModelAsync));
+
+    protected override async Task<ActionResult<IEnumerable<NamedEntityTreeItemResponseModel>>> GetAncestors(Guid descendantKey)
     {
-        async Task<NamedEntityTreeItemResponseModel> CreateEntityTreeItemViewModelAsync(IDictionaryItem dictionaryItem)
+        IDictionaryItem? dictionaryItem = await DictionaryItemService.GetAsync(descendantKey);
+        if (dictionaryItem is null)
         {
-            var hasChildren = await DictionaryItemService.CountChildrenAsync(dictionaryItem.Key) > 0;
-            return new NamedEntityTreeItemResponseModel
-            {
-                Name = dictionaryItem.ItemKey,
-                Id = dictionaryItem.Key,
-                Type = Constants.UdiEntityType.DictionaryItem,
-                HasChildren = hasChildren,
-                Parent = parentKey.HasValue
-                    ? new ReferenceByIdModel
-                    {
-                        Id = parentKey.Value
-                    }
-                    : null
-            };
+            // this looks weird - but we actually mimic how the rest of the ancestor (and children) endpoints actually work
+            return Ok(Enumerable.Empty<NamedEntityTreeItemResponseModel>());
         }
 
-        return await Task.WhenAll(dictionaryItems.Select(CreateEntityTreeItemViewModelAsync));
+        var ancestors = new List<IDictionaryItem>();
+        while (dictionaryItem?.ParentId is not null)
+        {
+            dictionaryItem = await DictionaryItemService.GetAsync(dictionaryItem.ParentId.Value);
+            if (dictionaryItem is not null)
+            {
+                ancestors.Add(dictionaryItem);
+            }
+        }
+
+        NamedEntityTreeItemResponseModel[] viewModels = await Task.WhenAll(ancestors.Select(CreateEntityTreeItemViewModelAsync));
+        return Ok(viewModels.Reverse());
+    }
+
+    private async Task<NamedEntityTreeItemResponseModel> CreateEntityTreeItemViewModelAsync(IDictionaryItem dictionaryItem)
+    {
+        var hasChildren = await DictionaryItemService.CountChildrenAsync(dictionaryItem.Key) > 0;
+        return new NamedEntityTreeItemResponseModel
+        {
+            Name = dictionaryItem.ItemKey,
+            Id = dictionaryItem.Key,
+            Type = Constants.UdiEntityType.DictionaryItem,
+            HasChildren = hasChildren,
+            Parent = dictionaryItem.ParentId.HasValue
+                ? new ReferenceByIdModel
+                {
+                    Id = dictionaryItem.ParentId.Value
+                }
+                : null
+        };
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/RootDictionaryTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/RootDictionaryTreeController.cs
@@ -29,6 +29,6 @@ public class RootDictionaryTreeController : DictionaryTreeControllerBase
 
         PagedModel<IDictionaryItem> paginatedItems = await DictionaryItemService.GetPagedAsync(null, skip, take);
 
-        return Ok(PagedViewModel(await MapTreeItemViewModels(null, paginatedItems.Items), paginatedItems.Total));
+        return Ok(PagedViewModel(await MapTreeItemViewModels(paginatedItems.Items), paginatedItems.Total));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/AncestorsDocumentTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/AncestorsDocumentTreeController.cs
@@ -1,0 +1,40 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.Services.Entities;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Document.Tree;
+
+[ApiVersion("1.0")]
+public class AncestorsDocumentTreeController : DocumentTreeControllerBase
+{
+    public AncestorsDocumentTreeController(
+        IEntityService entityService,
+        IUserStartNodeEntitiesService userStartNodeEntitiesService,
+        IDataTypeService dataTypeService,
+        IPublicAccessService publicAccessService,
+        AppCaches appCaches,
+        IBackOfficeSecurityAccessor backofficeSecurityAccessor,
+        IDocumentPresentationFactory documentPresentationFactory)
+        : base(
+            entityService,
+            userStartNodeEntitiesService,
+            dataTypeService,
+            publicAccessService,
+            appCaches,
+            backofficeSecurityAccessor,
+            documentPresentationFactory)
+    {
+    }
+
+    [HttpGet("ancestors")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(IEnumerable<DocumentTreeItemResponseModel>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IEnumerable<DocumentTreeItemResponseModel>>> Ancestors(Guid descendantId)
+        => await GetAncestors(descendantId);
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Tree/AncestorsDocumentTypeTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Tree/AncestorsDocumentTypeTreeController.cs
@@ -1,0 +1,22 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.DocumentType.Tree;
+
+[ApiVersion("1.0")]
+public class AncestorsDocumentTypeTreeController : DocumentTypeTreeControllerBase
+{
+    public AncestorsDocumentTypeTreeController(IEntityService entityService, IContentTypeService contentTypeService)
+        : base(entityService, contentTypeService)
+    {
+    }
+
+    [HttpGet("ancestors")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(IEnumerable<DocumentTypeTreeItemResponseModel>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IEnumerable<DocumentTypeTreeItemResponseModel>>> Ancestors(Guid descendantId)
+        => await GetAncestors(descendantId);
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/FolderManagementControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/FolderManagementControllerBase.cs
@@ -2,7 +2,6 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
-using Umbraco.Cms.Api.Management.ViewModels;
 using Umbraco.Cms.Api.Management.ViewModels.Folder;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
@@ -35,14 +34,11 @@ public abstract class FolderManagementControllerBase<TTreeEntity> : ManagementAp
                 .Build());
         }
 
-        EntityContainer? parentContainer = await _treeEntityTypeContainerService.GetParentAsync(container);
-
         // we could implement a mapper for this but it seems rather overkill at this point
         return Ok(new FolderResponseModel
         {
             Name = container.Name!,
-            Id = container.Key,
-            Parent = ReferenceByIdModel.ReferenceOrNull(parentContainer?.Key)
+            Id = container.Key
         });
     }
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Tree/AncestorsMediaTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Tree/AncestorsMediaTreeController.cs
@@ -1,0 +1,32 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.Services.Entities;
+using Umbraco.Cms.Api.Management.ViewModels.Media.Item;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Media.Tree;
+
+[ApiVersion("1.0")]
+public class AncestorsMediaTreeController : MediaTreeControllerBase
+{
+    public AncestorsMediaTreeController(
+        IEntityService entityService,
+        IUserStartNodeEntitiesService userStartNodeEntitiesService,
+        IDataTypeService dataTypeService,
+        AppCaches appCaches,
+        IBackOfficeSecurityAccessor backofficeSecurityAccessor,
+        IMediaPresentationFactory mediaPresentationFactory)
+        : base(entityService, userStartNodeEntitiesService, dataTypeService, appCaches, backofficeSecurityAccessor, mediaPresentationFactory)
+    {
+    }
+
+    [HttpGet("ancestors")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(IEnumerable<MediaTreeItemResponseModel>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IEnumerable<MediaTreeItemResponseModel>>> Ancestors(Guid descendantId)
+        => await GetAncestors(descendantId);
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Tree/AncestorsMediaTypeTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Tree/AncestorsMediaTypeTreeController.cs
@@ -1,0 +1,22 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.MediaType.Item;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.MediaType.Tree;
+
+[ApiVersion("1.0")]
+public class AncestorsMediaTypeTreeController : MediaTypeTreeControllerBase
+{
+    public AncestorsMediaTypeTreeController(IEntityService entityService, IMediaTypeService mediaTypeService)
+        : base(entityService, mediaTypeService)
+    {
+    }
+
+    [HttpGet("ancestors")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(IEnumerable<MediaTypeTreeItemResponseModel>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IEnumerable<MediaTypeTreeItemResponseModel>>> Ancestors(Guid descendantId)
+        => await GetAncestors(descendantId);
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Tree/AncestorsPartialViewTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Tree/AncestorsPartialViewTreeController.cs
@@ -1,0 +1,22 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
+using Umbraco.Cms.Core.IO;
+
+namespace Umbraco.Cms.Api.Management.Controllers.PartialView.Tree;
+
+[ApiVersion("1.0")]
+public class AncestorsPartialViewTreeController : PartialViewTreeControllerBase
+{
+    public AncestorsPartialViewTreeController(FileSystems fileSystems)
+        : base(fileSystems)
+    {
+    }
+
+    [HttpGet("ancestors")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(IEnumerable<FileSystemTreeItemPresentationModel>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IEnumerable<FileSystemTreeItemPresentationModel>>> Ancestors(string descendantPath)
+        => await GetAncestors(descendantPath);
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/Tree/AncestorsScriptTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/Tree/AncestorsScriptTreeController.cs
@@ -1,0 +1,22 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
+using Umbraco.Cms.Core.IO;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Script.Tree;
+
+[ApiVersion("1.0")]
+public class AncestorsScriptTreeController : ScriptTreeControllerBase
+{
+    public AncestorsScriptTreeController(FileSystems fileSystems)
+        : base(fileSystems)
+    {
+    }
+
+    [HttpGet("ancestors")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(IEnumerable<FileSystemTreeItemPresentationModel>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IEnumerable<FileSystemTreeItemPresentationModel>>> Ancestors(string descendantPath)
+        => await GetAncestors(descendantPath);
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Tree/AncestorsStaticFileTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Tree/AncestorsStaticFileTreeController.cs
@@ -1,0 +1,22 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
+using Umbraco.Cms.Core.IO;
+
+namespace Umbraco.Cms.Api.Management.Controllers.StaticFile.Tree;
+
+[ApiVersion("1.0")]
+public class AncestorsStaticFileTreeController : StaticFileTreeControllerBase
+{
+    public AncestorsStaticFileTreeController(IPhysicalFileSystem physicalFileSystem)
+        : base(physicalFileSystem)
+    {
+    }
+
+    [HttpGet("ancestors")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(IEnumerable<FileSystemTreeItemPresentationModel>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IEnumerable<FileSystemTreeItemPresentationModel>>> Ancestors(string descendantPath)
+        => await GetAncestors(descendantPath);
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Tree/StaticFileTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Tree/StaticFileTreeControllerBase.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Controllers.Tree;
 using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.IO;
 
@@ -32,7 +33,12 @@ public class StaticFileTreeControllerBase : FileSystemTreeControllerBase
             ? Array.Empty<string>()
             : base.GetFiles(path);
 
+    protected override FileSystemTreeItemPresentationModel[] GetAncestorDirectories(string path)
+        => IsAllowedPath(path)
+            ? base.GetAncestorDirectories(path)
+            : Array.Empty<FileSystemTreeItemPresentationModel>();
+
     private bool IsTreeRootPath(string path) => string.IsNullOrWhiteSpace(path);
 
-    private bool IsAllowedPath(string path) => _allowedRootFolders.Contains(path) || _allowedRootFolders.Any(folder => path.StartsWith($"{folder}/"));
+    private bool IsAllowedPath(string path) => _allowedRootFolders.Contains(path) || _allowedRootFolders.Any(folder => path.StartsWith($"{folder}{Path.DirectorySeparatorChar}"));
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Tree/AncestorsStylesheetTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Tree/AncestorsStylesheetTreeController.cs
@@ -1,0 +1,22 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
+using Umbraco.Cms.Core.IO;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet.Tree;
+
+[ApiVersion("1.0")]
+public class AncestorsStylesheetTreeController : StylesheetTreeControllerBase
+{
+    public AncestorsStylesheetTreeController(FileSystems fileSystems)
+        : base(fileSystems)
+    {
+    }
+
+    [HttpGet("ancestors")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(IEnumerable<FileSystemTreeItemPresentationModel>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IEnumerable<FileSystemTreeItemPresentationModel>>> Ancestors(string descendantPath)
+        => await GetAncestors(descendantPath);
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Tree/AncestorsTemplateTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Tree/AncestorsTemplateTreeController.cs
@@ -1,0 +1,22 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Template.Tree;
+
+[ApiVersion("1.0")]
+public class AncestorsTemplateTreeController : TemplateTreeControllerBase
+{
+    public AncestorsTemplateTreeController(IEntityService entityService)
+        : base(entityService)
+    {
+    }
+
+    [HttpGet("ancestors")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(IEnumerable<NamedEntityTreeItemResponseModel>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IEnumerable<NamedEntityTreeItemResponseModel>>> Ancestors(Guid descendantId)
+        => await GetAncestors(descendantId);
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Tree/FileSystemTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tree/FileSystemTreeControllerBase.cs
@@ -41,6 +41,24 @@ public abstract class FileSystemTreeControllerBase : ManagementApiControllerBase
         return await Task.FromResult(Ok(result));
     }
 
+    protected virtual async Task<ActionResult<IEnumerable<FileSystemTreeItemPresentationModel>>> GetAncestors(string path)
+    {
+        path = path.VirtualPathToSystemPath();
+        FileSystemTreeItemPresentationModel[] models = GetAncestorDirectories(path);
+
+        return await Task.FromResult(Ok(models));
+    }
+
+    protected virtual FileSystemTreeItemPresentationModel[] GetAncestorDirectories(string path)
+    {
+        var directories = path.Split(Path.DirectorySeparatorChar).Take(Range.EndAt(Index.FromEnd(1))).ToArray();
+        FileSystemTreeItemPresentationModel[] result = directories
+            .Select((directory, index) => MapViewModel(string.Join(Path.DirectorySeparatorChar, directories.Take(index + 1)), directory, true))
+            .ToArray();
+
+        return result;
+    }
+
     protected virtual string[] GetDirectories(string path) => FileSystem
         .GetDirectories(path)
         .OrderBy(directory => directory)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Tree/FolderTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tree/FolderTreeControllerBase.cs
@@ -3,6 +3,8 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Api.Management.ViewModels.Tree;
+using Umbraco.Cms.Core.Extensions;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Tree;
 
@@ -60,6 +62,30 @@ public abstract class FolderTreeControllerBase<TItem> : NamedEntityTreeControlle
         }
 
         return viewModel;
+    }
+
+    protected override async Task<IEntitySlim[]> GetAncestorEntitiesAsync(Guid descendantKey)
+    {
+        IEntitySlim? entity = EntityService.Get(descendantKey, ItemObjectType)
+                              ?? EntityService.Get(descendantKey, FolderObjectType);
+        if (entity is null)
+        {
+            // not much else we can do here but return nothing
+            return await Task.FromResult(Array.Empty<IEntitySlim>());
+        }
+
+        var ancestorIds = entity.AncestorIds();
+        // annoyingly we can't use EntityService.GetAll() with container object types, so we have to get them one by one
+        IEntitySlim[] containers = ancestorIds.Select(id => EntityService.Get(id, FolderObjectType)).WhereNotNull().ToArray();
+        IEntitySlim[] ancestors = ancestorIds.Any()
+            ? EntityService
+                .GetAll(ItemObjectType, ancestorIds)
+                .Union(containers)
+                .OrderBy(item => item.Level)
+                .ToArray()
+            : Array.Empty<IEntitySlim>();
+
+        return ancestors;
     }
 
     private IEntitySlim[] GetEntities(int parentId, long pageNumber, int pageSize, out long totalItems)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Tree/UserStartNodeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tree/UserStartNodeTreeControllerBase.cs
@@ -48,14 +48,6 @@ public abstract class UserStartNodeTreeControllerBase<TItem> : EntityTreeControl
             : CalculateAccessMap(() => _userStartNodeEntitiesService.ChildUserAccessEntities(children, UserStartNodePaths), out totalItems);
     }
 
-    protected override IEntitySlim[] GetEntities(Guid[] keys)
-    {
-        IEntitySlim[] entities = base.GetEntities(keys);
-        return UserHasRootAccess() || IgnoreUserStartNodes()
-            ? entities
-            : CalculateAccessMap(() => _userStartNodeEntitiesService.UserAccessEntities(entities, UserStartNodePaths), out _);
-    }
-
     protected override TItem[] MapTreeItemViewModels(Guid? parentKey, IEntitySlim[] entities)
     {
         if (UserHasRootAccess() || IgnoreUserStartNodes())

--- a/src/Umbraco.Cms.Api.Management/Mapping/DataType/DataTypeViewModelMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/DataType/DataTypeViewModelMapDefinition.cs
@@ -1,20 +1,13 @@
-﻿using Umbraco.Cms.Api.Management.ViewModels;
-using Umbraco.Cms.Api.Management.ViewModels.DataType;
+﻿using Umbraco.Cms.Api.Management.ViewModels.DataType;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
-using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Mapping.DataType;
 
 public class DataTypeViewModelMapDefinition : IMapDefinition
 {
-    private readonly IDataTypeService _dataTypeService;
-
-    public DataTypeViewModelMapDefinition(IDataTypeService dataTypeService)
-        => _dataTypeService = dataTypeService;
-
     public void DefineMaps(IUmbracoMapper mapper)
         => mapper.Define<IDataType, DataTypeResponseModel>((_, _) => new DataTypeResponseModel(), Map);
 
@@ -22,8 +15,6 @@ public class DataTypeViewModelMapDefinition : IMapDefinition
     private void Map(IDataType source, DataTypeResponseModel target, MapperContext context)
     {
         target.Id = source.Key;
-        Guid? parentId = _dataTypeService.GetContainer(source.ParentId)?.Key;
-        target.Parent = ReferenceByIdModel.ReferenceOrNull(parentId);
         target.Name = source.Name ?? string.Empty;
         target.EditorAlias = source.EditorAlias;
         target.EditorUiAlias = source.EditorUiAlias;

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -1540,6 +1540,75 @@
         ]
       }
     },
+    "/umbraco/management/api/v1/tree/data-type/ancestors": {
+      "get": {
+        "tags": [
+          "Data Type"
+        ],
+        "operationId": "GetTreeDataTypeAncestors",
+        "parameters": [
+          {
+            "name": "descendantId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DataTypeTreeItemResponseModel"
+                      }
+                    ]
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DataTypeTreeItemResponseModel"
+                      }
+                    ]
+                  }
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DataTypeTreeItemResponseModel"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
     "/umbraco/management/api/v1/tree/data-type/children": {
       "get": {
         "tags": [
@@ -2470,6 +2539,120 @@
                     "oneOf": [
                       {
                         "$ref": "#/components/schemas/DictionaryItemItemResponseModel"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/tree/dictionary/ancestors": {
+      "get": {
+        "tags": [
+          "Dictionary"
+        ],
+        "operationId": "GetTreeDictionaryAncestors",
+        "parameters": [
+          {
+            "name": "descendantId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/NamedEntityTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/DataTypeTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/DocumentBlueprintTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/DocumentTypeTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/FolderTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/MediaTypeTreeItemResponseModel"
+                      }
+                    ]
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/NamedEntityTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/DataTypeTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/DocumentBlueprintTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/DocumentTypeTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/FolderTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/MediaTypeTreeItemResponseModel"
+                      }
+                    ]
+                  }
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/NamedEntityTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/DataTypeTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/DocumentBlueprintTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/DocumentTypeTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/FolderTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/MediaTypeTreeItemResponseModel"
                       }
                     ]
                   }
@@ -4118,6 +4301,75 @@
                     "oneOf": [
                       {
                         "$ref": "#/components/schemas/DocumentTypeItemResponseModel"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/tree/document-type/ancestors": {
+      "get": {
+        "tags": [
+          "Document Type"
+        ],
+        "operationId": "GetTreeDocumentTypeAncestors",
+        "parameters": [
+          {
+            "name": "descendantId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DocumentTypeTreeItemResponseModel"
+                      }
+                    ]
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DocumentTypeTreeItemResponseModel"
+                      }
+                    ]
+                  }
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DocumentTypeTreeItemResponseModel"
                       }
                     ]
                   }
@@ -6628,6 +6880,75 @@
               "text/plain": {
                 "schema": {
                   "$ref": "#/components/schemas/PagedDocumentRecycleBinItemResponseModel"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/tree/document/ancestors": {
+      "get": {
+        "tags": [
+          "Document"
+        ],
+        "operationId": "GetTreeDocumentAncestors",
+        "parameters": [
+          {
+            "name": "descendantId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DocumentTreeItemResponseModel"
+                      }
+                    ]
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DocumentTreeItemResponseModel"
+                      }
+                    ]
+                  }
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DocumentTreeItemResponseModel"
+                      }
+                    ]
+                  }
                 }
               }
             }
@@ -10266,6 +10587,75 @@
         ]
       }
     },
+    "/umbraco/management/api/v1/tree/media-type/ancestors": {
+      "get": {
+        "tags": [
+          "Media Type"
+        ],
+        "operationId": "GetTreeMediaTypeAncestors",
+        "parameters": [
+          {
+            "name": "descendantId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MediaTypeTreeItemResponseModel"
+                      }
+                    ]
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MediaTypeTreeItemResponseModel"
+                      }
+                    ]
+                  }
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MediaTypeTreeItemResponseModel"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
     "/umbraco/management/api/v1/tree/media-type/children": {
       "get": {
         "tags": [
@@ -11798,6 +12188,75 @@
               "text/plain": {
                 "schema": {
                   "$ref": "#/components/schemas/PagedMediaRecycleBinItemResponseModel"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/tree/media/ancestors": {
+      "get": {
+        "tags": [
+          "Media"
+        ],
+        "operationId": "GetTreeMediaAncestors",
+        "parameters": [
+          {
+            "name": "descendantId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MediaTreeItemResponseModel"
+                      }
+                    ]
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MediaTreeItemResponseModel"
+                      }
+                    ]
+                  }
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MediaTreeItemResponseModel"
+                      }
+                    ]
+                  }
                 }
               }
             }
@@ -15413,6 +15872,74 @@
         ]
       }
     },
+    "/umbraco/management/api/v1/tree/partial-view/ancestors": {
+      "get": {
+        "tags": [
+          "Partial View"
+        ],
+        "operationId": "GetTreePartialViewAncestors",
+        "parameters": [
+          {
+            "name": "descendantPath",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/FileSystemTreeItemPresentationModel"
+                      }
+                    ]
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/FileSystemTreeItemPresentationModel"
+                      }
+                    ]
+                  }
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/FileSystemTreeItemPresentationModel"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
     "/umbraco/management/api/v1/tree/partial-view/children": {
       "get": {
         "tags": [
@@ -17562,6 +18089,74 @@
         ]
       }
     },
+    "/umbraco/management/api/v1/tree/script/ancestors": {
+      "get": {
+        "tags": [
+          "Script"
+        ],
+        "operationId": "GetTreeScriptAncestors",
+        "parameters": [
+          {
+            "name": "descendantPath",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/FileSystemTreeItemPresentationModel"
+                      }
+                    ]
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/FileSystemTreeItemPresentationModel"
+                      }
+                    ]
+                  }
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/FileSystemTreeItemPresentationModel"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
     "/umbraco/management/api/v1/tree/script/children": {
       "get": {
         "tags": [
@@ -18457,6 +19052,74 @@
                     "oneOf": [
                       {
                         "$ref": "#/components/schemas/StaticFileItemResponseModel"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/tree/static-file/ancestors": {
+      "get": {
+        "tags": [
+          "Static File"
+        ],
+        "operationId": "GetTreeStaticFileAncestors",
+        "parameters": [
+          {
+            "name": "descendantPath",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/FileSystemTreeItemPresentationModel"
+                      }
+                    ]
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/FileSystemTreeItemPresentationModel"
+                      }
+                    ]
+                  }
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/FileSystemTreeItemPresentationModel"
                       }
                     ]
                   }
@@ -19390,6 +20053,74 @@
               "text/plain": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/tree/stylesheet/ancestors": {
+      "get": {
+        "tags": [
+          "Stylesheet"
+        ],
+        "operationId": "GetTreeStylesheetAncestors",
+        "parameters": [
+          {
+            "name": "descendantPath",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/FileSystemTreeItemPresentationModel"
+                      }
+                    ]
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/FileSystemTreeItemPresentationModel"
+                      }
+                    ]
+                  }
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/FileSystemTreeItemPresentationModel"
+                      }
+                    ]
+                  }
                 }
               }
             }
@@ -20385,6 +21116,120 @@
                       "$ref": "#/components/schemas/TemplateQuerySettingsResponseModel"
                     }
                   ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/tree/template/ancestors": {
+      "get": {
+        "tags": [
+          "Template"
+        ],
+        "operationId": "GetTreeTemplateAncestors",
+        "parameters": [
+          {
+            "name": "descendantId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/NamedEntityTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/DataTypeTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/DocumentBlueprintTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/DocumentTypeTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/FolderTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/MediaTypeTreeItemResponseModel"
+                      }
+                    ]
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/NamedEntityTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/DataTypeTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/DocumentBlueprintTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/DocumentTypeTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/FolderTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/MediaTypeTreeItemResponseModel"
+                      }
+                    ]
+                  }
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/NamedEntityTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/DataTypeTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/DocumentBlueprintTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/DocumentTypeTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/FolderTreeItemResponseModel"
+                      },
+                      {
+                        "$ref": "#/components/schemas/MediaTypeTreeItemResponseModel"
+                      }
+                    ]
+                  }
                 }
               }
             }
@@ -26421,14 +27266,6 @@
             "type": "string",
             "format": "uuid"
           },
-          "parent": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/ReferenceByIdModel"
-              }
-            ],
-            "nullable": true
-          },
           "isDeletable": {
             "type": "boolean"
           }
@@ -27782,14 +28619,6 @@
           "id": {
             "type": "string",
             "format": "uuid"
-          },
-          "parent": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/ReferenceByIdModel"
-              }
-            ],
-            "nullable": true
           }
         },
         "additionalProperties": false

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DataTypeResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DataTypeResponseModel.cs
@@ -4,7 +4,5 @@ public class DataTypeResponseModel : DataTypeModelBase
 {
     public Guid Id { get; set; }
 
-    public ReferenceByIdModel? Parent { get; set; }
-
     public bool IsDeletable { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Folder/FolderResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Folder/FolderResponseModel.cs
@@ -3,6 +3,4 @@
 public class FolderResponseModel : FolderModelBase
 {
     public Guid Id { get; set; }
-
-    public ReferenceByIdModel? Parent { get; set; }
 }

--- a/src/Umbraco.Core/Extensions/TreeEntityExtensions.cs
+++ b/src/Umbraco.Core/Extensions/TreeEntityExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System.Globalization;
+using Umbraco.Cms.Core.Models.Entities;
+
+namespace Umbraco.Cms.Core.Extensions;
+
+public static class TreeEntityExtensions
+{
+    public static int[] AncestorIds(this ITreeEntity entity) => entity.Path
+        .Split(Constants.CharArrays.Comma)
+        .Select(item => int.Parse(item, CultureInfo.InvariantCulture))
+        .Take(new Range(Index.FromStart(1), Index.FromEnd(1)))
+        .ToArray();
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/TreeEntityExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/TreeEntityExtensionsTests.cs
@@ -1,0 +1,31 @@
+﻿using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Extensions;
+using Umbraco.Cms.Core.Models.Entities;
+using Range = System.Range;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Extensions;
+
+[TestFixture]
+public class TreeEntityExtensionsTests
+{
+    [TestCase("-1,1234", 0)]
+    [TestCase("-1,1234,5678", 1)]
+    [TestCase("-1,1234,5678,9012", 2)]
+    [TestCase("-1,1234,5678,9012,2345", 3)]
+    public void Parse_Ancestor_Ids_Excludes_Root_And_Self(string path, int expectedLength)
+    {
+        var entityMock = new Mock<ITreeEntity>();
+        entityMock.SetupGet(m => m.Path).Returns(path);
+
+        var expectedIds = path
+            .Split(',')
+            .Skip(1)
+            .Take(Range.EndAt(Index.FromEnd(1)))
+            .Select(int.Parse)
+            .ToArray();
+        var result = entityMock.Object.AncestorIds();
+        Assert.AreEqual(expectedLength, result.Length);
+        Assert.That(expectedIds, Is.EquivalentTo(result));
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

We need to know about ancestors in the Management API - among other things because:

- Deep linking to an item in a tree requires expanding the tree to said item location.
- MNTP needs a parent context to handle dynamic root queries.

We already have a few explicit implementations of parent context, but it is not something we have added on a broad scale, so we have opted to remove them in favor of using the ancestor endpoints instead.

### Testing this PR

Create structures to match the new ancestor endpoints, and use Swagger to query ancestors through these structures. The resulting ancestors should _not_ contain the queried item, nor the system root (-1).