### PR TITLE
V14: Run SQL Server Integration/Acceptance tests manually

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -358,7 +358,7 @@ stages:
       - job:
         timeoutInMinutes: 180
         # condition: or(eq(stageDependencies.Build.A.outputs['build.NBGV_PublicRelease'], 'True'), ${{parameters.sqlServerIntegrationTests}}) # Outcommented due to timeouts
-        condition: and(succeeded(), ${{parameters.sqlServerIntegrationTests}})
+        condition: or(${{parameters.sqlServerIntegrationTests}})
         displayName: Integration Tests (SQL Server)
         strategy:
           matrix:
@@ -577,7 +577,7 @@ stages:
       - job:
         displayName: E2E Tests (SQL Server)
         # condition: or(eq(stageDependencies.Build.A.outputs['build.NBGV_PublicRelease'], 'True'), ${{parameters.sqlServerAcceptanceTests}}) # Outcommented due to timeouts
-        condition: and(succeeded(), ${{parameters.sqlServerAcceptanceTests}})
+        condition: or(${{parameters.sqlServerAcceptanceTests}})
         variables:
           # Connection string
           CONNECTIONSTRINGS__UMBRACODBDSN: Data Source=(localdb)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\Umbraco.mdf;Integrated Security=True

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -357,7 +357,8 @@ stages:
       # Integration Tests (SQL Server)
       - job:
         timeoutInMinutes: 180
-        condition: or(eq(stageDependencies.Build.A.outputs['build.NBGV_PublicRelease'], 'True'), ${{parameters.sqlServerIntegrationTests}})
+        # condition: or(eq(stageDependencies.Build.A.outputs['build.NBGV_PublicRelease'], 'True'), ${{parameters.sqlServerIntegrationTests}}) # Outcommented due to timeouts
+        condition: and(succeeded(), ${{parameters.sqlServerIntegrationTests}})
         displayName: Integration Tests (SQL Server)
         strategy:
           matrix:
@@ -575,7 +576,8 @@ stages:
 
       - job:
         displayName: E2E Tests (SQL Server)
-        condition: or(eq(stageDependencies.Build.A.outputs['build.NBGV_PublicRelease'], 'True'), ${{parameters.sqlServerAcceptanceTests}})
+        # condition: or(eq(stageDependencies.Build.A.outputs['build.NBGV_PublicRelease'], 'True'), ${{parameters.sqlServerAcceptanceTests}}) # Outcommented due to timeouts
+        condition: and(succeeded(), ${{parameters.sqlServerAcceptanceTests}})
         variables:
           # Connection string
           CONNECTIONSTRINGS__UMBRACODBDSN: Data Source=(localdb)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\Umbraco.mdf;Integrated Security=True

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -358,7 +358,7 @@ stages:
       - job:
         timeoutInMinutes: 180
         # condition: or(eq(stageDependencies.Build.A.outputs['build.NBGV_PublicRelease'], 'True'), ${{parameters.sqlServerIntegrationTests}}) # Outcommented due to timeouts
-        condition: or(${{parameters.sqlServerIntegrationTests}})
+        condition: eq(${{parameters.sqlServerIntegrationTests}}, True)
         displayName: Integration Tests (SQL Server)
         strategy:
           matrix:
@@ -577,7 +577,7 @@ stages:
       - job:
         displayName: E2E Tests (SQL Server)
         # condition: or(eq(stageDependencies.Build.A.outputs['build.NBGV_PublicRelease'], 'True'), ${{parameters.sqlServerAcceptanceTests}}) # Outcommented due to timeouts
-        condition: or(${{parameters.sqlServerAcceptanceTests}})
+        condition: eq(${{parameters.sqlServerAcceptanceTests}}, True)
         variables:
           # Connection string
           CONNECTIONSTRINGS__UMBRACODBDSN: Data Source=(localdb)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\Umbraco.mdf;Integrated Security=True


### PR DESCRIPTION
This is a temp fix until we stop getting timeouts: sql server tests should only be run manually
