### PR TITLE
Remove the default value constraint on "isContainer" before deleting the column

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -65,7 +65,6 @@ public class UmbracoPlan : MigrationPlan
 
         // To 14.0.0
         To<V_14_0_0.AddPropertyEditorUiAliasColumn>("{419827A0-4FCE-464B-A8F3-247C6092AF55}");
-        To<V_14_0_0.MigrateDataTypeConfigurations>("{5F15A1CC-353D-4889-8C7E-F303B4766196}");
         To<V_14_0_0.AddGuidsToUserGroups>("{69E12556-D9B3-493A-8E8A-65EC89FB658D}");
         To<V_14_0_0.AddUserGroup2PermisionTable>("{F2B16CD4-F181-4BEE-81C9-11CF384E6025}");
         To<V_14_0_0.AddGuidsToUsers>("{A8E01644-9F2E-4988-8341-587EF5B7EA69}");
@@ -73,5 +72,6 @@ public class UmbracoPlan : MigrationPlan
         To<V_14_0_0.RenameTechnologyLeakingPropertyEditorAliases>("{80D282A4-5497-47FF-991F-BC0BCE603121}");
         To<V_14_0_0.MigrateSchduledPublishesToUtc>("{96525697-E9DC-4198-B136-25AD033442B8}");
         To<V_14_0_0.AddListViewKeysToDocumentTypes>("{7FC5AC9B-6F56-415B-913E-4A900629B853}");
+        To<V_14_0_0.MigrateDataTypeConfigurations>("{1539A010-2EB5-4163-8518-4AE2AA98AFC6}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddListViewKeysToDocumentTypes.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddListViewKeysToDocumentTypes.cs
@@ -44,7 +44,7 @@ public class AddListViewKeysToDocumentTypes : UnscopedMigrationBase
         if (ColumnExists(Constants.DatabaseSchema.Tables.ContentType, NewColumnName) is false)
         {
             IEnumerable<ContentTypeDto> contentTypeDtos = GetContentTypeDtos().Where(x => x.ListView is not null);
-
+            Delete.DefaultConstraint().OnTable(Constants.DatabaseSchema.Tables.ContentType).OnColumn("isContainer").Do();
             Delete.Column("isContainer").FromTable(Constants.DatabaseSchema.Tables.ContentType).Do();
             Create.Column(NewColumnName)
                 .OnTable(Constants.DatabaseSchema.Tables.ContentType)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The newly introduced listview migration (https://github.com/umbraco/Umbraco-CMS/pull/15687) does not play nice on SQL server due to the default value constraint on the `isContainer` column.

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/e8f54983-67d5-4677-9f68-8a610413455c)

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/0eea8cda-f922-40f7-ade5-bd287b9c076e)

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/167e49d4-a599-4ec4-80b9-f8be4164ca9c)

This PR ensures that the constraint is explicitly removed before we delete the column

As it turns out, the listview migration and the new datatype configuration migration (https://github.com/umbraco/Umbraco-CMS/pull/15733) also clash with each other, so the latter has to be moved to the end of `UmbracoPlan`. This unfortunately might affect any currently updated V14 databases, but there really is not much we can do about it.

### Testing this PR

Install V13 using SQL Server. Upgrade the DB to V14. The upgrade should complete 😄 