### PR TITLE
Validate data type configuration values

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ConfigurationEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/ConfigurationEditor.cs
@@ -81,7 +81,13 @@ public class ConfigurationEditor : IConfigurationEditor
         => configuration.IsNullOrWhiteSpace() ? new Dictionary<string, object>() : configurationEditorJsonSerializer.Deserialize<Dictionary<string, object>>(configuration) ?? new Dictionary<string, object>();
 
     /// <inheritdoc />
-    public virtual IEnumerable<ValidationResult> Validate(IDictionary<string, object> configuration) => Array.Empty<ValidationResult>();
+    public virtual IEnumerable<ValidationResult> Validate(IDictionary<string, object> configuration)
+        => Fields
+            .SelectMany(field =>
+                configuration.TryGetValue(field.Key, out var value)
+                    ? field.Validators.SelectMany(validator => validator.Validate(value, null, null))
+                    : Enumerable.Empty<ValidationResult>())
+            .ToArray();
 
     /// <summary>
     ///     Gets a field by its property name.


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

A left-over from the data type configuration and validation refactoring effort; we need to validate the data type configuration values.

Unline content, the data type configuration validation does not need to supply JSON path responses, because their schema is expected to be well-known and honoured by the client.

### Testing this PR

Use Swagger to attempt both create and update with invalid data type configurations. The attempts should yield a bad request in both cases.

The following data type configuration payload can be used to test, since the color picker validates the configured HEX codes:

```json
{
  "name": "Color Picker - Validation Test",
  "editorAlias": "Umbraco.ColorPicker",
  "editorUiAlias": null,
  "values": [
    {
      "alias": "useLabel",
      "value": true
    },
    {
      "alias": "items",
      "value": [
        {
          "value": "invalid",
          "label": "Black"
        },
        {
          "value": "cc0000",
          "label": "Red"
        },
        {
          "value": "ffffff",
          "label": "White"
        }
      ]
    }
  ]
}
```