### PR TITLE
Validate collisions in domain assignments

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/UpdateDomainsController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/UpdateDomainsController.cs
@@ -1,14 +1,14 @@
 ﻿using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Common.Builders;
+using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.Document;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Mapping;
-using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document;
 
@@ -17,20 +17,25 @@ public class UpdateDomainsController : DocumentControllerBase
 {
     private readonly IDomainService _domainService;
     private readonly IUmbracoMapper _umbracoMapper;
+    private readonly IDomainPresentationFactory _domainPresentationFactory;
 
-    public UpdateDomainsController(IDomainService domainService, IUmbracoMapper umbracoMapper)
+    public UpdateDomainsController(IDomainService domainService, IUmbracoMapper umbracoMapper, IDomainPresentationFactory domainPresentationFactory)
     {
         _domainService = domainService;
         _umbracoMapper = umbracoMapper;
+        _domainPresentationFactory = domainPresentationFactory;
     }
 
     [MapToApiVersion("1.0")]
     [HttpPut("{id:guid}/domains")]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
     public async Task<IActionResult> Update(Guid id, UpdateDomainsRequestModel updateModel)
     {
         DomainsUpdateModel domainsUpdateModel = _umbracoMapper.Map<DomainsUpdateModel>(updateModel)!;
 
-        Attempt<IEnumerable<IDomain>, DomainOperationStatus> result = await _domainService.UpdateDomainsAsync(id, domainsUpdateModel);
+        Attempt<DomainUpdateResult, DomainOperationStatus> result = await _domainService.UpdateDomainsAsync(id, domainsUpdateModel);
 
         return result.Success
             ? Ok()
@@ -51,6 +56,11 @@ public class UpdateDomainsController : DocumentControllerBase
                 DomainOperationStatus.DuplicateDomainName => Conflict(problemDetailsBuilder
                     .WithTitle("Duplicate domain name detected")
                     .WithDetail("One or more of the specified domain names were duplicates, possibly of assignments to other content items.")
+                    .Build()),
+                DomainOperationStatus.ConflictingDomainName => Conflict(problemDetailsBuilder
+                    .WithTitle("Conflicting domain name detected")
+                    .WithDetail("One or more of the specified domain names were conflicting with domain assignments to other content items.")
+                    .WithExtension("conflictingDomainNames", _domainPresentationFactory.CreateDomainAssignmentModels(result.Result.ConflictingDomains.EmptyNull()))
                     .Build()),
                 _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                     .WithTitle("Unknown domain update operation status.")

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/DocumentBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/DocumentBuilderExtensions.cs
@@ -15,6 +15,7 @@ internal static class DocumentBuilderExtensions
         builder.Services.AddTransient<IDocumentUrlFactory, DocumentUrlFactory>();
         builder.Services.AddTransient<IDocumentEditingPresentationFactory, DocumentEditingPresentationFactory>();
         builder.Services.AddTransient<IPublicAccessPresentationFactory, PublicAccessPresentationFactory>();
+        builder.Services.AddTransient<IDomainPresentationFactory, DomainPresentationFactory>();
 
         builder.WithCollectionBuilder<MapDefinitionCollectionBuilder>()
             .Add<DocumentMapDefinition>()

--- a/src/Umbraco.Cms.Api.Management/Factories/DomainPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DomainPresentationFactory.cs
@@ -1,0 +1,32 @@
+﻿using Umbraco.Cms.Api.Management.ViewModels;
+using Umbraco.Cms.Api.Management.ViewModels.Document;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.Factories;
+
+internal sealed class DomainPresentationFactory : IDomainPresentationFactory
+{
+    private readonly IEntityService _entityService;
+
+    public DomainPresentationFactory(IEntityService entityService)
+        => _entityService = entityService;
+
+    public IEnumerable<DomainAssignmentModel> CreateDomainAssignmentModels(IEnumerable<IDomain> domains)
+        => domains
+            .Where(domain => domain.RootContentId.HasValue)
+            .Select(domain =>
+            {
+                Attempt<Guid> keyResult = _entityService.GetKey(domain.RootContentId!.Value, UmbracoObjectTypes.Document);
+                return keyResult.Success
+                    ? new DomainAssignmentModel
+                    {
+                        DomainName = domain.DomainName, Content = new ReferenceByIdModel(keyResult.Result)
+                    }
+                    : null;
+            })
+            .WhereNotNull()
+            .ToArray();
+}

--- a/src/Umbraco.Cms.Api.Management/Factories/IDomainPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IDomainPresentationFactory.cs
@@ -1,0 +1,9 @@
+﻿using Umbraco.Cms.Api.Management.ViewModels.Document;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Api.Management.Factories;
+
+public interface IDomainPresentationFactory
+{
+    IEnumerable<DomainAssignmentModel> CreateDomainAssignmentModels(IEnumerable<IDomain> domains);
+}

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -5024,8 +5024,65 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "Success"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           },
           "401": {
             "description": "The resource is protected and requires an authentication token"

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/DomainAssignmentModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/DomainAssignmentModel.cs
@@ -1,0 +1,8 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Document;
+
+public sealed class DomainAssignmentModel
+{
+    public required string DomainName { get; set; }
+
+    public required ReferenceByIdModel Content { get; set; }
+}

--- a/src/Umbraco.Core/Models/ContentEditing/DomainUpdateResult.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/DomainUpdateResult.cs
@@ -1,0 +1,8 @@
+﻿namespace Umbraco.Cms.Core.Models.ContentEditing;
+
+public sealed class DomainUpdateResult
+{
+    public IEnumerable<IDomain> Domains { get; init; } = Enumerable.Empty<IDomain>();
+
+    public IEnumerable<IDomain>? ConflictingDomains { get; init; }
+}

--- a/src/Umbraco.Core/Services/IDomainService.cs
+++ b/src/Umbraco.Core/Services/IDomainService.cs
@@ -47,5 +47,5 @@ public interface IDomainService : IService
     /// </summary>
     /// <param name="contentKey">The key of the content item.</param>
     /// <param name="updateModel">The domain assignments to apply.</param>
-    Task<Attempt<IEnumerable<IDomain>, DomainOperationStatus>> UpdateDomainsAsync(Guid contentKey, DomainsUpdateModel updateModel);
+    Task<Attempt<DomainUpdateResult, DomainOperationStatus>> UpdateDomainsAsync(Guid contentKey, DomainsUpdateModel updateModel);
 }

--- a/src/Umbraco.Core/Services/OperationStatus/DomainOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/DomainOperationStatus.cs
@@ -6,5 +6,6 @@ public enum DomainOperationStatus
     CancelledByNotification,
     ContentNotFound,
     LanguageNotFound,
-    DuplicateDomainName
+    DuplicateDomainName,
+    ConflictingDomainName
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/UrlAndDomains/DomainAndUrlsTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/UrlAndDomains/DomainAndUrlsTests.cs
@@ -101,7 +101,7 @@ public class DomainAndUrlsTests : UmbracoIntegrationTest
             }
         }
 
-        VerifyDomains(result.Result.ToArray());
+        VerifyDomains(result.Result.Domains.ToArray());
 
         // re-get and verify again
         var domains = await domainService.GetAssignedDomainsAsync(Root.Key, true);
@@ -135,7 +135,7 @@ public class DomainAndUrlsTests : UmbracoIntegrationTest
             }
         }
 
-        VerifyDomains(result.Result.ToArray());
+        VerifyDomains(result.Result.Domains.ToArray());
 
         // re-get and verify again
         var domains = await domainService.GetAssignedDomainsAsync(Root.Key, true);
@@ -157,14 +157,14 @@ public class DomainAndUrlsTests : UmbracoIntegrationTest
         var result = await domainService.UpdateDomainsAsync(Root.Key, updateModel);
         Assert.IsTrue(result.Success);
         Assert.AreEqual(DomainOperationStatus.Success, result.Status);
-        Assert.AreEqual(3, result.Result.Count());
+        Assert.AreEqual(3, result.Result.Domains.Count());
 
         updateModel.Domains = Enumerable.Empty<DomainModel>();
 
         result = await domainService.UpdateDomainsAsync(Root.Key, updateModel);
         Assert.IsTrue(result.Success);
         Assert.AreEqual(DomainOperationStatus.Success, result.Status);
-        Assert.AreEqual(0, result.Result.Count());
+        Assert.AreEqual(0, result.Result.Domains.Count());
 
         // re-get and verify again
         var domains = await domainService.GetAssignedDomainsAsync(Root.Key, true);
@@ -186,16 +186,16 @@ public class DomainAndUrlsTests : UmbracoIntegrationTest
         var result = await domainService.UpdateDomainsAsync(Root.Key, updateModel);
         Assert.IsTrue(result.Success);
         Assert.AreEqual(DomainOperationStatus.Success, result.Status);
-        Assert.AreEqual(3, result.Result.Count());
+        Assert.AreEqual(3, result.Result.Domains.Count());
 
         updateModel.Domains = new[] { updateModel.Domains.First(), updateModel.Domains.Last() };
 
         result = await domainService.UpdateDomainsAsync(Root.Key, updateModel);
         Assert.IsTrue(result.Success);
         Assert.AreEqual(DomainOperationStatus.Success, result.Status);
-        Assert.AreEqual(2, result.Result.Count());
-        Assert.AreEqual(Cultures.First(), result.Result.First().LanguageIsoCode);
-        Assert.AreEqual(Cultures.Last(), result.Result.Last().LanguageIsoCode);
+        Assert.AreEqual(2, result.Result.Domains.Count());
+        Assert.AreEqual(Cultures.First(), result.Result.Domains.First().LanguageIsoCode);
+        Assert.AreEqual(Cultures.Last(), result.Result.Domains.Last().LanguageIsoCode);
     }
 
     [Test]
@@ -275,10 +275,10 @@ public class DomainAndUrlsTests : UmbracoIntegrationTest
 
         var result = await domainService.UpdateDomainsAsync(Root.Key, updateModel);
         Assert.IsTrue(result.Success);
-        Assert.AreEqual(1, result.Result.Count());
+        Assert.AreEqual(1, result.Result.Domains.Count());
 
         // default culture is represented as a wildcard domain
-        var domain = result.Result.First();
+        var domain = result.Result.Domains.First();
         Assert.IsTrue(domain.IsWildcard);
         Assert.AreEqual(culture, domain.LanguageIsoCode);
         Assert.AreEqual("*" + Root.Id, domain.DomainName);
@@ -352,7 +352,15 @@ public class DomainAndUrlsTests : UmbracoIntegrationTest
 
         result = await domainService.UpdateDomainsAsync(copy.Key, updateModel);
         Assert.IsFalse(result.Success);
-        Assert.AreEqual(DomainOperationStatus.DuplicateDomainName, result.Status);
+        Assert.AreEqual(DomainOperationStatus.ConflictingDomainName, result.Status);
+
+        Assert.IsNotNull(result.Result.ConflictingDomains);
+        Assert.IsNotEmpty(result.Result.ConflictingDomains);
+        Assert.AreEqual(updateModel.Domains.Count(), result.Result.ConflictingDomains.Count());
+        foreach (var culture in Cultures)
+        {
+            Assert.IsNotNull(result.Result.ConflictingDomains.SingleOrDefault(c => c.RootContentId == Root.Id && c.DomainName == GetDomainUrlFromCultureCode(culture)));
+        }
     }
 
     private static string GetDomainUrlFromCultureCode(string culture) =>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR ensures that the Management API detects and reports collisions in domain assignments.

### Testing this PR

Assign the same domain to two different documents. The last assignment should fail with some helpful instructions in the resulting problem details.