### PR TITLE
Added FileProvider support to StaticFilesTreeController

### DIFF
--- a/src/Umbraco.Web.BackOffice/Trees/StaticFilesTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/StaticFilesTreeController.cs
@@ -1,6 +1,9 @@
 using System.Net;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.IO;
@@ -16,8 +19,12 @@ public class StaticFilesTreeController : TreeController
     private const string AppPlugins = "App_Plugins";
     private const string Webroot = "wwwroot";
     private readonly IFileSystem _fileSystem;
+    private readonly CompositeFileProvider? _fileProvider;
+    private readonly IWebHostEnvironment? _hostingEnvironment;
     private readonly IMenuItemCollectionFactory _menuItemCollectionFactory;
+    private readonly Func<string, FormCollection, ActionResult<TreeNodeCollection>> _getTreeNodes;
 
+    [Obsolete($"Use the constructor with {nameof(IFileProvider)} instead.")]
     public StaticFilesTreeController(
         ILocalizedTextService localizedTextService,
         UmbracoApiControllerTypeCollection umbracoApiControllerTypeCollection,
@@ -28,13 +35,130 @@ public class StaticFilesTreeController : TreeController
     {
         _fileSystem = fileSystem;
         _menuItemCollectionFactory = menuItemCollectionFactory;
+        _getTreeNodes = GetTreeNodesFromPhysicalFileSystem;
     }
 
-    protected override ActionResult<TreeNodeCollection> GetTreeNodes(string id, FormCollection queryStrings)
+    [ActivatorUtilitiesConstructor]
+    public StaticFilesTreeController(
+        ILocalizedTextService localizedTextService,
+        UmbracoApiControllerTypeCollection umbracoApiControllerTypeCollection,
+        IEventAggregator eventAggregator,
+        IPhysicalFileSystem fileSystem,
+        IMenuItemCollectionFactory menuItemCollectionFactory,
+        IWebHostEnvironment hostingEnvironment)
+        : base(localizedTextService, umbracoApiControllerTypeCollection, eventAggregator)
     {
+        _fileSystem = fileSystem;
+
+        _fileProvider = new CompositeFileProvider(
+                hostingEnvironment.ContentRootFileProvider, // physical file provider
+                hostingEnvironment.WebRootFileProvider); // packages file provider
+
+        _menuItemCollectionFactory = menuItemCollectionFactory;
+        _getTreeNodes = GetTreeNodesFromCompositeFieProvider;
+    }
+
+    // GetTreeNodes method calls a privat method that was assigned by a class constructor
+    protected override ActionResult<TreeNodeCollection> GetTreeNodes(string id, FormCollection queryStrings) => _getTreeNodes(id, queryStrings);
+
+    // We don't have any menu item options (such as create/delete/reload) & only use the root node to load a custom UI
+    protected override ActionResult<MenuItemCollection> GetMenuForNode(string id, FormCollection queryStrings) =>
+        _menuItemCollectionFactory.Create();
+
+    private ActionResult<TreeNodeCollection> GetTreeNodesFromCompositeFieProvider(string id, FormCollection queryStrings)
+    {
+        if (_fileProvider is null)
+        {
+            throw new ArgumentNullException(nameof(_fileProvider));
+        }
+
         var path = string.IsNullOrEmpty(id) == false && id != Constants.System.RootString
             ? WebUtility.UrlDecode(id).TrimStart("/")
-            : "";
+            : string.Empty;
+        var nodes = new TreeNodeCollection();
+
+        IEnumerable<IFileInfo> directories = _fileProvider.GetDirectoryContents(path).Where(i => i.IsDirectory);
+
+        foreach (IFileInfo directory in directories)
+        {
+            if (directory == null)
+            {
+                continue;
+            }
+
+            // We don't want any other directories under the root node other than the ones serving static files - App_Plugins and wwwroot
+            if (id == Constants.System.RootString && directory.Name != AppPlugins && directory.Name != Webroot)
+            {
+                continue;
+            }
+
+            var relPath = string.IsNullOrEmpty(path) ? directory.Name : $"{path}/{directory.Name}";
+
+            // Get content of current path
+            IDirectoryContents content = _fileProvider.GetDirectoryContents(relPath);
+            var hasChildren = content.Any();
+
+            TreeNode node = CreateTreeNode(
+                WebUtility.UrlEncode(relPath),
+                path,
+                queryStrings,
+                directory.Name,
+                icon: Constants.Icons.Folder,
+                hasChildren);
+
+            if (node != null)
+            {
+                nodes.Add(node);
+            }
+        }
+
+        // Get files in current directory
+        IEnumerable<IFileInfo> files = _fileProvider.GetDirectoryContents(path).Where(i => !i.IsDirectory);
+
+        // Only add the files inside App_Plugins or wwwroot
+        if (id != Constants.System.RootString && (id.StartsWith(AppPlugins) || id.StartsWith(Webroot)))
+        {
+            foreach (IFileInfo file in files)
+            {
+                if (file == null)
+                {
+                    continue;
+                }
+
+                var name = file.Name;
+                var relName = string.IsNullOrEmpty(path) ? name : $"{path}/{name}";
+
+                TreeNode node = CreateTreeNode(
+                    WebUtility.UrlEncode(relName),
+                    path,
+                    queryStrings,
+                    name,
+                    icon: Constants.Icons.DefaultIcon,
+                    false);
+
+                if (node != null)
+                {
+                    nodes.Add(node);
+                }
+            }
+        }
+
+        return nodes;
+    }
+
+    private Exception GetArgumentNullException() => new ArgumentNullException(nameof(_fileSystem));
+
+    [Obsolete($"The metod supports getting tree nodes from physical file system. It is replaced by {nameof(GetTreeNodesFromCompositeFieProvider)}")]
+    private ActionResult<TreeNodeCollection> GetTreeNodesFromPhysicalFileSystem(string id, FormCollection queryStrings)
+    {
+        if (_fileSystem is null)
+        {
+            throw new ArgumentNullException(nameof(_fileSystem));
+        }
+
+        var path = string.IsNullOrEmpty(id) == false && id != Constants.System.RootString
+            ? WebUtility.UrlDecode(id).TrimStart("/")
+            : string.Empty;
 
         var nodes = new TreeNodeCollection();
         IEnumerable<string> directories = _fileSystem.GetDirectories(path);
@@ -50,8 +174,13 @@ public class StaticFilesTreeController : TreeController
             var hasChildren = _fileSystem.GetFiles(directory).Any() || _fileSystem.GetDirectories(directory).Any();
 
             var name = Path.GetFileName(directory);
-            TreeNode? node = CreateTreeNode(WebUtility.UrlEncode(directory), path, queryStrings, name,
-                Constants.Icons.Folder, hasChildren);
+            TreeNode? node = CreateTreeNode(
+                WebUtility.UrlEncode(directory),
+                path,
+                queryStrings,
+                name,
+                icon: Constants.Icons.Folder,
+                hasChildren);
 
             if (node != null)
             {
@@ -66,8 +195,13 @@ public class StaticFilesTreeController : TreeController
         foreach (var file in files)
         {
             var name = Path.GetFileName(file);
-            TreeNode? node = CreateTreeNode(WebUtility.UrlEncode(file), path, queryStrings, name,
-                Constants.Icons.DefaultIcon, false);
+            TreeNode? node = CreateTreeNode(
+                WebUtility.UrlEncode(file),
+                path,
+                queryStrings,
+                name,
+                icon: Constants.Icons.DefaultIcon,
+                false);
 
             if (node != null)
             {
@@ -77,8 +211,4 @@ public class StaticFilesTreeController : TreeController
 
         return nodes;
     }
-
-    // We don't have any menu item options (such as create/delete/reload) & only use the root node to load a custom UI
-    protected override ActionResult<MenuItemCollection> GetMenuForNode(string id, FormCollection queryStrings) =>
-        _menuItemCollectionFactory.Create();
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

[Link to issue](https://github.com/umbraco/Umbraco-CMS/issues/15706)

### Description

This change introduces a new constrctor for `StaticFilesTreeController` and a new method that is able to get static files from referenced RCL packages and not only from root project physical file system. Instead of `IFileSystem` a new `CompositeFileProvider` is created.

In new constructor the service `IFileSystem` is left in parameters because .NET 8 has a [new behaviour of selecting the constructor for creating a service](https://learn.microsoft.com/en-us/dotnet/core/compatibility/extensions/8.0/activatorutilities-createinstance-behavior#new-behavior). The attribute [ActivatorUtilitiesConstructor](https://github.com/dotnet/runtime/issues/42339) is decorating the new constructor anyway.

### How to test

- Create new RCL project and reference it in `Umbraco.Web.UI` project
 ```
<ItemGroup>
   <ProjectReference Include="..\..\..\Umbraco.Test.Package\Umbraco.Test.Package.csproj" />
 </ItemGroup>
```
> Note: If you create a RCL package with CLI, it references already built Umbraco packages `Umbraco.Web.BackOffice` and `Umbraco.Web.Website`. Replace these package references with project references from solution.
![image](https://github.com/umbraco/Umbraco-CMS/assets/18527163/3bc52d77-b6fe-4342-b655-414ace8ee232)


- Add `StaticWebAssetBasePath` property to package project `.csproj`
`<StaticWebAssetBasePath>App_Plugins/Umbraco.Test.Package</StaticWebAssetBasePath>`

- Add a test view in `wwwroot` 
![image](https://github.com/umbraco/Umbraco-CMS/assets/18527163/f550a3f8-7ca7-4514-990e-2a17f261416c)
![image](https://github.com/umbraco/Umbraco-CMS/assets/18527163/8fd06c51-ffb4-4249-814b-0e8d784533dd)

- Check that the package was picked up by Umbraco by navigating to the url of the file
`https://localhost:44331/App_Plugins/Umbraco.Test.Package/customView.html`
![image](https://github.com/umbraco/Umbraco-CMS/assets/18527163/2404b666-d59a-4ce2-bedb-855f474f435e)

- Try to set this view as a custom view for a block of a block grid
![selectingCustomView](https://github.com/umbraco/Umbraco-CMS/assets/18527163/e86c2ea3-4334-4722-9768-af7e3afbdeb4)
