### PR TITLE
V13.2 RC: The user panel does not work

### DIFF
--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoBackOffice/Default.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoBackOffice/Default.cshtml
@@ -16,6 +16,7 @@
 @inject IOptions<GlobalSettings> globalSettings
 @inject IRuntimeMinifier runtimeMinifier
 @inject IProfilerHtml profilerHtml
+@inject IBackOfficeExternalLoginProviders externalLogins
 @{
     bool.TryParse(Context.Request.Query["umbDebug"], out bool isDebug);
     var backOfficePath = globalSettings.Value.GetBackOfficePath(hostingEnvironment);
@@ -113,6 +114,8 @@
 
     <script>
         document.angularReady = function(app) {
+            @await Html.AngularValueExternalLoginInfoScriptAsync(externalLogins, ViewData.GetExternalSignInProviderErrors()!)
+            @Html.AngularValueResetPasswordCodeInfoScript(ViewData[ViewDataExtensions.TokenPasswordResetCode]!)
             @await Html.AngularValueTinyMceAssetsAsync(runtimeMinifier)
             //required for the noscript trick
             document.getElementById("mainwrapper").style.display = "inherit";
@@ -129,3 +132,4 @@
 
 </body>
 </html>
+


### PR DESCRIPTION
This fixes a regression that occurs due to #15715 where parts of the backoffice still rely on some of the removed variables.

It should now work again and be able to show external login providers:
![image](https://github.com/umbraco/Umbraco-CMS/assets/752371/13a2e0ae-4935-4014-b9e6-73a8459c923d)
