### PR TITLE
Finalized the data type config migration

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateDataTypeConfigurations.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateDataTypeConfigurations.cs
@@ -8,36 +8,33 @@ using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Infrastructure.Persistence.Dtos;
-using Umbraco.Cms.Infrastructure.Serialization;
 using Umbraco.Extensions;
 using PropertyEditorAliases = Umbraco.Cms.Core.Constants.PropertyEditors.Aliases;
 
 namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_14_0_0;
 
-// TODO: this migration is a work in progress; it will be amended for a while, thus it MUST be able to re-run several times without failing miserably
 public class MigrateDataTypeConfigurations : MigrationBase
 {
     private readonly IContentTypeService _contentTypeService;
     private readonly IMediaTypeService _mediaTypeService;
     private readonly IMemberTypeService _memberTypeService;
-    private readonly ILogger<MigrateDataTypeConfigurations> _logger;
     private readonly IConfigurationEditorJsonSerializer _configurationEditorJsonSerializer;
+    private readonly ILogger<MigrateDataTypeConfigurations> _logger;
 
     public MigrateDataTypeConfigurations(
         IMigrationContext context,
         IContentTypeService contentTypeService,
         IMediaTypeService mediaTypeService,
         IMemberTypeService memberTypeService,
+        IConfigurationEditorJsonSerializer configurationEditorJsonSerializer,
         ILogger<MigrateDataTypeConfigurations> logger)
         : base(context)
     {
         _contentTypeService = contentTypeService;
         _mediaTypeService = mediaTypeService;
-        _logger = logger;
         _memberTypeService = memberTypeService;
-
-        // TODO: inject this once we're rid of the Newtonsoft.Json based config serializer
-        _configurationEditorJsonSerializer = new SystemTextConfigurationEditorJsonSerializer();
+        _configurationEditorJsonSerializer = configurationEditorJsonSerializer;
+        _logger = logger;
     }
 
     protected override void Migrate()
@@ -95,7 +92,7 @@ public class MigrateDataTypeConfigurations : MigrationBase
                     PropertyEditorAliases.DropDownListFlexible => HandleDropDown(ref configurationData),
                     PropertyEditorAliases.EmailAddress => HandleEmailAddress(ref configurationData),
                     PropertyEditorAliases.Label => HandleLabel(ref configurationData),
-                    PropertyEditorAliases.ListView => HandleListView(ref configurationData),
+                    PropertyEditorAliases.ListView => HandleListView(ref configurationData, dataTypeDto.NodeDto?.UniqueId, allMediaTypes, allMemberTypes),
                     PropertyEditorAliases.MediaPicker3 => HandleMediaPicker(ref configurationData, allMediaTypes),
                     PropertyEditorAliases.MultiNodeTreePicker => HandleMultiNodeTreePicker(ref configurationData, allContentTypes, allMediaTypes, allMemberTypes),
                     PropertyEditorAliases.MultiUrlPicker => HandleMultiUrlPicker(ref configurationData),
@@ -306,8 +303,25 @@ public class MigrateDataTypeConfigurations : MigrationBase
 
     // ensure that list view configs have all configurations, as some have never been added by means of migration.
     // also performs a re-formatting of "layouts" and "includeProperties" to a V14 format
-    private bool HandleListView(ref Dictionary<string, object> configurationData)
+    private bool HandleListView(ref Dictionary<string, object> configurationData, Guid? dataTypeKey, IMediaType[] allMediaTypes, IMemberType[] allMemberTypes)
     {
+        var collectionViewType = dataTypeKey == Constants.DataTypes.Guids.ListViewMediaGuid || allMediaTypes.Any(mt => mt.ListView == dataTypeKey)
+            ? "Media"
+            : dataTypeKey == Constants.DataTypes.Guids.ListViewMembersGuid || allMemberTypes.Any(mt => mt.ListView == dataTypeKey)
+                ? "Member"
+                : "Document";
+
+        string? LayoutPathToCollectionView(string? path)
+            => "views/propertyeditors/listview/layouts/list/list.html".InvariantEquals(path)
+                ? TableCollectionView()
+                : "views/propertyeditors/listview/layouts/grid/grid.html".InvariantEquals(path)
+                    ? GridCollectionView()
+                    : null;
+
+        string TableCollectionView() => $"Umb.CollectionView.{collectionViewType}.Table";
+
+        string GridCollectionView() => $"Umb.CollectionView.{collectionViewType}.Grid";
+
         var layoutsValue = ConfigurationValue(configurationData, "layouts", true);
         if (layoutsValue is not null)
         {
@@ -324,8 +338,7 @@ public class MigrateDataTypeConfigurations : MigrationBase
                 IsSystem = layout.IsSystem == 1,
                 Selected = layout.Selected,
                 Icon = layout.Icon,
-                // TODO: this will be changed - likely into "Component", with some default translation of core layout paths (pending LKE)
-                Path = layout.Path
+                CollectionView = LayoutPathToCollectionView(layout.Path)
             }).ToArray();
         }
         else
@@ -335,8 +348,7 @@ public class MigrateDataTypeConfigurations : MigrationBase
                 new NewListViewLayout
                 {
                     Name = "List",
-                    // TODO: this will be changed - figure out the defaults (pending LKE)
-                    Path = "views/propertyeditors/listview/layouts/list/list.html",
+                    CollectionView = TableCollectionView(),
                     Icon = "icon-list",
                     IsSystem = true,
                     Selected = true
@@ -344,8 +356,7 @@ public class MigrateDataTypeConfigurations : MigrationBase
                 new NewListViewLayout
                 {
                     Name = "Grid",
-                    // TODO: this will be changed - figure out the defaults (pending LKE)
-                    Path = "views/propertyeditors/listview/layouts/grid/grid.html",
+                    CollectionView = GridCollectionView(),
                     Icon = "icon-thumbnails-small",
                     IsSystem = true,
                     Selected = true
@@ -731,7 +742,7 @@ public class MigrateDataTypeConfigurations : MigrationBase
     {
         public string? Name { get; set; }
 
-        public string? Path { get; set; }
+        public string? CollectionView { get; set; }
 
         public string? Icon { get; set; }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR cleans up the remaining TODOs from the V14 data type configuration migration:

- Inject the configuration serializer into the migration.
- Translate layout "path" to "collection view".

### Testing this PR

Upgrade a V13 database with list views to V14. Ideally construct additional list views with custom layouts for testing.

Verify that the listview (collection) data type configurations have been migrated, and their layout paths have been translated to "collection view" properties:

- The system "grid.html" layout should have `Umb.CollectionView.Document.Grid` or `Umb.CollectionView.Media.Grid` as collection view for document and media list views, respectively.
- The system "list.html" layout should have `Umb.CollectionView.Document.Table` or `Umb.CollectionView.Media.Table` as collection view for document and media list views, respectively.

Member list views are also migrated for the sake of completion, but they are going to be removed eventually (in favor of Users like filtering), so don't bother testing members.