### PR TITLE
Remove Newtonsoft.Json from Multi URL picker

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/MultiUrlPickerValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultiUrlPickerValueEditor.cs
@@ -2,9 +2,7 @@
 // See LICENSE for more details.
 
 using System.Runtime.Serialization;
-using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Linq;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentEditing;
@@ -149,13 +147,8 @@ public class MultiUrlPickerValueEditor : DataValueEditor, IDataValueReference
 
     public override object? FromEditor(ContentPropertyData editorValue, object? currentValue)
     {
-        // FIXME: get rid of Json.NET here
-        // FIXME: consider creating an object deserialization method on IJsonSerializer instead of relying on deserializing serialized JSON here (and likely other places as well)
-        var value = editorValue.Value is JArray jArray
-            ? jArray.ToString()
-            : editorValue.Value is JsonArray jsonArray
-                ? jsonArray.ToJsonString()
-                : string.Empty;
+        // the editor value is a JsonArray, which produces deserialize-able JSON with ToString() (deserialization happens later on)
+        var value = editorValue.Value?.ToString();
 
         if (string.IsNullOrEmpty(value))
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This removes the Newtonsoft.Json dependency from Multi URL picker. In fact, it removes all explicit JSON implementation dependencies 😄 

### Testing this PR

Create and update content with a multi URL picker property. It ShouldJustWork™ - the configured links should be saved and retrieved without any fuss.