### PR TITLE
Added the possibility to select all the cultures at once in the save and save&publish dialogs

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -336,6 +336,7 @@
     <key alias="variantSendForApprovalNotAllowed">Send for approval is not allowed</key>
     <key alias="variantScheduleNotAllowed">Schedule is not allowed</key>
     <key alias="variantUnpublishNotAllowed">Unpublish is not allowed</key>
+    <key alias="selectAllVariants">Select all variants</key>
   </area>
   <area alias="blueprints">
     <key alias="createBlueprintFrom"><![CDATA[Create a new Content Template from <em>%0%</em>]]></key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -334,6 +334,7 @@
     <key alias="variantSendForApprovalNotAllowed">Send for approval is not allowed</key>
     <key alias="variantScheduleNotAllowed">Schedule is not allowed</key>
     <key alias="variantUnpublishNotAllowed">Unpublish is not allowed</key>
+    <key alias="selectAllVariants">Select all variants</key>
   </area>
   <area alias="blueprints">
     <key alias="createBlueprintFrom"><![CDATA[Create a new Content Template from <em>%0%</em>]]></key>

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publish.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publish.controller.js
@@ -6,8 +6,10 @@
         var vm = this;
         vm.loading = true;
         vm.isNew = true;
+        vm.publishAll = false;
 
         vm.changeSelection = changeSelection;
+        vm.changePublishAllSelection = changePublishAllSelection;
 
         function allowPublish (variant) {
             return variant.allowedActions.includes("U");
@@ -38,6 +40,20 @@
             $scope.model.disableSubmitButton = !canPublish();
             //need to set the Save state to same as publish.
             variant.save = variant.publish;
+            //update publishAll checkbox value
+            updatePublishAllSelectionStatus();
+        }
+
+        function changePublishAllSelection(){
+            vm.availableVariants.forEach(variant => {
+                variant.publish = vm.publishAll;
+                variant.save = variant.publish;
+            });
+            $scope.model.disableSubmitButton = !canPublish();
+        }
+
+        function updatePublishAllSelectionStatus(){
+            vm.publishAll = vm.availableVariants.every(x => x.publish);
         }
 
         function hasAnyDataFilter(variant) {
@@ -138,7 +154,7 @@
 
             vm.availableVariants = vm.variants.filter(publishableVariantFilter);
             vm.missingMandatoryVariants = vm.variants.filter(notPublishableButMandatoryFilter);
-
+            
             // if any active varaiant that is available for publish, we set it to be published:
             vm.availableVariants.forEach(v => {
                 if(v.active && allowPublish(v)) {
@@ -151,6 +167,9 @@
             }
 
             $scope.model.disableSubmitButton = !canPublish();
+
+            //update publishAll checkbox value
+            updatePublishAllSelectionStatus();
 
             const localizeKey = vm.missingMandatoryVariants.length > 0 ? 'content_notReadyToPublish' : 
                 !$scope.model.title ? 'content_readyToPublish' : '';

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publish.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publish.html
@@ -3,13 +3,24 @@
   <div ng-if="vm.loading" style="min-height: 50px; position: relative;">
     <umb-load-indicator></umb-load-indicator>
   </div>
-
+  
   <div class="umb-list umb-list--condensed" ng-if="!vm.loading && vm.missingMandatoryVariants.length === 0">
 
     <div class="mb3">
       <p>
         <localize key="content_variantsToPublish">Which variants would you like to publish?</localize>
       </p>
+    </div>
+
+    <div class="umb-list-item" ng-if="vm.availableVariants.length > 1">
+      <umb-checkbox
+                    model="vm.publishAll"
+                    name="publishAllVariantsSelector"
+                    on-change="vm.changePublishAllSelection()"
+                    disabled="vm.availableVariants.length == 0">
+      <span class="umb-variant-selector-entry__title">
+        <localize key="content_selectAllVariants">Select all variants</localize>
+      </span>
     </div>
 
     <div class="umb-list-item"

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.controller.js
@@ -5,9 +5,11 @@
 
         var vm = this;
         vm.includeUnpublished = $scope.model.includeUnpublished || false;
+        vm.publishAll = false;
 
         vm.changeSelection = changeSelection;
         vm.toggleIncludeUnpublished = toggleIncludeUnpublished;
+        vm.changePublishAllSelection = changePublishAllSelection;
 
         function onInit() {
 
@@ -48,8 +50,10 @@
                     active.publish = active.save = true;
                 }
 
-                $scope.model.disableSubmitButton = !canPublish();
+                updatePublishAllSelectionStatus();
                 
+                $scope.model.disableSubmitButton = !canPublish();
+
             } else {
                 // localize help text for invariant content
                 vm.labels.help = {
@@ -97,8 +101,20 @@
             $scope.model.disableSubmitButton = !canPublish();
             //need to set the Save state to true if publish is true
             variant.save = variant.publish;
+            updatePublishAllSelectionStatus();
         }
 
+        function changePublishAllSelection(){
+            vm.displayVariants.forEach(variant => {
+                variant.publish = vm.publishAll;
+                variant.save = variant.publish;
+            });
+            $scope.model.disableSubmitButton = !canPublish();
+        }
+
+        function updatePublishAllSelectionStatus(){
+            vm.publishAll = vm.displayVariants.every(x => x.publish);
+        }
         
         function isMandatoryFilter(variant) {
             //determine a variant is 'dirty' (meaning it will show up as publish-able) if it's

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.html
@@ -38,6 +38,17 @@
 
         <div class="umb-list umb-list--condensed">
 
+            <div class="umb-list-item" ng-if="vm.displayVariants.length > 1">
+              <umb-checkbox
+                            model="vm.publishAll"
+                            name="publishAllVariantsSelector"
+                            on-change="vm.changePublishAllSelection()"
+                            disabled="vm.displayVariants.length == 0">
+              <span class="umb-variant-selector-entry__title">
+                <localize key="content_selectAllVariants">Select all variants</localize>
+              </span>
+            </div>
+
             <div class="umb-list-item umb-list--condensed" ng-repeat="variant in vm.displayVariants track by variant.compositeId">
                 <ng-form name="publishVariantSelectorForm">
                     <div class="umb-variant-selector-entry" ng-class="{'umb-list-item--error': publishVariantSelectorForm.publishVariantSelector.$invalid}">

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/save.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/save.controller.js
@@ -7,14 +7,28 @@
         vm.loading = true;
         vm.hasPristineVariants = false;
         vm.isNew = true;
+        vm.saveAll = false;
 
         vm.changeSelection = changeSelection;
+        vm.changeSaveAllSelection = changeSaveAllSelection;
 
         function changeSelection(variant) {
             var firstSelected = _.find(vm.variants, function (v) {
                 return v.save;
             });
             $scope.model.disableSubmitButton = !firstSelected; //disable submit button if there is none selected
+            updateSaveAllSelectionStatus();
+        }
+
+        function changeSaveAllSelection(){
+            vm.availableVariants.forEach(variant => {
+                variant.save = vm.saveAll;
+            });
+            $scope.model.disableSubmitButton = !vm.saveAll;
+        }
+
+        function updateSaveAllSelectionStatus(){
+            vm.saveAll = vm.availableVariants.every(x => x.save);
         }
 
         function allowUpdate (variant) {
@@ -91,6 +105,8 @@
                 }
 
                 vm.availableVariants = contentEditingHelper.getSortedVariantsAndSegments(vm.availableVariants);
+
+                updateSaveAllSelectionStatus();
 
             } else {
                 //disable save button if we have nothing to save

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/save.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/save.html
@@ -13,6 +13,17 @@
 
         <div class="umb-list umb-list--condensed">
 
+            <div class="umb-list-item" ng-if="vm.availableVariants.length > 1">
+                <umb-checkbox
+                              model="vm.saveAll"
+                              name="saveAllVariantsSelector"
+                              on-change="vm.changeSaveAllSelection()"
+                              disabled="vm.availableVariants.length == 0">
+                <span class="umb-variant-selector-entry__title">
+                  <localize key="content_selectAllVariants">Select all variants</localize>
+                </span>
+              </div>
+
             <div class="umb-list-item"
                  ng-repeat="variant in vm.availableVariants track by variant.compositeId">
                 <ng-form name="saveVariantSelectorForm">

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/sendtopublish.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/sendtopublish.controller.js
@@ -6,8 +6,10 @@
         var vm = this;
         vm.loading = true;
         vm.selectedVariants = [];
+        vm.sendToPublishAll = false;
 
         vm.changeSelection = changeSelection;
+        vm.changeSendToPublishAllSelection = changeSendToPublishAllSelection;
 
         function onInit() {
 
@@ -29,8 +31,9 @@
             if (vm.availableVariants.length !== 0) {
 
                 vm.availableVariants = contentEditingHelper.getSortedVariantsAndSegments(vm.availableVariants);
+                updateSendToPublishAllSelectionStatus();
             }
-
+            
             $scope.model.disableSubmitButton = true;
             vm.loading = false;
         }
@@ -55,10 +58,39 @@
 
           let firstSelected = vm.variants.find(v => v.save);
           $scope.model.disableSubmitButton = !firstSelected;
+          updateSendToPublishAllSelectionStatus();
+        }
+
+        function changeSendToPublishAllSelection(){
+
+            vm.availableVariants.forEach(variant => {
+
+                variant.publish = vm.sendToPublishAll;
+                let foundVariant = vm.selectedVariants.find(x => x.compositeId === variant.compositeId);
+
+                if (foundVariant === undefined) {
+                    variant.save = true;
+                    vm.selectedVariants.push(variant);
+                } else {
+                    if(!vm.sendToPublishAll){
+                        variant.save = false;
+                        let index = vm.selectedVariants.indexOf(foundVariant);
+                        if (index !== -1) {
+                            vm.selectedVariants.splice(index, 1);
+                        }
+                    }
+                }
+            });
+            let firstSelected = vm.variants.find(v => v.save);
+            $scope.model.disableSubmitButton = !firstSelected;
+        }
+
+        function updateSendToPublishAllSelectionStatus(){
+            vm.sendToPublishAll = vm.availableVariants.every(x => x.publish);
         }
 
 
-      function isMandatoryFilter(variant) {
+        function isMandatoryFilter(variant) {
             //determine a variant is 'dirty' (meaning it will show up as publish-able) if it's
             // * has a mandatory language
             // * without having a segment, segments cant be mandatory at current state of code.

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/sendtopublish.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/sendtopublish.html
@@ -10,6 +10,17 @@
 
     <div class="umb-list umb-list--condensed" ng-if="!vm.loading">
 
+        <div class="umb-list-item" ng-if="vm.availableVariants.length > 1">
+          <umb-checkbox
+                        model="vm.sendToPublishAll"
+                        name="sendToPublishAllVariantsSelector"
+                        on-change="vm.changeSendToPublishAllSelection()"
+                        disabled="vm.availableVariants.length == 0">
+          <span class="umb-variant-selector-entry__title">
+            <localize key="content_selectAllVariants">Select all variants</localize>
+          </span>
+        </div>
+
         <div class="umb-list-item" ng-repeat="variant in vm.availableVariants track by variant.compositeId">
             <ng-form name="publishVariantSelectorForm">
                 <div class="umb-variant-selector-entry" ng-class="{'umb-list-item--error': publishVariantSelectorForm.publishVariantSelector.$invalid}">


### PR DESCRIPTION
### Description
Implements this [#15297](https://github.com/umbraco/Umbraco-CMS/discussions/15297) 

Added a new checkbox on the top of the cultures' list inside the save/save&publish dialogs to allow editors to select all the items at once.

### Testing
1. Add at least 2 languages in your Umbraco backoffice
2. Create a document type which vary by culture
3. Create a new node, edit at least 2 cultures and click save or save&publish
4. Click the checkbox "Select all variants" and all the cultures in the list will be selected

If you edit just 1 culture the checkbox "Select all variants" should be hidden

--

While editing multiple cultures:
![image](https://github.com/umbraco/Umbraco-CMS/assets/161019175/cde789e5-1e58-41ab-bc56-84d012f1f03f)

While editing one single culture:
![image](https://github.com/umbraco/Umbraco-CMS/assets/161019175/ac984db0-9f2b-4a86-87d1-09fca64fd0fc)