### PR TITLE
Add filter option to the "dictionary overview" endpoint

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/AllDictionaryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/AllDictionaryController.cs
@@ -25,10 +25,10 @@ public class AllDictionaryController : DictionaryControllerBase
     [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<DictionaryOverviewResponseModel>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<PagedViewModel<DictionaryOverviewResponseModel>>> All(int skip = 0, int take = 100)
+    public async Task<ActionResult<PagedViewModel<DictionaryOverviewResponseModel>>> All(string? filter = null, int skip = 0, int take = 100)
     {
         // unfortunately we can't paginate here...we'll have to get all and paginate in memory
-        IDictionaryItem[] items = (await _dictionaryItemService.GetDescendantsAsync(Constants.System.RootKey)).ToArray();
+        IDictionaryItem[] items = (await _dictionaryItemService.GetDescendantsAsync(Constants.System.RootKey, filter)).ToArray();
         var model = new PagedViewModel<DictionaryOverviewResponseModel>
         {
             Total = items.Length,

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -1688,6 +1688,13 @@
         "operationId": "GetDictionary",
         "parameters": [
           {
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "skip",
             "in": "query",
             "schema": {

--- a/src/Umbraco.Core/Persistence/Repositories/IDictionaryRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IDictionaryRepository.cs
@@ -12,7 +12,7 @@ public interface IDictionaryRepository : IReadWriteQueryRepository<int, IDiction
 
     IDictionaryItem? Get(string key);
 
-    IEnumerable<IDictionaryItem> GetDictionaryItemDescendants(Guid? parentId);
+    IEnumerable<IDictionaryItem> GetDictionaryItemDescendants(Guid? parentId, string? filter = null);
 
     Dictionary<string, Guid> GetDictionaryItemKeyMap();
 }

--- a/src/Umbraco.Core/Services/DictionaryItemService.cs
+++ b/src/Umbraco.Core/Services/DictionaryItemService.cs
@@ -106,11 +106,11 @@ internal sealed class DictionaryItemService : RepositoryService, IDictionaryItem
         => await CountByQueryAsync(Query<IDictionaryItem>().Where(x => x.ParentId == parentId));
 
     /// <inheritdoc />
-    public async Task<IEnumerable<IDictionaryItem>> GetDescendantsAsync(Guid? parentId)
+    public async Task<IEnumerable<IDictionaryItem>> GetDescendantsAsync(Guid? parentId, string? filter = null)
     {
         using (ScopeProvider.CreateCoreScope(autoComplete: true))
         {
-            IDictionaryItem[] items = _dictionaryRepository.GetDictionaryItemDescendants(parentId).ToArray();
+            IDictionaryItem[] items = _dictionaryRepository.GetDictionaryItemDescendants(parentId, filter).ToArray();
             return await Task.FromResult(items);
         }
     }

--- a/src/Umbraco.Core/Services/IDictionaryItemService.cs
+++ b/src/Umbraco.Core/Services/IDictionaryItemService.cs
@@ -53,8 +53,9 @@ public interface IDictionaryItemService
     ///     Gets a list of descendants for a <see cref="IDictionaryItem" />
     /// </summary>
     /// <param name="parentId">Id of the parent, null will return all dictionary items</param>
+    /// <param name="filter">An optional filter, which will limit the results to only those dictionary items whose key starts with the filter value.</param>
     /// <returns>An enumerable list of <see cref="IDictionaryItem" /> objects</returns>
-    Task<IEnumerable<IDictionaryItem>> GetDescendantsAsync(Guid? parentId);
+    Task<IEnumerable<IDictionaryItem>> GetDescendantsAsync(Guid? parentId, string? filter = null);
 
     /// <summary>
     ///     Gets the root/top <see cref="IDictionaryItem" /> objects


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

It should be possible to perform a free text search for dictionary items in the "dictionary overview" UI. However, the backing API endpoint (`/umbraco/management/api/v1/dictionary`) has so far been lacking that option - this PR adds it.

### Testing this PR

Verify that:

1. The dictionary overview endpoint returns all items by default (paginated, but still).
2. It is possible to use the `filter` parameter to perform free text search for dictionary items. The endpoint should perform a "starts-with" search.