### PR TITLE
V14: ListView Service - Checks that `contentType` isn't `null` before checking for `.ListView`

### DIFF
--- a/src/Umbraco.Infrastructure/Services/ContentListViewServiceBase.cs
+++ b/src/Umbraco.Infrastructure/Services/ContentListViewServiceBase.cs
@@ -189,7 +189,7 @@ internal abstract class ContentListViewServiceBase<TContent, TContentType, TCont
 
     private async Task<Attempt<ListViewConfiguration?, ContentCollectionOperationStatus>> GetListViewConfigurationFromContentTypeAsync(TContentType? contentType)
     {
-        if (contentType?.ListView is null)
+        if (contentType is not null && contentType.ListView is null)
         {
             return Attempt.FailWithStatus<ListViewConfiguration?, ContentCollectionOperationStatus>(ContentCollectionOperationStatus.ContentNotCollection, null);
         }


### PR DESCRIPTION
I suspect PR #15687 introduced a small regression.
re: https://github.com/umbraco/Umbraco-CMS/pull/15687/files#diff-2ad7a39ca3a7e9fd7c4cbc72a2a28b28bf0d24c12449beff76ff8eb3b0a3ce99L192

I'd noticed on the frontend that the Media root was throwing an error for the Collection view, so debugging through it, I found that in the ListView Service, the `contentType` would be `null`, and not have a `.ListView` configured, so it'd throw an error - but really it needs to fallback to the default collection configuration (data-type).