### PR TITLE
Correct condition to ensured it support all cases for block value converter

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueConverter.cs
@@ -2,6 +2,7 @@
 // See LICENSE for more details.
 
 using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
 using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Logging;
@@ -132,7 +133,19 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
                 // NOTE: The intermediate object is just a JSON string, we don't actually convert from source -> intermediate since source is always just a JSON string
                 if (inter is not string intermediateBlockModelValue)
                 {
-                    return null;
+                    var value = inter.ToString();
+                    if (!value?.DetectIsJson() == true && !value?.Contains("layout") == true && !value?.Contains("contentData") == true && !value?.Contains("settingsData") == true)
+                    {
+                        // This is not a block grid model
+                        return null;
+                    }
+
+                    if (value == null)
+                    {
+                        return null;
+                    }
+
+                    intermediateBlockModelValue = value;
                 }
 
                 // Get configuration


### PR DESCRIPTION


### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes  https://github.com/umbraco/Umbraco-CMS/issues/15795

### Description
So umbraco there is incorrect assumption it will be always string, it might be Jobject as well if use with this package:
https://github.com/rickbutterfield/Umbraco.Community.BlockPreview
if you do it, use nested block editor inside of one grid blocks and you will be able to reproduce this issue when using block preview.