### PR TITLE
Improve upload temporary file

### DIFF
--- a/src/Umbraco.Cms.Api.Management/ViewModels/TemporaryFile/CreateTemporaryFileRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/TemporaryFile/CreateTemporaryFileRequestModel.cs
@@ -4,7 +4,7 @@ namespace Umbraco.Cms.Api.Management.ViewModels.TemporaryFile;
 
 public class CreateTemporaryFileRequestModel
 {
-    public required Guid Id { get; set; }
+    public Guid? Id { get; set; }
 
     public required IFormFile File { get; set; }
 }

--- a/src/Umbraco.Core/Models/TemporaryFileUpload/CreateTemporaryFileModel.cs
+++ b/src/Umbraco.Core/Models/TemporaryFileUpload/CreateTemporaryFileModel.cs
@@ -2,4 +2,5 @@
 
 public class CreateTemporaryFileModel : TemporaryFileModelBase
 {
+    public Guid? Key { get; set; }
 }

--- a/src/Umbraco.Core/Models/TemporaryFileUpload/TemporaryFileModel.cs
+++ b/src/Umbraco.Core/Models/TemporaryFileUpload/TemporaryFileModel.cs
@@ -2,5 +2,6 @@ namespace Umbraco.Cms.Core.Models.TemporaryFile;
 
 public class TemporaryFileModel : TemporaryFileModelBase
 {
+    public Guid Key { get; set; }
     public required DateTime AvailableUntil { get; set; }
 }

--- a/src/Umbraco.Core/Models/TemporaryFileUpload/TemporaryFileModelBase.cs
+++ b/src/Umbraco.Core/Models/TemporaryFileUpload/TemporaryFileModelBase.cs
@@ -4,7 +4,5 @@ public abstract class TemporaryFileModelBase
 {
     public required string FileName { get; set; }
 
-    public Guid Key { get; set; }
-
     public Func<Stream> OpenReadStream { get; set; } = () => Stream.Null;
 }

--- a/src/Umbraco.Core/Persistence/Repositories/ITemporaryFileRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/ITemporaryFileRepository.cs
@@ -31,4 +31,11 @@ public interface ITemporaryFileRepository
     /// </summary>
     /// <returns>The keys of the delete temporary files.</returns>
     Task<IEnumerable<Guid>> CleanUpOldTempFiles(DateTime dateTime);
+
+    /// <summary>
+    /// Fast way of checking whether a temporary file exists. Should be more performant then a <see cref="GetAsync"/>
+    /// </summary>
+    /// <param name="key"></param>
+    /// <returns></returns>
+    bool Exists(Guid key);
 }

--- a/src/Umbraco.Core/Services/TemporaryFileService.cs
+++ b/src/Umbraco.Core/Services/TemporaryFileService.cs
@@ -39,12 +39,14 @@ internal sealed class TemporaryFileService : ITemporaryFileService
             return Attempt.FailWithStatus<TemporaryFileModel?, TemporaryFileOperationStatus>(validationResult, null);
         }
 
-        TemporaryFileModel? temporaryFileModel = await _temporaryFileRepository.GetAsync(createModel.Key);
-        if (temporaryFileModel is not null)
+        if (createModel.Key is null)
+        {
+            createModel.Key = Guid.NewGuid();
+        }
+        else if (_temporaryFileRepository.Exists(createModel.Key.Value))
         {
             return Attempt.FailWithStatus<TemporaryFileModel?, TemporaryFileOperationStatus>(TemporaryFileOperationStatus.KeyAlreadyUsed, null);
         }
-
 
         await using Stream dataStream = createModel.OpenReadStream();
         dataStream.Seek(0, SeekOrigin.Begin);
@@ -53,10 +55,9 @@ internal sealed class TemporaryFileService : ITemporaryFileService
             return Attempt.FailWithStatus<TemporaryFileModel?, TemporaryFileOperationStatus>(TemporaryFileOperationStatus.UploadBlocked, null);
         }
 
-
-        temporaryFileModel = new TemporaryFileModel
+        var temporaryFileModel = new TemporaryFileModel
         {
-            Key = createModel.Key,
+            Key = createModel.Key.Value,
             FileName = createModel.FileName,
             OpenReadStream = createModel.OpenReadStream,
             AvailableUntil = DateTime.Now.Add(_runtimeSettings.TemporaryFileLifeTime)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LocalFileSystemTemporaryFileRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LocalFileSystemTemporaryFileRepository.cs
@@ -39,24 +39,13 @@ internal sealed class LocalFileSystemTemporaryFileRepository : ITemporaryFileRep
 
     public async Task<TemporaryFileModel?> GetAsync(Guid key)
     {
-
-        DirectoryInfo rootDirectory = GetRootDirectory();
-
-        DirectoryInfo? fileDirectory = rootDirectory.GetDirectories(key.ToString()).FirstOrDefault();
-        if (fileDirectory is null)
+        FileInfo[]? files = GetFileInfos(key);
+        if (files is null)
         {
             return null;
         }
 
-        FileInfo[] files = fileDirectory.GetFiles();
-
-        if (files.Length != 2)
-        {
-            _logger.LogError("Unexpected number of files in folder {FolderPath}",  fileDirectory.FullName);
-            return null;
-        }
-
-        var (actualFile, metadataFile) = GetFilesByType(files);
+        (IFileInfo actualFile, IFileInfo metadataFile) = GetFilesByType(files);
 
         FileMetaData metaData = await GetMetaDataAsync(metadataFile);
 
@@ -68,6 +57,8 @@ internal sealed class LocalFileSystemTemporaryFileRepository : ITemporaryFileRep
             AvailableUntil = metaData.AvailableUntil
         };
     }
+
+    public bool Exists(Guid key) => GetFileInfos(key) is not null;
 
     public async Task SaveAsync(TemporaryFileModel model)
     {
@@ -167,4 +158,25 @@ internal sealed class LocalFileSystemTemporaryFileRepository : ITemporaryFileRep
         files[0].Name == MetaDataFileName
             ? (new PhysicalFileInfo(files[1]), new PhysicalFileInfo(files[0]))
             : (new PhysicalFileInfo(files[0]), new PhysicalFileInfo(files[1]));
+
+    private FileInfo[]? GetFileInfos(Guid key)
+    {
+        DirectoryInfo rootDirectory = GetRootDirectory();
+
+        DirectoryInfo? fileDirectory = rootDirectory.GetDirectories(key.ToString()).FirstOrDefault();
+        if (fileDirectory is null)
+        {
+            return null;
+        }
+
+        FileInfo[] files = fileDirectory.GetFiles();
+
+        if (files.Length == 2)
+        {
+            return files;
+        }
+
+        _logger.LogError("Unexpected number of files in folder {FolderPath}",  fileDirectory.FullName);
+        return null;
+    }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
While reviewing https://github.com/umbraco/Umbraco-CMS/pull/15784 I noticed that when uploading a temp file without an id, the returned ID would be a zeroGuid, which is not in line of other endpoints.

This PR aims to fix this oversight and also optimize the codepath slightly by not having to read the filestream and deserialize the metadata to check whether an entry exists in the repository.

### Testing
- [ ] Uploading a temporary file with an ID supplied should work
- [ ] Uploading a temporary file without an ID should work
- [ ] Both uploads should be retrievable
- [ ] Both uploads should work in a consume path (assign to image property type for example)
- [ ] Both uploads should deletable