### PR TITLE
Reduce memory allocations for NuCache by introducing StringPool and ArrayPool.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
   </ItemGroup>
   <!-- Microsoft packages -->
   <ItemGroup>
+    <PackageVersion Include="CommunityToolkit.HighPerformance" Version="8.2.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />

--- a/src/Umbraco.PublishedCache.NuCache/DataSource/ArrayPoolingLimitedSerializer.cs
+++ b/src/Umbraco.PublishedCache.NuCache/DataSource/ArrayPoolingLimitedSerializer.cs
@@ -1,0 +1,62 @@
+using System.Buffers;
+using CommunityToolkit.HighPerformance.Buffers;
+using CSharpTest.Net.Serialization;
+
+namespace Umbraco.Cms.Infrastructure.PublishedCache.DataSource
+{
+    internal class ArrayPoolingLimitedSerializer
+    {
+        private readonly StringPool _internPool = new StringPool();
+        public string ReadString(Stream stream, bool intern = false)
+        {
+            unchecked
+            {
+                int sz = VariantNumberSerializer.Int32.ReadFrom(stream);
+                if (sz == 0)
+                {
+                    return string.Empty;
+                }
+
+                if (sz == int.MinValue)
+                {
+                    return string.Empty;
+                }
+
+                if (!(sz >= 0 && sz <= int.MaxValue))
+                {
+                    throw new InvalidDataException();
+                }
+
+                char[]? chars = null;
+                try
+                {
+                    chars = ArrayPool<char>.Shared.Rent(sz);
+                    for (int i = 0; i < sz; i++)
+                    {
+                        chars[i] = (char)VariantNumberSerializer.Int32.ReadFrom(stream);
+                    }
+
+                    Span<char> str = chars.AsSpan()[..sz];
+                    if (intern)
+                    {
+                        return _internPool.GetOrAdd(str);
+                    }
+
+                    return StringPool.Shared.GetOrAdd(str);
+                }
+                finally
+                {
+                    if (chars != null)
+                    {
+                        ArrayPool<char>.Shared.Return(chars, true);
+                    }
+                }
+            }
+        }
+
+#pragma warning disable IDE0032 // Use auto property
+        private static ArrayPoolingLimitedSerializer _stringSerializer = new ArrayPoolingLimitedSerializer();
+#pragma warning restore IDE0032 // Use auto property
+        internal static ArrayPoolingLimitedSerializer StringSerializer { get => _stringSerializer; set => _stringSerializer = value; }
+    }
+}

--- a/src/Umbraco.PublishedCache.NuCache/DataSource/BTree.ContentDataSerializer.cs
+++ b/src/Umbraco.PublishedCache.NuCache/DataSource/BTree.ContentDataSerializer.cs
@@ -23,8 +23,8 @@ public class ContentDataSerializer : ISerializer<ContentData>
     public ContentData ReadFrom(Stream stream)
     {
         var published = PrimitiveSerializer.Boolean.ReadFrom(stream);
-        var name = PrimitiveSerializer.String.ReadFrom(stream);
-        var urlSegment = PrimitiveSerializer.String.ReadFrom(stream);
+        var name = ArrayPoolingLimitedSerializer.StringSerializer.ReadString(stream);
+        var urlSegment = ArrayPoolingLimitedSerializer.StringSerializer.ReadString(stream);
         var versionId = PrimitiveSerializer.Int32.ReadFrom(stream);
         DateTime versionDate = PrimitiveSerializer.DateTime.ReadFrom(stream);
         var writerId = PrimitiveSerializer.Int32.ReadFrom(stream);

--- a/src/Umbraco.PublishedCache.NuCache/DataSource/BTree.ContentNodeKitSerializer.cs
+++ b/src/Umbraco.PublishedCache.NuCache/DataSource/BTree.ContentNodeKitSerializer.cs
@@ -23,7 +23,7 @@ internal class ContentNodeKitSerializer : ISerializer<ContentNodeKit>
             PrimitiveSerializer.Int32.ReadFrom(stream), // id
             PrimitiveSerializer.Guid.ReadFrom(stream), // uid
             PrimitiveSerializer.Int32.ReadFrom(stream), // level
-            PrimitiveSerializer.String.ReadFrom(stream), // path
+            ArrayPoolingLimitedSerializer.StringSerializer.ReadString(stream), // path
             PrimitiveSerializer.Int32.ReadFrom(stream), // sort order
             PrimitiveSerializer.Int32.ReadFrom(stream), // parent id
             PrimitiveSerializer.DateTime.ReadFrom(stream), // date created

--- a/src/Umbraco.PublishedCache.NuCache/DataSource/BTree.DictionaryOfCultureVariationSerializer.cs
+++ b/src/Umbraco.PublishedCache.NuCache/DataSource/BTree.DictionaryOfCultureVariationSerializer.cs
@@ -21,10 +21,10 @@ internal class DictionaryOfCultureVariationSerializer : SerializerBase,
         }
 
         // read each variation
-        var dict = new Dictionary<string, CultureVariation>(StringComparer.InvariantCultureIgnoreCase);
+        var dict = new Dictionary<string, CultureVariation>(pcount,StringComparer.InvariantCultureIgnoreCase);
         for (var i = 0; i < pcount; i++)
         {
-            var languageId = string.Intern(PrimitiveSerializer.String.ReadFrom(stream));
+            var languageId = ArrayPoolingLimitedSerializer.StringSerializer.ReadString(stream, true);
             var cultureVariation = new CultureVariation
             {
                 Name = ReadStringObject(stream),

--- a/src/Umbraco.PublishedCache.NuCache/DataSource/BTree.DictionaryOfPropertyDataSerializer.cs
+++ b/src/Umbraco.PublishedCache.NuCache/DataSource/BTree.DictionaryOfPropertyDataSerializer.cs
@@ -20,7 +20,7 @@ internal class DictionaryOfPropertyDataSerializer : SerializerBase, ISerializer<
         for (var i = 0; i < pcount; i++)
         {
             // read property alias
-            var key = string.Intern(PrimitiveSerializer.String.ReadFrom(stream));
+            var key = ArrayPoolingLimitedSerializer.StringSerializer.ReadString(stream, true);
 
             // read values count
             var vcount = PrimitiveSerializer.Int32.ReadFrom(stream);

--- a/src/Umbraco.PublishedCache.NuCache/DataSource/BTree.cs
+++ b/src/Umbraco.PublishedCache.NuCache/DataSource/BTree.cs
@@ -7,8 +7,18 @@ namespace Umbraco.Cms.Infrastructure.PublishedCache.DataSource;
 
 public class BTree
 {
+    /// <summary>
+    /// Custom Nucache GetTree.
+    /// </summary>
+    public static Func<string, bool, NuCacheSettings, ContentDataSerializer?, BPlusTree<int, ContentNodeKit>>? GetTreeFunc { get; set; }
+
     public static BPlusTree<int, ContentNodeKit> GetTree(string filepath, bool exists, NuCacheSettings settings, ContentDataSerializer? contentDataSerializer = null)
     {
+        if (GetTreeFunc != null)
+        {
+            return GetTreeFunc(filepath, exists, settings, contentDataSerializer);
+        }
+
         var keySerializer = new PrimitiveSerializer();
         var valueSerializer = new ContentNodeKitSerializer(contentDataSerializer);
         var options = new BPlusTree<int, ContentNodeKit>.OptionsV2(keySerializer, valueSerializer)
@@ -62,6 +72,8 @@ public class BTree
 
         return blockSize;
     }
+
+    
 
     /*
     class ListOfIntSerializer : ISerializer<List<int>>

--- a/src/Umbraco.PublishedCache.NuCache/DataSource/SerializerBase.cs
+++ b/src/Umbraco.PublishedCache.NuCache/DataSource/SerializerBase.cs
@@ -50,9 +50,7 @@ internal abstract class SerializerBase
             throw new NotSupportedException($"Cannot deserialize type '{type}', expected '{PrefixString}'.");
         }
 
-        return intern
-            ? string.Intern(PrimitiveSerializer.String.ReadFrom(stream))
-            : PrimitiveSerializer.String.ReadFrom(stream);
+        return ArrayPoolingLimitedSerializer.StringSerializer.ReadString(stream, intern);
     }
 
     private T? ReadStruct<T>(Stream stream, char t, Func<Stream, T> read)
@@ -102,7 +100,7 @@ internal abstract class SerializerBase
             case PrefixNull:
                 return null;
             case PrefixString:
-                return PrimitiveSerializer.String.ReadFrom(stream);
+                return ArrayPoolingLimitedSerializer.StringSerializer.ReadString(stream);
             case PrefixInt32:
                 return PrimitiveSerializer.Int32.ReadFrom(stream);
             case PrefixUInt16:

--- a/src/Umbraco.PublishedCache.NuCache/Umbraco.PublishedCache.NuCache.csproj
+++ b/src/Umbraco.PublishedCache.NuCache/Umbraco.PublishedCache.NuCache.csproj
@@ -7,10 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Umbraco.CSharpTest.Net.Collections"  />
+    <PackageReference Include="CommunityToolkit.HighPerformance" />
+    <PackageReference Include="Umbraco.CSharpTest.Net.Collections" />
     <PackageReference Include="MessagePack" />
     <PackageReference Include="K4os.Compression.LZ4" />
-    <PackageReference Include="Newtonsoft.Json"/>
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/15809 <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
Goal of this PR is to reduce memory use / allocations during startup by NuCache deserialization.

At startup and on content / media changes, the NuCache.db files get read.
The existing serializer allocates new strings and char arrays when it deserializes string content. As one can imagine, the more media / content a site has, the more the site needs to allocate memory to do these reads.

By using a ArrayPool<char>, it's possible to reuse the char arrays that get created as an intermediate step before they are turned into strings during this process and reduce memory allocations / garbage collector pressure.

A StringPool works a bit like string.Intern, except you don't need to create the instance of the string first if it is in the pool, and the string does not live in memory forever like with interning. 
If the string does not exist in the pool, a new string is allocated and is put in the pool, if the string is in the pool, no new string is allocated. There is a max size to the string pool by default so it won't just keep growing / holding references to strings.
This is especially helpful for strings like doctypealias and fileExtension as these will be repeated frequently. 

I've made use of two string pools, the Shared string pool for strings that are not expected to be internable previously and a separate StringPool  for strings that are expected to be internable (e.g. doctype alias). This is because the stringpool is a priority queue and will only keep the most recently used strings when the pool is full.

I've added a Function as well to allow overriding the NuCache tree creation process so the settings can be customised to the environment.

How to test?
The main thing is that these changes do not impact whether string content is deserialized correctly.
Creating a document with some text in a textstring field, saving the document, and rebooting should show the exact same text when it is read back from the published cache. Existing unit test coverage should pass.


<!-- Thanks for contributing to Umbraco CMS! -->
