### PR TITLE
V14: Enable user start node calculation

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/DocumentTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/DocumentTreeControllerBase.cs
@@ -63,23 +63,17 @@ public abstract class DocumentTreeControllerBase : UserStartNodeTreeControllerBa
         return responseModel;
     }
 
-    // TODO: delete these (faking start node setup for unlimited editor)
-    protected override int[] GetUserStartNodeIds() => new[] { -1 };
+    protected override int[] GetUserStartNodeIds()
+        => _backofficeSecurityAccessor
+               .BackOfficeSecurity?
+               .CurrentUser?
+               .CalculateContentStartNodeIds(EntityService, _appCaches)
+           ?? Array.Empty<int>();
 
-    protected override string[] GetUserStartNodePaths() => Array.Empty<string>();
-
-    // TODO: use these implementations instead of the dummy ones above once we have backoffice auth in place
-    // protected override int[] GetUserStartNodeIds()
-    //     => _backofficeSecurityAccessor
-    //            .BackOfficeSecurity?
-    //            .CurrentUser?
-    //            .CalculateContentStartNodeIds(EntityService, _appCaches)
-    //        ?? Array.Empty<int>();
-    //
-    // protected override string[] GetUserStartNodePaths()
-    //     => _backofficeSecurityAccessor
-    //            .BackOfficeSecurity?
-    //            .CurrentUser?
-    //            .GetContentStartNodePaths(EntityService, _appCaches)
-    //        ?? Array.Empty<string>();
+    protected override string[] GetUserStartNodePaths()
+        => _backofficeSecurityAccessor
+               .BackOfficeSecurity?
+               .CurrentUser?
+               .GetContentStartNodePaths(EntityService, _appCaches)
+           ?? Array.Empty<string>();
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Tree/MediaTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Tree/MediaTreeControllerBase.cs
@@ -59,23 +59,17 @@ public class MediaTreeControllerBase : UserStartNodeTreeControllerBase<MediaTree
         return responseModel;
     }
 
-    // TODO: delete these (faking start node setup for unlimited editor)
-    protected override int[] GetUserStartNodeIds() => new[] { -1 };
+    protected override int[] GetUserStartNodeIds()
+        => _backofficeSecurityAccessor
+               .BackOfficeSecurity?
+               .CurrentUser?
+               .CalculateMediaStartNodeIds(EntityService, _appCaches)
+           ?? Array.Empty<int>();
 
-    protected override string[] GetUserStartNodePaths() => Array.Empty<string>();
-
-    // TODO: use these implementations instead of the dummy ones above once we have backoffice auth in place
-    // protected override int[] GetUserStartNodeIds()
-    //     => _backofficeSecurityAccessor
-    //            .BackOfficeSecurity?
-    //            .CurrentUser?
-    //            .CalculateMediaStartNodeIds(EntityService, _appCaches)
-    //        ?? Array.Empty<int>();
-    //
-    // protected override string[] GetUserStartNodePaths()
-    //     => _backofficeSecurityAccessor
-    //            .BackOfficeSecurity?
-    //            .CurrentUser?
-    //            .GetMediaStartNodePaths(EntityService, _appCaches)
-    //        ?? Array.Empty<string>();
+    protected override string[] GetUserStartNodePaths()
+        => _backofficeSecurityAccessor
+               .BackOfficeSecurity?
+               .CurrentUser?
+               .GetMediaStartNodePaths(EntityService, _appCaches)
+           ?? Array.Empty<string>();
 }


### PR DESCRIPTION
# Notes
- Enables the calculation of user start nodes for content and media

# How to test
- This is really tricky to do from a clean v14 install as you have to use swagger for almost everthing
- So I recommend going from a v13 database with:
- A root and child document type
- Allow the `child` document type as child on `root`
- Allow the `root` document type as root
- Create a root content node
- Create a child content node
- Go to user groups and set the "Editor" user groups start node to child
- Create a new user that's only part of the editor user group
- (Migrate to v14 on this step if you did it on v13)
- Login as the new user, assert that you cannot navigate to the `Root` content node
- Assert you can see the child content node