### PR TITLE
V14: Removing workaround when GetConfiguredListViewDataTypeAsync for collection views

### DIFF
--- a/src/Umbraco.Infrastructure/Services/ContentListViewServiceBase.cs
+++ b/src/Umbraco.Infrastructure/Services/ContentListViewServiceBase.cs
@@ -203,32 +203,16 @@ internal abstract class ContentListViewServiceBase<TContent, TContentType, TCont
 
     private async Task<IDataType?> GetConfiguredListViewDataTypeAsync(TContentType? contentType)
     {
-        string? listViewSuffix = null;
-
-        // FIXME: Remove. This is a workaround to construct the custom list view name (content type - alias; media type- name)
-        // until we have the concrete content type + list view binding.
-        if (DefaultListViewKey == Constants.DataTypes.Guids.ListViewContentGuid)
+        // When contentType is not configured as a list view
+        if (contentType is not null && contentType.ListView is null)
         {
-            listViewSuffix = contentType?.Alias;
-        }
-        else if (DefaultListViewKey == Constants.DataTypes.Guids.ListViewMediaGuid)
-        {
-            listViewSuffix = contentType?.Name;
+            return null;
         }
 
-        // If we don't have a suffix (content type name or alias), we cannot look for the custom list view by name.
-        // So return the default one.
-        if (string.IsNullOrEmpty(listViewSuffix))
-        {
-            return await _dataTypeService.GetAsync(DefaultListViewKey);
-        }
+        // When we don't have a contentType (i.e. when root), we will get the default list view
+        Guid configuredListViewKey = contentType?.ListView ?? DefaultListViewKey;
 
-        // FIXME: Clean up! Get the configured list view from content type once the binding task AB#37205 is done.
-        // This is a hack based on legacy (same thing can be seen in ListViewContentAppFactory) - we cannot infer the list view associated with a content type otherwise.
-        // We can use the fact that when a custom list view is removed as the content type list view configuration, the corresponding list view data type gets deleted.
-        var customListViewName = Constants.Conventions.DataTypes.ListViewPrefix + listViewSuffix;
-
-        return _dataTypeService.GetDataType(customListViewName) ?? await _dataTypeService.GetAsync(DefaultListViewKey);
+        return await _dataTypeService.GetAsync(configuredListViewKey);
     }
 
     private async Task<PagedModel<TContent>> GetAllowedListViewItemsAsync(IUser user, int contentId, string? filter, Ordering? ordering, int skip, int take)


### PR DESCRIPTION
## Details
- Since the content type and collection view binding is in place (_thank you https://github.com/umbraco/Umbraco-CMS/pull/15687_ 🙌 ) we can remove the workaround when getting the configured list view data type on a content type (used by the collection view endpoints)

## Test
The same implementation is used for Document and Media collection views, so we can just test GET
`/umbraco/management/api/v1/collection/media` endpoint:
- The best approach here is to do the following set-up in v13 and copy over DB, and then Debug the code:
  - Create a new Media Type - i.e. "Album"
  - Allow as root - in Permissions content app
    - Add "Image" to Allowed child node types
  - Enable list view - in List view content app
    - Create a custom list view and add some more columns to "Columns Displayed" on the List view settings
  - In the Media section, create an example of the Album media type and  upload some images
- Put a breakpoint in https://github.com/umbraco/Umbraco-CMS/blob/v14/dev/src/Umbraco.Infrastructure/Services/ContentListViewServiceBase.cs#L199 and Debug:
  - Verify that `currentListViewDataType?.ConfigurationObject` > `IncludeProperties` have the correct values as the "Columns Displayed" on the configured List view in the following cases:
    - Don't modify any parameters **(keep the defaults)** and execute the GET `/umbraco/management/api/v1/collection/media` - Compare `IncludeProperties` against the "Columns Displayed" of the default list view data type (i.e. "List View - Media") - this way we will be checking the default list view configuration for root
    - Pass in the id of the newly created media from the "Album" media type to GET `/umbraco/management/api/v1/collection/media` - Compare `IncludeProperties` against the "Columns Displayed" of the custom list view data type (i.e. "List View - album") - this way we will be checking the custom list view configuration for a media item