### PR TITLE
Align parent contexts

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/FolderManagementControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/FolderManagementControllerBase.cs
@@ -1,7 +1,6 @@
 ﻿using System.Linq.Expressions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Management.ViewModels;
 using Umbraco.Cms.Api.Management.ViewModels.Folder;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
@@ -36,14 +35,11 @@ public abstract class FolderManagementControllerBase<TTreeEntity> : ManagementAp
                     .Build()));
         }
 
-        EntityContainer? parentContainer = await _treeEntityTypeContainerService.GetParentAsync(container);
-
         // we could implement a mapper for this but it seems rather overkill at this point
         return Ok(new FolderResponseModel
         {
             Name = container.Name!,
-            Id = container.Key,
-            Parent = ReferenceByIdModel.ReferenceOrNull(parentContainer?.Key)
+            Id = container.Key
         });
     }
 

--- a/src/Umbraco.Cms.Api.Management/Factories/DocumentTypeEditingPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DocumentTypeEditingPresentationFactory.cs
@@ -25,7 +25,7 @@ internal sealed class DocumentTypeEditingPresentationFactory : ContentTypeEditin
         MapCleanup(createModel, requestModel.Cleanup);
 
         createModel.Key = requestModel.Id;
-        createModel.ContainerKey = requestModel.Folder?.Id;
+        createModel.ContainerKey = requestModel.Parent?.Id;
         createModel.AllowedTemplateKeys = requestModel.AllowedTemplates.Select(reference => reference.Id).ToArray();
         createModel.DefaultTemplateKey = requestModel.DefaultTemplate?.Id;
         createModel.ListView = requestModel.Collection?.Id;

--- a/src/Umbraco.Cms.Api.Management/Factories/MediaTypeEditingPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/MediaTypeEditingPresentationFactory.cs
@@ -24,7 +24,7 @@ internal sealed class MediaTypeEditingPresentationFactory : ContentTypeEditingPr
         >(requestModel);
 
         createModel.Key = requestModel.Id;
-        createModel.ContainerKey = requestModel.Folder?.Id;
+        createModel.ContainerKey = requestModel.Parent?.Id;
         createModel.AllowedContentTypes = MapAllowedContentTypes(requestModel.AllowedMediaTypes);
         createModel.Compositions = MapCompositions(requestModel.Compositions);
         createModel.ListView = requestModel.Collection?.Id;

--- a/src/Umbraco.Cms.Api.Management/Mapping/DataType/DataTypeViewModelMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/DataType/DataTypeViewModelMapDefinition.cs
@@ -1,20 +1,13 @@
-﻿using Umbraco.Cms.Api.Management.ViewModels;
-using Umbraco.Cms.Api.Management.ViewModels.DataType;
+﻿using Umbraco.Cms.Api.Management.ViewModels.DataType;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
-using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Mapping.DataType;
 
 public class DataTypeViewModelMapDefinition : IMapDefinition
 {
-    private readonly IDataTypeService _dataTypeService;
-
-    public DataTypeViewModelMapDefinition(IDataTypeService dataTypeService)
-        => _dataTypeService = dataTypeService;
-
     public void DefineMaps(IUmbracoMapper mapper)
         => mapper.Define<IDataType, DataTypeResponseModel>((_, _) => new DataTypeResponseModel(), Map);
 
@@ -22,8 +15,6 @@ public class DataTypeViewModelMapDefinition : IMapDefinition
     private void Map(IDataType source, DataTypeResponseModel target, MapperContext context)
     {
         target.Id = source.Key;
-        Guid? parentId = _dataTypeService.GetContainer(source.ParentId)?.Key;
-        target.Parent = ReferenceByIdModel.ReferenceOrNull(parentId);
         target.Name = source.Name ?? string.Empty;
         target.EditorAlias = source.EditorAlias;
         target.EditorUiAlias = source.EditorUiAlias;

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -32822,7 +32822,7 @@
             "format": "uuid",
             "nullable": true
           },
-          "folder": {
+          "parent": {
             "oneOf": [
               {
                 "$ref": "#/components/schemas/ReferenceByIdModel"
@@ -32908,7 +32908,7 @@
             "format": "uuid",
             "nullable": true
           },
-          "folder": {
+          "parent": {
             "oneOf": [
               {
                 "$ref": "#/components/schemas/ReferenceByIdModel"

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -33836,14 +33836,6 @@
             "type": "string",
             "format": "uuid"
           },
-          "parent": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/ReferenceByIdModel"
-              }
-            ],
-            "nullable": true
-          },
           "isDeletable": {
             "type": "boolean"
           },
@@ -35252,14 +35244,6 @@
           "id": {
             "type": "string",
             "format": "uuid"
-          },
-          "parent": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/ReferenceByIdModel"
-              }
-            ],
-            "nullable": true
           }
         },
         "additionalProperties": false

--- a/src/Umbraco.Cms.Api.Management/ViewModels/ContentType/CreateContentTypeWithParentRequestModelBase.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/ContentType/CreateContentTypeWithParentRequestModelBase.cs
@@ -1,9 +1,9 @@
 ﻿namespace Umbraco.Cms.Api.Management.ViewModels.ContentType;
 
-public abstract class CreateContentTypeInFolderRequestModelBase<TPropertyType, TPropertyTypeContainer>
+public abstract class CreateContentTypeWithParentRequestModelBase<TPropertyType, TPropertyTypeContainer>
     : CreateContentTypeRequestModelBase<TPropertyType, TPropertyTypeContainer>
     where TPropertyType : PropertyTypeModelBase
     where TPropertyTypeContainer : PropertyTypeContainerModelBase
 {
-    public ReferenceByIdModel? Folder { get; set; }
+    public ReferenceByIdModel? Parent { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DataTypeResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DataTypeResponseModel.cs
@@ -4,8 +4,6 @@ public class DataTypeResponseModel : DataTypeModelBase
 {
     public Guid Id { get; set; }
 
-    public ReferenceByIdModel? Parent { get; set; }
-
     public bool IsDeletable { get; set; }
 
     public bool CanIgnoreStartNodes { get; set; }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/CreateDocumentTypeRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/CreateDocumentTypeRequestModel.cs
@@ -5,7 +5,7 @@ namespace Umbraco.Cms.Api.Management.ViewModels.DocumentType;
 
 [ShortGenericSchemaName<CreateDocumentTypePropertyTypeRequestModel, CreateDocumentTypePropertyTypeContainerRequestModel>("CreateContentTypeForDocumentTypeRequestModel")]
 public class CreateDocumentTypeRequestModel
-    : CreateContentTypeInFolderRequestModelBase<CreateDocumentTypePropertyTypeRequestModel, CreateDocumentTypePropertyTypeContainerRequestModel>
+    : CreateContentTypeWithParentRequestModelBase<CreateDocumentTypePropertyTypeRequestModel, CreateDocumentTypePropertyTypeContainerRequestModel>
 {
     public IEnumerable<ReferenceByIdModel> AllowedTemplates { get; set; } = Enumerable.Empty<ReferenceByIdModel>();
 

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Folder/FolderResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Folder/FolderResponseModel.cs
@@ -3,6 +3,4 @@
 public class FolderResponseModel : FolderModelBase
 {
     public Guid Id { get; set; }
-
-    public ReferenceByIdModel? Parent { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/MediaType/CreateMediaTypeRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/MediaType/CreateMediaTypeRequestModel.cs
@@ -5,7 +5,7 @@ namespace Umbraco.Cms.Api.Management.ViewModels.MediaType;
 
 [ShortGenericSchemaName<CreateMediaTypePropertyTypeRequestModel, CreateMediaTypePropertyTypeContainerRequestModel>("CreateContentTypeForMediaTypeRequestModel")]
 public class CreateMediaTypeRequestModel
-    : CreateContentTypeInFolderRequestModelBase<CreateMediaTypePropertyTypeRequestModel, CreateMediaTypePropertyTypeContainerRequestModel>
+    : CreateContentTypeWithParentRequestModelBase<CreateMediaTypePropertyTypeRequestModel, CreateMediaTypePropertyTypeContainerRequestModel>
 {
     public IEnumerable<MediaTypeSort> AllowedMediaTypes { get; set; } = Enumerable.Empty<MediaTypeSort>();
 


### PR DESCRIPTION
### Description

This PR aligns the `parent` contexts throughout the Management API:

1. Do not output a `parent` at resource detail level.
2. Use `parent` everywhere (instead of `folder`).