### PR TITLE
Localize validation messages with user lang files

### DIFF
--- a/src/Umbraco.Core/Models/Mapping/ContentPropertyDisplayMapper.cs
+++ b/src/Umbraco.Core/Models/Mapping/ContentPropertyDisplayMapper.cs
@@ -86,5 +86,7 @@ internal class ContentPropertyDisplayMapper : ContentPropertyBasicMapper<Content
         // Translate
         dest.Label = _textService.UmbracoDictionaryTranslate(_cultureDictionary, dest.Label);
         dest.Description = _textService.UmbracoDictionaryTranslate(_cultureDictionary, dest.Description);
+        dest.Validation.MandatoryMessage = _textService.UmbracoDictionaryTranslate(_cultureDictionary, dest.Validation.MandatoryMessage);
+        dest.Validation.PatternMessage = _textService.UmbracoDictionaryTranslate(_cultureDictionary, dest.Validation.PatternMessage);
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentServiceTests.cs
@@ -7,6 +7,7 @@ using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Dictionary;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
@@ -1195,7 +1196,7 @@ public class ContentServiceTests : UmbracoIntegrationTestWithContent
 
         // content cannot publish values because they are invalid
         var propertyValidationService = new PropertyValidationService(PropertyEditorCollection, DataTypeService,
-            TextService, ValueEditorCache);
+            TextService, ValueEditorCache, Mock.Of<ICultureDictionary>());
         var isValid = propertyValidationService.IsPropertyDataValid(content, out var invalidProperties,
             CultureImpact.Invariant);
         Assert.IsFalse(isValid);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/VariationTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/VariationTests.cs
@@ -5,6 +5,7 @@ using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Dictionary;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
@@ -615,6 +616,7 @@ public class VariationTests
             propertyEditorCollection,
             dataTypeService,
             localizedTextService,
-            new ValueEditorCache());
+            new ValueEditorCache(),
+            Mock.Of<ICultureDictionary>());
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Services/PropertyValidationServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Services/PropertyValidationServiceTests.cs
@@ -6,6 +6,7 @@ using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Dictionary;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
@@ -51,7 +52,7 @@ public class PropertyValidationServiceTests
 
         var propEditors = new PropertyEditorCollection(new DataEditorCollection(() => new[] { dataEditor }));
 
-        validationService = new PropertyValidationService(propEditors, dataTypeService.Object, Mock.Of<ILocalizedTextService>(), new ValueEditorCache());
+        validationService = new PropertyValidationService(propEditors, dataTypeService.Object, Mock.Of<ILocalizedTextService>(), new ValueEditorCache(), Mock.Of<ICultureDictionary>());
     }
 
     [Test]


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Although currently undocumented, it is possible to use [user lang files](https://docs.umbraco.com/umbraco-cms/extending/language-files#user-language-files) to localize the backoffice (instead of using dictionary items). However, that kind of localization does not extend to property validation messages.

This PR fixes it.

### Testing this PR

Create a user language file like this in `[site root]\config\lang`:

```xml
<?xml version="1.0" encoding="utf-8" standalone="yes"?>
<language>
    <area alias="validation">
        <key alias="mandatory-field">It's mandatory</key>
        <key alias="numeric-field">It's got to be a number</key>
    </area>
</language>
```

Use these language keys to configure property validation messages:

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/7fd5ec81-e508-4b9a-8071-1c572c74979a)

Now verify that the validation messages are indeed utilized by the backoffice:

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/329c6b0f-1c8d-4b16-b4af-41d9f0e8c0c7)

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/8a4711a0-a36f-4f90-8de5-0a337b8a9cba)


...also in block based editors:

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/fdb41194-a463-4d74-b9bd-6108b000ed0a)
