### PR TITLE
Remove legacy media picker from install

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Filter/DataTypeFilterControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Filter/DataTypeFilterControllerBase.cs
@@ -10,7 +10,7 @@ namespace Umbraco.Cms.Api.Management.Controllers.DataType.Filter;
 [ApiExplorerSettings(GroupName = "Data Type")]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Filter}/{Constants.UdiEntityType.DataType}")]
 // This auth policy might become problematic, as when getting DataTypes on Media types, you don't need access to the document tree.
-[Authorize(Policy = "New" + AuthorizationPolicies.TreeAccessDocumentsOrDocumentTypes)]
+[Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentsOrDocumentTypes)]
 public abstract class DataTypeFilterControllerBase : ManagementApiControllerBase
 {
 }

--- a/src/Umbraco.Core/Constants-DataTypes.cs
+++ b/src/Umbraco.Core/Constants-DataTypes.cs
@@ -55,16 +55,6 @@ public static partial class Constants
             public const string MemberPicker = "1EA2E01F-EBD8-4CE1-8D71-6B1149E63548";
 
             /// <summary>
-            ///     Guid for Media Picker as string
-            /// </summary>
-            public const string MediaPicker = "135D60E0-64D9-49ED-AB08-893C9BA44AE5";
-
-            /// <summary>
-            ///     Guid for Multiple Media Picker as string
-            /// </summary>
-            public const string MultipleMediaPicker = "9DBBCBBB-2327-434A-B355-AF1B84E5010A";
-
-            /// <summary>
             ///     Guid for Media Picker v3 as string
             /// </summary>
             public const string MediaPicker3 = "4309A3EA-0D78-4329-A06C-C80B036AF19A";
@@ -243,16 +233,6 @@ public static partial class Constants
             ///     Guid for Member Picker
             /// </summary>
             public static readonly Guid MemberPickerGuid = new(MemberPicker);
-
-            /// <summary>
-            ///     Guid for Media Picker
-            /// </summary>
-            public static readonly Guid MediaPickerGuid = new(MediaPicker);
-
-            /// <summary>
-            ///     Guid for Multiple Media Picker
-            /// </summary>
-            public static readonly Guid MultipleMediaPickerGuid = new(MultipleMediaPicker);
 
             /// <summary>
             ///     Guid for Media Picker v3

--- a/src/Umbraco.Core/Models/DataTypeExtensions.cs
+++ b/src/Umbraco.Core/Models/DataTypeExtensions.cs
@@ -12,8 +12,6 @@ public static class DataTypeExtensions
     {
         Constants.DataTypes.Guids.ContentPickerGuid,
         Constants.DataTypes.Guids.MemberPickerGuid,
-        Constants.DataTypes.Guids.MediaPickerGuid,
-        Constants.DataTypes.Guids.MultipleMediaPickerGuid,
         Constants.DataTypes.Guids.RelatedLinksGuid,
         Constants.DataTypes.Guids.MemberGuid,
         Constants.DataTypes.Guids.ImageCropperGuid,

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
@@ -771,44 +771,7 @@ internal class DatabaseDataCreator
             },
             Constants.DatabaseSchema.Tables.Node,
             "id");
-        ConditionalInsert(
-            Constants.Configuration.NamedOptions.InstallDefaultData.DataTypes,
-            Constants.DataTypes.Guids.MediaPicker,
-            new NodeDto
-            {
-                NodeId = 1048,
-                Trashed = false,
-                ParentId = -1,
-                UserId = -1,
-                Level = 1,
-                Path = "-1,1048",
-                SortOrder = 2,
-                UniqueId = Constants.DataTypes.Guids.MediaPickerGuid,
-                Text = "Media Picker (legacy)",
-                NodeObjectType = Constants.ObjectTypes.DataType,
-                CreateDate = DateTime.Now,
-            },
-            Constants.DatabaseSchema.Tables.Node,
-            "id");
-        ConditionalInsert(
-            Constants.Configuration.NamedOptions.InstallDefaultData.DataTypes,
-            Constants.DataTypes.Guids.MultipleMediaPicker,
-            new NodeDto
-            {
-                NodeId = 1049,
-                Trashed = false,
-                ParentId = -1,
-                UserId = -1,
-                Level = 1,
-                Path = "-1,1049",
-                SortOrder = 2,
-                UniqueId = Constants.DataTypes.Guids.MultipleMediaPickerGuid,
-                Text = "Multiple Media Picker (legacy)",
-                NodeObjectType = Constants.ObjectTypes.DataType,
-                CreateDate = DateTime.Now,
-            },
-            Constants.DatabaseSchema.Tables.Node,
-            "id");
+
         ConditionalInsert(
             Constants.Configuration.NamedOptions.InstallDefaultData.DataTypes,
             Constants.DataTypes.Guids.RelatedLinks,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR ensures we do not install the legacy media picker in V14 databases.

Also the datatype `filter` endpoint still has the temporary "New" auth policy applied, efficiently preventing it from being queried. This has been fixed too.

### Testing this PR

1. Install a fresh V14 database. There should be no "legacy" media pickers in it.
2. It should be possible to query the datatype `filter` endpoint.