### PR TITLE
Check for duplicate keys on media if we know it's a fresh entity

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Content/ContentControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Content/ContentControllerBase.cs
@@ -64,6 +64,10 @@ public class ContentControllerBase : ManagementApiControllerBase
                 .WithTitle("Invalid culture")
                 .WithDetail("One or more of the supplied culture codes did not match the configured languages.")
                 .Build()),
+            ContentEditingOperationStatus.DuplicateKey => BadRequest(problemDetailsBuilder
+                .WithTitle("Invalid Id")
+                .WithDetail("The supplied id is already in use.")
+                .Build()),
             ContentEditingOperationStatus.Unknown => StatusCode(
                 StatusCodes.Status500InternalServerError,
                 problemDetailsBuilder

--- a/src/Umbraco.Core/Services/MediaEditingService.cs
+++ b/src/Umbraco.Core/Services/MediaEditingService.cs
@@ -144,6 +144,7 @@ internal sealed class MediaEditingService
                 // these are the only result states currently expected from Save
                 OperationResultType.Success => ContentEditingOperationStatus.Success,
                 OperationResultType.FailedCancelledByEvent => ContentEditingOperationStatus.CancelledByNotification,
+                OperationResultType.FailedDuplicateKey => ContentEditingOperationStatus.DuplicateKey,
 
                 // for any other state we'll return "unknown" so we know that we need to amend this
                 _ => ContentEditingOperationStatus.Unknown

--- a/src/Umbraco.Core/Services/MediaService.cs
+++ b/src/Umbraco.Core/Services/MediaService.cs
@@ -756,6 +756,13 @@ namespace Umbraco.Cms.Core.Services
                 scope.WriteLock(Constants.Locks.MediaTree);
                 if (media.HasIdentity == false)
                 {
+                    if (_entityRepository.Get(media.Key, UmbracoObjectTypes.Media.GetGuid()) is not null)
+                    {
+                        scope.Complete();
+                        return Attempt.Fail<OperationResult?>(
+                            new OperationResult(OperationResultType.FailedDuplicateKey, eventMessages));
+                    }
+
                     media.CreatorId = userId;
                 }
 

--- a/src/Umbraco.Core/Services/OperationResultType.cs
+++ b/src/Umbraco.Core/Services/OperationResultType.cs
@@ -40,5 +40,10 @@ public enum OperationResultType : byte
     /// </summary>
     NoOperation = Failed | 6, // TODO: shouldn't it be a success?
 
+    /// <summary>
+    ///     The operation could not complete due to duplicate key detection
+    /// </summary>
+    FailedDuplicateKey = Failed | 7
+
     // TODO: In the future, we might need to add more operations statuses, potentially like 'FailedByPermissions', etc...
 }

--- a/src/Umbraco.Core/Services/OperationStatus/ContentEditingOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/ContentEditingOperationStatus.cs
@@ -18,5 +18,6 @@ public enum ContentEditingOperationStatus
     SortingInvalid,
     PropertyValidationError,
     InvalidCulture,
-    Unknown
+    DuplicateKey,
+    Unknown,
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
The media create endpoint returns a very generic 500 when you try to create a media item with a key that already exists. This PR aims to fix this by checking if a media entity exists with the supplied key when we know the IMedia does not have an identity (constructed from outside of the repository)

### Possible Test plan
- Create a media Item with key xxx <= success
- Create another media Item with key xxx <= fail with proper message
- Create a media Item with key yyy <= success
- Update media Item with key xxx <= success