### PR TITLE
V14: Data type filter endpoint - removes "New" prefix from authorization policy

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Filter/DataTypeFilterControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Filter/DataTypeFilterControllerBase.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
@@ -10,7 +10,7 @@ namespace Umbraco.Cms.Api.Management.Controllers.DataType.Filter;
 [ApiExplorerSettings(GroupName = "Data Type")]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Filter}/{Constants.UdiEntityType.DataType}")]
 // This auth policy might become problematic, as when getting DataTypes on Media types, you don't need access to the document tree.
-[Authorize(Policy = "New" + AuthorizationPolicies.TreeAccessDocumentsOrDocumentTypes)]
+[Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentsOrDocumentTypes)]
 public abstract class DataTypeFilterControllerBase : ManagementApiControllerBase
 {
 }


### PR DESCRIPTION
Whilst implementing the new data-type filter endpoint, I'd noticed that the `"New"` prefix was on the authorization policy, which threw an error on the frontend.