### PR TITLE
V14: Cleanup [ApiController] attribute usage

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Controllers/DeliveryApiControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/DeliveryApiControllerBase.cs
@@ -1,6 +1,6 @@
-using Microsoft.AspNetCore.Mvc;
 using System.Net;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Attributes;
 using Umbraco.Cms.Api.Common.Filters;
 using Umbraco.Cms.Api.Delivery.Configuration;

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/Security/MemberController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/Security/MemberController.cs
@@ -15,13 +15,12 @@ using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Web.Common.Security;
 using Umbraco.Extensions;
-using SignInResult = Microsoft.AspNetCore.Mvc.SignInResult;
 using IdentitySignInResult = Microsoft.AspNetCore.Identity.SignInResult;
+using SignInResult = Microsoft.AspNetCore.Mvc.SignInResult;
 
 namespace Umbraco.Cms.Api.Delivery.Controllers.Security;
 
 [ApiVersion("1.0")]
-[ApiController]
 [VersionedDeliveryApiRoute(Common.Security.Paths.MemberApi.EndpointTemplate)]
 [ApiExplorerSettings(IgnoreApi = true)]
 public class MemberController : DeliveryApiControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/AuditLog/AuditLogControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/AuditLog/AuditLogControllerBase.cs
@@ -3,7 +3,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.AuditLog;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("audit-log")]
 [ApiExplorerSettings(GroupName = "Audit Log")]
 public class AuditLogControllerBase : ManagementApiControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/Culture/CultureControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Culture/CultureControllerBase.cs
@@ -3,7 +3,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Culture;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("culture")]
 [ApiExplorerSettings(GroupName = "Culture")]
 public abstract class CultureControllerBase : ManagementApiControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/DataTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/DataTypeControllerBase.cs
@@ -9,7 +9,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType;
 
-[ApiController]
 [VersionedApiBackOfficeRoute(Constants.UdiEntityType.DataType)]
 [ApiExplorerSettings(GroupName = "Data Type")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentsOrDocumentTypes)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Filter/DataTypeFilterControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Filter/DataTypeFilterControllerBase.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType.Filter;
 
-[ApiController]
 [ApiExplorerSettings(GroupName = "Data Type")]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Filter}/{Constants.UdiEntityType.DataType}")]
 // This auth policy might become problematic, as when getting DataTypes on Media types, you don't need access to the document tree.

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DataTypeFolderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Folder/DataTypeFolderControllerBase.cs
@@ -9,7 +9,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType.Folder;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.DataType}/folder")]
 [ApiExplorerSettings(GroupName = "Data Type")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentTypes)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Item/DatatypeItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Item/DatatypeItemControllerBase.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType.Item;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Item}/{Constants.UdiEntityType.DataType}")]
 [ApiExplorerSettings(GroupName = "Data Type")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentsOrDocumentTypes)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Tree/DataTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Tree/DataTypeTreeControllerBase.cs
@@ -12,7 +12,6 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType.Tree;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.DataType}")]
 [ApiExplorerSettings(GroupName = "Data Type")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessDataTypes)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Tree/DataTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Tree/DataTypeTreeControllerBase.cs
@@ -1,12 +1,12 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Controllers.Tree;
+using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Api.Management.Controllers.Tree;
-using Umbraco.Cms.Api.Management.Routing;
-using Umbraco.Cms.Api.Management.ViewModels.Tree;
 using Umbraco.Cms.Web.Common.Authorization;
 using Umbraco.Extensions;
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/DictionaryControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/DictionaryControllerBase.cs
@@ -8,7 +8,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Dictionary;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("dictionary")]
 [ApiExplorerSettings(GroupName = "Dictionary")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessDictionary)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Item/DictionaryItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Item/DictionaryItemControllerBase.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Dictionary.Item;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Item}/dictionary")]
 [ApiExplorerSettings(GroupName = "Dictionary")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessDictionary)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/DictionaryTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/DictionaryTreeControllerBase.cs
@@ -1,12 +1,12 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Controllers.Tree;
+using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Api.Management.ViewModels;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Api.Management.Controllers.Tree;
-using Umbraco.Cms.Api.Management.ViewModels.Tree;
-using Umbraco.Cms.Api.Management.Routing;
-using Umbraco.Cms.Api.Management.ViewModels;
 using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Dictionary.Tree;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/DictionaryTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/DictionaryTreeControllerBase.cs
@@ -11,7 +11,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Dictionary.Tree;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/dictionary")]
 [ApiExplorerSettings(GroupName = "Dictionary")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessDictionaryOrTemplates)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Collection/DocumentCollectionControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Collection/DocumentCollectionControllerBase.cs
@@ -12,7 +12,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document.Collection;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Collection}/{Constants.UdiEntityType.Document}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Document))]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessDocuments)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/DocumentControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/DocumentControllerBase.cs
@@ -13,7 +13,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document;
 
-[ApiController]
 [VersionedApiBackOfficeRoute(Constants.UdiEntityType.Document)]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Document))]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessDocuments)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/DocumentControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/DocumentControllerBase.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Controllers.Content;
 using Umbraco.Cms.Api.Management.Routing;
-using Umbraco.Cms.Api.Management.ViewModels.Content;
 using Umbraco.Cms.Api.Management.ViewModels.Document;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.ContentEditing;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/DocumentItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/DocumentItemControllerBase.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document.Item;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Item}/{Constants.UdiEntityType.Document}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Document))]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessDocuments)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/RecycleBin/DocumentRecycleBinControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/RecycleBin/DocumentRecycleBinControllerBase.cs
@@ -1,14 +1,14 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Models.Entities;
-using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Api.Management.Controllers.RecycleBin;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.Filters;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Api.Management.ViewModels.Document.RecycleBin;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Entities;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document.RecycleBin;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/RecycleBin/DocumentRecycleBinControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/RecycleBin/DocumentRecycleBinControllerBase.cs
@@ -13,7 +13,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document.RecycleBin;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.RecycleBin}/{Constants.UdiEntityType.Document}")]
 [RequireDocumentTreeRootAccess]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Document))]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/DocumentTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/DocumentTreeControllerBase.cs
@@ -15,7 +15,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document.Tree;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.Document}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Document))]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessForContentTree)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/DocumentTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/DocumentTreeControllerBase.cs
@@ -1,16 +1,16 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Controllers.Tree;
+using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Api.Management.Services.Entities;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Api.Management.Controllers.Tree;
-using Umbraco.Cms.Api.Management.Factories;
-using Umbraco.Cms.Api.Management.Services.Entities;
-using Umbraco.Cms.Api.Management.ViewModels.Tree;
-using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document.Tree;

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/Item/DocumentBlueprintItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/Item/DocumentBlueprintItemControllerBase.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint.Item;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Item}/{Constants.UdiEntityType.DocumentBlueprint}")]
 [ApiExplorerSettings(GroupName = "Document Blueprint")]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessContent)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/Tree/DocumentBlueprintTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/Tree/DocumentBlueprintTreeControllerBase.cs
@@ -12,7 +12,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint.Tree;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.DocumentBlueprint}")]
 [ApiExplorerSettings(GroupName = "Document Blueprint")]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessContent)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/Tree/DocumentBlueprintTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/Tree/DocumentBlueprintTreeControllerBase.cs
@@ -1,13 +1,13 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Controllers.Tree;
+using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Api.Management.Controllers.Tree;
-using Umbraco.Cms.Api.Management.Factories;
-using Umbraco.Cms.Api.Management.ViewModels.Tree;
-using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint.Tree;

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/DocumentTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/DocumentTypeControllerBase.cs
@@ -8,7 +8,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DocumentType;
 
-[ApiController]
 [VersionedApiBackOfficeRoute(Constants.UdiEntityType.DocumentType)]
 [ApiExplorerSettings(GroupName = "Document Type")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentTypes)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Folder/DocumentTypeFolderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Folder/DocumentTypeFolderControllerBase.cs
@@ -9,7 +9,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DocumentType.Folder;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.DocumentType}/folder")]
 [ApiExplorerSettings(GroupName = "Document Type")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentTypes)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Item/DocumentTypeItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Item/DocumentTypeItemControllerBase.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DocumentType.Item;
 
-[ApiController]
 [VersionedApiBackOfficeRoute( $"{Constants.Web.RoutePath.Item}/{Constants.UdiEntityType.DocumentType}")]
 [ApiExplorerSettings(GroupName = "Document Type")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentTypes)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Tree/DocumentTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Tree/DocumentTypeTreeControllerBase.cs
@@ -1,12 +1,12 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Controllers.Tree;
+using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Api.Management.Controllers.Tree;
-using Umbraco.Cms.Api.Management.ViewModels.Tree;
-using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DocumentType.Tree;

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Tree/DocumentTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Tree/DocumentTypeTreeControllerBase.cs
@@ -11,7 +11,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DocumentType.Tree;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.DocumentType}")]
 [ApiExplorerSettings(GroupName = "Document Type")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentTypes)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/DynamicRoot/DynamicRootControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DynamicRoot/DynamicRootControllerBase.cs
@@ -3,7 +3,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DynamicRoot;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("dynamic-root")]
 [ApiExplorerSettings(GroupName = "Dynamic Root")]
 public abstract class DynamicRootControllerBase : ManagementApiControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/HealthCheck/Group/HealthCheckGroupControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/HealthCheck/Group/HealthCheckGroupControllerBase.cs
@@ -7,7 +7,6 @@ using Constants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Cms.Api.Management.Controllers.HealthCheck.Group;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.HealthChecks.RoutePath.HealthCheck}-group")]
 [ApiExplorerSettings(GroupName = "Health Check")]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessSettings)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/HealthCheck/HealthCheckControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/HealthCheck/HealthCheckControllerBase.cs
@@ -6,7 +6,6 @@ using Constants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Cms.Api.Management.Controllers.HealthCheck;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.HealthChecks.RoutePath.HealthCheck}")]
 [ApiExplorerSettings(GroupName = "Health Check")]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessSettings)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Help/HelpControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Help/HelpControllerBase.cs
@@ -3,7 +3,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Help;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("help")]
 [ApiExplorerSettings(GroupName = "Help")]
 public abstract class HelpControllerBase : ManagementApiControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/Indexer/IndexerControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Indexer/IndexerControllerBase.cs
@@ -3,7 +3,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Indexer;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("indexer")]
 [ApiExplorerSettings(GroupName = "Indexer")]
 public class IndexerControllerBase : ManagementApiControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/Install/InstallControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Install/InstallControllerBase.cs
@@ -10,7 +10,6 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 namespace Umbraco.Cms.Api.Management.Controllers.Install;
 
 [AllowAnonymous]
-[ApiController]
 [VersionedApiBackOfficeRoute("install")]
 [ApiExplorerSettings(GroupName = "Install")]
 [RequireRuntimeLevel(RuntimeLevel.Install)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Install/InstallControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Install/InstallControllerBase.cs
@@ -1,9 +1,9 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Api.Management.Filters;
 using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.Installer;
 using Umbraco.Cms.Core.Services.OperationStatus;
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Language/Item/LanguageEntityControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Language/Item/LanguageEntityControllerBase.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Language.Item;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Item}/{Constants.UdiEntityType.Language}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Language))]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessLanguages)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Language/LanguageControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Language/LanguageControllerBase.cs
@@ -7,7 +7,6 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Language;
 
-[ApiController]
 [VersionedApiBackOfficeRoute(Constants.UdiEntityType.Language)]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Language))]
 public abstract class LanguageControllerBase : ManagementApiControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/LogViewerControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/LogViewerControllerBase.cs
@@ -7,7 +7,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.LogViewer;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("log-viewer")]
 [ApiExplorerSettings(GroupName = "Log Viewer")]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessSettings)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/SavedSearch/SavedSearchLogViewerControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/SavedSearch/SavedSearchLogViewerControllerBase.cs
@@ -4,7 +4,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.LogViewer.SavedSearch;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("log-viewer/saved-search")]
 [ApiExplorerSettings(GroupName = "Log Viewer")]
 public class SavedSearchLogViewerControllerBase : LogViewerControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/SavedSearch/SavedSearchLogViewerControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/SavedSearch/SavedSearchLogViewerControllerBase.cs
@@ -8,7 +8,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.LogViewer.SavedSearch;
 [ApiExplorerSettings(GroupName = "Log Viewer")]
 public class SavedSearchLogViewerControllerBase : LogViewerControllerBase
 {
-
     protected IActionResult SavedSearchNotFound() => NotFound(new ProblemDetailsBuilder()
         .WithTitle("The saved search could not be found")
         .Build());

--- a/src/Umbraco.Cms.Api.Management/Controllers/ManagementApiControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/ManagementApiControllerBase.cs
@@ -16,6 +16,7 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers;
 
+[ApiController]
 [Authorize(Policy = AuthorizationPolicies.BackOfficeAccess)]
 [Authorize(Policy = AuthorizationPolicies.UmbracoFeatureEnabled)]
 [MapToApi(ManagementApiConfiguration.ApiName)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Collection/MediaCollectionControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Collection/MediaCollectionControllerBase.cs
@@ -12,7 +12,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Media.Collection;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Collection}/{Constants.UdiEntityType.Media}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Media))]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessMedia)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/MediaItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/MediaItemControllerBase.cs
@@ -8,7 +8,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 namespace Umbraco.Cms.Api.Management.Controllers.Media.Item;
 
 [ApiVersion("1.0")]
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Item}/{Constants.UdiEntityType.Media}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Media))]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessForMediaTree)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/MediaItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/MediaItemControllerBase.cs
@@ -7,7 +7,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Media.Item;
 
-[ApiVersion("1.0")]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Item}/{Constants.UdiEntityType.Media}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Media))]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessForMediaTree)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/MediaControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/MediaControllerBase.cs
@@ -13,7 +13,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Media;
 
-[ApiController]
 [VersionedApiBackOfficeRoute(Constants.UdiEntityType.Media)]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Media))]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessMedia)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/MediaControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/MediaControllerBase.cs
@@ -1,13 +1,10 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Controllers.Content;
 using Umbraco.Cms.Api.Management.Routing;
-using Umbraco.Cms.Api.Management.ViewModels.Content;
 using Umbraco.Cms.Api.Management.ViewModels.Media;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.ContentEditing;
-using Umbraco.Cms.Core.Models.ContentEditing.Validation;
 using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Cms.Web.Common.Authorization;
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/RecycleBin/MediaRecycleBinControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/RecycleBin/MediaRecycleBinControllerBase.cs
@@ -1,14 +1,14 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Models.Entities;
-using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Api.Management.Controllers.RecycleBin;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.Filters;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Api.Management.ViewModels.Media.RecycleBin;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Entities;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Media.RecycleBin;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/RecycleBin/MediaRecycleBinControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/RecycleBin/MediaRecycleBinControllerBase.cs
@@ -13,7 +13,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Media.RecycleBin;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.RecycleBin}/{Constants.UdiEntityType.Media}")]
 [RequireMediaTreeRootAccess]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Media))]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Tree/MediaTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Tree/MediaTreeControllerBase.cs
@@ -1,16 +1,16 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Controllers.Tree;
+using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Api.Management.Services.Entities;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Api.Management.Controllers.Tree;
-using Umbraco.Cms.Api.Management.Factories;
-using Umbraco.Cms.Api.Management.Services.Entities;
-using Umbraco.Cms.Api.Management.Routing;
-using Umbraco.Cms.Api.Management.ViewModels.Tree;
 using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Media.Tree;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Tree/MediaTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Tree/MediaTreeControllerBase.cs
@@ -15,7 +15,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Media.Tree;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.Media}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Media))]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessForMediaTree)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Folder/MediaTypeFolderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Folder/MediaTypeFolderControllerBase.cs
@@ -9,7 +9,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MediaType.Folder;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.MediaType}/folder")]
 [ApiExplorerSettings(GroupName = "Media Type")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessMediaTypes)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/MediaTypeItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/MediaTypeItemControllerBase.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MediaType.Item;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Item}/{Constants.UdiEntityType.MediaType}")]
 [ApiExplorerSettings(GroupName = "Media Type")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessMediaTypes)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/MediaTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/MediaTypeControllerBase.cs
@@ -8,7 +8,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MediaType;
 
-[ApiController]
 [VersionedApiBackOfficeRoute(Constants.UdiEntityType.MediaType)]
 [ApiExplorerSettings(GroupName = "Media Type")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessMediaTypes)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Tree/MediaTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Tree/MediaTypeTreeControllerBase.cs
@@ -11,7 +11,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MediaType.Tree;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.MediaType}")]
 [ApiExplorerSettings(GroupName = "Media Type")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessMediaTypes)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Tree/MediaTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Tree/MediaTypeTreeControllerBase.cs
@@ -1,12 +1,12 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Controllers.Tree;
+using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Api.Management.Controllers.Tree;
-using Umbraco.Cms.Api.Management.Routing;
-using Umbraco.Cms.Api.Management.ViewModels.Tree;
 using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MediaType.Tree;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/Filter/MemberFilterControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/Filter/MemberFilterControllerBase.cs
@@ -7,7 +7,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Member.Filter;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Filter}/{Constants.UdiEntityType.Member}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Member))]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessForMemberTree)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/Item/MemberItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/Item/MemberItemControllerBase.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Member.Item;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Item}/{Constants.UdiEntityType.Member}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Member))]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessForMemberTree)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/MemberControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/MemberControllerBase.cs
@@ -11,7 +11,6 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Member;
 
-[ApiController]
 [VersionedApiBackOfficeRoute(Constants.UdiEntityType.Member)]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Member))]
 // FIXME: implement authorization

--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/MemberControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/MemberControllerBase.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Controllers.Content;
 using Umbraco.Cms.Api.Management.Routing;
-using Umbraco.Cms.Api.Management.ViewModels.Content;
 using Umbraco.Cms.Api.Management.ViewModels.Member;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.ContentEditing;

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberGroup/Item/MemberGroupItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberGroup/Item/MemberGroupItemControllerBase.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MemberGroup.Item;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Item}/{Constants.UdiEntityType.MemberGroup}")]
 [ApiExplorerSettings(GroupName = "Member Group")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessMemberGroups)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberGroup/MemberGroupControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberGroup/MemberGroupControllerBase.cs
@@ -9,7 +9,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MemberGroup;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.MemberGroup}")]
 [ApiExplorerSettings(GroupName = "Member Group")]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessMembers)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberGroup/Tree/MemberGroupTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberGroup/Tree/MemberGroupTreeControllerBase.cs
@@ -1,11 +1,11 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Controllers.Tree;
+using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Api.Management.Controllers.Tree;
-using Umbraco.Cms.Api.Management.ViewModels.Tree;
-using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MemberGroup.Tree;

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberGroup/Tree/MemberGroupTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberGroup/Tree/MemberGroupTreeControllerBase.cs
@@ -10,7 +10,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MemberGroup.Tree;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.MemberGroup}")]
 [ApiExplorerSettings(GroupName = "Member Group")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessMemberGroups)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Item/MemberTypeItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Item/MemberTypeItemControllerBase.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MemberType.Item;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Item}/{Constants.UdiEntityType.MemberType}")]
 [ApiExplorerSettings(GroupName = "Member Type")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessMemberTypes)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/MemberTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/MemberTypeControllerBase.cs
@@ -8,7 +8,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MemberType;
 
-[ApiController]
 [VersionedApiBackOfficeRoute(Constants.UdiEntityType.MemberType)]
 [ApiExplorerSettings(GroupName = "Member Type")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessMemberTypes)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Tree/MemberTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Tree/MemberTypeTreeControllerBase.cs
@@ -10,7 +10,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MemberType.Tree;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.MemberType}")]
 [ApiExplorerSettings(GroupName = "Member Type")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessMemberTypes)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Tree/MemberTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Tree/MemberTypeTreeControllerBase.cs
@@ -1,11 +1,11 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Controllers.Tree;
+using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Api.Management.Controllers.Tree;
-using Umbraco.Cms.Api.Management.ViewModels.Tree;
-using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.MemberType.Tree;

--- a/src/Umbraco.Cms.Api.Management/Controllers/ModelsBuilder/ModelsBuilderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/ModelsBuilder/ModelsBuilderControllerBase.cs
@@ -5,7 +5,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.ModelsBuilder;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("models-builder")]
 [ApiExplorerSettings(GroupName = "Models Builder")]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessSettings)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/ObjectTypes/ObjectTypesControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/ObjectTypes/ObjectTypesControllerBase.cs
@@ -3,7 +3,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.ObjectTypes;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("object-types")]
 [ApiExplorerSettings(GroupName = "Object Types")]
 public class ObjectTypesControllerBase : ManagementApiControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/Package/Created/CreatedPackageControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Package/Created/CreatedPackageControllerBase.cs
@@ -4,7 +4,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Package.Created;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("package/created")]
 [ApiExplorerSettings(GroupName = "Package")]
 public class CreatedPackageControllerBase : PackageControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/Package/PackageControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Package/PackageControllerBase.cs
@@ -7,7 +7,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Package;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("package")]
 [ApiExplorerSettings(GroupName = "Package")]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessPackages)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Folder/PartialViewFolderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Folder/PartialViewFolderControllerBase.cs
@@ -8,7 +8,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PartialView.Folder;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.PartialView}/folder")]
 [ApiExplorerSettings(GroupName = "Partial View")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessPartialViews)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Item/PartialViewItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Item/PartialViewItemControllerBase.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PartialView.Item;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Item}/{Constants.UdiEntityType.PartialView}")]
 [ApiExplorerSettings(GroupName = "Partial View")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessPartialViews)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/PartialViewControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/PartialViewControllerBase.cs
@@ -8,7 +8,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PartialView;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.PartialView}")]
 [ApiExplorerSettings(GroupName = "Partial View")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessPartialViews)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Tree/PartialViewTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Tree/PartialViewTreeControllerBase.cs
@@ -8,7 +8,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PartialView.Tree;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.PartialView}")]
 [ApiExplorerSettings(GroupName = "Partial View")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessPartialViews)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Tree/PartialViewTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Tree/PartialViewTreeControllerBase.cs
@@ -1,9 +1,9 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Api.Management.Controllers.Tree;
 using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PartialView.Tree;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Preview/PreviewControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Preview/PreviewControllerBase.cs
@@ -1,7 +1,5 @@
-﻿using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
-using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Preview;
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Preview/PreviewControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Preview/PreviewControllerBase.cs
@@ -5,7 +5,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Preview;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("preview")]
 [ApiExplorerSettings(GroupName = "Preview")]
 public class PreviewControllerBase : ManagementApiControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/Profiling/ProfilingControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Profiling/ProfilingControllerBase.cs
@@ -7,7 +7,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Profiling;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("profiling")]
 [ApiExplorerSettings(GroupName = "Profiling")]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessSettings)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/PropertyType/PropertyTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PropertyType/PropertyTypeControllerBase.cs
@@ -7,7 +7,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PropertyType;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("property-type")]
 [ApiExplorerSettings(GroupName = "Property Type")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentTypes)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/PublishedCacheControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/PublishedCacheControllerBase.cs
@@ -3,7 +3,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PublishedCache;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("published-cache")]
 [ApiExplorerSettings(GroupName = "Published Cache")]
 public class PublishedCacheControllerBase : ManagementApiControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/RedirectUrlManagementControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/RedirectUrlManagementControllerBase.cs
@@ -5,7 +5,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.RedirectUrlManagement;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("redirect-management")]
 [ApiExplorerSettings(GroupName = "Redirect Management")]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessContent)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/RedirectUrlManagementControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/RedirectUrlManagementControllerBase.cs
@@ -10,5 +10,4 @@ namespace Umbraco.Cms.Api.Management.Controllers.RedirectUrlManagement;
 [Authorize(Policy = AuthorizationPolicies.SectionAccessContent)]
 public class RedirectUrlManagementControllerBase : ManagementApiControllerBase
 {
-
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Relation/RelationControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Relation/RelationControllerBase.cs
@@ -7,7 +7,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Relation;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("relation")]
 [ApiExplorerSettings(GroupName = "Relation")]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessContent)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Item/RelationTypeItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Item/RelationTypeItemControllerBase.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.RelationType.Item;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Item}/{Constants.UdiEntityType.RelationType}")]
 [ApiExplorerSettings(GroupName = "Relation Type")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessRelationTypes)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Query/RelationTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Query/RelationTypeControllerBase.cs
@@ -9,7 +9,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.RelationType.Query;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.RelationType}")]
 [ApiExplorerSettings(GroupName = "Relation Type")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessRelationTypes)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Tree/RelationTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Tree/RelationTypeTreeControllerBase.cs
@@ -11,7 +11,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.RelationType.Tree;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.RelationType}")]
 [ApiExplorerSettings(GroupName = "Relation Type")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessRelationTypes)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Tree/RelationTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Tree/RelationTypeTreeControllerBase.cs
@@ -1,12 +1,12 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Controllers.Tree;
+using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Api.Management.ViewModels;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Api.Management.Controllers.Tree;
-using Umbraco.Cms.Api.Management.ViewModels.Tree;
-using Umbraco.Cms.Api.Management.Routing;
-using Umbraco.Cms.Api.Management.ViewModels;
 using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.RelationType.Tree;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/Folder/ScriptFolderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/Folder/ScriptFolderControllerBase.cs
@@ -8,7 +8,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Script.Folder;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.Script}/folder")]
 [ApiExplorerSettings(GroupName = "Script")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessScripts)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/Item/ScriptItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/Item/ScriptItemControllerBase.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Script.Item;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Item}/{Constants.UdiEntityType.Script}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Script))]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessScripts)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/ScriptControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/ScriptControllerBase.cs
@@ -9,7 +9,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Script;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.Script}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Script))]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessScripts)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/Tree/ScriptTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/Tree/ScriptTreeControllerBase.cs
@@ -8,7 +8,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Script.Tree;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.Script}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Script))]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessScripts)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Searcher/SearcherControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Searcher/SearcherControllerBase.cs
@@ -3,7 +3,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Searcher;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("searcher")]
 [ApiExplorerSettings(GroupName = "Searcher")]
 public class SearcherControllerBase : ManagementApiControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeController.cs
@@ -2,7 +2,6 @@
 using Asp.Versioning;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -14,12 +13,12 @@ using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Web.Common.Security;
 using Umbraco.Extensions;
 using IdentitySignInResult = Microsoft.AspNetCore.Identity.SignInResult;
 using SignInResult = Microsoft.AspNetCore.Mvc.SignInResult;
-using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Web.Common.Security;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Security;
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeController.cs
@@ -24,7 +24,6 @@ using Umbraco.Cms.Web.Common.Security;
 namespace Umbraco.Cms.Api.Management.Controllers.Security;
 
 [ApiVersion("1.0")]
-[ApiController]
 [VersionedApiBackOfficeRoute(Common.Security.Paths.BackOfficeApi.EndpointTemplate)]
 [ApiExplorerSettings(IgnoreApi = true)]
 public class BackOfficeController : SecurityControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/SecurityControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/SecurityControllerBase.cs
@@ -8,7 +8,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Security;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("security")]
 [ApiExplorerSettings(GroupName = "Security")]
 [Authorize(Policy = AuthorizationPolicies.DenyLocalLoginIfConfigured)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Server/ServerControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Server/ServerControllerBase.cs
@@ -7,5 +7,4 @@ namespace Umbraco.Cms.Api.Management.Controllers.Server;
 [ApiExplorerSettings(GroupName = "Server")]
 public abstract class ServerControllerBase : ManagementApiControllerBase
 {
-
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Server/ServerControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Server/ServerControllerBase.cs
@@ -3,7 +3,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Server;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("server")]
 [ApiExplorerSettings(GroupName = "Server")]
 public abstract class ServerControllerBase : ManagementApiControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Item/StaticFileItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Item/StaticFileItemControllerBase.cs
@@ -4,7 +4,6 @@ using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Api.Management.Controllers.StaticFile.Item;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Item}/static-file")]
 [ApiExplorerSettings(GroupName = "Static File")]
 public class StaticFileItemControllerBase : ManagementApiControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Tree/StaticFileTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Tree/StaticFileTreeControllerBase.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Core.IO;
 
 namespace Umbraco.Cms.Api.Management.Controllers.StaticFile.Tree;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/static-file")]
 [ApiExplorerSettings(GroupName = "Static File")]
 public class StaticFileTreeControllerBase : FileSystemTreeControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Folder/StylesheetFolderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Folder/StylesheetFolderControllerBase.cs
@@ -8,7 +8,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet.Folder;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.Stylesheet}/folder")]
 [ApiExplorerSettings(GroupName = "Stylesheet")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessStylesheets)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Item/StylesheetItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Item/StylesheetItemControllerBase.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet.Item;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Item}/{Constants.UdiEntityType.Stylesheet}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Stylesheet))]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessStylesheets)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/StylesheetControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/StylesheetControllerBase.cs
@@ -9,7 +9,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.Stylesheet}")]
 [ApiExplorerSettings(GroupName = "Stylesheet")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessStylesheets)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Tree/StylesheetTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Tree/StylesheetTreeControllerBase.cs
@@ -8,7 +8,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet.Tree;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.Stylesheet}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Stylesheet))]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessStylesheets)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Tag/TagControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tag/TagControllerBase.cs
@@ -3,7 +3,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Tag;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("tag")]
 [ApiExplorerSettings(GroupName = "Tag")]
 public class TagControllerBase : ManagementApiControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/Telemetry/TelemetryControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Telemetry/TelemetryControllerBase.cs
@@ -5,7 +5,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Telemetry;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("telemetry")]
 [ApiExplorerSettings(GroupName = "Telemetry")]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessSettings)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Item/TemplateItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Item/TemplateItemControllerBase.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Template.Item;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Item}/{Constants.UdiEntityType.Template}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Template))]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessTemplates)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/TemplateControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/TemplateControllerBase.cs
@@ -9,7 +9,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Template;
 
-[ApiController]
 [VersionedApiBackOfficeRoute(Constants.UdiEntityType.Template)]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Template))]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessTemplates)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Tree/TemplateTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Tree/TemplateTreeControllerBase.cs
@@ -1,11 +1,11 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Controllers.Tree;
+using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Api.Management.Controllers.Tree;
-using Umbraco.Cms.Api.Management.ViewModels.Tree;
-using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Template.Tree;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Tree/TemplateTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Tree/TemplateTreeControllerBase.cs
@@ -10,7 +10,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Template.Tree;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.Template}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Template))]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessTemplates)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/TemporaryFile/TemporaryFileControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/TemporaryFile/TemporaryFileControllerBase.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.TemporaryFile;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("temporary-file")]
 [ApiExplorerSettings(GroupName = "Temporary File")]
 public abstract class TemporaryFileControllerBase : ManagementApiControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/Tour/TourControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tour/TourControllerBase.cs
@@ -5,7 +5,6 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Tour;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("tour")]
 [ApiExplorerSettings(GroupName = "Tour")]
 public class TourControllerBase : ManagementApiControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/TrackedReferencesControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/TrackedReference/TrackedReferencesControllerBase.cs
@@ -5,7 +5,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.TrackedReference;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("tracked-reference")]
 [ApiExplorerSettings(GroupName = "Tracked Reference")]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessContentOrMedia)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Tree/FileSystemTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tree/FileSystemTreeControllerBase.cs
@@ -1,10 +1,10 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Core.IO;
-using Umbraco.Cms.Api.Management.Services.Paging;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.Extensions;
+using Umbraco.Cms.Api.Management.Services.Paging;
 using Umbraco.Cms.Api.Management.ViewModels.FileSystem;
 using Umbraco.Cms.Api.Management.ViewModels.Tree;
+using Umbraco.Cms.Core.IO;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Tree;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Tree/FolderTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tree/FolderTreeControllerBase.cs
@@ -1,8 +1,8 @@
-﻿using Umbraco.Cms.Core;
+﻿using Umbraco.Cms.Api.Management.ViewModels.Tree;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Tree;
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Tree/UserStartNodeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tree/UserStartNodeTreeControllerBase.cs
@@ -1,9 +1,9 @@
-﻿using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Models.Entities;
-using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Api.Management.Models.Entities;
+﻿using Umbraco.Cms.Api.Management.Models.Entities;
 using Umbraco.Cms.Api.Management.Services.Entities;
 using Umbraco.Cms.Api.Management.ViewModels.Tree;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models.Entities;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Tree;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Upgrade/UpgradeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Upgrade/UpgradeControllerBase.cs
@@ -1,9 +1,9 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Api.Management.Filters;
 using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.Installer;
 using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Cms.Web.Common.Authorization;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Upgrade/UpgradeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Upgrade/UpgradeControllerBase.cs
@@ -10,7 +10,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Upgrade;
 
-[ApiController]
 [RequireRuntimeLevel(RuntimeLevel.Upgrade)]
 [VersionedApiBackOfficeRoute("upgrade")]
 [ApiExplorerSettings(GroupName = "Upgrade")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/Current/CurrentUserControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/Current/CurrentUserControllerBase.cs
@@ -3,7 +3,6 @@ using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User.Current;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("user/current")]
 public abstract class CurrentUserControllerBase : UserOrCurrentUserControllerBase
 {

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/Current/CurrentUserControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/Current/CurrentUserControllerBase.cs
@@ -1,11 +1,9 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Management.Routing;
+﻿using Umbraco.Cms.Api.Management.Routing;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User.Current;
 
 [VersionedApiBackOfficeRoute("user/current")]
 public abstract class CurrentUserControllerBase : UserOrCurrentUserControllerBase
 {
-
 }
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/Filter/UserFilterControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/Filter/UserFilterControllerBase.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Web.Common.Authorization;

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/Filter/UserFilterControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/Filter/UserFilterControllerBase.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User.Filter;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Filter}/user")]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessUsers)]
 public abstract class UserFilterControllerBase : UserOrCurrentUserControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/Item/UserItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/Item/UserItemControllerBase.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User.Item;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Item}/user")]
 [ApiExplorerSettings(GroupName = "User")]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessUsers)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/UserControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/UserControllerBase.cs
@@ -5,7 +5,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("user")]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessUsers)]
 public abstract class UserControllerBase : UserOrCurrentUserControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/UserControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/UserControllerBase.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Web.Common.Authorization;
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/UserOrCurrentUserControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/UserOrCurrentUserControllerBase.cs
@@ -5,7 +5,6 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User;
 
-[ApiController]
 [ApiExplorerSettings(GroupName = "User")]
 public abstract class UserOrCurrentUserControllerBase : ManagementApiControllerBase
 {

--- a/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/Item/UserGroupItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/Item/UserGroupItemControllerBase.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.UserGroup.Item;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Item}/user-group")]
 [ApiExplorerSettings(GroupName = "User Group")]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessUsers)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/UserGroupsControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/UserGroupsControllerBase.cs
@@ -8,7 +8,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.UserGroup;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("user-group")]
 [ApiExplorerSettings(GroupName = "User Group")]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessUsers)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Webhook/Item/WebhookEntityControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Webhook/Item/WebhookEntityControllerBase.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Webhook.Item;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.Webhook}")]
 [ApiExplorerSettings(GroupName = "Webhook")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessWebhooks)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Webhook/WebhookControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Webhook/WebhookControllerBase.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Webhook;
 
-[ApiController]
 [VersionedApiBackOfficeRoute("webhook")]
 [ApiExplorerSettings(GroupName = "Webhook")]
 public abstract class WebhookControllerBase : ManagementApiControllerBase


### PR DESCRIPTION
## Details
- According to [the docs](https://learn.microsoft.com/en-us/aspnet/core/web-api/?view=aspnetcore-5.0#attribute-on-multiple-controllers-2) applying the `[ApiController]` to our `ManagementApiControllerBase` is sufficient to apply it to all of our deriving controllers:
  - Applying it to `ManagementApiControllerBase`;
  - Removing `[ApiController]` from all deriving controllers - both from `ManagementApiControllerBase` and `DeliveryApiControllerBase`;
- Removing `[ApiVersion("1.0")]` from a base class (`MediaItemControllerBase`) - we only apply it to our APIs;
- General usages cleanup.

## Test
- Only `DeliveryApiControllerBase` and `ManagementApiControllerBase` have the `[ApiController]` attribute;
- Smoke test different endpoints - Get/Post/Put to make sure the binding still works.
