### PR TITLE
Enable member management authorization

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/Filter/MemberFilterControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/Filter/MemberFilterControllerBase.cs
@@ -10,7 +10,7 @@ namespace Umbraco.Cms.Api.Management.Controllers.Member.Filter;
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Filter}/{Constants.UdiEntityType.Member}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Member))]
-[Authorize(Policy = AuthorizationPolicies.SectionAccessForMemberTree)]
+[Authorize(Policy = AuthorizationPolicies.SectionAccessMembers)]
 public abstract class MemberFilterControllerBase : ManagementApiControllerBase
 {
     protected IActionResult MemberTypeNotFound()

--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/Filter/MemberFilterControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/Filter/MemberFilterControllerBase.cs
@@ -1,17 +1,13 @@
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Services.OperationStatus;
-using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Member.Filter;
 
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Filter}/{Constants.UdiEntityType.Member}")]
-[ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Member))]
-[Authorize(Policy = AuthorizationPolicies.SectionAccessMembers)]
-public abstract class MemberFilterControllerBase : ManagementApiControllerBase
+public abstract class MemberFilterControllerBase : MemberControllerBase
 {
     protected IActionResult MemberTypeNotFound()
         => OperationStatusResult(ContentEditingOperationStatus.NotFound, problemDetailsBuilder

--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/MemberControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/MemberControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Controllers.Content;
@@ -8,14 +9,14 @@ using Umbraco.Cms.Api.Management.ViewModels.Member;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Member;
 
 [ApiController]
 [VersionedApiBackOfficeRoute(Constants.UdiEntityType.Member)]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Member))]
-// FIXME: implement authorization
-// [Authorize(Policy = AuthorizationPolicies.SectionAccessMembers)]
+[Authorize(Policy = AuthorizationPolicies.SectionAccessMembers)]
 public class MemberControllerBase : ContentControllerBase
 {
     protected IActionResult MemberNotFound() => OperationStatusResult(MemberEditingOperationStatus.MemberNotFound, MemberNotFound);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Enabled section based authorization for member management endpoints.

### Testing
The following endpoints should only be available if you have access to the member section
- [ ] [GET] /umbraco/management/api/v1/filter/member
- [ ] [POST] /umbraco/management/api/v1/member
- [ ] [GET] /umbraco/management/api/v1/member/{id}
- [ ] [DELETE] /umbraco/management/api/v1/member/{id}
- [ ] [PUT] /umbraco/management/api/v1/member/{id}
- [ ] [PUT] /umbraco/management/api/v1/member/{id}/validate
- [ ] [POST] /umbraco/management/api/v1/member/{id}/validate

The following endpoint should be available when have access to either of the following sections: content, media, member (for use in pickers used in those sections)
- [ ] [GET] /umbraco/management/api/v1/item/member