### PR TITLE
V13: Incorrectly parsing item id by DeliveryApiContentIndex caused incorrect information when deleting a content item

### DIFF
--- a/src/Umbraco.Examine.Lucene/DeliveryApiContentIndex.cs
+++ b/src/Umbraco.Examine.Lucene/DeliveryApiContentIndex.cs
@@ -1,9 +1,9 @@
+using System.Globalization;
 using Examine;
 using Examine.Lucene;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Hosting;
@@ -125,8 +125,14 @@ public class DeliveryApiContentIndex : UmbracoExamineIndex
 
     private (string? ContentId, string? Culture) ParseItemId(string id)
     {
+        if (int.TryParse(id, out _))
+        {
+            return (id, null);
+        }
+
         DeliveryApiIndexCompositeIdModel compositeIdModel = _deliveryApiCompositeIdHandler.Decompose(id);
-        return (compositeIdModel.Id.ToString() ?? id, compositeIdModel.Culture);
+
+        return (compositeIdModel.Id?.ToString(CultureInfo.InvariantCulture), compositeIdModel.Culture);
     }
 
     protected override void OnTransformingIndexValues(IndexingItemEventArgs e)


### PR DESCRIPTION
## Details
Fixes https://github.com/umbraco/Umbraco-CMS/issues/15792
- As a result of the new https://github.com/umbraco/Umbraco-CMS/pull/15305, we didn't parse a noncomposite id correctly, so we returned an empty string instead of `null`, resulting in Lucene error _(seen in the logs):_
![Err](https://github.com/umbraco/Umbraco-CMS/assets/21998037/74cc6cb7-b972-4dff-86a1-07e7fe49e02a)
-
  - Which on its hand caused incorrect data in DeliveryApiContentIndex when a content item has been deleted.
- This PR fixes that and makes sure we follow the practice: `int.ToString(CultureInfo.InvariantCulture)` when converting ints to strings.

## Test
- Follow the Steps to reproduce in the original issue
  - Make sure that the total amount of items and the number of items in the `items` collection is correct after deleting a content item (**both variant and invariant**) and making a GET request to
`/umbraco/delivery/api/v2/content`
