### PR TITLE
Added a check for the runtime mode and showed the relevant error mess…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.create.controller.js
@@ -22,6 +22,7 @@ function contentCreateController($scope,
     function initialize() {
         $scope.loading = true;
         $scope.allowedTypes = null;
+        $scope.runtimeModeProduction = Umbraco.Sys.ServerVariables.application.runtimeMode == 'Production';
 
         var getAllowedTypes = contentTypeResource.getAllowedTypes($scope.currentNode.id).then(function (data) {
             $scope.allowedTypes = iconHelper.formatContentTypeIcons(data);

--- a/src/Umbraco.Web.UI.Client/src/views/content/create.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/create.html
@@ -9,10 +9,10 @@
             <h5 ng-show="selectBlueprint"><localize key="blueprints_selectBlueprint">Select a blueprint</localize></h5>
 
             <div ng-if="allowedTypes && allowedTypes.length === 0">
-                <p class="abstract" ng-if="!hasSettingsAccess">
+                <p class="abstract" ng-if="!hasSettingsAccess || runtimeModeProduction">
                     <localize key="create_noDocumentTypesWithNoSettingsAccess">The selected page in the content tree doesn't allow for any pages to be created below it.</localize>
                 </p>
-                <div ng-if="hasSettingsAccess && currentNode.id >= 0">
+                <div ng-if="hasSettingsAccess && currentNode.id >= 0 && !runtimeModeProduction">
                     <p class="abstract">
                         <localize key="create_noDocumentTypes">There are no allowed Document Types available for creating content here. You must enable these in <strong>Document
                             Types</strong> within the <strong>Settings</strong> section, by editing the <strong>Allowed child node


### PR DESCRIPTION
…age if

### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes the PR raised by @marcemarc 

Fixes #15758 

So now with this PR, when in Production Mode, instead of showing this:

![image](https://github.com/umbraco/Umbraco-CMS/assets/9142936/732f01fe-3a52-4fdf-ae43-a889cde977c1)

We now show this:

![image](https://github.com/umbraco/Umbraco-CMS/assets/9142936/770fd3a9-b639-496c-9456-d102aca7109d)