### PR TITLE
Fixing locking issues for document type saves.

### DIFF
--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDistributedLockingMechanism.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDistributedLockingMechanism.cs
@@ -134,9 +134,9 @@ public class SqlServerDistributedLockingMechanism : IDistributedLockingMechanism
 
             const string query = "SELECT value FROM umbracoLock WITH (REPEATABLEREAD)  WHERE id=@id";
 
-            db.Execute("SET LOCK_TIMEOUT " + _timeout.TotalMilliseconds + ";");
+            var lockTimeoutQuery = "SET LOCK_TIMEOUT " + _timeout.TotalMilliseconds + ";";
 
-            var i = db.ExecuteScalar<int?>(query, new { id = LockId });
+            var i = db.ExecuteScalar<int?>(lockTimeoutQuery + query, new { id = LockId });
 
             if (i == null)
             {
@@ -169,9 +169,9 @@ public class SqlServerDistributedLockingMechanism : IDistributedLockingMechanism
             const string query =
                 @"UPDATE umbracoLock WITH (REPEATABLEREAD) SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id=@id";
 
-            db.Execute("SET LOCK_TIMEOUT " + _timeout.TotalMilliseconds + ";");
+            var lockTimeoutQuery = "SET LOCK_TIMEOUT " + _timeout.TotalMilliseconds + ";";
 
-            var i = db.Execute(query, new { id = LockId });
+            var i = db.Execute(lockTimeoutQuery+query, new { id = LockId });
 
             if (i == 0)
             {

--- a/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteDistributedLockingMechanism.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteDistributedLockingMechanism.cs
@@ -154,7 +154,7 @@ public class SqliteDistributedLockingMechanism : IDistributedLockingMechanism
 
             try
             {
-                var i = command.ExecuteNonQuery();
+                var i = db.ExecuteNonQuery(command);
 
                 if (i == 0)
                 {

--- a/src/Umbraco.Core/Persistence/Constants-Locks.cs
+++ b/src/Umbraco.Core/Persistence/Constants-Locks.cs
@@ -70,5 +70,10 @@ public static partial class Constants
         ///     ScheduledPublishing job.
         /// </summary>
         public const int ScheduledPublishing = -341;
+
+        /// <summary>
+        ///     CacheInstructions service.
+        /// </summary>
+        public const int CacheInstructions = -342;
     }
 }

--- a/src/Umbraco.Core/Services/ContentTypeService.cs
+++ b/src/Umbraco.Core/Services/ContentTypeService.cs
@@ -29,7 +29,7 @@ public class ContentTypeService : ContentTypeServiceBase<IContentTypeRepository,
     // beware! order is important to avoid deadlocks
     protected override int[] ReadLockIds { get; } = { Constants.Locks.ContentTypes };
 
-    protected override int[] WriteLockIds { get; } = { Constants.Locks.ContentTree, Constants.Locks.ContentTypes };
+    protected override int[] WriteLockIds { get; } = { Constants.Locks.ContentTree, Constants.Locks.ContentTypes, Constants.Locks.CacheInstructions};
 
     protected override Guid ContainedObjectType => Constants.ObjectTypes.DocumentType;
 

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
@@ -1015,6 +1015,8 @@ internal class DatabaseDataCreator
             new LockDto { Id = Constants.Locks.Languages, Name = "Languages" });
         _database.Insert(Constants.DatabaseSchema.Tables.Lock, "id", false,
             new LockDto { Id = Constants.Locks.ScheduledPublishing, Name = "ScheduledPublishing" });
+        _database.Insert(Constants.DatabaseSchema.Tables.Lock, "id", false,
+            new LockDto { Id = Constants.Locks.CacheInstructions, Name = "CacheInstructions" });
 
         _database.Insert(Constants.DatabaseSchema.Tables.Lock, "id", false,
             new LockDto { Id = Constants.Locks.MainDom, Name = "MainDom" });

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -7,6 +7,7 @@ using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_10_0_0;
 using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_10_2_0;
 using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_10_5_0;
 using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_10_7_0;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_10_9_0;
 using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_8_0_0;
 using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_8_0_1;
 using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_8_1_0;
@@ -307,5 +308,8 @@ public class UmbracoPlan : MigrationPlan
 
         // to 10.7.0
         To<MigrateTagsFromNVarcharToNText>("{EF93F398-1385-4F07-808A-D3C518984442}");
+
+        // to 10.9.0
+        To<AddCacheInstructionLock>("{75AB5D21-4464-40F5-A9D1-3E8CE0D89E38}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_10_9_0/AddCacheInstructionLock.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_10_9_0/AddCacheInstructionLock.cs
@@ -1,0 +1,30 @@
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_10_9_0;
+
+internal class AddCacheInstructionLock : MigrationBase
+{
+    public AddCacheInstructionLock(IMigrationContext context)
+        : base(context)
+    {
+    }
+
+    protected override void Migrate()
+    {
+        var currentCount = Database
+            .Fetch<int>(
+                Sql()
+                    .SelectCount()
+                    .From<LockDto>()
+                    .Where<LockDto>(x => x.Id == Constants.Locks.CacheInstructions))
+            .FirstOrDefault();
+        if (currentCount == 0)
+        {
+            Database.Insert(Constants.DatabaseSchema.Tables.Lock, "id", false,
+                new LockDto { Id = Constants.Locks.CacheInstructions, Name = "CacheInstructions" });
+        }
+
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/IUmbracoDatabase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/IUmbracoDatabase.cs
@@ -36,5 +36,5 @@ public interface IUmbracoDatabase : IDatabase
     DatabaseSchemaResult ValidateSchema();
 
     /// <returns>The number of rows affected.</returns>
-    int ExecuteNonQuery(DbCommand command);
+    int ExecuteNonQuery(DbCommand command) => command.ExecuteNonQuery();
 }

--- a/src/Umbraco.Infrastructure/Persistence/IUmbracoDatabase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/IUmbracoDatabase.cs
@@ -1,3 +1,4 @@
+using System.Data.Common;
 using NPoco;
 using Umbraco.Cms.Infrastructure.Migrations.Install;
 
@@ -33,4 +34,7 @@ public interface IUmbracoDatabase : IDatabase
     bool IsUmbracoInstalled();
 
     DatabaseSchemaResult ValidateSchema();
+
+    /// <returns>The number of rows affected.</returns>
+    int ExecuteNonQuery(DbCommand command);
 }

--- a/src/Umbraco.Infrastructure/Persistence/UmbracoDatabase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/UmbracoDatabase.cs
@@ -224,6 +224,14 @@ public class UmbracoDatabase : Database, IUmbracoDatabase
         return databaseSchemaValidationResult ?? new DatabaseSchemaResult();
     }
 
+    public int ExecuteNonQuery(DbCommand command)
+    {
+        OnExecutingCommand(command);
+        var i = command.ExecuteNonQuery();
+        OnExecutedCommand(command);
+        return i;
+    }
+
     /// <summary>
     ///     Returns true if Umbraco database tables are detected to be installed
     /// </summary>

--- a/src/Umbraco.Infrastructure/Services/CacheInstructionService.cs
+++ b/src/Umbraco.Infrastructure/Services/CacheInstructionService.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
@@ -77,6 +78,7 @@ namespace Umbraco.Cms
             public bool IsColdBootRequired(int lastId)
             {
                 using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
+                scope.ReadLock(Constants.Locks.CacheInstructions);
                 if (lastId <= 0)
                 {
                     var count = _cacheInstructionRepository.CountAll();
@@ -103,6 +105,7 @@ namespace Umbraco.Cms
             public bool IsInstructionCountOverLimit(int lastId, int limit, out int count)
             {
                 using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
+                scope.ReadLock(Constants.Locks.CacheInstructions);
                 // Check for how many instructions there are to process, each row contains a count of the number of instructions contained in each
                 // row so we will sum these numbers to get the actual count.
                 count = _cacheInstructionRepository.CountPendingInstructions(lastId);
@@ -113,6 +116,7 @@ namespace Umbraco.Cms
             public int GetMaxInstructionId()
             {
                 using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
+                scope.ReadLock(Constants.Locks.CacheInstructions);
                 return _cacheInstructionRepository.GetMaxId();
             }
 
@@ -123,6 +127,7 @@ namespace Umbraco.Cms
 
                 using (ICoreScope scope = ScopeProvider.CreateCoreScope())
                 {
+                    scope.WriteLock(Constants.Locks.CacheInstructions);
                     _cacheInstructionRepository.Add(entity);
                     scope.Complete();
                 }
@@ -134,6 +139,7 @@ namespace Umbraco.Cms
                 // Write the instructions but only create JSON blobs with a max instruction count equal to MaxProcessingInstructionCount.
                 using (ICoreScope scope = ScopeProvider.CreateCoreScope())
                 {
+                    scope.WriteLock(Constants.Locks.CacheInstructions);
                     foreach (IEnumerable<RefreshInstruction> instructionsBatch in instructions.InGroupsOf(
                                  _globalSettings.DatabaseServerMessenger.MaxProcessingInstructionCount))
                     {
@@ -157,6 +163,7 @@ namespace Umbraco.Cms
                 using (_profilingLogger.DebugDuration<CacheInstructionService>("Syncing from database..."))
                 using (ICoreScope scope = ScopeProvider.CreateCoreScope())
                 {
+                    scope.ReadLock(Constants.Locks.CacheInstructions);
                     var numberOfInstructionsProcessed = ProcessDatabaseInstructions(cacheRefreshers, cancellationToken, localIdentity, ref lastId);
 
                     // Check for pruning throttling.
@@ -251,6 +258,7 @@ namespace Umbraco.Cms
                     List<RefreshInstruction> instructionBatch = GetAllInstructions(jsonInstructions);
 
                     // Process as per-normal.
+
                     var success = ProcessDatabaseInstructions(cacheRefreshers, instructionBatch, instruction, processed, cancellationToken, ref lastId);
 
                     // If they couldn't be all processed (i.e. we're shutting down) then exit.

--- a/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentService.cs
+++ b/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentService.cs
@@ -127,9 +127,18 @@ public class NuCacheContentService : RepositoryService, INuCacheContentService
     {
         using (ICoreScope scope = ScopeProvider.CreateCoreScope(repositoryCacheMode: RepositoryCacheMode.Scoped))
         {
-            scope.ReadLock(Constants.Locks.ContentTree);
-            scope.ReadLock(Constants.Locks.MediaTree);
-            scope.ReadLock(Constants.Locks.MemberTree);
+            if (contentTypeIds is not null && contentTypeIds.Any())
+            {
+                scope.ReadLock(Constants.Locks.ContentTree);
+            }
+            if (mediaTypeIds is not null && mediaTypeIds.Any())
+            {
+                scope.ReadLock(Constants.Locks.MediaTree);
+            }
+            if (memberTypeIds is not null && memberTypeIds.Any())
+            {
+                scope.ReadLock(Constants.Locks.MemberTree);
+            }
 
             _repository.Rebuild(contentTypeIds, mediaTypeIds, memberTypeIds);
 

--- a/tests/Umbraco.Tests.Common/TestHelpers/TestDatabase.cs
+++ b/tests/Umbraco.Tests.Common/TestHelpers/TestDatabase.cs
@@ -93,6 +93,7 @@ public class TestDatabase : IUmbracoDatabase
     public bool IsUmbracoInstalled() => true;
 
     public DatabaseSchemaResult ValidateSchema() => throw new NotImplementedException();
+    public int ExecuteNonQuery(DbCommand command) => throw new NotImplementedException();
 
     public DbParameter CreateParameter() => throw new NotImplementedException();
 

--- a/tests/Umbraco.Tests.Common/TestHelpers/TestDatabase.cs
+++ b/tests/Umbraco.Tests.Common/TestHelpers/TestDatabase.cs
@@ -93,7 +93,6 @@ public class TestDatabase : IUmbracoDatabase
     public bool IsUmbracoInstalled() => true;
 
     public DatabaseSchemaResult ValidateSchema() => throw new NotImplementedException();
-    public int ExecuteNonQuery(DbCommand command) => throw new NotImplementedException();
 
     public DbParameter CreateParameter() => throw new NotImplementedException();
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/LocksTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/LocksTests.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NPoco;
@@ -15,7 +10,6 @@ using Umbraco.Cms.Persistence.Sqlite.Interceptors;
 using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
-using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence;
 
@@ -153,6 +147,37 @@ public class LocksTests : UmbracoIntegrationTest
         }
 
         Assert.AreEqual(0, sqlCount);
+    }
+
+    [Test]
+    public void GivenNonEagerLocking_WhenDbIsAccessed_ThenSqlIsExecuted()
+    {
+        var sqlCount = 0;
+
+        using (var scope = ScopeProvider.CreateScope())
+        {
+            var db = ScopeAccessor.AmbientScope.Database;
+            try
+            {
+                db.EnableSqlCount = true;
+
+                // Issue a lock request, but we are using non-eager
+                // locks so this only queues the request.
+                // The lock will not be issued unless we resolve
+                // scope.Database
+                scope.WriteLock(Constants.Locks.Servers);
+
+                scope.Database.ExecuteScalar<int>("SELECT 1");
+
+                sqlCount = db.SqlCount;
+            }
+            finally
+            {
+                db.EnableSqlCount = false;
+            }
+        }
+
+        Assert.AreEqual(2,sqlCount);
     }
 
     [Test]


### PR DESCRIPTION
### Description
This PR introduces a new lock for Cache Instructions, as this could lead to deadlocks.

Further it optimizes what locks are taking when `NuCache` is rebuilt, and only takes the lock for document, media and members when needed.

The SQL server lock is also optimized to only do one roundtrip to the database per lock instead of two.

Finally, the Sqlite lock did not call the OnExecutedCommand methods so was only passing a test by luck. This is not fixed by adding a new method on the `IUmbracoDatabase` with a default implementation, to avoid breaking changes.

I really hope this is the root cause to https://github.com/umbraco/Umbraco-CMS/issues/14195 🙈 

### Test
Things should still work, but one way to test it, is to load test the endpoints. This can quite easily be done by using the keyboard shortcuts in backoffice to save many times if you hold the short cuts down for like 30 sec.

#### Interesting things to test
  - Load test Document Type Save
  - Load test Media Type Save
  - Load test Member Type Save
  - Load test Document Save
   
 All tests needs to be done both with SqlServer and SQLite.

