### PR TITLE
Avoid string.Format allocations by ProfilingViewEngine when profiler is not enabled.

### DIFF
--- a/src/Umbraco.Core/Logging/IProfiler.cs
+++ b/src/Umbraco.Core/Logging/IProfiler.cs
@@ -27,4 +27,9 @@ public interface IProfiler
     ///     authenticated or you want to clear the results, based upon some other mechanism.
     /// </remarks>
     void Stop(bool discardResults = false);
+
+    /// <summary>
+    /// Whether the profiler is enabled.
+    /// </summary>
+    bool IsEnabled => true;
 }

--- a/src/Umbraco.Core/Logging/LogProfiler.cs
+++ b/src/Umbraco.Core/Logging/LogProfiler.cs
@@ -35,6 +35,9 @@ public class LogProfiler : IProfiler
         // the log never stops
     }
 
+    /// <inheritdoc />
+    public bool IsEnabled => _logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug);
+
     // a lightweight disposable timer
     private class LightDisposableTimer : DisposableObjectSlim
     {

--- a/src/Umbraco.Core/Logging/NoopProfiler.cs
+++ b/src/Umbraco.Core/Logging/NoopProfiler.cs
@@ -14,6 +14,9 @@ public class NoopProfiler : IProfiler
     {
     }
 
+    /// <inheritdoc/>
+    public bool IsEnabled => false;
+
     private class VoidDisposable : DisposableObjectSlim
     {
         protected override void DisposeResources()

--- a/src/Umbraco.Web.Common/Profiler/WebProfiler.cs
+++ b/src/Umbraco.Web.Common/Profiler/WebProfiler.cs
@@ -24,6 +24,9 @@ public class WebProfiler : IProfiler
     private int _first;
     private MiniProfiler? _startupProfiler;
 
+    /// <inheritdoc />
+    public bool IsEnabled => true;
+
     public IDisposable? Step(string name) => MiniProfiler.Current?.Step(name);
 
     public void Start()

--- a/src/Umbraco.Web.Website/ViewEngines/ProfilingViewEngine.cs
+++ b/src/Umbraco.Web.Website/ViewEngines/ProfilingViewEngine.cs
@@ -19,7 +19,7 @@ public class ProfilingViewEngine : IViewEngine
 
     public ViewEngineResult FindView(ActionContext context, string viewName, bool isMainPage)
     {
-        using (_profiler.Step(string.Format("{0}.FindView, {1}, {2}", _name, viewName, isMainPage)))
+        using (_profiler.IsEnabled ? _profiler.Step(string.Format("{0}.FindView, {1}, {2}", _name, viewName, isMainPage)) : null)
         {
             return WrapResult(Inner.FindView(context, viewName, isMainPage));
         }
@@ -27,7 +27,7 @@ public class ProfilingViewEngine : IViewEngine
 
     public ViewEngineResult GetView(string? executingFilePath, string viewPath, bool isMainPage)
     {
-        using (_profiler.Step(string.Format("{0}.GetView, {1}, {2}, {3}", _name, executingFilePath, viewPath, isMainPage)))
+        using (_profiler.IsEnabled ? _profiler.Step(string.Format("{0}.GetView, {1}, {2}, {3}", _name, executingFilePath, viewPath, isMainPage)) : null)
         {
             return Inner.GetView(executingFilePath, viewPath, isMainPage);
         }

--- a/tests/Umbraco.Tests.Common/TestHelpers/Stubs/TestProfiler.cs
+++ b/tests/Umbraco.Tests.Common/TestHelpers/Stubs/TestProfiler.cs
@@ -39,6 +39,9 @@ public class TestProfiler : IProfiler
         }
     }
 
+    /// <inheritdoc/>
+    public bool IsEnabled => _enabled;
+
     public static void Enable() => _enabled = true;
 
     public static void Disable() => _enabled = false;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

Each time ProfilingViewEngine.FindView and ProfilingViewEngine.GetView is called (each time a view is used) the ProfilingViewEngine calls string.Format for a log message as part of profiling. However, if Umbraco is not in debug mode, this is unnecessary as the IProfiler will be a NoOp and will discard the formatted string, however this formatted string is still allocated.

This PR adds a IsEnabled property to IProfiler, so the string.Format allocations can be avoided when the IProfiler is not enabled.

How to test?
Check that IProfiler.Step is not called when IProfiler is not enabled.

<!-- Thanks for contributing to Umbraco CMS! -->
