### PR TITLE
Update documentation for GetAllContentTags method in ITagQuery interface

### DIFF
--- a/src/Umbraco.Core/PublishedCache/ITagQuery.cs
+++ b/src/Umbraco.Core/PublishedCache/ITagQuery.cs
@@ -33,6 +33,11 @@ public interface ITagQuery
     /// <summary>
     ///     Gets all document tags.
     /// </summary>
+    ///   /// <remarks>
+    ///     If no culture is specified, it retrieves tags with an invariant culture.
+    ///     If a culture is specified, it only retrieves tags for that culture.
+    ///     Use "*" to retrieve tags for all cultures.
+    /// </remarks>
     IEnumerable<TagModel?> GetAllContentTags(string? group = null, string? culture = null);
 
     /// <summary>


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <[!-- link to the issue here!](https://github.com/umbraco/Umbraco-CMS/issues/15707) -->

### Description
<!-- 
I updated the documentation for the GetAllContentTags method in the ITagQuery interface. The documentation now clarifies the behavior of the method with regard to culture parameters:
![image](https://github.com/umbraco/Umbraco-CMS/assets/143370089/6945a2b0-9e36-438f-9a3c-c87c424e4872)


-->


