### PR TITLE
Removed "type" from tree item response models

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/DictionaryTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/DictionaryTreeControllerBase.cs
@@ -36,7 +36,6 @@ public class DictionaryTreeControllerBase : NamedEntityTreeControllerBase<NamedE
             {
                 Name = dictionaryItem.ItemKey,
                 Id = dictionaryItem.Key,
-                Type = Constants.UdiEntityType.DictionaryItem,
                 HasChildren = hasChildren,
                 Parent = parentKey.HasValue
                     ? new ReferenceByIdModel

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Tree/PartialViewTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Tree/PartialViewTreeControllerBase.cs
@@ -18,6 +18,4 @@ public class PartialViewTreeControllerBase : FileSystemTreeControllerBase
                         throw new ArgumentException("Missing partial views file system", nameof(fileSystems));
 
     protected override IFileSystem FileSystem { get; }
-
-    protected override string ItemType(string path) => Constants.UdiEntityType.PartialView;
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Tree/RelationTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Tree/RelationTypeTreeControllerBase.cs
@@ -30,7 +30,6 @@ public class RelationTypeTreeControllerBase : NamedEntityTreeControllerBase<Name
         {
             Name = relationType.Name!,
             Id = relationType.Key,
-            Type = Constants.UdiEntityType.RelationType,
             HasChildren = false,
             Parent = parentKey.HasValue
                 ? new ReferenceByIdModel

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/Tree/ScriptTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/Tree/ScriptTreeControllerBase.cs
@@ -18,6 +18,4 @@ public class ScriptTreeControllerBase : FileSystemTreeControllerBase
                         throw new ArgumentException("Missing scripts file system", nameof(fileSystems));
 
     protected override IFileSystem FileSystem { get; }
-
-    protected override string ItemType(string path) => Constants.UdiEntityType.Script;
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Tree/StaticFileTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Tree/StaticFileTreeControllerBase.cs
@@ -17,8 +17,6 @@ public class StaticFileTreeControllerBase : FileSystemTreeControllerBase
 
     protected override IFileSystem FileSystem { get; }
 
-    protected override string ItemType(string path) => "static-file";
-
     protected override string[] GetDirectories(string path) =>
         IsTreeRootPath(path)
             ? _allowedRootFolders

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Tree/StylesheetTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Tree/StylesheetTreeControllerBase.cs
@@ -18,6 +18,4 @@ public class StylesheetTreeControllerBase : FileSystemTreeControllerBase
                         throw new ArgumentException("Missing stylesheets file system", nameof(fileSystems));
 
     protected override IFileSystem FileSystem { get; }
-
-    protected override string ItemType(string path) => Constants.UdiEntityType.Stylesheet;
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Tree/EntityTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tree/EntityTreeControllerBase.cs
@@ -14,15 +14,8 @@ namespace Umbraco.Cms.Api.Management.Controllers.Tree;
 public abstract class EntityTreeControllerBase<TItem> : ManagementApiControllerBase
     where TItem : EntityTreeItemResponseModel, new()
 {
-    private readonly string _itemUdiType;
-
     protected EntityTreeControllerBase(IEntityService entityService)
-    {
-        EntityService = entityService;
-
-        // ReSharper disable once VirtualMemberCallInConstructor
-        _itemUdiType = ItemObjectType.GetUdiType();
-    }
+        => EntityService = entityService;
 
     protected IEntityService EntityService { get; }
 
@@ -117,7 +110,6 @@ public abstract class EntityTreeControllerBase<TItem> : ManagementApiControllerB
         var viewModel = new TItem
         {
             Id = entity.Key,
-            Type = _itemUdiType,
             HasChildren = entity.HasChildren,
             Parent = parentKey.HasValue
                 ? new ReferenceByIdModel

--- a/src/Umbraco.Cms.Api.Management/Controllers/Tree/FileSystemTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tree/FileSystemTreeControllerBase.cs
@@ -13,8 +13,6 @@ public abstract class FileSystemTreeControllerBase : ManagementApiControllerBase
 {
     protected abstract IFileSystem FileSystem { get; }
 
-    protected abstract string ItemType(string path);
-
     protected async Task<ActionResult<PagedViewModel<FileSystemTreeItemPresentationModel>>> GetRoot(int skip, int take)
     {
         if (PaginationService.ConvertSkipTakeToPaging(skip, take, out var pageNumber, out var pageSize, out ProblemDetails? error) == false)
@@ -88,7 +86,6 @@ public abstract class FileSystemTreeControllerBase : ManagementApiControllerBase
             Path = path.SystemPathToVirtualPath(),
             Name = name,
             HasChildren = isFolder && DirectoryHasChildren(path),
-            Type = ItemType(path),
             IsFolder = isFolder,
             Parent = parentPath.IsNullOrWhiteSpace()
                 ? null

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -32241,14 +32241,10 @@
           "hasChildren",
           "id",
           "isTrashed",
-          "noAccess",
-          "type"
+          "noAccess"
         ],
         "type": "object",
         "properties": {
-          "type": {
-            "type": "string"
-          },
           "hasChildren": {
             "type": "boolean"
           },
@@ -39634,14 +39630,10 @@
       },
       "TreeItemPresentationModel": {
         "required": [
-          "hasChildren",
-          "type"
+          "hasChildren"
         ],
         "type": "object",
         "properties": {
-          "type": {
-            "type": "string"
-          },
           "hasChildren": {
             "type": "boolean"
           }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Tree/TreeItemPresentationModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Tree/TreeItemPresentationModel.cs
@@ -2,7 +2,5 @@
 
 public class TreeItemPresentationModel
 {
-    public string Type { get; set; } = string.Empty;
-
     public bool HasChildren { get; set; }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR removes the "type" property of tree item response models in the Management API. It has long since been decided that this property was a client concern, so we need to remove it for clarity.

### Breaking change

This PR modifies the current API contract, thus it is breaking 👍 

### Testing this PR

The Management API should work as per usual 😄 