### PR TITLE
V14: Expose default list view ids in datatype configuration endpoint

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/ConfigurationDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/ConfigurationDataTypeController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Api.Management.ViewModels.DataType;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DataType;
@@ -22,7 +23,10 @@ public class ConfigurationDataTypeController : DataTypeControllerBase
         var responseModel = new DatatypeConfigurationResponseModel
         {
             CanBeChanged = _dataTypesSettings.CanBeChanged,
+            DocumentListViewId = Constants.DataTypes.Guids.ListViewContentGuid,
+            MediaListViewId = Constants.DataTypes.Guids.ListViewMediaGuid,
+            MemberListViewId = Constants.DataTypes.Guids.ListViewMembersGuid,
         };
-        return Task.FromResult<IActionResult>(Ok());
+        return Task.FromResult<IActionResult>(Ok(responseModel));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DatatypeConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DatatypeConfigurationResponseModel.cs
@@ -4,5 +4,11 @@ namespace Umbraco.Cms.Api.Management.ViewModels.DataType;
 
 public class DatatypeConfigurationResponseModel
 {
-    public required DataTypeChangeMode CanBeChanged { get; set; }
+    public required DataTypeChangeMode CanBeChanged { get; init; }
+
+    public required Guid DocumentListViewId { get; init; }
+
+    public required Guid MediaListViewId { get; init; }
+
+    public required Guid MemberListViewId { get; init; }
 }


### PR DESCRIPTION
Exposes the default list view ids in the datatype configuration endpoint