### PR TITLE
Add "is deletable" to relation types + align namespaces for controllers

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/ByKeyRelationTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/ByKeyRelationTypeController.cs
@@ -6,7 +6,7 @@ using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 
-namespace Umbraco.Cms.Api.Management.Controllers.RelationType.Query;
+namespace Umbraco.Cms.Api.Management.Controllers.RelationType;
 
 [ApiVersion("1.0")]
 public class ByKeyRelationTypeController : RelationTypeControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/CreateRelationTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/CreateRelationTypeController.cs
@@ -9,7 +9,7 @@ using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 
-namespace Umbraco.Cms.Api.Management.Controllers.RelationType.Query;
+namespace Umbraco.Cms.Api.Management.Controllers.RelationType;
 
 [ApiVersion("1.0")]
 public class CreateRelationTypeController : RelationTypeControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/DeleteRelationTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/DeleteRelationTypeController.cs
@@ -7,7 +7,7 @@ using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 
-namespace Umbraco.Cms.Api.Management.Controllers.RelationType.Query;
+namespace Umbraco.Cms.Api.Management.Controllers.RelationType;
 
 [ApiVersion("1.0")]
 public class DeleteRelationTypeController : RelationTypeControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/RelationTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/RelationTypeControllerBase.cs
@@ -7,7 +7,7 @@ using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Cms.Web.Common.Authorization;
 
-namespace Umbraco.Cms.Api.Management.Controllers.RelationType.Query;
+namespace Umbraco.Cms.Api.Management.Controllers.RelationType;
 
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.RelationType}")]
 [ApiExplorerSettings(GroupName = "Relation Type")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Tree/RelationTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Tree/RelationTypeTreeControllerBase.cs
@@ -8,6 +8,7 @@ using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Web.Common.Authorization;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.RelationType.Tree;
 
@@ -16,7 +17,7 @@ namespace Umbraco.Cms.Api.Management.Controllers.RelationType.Tree;
 [Authorize(Policy = AuthorizationPolicies.TreeAccessRelationTypes)]
 // NOTE: at the moment relation types aren't supported by EntityService, so we have little use of the
 // tree controller base. We'll keep it though, in the hope that we can mend EntityService.
-public class RelationTypeTreeControllerBase : NamedEntityTreeControllerBase<NamedEntityTreeItemResponseModel>
+public class RelationTypeTreeControllerBase : NamedEntityTreeControllerBase<RelationTypeTreeItemResponseModel>
 {
     public RelationTypeTreeControllerBase(IEntityService entityService)
         : base(entityService)
@@ -25,13 +26,14 @@ public class RelationTypeTreeControllerBase : NamedEntityTreeControllerBase<Name
 
     protected override UmbracoObjectTypes ItemObjectType => UmbracoObjectTypes.RelationType;
 
-    protected IEnumerable<NamedEntityTreeItemResponseModel> MapTreeItemViewModels(Guid? parentKey, IEnumerable<IRelationType> relationTypes)
-        => relationTypes.Select(relationType => new NamedEntityTreeItemResponseModel
+    protected IEnumerable<RelationTypeTreeItemResponseModel> MapTreeItemViewModels(Guid? parentKey, IEnumerable<IRelationType> relationTypes)
+        => relationTypes.Select(relationType => new RelationTypeTreeItemResponseModel
         {
             Name = relationType.Name!,
             Id = relationType.Key,
             Type = Constants.UdiEntityType.RelationType,
             HasChildren = false,
+            IsDeletable = relationType.IsDeletableRelationType(),
             Parent = parentKey.HasValue
                 ? new ReferenceByIdModel
                 {

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Tree/RootRelationTypeTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Tree/RootRelationTypeTreeController.cs
@@ -19,12 +19,12 @@ public class RootRelationTypeTreeController : RelationTypeTreeControllerBase
 
     [HttpGet("root")]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(typeof(PagedViewModel<NamedEntityTreeItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<PagedViewModel<NamedEntityTreeItemResponseModel>>> Root(int skip = 0, int take = 100)
+    [ProducesResponseType(typeof(PagedViewModel<RelationTypeTreeItemResponseModel>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<PagedViewModel<RelationTypeTreeItemResponseModel>>> Root(int skip = 0, int take = 100)
     {
         PagedModel<IRelationType> pagedRelationTypes = await _relationService.GetPagedRelationTypesAsync(skip, take);
 
-        PagedViewModel<NamedEntityTreeItemResponseModel> pagedResult = PagedViewModel(
+        PagedViewModel<RelationTypeTreeItemResponseModel> pagedResult = PagedViewModel(
             MapTreeItemViewModels(null, pagedRelationTypes.Items),
             pagedRelationTypes.Total);
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/UpdateRelationTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/UpdateRelationTypeController.cs
@@ -1,7 +1,6 @@
 ﻿using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Common.Builders;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.RelationType;
 using Umbraco.Cms.Core;
@@ -10,7 +9,7 @@ using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 
-namespace Umbraco.Cms.Api.Management.Controllers.RelationType.Query;
+namespace Umbraco.Cms.Api.Management.Controllers.RelationType;
 
 [ApiVersion("1.0")]
 public class UpdateRelationTypeController : RelationTypeControllerBase

--- a/src/Umbraco.Cms.Api.Management/Mapping/Item/ItemTypeMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Item/ItemTypeMapDefinition.cs
@@ -3,7 +3,6 @@ using Umbraco.Cms.Api.Management.ViewModels.Dictionary.Item;
 using Umbraco.Cms.Api.Management.ViewModels.DocumentType.Item;
 using Umbraco.Cms.Api.Management.ViewModels.Language.Item;
 using Umbraco.Cms.Api.Management.ViewModels.MediaType.Item;
-using Umbraco.Cms.Api.Management.ViewModels.Member.Item;
 using Umbraco.Cms.Api.Management.ViewModels.MemberGroup.Item;
 using Umbraco.Cms.Api.Management.ViewModels.MemberType.Item;
 using Umbraco.Cms.Api.Management.ViewModels.RelationType.Item;
@@ -105,6 +104,7 @@ public class ItemTypeMapDefinition : IMapDefinition
     {
         target.Id = source.Key;
         target.Name = source.Name ?? string.Empty;
+        target.IsDeletable = source.IsDeletableRelationType();
     }
 
     // Umbraco.Code.MapAll

--- a/src/Umbraco.Cms.Api.Management/Mapping/RelationType/RelationTypeViewModelsMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/RelationType/RelationTypeViewModelsMapDefinition.cs
@@ -29,7 +29,7 @@ public class RelationTypeViewModelsMapDefinition : IMapDefinition
         target.ParentObjectType = source.ParentObjectType;
         target.Path = "-1," + source.Id;
 
-        target.IsSystemRelationType = source.IsSystemRelationType();
+        target.IsDeletable = source.IsDeletableRelationType();
 
         // Set the "friendly" and entity names for the parent and child object types
         if (source.ParentObjectType.HasValue)

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -21051,17 +21051,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedNamedEntityTreeItemResponseModel"
+                  "$ref": "#/components/schemas/PagedRelationTypeTreeItemResponseModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedNamedEntityTreeItemResponseModel"
+                  "$ref": "#/components/schemas/PagedRelationTypeTreeItemResponseModel"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedNamedEntityTreeItemResponseModel"
+                  "$ref": "#/components/schemas/PagedRelationTypeTreeItemResponseModel"
                 }
               }
             }
@@ -37722,6 +37722,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/MediaTypeTreeItemResponseModel"
+                },
+                {
+                  "$ref": "#/components/schemas/RelationTypeTreeItemResponseModel"
                 }
               ]
             }
@@ -37913,6 +37916,30 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/RelationResponseModel"
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedRelationTypeTreeItemResponseModel": {
+        "required": [
+          "items",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/RelationTypeTreeItemResponseModel"
                 }
               ]
             }
@@ -38719,18 +38746,26 @@
         "additionalProperties": false
       },
       "RelationTypeItemResponseModel": {
+        "required": [
+          "isDeletable"
+        ],
         "type": "object",
         "allOf": [
           {
             "$ref": "#/components/schemas/NamedItemResponseModelBaseModel"
           }
         ],
+        "properties": {
+          "isDeletable": {
+            "type": "boolean"
+          }
+        },
         "additionalProperties": false
       },
       "RelationTypeResponseModel": {
         "required": [
           "id",
-          "isSystemRelationType",
+          "isDeletable",
           "path"
         ],
         "type": "object",
@@ -38752,7 +38787,7 @@
             "minLength": 1,
             "type": "string"
           },
-          "isSystemRelationType": {
+          "isDeletable": {
             "type": "boolean"
           },
           "parentObjectTypeName": {
@@ -38762,6 +38797,23 @@
           "childObjectTypeName": {
             "type": "string",
             "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "RelationTypeTreeItemResponseModel": {
+        "required": [
+          "isDeletable"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NamedEntityTreeItemResponseModel"
+          }
+        ],
+        "properties": {
+          "isDeletable": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false

--- a/src/Umbraco.Cms.Api.Management/ViewModels/RelationType/Item/RelationTypeItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/RelationType/Item/RelationTypeItemResponseModel.cs
@@ -4,5 +4,5 @@ namespace Umbraco.Cms.Api.Management.ViewModels.RelationType.Item;
 
 public class RelationTypeItemResponseModel : NamedItemResponseModelBase
 {
-
+    public bool IsDeletable { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/RelationType/RelationTypeResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/RelationType/RelationTypeResponseModel.cs
@@ -11,7 +11,7 @@ public class RelationTypeResponseModel : RelationTypeBaseModel
     [Required]
     public string Path { get; set; } = string.Empty;
 
-    public bool IsSystemRelationType { get; set; }
+    public bool IsDeletable { get; set; }
 
     /// <summary>
     ///     Gets or sets the Parent's object type name.

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Tree/RelationTypeTreeItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Tree/RelationTypeTreeItemResponseModel.cs
@@ -1,0 +1,6 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Tree;
+
+public class RelationTypeTreeItemResponseModel : NamedEntityTreeItemResponseModel
+{
+    public bool IsDeletable { get; set; }
+}

--- a/src/Umbraco.Core/Models/RelationTypeExtensions.cs
+++ b/src/Umbraco.Core/Models/RelationTypeExtensions.cs
@@ -14,4 +14,7 @@ public static class RelationTypeExtensions
         || relationType.Alias == Constants.Conventions.RelationTypes.RelateDocumentOnCopyAlias
         || relationType.Alias == Constants.Conventions.RelationTypes.RelateParentDocumentOnDeleteAlias
         || relationType.Alias == Constants.Conventions.RelationTypes.RelateParentMediaFolderOnDeleteAlias;
+
+    public static bool IsDeletableRelationType(this IRelationType relationType)
+        => relationType.IsSystemRelationType() is false;
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Added "is deletable" for all relation type models to flag system relation types as non-deletable. Notice that this replaces `IsSystemRelationType` on `RelationTypeResponseModel `.

### Testing this PR

System relation types should be marked as non-deletable in:
- Tree models.
- Item models.
- "Full" models.