### PR TITLE
V14: Create member filter

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/Filter/FilterMemberFilterController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/Filter/FilterMemberFilterController.cs
@@ -49,7 +49,7 @@ public class FilterMemberFilterController : MemberFilterControllerBase
             Filter = filter,
         };
 
-        PagedModel<IMember> members = _memberService.FilterAsync(memberFilter, orderBy, orderDirection, skip, take);
+        PagedModel<IMember> members = await _memberService.FilterAsync(memberFilter, orderBy, orderDirection, skip, take);
 
         var pageViewModel = new PagedViewModel<MemberResponseModel>
         {

--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/Filter/FilterMemberFilterController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/Filter/FilterMemberFilterController.cs
@@ -6,6 +6,7 @@ using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.Member;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Member.Filter;
@@ -39,7 +40,16 @@ public class FilterMemberFilterController : MemberFilterControllerBase
         int skip = 0,
         int take = 100)
     {
-        PagedModel<IMember> members = _memberService.FilterAsync(memberTypeId, memberGroupName, isApproved, isLockedOut, orderBy, orderDirection, filter, skip, take);
+        var memberFilter = new MemberFilter()
+        {
+            MemberTypeId = memberTypeId,
+            MemberGroupName = memberGroupName,
+            IsApproved = isApproved,
+            IsLockedOut = isLockedOut,
+            Filter = filter,
+        };
+
+        PagedModel<IMember> members = _memberService.FilterAsync(memberFilter, orderBy, orderDirection, skip, take);
 
         var pageViewModel = new PagedViewModel<MemberResponseModel>
         {

--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/Filter/FilterMemberFilterController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/Filter/FilterMemberFilterController.cs
@@ -32,13 +32,14 @@ public class FilterMemberFilterController : MemberFilterControllerBase
         Guid? memberTypeId = null,
         string? memberGroupName = null,
         bool? isApproved = null,
+        bool? isLockedOut = null,
         string orderBy = "username",
         Direction orderDirection = Direction.Ascending,
         string? filter = null,
         int skip = 0,
         int take = 100)
     {
-        PagedModel<IMember> members = _memberService.FilterAsync(memberTypeId, memberGroupName, isApproved, orderBy, orderDirection, filter, skip, take);
+        PagedModel<IMember> members = _memberService.FilterAsync(memberTypeId, memberGroupName, isApproved, isLockedOut, orderBy, orderDirection, filter, skip, take);
 
         var pageViewModel = new PagedViewModel<MemberResponseModel>
         {

--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/Filter/FilterMemberFilterController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/Filter/FilterMemberFilterController.cs
@@ -31,14 +31,14 @@ public class FilterMemberFilterController : MemberFilterControllerBase
     public async Task<IActionResult> Filter(
         Guid? memberTypeId = null,
         string? memberGroupName = null,
+        bool? isApproved = null,
         string orderBy = "username",
         Direction orderDirection = Direction.Ascending,
         string? filter = null,
         int skip = 0,
         int take = 100)
     {
-
-        PagedModel<IMember> members = _memberService.FilterAsync(memberTypeId, memberGroupName, orderBy, orderDirection, filter, skip, take);
+        PagedModel<IMember> members = _memberService.FilterAsync(memberTypeId, memberGroupName, isApproved, orderBy, orderDirection, filter, skip, take);
 
         var pageViewModel = new PagedViewModel<MemberResponseModel>
         {

--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/Filter/FilterMemberFilterController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/Filter/FilterMemberFilterController.cs
@@ -13,16 +13,13 @@ namespace Umbraco.Cms.Api.Management.Controllers.Member.Filter;
 [ApiVersion("1.0")]
 public class FilterMemberFilterController : MemberFilterControllerBase
 {
-    private readonly IMemberTypeService _memberTypeService;
     private readonly IMemberService _memberService;
     private readonly IMemberPresentationFactory _memberPresentationFactory;
 
     public FilterMemberFilterController(
-        IMemberTypeService memberTypeService,
         IMemberService memberService,
         IMemberPresentationFactory memberPresentationFactory)
     {
-        _memberTypeService = memberTypeService;
         _memberService = memberService;
         _memberPresentationFactory = memberPresentationFactory;
     }
@@ -33,38 +30,20 @@ public class FilterMemberFilterController : MemberFilterControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Filter(
         Guid? memberTypeId = null,
+        string? memberGroupName = null,
         string orderBy = "username",
         Direction orderDirection = Direction.Ascending,
         string? filter = null,
         int skip = 0,
         int take = 100)
     {
-        // TODO: Move to service once we have FilterAsync method for members
-        string? memberTypeAlias = null;
-        if (memberTypeId.HasValue)
-        {
-            IMemberType? memberType = await _memberTypeService.GetAsync(memberTypeId.Value);
-            if (memberType == null)
-            {
-                return MemberTypeNotFound();
-            }
 
-            memberTypeAlias = memberType.Alias;
-        }
-
-        IEnumerable<IMember> members = await Task.FromResult(_memberService.GetAll(
-            skip,
-            take,
-            out var totalRecords,
-            orderBy,
-            orderDirection,
-            memberTypeAlias,
-            filter ?? string.Empty));
+        PagedModel<IMember> members = _memberService.FilterAsync(memberTypeId, memberGroupName, orderBy, orderDirection, filter, skip, take);
 
         var pageViewModel = new PagedViewModel<MemberResponseModel>
         {
-            Items = await _memberPresentationFactory.CreateMultipleAsync(members),
-            Total = totalRecords,
+            Items = await _memberPresentationFactory.CreateMultipleAsync(members.Items),
+            Total = members.Total,
         };
 
         return Ok(pageViewModel);

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -16637,6 +16637,27 @@
             }
           },
           {
+            "name": "memberGroupName",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "isApproved",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "isLockedOut",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
             "name": "orderBy",
             "in": "query",
             "schema": {
@@ -31230,6 +31251,62 @@
       }
     },
     "/umbraco/management/api/v1/webhook": {
+      "get": {
+        "tags": [
+          "Webhook"
+        ],
+        "operationId": "GetWebhook",
+        "parameters": [
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedWebhookResponseModel"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedWebhookResponseModel"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedWebhookResponseModel"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      },
       "post": {
         "tags": [
           "Webhook"
@@ -34061,12 +34138,27 @@
       },
       "DatatypeConfigurationResponseModel": {
         "required": [
-          "canBeChanged"
+          "canBeChanged",
+          "documentListViewId",
+          "mediaListViewId",
+          "memberListViewId"
         ],
         "type": "object",
         "properties": {
           "canBeChanged": {
             "$ref": "#/components/schemas/DataTypeChangeModeModel"
+          },
+          "documentListViewId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "mediaListViewId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "memberListViewId": {
+            "type": "string",
+            "format": "uuid"
           }
         },
         "additionalProperties": false
@@ -38081,6 +38173,30 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/UserResponseModel"
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedWebhookResponseModel": {
+        "required": [
+          "items",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/WebhookResponseModel"
                 }
               ]
             }

--- a/src/Umbraco.Core/Models/Membership/MemberFilter.cs
+++ b/src/Umbraco.Core/Models/Membership/MemberFilter.cs
@@ -1,0 +1,14 @@
+﻿namespace Umbraco.Cms.Core.Models.Membership;
+
+public class MemberFilter
+{
+    public Guid? MemberTypeId { get; set; }
+
+    public string? MemberGroupName { get; set; }
+
+    public bool? IsApproved { get; set; }
+
+    public bool? IsLockedOut { get; set; }
+
+    public string? Filter { get; set; }
+}

--- a/src/Umbraco.Core/Persistence/Repositories/IMemberRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IMemberRepository.cs
@@ -1,5 +1,7 @@
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Persistence.Querying;
+using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Core.Persistence.Repositories;
 
@@ -38,4 +40,6 @@ public interface IMemberRepository : IContentRepository<int, IMember>
     /// <param name="query"></param>
     /// <returns></returns>
     int GetCountByQuery(IQuery<IMember>? query);
+
+    Task<PagedModel<IMember>> GetPagedByFilterAsync(MemberFilter memberFilter,int skip, int take, Ordering? ordering = null);
 }

--- a/src/Umbraco.Core/Services/IMemberService.cs
+++ b/src/Umbraco.Core/Services/IMemberService.cs
@@ -95,6 +95,7 @@ public interface IMemberService : IMembershipMemberService, IContentServiceBase<
         Guid? memberTypeId = null,
         string? memberGroupName = null,
         bool? isApproved = null,
+        bool? isLockedOut = null,
         string orderBy = "username",
         Direction orderDirection = Direction.Ascending,
         string? filter = null,

--- a/src/Umbraco.Core/Services/IMemberService.cs
+++ b/src/Umbraco.Core/Services/IMemberService.cs
@@ -92,7 +92,7 @@ public interface IMemberService : IMembershipMemberService, IContentServiceBase<
         string? memberTypeAlias,
         string filter);
 
-    public PagedModel<IMember> FilterAsync(
+    public Task<PagedModel<IMember>> FilterAsync(
         MemberFilter memberFilter,
         string orderBy = "username",
         Direction orderDirection = Direction.Ascending,

--- a/src/Umbraco.Core/Services/IMemberService.cs
+++ b/src/Umbraco.Core/Services/IMemberService.cs
@@ -91,6 +91,15 @@ public interface IMemberService : IMembershipMemberService, IContentServiceBase<
         string? memberTypeAlias,
         string filter);
 
+    public PagedModel<IMember> FilterAsync(
+        Guid? memberTypeId = null,
+        string? memberGroupName = null,
+        string orderBy = "username",
+        Direction orderDirection = Direction.Ascending,
+        string? filter = null,
+        int skip = 0,
+        int take = 100);
+
     /// <summary>
     ///     Creates an <see cref="IMember" /> object without persisting it
     /// </summary>

--- a/src/Umbraco.Core/Services/IMemberService.cs
+++ b/src/Umbraco.Core/Services/IMemberService.cs
@@ -1,4 +1,5 @@
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Persistence.Querying;
 
 namespace Umbraco.Cms.Core.Services;
@@ -92,13 +93,9 @@ public interface IMemberService : IMembershipMemberService, IContentServiceBase<
         string filter);
 
     public PagedModel<IMember> FilterAsync(
-        Guid? memberTypeId = null,
-        string? memberGroupName = null,
-        bool? isApproved = null,
-        bool? isLockedOut = null,
+        MemberFilter memberFilter,
         string orderBy = "username",
         Direction orderDirection = Direction.Ascending,
-        string? filter = null,
         int skip = 0,
         int take = 100);
 

--- a/src/Umbraco.Core/Services/IMemberService.cs
+++ b/src/Umbraco.Core/Services/IMemberService.cs
@@ -94,6 +94,7 @@ public interface IMemberService : IMembershipMemberService, IContentServiceBase<
     public PagedModel<IMember> FilterAsync(
         Guid? memberTypeId = null,
         string? memberGroupName = null,
+        bool? isApproved = null,
         string orderBy = "username",
         Direction orderDirection = Direction.Ascending,
         string? filter = null,

--- a/src/Umbraco.Core/Services/MemberService.cs
+++ b/src/Umbraco.Core/Services/MemberService.cs
@@ -102,6 +102,7 @@ namespace Umbraco.Cms.Core.Services
         public PagedModel<IMember> FilterAsync(
             Guid? memberTypeId = null,
             string? memberGroupName = null,
+            bool? isApproved = null,
             string orderBy = "username",
             Direction orderDirection = Direction.Ascending,
             string? filter = null,
@@ -129,7 +130,7 @@ namespace Umbraco.Cms.Core.Services
                 members = _memberRepository.FindMembersInRole(memberGroupName, string.Empty);
                 if (filter is not null)
                 {
-                    members = members.Where(x => (x.Name != null && x.Name.Contains(filter)) || x.Username.Contains(filter) || x.Email.Contains(filter) || x.Id == filterAsIntId || x.Key == filterAsGuid).ToArray();
+                    members = members.Where(x => (x.Name != null && x.Name.Contains(filter)) || x.Username.Contains(filter) || x.Email.Contains(filter) || x.Id == filterAsIntId || x.Key == filterAsGuid || (isApproved is not null && x.IsApproved == isApproved)).ToArray();
                 }
 
                 totalRecords = members.Count();
@@ -137,7 +138,8 @@ namespace Umbraco.Cms.Core.Services
             }
             else
             {
-                IQuery<IMember>? query2 = filter == null ? null : Query<IMember>().Where(x => (x.Name != null && x.Name.Contains(filter)) || x.Username.Contains(filter) || x.Email.Contains(filter) || x.Id == filterAsIntId || x.Key == filterAsGuid);
+                IQuery<IMember> query2 = isApproved is null ? Query<IMember>() : Query<IMember>().Where(x => x.IsApproved == isApproved);
+                query2 = filter == null ? query2 : query2.Where(x => (x.Name != null && x.Name.Contains(filter)) || x.Username.Contains(filter) || x.Email.Contains(filter) || x.Id == filterAsIntId || x.Key == filterAsGuid);
                 members = _memberRepository.GetPage(query1, pageNumber, pageSize, out totalRecords, query2, Ordering.By(orderBy, orderDirection, isCustomField: true));
             }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
 using NPoco;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
@@ -200,6 +201,104 @@ public class MemberRepository : ContentRepositoryBase<int, IMember, MemberReposi
             .Append(new Sql("WHERE umbracoNode.id IN (" + sql.SQL + ")", sql.Arguments));
 
         return Database.ExecuteScalar<int>(fullSql);
+    }
+
+    public async Task<PagedModel<IMember>> GetPagedByFilterAsync(MemberFilter memberFilter, int skip, int take, Ordering? ordering = null)
+    {
+        Sql<ISqlContext> sql = Sql().Select<NodeDto>(x => x.NodeId)
+            .From<NodeDto>()
+            .InnerJoin<MemberDto>().On<NodeDto, MemberDto>((n, m) => n.NodeId == m.NodeId);
+
+        if (memberFilter.MemberTypeId.HasValue)
+        {
+            sql =  sql
+                .InnerJoin<ContentDto>().On<NodeDto, ContentDto>((memberNode, memberContent) => memberContent.NodeId == memberNode.NodeId)
+                .InnerJoin<NodeDto>("mtn").On<NodeDto, ContentDto>((memberTypeNode, memberContent) => memberContent.ContentTypeId == memberTypeNode.NodeId && memberTypeNode.UniqueId == memberFilter.MemberTypeId, "mtn");
+        }
+
+        if (memberFilter.MemberGroupName.IsNullOrWhiteSpace() is false)
+        {
+            sql =  sql
+                .InnerJoin<Member2MemberGroupDto>().On<MemberDto, Member2MemberGroupDto>((m, memberToGroup) => m.NodeId == memberToGroup.Member)
+                .InnerJoin<NodeDto>("mgn").On<NodeDto, Member2MemberGroupDto>((memberGroupNode, memberToGroup) => memberToGroup.MemberGroup == memberGroupNode.NodeId && memberGroupNode.Text == memberFilter.MemberGroupName, "mgn");
+        }
+
+        if (memberFilter.IsApproved is not null)
+        {
+            sql = sql.Where<MemberDto>(member => member.IsApproved == memberFilter.IsApproved);
+        }
+
+        if (memberFilter.IsLockedOut is not null)
+        {
+            sql = sql.Where<MemberDto>(member => member.IsLockedOut == memberFilter.IsLockedOut);
+        }
+
+        if (memberFilter.Filter is not null)
+        {
+            var whereClauses = new List<Func<Sql<ISqlContext>, Sql<ISqlContext>>>()
+            {
+                (x) => x.Where<NodeDto>(memberNode => memberNode.Text != null && memberNode.Text.Contains(memberFilter.Filter)),
+                (x) => x.Where<MemberDto>(memberNode => memberNode.Email.Contains(memberFilter.Filter)),
+                (x) => x.Where<MemberDto>(memberNode => memberNode.LoginName.Contains(memberFilter.Filter))
+            };
+
+            if (int.TryParse(memberFilter.Filter, out int filterAsIntId))
+            {
+                whereClauses.Add((x) => x.Where<NodeDto>(memberNode => memberNode.NodeId == filterAsIntId));
+            }
+            if (Guid.TryParse(memberFilter.Filter, out Guid filterAsGuid))
+            {
+                whereClauses.Add((x) => x.Where<NodeDto>(memberNode => memberNode.UniqueId == filterAsGuid));
+            }
+
+            sql = sql.WhereAny(whereClauses.ToArray());
+        }
+
+        if (ordering is not null)
+        {
+            ApplyOrdering(ref sql, ordering);
+        }
+
+        var pageIndex = skip / take;
+        Page<MemberDto>? pageResult = await Database.PageAsync<MemberDto>(pageIndex+1, take, sql);
+
+        // shortcut so our join is not too big, but we also hope these are cached, so we don't have to map them again.
+        var nodeIds = pageResult.Items.Select(x => x.NodeId).ToArray();
+
+        return new PagedModel<IMember>(pageResult.TotalItems, nodeIds.Any() ? GetMany(nodeIds) : Array.Empty<IMember>());
+    }
+
+    private void ApplyOrdering(ref Sql<ISqlContext> sql, Ordering ordering)
+    {
+        if (sql == null)
+        {
+            throw new ArgumentNullException(nameof(sql));
+        }
+
+        if (ordering == null)
+        {
+            throw new ArgumentNullException(nameof(ordering));
+        }
+
+        if (ordering.OrderBy.IsNullOrWhiteSpace())
+        {
+            return;
+        }
+
+        var orderBy = ordering.OrderBy.ToLowerInvariant() switch
+        {
+            "username" => sql.GetAliasedField(SqlSyntax.GetFieldName<MemberDto>(x => x.LoginName)),
+            _ => throw new NotSupportedException("Ordering not supported")
+        };
+
+        if (ordering.Direction == Direction.Ascending)
+        {
+            sql.OrderBy(orderBy);
+        }
+        else
+        {
+            sql.OrderByDescending(orderBy);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
# Notes
- Adds capability to filter by membergroup name, isAllowed & isLocked out on the filter endpoint
- Adds `MemberFilter`, to mimic the behavior of the user filter endpoint.
- Implements `FilterAsync` on the IMemberService

# How to test
- Create lots of groups and member groups on a v13 instance (you can also do this in the new backoffice, just a bit more tedious and buggy 😛)
- Upgrade your database to v14
- Use the new filter endpoint, and assert all the new filter properties work (group name, isApproved, isLocked)
- Assert that it also works in combination with others