### PR TITLE
Inject existing MvcNewtonsoftJsonOptions into UmbracoJsonModelBinder to respect existing settings

### DIFF
--- a/src/Umbraco.Web.Common/ModelBinders/UmbracoJsonModelBinder.cs
+++ b/src/Umbraco.Web.Common/ModelBinders/UmbracoJsonModelBinder.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.ObjectPool;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Umbraco.Cms.Web.Common.Formatters;
 
@@ -19,17 +20,18 @@ public class UmbracoJsonModelBinder : BodyModelBinder
     public UmbracoJsonModelBinder(
         ArrayPool<char> arrayPool,
         ObjectPoolProvider objectPoolProvider,
+        IOptions<MvcNewtonsoftJsonOptions> jsonOptions,
         IHttpRequestStreamReaderFactory readerFactory,
         ILoggerFactory loggerFactory)
-        : base(GetNewtonsoftJsonFormatter(loggerFactory, arrayPool, objectPoolProvider), readerFactory, loggerFactory)
+        : base(GetNewtonsoftJsonFormatter(loggerFactory, arrayPool, objectPoolProvider, jsonOptions.Value), readerFactory, loggerFactory)
     {
     }
 
-    private static IInputFormatter[] GetNewtonsoftJsonFormatter(ILoggerFactory logger, ArrayPool<char> arrayPool, ObjectPoolProvider objectPoolProvider)
+    private static IInputFormatter[] GetNewtonsoftJsonFormatter(ILoggerFactory logger, ArrayPool<char> arrayPool, ObjectPoolProvider objectPoolProvider, MvcNewtonsoftJsonOptions jsonOptions)
     {
-        var jsonOptions = new MvcNewtonsoftJsonOptions { AllowInputFormatterExceptionMessages = true };
+        jsonOptions.AllowInputFormatterExceptionMessages = true;
 
-        JsonSerializerSettings ss = jsonOptions.SerializerSettings; // Just use the defaults as base
+        JsonSerializerSettings ss = jsonOptions.SerializerSettings;
 
         // We need to ignore required attributes when serializing. E.g UserSave.ChangePassword. Otherwise the model is not model bound.
         ss.ContractResolver = new IgnoreRequiredAttributesResolver();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes https://github.com/umbraco/Umbraco-CMS/issues/15882

### Description
This injects `IOptions<MvcNewtonsoftJsonOptions>` in `UmbracoJsonModelBinder`. This ensures that any globally configured settings for Newtonsoft.JSON are actually respected.

To test, create an `UmbracoApiController` and ensure that JSON parsing work correctly. Then attempt changing a Newtonsoft.JSON setting, like this: 
```
 services.PostConfigure<MvcNewtonsoftJsonOptions>(options =>
 {
     options.SerializerSettings.DateParseHandling = Newtonsoft.Json.DateParseHandling.DateTimeOffset;
 });
```
And ensure that this applies to the `UmbracoApiController`
