### PR TITLE
Port V13 backoffice cookie validation to V14

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeCookieOptions.cs
+++ b/src/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeCookieOptions.cs
@@ -1,0 +1,256 @@
+﻿using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Api.Management.Security;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.Net;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Web.Common.Security;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.Configuration;
+
+/// <summary>
+///     Used to configure <see cref="CookieAuthenticationOptions" /> for the back office authentication type
+/// </summary>
+public class ConfigureBackOfficeCookieOptions : IConfigureNamedOptions<CookieAuthenticationOptions>
+{
+    private readonly IDataProtectionProvider _dataProtection;
+    private readonly GlobalSettings _globalSettings;
+    private readonly IIpResolver _ipResolver;
+    private readonly IRuntimeState _runtimeState;
+    private readonly SecuritySettings _securitySettings;
+    private readonly ISystemClock _systemClock;
+    private readonly IUserService _userService;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="ConfigureBackOfficeCookieOptions" /> class.
+    /// </summary>
+    /// <param name="securitySettings">The <see cref="SecuritySettings" /> options</param>
+    /// <param name="globalSettings">The <see cref="GlobalSettings" /> options</param>
+    /// <param name="hostingEnvironment">The <see cref="IHostingEnvironment" /></param>
+    /// <param name="runtimeState">The <see cref="IRuntimeState" /></param>
+    /// <param name="dataProtection">The <see cref="IDataProtectionProvider" /></param>
+    /// <param name="userService">The <see cref="IUserService" /></param>
+    /// <param name="ipResolver">The <see cref="IIpResolver" /></param>
+    /// <param name="systemClock">The <see cref="ISystemClock" /></param>
+    public ConfigureBackOfficeCookieOptions(
+        IOptions<SecuritySettings> securitySettings,
+        IOptions<GlobalSettings> globalSettings,
+        IRuntimeState runtimeState,
+        IDataProtectionProvider dataProtection,
+        IUserService userService,
+        IIpResolver ipResolver,
+        ISystemClock systemClock)
+    {
+        _securitySettings = securitySettings.Value;
+        _globalSettings = globalSettings.Value;
+        _runtimeState = runtimeState;
+        _dataProtection = dataProtection;
+        _userService = userService;
+        _ipResolver = ipResolver;
+        _systemClock = systemClock;
+    }
+
+    /// <inheritdoc />
+    public void Configure(string? name, CookieAuthenticationOptions options)
+    {
+        if (name != Constants.Security.BackOfficeAuthenticationType)
+        {
+            return;
+        }
+
+        Configure(options);
+    }
+
+    /// <inheritdoc />
+    public void Configure(CookieAuthenticationOptions options)
+    {
+        options.SlidingExpiration = false;
+        options.ExpireTimeSpan = _globalSettings.TimeOut;
+        options.Cookie.Domain = _securitySettings.AuthCookieDomain;
+        options.Cookie.Name = _securitySettings.AuthCookieName;
+        options.Cookie.HttpOnly = true;
+        options.Cookie.SecurePolicy =
+            _globalSettings.UseHttps ? CookieSecurePolicy.Always : CookieSecurePolicy.SameAsRequest;
+        options.Cookie.Path = "/";
+
+        // NOTE: matches route in BackOfficeLoginController
+        const string backOfficeLoginPath = "/umbraco/login";
+        options.LoginPath = backOfficeLoginPath;
+        options.LogoutPath = backOfficeLoginPath;
+        options.AccessDeniedPath = backOfficeLoginPath;
+
+        options.DataProtectionProvider = _dataProtection;
+
+        // NOTE: This is borrowed directly from aspnetcore source
+        // Note: the purpose for the data protector must remain fixed for interop to work.
+        IDataProtector dataProtector = options.DataProtectionProvider.CreateProtector(
+            "Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationMiddleware",
+            Constants.Security.BackOfficeAuthenticationType,
+            "v2");
+        var ticketDataFormat = new TicketDataFormat(dataProtector);
+
+        options.TicketDataFormat = new BackOfficeSecureDataFormat(_globalSettings.TimeOut, ticketDataFormat);
+
+        options.Events = new CookieAuthenticationEvents
+        {
+            // IMPORTANT! If you set any of OnRedirectToLogin, OnRedirectToAccessDenied, OnRedirectToLogout, OnRedirectToReturnUrl
+            // you need to be aware that this will bypass the default behavior of returning the correct status codes for ajax requests and
+            // not redirecting for non-ajax requests. This is because the default behavior is baked into this class here:
+            // https://github.com/dotnet/aspnetcore/blob/master/src/Security/Authentication/Cookies/src/CookieAuthenticationEvents.cs#L58
+            // It would be possible to re-use the default behavior if any of these need to be set but that must be taken into account else
+            // our back office requests will not function correctly. For now we don't need to set/configure any of these callbacks because
+            // the defaults work fine with our setup.
+            OnValidatePrincipal = async ctx =>
+            {
+                // We need to resolve the BackOfficeSecurityStampValidator per request as a requirement (even in aspnetcore they do this)
+                BackOfficeSecurityStampValidator securityStampValidator =
+                    ctx.HttpContext.RequestServices.GetRequiredService<BackOfficeSecurityStampValidator>();
+
+                // Same goes for the signinmanager
+                IBackOfficeSignInManager signInManager =
+                    ctx.HttpContext.RequestServices.GetRequiredService<IBackOfficeSignInManager>();
+
+                ClaimsIdentity? backOfficeIdentity = ctx.Principal?.GetUmbracoIdentity();
+                if (backOfficeIdentity == null)
+                {
+                    ctx.RejectPrincipal();
+                    await signInManager.SignOutAsync();
+                }
+
+                // ensure the thread culture is set
+                backOfficeIdentity?.EnsureCulture();
+
+                EnsureTicketRenewalIfKeepUserLoggedIn(ctx);
+
+                // add or update a claim to track when the cookie expires, we use this to track time remaining
+                backOfficeIdentity?.AddOrUpdateClaim(new Claim(
+                    Constants.Security.TicketExpiresClaimType,
+                    ctx.Properties.ExpiresUtc!.Value.ToString("o"),
+                    ClaimValueTypes.DateTime,
+                    Constants.Security.BackOfficeAuthenticationType,
+                    Constants.Security.BackOfficeAuthenticationType,
+                    backOfficeIdentity));
+
+                await securityStampValidator.ValidateAsync(ctx);
+
+                // We have to manually specify Issued and Expires,
+                // because the SecurityStampValidator refreshes the principal every 30 minutes,
+                // When the principal is refreshed the Issued is update to time of refresh, however, the Expires remains unchanged
+                // When we then try and renew, the difference of issued and expires effectively becomes the new ExpireTimeSpan
+                // meaning we effectively lose 30 minutes of our ExpireTimeSpan for EVERY principal refresh if we don't
+                // https://github.com/dotnet/aspnetcore/blob/main/src/Security/Authentication/Cookies/src/CookieAuthenticationHandler.cs#L115
+                ctx.Properties.IssuedUtc = _systemClock.UtcNow;
+                ctx.Properties.ExpiresUtc = _systemClock.UtcNow.Add(_globalSettings.TimeOut);
+                ctx.ShouldRenew = true;
+            },
+            OnSigningIn = ctx =>
+            {
+                // occurs when sign in is successful but before the ticket is written to the outbound cookie
+                ClaimsIdentity? backOfficeIdentity = ctx.Principal?.GetUmbracoIdentity();
+                if (backOfficeIdentity != null)
+                {
+                    // generate a session id and assign it
+                    // create a session token - if we are configured and not in an upgrade state then use the db, otherwise just generate one
+                    Guid session = _runtimeState.Level == RuntimeLevel.Run
+                        ? _userService.CreateLoginSession(
+                            backOfficeIdentity.GetId()!.Value,
+                            _ipResolver.GetCurrentRequestIpAddress())
+                        : Guid.NewGuid();
+
+                    // add our session claim
+                    backOfficeIdentity.AddClaim(new Claim(
+                        Constants.Security.SessionIdClaimType,
+                        session.ToString(),
+                        ClaimValueTypes.String,
+                        Constants.Security.BackOfficeAuthenticationType,
+                        Constants.Security.BackOfficeAuthenticationType,
+                        backOfficeIdentity));
+
+                    // since it is a cookie-based authentication add that claim
+                    backOfficeIdentity.AddClaim(new Claim(
+                        ClaimTypes.CookiePath,
+                        "/",
+                        ClaimValueTypes.String,
+                        Constants.Security.BackOfficeAuthenticationType,
+                        Constants.Security.BackOfficeAuthenticationType,
+                        backOfficeIdentity));
+                }
+
+                return Task.CompletedTask;
+            },
+            OnSignedIn = ctx =>
+            {
+                // occurs when sign in is successful and after the ticket is written to the outbound cookie
+
+                // When we are signed in with the cookie, assign the principal to the current HttpContext
+                ctx.HttpContext.SetPrincipalForRequest(ctx.Principal);
+
+                return Task.CompletedTask;
+            },
+            OnSigningOut = ctx =>
+            {
+                // Clear the user's session on sign out
+                if (ctx.HttpContext?.User?.Identity != null)
+                {
+                    var claimsIdentity = ctx.HttpContext.User.Identity as ClaimsIdentity;
+                    var sessionId = claimsIdentity?.FindFirstValue(Constants.Security.SessionIdClaimType);
+                    if (sessionId.IsNullOrWhiteSpace() == false && Guid.TryParse(sessionId, out Guid guidSession))
+                    {
+                        _userService.ClearLoginSession(guidSession);
+                    }
+                }
+
+                // Remove all of our cookies
+                var cookies = new[]
+                {
+                    _securitySettings.AuthCookieName,
+                    Constants.Web.PreviewCookieName, Constants.Security.BackOfficeExternalCookieName,
+                    Constants.Web.AngularCookieName, Constants.Web.CsrfValidationCookieName
+                };
+                foreach (var cookie in cookies)
+                {
+                    ctx.Options.CookieManager.DeleteCookie(ctx.HttpContext!, cookie, new CookieOptions { Path = "/" });
+                }
+
+                return Task.CompletedTask;
+            }
+        };
+    }
+
+    /// <summary>
+    ///     Ensures the ticket is renewed if the <see cref="SecuritySettings.KeepUserLoggedIn" /> is set to true
+    ///     and the current request is for the get user seconds endpoint
+    /// </summary>
+    /// <param name="context">The <see cref="CookieValidatePrincipalContext" /></param>
+    private void EnsureTicketRenewalIfKeepUserLoggedIn(CookieValidatePrincipalContext context)
+    {
+        if (!_securitySettings.KeepUserLoggedIn)
+        {
+            return;
+        }
+
+        DateTimeOffset currentUtc = _systemClock.UtcNow;
+        DateTimeOffset? issuedUtc = context.Properties.IssuedUtc;
+        DateTimeOffset? expiresUtc = context.Properties.ExpiresUtc;
+
+        if (expiresUtc.HasValue && issuedUtc.HasValue)
+        {
+            TimeSpan timeElapsed = currentUtc.Subtract(issuedUtc.Value);
+            TimeSpan timeRemaining = expiresUtc.Value.Subtract(currentUtc);
+
+            // if it's time to renew, then do it
+            if (timeRemaining < timeElapsed)
+            {
+                context.ShouldRenew = true;
+            }
+        }
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeSecurityStampValidatorOptions.cs
+++ b/src/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeSecurityStampValidatorOptions.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Api.Management.Security;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Web.Common.Security;
+
+namespace Umbraco.Cms.Api.Management.Configuration;
+
+/// <summary>
+///     Configures the back office security stamp options.
+/// </summary>
+public class ConfigureBackOfficeSecurityStampValidatorOptions : IConfigureOptions<BackOfficeSecurityStampValidatorOptions>
+{
+    private readonly SecuritySettings _securitySettings;
+
+    public ConfigureBackOfficeSecurityStampValidatorOptions()
+        : this(StaticServiceProvider.Instance.GetRequiredService<IOptions<SecuritySettings>>())
+    {
+    }
+
+    public ConfigureBackOfficeSecurityStampValidatorOptions(IOptions<SecuritySettings> securitySettings)
+        => _securitySettings = securitySettings.Value;
+
+    /// <inheritdoc />
+    public void Configure(BackOfficeSecurityStampValidatorOptions options)
+        => ConfigureSecurityStampOptions.ConfigureOptions(options, _securitySettings);
+}

--- a/src/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeSecurityStampValidatorOptions.cs
+++ b/src/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeSecurityStampValidatorOptions.cs
@@ -1,8 +1,6 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
+﻿using Microsoft.Extensions.Options;
 using Umbraco.Cms.Api.Management.Security;
 using Umbraco.Cms.Core.Configuration.Models;
-using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Web.Common.Security;
 
 namespace Umbraco.Cms.Api.Management.Configuration;
@@ -13,16 +11,18 @@ namespace Umbraco.Cms.Api.Management.Configuration;
 public class ConfigureBackOfficeSecurityStampValidatorOptions : IConfigureOptions<BackOfficeSecurityStampValidatorOptions>
 {
     private readonly SecuritySettings _securitySettings;
+    private readonly TimeProvider _timeProvider;
 
-    public ConfigureBackOfficeSecurityStampValidatorOptions()
-        : this(StaticServiceProvider.Instance.GetRequiredService<IOptions<SecuritySettings>>())
+    public ConfigureBackOfficeSecurityStampValidatorOptions(IOptions<SecuritySettings> securitySettings, TimeProvider timeProvider)
     {
+        _timeProvider = timeProvider;
+        _securitySettings = securitySettings.Value;
     }
-
-    public ConfigureBackOfficeSecurityStampValidatorOptions(IOptions<SecuritySettings> securitySettings)
-        => _securitySettings = securitySettings.Value;
 
     /// <inheritdoc />
     public void Configure(BackOfficeSecurityStampValidatorOptions options)
-        => ConfigureSecurityStampOptions.ConfigureOptions(options, _securitySettings);
+    {
+        options.TimeProvider = _timeProvider;
+        ConfigureSecurityStampOptions.ConfigureOptions(options, _securitySettings);
+    }
 }

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeAuthBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeAuthBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Api.Common.DependencyInjection;
+using Umbraco.Cms.Api.Management.Configuration;
 using Umbraco.Cms.Api.Management.Handlers;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DependencyInjection;
@@ -52,11 +53,7 @@ public static class BackOfficeAuthBuilderExtensions
         builder.Services
             .AddAuthentication()
             // Add our custom schemes which are cookie handlers
-            .AddCookie(Constants.Security.BackOfficeAuthenticationType, options =>
-            {
-                options.LoginPath = "/umbraco/login";
-                options.Cookie.Name = Constants.Security.BackOfficeAuthenticationType;
-            })
+            .AddCookie(Constants.Security.BackOfficeAuthenticationType)
             .AddCookie(Constants.Security.BackOfficeExternalAuthenticationType, o =>
             {
                 o.Cookie.Name = Constants.Security.BackOfficeExternalAuthenticationType;
@@ -75,6 +72,10 @@ public static class BackOfficeAuthBuilderExtensions
                 o.Cookie.Name = Constants.Security.BackOfficeTwoFactorRememberMeAuthenticationType;
                 o.ExpireTimeSpan = TimeSpan.FromMinutes(5);
             });
+
+        builder.Services.AddScoped<BackOfficeSecurityStampValidator>();
+        builder.Services.ConfigureOptions<ConfigureBackOfficeCookieOptions>();
+        builder.Services.ConfigureOptions<ConfigureBackOfficeSecurityStampValidatorOptions>();
 
         return builder;
     }

--- a/src/Umbraco.Cms.Api.Management/Security/BackOfficeSecurityStampValidator.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/BackOfficeSecurityStampValidator.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Identity;
+﻿using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Security;
@@ -13,8 +12,9 @@ public class BackOfficeSecurityStampValidator : SecurityStampValidator<BackOffic
 {
     public BackOfficeSecurityStampValidator(
         IOptions<BackOfficeSecurityStampValidatorOptions> options,
-        BackOfficeSignInManager signInManager, ISystemClock clock, ILoggerFactory logger)
-        : base(options, signInManager, clock, logger)
+        BackOfficeSignInManager signInManager,
+        ILoggerFactory logger)
+        : base(options, signInManager, logger)
     {
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Security/BackOfficeSecurityStampValidator.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/BackOfficeSecurityStampValidator.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Security;
+
+namespace Umbraco.Cms.Api.Management.Security;
+
+/// <summary>
+///     A security stamp validator for the back office
+/// </summary>
+public class BackOfficeSecurityStampValidator : SecurityStampValidator<BackOfficeIdentityUser>
+{
+    public BackOfficeSecurityStampValidator(
+        IOptions<BackOfficeSecurityStampValidatorOptions> options,
+        BackOfficeSignInManager signInManager, ISystemClock clock, ILoggerFactory logger)
+        : base(options, signInManager, clock, logger)
+    {
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Security/BackOfficeSecurityStampValidatorOptions.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/BackOfficeSecurityStampValidatorOptions.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.AspNetCore.Identity;
+
+namespace Umbraco.Cms.Api.Management.Security;
+
+/// <summary>
+///     Custom <see cref="SecurityStampValidatorOptions" /> for the back office
+/// </summary>
+public class BackOfficeSecurityStampValidatorOptions : SecurityStampValidatorOptions
+{
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Right now, the cookie validation for V14 is lacking a lot of basic stuff. For starters, if a user has authenticated against one database, the user authentication survives swapping out the entire DB with another DB (or delete and recreate the DB), as long as the user exist by the same email in both databases 🤦 

This PR ports over all (almost all) the current cookie validation from V13 to V14, to handle these silly things.

A few things have been explicitly omitted, because they seems to have little meaning in the Management API. Please consider if this is as meaningful as I think 😆 

- [`BackOfficeCookieManager`](https://github.com/umbraco/Umbraco-CMS/blob/v13/dev/src/Umbraco.Web.BackOffice/Security/BackOfficeCookieManager.cs).
- [`IsRemainingSecondsRequest`](https://github.com/umbraco/Umbraco-CMS/blob/v13/dev/src/Umbraco.Web.BackOffice/Security/ConfigureBackOfficeCookieOptions.cs#L315-L330).
- [`BackOfficeSessionIdValidator`](https://github.com/umbraco/Umbraco-CMS/blob/v13/dev/src/Umbraco.Web.BackOffice/Security/BackOfficeSessionIdValidator.cs) and the corresponding [`EnsureValidSessionId`](https://github.com/umbraco/Umbraco-CMS/blob/v13/dev/src/Umbraco.Web.BackOffice/Security/ConfigureBackOfficeCookieOptions.cs#L273-L284)

Notice that this PR brings back the V13 backoffice cookie name (default `UMB_UCONTEXT`, configurable in security settings) - it has up until now been hardcoded to the name `UmbracoBackOffice` in V14.

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/5a90a562-2191-418b-be41-ae091600506f)

### Testing this PR

#### Swagger

1. Authenticate Swagger against the Management API.
2. Stop the site **_without signing out from swagger_**.
3. Delete and recreate the database using unintended install.
4. Perform any operation in Swagger **_without reloading swagger first_**. This should fail with a 401 because the previously issued token does not exist in the newly created DB.
5. Sign out from Swagger.
6. Re-authenticate Swagger against the Management API. Verify that you are indeed asked to sign in again.

#### Backoffice

1. Sign into the backoffice.
2. Stop the site **_without signing out from the backoffice_**.
3. Delete and recreate the database using unintended install.
4. Reload the backoffice. You should be alerted that your session has expired, because all issued tokens (including the refresh tokens) no longer exist.
5. Go to `/umbraco/login`. Verify that you are indeed asked to sign in again.
