### PR TITLE
Workaround for failing entity tree children

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Tree/FolderTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tree/FolderTreeControllerBase.cs
@@ -69,6 +69,7 @@ public abstract class FolderTreeControllerBase<TItem> : NamedEntityTreeControlle
             ? Array.Empty<IEntitySlim>()
             : EntityService.GetPagedChildren(
                     parentKey,
+                    new [] { FolderObjectType, ItemObjectType },
                     ItemObjectType,
                     skip,
                     take,

--- a/src/Umbraco.Core/Services/EntityService.cs
+++ b/src/Umbraco.Core/Services/EntityService.cs
@@ -359,8 +359,27 @@ public class EntityService : RepositoryService, IEntityService
         => GetPagedChildren(id, objectType, pageIndex, pageSize, false, filter, ordering, out totalRecords);
 
     public IEnumerable<IEntitySlim> GetPagedChildren(
-        Guid? key,
-        UmbracoObjectTypes objectType,
+        Guid? parentKey,
+        UmbracoObjectTypes childObjectType,
+        int skip,
+        int take,
+        out long totalRecords,
+        IQuery<IUmbracoEntity>? filter = null,
+        Ordering? ordering = null)
+        => GetPagedChildren(
+            parentKey,
+            new[] { childObjectType },
+            childObjectType,
+            skip,
+            take,
+            out totalRecords,
+            filter,
+            ordering);
+
+    public IEnumerable<IEntitySlim> GetPagedChildren(
+        Guid? parentKey,
+        IEnumerable<UmbracoObjectTypes> parentObjectTypes,
+        UmbracoObjectTypes childObjectType,
         int skip,
         int take,
         out long totalRecords,
@@ -369,7 +388,9 @@ public class EntityService : RepositoryService, IEntityService
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope();
 
-        if (ResolveKey(key, objectType, out int parentId) is false)
+        var parentId = 0;
+        var parentIdResolved = parentObjectTypes.Any(parentObjectType => ResolveKey(parentKey, parentObjectType, out parentId));
+        if (parentIdResolved is false)
         {
             totalRecords = 0;
             return Enumerable.Empty<IEntitySlim>();
@@ -379,7 +400,7 @@ public class EntityService : RepositoryService, IEntityService
 
         IEnumerable<IEntitySlim> children = GetPagedChildren(
             parentId,
-            objectType,
+            childObjectType,
             pageNumber,
             pageSize,
             out totalRecords,

--- a/src/Umbraco.Core/Services/IEntityService.cs
+++ b/src/Umbraco.Core/Services/IEntityService.cs
@@ -202,8 +202,27 @@ public interface IEntityService
     IEnumerable<IEntitySlim> GetDescendants(int id, UmbracoObjectTypes objectType);
 
     IEnumerable<IEntitySlim> GetPagedChildren(
-        Guid? key,
-        UmbracoObjectTypes objectType,
+        Guid? parentKey,
+        UmbracoObjectTypes childObjectType,
+        int skip,
+        int take,
+        out long totalRecords,
+        IQuery<IUmbracoEntity>? filter = null,
+        Ordering? ordering = null)
+        => GetPagedChildren(
+            parentKey,
+            new[] { childObjectType },
+            childObjectType,
+            skip,
+            take,
+            out totalRecords,
+            filter,
+            ordering);
+
+    IEnumerable<IEntitySlim> GetPagedChildren(
+        Guid? parentKey,
+        IEnumerable<UmbracoObjectTypes> parentObjectTypes,
+        UmbracoObjectTypes childObjectType,
         int skip,
         int take,
         out long totalRecords,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The refactor in https://github.com/umbraco/Umbraco-CMS/pull/15856 has had the side effect of breaking entity trees that can hold multiple entity types. More to the point, the trees currently affected are the ones that have containers (folders) - like the document type and data type trees.

This PR introduces what can best be described as a workaround. Fortunately we already have a follow-up task planned that will make it possible to paginate multiple entity types in entity trees (among other reasons to ensure correct pagination for these "folder trees").

### Testing this PR

1. It should be possible to see direct children of folders in entity trees:
![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/a2b3b3a5-97e7-4a07-a53d-125514cea7a8)

2. Slightly more complex child structures should also work. Specifically for document types, these can be created beneath one another (inheritance), while the topmost ones still can reside in a folder.
![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/ede20fb1-ec9d-459c-845a-e47932cfc10c)

Apparently, the backoffice UI currently does not support creating inherited document types, so this will have to be done using Swagger. The following payload should do the trick:

```json
{
    "alias": "testInherited",
    "name": "Test inherited",
    "description": null,
    "icon": "icon-document",
    "allowedAsRoot": false,
    "variesByCulture": false,
    "variesBySegment": false,
    "collection": null,
    "isElement": false,
    "properties": [],
    "containers": [],
    "id": "0e791fda-5f94-4b4f-9245-7d3c80ea0c6d",
    "parent": null,
    "allowedTemplates": [],
    "defaultTemplate": null,
    "cleanup": {
        "preventCleanup": false,
        "keepAllVersionsNewerThanDays": null,
        "keepLatestVersionPerDayForDays": null
    },
    "allowedDocumentTypes": [],
    "compositions": [{
            "documentType": {
                "id": "[ID OF PARENT DOCUMENT TYPE]"
            },
            "compositionType": "Inheritance"
        }
    ]
}
```
