### PR TITLE
v14: Fix umbracopackage template

### DIFF
--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -10,7 +10,6 @@ using Umbraco.Cms.Api.Management.Services;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Web.BackOffice.Services;
 using Umbraco.Cms.Web.Common.ApplicationBuilder;
 
 namespace Umbraco.Extensions;

--- a/src/Umbraco.Cms.Api.Management/Services/ConflictingRouteService.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/ConflictingRouteService.cs
@@ -4,7 +4,7 @@ using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Web.Common.Attributes;
 
-namespace Umbraco.Cms.Web.BackOffice.Services;
+namespace Umbraco.Cms.Api.Management.Services;
 
 public class ConflictingRouteService : IConflictingRouteService
 {

--- a/templates/UmbracoPackage/UmbracoPackage.csproj
+++ b/templates/UmbracoPackage/UmbracoPackage.csproj
@@ -14,10 +14,10 @@
     <Description>...</Description>
     <PackageTags>umbraco plugin package</PackageTags>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Umbraco.Cms.Web.Website" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
-    <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
+    <PackageReference Include="Umbraco.Cms.Web.Common" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/UmbracoPackageRcl/UmbracoPackage.csproj
+++ b/templates/UmbracoPackageRcl/UmbracoPackage.csproj
@@ -22,6 +22,6 @@
 
   <ItemGroup>
     <PackageReference Include="Umbraco.Cms.Web.Website" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
-    <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
+    <PackageReference Include="Umbraco.Cms.Web.Common" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/15881

# Notes
- Removes the last mentions of `Umbraco.Cms.Web.Backoffice`
- Adds reference to `Umbraco.Cms.Web.Common` as they have the swagger classes needed for packages 👍 

# How to test
- In the root of the repository, open a terminal and run following commands:
-  `dotnet pack -o nugetFolder`
- `dotnet nuget add source [PATH TO "nugetFolder" HERE]`
- `cd nugetFolder`
- `dotnet new install ./Umbraco.Templates.14.0.0--beta002.preview.471.g1e8d117.nupkg`
- Navigate to another folder where you want to install your template
- `dotnet new umbracopackage -n "TestName"`
This should now work 🙌 