### PR TITLE
DataTypeSplit datacollector should not care about propertyEditors

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/PreMigration/DataTypeSplitDataCollector.cs
+++ b/src/Umbraco.Infrastructure/Migrations/PreMigration/DataTypeSplitDataCollector.cs
@@ -92,7 +92,8 @@ public class DataTypeSplitDataCollector : INotificationHandler<UmbracoApplicatio
 
         var fromCodeEditorsData = _dataEditors
             .Where(de =>
-                de.GetType().Assembly.GetName().FullName
+                de.Type == EditorType.PropertyValue
+                && de.GetType().Assembly.GetName().FullName
                     .StartsWith("umbraco.core", StringComparison.InvariantCultureIgnoreCase) is false
                 && de.GetType().Assembly.GetName().FullName
                     .StartsWith("umbraco.infrastructure", StringComparison.InvariantCultureIgnoreCase) is false)


### PR DESCRIPTION
### Description
Quick fix for https://github.com/umbraco/Umbraco-CMS/issues/15872
It is possible to have the same Alias for a dataEditor used as a propertyEditor and a dataEditor used as a macroparameterEditor.

The DataTypeSplit Datacollector does not care about the macroParameterEditors as they will not be migrated to v14. => only get the DataEditors from code that are used as propertyEditors thus using aliases (which should be unique) safely as dictionary keys again.
