### PR TITLE
Added missing locks and use timeout on all of them in ObjectCacheAppCache

### DIFF
--- a/src/Umbraco.Core/Cache/ObjectCacheAppCache.cs
+++ b/src/Umbraco.Core/Cache/ObjectCacheAppCache.cs
@@ -353,9 +353,6 @@ public class ObjectCacheAppCache : IAppPolicyCache, IDisposable
         }
     }
 
-    /// <remarks>
-    /// Requires to be called inside a write lock
-    /// </remarks>
     private MemoryCacheEntryOptions GetOptions(TimeSpan? timeout = null, bool isSliding = false)
     {
         var options = new MemoryCacheEntryOptions();

--- a/src/Umbraco.Core/Cache/ObjectCacheAppCache.cs
+++ b/src/Umbraco.Core/Cache/ObjectCacheAppCache.cs
@@ -194,9 +194,9 @@ public class ObjectCacheAppCache : IAppPolicyCache, IDisposable
         }
         finally
         {
-            if (_locker.IsReadLockHeld)
+            if (_locker.IsWriteLockHeld)
             {
-                _locker.ExitReadLock();
+                _locker.ExitWriteLock();
             }
         }
     }


### PR DESCRIPTION
### Description
This PR ensures we have locks every time we interfere with the memory cache and hashset.  Further, to ensure we do not potentially end in infinite deadlocks, I added a timeout to all of them

Fixes a comment here https://github.com/umbraco/Umbraco-CMS/pull/15173#issuecomment-2004264906

### Test
Ensure the cache still works.. I would expect the test suites to test this pretty intensive.

Ultimately, this fix is due to our hunt for the issue where the hashset suddenly is out of sync with the memory cache. So what ever you can think of as a test, would be nice.