### PR TITLE
Prevent template circular references

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/TemplateControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/TemplateControllerBase.cs
@@ -30,6 +30,10 @@ public class TemplateControllerBase : ManagementApiControllerBase
                 .WithTitle("Duplicate alias")
                 .WithDetail("A template with that alias already exists.")
                 .Build()),
+            TemplateOperationStatus.CircularMasterTemplateReference => BadRequest(problemDetailsBuilder
+                .WithTitle("Invalid master template")
+                .WithDetail("The master template referenced in the template leads to a circular reference.")
+                .Build()),
             _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown template operation status.")
                 .Build()),

--- a/src/Umbraco.Core/Services/OperationStatus/TemplateOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/TemplateOperationStatus.cs
@@ -7,5 +7,6 @@ public enum TemplateOperationStatus
     InvalidAlias,
     DuplicateAlias,
     TemplateNotFound,
-    MasterTemplateNotFound
+    MasterTemplateNotFound,
+    CircularMasterTemplateReference
 }

--- a/src/Umbraco.Core/Services/TemplateService.cs
+++ b/src/Umbraco.Core/Services/TemplateService.cs
@@ -425,7 +425,7 @@ public class TemplateService : RepositoryService, ITemplateService
     private async Task<bool> HasCircularReference(string parsedMasterTemplateAlias, ITemplate template, ITemplate masterTemplate)
     {
         // quick check without extra DB calls as we already have both templates
-        if (parsedMasterTemplateAlias.IsNullOrWhiteSpace() == false
+        if (parsedMasterTemplateAlias.IsNullOrWhiteSpace() is false
             && masterTemplate.MasterTemplateAlias is not null
             && masterTemplate.MasterTemplateAlias.Equals(template.Alias))
         {
@@ -449,7 +449,7 @@ public class TemplateService : RepositoryService, ITemplateService
         }
 
         ITemplate? masterTemplate = await GetAsync(masterTemplateAlias);
-        if (masterTemplate == null)
+        if (masterTemplate is null)
         {
             // this should not happen unless somebody manipulated the data by hand as this function is only called between persisted items
             return false;

--- a/src/Umbraco.Core/Services/TemplateService.cs
+++ b/src/Umbraco.Core/Services/TemplateService.cs
@@ -242,6 +242,14 @@ public class TemplateService : RepositoryService, ITemplateService
                 return Attempt.FailWithStatus(TemplateOperationStatus.MasterTemplateNotFound, template);
             }
 
+            // detect immediate circular references
+            if (masterTemplateAlias.IsNullOrWhiteSpace() == false
+            && masterTemplate?.MasterTemplateAlias is not null
+            && masterTemplate.MasterTemplateAlias.Equals(template.Alias))
+            {
+                return Attempt.FailWithStatus(TemplateOperationStatus.CircularMasterTemplateReference, template);
+            }
+
             await SetMasterTemplateAsync(template, masterTemplate, userKey);
 
             EventMessages eventMessages = EventMessagesFactory.Get();

--- a/src/Umbraco.Core/Services/TemplateService.cs
+++ b/src/Umbraco.Core/Services/TemplateService.cs
@@ -424,6 +424,7 @@ public class TemplateService : RepositoryService, ITemplateService
 
     private async Task<bool> HasCircularReference(string parsedMasterTemplateAlias, ITemplate template, ITemplate masterTemplate)
     {
+        // quick check without extra DB calls as we already have both templates
         if (parsedMasterTemplateAlias.IsNullOrWhiteSpace() == false
             && masterTemplate.MasterTemplateAlias is not null
             && masterTemplate.MasterTemplateAlias.Equals(template.Alias))
@@ -432,10 +433,10 @@ public class TemplateService : RepositoryService, ITemplateService
         }
 
         var processedTemplates = new List<ITemplate> { template, masterTemplate };
-        return await HasCircularReference(processedTemplates, masterTemplate.MasterTemplateAlias);
+        return await HasRecursiveCircularReference(processedTemplates, masterTemplate.MasterTemplateAlias);
     }
 
-    private async Task<bool> HasCircularReference(List<ITemplate> referencedTemplates, string? masterTemplateAlias)
+    private async Task<bool> HasRecursiveCircularReference(List<ITemplate> referencedTemplates, string? masterTemplateAlias)
     {
         if (masterTemplateAlias is null)
         {
@@ -456,6 +457,6 @@ public class TemplateService : RepositoryService, ITemplateService
 
         referencedTemplates.Add(masterTemplate);
 
-        return await HasCircularReference(referencedTemplates, masterTemplate.MasterTemplateAlias);
+        return await HasRecursiveCircularReference(referencedTemplates, masterTemplate.MasterTemplateAlias);
     }
 }


### PR DESCRIPTION
### Prerequisites
- [x] I have added steps to test this contribution in the description below

### Description
It is currently possible to make circular references when updating/creating templates trough the management api. This PR makes those type of requests fail gracefully instead.

### Testing
Create any kind of circular dependency trough the backoffice UI. It will allow you to select templates as a master that lead to circular references, but when trying to save the change you should get a nice warning

Saving valid templates should still work
