### PR TITLE
Cache a dictionary of dictionaries

### DIFF
--- a/src/Umbraco.Web.Common/UmbracoHelper.cs
+++ b/src/Umbraco.Web.Common/UmbracoHelper.cs
@@ -1,10 +1,10 @@
 using System.Globalization;
-using System.Xml.XPath;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Dictionary;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Core.Templates;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Web.Common;
 

--- a/src/Umbraco.Web.Common/UmbracoHelper.cs
+++ b/src/Umbraco.Web.Common/UmbracoHelper.cs
@@ -104,15 +104,15 @@ public class UmbracoHelper
     /// <summary>
     ///     Returns the dictionary value for the key specified
     /// </summary>
-    /// <param name="key"></param>
-    /// <returns></returns>
+    /// <param name="key">Key of dictionary item.</param>
+    /// <returns>The dictionary value, should one exist.</returns>
     public string? GetDictionaryValue(string key) => GetDictionaryValue(key, Thread.CurrentThread.CurrentUICulture);
 
 
     /// <summary>
     ///     Returns the dictionary value for the key specified, and if empty returns the specified default fall back value
     /// </summary>
-    /// <param name="key">key of dictionary item.</param>
+    /// <param name="key">Key of dictionary item.</param>
     /// <param name="specificCulture">the specific culture on which the result well be back upon</param>
     /// <returns>The dictionary value, should one exist.</returns>
     public string? GetDictionaryValue(string key, CultureInfo specificCulture)
@@ -133,24 +133,6 @@ public class UmbracoHelper
         if (string.IsNullOrWhiteSpace(dictionaryValue))
         {
             dictionaryValue = defaultValue;
-        }
-
-        return dictionaryValue;
-    }
-
-    /// <summary>
-    ///     Returns the dictionary value for the key specified, and if empty returns the specified default fall back value
-    /// </summary>
-    /// <param name="key">key of dictionary item</param>
-    /// <param name="altText">fall back text if dictionary item is empty - Name altText to match Umbraco.Field</param>
-    /// <returns>Returns the dictionary value, or a default value if none exists.</returns>
-    [Obsolete("Use GetDictionaryValueOrDefault instead, scheduled for removal in v14.")]
-    public string GetDictionaryValue(string key, string altText)
-    {
-        var dictionaryValue = GetDictionaryValue(key);
-        if (string.IsNullOrWhiteSpace(dictionaryValue))
-        {
-            dictionaryValue = altText;
         }
 
         return dictionaryValue;

--- a/src/Umbraco.Web.Common/UmbracoHelper.cs
+++ b/src/Umbraco.Web.Common/UmbracoHelper.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Xml.XPath;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Dictionary;
 using Umbraco.Cms.Core.Models.PublishedContent;
@@ -18,7 +19,7 @@ public class UmbracoHelper
     private readonly IUmbracoComponentRenderer _componentRenderer;
     private readonly ICultureDictionaryFactory _cultureDictionaryFactory;
     private readonly IPublishedContentQuery _publishedContentQuery;
-    private ICultureDictionary? _cultureDictionary;
+    private readonly Dictionary<CultureInfo, ICultureDictionary> _cultureDictionaries = [];
 
     private IPublishedContent? _currentPage;
 
@@ -105,27 +106,27 @@ public class UmbracoHelper
     /// </summary>
     /// <param name="key"></param>
     /// <returns></returns>
-    public string? GetDictionaryValue(string key) => CultureDictionary[key];
+    public string? GetDictionaryValue(string key) => GetDictionaryValue(key, Thread.CurrentThread.CurrentUICulture);
 
 
     /// <summary>
     ///     Returns the dictionary value for the key specified, and if empty returns the specified default fall back value
     /// </summary>
-    /// <param name="key">key of dictionary item</param>
+    /// <param name="key">key of dictionary item.</param>
     /// <param name="specificCulture">the specific culture on which the result well be back upon</param>
-    /// <returns></returns>
+    /// <returns>The dictionary value, should one exist.</returns>
     public string? GetDictionaryValue(string key, CultureInfo specificCulture)
     {
-        _cultureDictionary = _cultureDictionaryFactory.CreateDictionary(specificCulture);
-        return GetDictionaryValue(key);
+        ICultureDictionary cultureDictionary = GetCultureDictionary(specificCulture);
+        return cultureDictionary[key];
     }
 
     /// <summary>
     ///     Returns the dictionary value for the key specified, and if empty returns the specified default fall back value
     /// </summary>
-    /// <param name="key">key of dictionary item</param>
-    /// <param name="defaultValue">fall back text if dictionary item is empty - Name altText to match Umbraco.Field</param>
-    /// <returns></returns>
+    /// <param name="key">key of dictionary item.</param>
+    /// <param name="defaultValue">fall back text if dictionary item is empty - Name altText to match Umbraco.Field.</param>
+    /// <returns>Returns the dictionary value, or a default value if none exists.</returns>
     public string GetDictionaryValueOrDefault(string key, string defaultValue)
     {
         var dictionaryValue = GetDictionaryValue(key);
@@ -141,25 +142,68 @@ public class UmbracoHelper
     ///     Returns the dictionary value for the key specified, and if empty returns the specified default fall back value
     /// </summary>
     /// <param name="key">key of dictionary item</param>
-    /// <param name="specificCulture">the specific culture on which the result well be back upon</param>
-    /// <param name="defaultValue">fall back text if dictionary item is empty - Name altText to match Umbraco.Field</param>
-    /// <returns></returns>
+    /// <param name="altText">fall back text if dictionary item is empty - Name altText to match Umbraco.Field</param>
+    /// <returns>Returns the dictionary value, or a default value if none exists.</returns>
+    [Obsolete("Use GetDictionaryValueOrDefault instead, scheduled for removal in v14.")]
+    public string GetDictionaryValue(string key, string altText)
+    {
+        var dictionaryValue = GetDictionaryValue(key);
+        if (string.IsNullOrWhiteSpace(dictionaryValue))
+        {
+            dictionaryValue = altText;
+        }
+
+        return dictionaryValue;
+    }
+
+    /// <summary>
+    ///     Returns the dictionary value for the key specified, and if empty returns the specified default fall back value
+    /// </summary>
+    /// <param name="key">Key of dictionary item.</param>
+    /// <param name="specificCulture">The specific culture on which the result well be back upon.</param>
+    /// <param name="defaultValue">Fall back text if dictionary item is empty - Name altText to match Umbraco.Field.</param>
+    /// <returns>Returns the dictionary value, or a default value if none exists.</returns>
     public string GetDictionaryValueOrDefault(string key, CultureInfo specificCulture, string defaultValue)
     {
-        _cultureDictionary = _cultureDictionaryFactory.CreateDictionary(specificCulture);
-        var dictionaryValue = GetDictionaryValue(key);
+        var dictionaryValue = GetDictionaryValue(key, specificCulture);
         if (string.IsNullOrWhiteSpace(dictionaryValue))
         {
             dictionaryValue = defaultValue;
         }
+
         return dictionaryValue;
     }
 
+    /// <summary>
+    ///     Gets the ICultureDictionary for the current UI Culture for access to dictionary items
+    /// </summary>
+    public ICultureDictionary CultureDictionary => GetCultureDictionary(Thread.CurrentThread.CurrentUICulture);
 
     /// <summary>
-    ///     Returns the ICultureDictionary for access to dictionary items
+    ///     Gets the ICultureDictionary for access to dictionary items for a specific culture
     /// </summary>
-    public ICultureDictionary CultureDictionary => _cultureDictionary ??= _cultureDictionaryFactory.CreateDictionary();
+    /// <param name="specificCulture">The culture of the culture dictionary you want to retrieve.</param>
+    /// <returns>Returns the culture dictionary for the specified culture.</returns>
+    public ICultureDictionary GetCultureDictionary(CultureInfo specificCulture)
+    {
+        CreateCultureDictionary(specificCulture);
+        return _cultureDictionaries.GetValue(specificCulture)!;
+    }
+
+    /// <summary>
+    ///     Creates a culture dictionary for a specific culture if it doesn't already exist
+    /// </summary>
+    /// <param name="specificCulture">The culture to create a culture dictionary for.</param>
+    internal void CreateCultureDictionary(CultureInfo specificCulture)
+    {
+        if (_cultureDictionaries.ContainsKey(specificCulture))
+        {
+            return;
+        }
+
+        ICultureDictionary dictionary = _cultureDictionaryFactory.CreateDictionary(specificCulture);
+        _cultureDictionaries.Add(specificCulture, dictionary);
+    }
 
     #endregion
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->
Fixes #15765

### Description
The current implementation only allows for one culture dictionary to be cached at a time. This would result in the cached culture dictionary being whatever the last culture you requested was, which would have confusing results. This new implementation allows for caching all cultures.

### Testing
- Create a site with two or more cultures
- Add some dictionary items
- Add the following to your view 

```
@Umbraco.GetDictionaryValue("Key")
@Umbraco.GetDictionaryValue("Key", CultureInfo.GetCultureInfo("your-other-culture"))
@Umbraco.GetDictionaryValue("Key")
```
- Observe that the values are for the correct culture

