### PR TITLE
Add additional lock timeouts and clean-up `ObjectCacheAppCache`

### DIFF
--- a/src/Umbraco.Core/Cache/ObjectCacheAppCache.cs
+++ b/src/Umbraco.Core/Cache/ObjectCacheAppCache.cs
@@ -39,7 +39,7 @@ public class ObjectCacheAppCache : IAppPolicyCache, IDisposable
     /// </summary>
     /// <param name="options">The options.</param>
     /// <param name="loggerFactory">The logger factory.</param>
-    public ObjectCacheAppCache(IOptions<MemoryCacheOptions> options, ILoggerFactory loggerFactory)
+    internal ObjectCacheAppCache(IOptions<MemoryCacheOptions> options, ILoggerFactory loggerFactory)
         => MemoryCache = new MemoryCache(options, loggerFactory);
 
     /// <inheritdoc />


### PR DESCRIPTION
This extends PR https://github.com/umbraco/Umbraco-CMS/pull/15902 with additional lock timeouts in `SearchByPredicate()` when entering the upgradable read lock and in `Clear()` when taking the write lock. The timeout exception messages are also updated to clearly state when it occurred, which should make debugging easier.

I've also cleaned up the constructor, as that still had the `IHostEnvironment` parameter (kept in PR https://github.com/umbraco/Umbraco-CMS/pull/15173 to maintain backwards compatibility, but this got merged to v14, so can be breaking now).