### PR TITLE
V14: Add reserved fields to config endpoints

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/ConfigurationDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/ConfigurationDocumentController.cs
@@ -20,7 +20,7 @@ public class ConfigurationDocumentController : DocumentControllerBase
     [ProducesResponseType(typeof(DocumentConfigurationResponseModel), StatusCodes.Status200OK)]
     public Task<IActionResult> Configuration()
     {
-        DocumentConfigurationResponseModel responseModel = _configurationPresentationFactory.CreateDocumentConfigurationModel();
+        DocumentConfigurationResponseModel responseModel = _configurationPresentationFactory.CreateDocumentConfigurationResponseModel();
         return Task.FromResult<IActionResult>(Ok(responseModel));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/ConfigurationDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/ConfigurationDocumentController.cs
@@ -1,43 +1,26 @@
 ﻿using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
+using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.Document;
-using Umbraco.Cms.Core.Configuration.Models;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Document;
 
 [ApiVersion("1.0")]
 public class ConfigurationDocumentController : DocumentControllerBase
 {
-    private readonly GlobalSettings _globalSettings;
-    private readonly ContentSettings _contentSettings;
-    private readonly SegmentSettings _segmentSettings;
+    private readonly IConfigurationPresentationFactory _configurationPresentationFactory;
 
     public ConfigurationDocumentController(
-        IOptionsSnapshot<GlobalSettings> globalSettings,
-        IOptionsSnapshot<ContentSettings> contentSettings,
-        IOptionsSnapshot<SegmentSettings> segmentSettings)
-    {
-        _contentSettings = contentSettings.Value;
-        _globalSettings = globalSettings.Value;
-        _segmentSettings = segmentSettings.Value;
-    }
+        IConfigurationPresentationFactory configurationPresentationFactory) =>
+        _configurationPresentationFactory = configurationPresentationFactory;
 
     [HttpGet("configuration")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(DocumentConfigurationResponseModel), StatusCodes.Status200OK)]
     public Task<IActionResult> Configuration()
     {
-        var responseModel = new DocumentConfigurationResponseModel
-        {
-            DisableDeleteWhenReferenced = _contentSettings.DisableDeleteWhenReferenced,
-            DisableUnpublishWhenReferenced = _contentSettings.DisableUnpublishWhenReferenced,
-            SanitizeTinyMce = _globalSettings.SanitizeTinyMce,
-            AllowEditInvariantFromNonDefault = _contentSettings.AllowEditInvariantFromNonDefault,
-            AllowNonExistingSegmentsCreation = _segmentSettings.AllowCreation,
-        };
-
+        DocumentConfigurationResponseModel responseModel = _configurationPresentationFactory.Create();
         return Task.FromResult<IActionResult>(Ok(responseModel));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/ConfigurationMediaController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/ConfigurationMediaController.cs
@@ -1,35 +1,25 @@
 ﻿using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
+using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.Media;
-using Umbraco.Cms.Core.Configuration.Models;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Media;
 
 [ApiVersion("1.0")]
 public class ConfigurationMediaController : MediaControllerBase
 {
-    private readonly GlobalSettings _globalSettings;
-    private readonly ContentSettings _contentSettings;
+    private readonly IConfigurationPresentationFactory _configurationPresentationFactory;
 
-    public ConfigurationMediaController(IOptionsSnapshot<GlobalSettings> globalSettings, IOptionsSnapshot<ContentSettings> contentSettings)
-    {
-        _contentSettings = contentSettings.Value;
-        _globalSettings = globalSettings.Value;
-    }
+
+    public ConfigurationMediaController(IConfigurationPresentationFactory configurationPresentationFactory) => _configurationPresentationFactory = configurationPresentationFactory;
 
     [HttpGet("configuration")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(MediaConfigurationResponseModel), StatusCodes.Status200OK)]
     public Task<IActionResult> Configuration()
     {
-        var responseModel = new MediaConfigurationResponseModel
-        {
-            DisableDeleteWhenReferenced = _contentSettings.DisableDeleteWhenReferenced,
-            DisableUnpublishWhenReferenced = _contentSettings.DisableUnpublishWhenReferenced,
-            SanitizeTinyMce = _globalSettings.SanitizeTinyMce,
-        };
+        MediaConfigurationResponseModel responseModel = _configurationPresentationFactory.CreateMediaConfigurationResponseModel();
         return Task.FromResult<IActionResult>(Ok(responseModel));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/ConfigurationMediaController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/ConfigurationMediaController.cs
@@ -12,7 +12,8 @@ public class ConfigurationMediaController : MediaControllerBase
     private readonly IConfigurationPresentationFactory _configurationPresentationFactory;
 
 
-    public ConfigurationMediaController(IConfigurationPresentationFactory configurationPresentationFactory) => _configurationPresentationFactory = configurationPresentationFactory;
+    public ConfigurationMediaController(IConfigurationPresentationFactory configurationPresentationFactory)
+        => _configurationPresentationFactory = configurationPresentationFactory;
 
     [HttpGet("configuration")]
     [MapToApiVersion("1.0")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/ConfigurationMemberController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/ConfigurationMemberController.cs
@@ -2,25 +2,25 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
-using Umbraco.Cms.Api.Management.ViewModels.Document;
+using Umbraco.Cms.Api.Management.ViewModels.Member;
 
-namespace Umbraco.Cms.Api.Management.Controllers.Document;
+namespace Umbraco.Cms.Api.Management.Controllers.Member;
 
 [ApiVersion("1.0")]
-public class ConfigurationDocumentController : DocumentControllerBase
+public class ConfigurationMemberController : MemberControllerBase
 {
     private readonly IConfigurationPresentationFactory _configurationPresentationFactory;
 
-    public ConfigurationDocumentController(
+    public ConfigurationMemberController(
         IConfigurationPresentationFactory configurationPresentationFactory) =>
         _configurationPresentationFactory = configurationPresentationFactory;
 
     [HttpGet("configuration")]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(typeof(DocumentConfigurationResponseModel), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(MemberConfigurationResponseModel), StatusCodes.Status200OK)]
     public Task<IActionResult> Configuration()
     {
-        DocumentConfigurationResponseModel responseModel = _configurationPresentationFactory.CreateDocumentConfigurationModel();
+        MemberConfigurationResponseModel responseModel = _configurationPresentationFactory.CreateMemberConfigurationResponseModel();
         return Task.FromResult<IActionResult>(Ok(responseModel));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/ConfigurationBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/ConfigurationBuilderExtensions.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Core.DependencyInjection;
+
+namespace Umbraco.Cms.Api.Management.DependencyInjection;
+
+public static class ConfigurationBuilderExtensions
+{
+    internal static IUmbracoBuilder AddConfigurationFactories(this IUmbracoBuilder builder)
+    {
+        builder.Services.AddTransient<IConfigurationPresentationFactory, ConfigurationPresentationFactory>();
+
+        return builder;
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -32,6 +32,7 @@ public static partial class UmbracoBuilderExtensions
                 .AddSearchManagement()
                 .AddTrees()
                 .AddAuditLogs()
+                .AddConfigurationFactories()
                 .AddDocuments()
                 .AddDocumentTypes()
                 .AddMedia()

--- a/src/Umbraco.Cms.Api.Management/Factories/ConfigurationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/ConfigurationPresentationFactory.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Options;
 using Umbraco.Cms.Api.Management.ViewModels.Document;
+using Umbraco.Cms.Api.Management.ViewModels.Media;
 using Umbraco.Cms.Api.Management.ViewModels.Member;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
@@ -46,6 +47,28 @@ public class ConfigurationPresentationFactory : IConfigurationPresentationFactor
         {
             ReservedFieldNames = GetMemberReservedFieldNames(),
         };
+
+    public MediaConfigurationResponseModel CreateMediaConfigurationResponseModel()
+    {
+        var responseModel = new MediaConfigurationResponseModel
+        {
+            DisableDeleteWhenReferenced = _contentSettings.DisableDeleteWhenReferenced,
+            DisableUnpublishWhenReferenced = _contentSettings.DisableUnpublishWhenReferenced,
+            SanitizeTinyMce = _globalSettings.SanitizeTinyMce,
+            ReservedFieldNames = GetMediaReservedFieldNames(),
+        };
+        return responseModel;
+    }
+
+    private ISet<string> GetMediaReservedFieldNames()
+    {
+        var reservedProperties = typeof(IPublishedContent).GetPublicProperties().Select(x => x.Name).ToHashSet();
+        var reservedMethods = typeof(IPublishedContent).GetPublicMethods().Select(x => x.Name).ToHashSet();
+        reservedProperties.UnionWith(reservedMethods);
+        reservedProperties.UnionWith(_memberPropertySettings.ReservedFieldNames);
+
+        return reservedProperties;
+    }
 
     private ISet<string> GetMemberReservedFieldNames()
     {

--- a/src/Umbraco.Cms.Api.Management/Factories/ConfigurationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/ConfigurationPresentationFactory.cs
@@ -3,10 +3,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Document;
 using Umbraco.Cms.Api.Management.ViewModels.Media;
 using Umbraco.Cms.Api.Management.ViewModels.Member;
 using Umbraco.Cms.Core.Configuration.Models;
-using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Factories;
 
@@ -18,10 +15,10 @@ public class ConfigurationPresentationFactory : IConfigurationPresentationFactor
     private readonly SegmentSettings _segmentSettings;
 
     public ConfigurationPresentationFactory(
-        IOptionsSnapshot<GlobalSettings> globalSettings,
-        IOptionsSnapshot<ContentSettings> contentSettings,
-        IOptionsSnapshot<SegmentSettings> segmentSettings,
-        IReservedFieldNamesService reservedFieldNamesService)
+        IReservedFieldNamesService reservedFieldNamesService,
+        IOptions<GlobalSettings> globalSettings,
+        IOptions<ContentSettings> contentSettings,
+        IOptions<SegmentSettings> segmentSettings)
     {
         _reservedFieldNamesService = reservedFieldNamesService;
         _globalSettings = globalSettings.Value;
@@ -29,7 +26,7 @@ public class ConfigurationPresentationFactory : IConfigurationPresentationFactor
         _segmentSettings = segmentSettings.Value;
     }
 
-    public DocumentConfigurationResponseModel CreateDocumentConfigurationModel() =>
+    public DocumentConfigurationResponseModel CreateDocumentConfigurationResponseModel() =>
         new()
         {
             DisableDeleteWhenReferenced = _contentSettings.DisableDeleteWhenReferenced,
@@ -46,15 +43,12 @@ public class ConfigurationPresentationFactory : IConfigurationPresentationFactor
             ReservedFieldNames = _reservedFieldNamesService.GetMemberReservedFieldNames(),
         };
 
-    public MediaConfigurationResponseModel CreateMediaConfigurationResponseModel()
-    {
-        var responseModel = new MediaConfigurationResponseModel
+    public MediaConfigurationResponseModel CreateMediaConfigurationResponseModel() =>
+        new()
         {
             DisableDeleteWhenReferenced = _contentSettings.DisableDeleteWhenReferenced,
             DisableUnpublishWhenReferenced = _contentSettings.DisableUnpublishWhenReferenced,
             SanitizeTinyMce = _globalSettings.SanitizeTinyMce,
             ReservedFieldNames = _reservedFieldNamesService.GetMediaReservedFieldNames(),
         };
-        return responseModel;
-    }
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/ConfigurationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/ConfigurationPresentationFactory.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.Extensions.Options;
+using Umbraco.Cms.Api.Management.ViewModels.Document;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.Factories;
+
+public class ConfigurationPresentationFactory : IConfigurationPresentationFactory
+{
+    private readonly ContentPropertySettings _contentPropertySettings;
+    private readonly GlobalSettings _globalSettings;
+    private readonly ContentSettings _contentSettings;
+    private readonly SegmentSettings _segmentSettings;
+
+    public ConfigurationPresentationFactory(IOptionsSnapshot<GlobalSettings> globalSettings, IOptionsSnapshot<ContentSettings> contentSettings, IOptionsSnapshot<SegmentSettings> segmentSettings, IOptionsSnapshot<ContentPropertySettings> contentPropertySettings)
+    {
+        _contentPropertySettings = contentPropertySettings.Value;
+        _globalSettings = globalSettings.Value;
+        _contentSettings = contentSettings.Value;
+        _segmentSettings = segmentSettings.Value;
+    }
+
+    public DocumentConfigurationResponseModel Create() =>
+        new()
+        {
+            DisableDeleteWhenReferenced = _contentSettings.DisableDeleteWhenReferenced,
+            DisableUnpublishWhenReferenced = _contentSettings.DisableUnpublishWhenReferenced,
+            SanitizeTinyMce = _globalSettings.SanitizeTinyMce,
+            AllowEditInvariantFromNonDefault = _contentSettings.AllowEditInvariantFromNonDefault,
+            AllowNonExistingSegmentsCreation = _segmentSettings.AllowCreation,
+            ReservedFieldNames = GetReservedFieldNames(),
+        };
+
+    private ISet<string> GetReservedFieldNames()
+    {
+        var reservedProperties = typeof(IPublishedContent).GetPublicProperties().Select(x => x.Name).ToHashSet();
+        var reservedMethods = typeof(IPublishedContent).GetPublicMethods().Select(x => x.Name).ToHashSet();
+        reservedProperties.UnionWith(reservedMethods);
+        reservedProperties.UnionWith(_contentPropertySettings.ReservedFieldNames);
+
+        return reservedProperties;
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Factories/IConfigurationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IConfigurationPresentationFactory.cs
@@ -1,4 +1,5 @@
 ﻿using Umbraco.Cms.Api.Management.ViewModels.Document;
+using Umbraco.Cms.Api.Management.ViewModels.Media;
 using Umbraco.Cms.Api.Management.ViewModels.Member;
 
 namespace Umbraco.Cms.Api.Management.Factories;
@@ -7,4 +8,5 @@ public interface IConfigurationPresentationFactory
 {
     DocumentConfigurationResponseModel CreateDocumentConfigurationModel();
     MemberConfigurationResponseModel CreateMemberConfigurationResponseModel();
+    MediaConfigurationResponseModel CreateMediaConfigurationResponseModel();
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/IConfigurationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IConfigurationPresentationFactory.cs
@@ -6,7 +6,9 @@ namespace Umbraco.Cms.Api.Management.Factories;
 
 public interface IConfigurationPresentationFactory
 {
-    DocumentConfigurationResponseModel CreateDocumentConfigurationModel();
+    DocumentConfigurationResponseModel CreateDocumentConfigurationResponseModel();
+
     MemberConfigurationResponseModel CreateMemberConfigurationResponseModel();
+
     MediaConfigurationResponseModel CreateMediaConfigurationResponseModel();
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/IConfigurationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IConfigurationPresentationFactory.cs
@@ -1,8 +1,10 @@
 ﻿using Umbraco.Cms.Api.Management.ViewModels.Document;
+using Umbraco.Cms.Api.Management.ViewModels.Member;
 
 namespace Umbraco.Cms.Api.Management.Factories;
 
 public interface IConfigurationPresentationFactory
 {
-    DocumentConfigurationResponseModel Create();
+    DocumentConfigurationResponseModel CreateDocumentConfigurationModel();
+    MemberConfigurationResponseModel CreateMemberConfigurationResponseModel();
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/IConfigurationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IConfigurationPresentationFactory.cs
@@ -1,0 +1,8 @@
+﻿using Umbraco.Cms.Api.Management.ViewModels.Document;
+
+namespace Umbraco.Cms.Api.Management.Factories;
+
+public interface IConfigurationPresentationFactory
+{
+    DocumentConfigurationResponseModel Create();
+}

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -17429,6 +17429,56 @@
         ]
       }
     },
+    "/umbraco/management/api/v1/member/configuration": {
+      "get": {
+        "tags": [
+          "Member"
+        ],
+        "operationId": "GetMemberConfiguration",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/MemberConfigurationResponseModel"
+                    }
+                  ]
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/MemberConfigurationResponseModel"
+                    }
+                  ]
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/MemberConfigurationResponseModel"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
     "/umbraco/management/api/v1/member/validate": {
       "post": {
         "tags": [
@@ -34371,6 +34421,7 @@
           "allowNonExistingSegmentsCreation",
           "disableDeleteWhenReferenced",
           "disableUnpublishWhenReferenced",
+          "reservedFieldNames",
           "sanitizeTinyMce"
         ],
         "type": "object",
@@ -34389,6 +34440,13 @@
           },
           "allowNonExistingSegmentsCreation": {
             "type": "boolean"
+          },
+          "reservedFieldNames": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "additionalProperties": false
@@ -36085,6 +36143,7 @@
         "required": [
           "disableDeleteWhenReferenced",
           "disableUnpublishWhenReferenced",
+          "reservedFieldNames",
           "sanitizeTinyMce"
         ],
         "type": "object",
@@ -36097,6 +36156,13 @@
           },
           "sanitizeTinyMce": {
             "type": "boolean"
+          },
+          "reservedFieldNames": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "additionalProperties": false
@@ -36433,6 +36499,22 @@
             "$ref": "#/components/schemas/VariantResponseModelBaseModel"
           }
         ],
+        "additionalProperties": false
+      },
+      "MemberConfigurationResponseModel": {
+        "required": [
+          "reservedFieldNames"
+        ],
+        "type": "object",
+        "properties": {
+          "reservedFieldNames": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
         "additionalProperties": false
       },
       "MemberGroupItemResponseModel": {

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentConfigurationResponseModel.cs
@@ -11,4 +11,6 @@ public class DocumentConfigurationResponseModel
     public required bool AllowEditInvariantFromNonDefault { get; set; }
 
     public required bool AllowNonExistingSegmentsCreation { get; set; }
+
+    public required ISet<string> ReservedFieldNames { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Media/MediaConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Media/MediaConfigurationResponseModel.cs
@@ -7,4 +7,6 @@ public class MediaConfigurationResponseModel
     public required bool DisableUnpublishWhenReferenced { get; set; }
 
     public required bool SanitizeTinyMce { get; set; }
+
+    public required ISet<string> ReservedFieldNames { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Member/MemberConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Member/MemberConfigurationResponseModel.cs
@@ -1,0 +1,6 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Member;
+
+public class MemberConfigurationResponseModel
+{
+    public required ISet<string> ReservedFieldNames { get; set; }
+}

--- a/src/Umbraco.Core/Models/ContentPropertySettings.cs
+++ b/src/Umbraco.Core/Models/ContentPropertySettings.cs
@@ -2,7 +2,7 @@
 
 public class ContentPropertySettings
 {
-    private readonly HashSet<string> _reservedFieldNames = [];
+    private readonly HashSet<string> _reservedFieldNames = new();
 
     /// <summary>
     /// Gets a set of standard names for fields that cannot be used for custom properties.

--- a/src/Umbraco.Core/Models/ContentPropertySettings.cs
+++ b/src/Umbraco.Core/Models/ContentPropertySettings.cs
@@ -1,0 +1,13 @@
+﻿namespace Umbraco.Cms.Core.Models;
+
+public class ContentPropertySettings
+{
+    private readonly HashSet<string> _reservedFieldNames = [];
+
+    /// <summary>
+    /// Gets a set of standard names for fields that cannot be used for custom properties.
+    /// </summary>
+    public ISet<string> ReservedFieldNames => _reservedFieldNames;
+
+    public bool AddReservedFieldName(string name) => _reservedFieldNames.Add(name);
+}

--- a/src/Umbraco.Core/Models/MediaPropertySettings.cs
+++ b/src/Umbraco.Core/Models/MediaPropertySettings.cs
@@ -1,0 +1,13 @@
+﻿namespace Umbraco.Cms.Core.Models;
+
+public class MediaPropertySettings
+{
+    private readonly HashSet<string> _reservedFieldNames = [];
+
+    /// <summary>
+    /// Gets a set of standard names for fields that cannot be used for custom properties.
+    /// </summary>
+    public ISet<string> ReservedFieldNames => _reservedFieldNames;
+
+    public bool AddReservedFieldName(string name) => _reservedFieldNames.Add(name);
+}

--- a/src/Umbraco.Core/Models/MediaPropertySettings.cs
+++ b/src/Umbraco.Core/Models/MediaPropertySettings.cs
@@ -2,7 +2,7 @@
 
 public class MediaPropertySettings
 {
-    private readonly HashSet<string> _reservedFieldNames = [];
+    private readonly HashSet<string> _reservedFieldNames = new();
 
     /// <summary>
     /// Gets a set of standard names for fields that cannot be used for custom properties.

--- a/src/Umbraco.Core/Models/MemberPropertySettings.cs
+++ b/src/Umbraco.Core/Models/MemberPropertySettings.cs
@@ -2,7 +2,7 @@
 
 public class MemberPropertySettings
 {
-    private readonly HashSet<string> _reservedFieldNames = [];
+    private readonly HashSet<string> _reservedFieldNames = new();
 
     /// <summary>
     /// Gets a set of standard names for fields that cannot be used for custom properties.

--- a/src/Umbraco.Core/Models/MemberPropertySettings.cs
+++ b/src/Umbraco.Core/Models/MemberPropertySettings.cs
@@ -1,0 +1,13 @@
+﻿namespace Umbraco.Cms.Core.Models;
+
+public class MemberPropertySettings
+{
+    private readonly HashSet<string> _reservedFieldNames = [];
+
+    /// <summary>
+    /// Gets a set of standard names for fields that cannot be used for custom properties.
+    /// </summary>
+    public ISet<string> ReservedFieldNames => _reservedFieldNames;
+
+    public bool AddReservedFieldName(string name) => _reservedFieldNames.Add(name);
+}

--- a/src/Umbraco.Core/Services/IReservedFieldNamesService.cs
+++ b/src/Umbraco.Core/Services/IReservedFieldNamesService.cs
@@ -1,0 +1,10 @@
+﻿namespace Umbraco.Cms.Core.Services;
+
+public interface IReservedFieldNamesService
+{
+    ISet<string> GetDocumentReservedFieldNames();
+
+    ISet<string> GetMediaReservedFieldNames();
+
+    ISet<string> GetMemberReservedFieldNames();
+}

--- a/src/Umbraco.PublishedCache.NuCache/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.PublishedCache.NuCache/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -35,6 +35,7 @@ public static class UmbracoBuilderExtensions
         builder.Services.TryAddTransient(factory => new PublishedSnapshotServiceOptions());
         builder.SetPublishedSnapshotService<PublishedSnapshotService>();
         builder.Services.TryAddSingleton<IPublishedSnapshotStatus, PublishedSnapshotStatus>();
+        builder.Services.TryAddTransient<IReservedFieldNamesService, ReservedFieldNamesService>();
 
         // replace this service since we want to improve the content/media
         // mapping lookups if we are using nucache.

--- a/src/Umbraco.PublishedCache.NuCache/ReservedFieldNamesService.cs
+++ b/src/Umbraco.PublishedCache.NuCache/ReservedFieldNamesService.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Infrastructure.PublishedCache;
+
+internal class ReservedFieldNamesService : IReservedFieldNamesService
+{
+    private readonly ContentPropertySettings _contentPropertySettings;
+    private readonly MemberPropertySettings _memberPropertySettings;
+    private readonly MediaPropertySettings _mediaPropertySettings;
+
+    public ReservedFieldNamesService(IOptionsSnapshot<ContentPropertySettings> contentPropertySettings, IOptionsSnapshot<MemberPropertySettings> memberPropertySettings, IOptionsSnapshot<MediaPropertySettings> mediaPropertySettings)
+    {
+        _contentPropertySettings = contentPropertySettings.Value;
+        _memberPropertySettings = memberPropertySettings.Value;
+        _mediaPropertySettings = mediaPropertySettings.Value;
+    }
+
+    public ISet<string> GetDocumentReservedFieldNames()
+    {
+        var reservedProperties = typeof(IPublishedContent).GetPublicProperties().Select(x => x.Name).ToHashSet();
+        var reservedMethods = typeof(IPublishedContent).GetPublicMethods().Select(x => x.Name).ToHashSet();
+        reservedProperties.UnionWith(reservedMethods);
+        reservedProperties.UnionWith(_contentPropertySettings.ReservedFieldNames);
+
+        return reservedProperties;
+    }
+
+    public ISet<string> GetMediaReservedFieldNames()
+    {
+        var reservedProperties = typeof(IPublishedContent).GetPublicProperties().Select(x => x.Name).ToHashSet();
+        var reservedMethods = typeof(IPublishedContent).GetPublicMethods().Select(x => x.Name).ToHashSet();
+        reservedProperties.UnionWith(reservedMethods);
+        reservedProperties.UnionWith(_mediaPropertySettings.ReservedFieldNames);
+
+        return reservedProperties;
+    }
+
+    public ISet<string> GetMemberReservedFieldNames()
+    {
+        var reservedProperties = typeof(PublishedMember).GetPublicProperties().Select(x => x.Name).ToHashSet();
+        var reservedMethods = typeof(PublishedMember).GetPublicMethods().Select(x => x.Name).ToHashSet();
+        reservedProperties.UnionWith(reservedMethods);
+        reservedProperties.UnionWith(_memberPropertySettings.ReservedFieldNames);
+
+        return reservedProperties;
+    }
+}

--- a/src/Umbraco.PublishedCache.NuCache/ReservedFieldNamesService.cs
+++ b/src/Umbraco.PublishedCache.NuCache/ReservedFieldNamesService.cs
@@ -12,7 +12,10 @@ internal class ReservedFieldNamesService : IReservedFieldNamesService
     private readonly MemberPropertySettings _memberPropertySettings;
     private readonly MediaPropertySettings _mediaPropertySettings;
 
-    public ReservedFieldNamesService(IOptionsSnapshot<ContentPropertySettings> contentPropertySettings, IOptionsSnapshot<MemberPropertySettings> memberPropertySettings, IOptionsSnapshot<MediaPropertySettings> mediaPropertySettings)
+    public ReservedFieldNamesService(
+        IOptions<ContentPropertySettings> contentPropertySettings,
+        IOptions<MemberPropertySettings> memberPropertySettings,
+        IOptions<MediaPropertySettings> mediaPropertySettings)
     {
         _contentPropertySettings = contentPropertySettings.Value;
         _memberPropertySettings = memberPropertySettings.Value;


### PR DESCRIPTION
# Notes
- Added configuration endpoint for members
- Added new ConfigurationPresentationFactory, that is responsible for creating the configuration models
- Added new `IReservedNamesService` that will return all the reserved names for a given model (Member, Media, Content)
- Added 3 new property settings, so that users (or package devs) can define their own reserved names.

# How to test
- Using the 3 configuration endpoint, assert that you get the correct list of reserved names
- Try configuring the property settings & add some reserved names yourself, assert these also get returned via the endpoints
- You can use this code to configure the property settings:

```
public class TestComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder) =>
        builder.Services.Configure<ContentPropertySettings>(
            x =>
            {
                x.AddReservedFieldName("myReservedFieldName");
                x.AddReservedFieldName("anotherOne");
            });
}

```
