### PR TITLE
Ensure correct access to all manifests + introduce "public" package manifests

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Package/AllPackageManifestController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Package/AllPackageManifestController.cs
@@ -1,13 +1,16 @@
 ﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Package;
 using Umbraco.Cms.Core.Manifest;
 using Umbraco.Cms.Core.Mapping;
+using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Package;
 
 [ApiVersion("1.0")]
+[Authorize(Policy = AuthorizationPolicies.BackOfficeAccess)]
 public class AllPackageManifestController : PackageControllerBase
 {
     private readonly IPackageManifestService _packageManifestService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Package/PublicPackageManifestController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Package/PublicPackageManifestController.cs
@@ -1,4 +1,5 @@
 ﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Package;
@@ -8,24 +9,25 @@ using Umbraco.Cms.Core.Mapping;
 namespace Umbraco.Cms.Api.Management.Controllers.Package;
 
 [ApiVersion("1.0")]
-public class AllPackageManifestController : PackageControllerBase
+[AllowAnonymous]
+public class PublicPackageManifestController : PackageControllerBase
 {
     private readonly IPackageManifestService _packageManifestService;
     private readonly IUmbracoMapper _umbracoMapper;
 
-    public AllPackageManifestController(IPackageManifestService packageManifestService, IUmbracoMapper umbracoMapper)
+    public PublicPackageManifestController(IPackageManifestService packageManifestService, IUmbracoMapper umbracoMapper)
     {
         _packageManifestService = packageManifestService;
         _umbracoMapper = umbracoMapper;
     }
 
     // NOTE: this endpoint is deliberately created as non-paginated to ensure the fastest possible client initialization
-    [HttpGet("manifest")]
+    [HttpGet("manifest/public")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<PackageManifestResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> AllPackageManifests()
+    public async Task<IActionResult> PublicPackageManifests()
     {
-        PackageManifest[] packageManifests = (await _packageManifestService.GetAllPackageManifestsAsync()).ToArray();
+        PackageManifest[] packageManifests = (await _packageManifestService.GetPublicPackageManifestsAsync()).Where(m => m.AllowPublicAccess).ToArray();
         return Ok(_umbracoMapper.MapEnumerable<PackageManifest, PackageManifestResponseModel>(packageManifests));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Package/PublicPackageManifestController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Package/PublicPackageManifestController.cs
@@ -27,7 +27,7 @@ public class PublicPackageManifestController : PackageControllerBase
     [ProducesResponseType(typeof(IEnumerable<PackageManifestResponseModel>), StatusCodes.Status200OK)]
     public async Task<IActionResult> PublicPackageManifests()
     {
-        PackageManifest[] packageManifests = (await _packageManifestService.GetPublicPackageManifestsAsync()).Where(m => m.AllowPublicAccess).ToArray();
+        PackageManifest[] packageManifests = (await _packageManifestService.GetPublicPackageManifestsAsync()).ToArray();
         return Ok(_umbracoMapper.MapEnumerable<PackageManifest, PackageManifestResponseModel>(packageManifests));
     }
 }

--- a/src/Umbraco.Core/Manifest/IPackageManifestService.cs
+++ b/src/Umbraco.Core/Manifest/IPackageManifestService.cs
@@ -2,7 +2,9 @@
 
 public interface IPackageManifestService
 {
-    Task<IEnumerable<PackageManifest>> GetPackageManifestsAsync();
+    Task<IEnumerable<PackageManifest>> GetAllPackageManifestsAsync();
+
+    Task<IEnumerable<PackageManifest>> GetPublicPackageManifestsAsync();
 
     Task<PackageManifestImportmap> GetPackageManifestImportmapAsync();
 }

--- a/src/Umbraco.Core/Manifest/PackageManifest.cs
+++ b/src/Umbraco.Core/Manifest/PackageManifest.cs
@@ -6,6 +6,8 @@ public class PackageManifest
 
     public string? Version { get; set; }
 
+    public bool AllowPublicAccess { get; set; }
+
     public bool AllowTelemetry { get; set; } = true;
 
     public required object[] Extensions { get; set; }

--- a/src/Umbraco.Infrastructure/Manifest/PackageManifestService.cs
+++ b/src/Umbraco.Infrastructure/Manifest/PackageManifestService.cs
@@ -22,7 +22,7 @@ internal sealed class PackageManifestService : IPackageManifestService
         _cache = appCaches.RuntimeCache;
     }
 
-    public async Task<IEnumerable<PackageManifest>> GetPackageManifestsAsync()
+    public async Task<IEnumerable<PackageManifest>> GetAllPackageManifestsAsync()
         => await _cache.GetCacheItemAsync(
                $"{nameof(PackageManifestService)}-PackageManifests",
                async () =>
@@ -37,9 +37,12 @@ internal sealed class PackageManifestService : IPackageManifestService
                _packageManifestSettings.CacheTimeout)
            ?? Array.Empty<PackageManifest>();
 
+    public async Task<IEnumerable<PackageManifest>> GetPublicPackageManifestsAsync()
+        => (await GetAllPackageManifestsAsync()).Where(manifest => manifest.AllowPublicAccess).ToArray();
+
     public async Task<PackageManifestImportmap> GetPackageManifestImportmapAsync()
     {
-        IEnumerable<PackageManifest> packageManifests = await GetPackageManifestsAsync();
+        IEnumerable<PackageManifest> packageManifests = await GetAllPackageManifestsAsync();
         var manifests = packageManifests.Select(x => x.Importmap).WhereNotNull().ToList();
 
         var importDict = manifests

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Manifest/PackageManifestServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Manifest/PackageManifestServiceTests.cs
@@ -22,7 +22,8 @@ public class PackageManifestServiceTests
         _readerMock.Setup(r => r.ReadPackageManifestsAsync()).ReturnsAsync(
             new[]
             {
-                new PackageManifest { Name = "Test", Extensions = Array.Empty<object>() }
+                new PackageManifest { Name = "Test", Extensions = Array.Empty<object>(), AllowPublicAccess = false },
+                new PackageManifest { Name = "Test Public", Extensions = Array.Empty<object>(), AllowPublicAccess = true}
             });
 
         _runtimeCache = new ObjectCacheAppCache();
@@ -37,14 +38,14 @@ public class PackageManifestServiceTests
     [Test]
     public async Task Caches_PackageManifests()
     {
-        var result = await _service.GetPackageManifestsAsync();
-        Assert.AreEqual(1, result.Count());
+        var result = await _service.GetAllPackageManifestsAsync();
+        Assert.AreEqual(2, result.Count());
 
-        var result2 = await _service.GetPackageManifestsAsync();
-        Assert.AreEqual(1, result2.Count());
+        var result2 = await _service.GetAllPackageManifestsAsync();
+        Assert.AreEqual(2, result2.Count());
 
-        var result3 = await _service.GetPackageManifestsAsync();
-        Assert.AreEqual(1, result3.Count());
+        var result3 = await _service.GetAllPackageManifestsAsync();
+        Assert.AreEqual(2, result3.Count());
 
         _readerMock.Verify(r => r.ReadPackageManifestsAsync(), Times.Exactly(1));
     }
@@ -52,18 +53,28 @@ public class PackageManifestServiceTests
     [Test]
     public async Task Reloads_PackageManifest_After_Cache_Clear()
     {
-        var result = await _service.GetPackageManifestsAsync();
-        Assert.AreEqual(1, result.Count());
+        var result = await _service.GetAllPackageManifestsAsync();
+        Assert.AreEqual(2, result.Count());
         _runtimeCache.Clear();
 
-        var result2 = await _service.GetPackageManifestsAsync();
-        Assert.AreEqual(1, result2.Count());
+        var result2 = await _service.GetAllPackageManifestsAsync();
+        Assert.AreEqual(2, result2.Count());
         _runtimeCache.Clear();
 
-        var result3 = await _service.GetPackageManifestsAsync();
-        Assert.AreEqual(1, result3.Count());
+        var result3 = await _service.GetAllPackageManifestsAsync();
+        Assert.AreEqual(2, result3.Count());
         _runtimeCache.Clear();
 
         _readerMock.Verify(r => r.ReadPackageManifestsAsync(), Times.Exactly(3));
+    }
+
+    [Test]
+    public async Task Supports_Public_PackageManifests()
+    {
+        var result = await _service.GetPublicPackageManifestsAsync();
+        Assert.AreEqual(1, result.Count());
+
+        result = await _service.GetAllPackageManifestsAsync();
+        Assert.AreEqual(2, result.Count());
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Currently the editor needs access to the packages section in order to load package manifests. This won't do, because everyone with access to the backoffice potentially has to load package manifests.

Also, we need publicly available manifests, i.e. manifests that are allowed to load without backoffice access. These are necessary to power customizations of the login screen. It must be an explicit opt-in to be a "public" manifest.

Example of a manifest with public access:

```json
{
    "name": "My Public Package #1",
    "version": "1.0.0",
    "allowPublicAccess": true,
    "extensions": [{
        "alias": "My.Whatever",
            "name": "My Whatever"
        }
    ]
}
```

### Testing this PR

1. The "all package manifests" endpoint should be available for users without access to packages, settings or the like. That is, a "simple" content editor with only content access should still be able to load the manifests.
2. The new "public manifests" endpoint should be available without authentication.
