### PR TITLE
Introduce path provider and resolver for the Content Delivery API

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Controllers/Content/ByRouteContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/Content/ByRouteContentApiController.cs
@@ -8,7 +8,6 @@ using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Delivery.Controllers.Content;
 
@@ -16,10 +15,11 @@ namespace Umbraco.Cms.Api.Delivery.Controllers.Content;
 [ApiVersion("2.0")]
 public class ByRouteContentApiController : ContentApiItemControllerBase
 {
-    private readonly IRequestRoutingService _requestRoutingService;
+    private readonly IApiContentPathResolver _apiContentPathResolver;
     private readonly IRequestRedirectService _requestRedirectService;
     private readonly IRequestPreviewService _requestPreviewService;
     private readonly IRequestMemberAccessService _requestMemberAccessService;
+    private const string PreviewContentRequestPathPrefix = $"/{Constants.DeliveryApi.Routing.PreviewContentPathPrefix}";
 
     [Obsolete($"Please use the constructor that does not accept {nameof(IPublicAccessService)}. Will be removed in V14.")]
     public ByRouteContentApiController(
@@ -58,7 +58,7 @@ public class ByRouteContentApiController : ContentApiItemControllerBase
     {
     }
 
-    [ActivatorUtilitiesConstructor]
+    [Obsolete($"Please use the constructor that accepts {nameof(IApiContentPathResolver)}. Will be removed in V15.")]
     public ByRouteContentApiController(
         IApiPublishedContentCache apiPublishedContentCache,
         IApiContentResponseBuilder apiContentResponseBuilder,
@@ -66,12 +66,50 @@ public class ByRouteContentApiController : ContentApiItemControllerBase
         IRequestRedirectService requestRedirectService,
         IRequestPreviewService requestPreviewService,
         IRequestMemberAccessService requestMemberAccessService)
+        : this(
+            apiPublishedContentCache,
+            apiContentResponseBuilder,
+            requestRedirectService,
+            requestPreviewService,
+            requestMemberAccessService,
+            StaticServiceProvider.Instance.GetRequiredService<IApiContentPathResolver>())
+    {
+    }
+
+    [Obsolete($"Please use the non-obsolete constructor. Will be removed in V15.")]
+    public ByRouteContentApiController(
+        IApiPublishedContentCache apiPublishedContentCache,
+        IApiContentResponseBuilder apiContentResponseBuilder,
+        IPublicAccessService publicAccessService,
+        IRequestRoutingService requestRoutingService,
+        IRequestRedirectService requestRedirectService,
+        IRequestPreviewService requestPreviewService,
+        IRequestMemberAccessService requestMemberAccessService,
+        IApiContentPathResolver apiContentPathResolver)
+        : this(
+            apiPublishedContentCache,
+            apiContentResponseBuilder,
+            requestRedirectService,
+            requestPreviewService,
+            requestMemberAccessService,
+            apiContentPathResolver)
+    {
+    }
+
+    [ActivatorUtilitiesConstructor]
+    public ByRouteContentApiController(
+        IApiPublishedContentCache apiPublishedContentCache,
+        IApiContentResponseBuilder apiContentResponseBuilder,
+        IRequestRedirectService requestRedirectService,
+        IRequestPreviewService requestPreviewService,
+        IRequestMemberAccessService requestMemberAccessService,
+        IApiContentPathResolver apiContentPathResolver)
         : base(apiPublishedContentCache, apiContentResponseBuilder)
     {
-        _requestRoutingService = requestRoutingService;
         _requestRedirectService = requestRedirectService;
         _requestPreviewService = requestPreviewService;
         _requestMemberAccessService = requestMemberAccessService;
+        _apiContentPathResolver = apiContentPathResolver;
     }
 
     [HttpGet("item/{*path}")]
@@ -105,8 +143,6 @@ public class ByRouteContentApiController : ContentApiItemControllerBase
     private async Task<IActionResult> HandleRequest(string path)
     {
         path = DecodePath(path);
-
-        path = path.TrimStart("/");
         path = path.Length == 0 ? "/" : path;
 
         IPublishedContent? contentItem = GetContent(path);
@@ -128,17 +164,12 @@ public class ByRouteContentApiController : ContentApiItemControllerBase
     }
 
     private IPublishedContent? GetContent(string path)
-        => path.StartsWith(Constants.DeliveryApi.Routing.PreviewContentPathPrefix)
+        => path.StartsWith(PreviewContentRequestPathPrefix)
             ? GetPreviewContent(path)
             : GetPublishedContent(path);
 
     private IPublishedContent? GetPublishedContent(string path)
-    {
-        var contentRoute = _requestRoutingService.GetContentRoute(path);
-
-        IPublishedContent? contentItem = ApiPublishedContentCache.GetByRoute(contentRoute);
-        return contentItem;
-    }
+        => _apiContentPathResolver.ResolveContentPath(path);
 
     private IPublishedContent? GetPreviewContent(string path)
     {
@@ -147,7 +178,7 @@ public class ByRouteContentApiController : ContentApiItemControllerBase
             return null;
         }
 
-        if (Guid.TryParse(path.AsSpan(Constants.DeliveryApi.Routing.PreviewContentPathPrefix.Length).TrimEnd("/"), out Guid contentId) is false)
+        if (Guid.TryParse(path.AsSpan(PreviewContentRequestPathPrefix.Length).TrimEnd("/"), out Guid contentId) is false)
         {
             return null;
         }

--- a/src/Umbraco.Core/DeliveryApi/ApiContentPathProvider.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiContentPathProvider.cs
@@ -1,0 +1,16 @@
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Routing;
+
+namespace Umbraco.Cms.Core.DeliveryApi;
+
+// NOTE: left unsealed on purpose so it is extendable.
+public class ApiContentPathProvider : IApiContentPathProvider
+{
+    private readonly IPublishedUrlProvider _publishedUrlProvider;
+
+    public ApiContentPathProvider(IPublishedUrlProvider publishedUrlProvider)
+        => _publishedUrlProvider = publishedUrlProvider;
+
+    public virtual string? GetContentPath(IPublishedContent content, string? culture)
+        => _publishedUrlProvider.GetUrl(content, UrlMode.Relative, culture);
+}

--- a/src/Umbraco.Core/DeliveryApi/ApiContentPathResolver.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiContentPathResolver.cs
@@ -1,0 +1,26 @@
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Core.DeliveryApi;
+
+// NOTE: left unsealed on purpose so it is extendable.
+public class ApiContentPathResolver : IApiContentPathResolver
+{
+    private readonly IRequestRoutingService _requestRoutingService;
+    private readonly IApiPublishedContentCache _apiPublishedContentCache;
+
+    public ApiContentPathResolver(IRequestRoutingService requestRoutingService, IApiPublishedContentCache apiPublishedContentCache)
+    {
+        _requestRoutingService = requestRoutingService;
+        _apiPublishedContentCache = apiPublishedContentCache;
+    }
+
+    public virtual IPublishedContent? ResolveContentPath(string path)
+    {
+        path = path.EnsureStartsWith("/");
+
+        var contentRoute = _requestRoutingService.GetContentRoute(path);
+        IPublishedContent? contentItem = _apiPublishedContentCache.GetByRoute(contentRoute);
+        return contentItem;
+    }
+}

--- a/src/Umbraco.Core/DeliveryApi/IApiContentPathProvider.cs
+++ b/src/Umbraco.Core/DeliveryApi/IApiContentPathProvider.cs
@@ -1,0 +1,8 @@
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace Umbraco.Cms.Core.DeliveryApi;
+
+public interface IApiContentPathProvider
+{
+    string? GetContentPath(IPublishedContent content, string? culture);
+}

--- a/src/Umbraco.Core/DeliveryApi/IApiContentPathResolver.cs
+++ b/src/Umbraco.Core/DeliveryApi/IApiContentPathResolver.cs
@@ -1,0 +1,8 @@
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace Umbraco.Cms.Core.DeliveryApi;
+
+public interface IApiContentPathResolver
+{
+    IPublishedContent? ResolveContentPath(string path);
+}

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -453,6 +453,8 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddSingleton<IApiMediaQueryService, NoopApiMediaQueryService>();
         builder.Services.AddSingleton<IApiMediaUrlProvider, ApiMediaUrlProvider>();
         builder.Services.AddSingleton<IApiContentRouteBuilder, ApiContentRouteBuilder>();
+        builder.Services.AddSingleton<IApiContentPathProvider, ApiContentPathProvider>();
+        builder.Services.AddSingleton<IApiContentPathResolver, ApiContentPathResolver>();
         builder.Services.AddSingleton<IApiPublishedContentCache, ApiPublishedContentCache>();
         builder.Services.AddSingleton<IApiRichTextElementParser, ApiRichTextElementParser>();
         builder.Services.AddSingleton<IApiRichTextMarkupParser, ApiRichTextMarkupParser>();

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ContentBuilderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ContentBuilderTests.cs
@@ -31,12 +31,12 @@ public class ContentBuilderTests : DeliveryApiTests
         content.SetupGet(c => c.CreateDate).Returns(new DateTime(2023, 06, 01));
         content.SetupGet(c => c.UpdateDate).Returns(new DateTime(2023, 07, 12));
 
-        var publishedUrlProvider = new Mock<IPublishedUrlProvider>();
-        publishedUrlProvider
-            .Setup(p => p.GetUrl(It.IsAny<IPublishedContent>(), It.IsAny<UrlMode>(), It.IsAny<string?>(), It.IsAny<Uri?>()))
-            .Returns((IPublishedContent content, UrlMode mode, string? culture, Uri? current) => $"url:{content.UrlSegment}");
+        var apiContentRouteProvider = new Mock<IApiContentPathProvider>();
+        apiContentRouteProvider
+            .Setup(p => p.GetContentPath(It.IsAny<IPublishedContent>(), It.IsAny<string?>()))
+            .Returns((IPublishedContent c, string? culture) => $"url:{c.UrlSegment}");
 
-        var routeBuilder = CreateContentRouteBuilder(publishedUrlProvider.Object, CreateGlobalSettings());
+        var routeBuilder = CreateContentRouteBuilder(apiContentRouteProvider.Object, CreateGlobalSettings());
 
         var builder = new ApiContentBuilder(new ApiContentNameProvider(), routeBuilder, CreateOutputExpansionStrategyAccessor());
         var result = builder.Build(content.Object);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ContentPickerValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ContentPickerValueConverterTests.cs
@@ -18,7 +18,7 @@ public class ContentPickerValueConverterTests : PropertyValueConverterTests
             PublishedSnapshotAccessor,
             new ApiContentBuilder(
                 nameProvider ?? new ApiContentNameProvider(),
-                CreateContentRouteBuilder(PublishedUrlProvider, CreateGlobalSettings()),
+                CreateContentRouteBuilder(ApiContentPathProvider, CreateGlobalSettings()),
                 CreateOutputExpansionStrategyAccessor()));
 
     [Test]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/DeliveryApiTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/DeliveryApiTests.cs
@@ -114,7 +114,7 @@ public class DeliveryApiTests
         => $"{name.ToLowerInvariant().Replace(" ", "-")}{(culture.IsNullOrWhiteSpace() ? string.Empty : $"-{culture}")}";
 
     protected ApiContentRouteBuilder CreateContentRouteBuilder(
-        IPublishedUrlProvider publishedUrlProvider,
+        IApiContentPathProvider contentPathProvider,
         IOptions<GlobalSettings> globalSettings,
         IVariationContextAccessor? variationContextAccessor = null,
         IPublishedSnapshotAccessor? publishedSnapshotAccessor = null,
@@ -129,7 +129,7 @@ public class DeliveryApiTests
         }
 
         return new ApiContentRouteBuilder(
-            publishedUrlProvider,
+            contentPathProvider,
             globalSettings,
             variationContextAccessor ?? Mock.Of<IVariationContextAccessor>(),
             publishedSnapshotAccessor ?? Mock.Of<IPublishedSnapshotAccessor>(),

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MultiNodeTreePickerValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MultiNodeTreePickerValueConverterTests.cs
@@ -21,7 +21,7 @@ public class MultiNodeTreePickerValueConverterTests : PropertyValueConverterTest
 
         var contentNameProvider = new ApiContentNameProvider();
         var apiUrProvider = new ApiMediaUrlProvider(PublishedUrlProvider);
-        routeBuilder = routeBuilder ?? CreateContentRouteBuilder(PublishedUrlProvider, CreateGlobalSettings());
+        routeBuilder = routeBuilder ?? CreateContentRouteBuilder(ApiContentPathProvider, CreateGlobalSettings());
         return new MultiNodeTreePickerValueConverter(
             PublishedSnapshotAccessor,
             Mock.Of<IUmbracoContextAccessor>(),

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MultiUrlPickerValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MultiUrlPickerValueConverterTests.cs
@@ -294,7 +294,7 @@ public class MultiUrlPickerValueConverterTests : PropertyValueConverterTests
 
     private MultiUrlPickerValueConverter MultiUrlPickerValueConverter()
     {
-        var routeBuilder = CreateContentRouteBuilder(PublishedUrlProvider, CreateGlobalSettings());
+        var routeBuilder = CreateContentRouteBuilder(ApiContentPathProvider, CreateGlobalSettings());
         return new MultiUrlPickerValueConverter(
             PublishedSnapshotAccessor,
             Mock.Of<IProfilingLogger>(),

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/OutputExpansionStrategyTestBase.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/OutputExpansionStrategyTestBase.cs
@@ -452,5 +452,5 @@ public abstract class OutputExpansionStrategyTestBase : PropertyValueConverterTe
         return new PublishedElementPropertyBase(elementPropertyType, parent, false, PropertyCacheLevel.None);
     }
 
-    protected IApiContentRouteBuilder ApiContentRouteBuilder() => CreateContentRouteBuilder(PublishedUrlProvider, CreateGlobalSettings());
+    protected IApiContentRouteBuilder ApiContentRouteBuilder() => CreateContentRouteBuilder(ApiContentPathProvider, CreateGlobalSettings());
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/PropertyValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/PropertyValueConverterTests.cs
@@ -1,5 +1,6 @@
 using Moq;
 using NUnit.Framework;
+using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Routing;
@@ -11,6 +12,8 @@ public class PropertyValueConverterTests : DeliveryApiTests
     protected IPublishedSnapshotAccessor PublishedSnapshotAccessor { get; private set; }
 
     protected IPublishedUrlProvider PublishedUrlProvider { get; private set; }
+
+    protected IApiContentPathProvider ApiContentPathProvider { get; private set; }
 
     protected IPublishedContent PublishedContent { get; private set; }
 
@@ -69,6 +72,7 @@ public class PropertyValueConverterTests : DeliveryApiTests
             .Setup(p => p.GetMediaUrl(publishedMedia.Object, It.IsAny<UrlMode>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<Uri?>()))
             .Returns("the-media-url");
         PublishedUrlProvider = PublishedUrlProviderMock.Object;
+        ApiContentPathProvider = new ApiContentPathProvider(PublishedUrlProvider);
 
         var publishedSnapshotAccessor = new Mock<IPublishedSnapshotAccessor>();
         var publishedSnapshotObject = publishedSnapshot.Object;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

In certain cases it would be nice to be able to customise the content paths returned by the Content Delivery API - for example if one has a collection of shared content that is reused between multiple roots (sites).

This PR introduces the _content path provider_ and the matching _content path resolver_. Think of these as URL Provider and Content Finder for the Content Delivery API here.

The core implementations (`ApiContentPathProvider`, `ApiContentPathResolver`) are left public and unsealed to enable extendability.

## Testing this PR

Consider a content structure like this:

<img width="262" alt="image" src="https://github.com/umbraco/Umbraco-CMS/assets/7405322/189886e3-b8b0-40ce-a018-db30522ebfbf">

The following code adds custom paths to "Root One" and everything below (prefixes the content path with `/my-path`):

```csharp
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.DeliveryApi;
using Umbraco.Cms.Core.Models.PublishedContent;
using Umbraco.Cms.Core.Routing;

namespace Umbraco.Cms.Web.UI.Custom;

public class MyApiContentPathComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
        => builder.Services
            .AddSingleton<IApiContentPathProvider, MyApiContentPathProvider>()
            .AddSingleton<IApiContentPathResolver, MyApiContentPathResolver>();
}

public class MyApiContentPathProvider : ApiContentPathProvider
{
    public MyApiContentPathProvider(IPublishedUrlProvider publishedUrlProvider)
        : base(publishedUrlProvider)
    {
    }

    public override string? GetContentPath(IPublishedContent content, string? culture)
    {
        var path = base.GetContentPath(content, culture);
        if (path.IsNullOrWhiteSpace() is false && content.Root().Name == "Root One")
        {
            path = $"/my-path{path.EnsureStartsWith('/')}";
        }

        return path;
    }
}

public class MyApiContentPathResolver : ApiContentPathResolver
{
    public MyApiContentPathResolver(
        IRequestRoutingService requestRoutingService,
        IApiPublishedContentCache apiPublishedContentCache)
        : base(requestRoutingService, apiPublishedContentCache)
    {
    }

    public override IPublishedContent? ResolveContentPath(string path)
        => base.ResolveContentPath(path.TrimStart("/my-path"));
}
```

This should yield custom paths for _published_ content in the Content Delivery API output

<img width="517" alt="image" src="https://github.com/umbraco/Umbraco-CMS/assets/7405322/cb933bda-0a81-4281-812b-b449eb9de165">

...while _unpublished_ content retains the default preview path (remember to supply an API key to fetch unpublished content):

<img width="458" alt="image" src="https://github.com/umbraco/Umbraco-CMS/assets/7405322/78f47cf3-7e1a-420a-9641-399635840464">

It should be possible to request the content by the custom path:

<img width="910" alt="image" src="https://github.com/umbraco/Umbraco-CMS/assets/7405322/c05fef86-1ed7-4959-9246-d2bdccecc64e">

...and unpublished content by the preview path:

<img width="1021" alt="image" src="https://github.com/umbraco/Umbraco-CMS/assets/7405322/31d08684-3ca1-4d21-a32e-6494e40aebb4">

