### PR TITLE
Update valid reasons to not have a template on a content node to include having umbracoRedirect

### DIFF
--- a/src/Umbraco.Web.Website/Routing/UmbracoRouteValuesFactory.cs
+++ b/src/Umbraco.Web.Website/Routing/UmbracoRouteValuesFactory.cs
@@ -128,11 +128,12 @@ public class UmbracoRouteValuesFactory : IUmbracoRouteValuesFactory
         IPublishedRequest request = def.PublishedRequest;
 
         // Here we need to check if there is no hijacked route and no template assigned but there is a content item.
-        // If this is the case we want to return a blank page.
+        // If this is the case we want to return a blank page, the only exception being if the content item has a redirect field present.
         // We also check if templates have been disabled since if they are then we're allowed to render even though there's no template,
         // for example for json rendering in headless.
         if (request.HasPublishedContent()
             && !request.HasTemplate()
+            && !request.IsRedirect()
             && !_umbracoFeatures.Disabled.DisableTemplates
             && !hasHijackedRoute)
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #15724 

### Description

In Umbraco 8 it used to be possible to have a doctype with no template assigned and an 'umbracoRedirect' field present that when hit would redirect a user to a chosen page. In Umbraco 10 onwards, this functionality will only work if a template has also been assigned to the doctype. This PR restores the original behaviour.

This appears to happen because:-
* In Umbraco 8, as part of the 'GetHandlerForRoute()' method in 'Mvc\RenderRouteHandler.cs' a check is initially performed to see if the request has no template. If so it would begin to update it to a 404 via 'UpdateRequestToNotFound', before promptly exiting if it is detected it is a redirect and not following through any further on the 404 behaviour.
* In the newer Umbraco versions, the equivalent 'CheckNoTemplateAsync' method in Routing/UmbracoRouteValuesFactory.cs begins the same, calling an 'UpdateRequestAsync' method to begin updating this to a 404. However due to changes with a fresh copy of the request being created and null content entry now being passed in, the original 'IsRedirect' value is reset so it will no longer know it needs to do a redirect and continues through standard 404 behaviour.

To replicate the Umbraco 8 behaviour, I've moved an additional check for 'IsRedirect' to the outer point in UmbracoRouteValuesFactory. As having a redirect field should be a valid reason to not have a template in the first place, this avoids it unnecessarily performing any further checks for the presence of the template and it'll then follow through the redirect behaviour instead.

An alternative way of approaching this could have been to update the inner behaviour on PublishedRouter/UpdateRequestAsync() to copy back in the redirect status after it is cleared. However as this method is used in multiple places changing this could have more of a regression impact.

### Testing

To test this:-

1) Create a new document type without a template
2) Give it a property named umbracoRedirect with a content picker editor.
3) Allow it wherever you need in the node tree.
4) Add a node of this type, choose a page to be redirected to in the field, and save & publish.
5) Visit the node address of the original node and you should now be redirected despite no template.

Some additional variations validated with this PR:-
* Content node with umbracoRedirect set and no template assigned. This would return a 404 'no template' error previously, but now will follow the redirect as per older Umbraco behaviour
* Content node with umbracoRedirect set and a template assigned. This would redirect fine previously, and still does so
* Content node with umbracoRedirect field present, but nothing picked and no template assigned. This would return the 404 'no template' error previously, and still does so as we are not able to redirect anywhere else
* Content node with umbracoRedirect field present, but nothing picked and a template assigned. This would return the content page itself and still does so.
* Ensured unit tests for UpdateRequestAsync still pass correctly

Thanks,
Terence