### PR TITLE
Use the correct localization keys for core property validation errors

### DIFF
--- a/src/Umbraco.Core/Constants-Validation.cs
+++ b/src/Umbraco.Core/Constants-Validation.cs
@@ -8,11 +8,11 @@ public static partial class Constants
         {
             public static class Properties
             {
-                public const string Missing = "#validation.property.missing";
+                public const string Missing = "#validation.invalidNull";
 
-                public const string Empty = "#validation.property.empty";
+                public const string Empty = "#validation.invalidEmpty";
 
-                public const string PatternMismatch = "#validation.property.pattern";
+                public const string PatternMismatch = "#validation.invalidPattern";
             }
         }
     }


### PR DESCRIPTION
### Description

When performing document/media/member property validation, there are three core validation errors that can occur:

- A mandatory value was not supplied.
- A mandatory value was empty.
- A value did not match the configured validation (regex) pattern.

Per property one can configure specific validation error messages, but by default these are blank - which means we use error messages defined in the core instead.

Since these core error messages are localized in the client, the server has to return a localization key. And as of right now, the localization keys returned are wrong 😆 so this PR fixes the localization keys returned by the server to match those known by the client.