### PR TITLE
V13: Align database schemas of migrated and new database

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -105,5 +105,6 @@ public class UmbracoPlan : MigrationPlan
         To<V_13_0_0.ChangeWebhookRequestObjectColumnToNvarcharMax>("{F74CDA0C-7AAA-48C8-94C6-C6EC3C06F599}");
         To<V_13_0_0.ChangeWebhookUrlColumnsToNvarcharMax>("{21C42760-5109-4C03-AB4F-7EA53577D1F5}");
         To<V_13_0_0.AddExceptionOccured>("{6158F3A3-4902-4201-835E-1ED7F810B2D8}");
+        To<V_13_3_0.AlignUpgradedDatabase>("{985AF2BA-69D3-4DBA-95E0-AD3FA7459FA7}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_3_0/AlignUpgradedDatabase.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_3_0/AlignUpgradedDatabase.cs
@@ -34,7 +34,7 @@ public class AlignUpgradedDatabase : MigrationBase
         MakeRelationTypeIndexUnique(indexes);
         RemoveUserGroupDefault(columns);
         MakeWebhookUrlNotNullable(columns);
-        MakeWebhoolLogUrlNotNullable(columns);
+        MakeWebhookLogUrlNotNullable(columns);
     }
 
     private void MakeIndexUnique<TDto>(string tableName, string indexName, IEnumerable<Tuple<string, string, string, bool>> indexes)
@@ -117,6 +117,7 @@ public class AlignUpgradedDatabase : MigrationBase
 
     private void AlignContentVersionTable(ColumnInfo[] columns)
     {
+        // We need to do this to ensure we don't try to rename the constraint if it doesn't exist.
         const string tableName = "umbracoContentVersion";
         const string columnName = "VersionDate";
         ColumnInfo? versionDateColumn = columns
@@ -175,6 +176,6 @@ public class AlignUpgradedDatabase : MigrationBase
     private void MakeWebhookUrlNotNullable(ColumnInfo[] columns)
         => MakeNvarCharColumnNotNullable("umbracoWebhook", "url", columns);
 
-    private void MakeWebhoolLogUrlNotNullable(ColumnInfo[] columns)
+    private void MakeWebhookLogUrlNotNullable(ColumnInfo[] columns)
         => MakeNvarCharColumnNotNullable("umbracoWebhookLog", "url", columns);
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_3_0/AlignUpgradedDatabase.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_3_0/AlignUpgradedDatabase.cs
@@ -1,4 +1,6 @@
 ﻿using NPoco;
+using Umbraco.Cms.Infrastructure.Migrations.Expressions.Alter.Expressions;
+using Umbraco.Cms.Infrastructure.Persistence;
 using ColumnInfo = Umbraco.Cms.Infrastructure.Persistence.SqlSyntax.ColumnInfo;
 
 namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_13_3_0;
@@ -22,8 +24,15 @@ public class AlignUpgradedDatabase : MigrationBase
             return;
         }
 
-        IEnumerable<ColumnInfo> columns = SqlSyntax.GetColumnsInSchema(Context.Database);
+        ColumnInfo[] columns = SqlSyntax.GetColumnsInSchema(Context.Database).ToArray();
 
+        DropCacheInstructionDefaultConstraint(columns);
+        RenameVersionDateColumn(columns);
+
+    }
+
+    private void DropCacheInstructionDefaultConstraint(IEnumerable<ColumnInfo> columns)
+    {
         const string cacheTableName = "umbracoCacheInstruction";
         const string cacheColumnName = "jsonInstruction";
         ColumnInfo? jsonInstructionColumn = columns
@@ -40,5 +49,32 @@ public class AlignUpgradedDatabase : MigrationBase
                 .OnTable(cacheTableName)
                 .OnColumn(cacheColumnName).Do();
         }
+    }
+
+    private void RenameVersionDateColumn(IEnumerable<ColumnInfo> columns)
+    {
+        const string tableName = "umbracoContentVersion";
+        const string columnName = "VersionDate";
+        ColumnInfo? versionDateColumn = columns
+            .FirstOrDefault(x => x is { TableName: tableName, ColumnName: columnName });
+
+        if (versionDateColumn is null)
+        {
+            // The column was not found I.E. the column is correctly named
+            return;
+        }
+
+        Rename.Column(columnName)
+            .OnTable(tableName)
+            .To("versionDate")
+            .Do();
+
+        // Renames the default constraint for the column,
+        // apparently the content version table used to be prefixed with cms and not umbraco
+        // We don't have a fluid way to rename the default constraint so we have to use raw SQL
+        // This should be okay though since we are only running this migration on SQL Server
+        Sql<ISqlContext> renameConstraintQuery = Database.SqlContext.Sql(
+            "EXEC sp_rename N'DF_cmsContentVersion_VersionDate', N'DF_umbracoContentVersion_versionDate', N'OBJECT'");
+        Database.Execute(renameConstraintQuery);
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_3_0/AlignUpgradedDatabase.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_3_0/AlignUpgradedDatabase.cs
@@ -11,7 +11,8 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_13_3_0;
 /// </summary>
 public class AlignUpgradedDatabase : MigrationBase
 {
-    public AlignUpgradedDatabase(IMigrationContext context) : base(context)
+    public AlignUpgradedDatabase(IMigrationContext context)
+        : base(context)
     {
     }
 
@@ -24,7 +25,6 @@ public class AlignUpgradedDatabase : MigrationBase
         }
 
         ColumnInfo[] columns = SqlSyntax.GetColumnsInSchema(Context.Database).ToArray();
-        // Indexes are in format TableName, IndexName, ColumnName, IsUnique
         Tuple<string, string, string, bool>[] indexes = SqlSyntax.GetDefinedIndexes(Database).ToArray();
 
         DropCacheInstructionDefaultConstraint(columns);
@@ -40,6 +40,7 @@ public class AlignUpgradedDatabase : MigrationBase
     private void MakeIndexUnique<TDto>(string tableName, string indexName, IEnumerable<Tuple<string, string, string, bool>> indexes)
     {
         // Let's only mess with the indexes if we have to.
+        // Indexes are in format TableName, IndexName, ColumnName, IsUnique
         Tuple<string, string, string, bool>? loginProviderIndex = indexes.FirstOrDefault(x =>
             x.Item1 == tableName && x.Item2 == indexName);
 
@@ -59,7 +60,7 @@ public class AlignUpgradedDatabase : MigrationBase
 
         if (targetColumn is null)
         {
-            throw new InvalidOperationException("Could not find target column.");
+            throw new InvalidOperationException($"Could not find {columnName} column on {tableName} table.");
         }
 
         if (targetColumn.ColumnDefault is null)

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_3_0/AlignUpgradedDatabase.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_3_0/AlignUpgradedDatabase.cs
@@ -1,0 +1,44 @@
+﻿using NPoco;
+using ColumnInfo = Umbraco.Cms.Infrastructure.Persistence.SqlSyntax.ColumnInfo;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_13_3_0;
+
+/// <summary>
+/// We see some differences between an updated database and a fresh one,
+/// the purpose of this migration is to align the two.
+/// </summary>
+public class AlignUpgradedDatabase : MigrationBase
+{
+    public AlignUpgradedDatabase(IMigrationContext context) : base(context)
+    {
+    }
+
+    protected override void Migrate()
+    {
+        // We ignore SQLite since it's considered a development DB
+
+        if (DatabaseType == DatabaseType.SQLite)
+        {
+            return;
+        }
+
+        IEnumerable<ColumnInfo> columns = SqlSyntax.GetColumnsInSchema(Context.Database);
+
+        const string cacheTableName = "umbracoCacheInstruction";
+        const string cacheColumnName = "jsonInstruction";
+        ColumnInfo? jsonInstructionColumn = columns
+            .FirstOrDefault(x => x is { TableName: cacheTableName, ColumnName: cacheColumnName });
+
+        if (jsonInstructionColumn is null)
+        {
+            throw new InvalidOperationException("Could not find cache instruction column");
+        }
+
+        if (jsonInstructionColumn.ColumnDefault != null)
+        {
+            Delete.DefaultConstraint()
+                .OnTable(cacheTableName)
+                .OnColumn(cacheColumnName).Do();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a migration that aligns the schemas of migrated V7 and brand-new V13 databases. 

To compare I've used the schema compare tool in VS, with column order disabled, after the migration the schemas align. 

## Testing

To test this I've migrated a v7 database, with a piece of simple content up to v13/dev and run the migration, after this I've verified that the content still works and that the schemas are now aligned.
 
Additionally I've tested that on a fresh V13 data base no SQL queries are executed. 