### PR TITLE
Document version endpoints

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Version/ByKeyDocumentVersionController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Version/ByKeyDocumentVersionController.cs
@@ -8,14 +8,14 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 
-namespace Umbraco.Cms.Api.Management.Controllers.Document.Versions;
+namespace Umbraco.Cms.Api.Management.Controllers.Document.Version;
 
 [ApiVersion("1.0")]
-public class GetByKeyDocumentVersionController : DocumentVersionControllerBase
+public class ByKeyDocumentVersionController : DocumentVersionControllerBase
 {
     private readonly IUmbracoMapper _umbracoMapper;
 
-    public GetByKeyDocumentVersionController(
+    public ByKeyDocumentVersionController(
         IContentVersionService contentVersionService,
         IUmbracoMapper umbracoMapper)
         : base(contentVersionService)
@@ -28,7 +28,7 @@ public class GetByKeyDocumentVersionController : DocumentVersionControllerBase
     [ProducesResponseType(typeof(DocumentVersionResponseModel), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> Get(Guid id)
+    public async Task<IActionResult> ByKey(Guid id)
     {
         Attempt<IContent?, ContentVersionOperationStatus> attempt =
             await ContentVersionService.GetAsync(id);

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Version/ByKeyDocumentVersionController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Version/ByKeyDocumentVersionController.cs
@@ -13,13 +13,14 @@ namespace Umbraco.Cms.Api.Management.Controllers.Document.Version;
 [ApiVersion("1.0")]
 public class ByKeyDocumentVersionController : DocumentVersionControllerBase
 {
+    private readonly IContentVersionService _contentVersionService;
     private readonly IUmbracoMapper _umbracoMapper;
 
     public ByKeyDocumentVersionController(
         IContentVersionService contentVersionService,
         IUmbracoMapper umbracoMapper)
-        : base(contentVersionService)
     {
+        _contentVersionService = contentVersionService;
         _umbracoMapper = umbracoMapper;
     }
 
@@ -31,7 +32,7 @@ public class ByKeyDocumentVersionController : DocumentVersionControllerBase
     public async Task<IActionResult> ByKey(Guid id)
     {
         Attempt<IContent?, ContentVersionOperationStatus> attempt =
-            await ContentVersionService.GetAsync(id);
+            await _contentVersionService.GetAsync(id);
 
         return attempt.Success is true
             ? Ok(_umbracoMapper.Map<DocumentVersionResponseModel>(attempt.Result))

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Version/DocumentVersionControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Version/DocumentVersionControllerBase.cs
@@ -14,13 +14,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.Document.Version;
 [Authorize(Policy = AuthorizationPolicies.TreeAccessDocuments)]
 public abstract class DocumentVersionControllerBase : ManagementApiControllerBase
 {
-    protected readonly IContentVersionService ContentVersionService;
-
-    public DocumentVersionControllerBase(IContentVersionService contentVersionService)
-    {
-        ContentVersionService = contentVersionService;
-    }
-
     protected IActionResult MapFailure(ContentVersionOperationStatus status)
         => OperationStatusResult(status, problemDetailsBuilder => status switch
         {

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Version/DocumentVersionControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Version/DocumentVersionControllerBase.cs
@@ -7,13 +7,12 @@ using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Cms.Web.Common.Authorization;
 
-namespace Umbraco.Cms.Api.Management.Controllers.Document.Versions;
+namespace Umbraco.Cms.Api.Management.Controllers.Document.Version;
 
-[ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.Document}-version")]
-[ApiExplorerSettings(GroupName = $"{Constants.UdiEntityType.Document} Version")]
+[ApiExplorerSettings(GroupName = $"{nameof(Constants.UdiEntityType.Document)} Version")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessDocuments)]
-public class DocumentVersionControllerBase : ManagementApiControllerBase
+public abstract class DocumentVersionControllerBase : ManagementApiControllerBase
 {
     protected readonly IContentVersionService ContentVersionService;
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Version/GetDocumentVersionsController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Version/GetDocumentVersionsController.cs
@@ -9,7 +9,7 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 
-namespace Umbraco.Cms.Api.Management.Controllers.Document.Versions;
+namespace Umbraco.Cms.Api.Management.Controllers.Document.Version;
 
 [ApiVersion("1.0")]
 public class GetDocumentVersionsController : DocumentVersionControllerBase

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Version/GetDocumentVersionsController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Version/GetDocumentVersionsController.cs
@@ -14,13 +14,14 @@ namespace Umbraco.Cms.Api.Management.Controllers.Document.Version;
 [ApiVersion("1.0")]
 public class GetDocumentVersionsController : DocumentVersionControllerBase
 {
+    private readonly IContentVersionService _contentVersionService;
     private readonly IDocumentVersionPresentationFactory _documentVersionPresentationFactory;
 
     public GetDocumentVersionsController(
         IContentVersionService contentVersionService,
         IDocumentVersionPresentationFactory documentVersionPresentationFactory)
-        : base(contentVersionService)
     {
+        _contentVersionService = contentVersionService;
         _documentVersionPresentationFactory = documentVersionPresentationFactory;
     }
 
@@ -35,7 +36,7 @@ public class GetDocumentVersionsController : DocumentVersionControllerBase
         // old ContentController.GetRollbackVersions()
         // get all versions for a given document
         Attempt<PagedModel<ContentVersionMeta>?, ContentVersionOperationStatus> attempt =
-            await ContentVersionService.GetContentVersionsAsync(documentId, culture, skip, take);
+            await _contentVersionService.GetContentVersionsAsync(documentId, culture, skip, take);
 
         return attempt.Success is true
             ? Ok(await _documentVersionPresentationFactory.CreatedPagedResponseModelAsync(attempt.Result!))

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Version/RollbackDocumentVersionController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Version/RollbackDocumentVersionController.cs
@@ -11,13 +11,14 @@ namespace Umbraco.Cms.Api.Management.Controllers.Document.Version;
 [ApiVersion("1.0")]
 public class RollbackDocumentVersionController : DocumentVersionControllerBase
 {
+    private readonly IContentVersionService _contentVersionService;
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
 
     public RollbackDocumentVersionController(
         IContentVersionService contentVersionService,
         IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
-        : base(contentVersionService)
     {
+        _contentVersionService = contentVersionService;
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
@@ -29,7 +30,7 @@ public class RollbackDocumentVersionController : DocumentVersionControllerBase
     public async Task<IActionResult> Rollback(Guid id, string? culture)
     {
         Attempt<ContentVersionOperationStatus> attempt =
-            await ContentVersionService.RollBackAsync(id, culture, CurrentUserKey(_backOfficeSecurityAccessor));
+            await _contentVersionService.RollBackAsync(id, culture, CurrentUserKey(_backOfficeSecurityAccessor));
 
         return attempt.Success is true
             ? Ok()

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Version/RollbackDocumentVersionController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Version/RollbackDocumentVersionController.cs
@@ -6,14 +6,14 @@ using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 
-namespace Umbraco.Cms.Api.Management.Controllers.Document.Versions;
+namespace Umbraco.Cms.Api.Management.Controllers.Document.Version;
 
 [ApiVersion("1.0")]
-public class UpdatePreventCleanupDocumentVersionController : DocumentVersionControllerBase
+public class RollbackDocumentVersionController : DocumentVersionControllerBase
 {
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
 
-    public UpdatePreventCleanupDocumentVersionController(
+    public RollbackDocumentVersionController(
         IContentVersionService contentVersionService,
         IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
         : base(contentVersionService)
@@ -22,14 +22,14 @@ public class UpdatePreventCleanupDocumentVersionController : DocumentVersionCont
     }
 
     [MapToApiVersion("1.0")]
-    [HttpPut("{id:guid}/preventCleanup")]
+    [HttpPost("{id:guid}/rollback")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> Set(Guid id, bool preventCleanup)
+    public async Task<IActionResult> Rollback(Guid id, string? culture)
     {
         Attempt<ContentVersionOperationStatus> attempt =
-            await ContentVersionService.SetPreventCleanupAsync(id, preventCleanup, CurrentUserKey(_backOfficeSecurityAccessor));
+            await ContentVersionService.RollBackAsync(id, culture, CurrentUserKey(_backOfficeSecurityAccessor));
 
         return attempt.Success is true
             ? Ok()

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Version/UpdatePreventCleanupDocumentVersionController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Version/UpdatePreventCleanupDocumentVersionController.cs
@@ -6,14 +6,14 @@ using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 
-namespace Umbraco.Cms.Api.Management.Controllers.Document.Versions;
+namespace Umbraco.Cms.Api.Management.Controllers.Document.Version;
 
 [ApiVersion("1.0")]
-public class RollbackDocumentVersionController : DocumentVersionControllerBase
+public class UpdatePreventCleanupDocumentVersionController : DocumentVersionControllerBase
 {
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
 
-    public RollbackDocumentVersionController(
+    public UpdatePreventCleanupDocumentVersionController(
         IContentVersionService contentVersionService,
         IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
         : base(contentVersionService)
@@ -22,14 +22,14 @@ public class RollbackDocumentVersionController : DocumentVersionControllerBase
     }
 
     [MapToApiVersion("1.0")]
-    [HttpPost("{id:guid}/rollback")]
+    [HttpPut("{id:guid}/preventCleanup")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> Rollback(Guid id, string? culture)
+    public async Task<IActionResult> Set(Guid id, bool preventCleanup)
     {
         Attempt<ContentVersionOperationStatus> attempt =
-            await ContentVersionService.RollBackAsync(id, culture, CurrentUserKey(_backOfficeSecurityAccessor));
+            await ContentVersionService.SetPreventCleanupAsync(id, preventCleanup, CurrentUserKey(_backOfficeSecurityAccessor));
 
         return attempt.Success is true
             ? Ok()

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Version/UpdatePreventCleanupDocumentVersionController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Version/UpdatePreventCleanupDocumentVersionController.cs
@@ -11,13 +11,14 @@ namespace Umbraco.Cms.Api.Management.Controllers.Document.Version;
 [ApiVersion("1.0")]
 public class UpdatePreventCleanupDocumentVersionController : DocumentVersionControllerBase
 {
+    private readonly IContentVersionService _contentVersionService;
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
 
     public UpdatePreventCleanupDocumentVersionController(
         IContentVersionService contentVersionService,
         IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
-        : base(contentVersionService)
     {
+        _contentVersionService = contentVersionService;
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
@@ -29,7 +30,7 @@ public class UpdatePreventCleanupDocumentVersionController : DocumentVersionCont
     public async Task<IActionResult> Set(Guid id, bool preventCleanup)
     {
         Attempt<ContentVersionOperationStatus> attempt =
-            await ContentVersionService.SetPreventCleanupAsync(id, preventCleanup, CurrentUserKey(_backOfficeSecurityAccessor));
+            await _contentVersionService.SetPreventCleanupAsync(id, preventCleanup, CurrentUserKey(_backOfficeSecurityAccessor));
 
         return attempt.Success is true
             ? Ok()

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Versions/DocumentVersionControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Versions/DocumentVersionControllerBase.cs
@@ -11,8 +11,8 @@ namespace Umbraco.Cms.Api.Management.Controllers.Document.Versions;
 
 [ApiController]
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.Document}-version")]
-[ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Document))]
-[Authorize(Policy = "New" + AuthorizationPolicies.TreeAccessDocuments)]
+[ApiExplorerSettings(GroupName = $"{Constants.UdiEntityType.Document} Version")]
+[Authorize(Policy = AuthorizationPolicies.TreeAccessDocuments)]
 public class DocumentVersionControllerBase : ManagementApiControllerBase
 {
     protected readonly IContentVersionService ContentVersionService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Versions/RollbackDocumentVersionController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Versions/RollbackDocumentVersionController.cs
@@ -22,7 +22,7 @@ public class RollbackDocumentVersionController : DocumentVersionControllerBase
     }
 
     [MapToApiVersion("1.0")]
-    [HttpPost("/{id:guid}/rollback")]
+    [HttpPost("{id:guid}/rollback")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentVersion/AllDocumentVersionController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentVersion/AllDocumentVersionController.cs
@@ -36,12 +36,14 @@ public class AllDocumentVersionController : DocumentVersionControllerBase
         Attempt<PagedModel<ContentVersionMeta>?, ContentVersionOperationStatus> attempt =
             await _contentVersionService.GetPagedContentVersionsAsync(documentId, culture, skip, take);
 
+        var pagedViewModel = new PagedViewModel<DocumentVersionItemResponseModel>
+        {
+            Total = attempt.Result!.Total,
+            Items = await _documentVersionPresentationFactory.CreateMultipleAsync(attempt.Result!.Items),
+        };
+
         return attempt.Success
-            ? Ok(new PagedViewModel<DocumentVersionItemResponseModel>
-            {
-                Total = attempt.Result!.Total,
-                Items = await _documentVersionPresentationFactory.CreateMultipleAsync(attempt.Result!.Items),
-            })
+            ? Ok(pagedViewModel)
             : MapFailure(attempt.Status);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentVersion/ByKeyDocumentVersionController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentVersion/ByKeyDocumentVersionController.cs
@@ -8,7 +8,7 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 
-namespace Umbraco.Cms.Api.Management.Controllers.Document.Version;
+namespace Umbraco.Cms.Api.Management.Controllers.DocumentVersion;
 
 [ApiVersion("1.0")]
 public class ByKeyDocumentVersionController : DocumentVersionControllerBase
@@ -34,7 +34,7 @@ public class ByKeyDocumentVersionController : DocumentVersionControllerBase
         Attempt<IContent?, ContentVersionOperationStatus> attempt =
             await _contentVersionService.GetAsync(id);
 
-        return attempt.Success is true
+        return attempt.Success
             ? Ok(_umbracoMapper.Map<DocumentVersionResponseModel>(attempt.Result))
             : MapFailure(attempt.Status);
     }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentVersion/DocumentVersionControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentVersion/DocumentVersionControllerBase.cs
@@ -3,11 +3,10 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Cms.Web.Common.Authorization;
 
-namespace Umbraco.Cms.Api.Management.Controllers.Document.Version;
+namespace Umbraco.Cms.Api.Management.Controllers.DocumentVersion;
 
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.Document}-version")]
 [ApiExplorerSettings(GroupName = $"{nameof(Constants.UdiEntityType.Document)} Version")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentVersion/RollbackDocumentVersionController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentVersion/RollbackDocumentVersionController.cs
@@ -6,7 +6,7 @@ using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 
-namespace Umbraco.Cms.Api.Management.Controllers.Document.Version;
+namespace Umbraco.Cms.Api.Management.Controllers.DocumentVersion;
 
 [ApiVersion("1.0")]
 public class RollbackDocumentVersionController : DocumentVersionControllerBase
@@ -32,7 +32,7 @@ public class RollbackDocumentVersionController : DocumentVersionControllerBase
         Attempt<ContentVersionOperationStatus> attempt =
             await _contentVersionService.RollBackAsync(id, culture, CurrentUserKey(_backOfficeSecurityAccessor));
 
-        return attempt.Success is true
+        return attempt.Success
             ? Ok()
             : MapFailure(attempt.Result);
     }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentVersion/UpdatePreventCleanupDocumentVersionController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentVersion/UpdatePreventCleanupDocumentVersionController.cs
@@ -6,7 +6,7 @@ using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 
-namespace Umbraco.Cms.Api.Management.Controllers.Document.Version;
+namespace Umbraco.Cms.Api.Management.Controllers.DocumentVersion;
 
 [ApiVersion("1.0")]
 public class UpdatePreventCleanupDocumentVersionController : DocumentVersionControllerBase
@@ -23,7 +23,7 @@ public class UpdatePreventCleanupDocumentVersionController : DocumentVersionCont
     }
 
     [MapToApiVersion("1.0")]
-    [HttpPut("{id:guid}/preventCleanup")]
+    [HttpPut("{id:guid}/prevent-cleanup")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
@@ -32,7 +32,7 @@ public class UpdatePreventCleanupDocumentVersionController : DocumentVersionCont
         Attempt<ContentVersionOperationStatus> attempt =
             await _contentVersionService.SetPreventCleanupAsync(id, preventCleanup, CurrentUserKey(_backOfficeSecurityAccessor));
 
-        return attempt.Success is true
+        return attempt.Success
             ? Ok()
             : MapFailure(attempt.Result);
     }

--- a/src/Umbraco.Cms.Api.Management/Factories/DocumentVersionPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DocumentVersionPresentationFactory.cs
@@ -21,7 +21,7 @@ internal sealed class DocumentVersionPresentationFactory : IDocumentVersionPrese
 
     public async Task<DocumentVersionItemResponseModel> CreateAsync(ContentVersionMeta contentVersion) =>
         new(
-            new ReferenceByIdModel(contentVersion.VersionId.ToGuid()), // this is a magic guid since versions do not have keys in the DB
+            contentVersion.VersionId.ToGuid(), // this is a magic guid since versions do not have keys in the DB
             new ReferenceByIdModel(_entityService.GetKey(contentVersion.ContentId, UmbracoObjectTypes.Document).Result),
             new ReferenceByIdModel(_entityService.GetKey(contentVersion.ContentTypeId, UmbracoObjectTypes.DocumentType)
                 .Result),

--- a/src/Umbraco.Cms.Api.Management/Factories/DocumentVersionPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DocumentVersionPresentationFactory.cs
@@ -1,4 +1,3 @@
-using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.ViewModels;
 using Umbraco.Cms.Api.Management.ViewModels.Document;
 using Umbraco.Cms.Core.Models;
@@ -32,7 +31,6 @@ internal sealed class DocumentVersionPresentationFactory : IDocumentVersionPrese
             contentVersion.CurrentDraftVersion,
             contentVersion.PreventCleanup);
 
-    public async Task<IEnumerable<DocumentVersionItemResponseModel>> CreateMultipleAsync(
-        IEnumerable<ContentVersionMeta> contentVersions) =>
+    public async Task<IEnumerable<DocumentVersionItemResponseModel>> CreateMultipleAsync(IEnumerable<ContentVersionMeta> contentVersions) =>
         await Task.WhenAll(contentVersions.Select(CreateAsync));
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/DocumentVersionPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DocumentVersionPresentationFactory.cs
@@ -20,7 +20,7 @@ internal sealed class DocumentVersionPresentationFactory : IDocumentVersionPrese
         _userIdKeyResolver = userIdKeyResolver;
     }
 
-    public async Task<DocumentVersionItemResponseModel> CreateResponseModelAsync(ContentVersionMeta contentVersion) =>
+    public async Task<DocumentVersionItemResponseModel> CreateAsync(ContentVersionMeta contentVersion) =>
         new(
             new ReferenceByIdModel(contentVersion.VersionId.ToGuid()), // this is a magic guid since versions do not have keys in the DB
             new ReferenceByIdModel(_entityService.GetKey(contentVersion.ContentId, UmbracoObjectTypes.Document).Result),
@@ -32,11 +32,7 @@ internal sealed class DocumentVersionPresentationFactory : IDocumentVersionPrese
             contentVersion.CurrentDraftVersion,
             contentVersion.PreventCleanup);
 
-    public async Task<PagedViewModel<DocumentVersionItemResponseModel>> CreatedPagedResponseModelAsync(
-        PagedModel<ContentVersionMeta> pagedContentVersionMeta) =>
-        new()
-        {
-            Total = pagedContentVersionMeta.Total,
-            Items = await Task.WhenAll(pagedContentVersionMeta.Items.Select(CreateResponseModelAsync)),
-        };
+    public async Task<IEnumerable<DocumentVersionItemResponseModel>> CreateMultipleAsync(
+        IEnumerable<ContentVersionMeta> contentVersions) =>
+        await Task.WhenAll(contentVersions.Select(CreateAsync));
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/IDocumentVersionPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IDocumentVersionPresentationFactory.cs
@@ -1,4 +1,3 @@
-using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.ViewModels.Document;
 using Umbraco.Cms.Core.Models;
 

--- a/src/Umbraco.Cms.Api.Management/Factories/IDocumentVersionPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IDocumentVersionPresentationFactory.cs
@@ -6,8 +6,8 @@ namespace Umbraco.Cms.Api.Management.Factories;
 
 public interface IDocumentVersionPresentationFactory
 {
-    Task<DocumentVersionItemResponseModel> CreateResponseModelAsync(ContentVersionMeta contentVersion);
+    Task<DocumentVersionItemResponseModel> CreateAsync(ContentVersionMeta contentVersion);
 
-    Task<PagedViewModel<DocumentVersionItemResponseModel>> CreatedPagedResponseModelAsync(
-        PagedModel<ContentVersionMeta> pagedContentVersionMeta);
+    Task<IEnumerable<DocumentVersionItemResponseModel>> CreateMultipleAsync(
+        IEnumerable<ContentVersionMeta> contentVersions);
 }

--- a/src/Umbraco.Cms.Api.Management/Mapping/Document/DocumentVersionMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Document/DocumentVersionMapDefinition.cs
@@ -1,11 +1,9 @@
 ﻿using Umbraco.Cms.Api.Management.Mapping.Content;
 using Umbraco.Cms.Api.Management.ViewModels;
 using Umbraco.Cms.Api.Management.ViewModels.Document;
-using Umbraco.Cms.Api.Management.ViewModels.Document.Collection;
 using Umbraco.Cms.Api.Management.ViewModels.DocumentType;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Models.Mapping;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Extensions;
 
@@ -13,12 +11,9 @@ namespace Umbraco.Cms.Api.Management.Mapping.Document;
 
 public class DocumentVersionMapDefinition : ContentMapDefinition<IContent, DocumentValueModel, DocumentVariantResponseModel>, IMapDefinition
 {
-    private readonly CommonMapper _commonMapper;
-
-    public DocumentVersionMapDefinition(PropertyEditorCollection propertyEditorCollection, CommonMapper commonMapper)
+    public DocumentVersionMapDefinition(PropertyEditorCollection propertyEditorCollection)
         : base(propertyEditorCollection)
     {
-        _commonMapper = commonMapper;
     }
 
     public void DefineMaps(IUmbracoMapper mapper)

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -5316,6 +5316,450 @@
         ]
       }
     },
+    "/umbraco/management/api/v1/document-version": {
+      "get": {
+        "tags": [
+          "document Version"
+        ],
+        "operationId": "GetDocumentVersion",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "culture",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedDocumentVersionItemResponseModel"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedDocumentVersionItemResponseModel"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedDocumentVersionItemResponseModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/document-version/{id}": {
+      "get": {
+        "tags": [
+          "document Version"
+        ],
+        "operationId": "GetDocumentVersionById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DocumentVersionResponseModel"
+                    }
+                  ]
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DocumentVersionResponseModel"
+                    }
+                  ]
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DocumentVersionResponseModel"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/document-version/{id}/preventCleanup": {
+      "put": {
+        "tags": [
+          "document Version"
+        ],
+        "operationId": "PutDocumentVersionByIdPreventCleanup",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "preventCleanup",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/document-version/{id}/rollback": {
+      "post": {
+        "tags": [
+          "document Version"
+        ],
+        "operationId": "PostDocumentVersionByIdRollback",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "culture",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
     "/umbraco/management/api/v1/collection/document/{id}": {
       "get": {
         "tags": [
@@ -35902,6 +36346,92 @@
         ],
         "type": "string"
       },
+      "DocumentVersionItemResponseModel": {
+        "required": [
+          "content",
+          "contentType",
+          "currentDraftVersion",
+          "currentPublishedVersion",
+          "preventCleanup",
+          "user",
+          "version",
+          "versionDate"
+        ],
+        "type": "object",
+        "properties": {
+          "content": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ReferenceByIdModel"
+              }
+            ]
+          },
+          "contentType": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ReferenceByIdModel"
+              }
+            ]
+          },
+          "version": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ReferenceByIdModel"
+              }
+            ]
+          },
+          "user": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ReferenceByIdModel"
+              }
+            ]
+          },
+          "versionDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "currentPublishedVersion": {
+            "type": "boolean"
+          },
+          "currentDraftVersion": {
+            "type": "boolean"
+          },
+          "preventCleanup": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "DocumentVersionResponseModel": {
+        "required": [
+          "documentType"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ContentForDocumentResponseModel"
+          }
+        ],
+        "properties": {
+          "document": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ReferenceByIdModel"
+              }
+            ],
+            "nullable": true
+          },
+          "documentType": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/DocumentTypeReferenceResponseModel"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
       "DomainPresentationModel": {
         "required": [
           "domainName",
@@ -38547,6 +39077,30 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/DocumentTypeTreeItemResponseModel"
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedDocumentVersionItemResponseModel": {
+        "required": [
+          "items",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DocumentVersionItemResponseModel"
                 }
               ]
             }

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -36349,32 +36349,29 @@
       },
       "DocumentVersionItemResponseModel": {
         "required": [
-          "content",
-          "contentType",
-          "currentDraftVersion",
-          "currentPublishedVersion",
+          "document",
+          "documentType",
+          "id",
+          "isCurrentDraftVersion",
+          "isCurrentPublishedVersion",
           "preventCleanup",
           "user",
-          "version",
           "versionDate"
         ],
         "type": "object",
         "properties": {
-          "content": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "document": {
             "oneOf": [
               {
                 "$ref": "#/components/schemas/ReferenceByIdModel"
               }
             ]
           },
-          "contentType": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/ReferenceByIdModel"
-              }
-            ]
-          },
-          "version": {
+          "documentType": {
             "oneOf": [
               {
                 "$ref": "#/components/schemas/ReferenceByIdModel"
@@ -36392,10 +36389,10 @@
             "type": "string",
             "format": "date-time"
           },
-          "currentPublishedVersion": {
+          "isCurrentPublishedVersion": {
             "type": "boolean"
           },
-          "currentDraftVersion": {
+          "isCurrentDraftVersion": {
             "type": "boolean"
           },
           "preventCleanup": {

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -5326,6 +5326,7 @@
           {
             "name": "documentId",
             "in": "query",
+            "required": true,
             "schema": {
               "type": "string",
               "format": "uuid"
@@ -5530,7 +5531,7 @@
         ]
       }
     },
-    "/umbraco/management/api/v1/document-version/{id}/preventCleanup": {
+    "/umbraco/management/api/v1/document-version/{id}/prevent-cleanup": {
       "put": {
         "tags": [
           "Document Version"

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -5319,7 +5319,7 @@
     "/umbraco/management/api/v1/document-version": {
       "get": {
         "tags": [
-          "document Version"
+          "Document Version"
         ],
         "operationId": "GetDocumentVersion",
         "parameters": [
@@ -5432,7 +5432,7 @@
     "/umbraco/management/api/v1/document-version/{id}": {
       "get": {
         "tags": [
-          "document Version"
+          "Document Version"
         ],
         "operationId": "GetDocumentVersionById",
         "parameters": [
@@ -5533,7 +5533,7 @@
     "/umbraco/management/api/v1/document-version/{id}/preventCleanup": {
       "put": {
         "tags": [
-          "document Version"
+          "Document Version"
         ],
         "operationId": "PutDocumentVersionByIdPreventCleanup",
         "parameters": [
@@ -5648,7 +5648,7 @@
     "/umbraco/management/api/v1/document-version/{id}/rollback": {
       "post": {
         "tags": [
-          "document Version"
+          "Document Version"
         ],
         "operationId": "PostDocumentVersionByIdRollback",
         "parameters": [

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentVersionItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentVersionItemResponseModel.cs
@@ -3,39 +3,39 @@ namespace Umbraco.Cms.Api.Management.ViewModels.Document;
 public class DocumentVersionItemResponseModel
 {
     public DocumentVersionItemResponseModel(
-        ReferenceByIdModel version,
-        ReferenceByIdModel content,
-        ReferenceByIdModel contentType,
+        Guid id,
+        ReferenceByIdModel document,
+        ReferenceByIdModel documentType,
         ReferenceByIdModel user,
         DateTimeOffset versionDate,
-        bool currentPublishedVersion,
-        bool currentDraftVersion,
+        bool isCurrentPublishedVersion,
+        bool isCurrentDraftVersion,
         bool preventCleanup)
     {
-        Version = version;
-        Content = content;
-        ContentType = contentType;
+        Id = id;
+        Document = document;
+        DocumentType = documentType;
 
         User = user;
         VersionDate = versionDate;
-        CurrentPublishedVersion = currentPublishedVersion;
-        CurrentDraftVersion = currentDraftVersion;
+        IsCurrentPublishedVersion = isCurrentPublishedVersion;
+        IsCurrentDraftVersion = isCurrentDraftVersion;
         PreventCleanup = preventCleanup;
     }
 
-    public ReferenceByIdModel Content { get; }
+    public Guid Id { get; }
 
-    public ReferenceByIdModel ContentType { get; }
+    public ReferenceByIdModel Document { get; }
 
-    public ReferenceByIdModel Version { get; }
+    public ReferenceByIdModel DocumentType { get; }
 
     public ReferenceByIdModel User { get; }
 
     public DateTimeOffset VersionDate { get; }
 
-    public bool CurrentPublishedVersion { get; }
+    public bool IsCurrentPublishedVersion { get; }
 
-    public bool CurrentDraftVersion { get; }
+    public bool IsCurrentDraftVersion { get; }
 
     public bool PreventCleanup { get; }
 }

--- a/src/Umbraco.Core/Services/ContentVersionService.cs
+++ b/src/Umbraco.Core/Services/ContentVersionService.cs
@@ -52,7 +52,7 @@ internal class ContentVersionService : IContentVersionService
         _userIdKeyResolver = userIdKeyResolver;
     }
 
-    [Obsolete]
+    [Obsolete("Use the non obsolete constructor instead. Scheduled to be removed in v15")]
     public ContentVersionService(
         ILogger<ContentVersionService> logger,
         IDocumentVersionRepository documentVersionRepository,
@@ -112,7 +112,7 @@ internal class ContentVersionService : IContentVersionService
     public void SetPreventCleanup(int versionId, bool preventCleanup, int userId = Constants.Security.SuperUserId)
         => HandleSetPreventCleanup(versionId, preventCleanup, userId);
 
-    public async Task<Attempt<PagedModel<ContentVersionMeta>?, ContentVersionOperationStatus>> GetContentVersionsAsync(Guid contentId, string? culture, int skip, int take)
+    public async Task<Attempt<PagedModel<ContentVersionMeta>?, ContentVersionOperationStatus>> GetPagedContentVersionsAsync(Guid contentId, string? culture, int skip, int take)
     {
         IEntitySlim? document = await Task.FromResult(_entityService.Get(contentId, UmbracoObjectTypes.Document));
         if (document is null)

--- a/src/Umbraco.Core/Services/IContentVersionService.cs
+++ b/src/Umbraco.Core/Services/IContentVersionService.cs
@@ -24,7 +24,7 @@ public interface IContentVersionService
     void SetPreventCleanup(int versionId, bool preventCleanup, int userId = -1);
 
     ContentVersionMeta? Get(int versionId);
-    Task<Attempt<PagedModel<ContentVersionMeta>?, ContentVersionOperationStatus>> GetContentVersionsAsync(Guid contentId, string? culture, int skip, int take);
+    Task<Attempt<PagedModel<ContentVersionMeta>?, ContentVersionOperationStatus>> GetPagedContentVersionsAsync(Guid contentId, string? culture, int skip, int take);
     Task<Attempt<IContent?, ContentVersionOperationStatus>> GetAsync(Guid versionId);
 
     Task<Attempt<ContentVersionOperationStatus>> SetPreventCleanupAsync(Guid versionId, bool preventCleanup, Guid userKey);

--- a/src/Umbraco.Core/Services/Pagination/PaginationConverter.cs
+++ b/src/Umbraco.Core/Services/Pagination/PaginationConverter.cs
@@ -1,4 +1,4 @@
-namespace Umbraco.Cms.Api.Management.Services.Paging;
+namespace Umbraco.Cms.Core.Services.Pagination;
 
 internal static class PaginationConverter
 {

--- a/src/Umbraco.Infrastructure/Security/UmbracoUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/UmbracoUserStore.cs
@@ -3,7 +3,6 @@ using System.Globalization;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Identity;
 using Umbraco.Cms.Core.Extensions;
-using Umbraco.Cms.Infrastructure.Extensions;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Security;

--- a/tests/Umbraco.Tests.UnitTests/AutoFixture/Customizations/UmbracoCustomizations.cs
+++ b/tests/Umbraco.Tests.UnitTests/AutoFixture/Customizations/UmbracoCustomizations.cs
@@ -33,7 +33,8 @@ internal class UmbracoCustomizations : ICustomization
             .Customize(new ConstructorCustomization(typeof(MemberManager), new GreedyConstructorQuery()))
             .Customize(new ConstructorCustomization(typeof(DatabaseSchemaCreatorFactory), new GreedyConstructorQuery()))
             .Customize(new ConstructorCustomization(typeof(InstallHelper), new GreedyConstructorQuery()))
-            .Customize(new ConstructorCustomization(typeof(DatabaseBuilder), new GreedyConstructorQuery()));
+            .Customize(new ConstructorCustomization(typeof(DatabaseBuilder), new GreedyConstructorQuery()))
+            .Customize(new ConstructorCustomization(typeof(ContentVersionService), new GreedyConstructorQuery()));
 
         // When requesting an IUserStore ensure we actually uses a IUserLockoutStore
         fixture.Customize<IUserStore<BackOfficeIdentityUser>>(cc =>

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/IntGuidIntConversionTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/IntGuidIntConversionTests.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
 using Umbraco.Cms.Core.Extensions;
-using Umbraco.Cms.Infrastructure.Extensions;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Extensions;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Adds management API endpoints for
- getting a list of version for a given document
- get details about a version with a specific id
- toggle the preventCleanup for a specific version
- rollback to a specific version

### Testing
- Publish a document
- Update the document and publish again (repeat a few times)
- [ ] Make sure the relevant get endpoints reflect the changed data
- [ ] Make sure the toggle and rollback endpoints work as expected
- [ ] Nothing else breaks

### Breaking changes
- IContentVersionService methods have been brought into the async age
- IContentVersionService default constructor has been changed
