### PR TITLE
Use an extension method for fetching a required user in a common way

### DIFF
--- a/src/Umbraco.Core/Extensions/UserServiceExtensions.cs
+++ b/src/Umbraco.Core/Extensions/UserServiceExtensions.cs
@@ -1,0 +1,11 @@
+﻿using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Core.Extensions;
+
+public static class UserServiceExtensions
+{
+    public static async Task<IUser> GetRequiredUserAsync(this IUserService userService, Guid key)
+        => await userService.GetAsync(key)
+           ?? throw new InvalidOperationException($"Could not find user with key: {key}");
+}

--- a/src/Umbraco.Core/Services/AuditService.cs
+++ b/src/Umbraco.Core/Services/AuditService.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Exceptions;
+using Umbraco.Cms.Core.Extensions;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Models.Membership;
@@ -235,11 +236,7 @@ public sealed class AuditService : RepositoryService, IAuditService
 
             using (ScopeProvider.CreateCoreScope(autoComplete: true))
             {
-                var user = await _userService.GetAsync(entityKey);
-                if (user is null)
-                {
-                    throw new ArgumentNullException($"Could not find user with key {entityKey}");
-                }
+                IUser user = await _userService.GetRequiredUserAsync(entityKey);
 
                 IQuery<IAuditItem> query = Query<IAuditItem>().Where(x => x.UserId == user.Id);
                 IQuery<IAuditItem>? customFilter = sinceDate.HasValue ? Query<IAuditItem>().Where(x => x.CreateDate >= sinceDate) : null;

--- a/src/Umbraco.Core/Services/MediaImportService.cs
+++ b/src/Umbraco.Core/Services/MediaImportService.cs
@@ -1,4 +1,5 @@
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Extensions;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Membership;
@@ -46,8 +47,7 @@ internal sealed class MediaImportService : IMediaImportService
             throw new InvalidOperationException("Could not read from file stream, please ensure it is open and readable");
         }
 
-        IUser user = await _userService.GetAsync(userKey)
-                     ?? throw new ArgumentException($"Could not find a user with the specified user key ({userKey})", nameof(userKey));
+        IUser user = await _userService.GetRequiredUserAsync(userKey);
 
         var safeFileName = fileName.ToSafeFileName(_shortStringHelper);
         var mediaItemName = safeFileName.ToFriendlyName();

--- a/src/Umbraco.Core/Services/MemberContentEditingService.cs
+++ b/src/Umbraco.Core/Services/MemberContentEditingService.cs
@@ -39,8 +39,7 @@ internal sealed class MemberContentEditingService
         IMemberType memberType = await ContentTypeService.GetAsync(member.ContentType.Key)
                                  ?? throw new InvalidOperationException($"The member type {member.ContentType.Alias} could not be found.");
 
-        IUser user = await _userService.GetAsync(userKey)
-                     ?? throw new InvalidOperationException("The supplied user key did not match any existing user");
+        IUser user = await _userService.GetRequiredUserAsync(userKey);
 
         if (ValidateAccessToSensitiveProperties(member, memberType, updateModel, user) is false)
         {

--- a/src/Umbraco.Infrastructure/Services/Implement/PackagingService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/PackagingService.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Extensions;
 using Umbraco.Cms.Core.Manifest;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Packaging;
@@ -126,7 +127,7 @@ public class PackagingService : IPackagingService
             return Attempt.FailWithStatus<PackageDefinition?, PackageOperationStatus>(PackageOperationStatus.NotFound, null);
         }
 
-        int currentUserId = _userService.GetAsync(userKey).Result?.Id ?? Constants.Security.SuperUserId;
+        int currentUserId = (await _userService.GetRequiredUserAsync(userKey)).Id;
         _auditService.Add(AuditType.Delete, currentUserId, -1, "Package", $"Created package '{package.Name}' deleted. Package key: {key}");
         _createdPackages.Delete(package.Id);
 
@@ -189,7 +190,7 @@ public class PackagingService : IPackagingService
             return Attempt.FailWithStatus(PackageOperationStatus.DuplicateItemName, package);
         }
 
-        int currentUserId = _userService.GetAsync(userKey).Result?.Id ?? Constants.Security.SuperUserId;
+        int currentUserId = (await _userService.GetRequiredUserAsync(userKey)).Id;
         _auditService.Add(AuditType.New, currentUserId, -1, "Package", $"Created package '{package.Name}' created. Package key: {package.PackageId}");
         scope.Complete();
         return await Task.FromResult(Attempt.SucceedWithStatus(PackageOperationStatus.Success, package));
@@ -205,7 +206,7 @@ public class PackagingService : IPackagingService
             return Attempt.FailWithStatus(PackageOperationStatus.NotFound, package);
         }
 
-        int currentUserId = _userService.GetAsync(userKey).Result?.Id ?? Constants.Security.SuperUserId;
+        int currentUserId = (await _userService.GetRequiredUserAsync(userKey)).Id;
         _auditService.Add(AuditType.New, currentUserId, -1, "Package", $"Created package '{package.Name}' updated. Package key: {package.PackageId}");
         scope.Complete();
         return await Task.FromResult(Attempt.SucceedWithStatus(PackageOperationStatus.Success, package));

--- a/tests/Umbraco.Tests.Integration/ManagementApi/ManagementApiTest.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/ManagementApiTest.cs
@@ -15,6 +15,7 @@ using Umbraco.Cms.Api.Management.Controllers;
 using Umbraco.Cms.Api.Management.Controllers.Security;
 using Umbraco.Cms.Api.Management.Security;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Extensions;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Scoping;
@@ -60,8 +61,7 @@ public abstract class ManagementApiTest<T> : UmbracoTestServerTestBase
             IUser user;
             if (isAdmin)
             {
-                user = await userService.GetAsync(userKey) ??
-                       throw new Exception("Super user not found.");
+                user = await userService.GetRequiredUserAsync(userKey);
                 user.Username = user.Email = username;
                 userService.Save(user);
             }


### PR DESCRIPTION
### Description

There are a few places where we expect a user to exist, and throw an exception if the user is not found. This PR adds an extension method to handle that kind of "required user fetching" in the same way across the codebase, instead of having individually implemented exception handling.