### PR TITLE
v14: Align Deploy interfaces, remove obsolete methods and default interface implementations

### DIFF
--- a/src/Umbraco.Core/Deploy/ArtifactBase.cs
+++ b/src/Umbraco.Core/Deploy/ArtifactBase.cs
@@ -44,7 +44,7 @@ public abstract class ArtifactBase<TUdi> : IArtifact
     public string Name { get; set; }
 
     /// <inheritdoc />
-    public string Alias { get; set; } = string.Empty;
+    public string? Alias { get; set; }
 
     /// <summary>
     /// Gets the checksum.

--- a/src/Umbraco.Core/Deploy/ArtifactBase.cs
+++ b/src/Umbraco.Core/Deploy/ArtifactBase.cs
@@ -34,7 +34,7 @@ public abstract class ArtifactBase<TUdi> : IArtifact
     public IEnumerable<ArtifactDependency> Dependencies
     {
         get => _dependencies ??= Array.Empty<ArtifactDependency>();
-        set => _dependencies = value.OrderBy(x => x.Udi);
+        set => _dependencies = value.OrderBy(x => x.Udi).ToArray();
     }
 
     /// <inheritdoc />

--- a/src/Umbraco.Core/Deploy/ArtifactBase.cs
+++ b/src/Umbraco.Core/Deploy/ArtifactBase.cs
@@ -53,17 +53,4 @@ public abstract class ArtifactBase<TUdi> : IArtifact
     /// The checksum.
     /// </returns>
     protected abstract string GetChecksum();
-
-    /// <summary>
-    /// Prevents the <see cref="Checksum" /> property from being serialized.
-    /// </summary>
-    /// <returns>
-    /// Returns <c>false</c> to prevent the property from being serialized.
-    /// </returns>
-    /// <remarks>
-    /// Note that we can't use <see cref="NonSerializedAttribute" /> here as that works only on fields, not properties.  And we want to avoid using [JsonIgnore]
-    /// as that would require an external dependency in Umbraco.Cms.Core.
-    /// So using this method of excluding properties from serialized data, documented here: https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm
-    /// </remarks>
-    public bool ShouldSerializeChecksum() => false;
 }

--- a/src/Umbraco.Core/Deploy/ArtifactBase.cs
+++ b/src/Umbraco.Core/Deploy/ArtifactBase.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Core.Deploy;
 public abstract class ArtifactBase<TUdi> : IArtifact
     where TUdi : Udi
 {
-    private IEnumerable<ArtifactDependency> _dependencies;
+    private IEnumerable<ArtifactDependency>? _dependencies;
     private readonly Lazy<string> _checksum;
 
     /// <summary>
@@ -20,7 +20,7 @@ public abstract class ArtifactBase<TUdi> : IArtifact
         Udi = udi ?? throw new ArgumentNullException(nameof(udi));
         Name = Udi.ToString();
 
-        _dependencies = dependencies ?? Enumerable.Empty<ArtifactDependency>();
+        _dependencies = dependencies;
         _checksum = new Lazy<string>(GetChecksum);
     }
 
@@ -33,7 +33,7 @@ public abstract class ArtifactBase<TUdi> : IArtifact
     /// <inheritdoc />
     public IEnumerable<ArtifactDependency> Dependencies
     {
-        get => _dependencies;
+        get => _dependencies ??= Array.Empty<ArtifactDependency>();
         set => _dependencies = value.OrderBy(x => x.Udi);
     }
 

--- a/src/Umbraco.Core/Deploy/IDataTypeConfigurationConnector.cs
+++ b/src/Umbraco.Core/Deploy/IDataTypeConfigurationConnector.cs
@@ -39,5 +39,5 @@ public interface IDataTypeConfigurationConnector
     /// <returns>
     /// The data type configuration.
     /// </returns>
-    object? FromArtifact(IDataType dataType, string? configuration, IContextCache contextCache);
+    IDictionary<string, object> FromArtifact(IDataType dataType, string? configuration, IContextCache contextCache);
 }

--- a/src/Umbraco.Core/Deploy/IDeployContext.cs
+++ b/src/Umbraco.Core/Deploy/IDeployContext.cs
@@ -53,9 +53,4 @@ public interface IDeployContext
     /// </returns>
     T? Item<T>(string key)
         where T : class;
-
-    ///// <summary>
-    ///// Gets the global deployment cancellation token.
-    ///// </summary>
-    // CancellationToken CancellationToken { get; }
 }

--- a/src/Umbraco.Core/Deploy/IFileSource.cs
+++ b/src/Umbraco.Core/Deploy/IFileSource.cs
@@ -77,38 +77,13 @@ public interface IFileSource
     /// </returns>
     Task<long> GetFileLengthAsync(StringUdi udi, CancellationToken token);
 
-    // TODO (V14): Remove obsolete methods and default implementations for GetFiles and GetFilesAsync overloads.
-
-    /// <summary>
-    /// Gets files and store them using a file store.
-    /// </summary>
-    /// <param name="udis">The UDIs of the files to get.</param>
-    /// <param name="fileTypes">A collection of file types which can store the files.</param>
-    [Obsolete("Please use the method overload taking all parameters. This method overload will be removed in Umbraco 14.")]
-    void GetFiles(IEnumerable<StringUdi> udis, IFileTypeCollection fileTypes);
-
     /// <summary>
     /// Gets files and store them using a file store.
     /// </summary>
     /// <param name="udis">The UDIs of the files to get.</param>
     /// <param name="continueOnFileNotFound">A flag indicating whether to continue if a file isn't found or to stop and throw a FileNotFoundException.</param>
     /// <param name="fileTypes">A collection of file types which can store the files.</param>
-    void GetFiles(IEnumerable<StringUdi> udis, bool continueOnFileNotFound, IFileTypeCollection fileTypes)
-#pragma warning disable CS0618 // Type or member is obsolete
-        => GetFiles(udis, fileTypes);
-#pragma warning restore CS0618 // Type or member is obsolete
-
-    /// <summary>
-    /// Gets files and store them using a file store.
-    /// </summary>
-    /// <param name="udis">The UDIs of the files to get.</param>
-    /// <param name="fileTypes">A collection of file types which can store the files.</param>
-    /// <param name="token">A cancellation token.</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation.
-    /// </returns>
-    [Obsolete("Please use the method overload taking all parameters. This method overload will be removed in Umbraco 14.")]
-    Task GetFilesAsync(IEnumerable<StringUdi> udis, IFileTypeCollection fileTypes, CancellationToken token);
+    void GetFiles(IEnumerable<StringUdi> udis, bool continueOnFileNotFound, IFileTypeCollection fileTypes);
 
     /// <summary>
     /// Gets files and store them using a file store.
@@ -120,8 +95,5 @@ public interface IFileSource
     /// <returns>
     /// The task object representing the asynchronous operation.
     /// </returns>
-    Task GetFilesAsync(IEnumerable<StringUdi> udis, IFileTypeCollection fileTypes, bool continueOnFileNotFound, CancellationToken token)
-#pragma warning disable CS0618 // Type or member is obsolete
-        => GetFilesAsync(udis, fileTypes, token);
-#pragma warning restore CS0618 // Type or member is obsolete
+    Task GetFilesAsync(IEnumerable<StringUdi> udis, IFileTypeCollection fileTypes, bool continueOnFileNotFound, CancellationToken token);
 }

--- a/src/Umbraco.Core/Deploy/IFileTypeCollection.cs
+++ b/src/Umbraco.Core/Deploy/IFileTypeCollection.cs
@@ -27,18 +27,7 @@ public interface IFileTypeCollection
     /// <returns>
     ///   <c>true</c> if the file type associated with the specified entity type was found; otherwise, <c>false</c>.
     /// </returns>
-    bool TryGetValue(string entityType, [NotNullWhen(true)] out IFileType? fileType)
-    {
-        // TODO (V14): Remove default implementation
-        if (Contains(entityType))
-        {
-            fileType = this[entityType];
-            return true;
-        }
-
-        fileType = null;
-        return false;
-    }
+    bool TryGetValue(string entityType, [NotNullWhen(true)] out IFileType? fileType);
 
     /// <summary>
     /// Determines whether this collection contains a file type for the specified entity type.
@@ -55,5 +44,5 @@ public interface IFileTypeCollection
     /// <returns>
     /// The entity types.
     /// </returns>
-    ICollection<string> GetEntityTypes() => Array.Empty<string>(); // TODO (V14): Remove default implementation
+    ICollection<string> GetEntityTypes();
 }

--- a/src/Umbraco.Core/Deploy/IImageSourceParser.cs
+++ b/src/Umbraco.Core/Deploy/IImageSourceParser.cs
@@ -10,20 +10,6 @@ public interface IImageSourceParser
     /// </summary>
     /// <param name="value">The property value.</param>
     /// <param name="dependencies">A list of dependencies.</param>
-    /// <returns>
-    /// The parsed value.
-    /// </returns>
-    /// <remarks>
-    /// Turns src="/media/..." into src="umb://media/..." and adds the corresponding udi to the dependencies.
-    /// </remarks>
-    [Obsolete("Please use the overload taking all parameters. This method will be removed in Umbraco 14.")]
-    string ToArtifact(string value, ICollection<Udi> dependencies);
-
-    /// <summary>
-    /// Parses an Umbraco property value and produces an artifact property value.
-    /// </summary>
-    /// <param name="value">The property value.</param>
-    /// <param name="dependencies">A list of dependencies.</param>
     /// <param name="contextCache">The context cache.</param>
     /// <returns>
     /// The parsed value.
@@ -31,23 +17,7 @@ public interface IImageSourceParser
     /// <remarks>
     /// Turns src="/media/..." into src="umb://media/..." and adds the corresponding udi to the dependencies.
     /// </remarks>
-    string ToArtifact(string value, ICollection<Udi> dependencies, IContextCache contextCache)
-#pragma warning disable CS0618 // Type or member is obsolete
-        => ToArtifact(value, dependencies);
-#pragma warning restore CS0618 // Type or member is obsolete
-
-    /// <summary>
-    /// Parses an artifact property value and produces an Umbraco property value.
-    /// </summary>
-    /// <param name="value">The artifact property value.</param>
-    /// <returns>
-    /// The parsed value.
-    /// </returns>
-    /// <remarks>
-    /// Turns umb://media/... into /media/....
-    /// </remarks>
-    [Obsolete("Please use the overload taking all parameters. This method will be removed in Umbraco 14.")]
-    string FromArtifact(string value);
+    string ToArtifact(string value, ICollection<Udi> dependencies, IContextCache contextCache);
 
     /// <summary>
     /// Parses an artifact property value and produces an Umbraco property value.
@@ -60,8 +30,5 @@ public interface IImageSourceParser
     /// <remarks>
     /// Turns umb://media/... into /media/....
     /// </remarks>
-    string FromArtifact(string value, IContextCache contextCache)
-#pragma warning disable CS0618 // Type or member is obsolete
-        => FromArtifact(value);
-#pragma warning restore CS0618 // Type or member is obsolete
+    string FromArtifact(string value, IContextCache contextCache);
 }

--- a/src/Umbraco.Core/Deploy/ILocalLinkParser.cs
+++ b/src/Umbraco.Core/Deploy/ILocalLinkParser.cs
@@ -10,21 +10,6 @@ public interface ILocalLinkParser
     /// </summary>
     /// <param name="value">The property value.</param>
     /// <param name="dependencies">A list of dependencies.</param>
-    /// <returns>
-    /// The parsed value.
-    /// </returns>
-    /// <remarks>
-    /// Turns {{localLink:1234}} into {{localLink:umb://{type}/{id}}} and adds the corresponding udi to the
-    /// dependencies.
-    /// </remarks>
-    [Obsolete("Please use the overload taking all parameters. This method will be removed in Umbraco 14.")]
-    string ToArtifact(string value, ICollection<Udi> dependencies);
-
-    /// <summary>
-    /// Parses an Umbraco property value and produces an artifact property value.
-    /// </summary>
-    /// <param name="value">The property value.</param>
-    /// <param name="dependencies">A list of dependencies.</param>
     /// <param name="contextCache">The context cache.</param>
     /// <returns>
     /// The parsed value.
@@ -33,23 +18,7 @@ public interface ILocalLinkParser
     /// Turns {{localLink:1234}} into {{localLink:umb://{type}/{id}}} and adds the corresponding udi to the
     /// dependencies.
     /// </remarks>
-    string ToArtifact(string value, ICollection<Udi> dependencies, IContextCache contextCache)
-#pragma warning disable CS0618 // Type or member is obsolete
-        => ToArtifact(value, dependencies);
-#pragma warning restore CS0618 // Type or member is obsolete
-
-    /// <summary>
-    /// Parses an artifact property value and produces an Umbraco property value.
-    /// </summary>
-    /// <param name="value">The artifact property value.</param>
-    /// <returns>
-    /// The parsed value.
-    /// </returns>
-    /// <remarks>
-    /// Turns {{localLink:umb://{type}/{id}}} into {{localLink:1234}}.
-    /// </remarks>
-    [Obsolete("Please use the overload taking all parameters. This method will be removed in Umbraco 14.")]
-    string FromArtifact(string value);
+    string ToArtifact(string value, ICollection<Udi> dependencies, IContextCache contextCache);
 
     /// <summary>
     /// Parses an artifact property value and produces an Umbraco property value.
@@ -62,8 +31,5 @@ public interface ILocalLinkParser
     /// <remarks>
     /// Turns {{localLink:umb://{type}/{id}}} into {{localLink:1234}}.
     /// </remarks>
-    string FromArtifact(string value, IContextCache contextCache)
-#pragma warning disable CS0618 // Type or member is obsolete
-        => FromArtifact(value);
-#pragma warning restore CS0618 // Type or member is obsolete
+    string FromArtifact(string value, IContextCache contextCache);
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Deploy/ArtifactBaseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Deploy/ArtifactBaseTests.cs
@@ -20,7 +20,7 @@ public class ArtifactBaseTests
         var serialized = JsonConvert.SerializeObject(artifact);
 
         var expected =
-            "{\"Udi\":\"umb://test/3382d5433b5749d08919bc9961422a1f\",\"Dependencies\":[],\"Name\":\"Test Name\",\"Alias\":\"testAlias\"}";
+            "{\"Udi\":\"umb://test/3382d5433b5749d08919bc9961422a1f\",\"Dependencies\":[],\"Checksum\":\"test checksum value\",\"Name\":\"Test Name\",\"Alias\":\"testAlias\"}";
         Assert.AreEqual(expected, serialized);
     }
 


### PR DESCRIPTION
This cleans up some of the Deploy interfaces within the CMS:
- Align the `IDataTypeConfigurationConnector.FromArtifact(...)` return type with `IDataType.ConfigurationData` (following the data type refactor done in PR https://github.com/umbraco/Umbraco-CMS/pull/13605);
- Align the `ArtifactBase<>.Alias` property nullability with the `IArtifact` interface;
- Ensure the `ArtifactBase<>.Dependencies` collection is lazily set when empty (only allocating when being iterated);
- Remove `ShouldSerializeChecksum()`, since that was specific to the Newtonsoft.Json implementation (to avoid serializing the `Checksum` property without having to take a reference to add `JsonIgnore` attribute);
- Remove obsolete methods and default interface implementations.