### PR TITLE
Fix swagger schema error after #15946

### DIFF
--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -37368,9 +37368,6 @@
         "additionalProperties": false
       },
       "DocumentVersionResponseModel": {
-        "required": [
-          "documentType"
-        ],
         "type": "object",
         "allOf": [
           {
@@ -37385,13 +37382,6 @@
               }
             ],
             "nullable": true
-          },
-          "documentType": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/DocumentTypeReferenceResponseModel"
-              }
-            ]
           }
         },
         "additionalProperties": false

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentVersionResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentVersionResponseModel.cs
@@ -1,11 +1,6 @@
-using Umbraco.Cms.Api.Management.ViewModels.Content;
-using Umbraco.Cms.Api.Management.ViewModels.DocumentType;
-
 namespace Umbraco.Cms.Api.Management.ViewModels.Document;
 
-public class DocumentVersionResponseModel : ContentResponseModelBase<DocumentValueModel, DocumentVariantResponseModel>
+public class DocumentVersionResponseModel : DocumentResponseModelBase<DocumentValueModel, DocumentVariantResponseModel>
 {
     public ReferenceByIdModel? Document { get; set; }
-
-    public DocumentTypeReferenceResponseModel DocumentType { get; set; } = new();
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Following the merge of #15946 the Swagger schema generation reports this error:

```
An unhandled exception has occurred while executing the request.
Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorException: Failed to generate Operation for action - Umbraco.Cms.Api.Management.Controllers.DocumentVersion.ByKeyDocumentVersionController.ByKey (Umbraco.Cms.Api.Management). See inner exception
 ---> Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorException: Failed to generate schema for type - Umbraco.Cms.Api.Management.ViewModels.Document.DocumentVersionResponseModel. See inner exception
 ---> System.InvalidOperationException: Can't use schemaId "$ContentForDocumentResponseModel" for type "$Umbraco.Cms.Api.Management.ViewModels.Content.ContentResponseModelBase`2[Umbraco.Cms.Api.Management.ViewModels.Document.DocumentValueModel,Umbraco.Cms.Api.Management.View
Models.Document.DocumentVariantResponseModel]". The same schemaId is already used for type "$Umbraco.Cms.Api.Management.ViewModels.Document.DocumentResponseModelBase`2[Umbraco.Cms.Api.Management.ViewModels.Document.DocumentValueModel,Umbraco.Cms.Api.Management.ViewModels.Document.DocumentVariantResponseModel]"
```

This PR fixes it.

### Testing this PR

1. Verify that the Swagger doc can load.
2. Test that the document versioning endpoints from #15946 still work.