### PR TITLE
V14: Remove member list view

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/ConfigurationDataTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/ConfigurationDataTypeController.cs
@@ -25,7 +25,6 @@ public class ConfigurationDataTypeController : DataTypeControllerBase
             CanBeChanged = _dataTypesSettings.CanBeChanged,
             DocumentListViewId = Constants.DataTypes.Guids.ListViewContentGuid,
             MediaListViewId = Constants.DataTypes.Guids.ListViewMediaGuid,
-            MemberListViewId = Constants.DataTypes.Guids.ListViewMembersGuid,
         };
         return Task.FromResult<IActionResult>(Ok(responseModel));
     }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DatatypeConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DatatypeConfigurationResponseModel.cs
@@ -9,6 +9,4 @@ public class DatatypeConfigurationResponseModel
     public required Guid DocumentListViewId { get; init; }
 
     public required Guid MediaListViewId { get; init; }
-
-    public required Guid MemberListViewId { get; init; }
 }

--- a/src/Umbraco.Core/Constants-DataTypes.cs
+++ b/src/Umbraco.Core/Constants-DataTypes.cs
@@ -285,11 +285,6 @@ public static partial class Constants
             public static readonly Guid ListViewMediaGuid = new(ListViewMedia);
 
             /// <summary>
-            ///     Guid for List View - Members
-            /// </summary>
-            public static readonly Guid ListViewMembersGuid = new(ListViewMembers);
-
-            /// <summary>
             ///     Guid for Date Picker with time
             /// </summary>
             public static readonly Guid DatePickerWithTimeGuid = new(DatePickerWithTime);

--- a/src/Umbraco.Core/Models/DataTypeExtensions.cs
+++ b/src/Umbraco.Core/Models/DataTypeExtensions.cs
@@ -18,7 +18,6 @@ public static class DataTypeExtensions
         Constants.DataTypes.Guids.TagsGuid,
         Constants.DataTypes.Guids.ListViewContentGuid,
         Constants.DataTypes.Guids.ListViewMediaGuid,
-        Constants.DataTypes.Guids.ListViewMembersGuid,
         Constants.DataTypes.Guids.DatePickerWithTimeGuid,
         Constants.DataTypes.Guids.ApprovedColorGuid,
         Constants.DataTypes.Guids.DropdownMultipleGuid,
@@ -56,7 +55,6 @@ public static class DataTypeExtensions
         // these data types are required for default list view handling
         Constants.DataTypes.Guids.ListViewContentGuid,
         Constants.DataTypes.Guids.ListViewMediaGuid,
-        Constants.DataTypes.Guids.ListViewMembersGuid,
     };
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
@@ -676,25 +676,6 @@ internal class DatabaseDataCreator
             "id");
         ConditionalInsert(
             Constants.Configuration.NamedOptions.InstallDefaultData.DataTypes,
-            Constants.DataTypes.Guids.ListViewMembers,
-            new NodeDto
-            {
-                NodeId = Constants.DataTypes.DefaultMembersListView,
-                Trashed = false,
-                ParentId = -1,
-                UserId = -1,
-                Level = 1,
-                Path = $"-1,{Constants.DataTypes.DefaultMembersListView}",
-                SortOrder = 2,
-                UniqueId = Constants.DataTypes.Guids.ListViewMembersGuid,
-                Text = Constants.Conventions.DataTypes.ListViewPrefix + "Members",
-                NodeObjectType = Constants.ObjectTypes.DataType,
-                CreateDate = DateTime.Now,
-            },
-            Constants.DatabaseSchema.Tables.Node,
-            "id");
-        ConditionalInsert(
-            Constants.Configuration.NamedOptions.InstallDefaultData.DataTypes,
             Constants.DataTypes.Guids.Tags,
             new NodeDto
             {

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddListViewKeysToDocumentTypes.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddListViewKeysToDocumentTypes.cs
@@ -115,11 +115,6 @@ public class AddListViewKeysToDocumentTypes : UnscopedMigrationBase
             return Constants.DataTypes.Guids.ListViewMediaGuid;
         }
 
-        if (dto.NodeDto.NodeObjectType == Constants.ObjectTypes.MemberType)
-        {
-            return Constants.DataTypes.Guids.ListViewMembersGuid;
-        }
-
         // No custom list view was found, and not one of the default types either. Therefore we cannot find it.
         return null;
     }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateDataTypeConfigurations.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateDataTypeConfigurations.cs
@@ -93,7 +93,7 @@ public class MigrateDataTypeConfigurations : MigrationBase
                     PropertyEditorAliases.DropDownListFlexible => HandleDropDown(ref configurationData),
                     PropertyEditorAliases.EmailAddress => HandleEmailAddress(ref configurationData),
                     PropertyEditorAliases.Label => HandleLabel(ref configurationData),
-                    PropertyEditorAliases.ListView => HandleListView(ref configurationData, dataTypeDto.NodeDto?.UniqueId, allMediaTypes, allMemberTypes),
+                    PropertyEditorAliases.ListView => HandleListView(ref configurationData, dataTypeDto.NodeDto?.UniqueId, allMediaTypes),
                     PropertyEditorAliases.MediaPicker3 => HandleMediaPicker(ref configurationData, allMediaTypes),
                     PropertyEditorAliases.MultiNodeTreePicker => HandleMultiNodeTreePicker(ref configurationData, allContentTypes, allMediaTypes, allMemberTypes),
                     PropertyEditorAliases.MultiUrlPicker => HandleMultiUrlPicker(ref configurationData),
@@ -308,13 +308,11 @@ public class MigrateDataTypeConfigurations : MigrationBase
 
     // ensure that list view configs have all configurations, as some have never been added by means of migration.
     // also performs a re-formatting of "layouts" and "includeProperties" to a V14 format
-    private bool HandleListView(ref Dictionary<string, object> configurationData, Guid? dataTypeKey, IMediaType[] allMediaTypes, IMemberType[] allMemberTypes)
+    private bool HandleListView(ref Dictionary<string, object> configurationData, Guid? dataTypeKey, IMediaType[] allMediaTypes)
     {
         var collectionViewType = dataTypeKey == Constants.DataTypes.Guids.ListViewMediaGuid || allMediaTypes.Any(mt => mt.ListView == dataTypeKey)
             ? "Media"
-            : dataTypeKey == Constants.DataTypes.Guids.ListViewMembersGuid || allMemberTypes.Any(mt => mt.ListView == dataTypeKey)
-                ? "Member"
-                : "Document";
+            : "Document";
 
         string? LayoutPathToCollectionView(string? path)
             => "views/propertyeditors/listview/layouts/list/list.html".InvariantEquals(path)


### PR DESCRIPTION
# Notes
- Remove default member list view data-type from installation
- Makes the member - list view deletable
- Removes the Member list view key constant

# How to test
- start from `v14/dev`  branch
- Install the solution
- Swap to this branch
- Ensure that you can delete the member list view.

- Start from this branch
- Install the solution
- Assert that the member list view no longer gets created upon install