### PR TITLE
V14: Download Created Package MIME type

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Package/Created/DownloadCreatedPackageController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Package/Created/DownloadCreatedPackageController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Net.Http.Headers;
 using Umbraco.Cms.Core.Packaging;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Package.Created;
 
@@ -50,11 +51,15 @@ public class DownloadCreatedPackageController : CreatedPackageControllerBase
             DispositionType = DispositionTypeNames.Attachment
         };
 
-        Response.Headers.Add("Content-Disposition", contentDisposition.ToString());
+        Response.Headers.Append("Content-Disposition", contentDisposition.ToString());
+
+        var mediaType = fileName.InvariantEndsWith(".zip")
+            ? MediaTypeNames.Application.Zip
+            : MediaTypeNames.Text.Xml;
 
         var result = new FileStreamResult(
             fileStream,
-            new MediaTypeHeaderValue(MediaTypeNames.Application.Octet) { Charset = encoding.WebName });
+            new MediaTypeHeaderValue(mediaType) { Charset = encoding.WebName });
 
         return result;
     }


### PR DESCRIPTION
Sets the appropriate MIME type of the Created Package download, this would be either an XML string or a ZIP file.
The MIME type will be used on the v14 client-side to handle the response content accordingly.