### PR TITLE
Fix 11782: Create missing UI folder on temp path when using Umbraco.Tests.Integration

### DIFF
--- a/tests/Umbraco.Tests.Integration/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/tests/Umbraco.Tests.Integration/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -123,7 +123,18 @@ public static class UmbracoBuilderExtensions
 
                 var currFolder = new DirectoryInfo(srcFolder);
 
-                var uiProject = currFolder.GetDirectories("Umbraco.Web.UI", SearchOption.TopDirectoryOnly).First();
+                if (!currFolder.Exists)
+                {
+                    currFolder = new DirectoryInfo(Path.GetTempPath());
+                }
+
+                var uiProject = currFolder.GetDirectories("Umbraco.Web.UI", SearchOption.TopDirectoryOnly).FirstOrDefault();
+                if (uiProject == null)
+                {
+                    uiProject = new DirectoryInfo(Path.Combine(Path.GetTempPath(), "Umbraco.Web.UI"));
+                    uiProject.Create();
+                }
+
                 var mainLangFolder = new DirectoryInfo(Path.Combine(uiProject.FullName, globalSettings.Value.UmbracoPath.TrimStart("~/"), "config", "lang"));
 
                 return new LocalizedTextServiceFileSources(


### PR DESCRIPTION
Implementors using Umbraco.Tests.Integration won't have to override GetLocalizedTextService

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #11782 

### Description

For a long while implementors have had to replace the LocalizedTextService factory when deriving from UmbracoIntegrationTest et. al.  
With these changes the code will detect whether if found the Umbraco UI project or not, and if not an empty folder is created in the user's temp folder.  
