### PR TITLE
Return 404 instead of 500 when an "original parent" has been deleted

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/RecycleBin/RecycleBinControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RecycleBin/RecycleBinControllerBase.cs
@@ -88,7 +88,7 @@ public abstract class RecycleBinControllerBase<TItem> : ContentControllerBase
                 .WithTitle($"The {contentType} is not trashed")
                 .WithDetail($"The {contentType} needs to be trashed for the parent-before-recycled relation to be created.")
                 .Build()),
-            RecycleBinQueryResultType.NoParentRecycleRelation => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
+            RecycleBinQueryResultType.NoParentRecycleRelation => NotFound(problemDetailsBuilder
                 .WithTitle("The parent relation could not be found")
                 .WithDetail($"The relation between the parent and the {contentType} that should have been created when the {contentType} was deleted could not be found.")
                 .Build()),


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The API explicitly returns a 500 response code if the "original parent" of a "restore from recycle bin" attempt is not found:

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/189538c3-3488-4922-b9da-2c09d194b208)

This seems very dramatic 😄 specially since this is a normal, expected scenario; the "original parent" has simply been deleted from the recycle bin, before the attempt to restore the previous child is made.

This PR changes the response code to be a 404 instead. Less dramatic 😛 

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/7ee9d042-9811-4661-b8dd-76b3b118d9dc)

### Testing this PR

1. Create a parent and a child document.
2. Move the child to the recycle bin.
3. Delete the parent entirely.
4. Request the "original parent" from `/umbraco/management/api/v1/recycle-bin/document/{key}/original-parent`.
5. Verify that a 404 is returned.

Rinse and repeat for media.

Note that "move to recycle bin" and "delete" operations are currently only functional through the API (in other words, use Swagger).
