### PR TITLE
Rename Examine based entity search service

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/SearchDocumentItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/SearchDocumentItemController.cs
@@ -12,12 +12,12 @@ namespace Umbraco.Cms.Api.Management.Controllers.Document.Item;
 [ApiVersion("1.0")]
 public class SearchDocumentItemController : DocumentItemControllerBase
 {
-    private readonly IExamineEntitySearchService _examineEntitySearchService;
+    private readonly IIndexedEntitySearchService _indexedEntitySearchService;
     private readonly IDocumentPresentationFactory _documentPresentationFactory;
 
-    public SearchDocumentItemController(IExamineEntitySearchService examineEntitySearchService, IDocumentPresentationFactory documentPresentationFactory)
+    public SearchDocumentItemController(IIndexedEntitySearchService indexedEntitySearchService, IDocumentPresentationFactory documentPresentationFactory)
     {
-        _examineEntitySearchService = examineEntitySearchService;
+        _indexedEntitySearchService = indexedEntitySearchService;
         _documentPresentationFactory = documentPresentationFactory;
     }
 
@@ -26,7 +26,7 @@ public class SearchDocumentItemController : DocumentItemControllerBase
     [ProducesResponseType(typeof(PagedModel<DocumentItemResponseModel>), StatusCodes.Status200OK)]
     public async Task<ActionResult> Search(string query, int skip = 0, int take = 100)
     {
-        PagedModel<IEntitySlim> searchResult = _examineEntitySearchService.Search(UmbracoObjectTypes.Document, query, skip, take);
+        PagedModel<IEntitySlim> searchResult = _indexedEntitySearchService.Search(UmbracoObjectTypes.Document, query, skip, take);
         var result = new PagedModel<DocumentItemResponseModel>
         {
             Items = searchResult.Items.OfType<IDocumentEntitySlim>().Select(_documentPresentationFactory.CreateItemResponseModel),

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/SearchMediaItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/SearchMediaItemController.cs
@@ -12,12 +12,12 @@ namespace Umbraco.Cms.Api.Management.Controllers.Media.Item;
 [ApiVersion("1.0")]
 public class SearchMediaItemController : MediaItemControllerBase
 {
-    private readonly IExamineEntitySearchService _examineEntitySearchService;
+    private readonly IIndexedEntitySearchService _indexedEntitySearchService;
     private readonly IMediaPresentationFactory _mediaPresentationFactory;
 
-    public SearchMediaItemController(IExamineEntitySearchService examineEntitySearchService, IMediaPresentationFactory mediaPresentationFactory)
+    public SearchMediaItemController(IIndexedEntitySearchService indexedEntitySearchService, IMediaPresentationFactory mediaPresentationFactory)
     {
-        _examineEntitySearchService = examineEntitySearchService;
+        _indexedEntitySearchService = indexedEntitySearchService;
         _mediaPresentationFactory = mediaPresentationFactory;
     }
 
@@ -26,7 +26,7 @@ public class SearchMediaItemController : MediaItemControllerBase
     [ProducesResponseType(typeof(PagedModel<MediaItemResponseModel>), StatusCodes.Status200OK)]
     public async Task<ActionResult> Search(string query, int skip = 0, int take = 100)
     {
-        PagedModel<IEntitySlim> searchResult = _examineEntitySearchService.Search(UmbracoObjectTypes.Media, query, skip, take);
+        PagedModel<IEntitySlim> searchResult = _indexedEntitySearchService.Search(UmbracoObjectTypes.Media, query, skip, take);
         var result = new PagedModel<MediaItemResponseModel>
         {
             Items = searchResult.Items.OfType<IMediaEntitySlim>().Select(_mediaPresentationFactory.CreateItemResponseModel),

--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/Item/SearchMemberItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/Item/SearchMemberItemController.cs
@@ -12,12 +12,12 @@ namespace Umbraco.Cms.Api.Management.Controllers.Member.Item;
 [ApiVersion("1.0")]
 public class SearchMemberItemController : MemberItemControllerBase
 {
-    private readonly IExamineEntitySearchService _examineEntitySearchService;
+    private readonly IIndexedEntitySearchService _indexedEntitySearchService;
     private readonly IMemberPresentationFactory _memberPresentationFactory;
 
-    public SearchMemberItemController(IExamineEntitySearchService examineEntitySearchService, IMemberPresentationFactory memberPresentationFactory)
+    public SearchMemberItemController(IIndexedEntitySearchService indexedEntitySearchService, IMemberPresentationFactory memberPresentationFactory)
     {
-        _examineEntitySearchService = examineEntitySearchService;
+        _indexedEntitySearchService = indexedEntitySearchService;
         _memberPresentationFactory = memberPresentationFactory;
     }
 
@@ -26,7 +26,7 @@ public class SearchMemberItemController : MemberItemControllerBase
     [ProducesResponseType(typeof(PagedModel<MemberItemResponseModel>), StatusCodes.Status200OK)]
     public async Task<ActionResult> Search(string query, int skip = 0, int take = 100)
     {
-        PagedModel<IEntitySlim> searchResult = _examineEntitySearchService.Search(UmbracoObjectTypes.Member, query, skip, take);
+        PagedModel<IEntitySlim> searchResult = _indexedEntitySearchService.Search(UmbracoObjectTypes.Member, query, skip, take);
         var result = new PagedModel<MemberItemResponseModel>
         {
             Items = searchResult.Items.OfType<IMemberEntitySlim>().Select(_memberPresentationFactory.CreateItemResponseModel),

--- a/src/Umbraco.Core/Services/IEntitySearchService.cs
+++ b/src/Umbraco.Core/Services/IEntitySearchService.cs
@@ -3,6 +3,9 @@ using Umbraco.Cms.Core.Models.Entities;
 
 namespace Umbraco.Cms.Core.Services;
 
+/// <summary>
+/// Performs entity search directly against the database.
+/// </summary>
 public interface IEntitySearchService
 {
     PagedModel<IEntitySlim> Search(UmbracoObjectTypes objectType, string query, int skip = 0, int take = 100);

--- a/src/Umbraco.Core/Services/IIndexedEntitySearchService.cs
+++ b/src/Umbraco.Core/Services/IIndexedEntitySearchService.cs
@@ -3,6 +3,13 @@ using Umbraco.Cms.Core.Models.Entities;
 
 namespace Umbraco.Cms.Core.Services;
 
+/// <summary>
+/// Performs entity search against search indexes.
+/// </summary>
+/// <remarks>
+/// Note that this service only supports entity types that are included in search indexes.
+/// By default this means documents, media and members.
+/// </remarks>
 public interface IIndexedEntitySearchService
 {
     PagedModel<IEntitySlim> Search(UmbracoObjectTypes objectType, string query, int skip = 0, int take = 100, bool ignoreUserStartNodes = false);

--- a/src/Umbraco.Core/Services/IIndexedEntitySearchService.cs
+++ b/src/Umbraco.Core/Services/IIndexedEntitySearchService.cs
@@ -3,7 +3,7 @@ using Umbraco.Cms.Core.Models.Entities;
 
 namespace Umbraco.Cms.Core.Services;
 
-public interface IExamineEntitySearchService
+public interface IIndexedEntitySearchService
 {
     PagedModel<IEntitySlim> Search(UmbracoObjectTypes objectType, string query, int skip = 0, int take = 100, bool ignoreUserStartNodes = false);
 }

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Services.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Services.cs
@@ -63,7 +63,7 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddUnique<IContentListViewService, ContentListViewService>();
         builder.Services.AddUnique<IMediaListViewService, MediaListViewService>();
         builder.Services.AddUnique<IEntitySearchService, EntitySearchService>();
-        builder.Services.AddUnique<IExamineEntitySearchService, ExamineEntitySearchService>();
+        builder.Services.AddUnique<IIndexedEntitySearchService, IndexedEntitySearchService>();
 
         return builder;
     }

--- a/src/Umbraco.Infrastructure/Services/Implement/IndexedEntitySearchService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/IndexedEntitySearchService.cs
@@ -8,12 +8,12 @@ using Umbraco.Cms.Infrastructure.Examine;
 
 namespace Umbraco.Cms.Infrastructure.Services.Implement;
 
-internal sealed class ExamineEntitySearchService : IExamineEntitySearchService
+internal sealed class IndexedEntitySearchService : IIndexedEntitySearchService
 {
     private readonly IBackOfficeExamineSearcher _backOfficeExamineSearcher;
     private readonly IEntityService _entityService;
 
-    public ExamineEntitySearchService(IBackOfficeExamineSearcher backOfficeExamineSearcher, IEntityService entityService)
+    public IndexedEntitySearchService(IBackOfficeExamineSearcher backOfficeExamineSearcher, IEntityService entityService)
     {
         _backOfficeExamineSearcher = backOfficeExamineSearcher;
         _entityService = entityService;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

As correctly pointed out in [this comment](https://github.com/umbraco/Umbraco-CMS/pull/15972#issuecomment-2035474833), the newly introduced `IExamineEntitySearchService` is counter productive towards the eventual goal of decoupling ourselves a little more from Examine.

Furthermore, the naming in itself bleeds technology, which is clearly a mistake on yours truly when implementing the thing.

This PR renames it to `IIndexedEntitySearchService` instead. It was the best I could come up with 🙈 

### Testing this PR

Everything should still work exactly as before. Steps from https://github.com/umbraco/Umbraco-CMS/pull/15972 can be reused, but basically - if document items can be searched, all is good. Don't forget to rebuild the Examine indexes, though 👍 