### PR TITLE
V14: Use ITemplateService in DocumentPresentationFactory

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Factories/DocumentPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DocumentPresentationFactory.cs
@@ -19,20 +19,20 @@ internal sealed class DocumentPresentationFactory : IDocumentPresentationFactory
 {
     private readonly IUmbracoMapper _umbracoMapper;
     private readonly IDocumentUrlFactory _documentUrlFactory;
-    private readonly IFileService _fileService;
+    private readonly ITemplateService _templateService;
     private readonly IPublicAccessService _publicAccessService;
     private readonly TimeProvider _timeProvider;
 
     public DocumentPresentationFactory(
         IUmbracoMapper umbracoMapper,
         IDocumentUrlFactory documentUrlFactory,
-        IFileService fileService,
+        ITemplateService templateService,
         IPublicAccessService publicAccessService,
         TimeProvider timeProvider)
     {
         _umbracoMapper = umbracoMapper;
         _documentUrlFactory = documentUrlFactory;
-        _fileService = fileService;
+        _templateService = templateService;
         _publicAccessService = publicAccessService;
         _timeProvider = timeProvider;
     }
@@ -44,7 +44,7 @@ internal sealed class DocumentPresentationFactory : IDocumentPresentationFactory
         responseModel.Urls = await _documentUrlFactory.GetUrlsAsync(content);
 
         Guid? templateKey = content.TemplateId.HasValue
-            ? _fileService.GetTemplate(content.TemplateId.Value)?.Key
+            ? _templateService.GetAsync(content.TemplateId.Value).Result?.Key
             : null;
 
         responseModel.Template = templateKey.HasValue


### PR DESCRIPTION
Updates the `DocumentPresentationFactory` to use the `ITemplateService` instead of the obsoleted `IFileService`.


## Testing

When getting a document the correct template key should be shown if any, and null if there is no template