### PR TITLE
Remove __Key field from Backoffice Search if query is not a Guid

### DIFF
--- a/src/Umbraco.Examine.Lucene/BackOfficeExamineSearcher.cs
+++ b/src/Umbraco.Examine.Lucene/BackOfficeExamineSearcher.cs
@@ -81,6 +81,11 @@ public class BackOfficeExamineSearcher : IBackOfficeExamineSearcher
         {
             query = "\"" + g + "\"";
         }
+        else
+        {
+            // No Guid so no need to search the __Key field to prevent irrelevant results
+            fields.Remove(UmbracoExamineFieldNames.NodeKeyFieldName);
+        }
 
         IUser? currentUser = _backOfficeSecurityAccessor?.BackOfficeSecurity?.CurrentUser;
 


### PR DESCRIPTION
When a short search query is used, irrelevant results may arise because the query appears in the Key guide.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/16003

### Description

    When a short search query is used in the Backoffice Search, irrelevant results may arise because the query appears in the Key value.

Before:
![afbeelding](https://github.com/umbraco/Umbraco-CMS/assets/18614643/301c8563-3ec9-45c0-94ca-e59434a84363)

After:

![afbeelding](https://github.com/umbraco/Umbraco-CMS/assets/18614643/6f11e97e-7d34-478d-86e0-1c198abadfa5)


<!-- Thanks for contributing to Umbraco CMS! -->

[Added by HQ] Breaking changes:
This PR introduces a functional breaking change that can have an impact on how people interact with the Backoffice: it disables partial key searches.