### PR TITLE
Support using absolute urls when domain is matched and mode is auto.

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/RequestHandlerSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/RequestHandlerSettings.cs
@@ -16,6 +16,7 @@ public class RequestHandlerSettings
     internal const bool StaticAddTrailingSlash = true;
     internal const string StaticConvertUrlsToAscii = "try";
     internal const bool StaticEnableDefaultCharReplacements = true;
+    internal const bool StaticUseAbsoluteUrlForAutoWhenDomainMatches = false;
 
     internal static readonly CharItem[] DefaultCharCollection =
     {
@@ -83,4 +84,10 @@ public class RequestHandlerSettings
     ///     Add additional character replacements, or override defaults
     /// </summary>
     public IEnumerable<CharItem>? UserDefinedCharCollection { get; set; }
+
+    /// <summary>
+    ///  Gets or Sets a value indicating whether to use UrlMode.Absolute or UrlMode.Relative when UrlMode.Auto is used and the domain Authority matches.
+    /// </summary>
+    [DefaultValue(StaticUseAbsoluteUrlForAutoWhenDomainMatches)]
+    public bool UseAbsoluteUrlForAutoWhenDomainMatches { get; set; } = StaticUseAbsoluteUrlForAutoWhenDomainMatches;
 }

--- a/src/Umbraco.Core/Routing/DefaultUrlProvider.cs
+++ b/src/Umbraco.Core/Routing/DefaultUrlProvider.cs
@@ -24,20 +24,20 @@ public class DefaultUrlProvider : IUrlProvider
     private readonly UriUtility _uriUtility;
     private RequestHandlerSettings _requestSettings;
 
-        public DefaultUrlProvider(
-            IOptionsMonitor<RequestHandlerSettings> requestSettings,
-            ILogger<DefaultUrlProvider> logger,
-            ISiteDomainMapper siteDomainMapper,
-            IUmbracoContextAccessor umbracoContextAccessor,
-            UriUtility uriUtility,
-            ILocalizationService localizationService)
-        {
-            _requestSettings = requestSettings.CurrentValue;
-            _logger = logger;
-            _siteDomainMapper = siteDomainMapper;
-            _umbracoContextAccessor = umbracoContextAccessor;
-            _uriUtility = uriUtility;
-            _localizationService = localizationService;
+    public DefaultUrlProvider(
+        IOptionsMonitor<RequestHandlerSettings> requestSettings,
+        ILogger<DefaultUrlProvider> logger,
+        ISiteDomainMapper siteDomainMapper,
+        IUmbracoContextAccessor umbracoContextAccessor,
+        UriUtility uriUtility,
+        ILocalizationService localizationService)
+    {
+        _requestSettings = requestSettings.CurrentValue;
+        _logger = logger;
+        _siteDomainMapper = siteDomainMapper;
+        _umbracoContextAccessor = umbracoContextAccessor;
+        _uriUtility = uriUtility;
+        _localizationService = localizationService;
 
         requestSettings.OnChange(x => _requestSettings = x);
     }
@@ -209,7 +209,7 @@ public class DefaultUrlProvider : IUrlProvider
                 if (current != null && domainUri.Uri.GetLeftPart(UriPartial.Authority) ==
                     current.GetLeftPart(UriPartial.Authority))
                 {
-                    mode = UrlMode.Relative;
+                    mode = _requestSettings.UseAbsoluteUrlForAutoWhenDomainMatches ? UrlMode.Absolute : UrlMode.Relative;
                 }
                 else
                 {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/UrlsProviderWithDomainsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/UrlsProviderWithDomainsTests.cs
@@ -328,15 +328,19 @@ public class UrlsProviderWithDomainsTests : UrlRoutingTestBase
     }
 
     // with one domain, not at root
-    [TestCase(1001, "http://domain1.com", false, "/1001/")]
-    [TestCase(10011, "http://domain1.com", false, "/")]
-    [TestCase(100111, "http://domain1.com", false, "/1001-1-1/")]
-    [TestCase(1002, "http://domain1.com", false, "/1002/")]
-    public void Get_Url_DeepDomain(int nodeId, string currentUrl, bool absolute, string expected)
+    [TestCase(1001, "http://domain1.com", false, "/1001/", false)]
+    [TestCase(10011, "http://domain1.com", false, "/", false)]
+    [TestCase(100111, "http://domain1.com", false, "/1001-1-1/", false)]
+    [TestCase(1002, "http://domain1.com", false, "/1002/", false)]
+    [TestCase(1001, "http://domain1.com", false, "/1001/", true)]
+    [TestCase(10011, "http://domain1.com", false, "http://domain1.com/", true)]
+    [TestCase(100111, "http://domain1.com", false, "http://domain1.com/1001-1-1/", true)]
+    [TestCase(1002, "http://domain1.com", false, "/1002/", true)]
+    public void Get_Url_DeepDomain(int nodeId, string currentUrl, bool absolute, string expected, bool useAbsoluteUrlForAutoWhenDomainMatches)
     {
         SetDomains3();
 
-        var requestHandlerSettings = new RequestHandlerSettings { AddTrailingSlash = true };
+        var requestHandlerSettings = new RequestHandlerSettings { AddTrailingSlash = true, UseAbsoluteUrlForAutoWhenDomainMatches = useAbsoluteUrlForAutoWhenDomainMatches };
         GlobalSettings.HideTopLevelNodeFromPath = false;
 
         var umbracoContextAccessor = GetUmbracoContextAccessor("/test");


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
What?
Optionally allow the DefaultUrlProvider to return Absolute Url's when the domain matches and UrlMode.Auto.
Keep behaviour using UrlMode.Auto to return Relative Urls from DefaultUrlProvider when the domain does not match.

Why?
I'd like to return a relative url when the current request domain does not match the domain assigned to the node / it's ancestor, and a Absolute Url if it matches.

How to test?
Updated relevant test cases in pr.
Adds option UseAbsoluteUrlForAutoWhenDomainMatches to RequestHandler settings to enable.

<!-- Thanks for contributing to Umbraco CMS! -->
