### PR TITLE
Ensure authenticated to see webprofiler log

### DIFF
--- a/src/Umbraco.Web.Common/Repositories/WebProfilerRepository.cs
+++ b/src/Umbraco.Web.Common/Repositories/WebProfilerRepository.cs
@@ -21,7 +21,7 @@ internal class WebProfilerRepository : IWebProfilerRepository
     {
         if (status)
         {
-            _httpContextAccessor.GetRequiredHttpContext().Response.Cookies.Append(CookieName, string.Empty, new CookieOptions { Expires = DateTime.Now.AddYears(1) });
+            _httpContextAccessor.GetRequiredHttpContext().Response.Cookies.Append(CookieName, "1", new CookieOptions { Expires = DateTime.Now.AddYears(1) });
         }
         else
         {


### PR DESCRIPTION
### Summary
This PR solves a FIXME, and ensure you are authenticated to see the miniprofiler logs

### Test
- Enable the dashboard in backend (Ensure frontend is updated, because there was a bug)
- Go to https://localhost:44339/umbraco/profiler/results-index
  - If authenticated in backend and access to settings, you can see it
  - Otherwise not