### PR TITLE
Deduplicate the magic string "/management/api/"

### DIFF
--- a/src/Umbraco.Cms.Api.Common/Security/Paths.cs
+++ b/src/Umbraco.Cms.Api.Common/Security/Paths.cs
@@ -1,3 +1,5 @@
+using Umbraco.Cms.Core;
+
 namespace Umbraco.Cms.Api.Common.Security;
 
 public static class Paths
@@ -14,7 +16,7 @@ public static class Paths
 
         public static readonly string RevokeEndpoint = EndpointPath($"{EndpointTemplate}/revoke");
 
-        private static string EndpointPath(string relativePath) => $"/umbraco/management/api/v1/{relativePath}";
+        private static string EndpointPath(string relativePath) => $"/umbraco{Constants.Web.ManagementApiPath}v1/{relativePath}";
     }
 
     public static class MemberApi

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/ApplicationBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/ApplicationBuilderExtensions.cs
@@ -27,8 +27,7 @@ internal static class ApplicationBuilderExtensions
                 var officePath = settings.GetBackOfficePath(hostingEnvironment);
 
                 // Only use the API exception handler when we are requesting an API
-                // FIXME: magic string "management/api" is used several times across the codebase
-                return httpContext.Request.Path.Value?.StartsWith($"{officePath}/management/api/") ?? false;
+                return httpContext.Request.Path.Value?.StartsWith($"{officePath}{Constants.Web.ManagementApiPath}") ?? false;
             },
             innerBuilder =>
             {
@@ -65,8 +64,7 @@ internal static class ApplicationBuilderExtensions
             endpoints.MapControllers();
 
             // Serve contract
-            // FIXME: magic string "management/api" is used several times across the codebase
-            endpoints.MapGet($"{officePath}/management/api/openapi.json", async context =>
+            endpoints.MapGet($"{officePath}{Constants.Web.ManagementApiPath}openapi.json", async context =>
             {
                 await context.Response.SendFileAsync(new EmbeddedFileProvider(typeof(ManagementApiComposer).Assembly).GetFileInfo("OpenApi.json"));
             });

--- a/src/Umbraco.Cms.Api.Management/Routing/VersionedApiBackOfficeRouteAttribute.cs
+++ b/src/Umbraco.Cms.Api.Management/Routing/VersionedApiBackOfficeRouteAttribute.cs
@@ -1,5 +1,4 @@
-﻿
-
+﻿using Umbraco.Cms.Core;
 using Umbraco.Cms.Web.Common.Routing;
 
 namespace Umbraco.Cms.Api.Management.Routing;
@@ -7,7 +6,7 @@ namespace Umbraco.Cms.Api.Management.Routing;
 public class VersionedApiBackOfficeRouteAttribute : BackOfficeRouteAttribute
 {
     public VersionedApiBackOfficeRouteAttribute(string template)
-        : base($"management/api/v{{version:apiVersion}}/{template.TrimStart('/')}")
+        : base($"{Constants.Web.ManagementApiPath}v{{version:apiVersion}}/{template.TrimStart('/')}")
     {
     }
 }

--- a/src/Umbraco.Core/Constants-Web.cs
+++ b/src/Umbraco.Core/Constants-Web.cs
@@ -62,6 +62,11 @@ public static partial class Constants
             public const string BackOfficeLoginArea = "UmbracoLogin"; // Used for area routes of non-api controllers for login
         }
 
+        /// <summary>
+        ///     The "base" path to the Management API
+        /// </summary>
+        public const string ManagementApiPath = "/management/api/";
+
         public static class Routing
         {
             public const string ControllerToken = "controller";

--- a/src/Umbraco.Core/Routing/UmbracoRequestPaths.cs
+++ b/src/Umbraco.Core/Routing/UmbracoRequestPaths.cs
@@ -40,7 +40,7 @@ public class UmbracoRequestPaths
         _previewMvcPath = "/" + mvcArea + "/Preview/";
         _surfaceMvcPath = "/" + mvcArea + "/Surface/";
         _apiMvcPath = "/" + mvcArea + "/Api/";
-        _managementApiPath = "/" + mvcArea + "/management/api/";
+        _managementApiPath = "/" + mvcArea + Constants.Web.ManagementApiPath;
         _installPath = hostingEnvironment.ToAbsolute(Constants.SystemDirectories.Install);
         _umbracoRequestPathsOptions = umbracoRequestPathsOptions;
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The magic string `"/management/api/"` is used in multiple places throughout the codebase. This PR moves it to a constant.

### Testing this PR

This PR should _not_ introduce any behavioural changes. Test that it is still possible to:

1. Log into the backoffice, browse items and log out again.
2. Authenticate against the Management API from Swagger.
