### PR TITLE
v14: Remove `Newtonsoft.Json` from tests

### DIFF
--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -21,6 +21,5 @@
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="NUnit" Version="3.14.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" PrivateAssets="all" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>

--- a/tests/Umbraco.Tests.Common/Umbraco.Tests.Common.csproj
+++ b/tests/Umbraco.Tests.Common/Umbraco.Tests.Common.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="Moq" />
     <PackageReference Include="AutoFixture.NUnit3" />
     <PackageReference Include="NUnit" />
-    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Umbraco.Tests.Integration/NewBackoffice/OpenAPIContractTest.cs
+++ b/tests/Umbraco.Tests.Integration/NewBackoffice/OpenAPIContractTest.cs
@@ -1,13 +1,10 @@
+using System.Text.Json.Nodes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using NUnit.Framework;
-using Umbraco.Cms.Api.Management;
 using Umbraco.Cms.Api.Management.Controllers.Install;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
-using Umbraco.Cms.Persistence.EFCore.Composition;
 using Umbraco.Cms.Tests.Integration.TestServerTest;
 using Umbraco.Cms.Web.Common.ApplicationBuilder;
 
@@ -47,16 +44,13 @@ internal sealed class OpenAPIContractTest : UmbracoTestServerTestBase
 
         var urlToContract = $"{officePath}/management/api/openapi.json";
         var swaggerPath = $"{officePath}/swagger/management/swagger.json";
-        var apiContract = JObject.Parse(await Client.GetStringAsync(urlToContract));
+        var apiContract = JsonNode.Parse(await Client.GetStringAsync(urlToContract)).AsObject();
 
         var generatedJsonString = await Client.GetStringAsync(swaggerPath);
-        var mergedContract = JObject.Parse(generatedJsonString);
-        var originalGeneratedContract = JObject.Parse(generatedJsonString);
+        var mergedContract = JsonNode.Parse(generatedJsonString).AsObject();
+        var originalGeneratedContract = JsonNode.Parse(generatedJsonString).AsObject();
 
-        mergedContract.Merge(apiContract, new JsonMergeSettings
-        {
-            MergeArrayHandling = MergeArrayHandling.Merge
-        });
+        mergedContract.MergeLeft(apiContract);
 
         foreach (var key in keysToIgnore)
         {
@@ -64,6 +58,6 @@ internal sealed class OpenAPIContractTest : UmbracoTestServerTestBase
             mergedContract.Remove(key);
         }
 
-        Assert.AreEqual(originalGeneratedContract.ToString(Formatting.Indented), mergedContract.ToString(Formatting.Indented), $"Generated API do not respect the contract.");
+        Assert.AreEqual(originalGeneratedContract.ToJsonString(), mergedContract.ToJsonString(), $"Generated API do not respect the contract.");
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexTest.cs
@@ -1,16 +1,12 @@
-using System.Collections.Generic;
-using System.Linq;
 using Bogus;
 using Examine;
 using Lucene.Net.Util;
-using Newtonsoft.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Infrastructure.Examine;
 using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
-using Umbraco.Extensions;
 using Constants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Examine.Lucene.UmbracoExamine;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/TagServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/TagServiceTests.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using System.Linq;
-using Newtonsoft.Json;
+using System.Text.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
@@ -12,7 +11,6 @@ using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
-using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
 
@@ -83,7 +81,7 @@ public class TagServiceTests : UmbracoIntegrationTest
         // get it back
         content1 = ContentService.GetById(content1.Id);
         var tagsValue = content1.GetValue("tags").ToString();
-        var tagsValues = JsonConvert.DeserializeObject<string[]>(tagsValue);
+        var tagsValues = JsonSerializer.Deserialize<string[]>(tagsValue);
         Assert.AreEqual(3, tagsValues.Length);
         Assert.Contains("pig", tagsValues);
         Assert.Contains("goat", tagsValues);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/RefresherTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/RefresherTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using Newtonsoft.Json;
+using System.Text.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Services.Changes;
@@ -19,8 +19,8 @@ public class RefresherTests
             new MediaCacheRefresher.JsonPayload(1234, Guid.NewGuid(), TreeChangeTypes.None),
         };
 
-        var json = JsonConvert.SerializeObject(source);
-        var payload = JsonConvert.DeserializeObject<MediaCacheRefresher.JsonPayload[]>(json);
+        var json = JsonSerializer.Serialize(source);
+        var payload = JsonSerializer.Deserialize<MediaCacheRefresher.JsonPayload[]>(json);
 
         Assert.AreEqual(source[0].Id, payload[0].Id);
         Assert.AreEqual(source[0].Key, payload[0].Key);
@@ -40,8 +40,8 @@ public class RefresherTests
             }
         };
 
-        var json = JsonConvert.SerializeObject(source);
-        var payload = JsonConvert.DeserializeObject<ContentCacheRefresher.JsonPayload[]>(json);
+        var json = JsonSerializer.Serialize(source);
+        var payload = JsonSerializer.Deserialize<ContentCacheRefresher.JsonPayload[]>(json);
 
         Assert.AreEqual(source[0].Id, payload[0].Id);
         Assert.AreEqual(source[0].Key, payload[0].Key);
@@ -57,8 +57,8 @@ public class RefresherTests
             new ContentTypeCacheRefresher.JsonPayload("xxx", 1234, ContentTypeChangeTypes.None),
         };
 
-        var json = JsonConvert.SerializeObject(source);
-        var payload = JsonConvert.DeserializeObject<ContentTypeCacheRefresher.JsonPayload[]>(json);
+        var json = JsonSerializer.Serialize(source);
+        var payload = JsonSerializer.Deserialize<ContentTypeCacheRefresher.JsonPayload[]>(json);
 
         Assert.AreEqual(source[0].ItemType, payload[0].ItemType);
         Assert.AreEqual(source[0].Id, payload[0].Id);
@@ -73,8 +73,8 @@ public class RefresherTests
             new DataTypeCacheRefresher.JsonPayload(1234, Guid.NewGuid(), true),
         };
 
-        var json = JsonConvert.SerializeObject(source);
-        var payload = JsonConvert.DeserializeObject<DataTypeCacheRefresher.JsonPayload[]>(json);
+        var json = JsonSerializer.Serialize(source);
+        var payload = JsonSerializer.Deserialize<DataTypeCacheRefresher.JsonPayload[]>(json);
 
         Assert.AreEqual(source[0].Id, payload[0].Id);
         Assert.AreEqual(source[0].Key, payload[0].Key);
@@ -89,8 +89,8 @@ public class RefresherTests
             new DomainCacheRefresher.JsonPayload(1234, DomainChangeTypes.None)
         };
 
-        var json = JsonConvert.SerializeObject(source);
-        var payload = JsonConvert.DeserializeObject<DomainCacheRefresher.JsonPayload[]>(json);
+        var json = JsonSerializer.Serialize(source);
+        var payload = JsonSerializer.Deserialize<DomainCacheRefresher.JsonPayload[]>(json);
 
         Assert.AreEqual(source[0].Id, payload[0].Id);
         Assert.AreEqual(source[0].ChangeType, payload[0].ChangeType);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/CoreThings/UdiTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/CoreThings/UdiTests.cs
@@ -1,14 +1,10 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using Newtonsoft.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Deploy;
-using Umbraco.Cms.Infrastructure.Serialization;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.CoreThings;
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Deploy/ArtifactBaseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Deploy/ArtifactBaseTests.cs
@@ -1,10 +1,11 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using Newtonsoft.Json;
+using System.Text.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Deploy;
+using Umbraco.Cms.Infrastructure.Serialization;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Deploy;
 
@@ -17,7 +18,14 @@ public class ArtifactBaseTests
         var udi = new GuidUdi("test", Guid.Parse("3382d5433b5749d08919bc9961422a1f"));
         var artifact = new TestArtifact(udi, new List<ArtifactDependency>()) { Name = "Test Name", Alias = "testAlias" };
 
-        var serialized = JsonConvert.SerializeObject(artifact);
+        var serialized = JsonSerializer.Serialize(artifact, new JsonSerializerOptions()
+        {
+            Converters =
+            {
+                new JsonUdiConverter(),
+                new JsonGuidUdiConverter()
+            }
+        });
 
         var expected =
             "{\"Udi\":\"umb://test/3382d5433b5749d08919bc9961422a1f\",\"Dependencies\":[],\"Checksum\":\"test checksum value\",\"Name\":\"Test Name\",\"Alias\":\"testAlias\"}";

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/ContentTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/ContentTests.cs
@@ -1,15 +1,12 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
-using System.Threading;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
-using Newtonsoft.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Logging;
@@ -503,7 +500,7 @@ public class ContentTests
         content.UpdateDate = DateTime.Now;
         content.WriterId = 23;
 
-        var json = JsonConvert.SerializeObject(content);
+        var json = JsonSerializer.Serialize(content);
         Debug.Print(json);
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/ContentTypeTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/ContentTypeTests.cs
@@ -2,8 +2,7 @@
 // See LICENSE for more details.
 
 using System.Diagnostics;
-using System.Linq;
-using Newtonsoft.Json;
+using System.Text.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
@@ -178,7 +177,7 @@ public class ContentTypeTests
         // Arrange
         var contentType = BuildContentType();
 
-        var json = JsonConvert.SerializeObject(contentType);
+        var json = JsonSerializer.Serialize(contentType);
         Debug.Print(json);
     }
 
@@ -241,7 +240,7 @@ public class ContentTypeTests
         // Arrange
         var contentType = BuildMediaType();
 
-        var json = JsonConvert.SerializeObject(contentType);
+        var json = JsonSerializer.Serialize(contentType);
         Debug.Print(json);
     }
 
@@ -304,7 +303,7 @@ public class ContentTypeTests
         // Arrange
         var contentType = BuildMemberType();
 
-        var json = JsonConvert.SerializeObject(contentType);
+        var json = JsonSerializer.Serialize(contentType);
         Debug.Print(json);
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/DictionaryItemTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/DictionaryItemTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using Newtonsoft.Json;
+using System.Text.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Tests.Common.Builders;
@@ -57,7 +57,7 @@ public class DictionaryItemTests
             .WithRandomTranslations(2)
             .Build();
 
-        Assert.DoesNotThrow(() => JsonConvert.SerializeObject(item));
+        Assert.DoesNotThrow(() => JsonSerializer.Serialize(item));
     }
 
     [TestCase("en-AU", "en-AU value")]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/DictionaryTranslationTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/DictionaryTranslationTests.cs
@@ -2,8 +2,7 @@
 // See LICENSE for more details.
 
 using System.Diagnostics;
-using System.Linq;
-using Newtonsoft.Json;
+using System.Text.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Tests.Common.Builders;
@@ -48,7 +47,7 @@ public class DictionaryTranslationTests
     {
         var item = BuildDictionaryTranslation();
 
-        var json = JsonConvert.SerializeObject(item);
+        var json = JsonSerializer.Serialize(item);
         Debug.Print(json);
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/DocumentEntityTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/DocumentEntityTests.cs
@@ -2,7 +2,7 @@
 // See LICENSE for more details.
 
 using System.Diagnostics;
-using Newtonsoft.Json;
+using System.Text.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
@@ -38,7 +38,7 @@ public class DocumentEntityTests
             .Done()
             .Build();
 
-        var json = JsonConvert.SerializeObject(item);
+        var json = JsonSerializer.Serialize(item);
         Debug.Print(json);
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/LanguageTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/LanguageTests.cs
@@ -1,7 +1,8 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Tests.Common.Builders;
@@ -47,6 +48,10 @@ public class LanguageTests
     {
         var item = _builder.Build();
 
-        Assert.DoesNotThrow(() => JsonConvert.SerializeObject(item));
+        Assert.DoesNotThrow(() => JsonSerializer.Serialize(item, new JsonSerializerOptions()
+        {
+            // Ignore CultureInfo reference
+            ReferenceHandler = ReferenceHandler.IgnoreCycles
+        }));
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/MemberGroupTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/MemberGroupTests.cs
@@ -2,7 +2,7 @@
 // See LICENSE for more details.
 
 using System.Diagnostics;
-using Newtonsoft.Json;
+using System.Text.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Tests.Common.Builders;
@@ -52,7 +52,7 @@ public class MemberGroupTests
     {
         var group = BuildMemberGroup();
 
-        var json = JsonConvert.SerializeObject(group);
+        var json = JsonSerializer.Serialize(group);
         Debug.Print(json);
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/MemberTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/MemberTests.cs
@@ -2,8 +2,7 @@
 // See LICENSE for more details.
 
 using System.Diagnostics;
-using System.Linq;
-using Newtonsoft.Json;
+using System.Text.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Tests.Common.Builders;
@@ -79,7 +78,7 @@ public class MemberTests
     {
         var member = BuildMember();
 
-        var json = JsonConvert.SerializeObject(member);
+        var json = JsonSerializer.Serialize(member);
         Debug.Print(json);
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/PropertyGroupTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/PropertyGroupTests.cs
@@ -2,7 +2,7 @@
 // See LICENSE for more details.
 
 using System.Diagnostics;
-using Newtonsoft.Json;
+using System.Text.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Tests.Common.Builders;
@@ -55,7 +55,7 @@ public class PropertyGroupTests
     {
         var pg = BuildPropertyGroup();
 
-        var json = JsonConvert.SerializeObject(pg);
+        var json = JsonSerializer.Serialize(pg);
         Debug.Print(json);
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/PropertyTypeTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/PropertyTypeTests.cs
@@ -2,9 +2,8 @@
 // See LICENSE for more details.
 
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
-using Newtonsoft.Json;
+using System.Text.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Tests.Common.Builders;
@@ -65,7 +64,7 @@ public class PropertyTypeTests
     {
         var pt = BuildPropertyType();
 
-        var json = JsonConvert.SerializeObject(pt);
+        var json = JsonSerializer.Serialize(pt);
         Debug.Print(json);
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/RelationTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/RelationTests.cs
@@ -2,7 +2,7 @@
 // See LICENSE for more details.
 
 using System.Diagnostics;
-using Newtonsoft.Json;
+using System.Text.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Tests.Common.Builders;
@@ -51,7 +51,7 @@ public class RelationTests
     {
         var relation = BuildRelation();
 
-        var json = JsonConvert.SerializeObject(relation);
+        var json = JsonSerializer.Serialize(relation);
         Debug.Print(json);
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/RelationTypeTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/RelationTypeTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using Newtonsoft.Json;
+using System.Text.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Tests.Common.Builders;
@@ -53,6 +53,6 @@ public class RelationTypeTests
     {
         IRelationType item = _builder.Build();
 
-        Assert.DoesNotThrow(() => JsonConvert.SerializeObject(item));
+        Assert.DoesNotThrow(() => JsonSerializer.Serialize(item));
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/StylesheetTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/StylesheetTests.cs
@@ -2,8 +2,7 @@
 // See LICENSE for more details.
 
 using System.Diagnostics;
-using System.Linq;
-using Newtonsoft.Json;
+using System.Text.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Tests.Common.Builders;
@@ -133,7 +132,7 @@ public class StylesheetTests
             .Build();
 
         // Act
-        var json = JsonConvert.SerializeObject(stylesheet);
+        var json = JsonSerializer.Serialize(stylesheet);
         Debug.Print(json);
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/TemplateTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/TemplateTests.cs
@@ -2,9 +2,8 @@
 // See LICENSE for more details.
 
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
-using Newtonsoft.Json;
+using System.Text.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Tests.Common.Builders;
@@ -60,7 +59,7 @@ public class TemplateTests
     {
         var template = BuildTemplate();
 
-        var json = JsonConvert.SerializeObject(template);
+        var json = JsonSerializer.Serialize(template);
         Debug.Print(json);
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/UserGroupTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/UserGroupTests.cs
@@ -1,10 +1,8 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using Newtonsoft.Json;
+using System.Text.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Tests.Common.Builders;
@@ -52,7 +50,7 @@ public class UserGroupTests
     {
         var item = Build();
 
-        var json = JsonConvert.SerializeObject(item);
+        var json = JsonSerializer.Serialize(item);
         Debug.Print(json);
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/UserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/UserTests.cs
@@ -2,8 +2,7 @@
 // See LICENSE for more details.
 
 using System.Diagnostics;
-using System.Linq;
-using Newtonsoft.Json;
+using System.Text.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Tests.Common.Builders;
@@ -44,7 +43,7 @@ public class UserTests
     {
         var item = BuildUser();
 
-        var json = JsonConvert.SerializeObject(item);
+        var json = JsonSerializer.Serialize(item);
         Debug.Print(json);
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/RichTextPropertyEditorHelperTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/RichTextPropertyEditorHelperTests.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.Extensions.Logging;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging;
 using Moq;
-using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.PropertyEditors;
@@ -25,14 +25,14 @@ public class RichTextPropertyEditorHelperTests
     [Test]
     public void Can_Parse_JObject()
     {
-        var input = JObject.Parse(""""
+        var input = JsonNode.Parse(""""
                                   {
                                    "markup": "<p>this is some markup</p><umb-rte-block data-content-udi=\"umb://element/36cc710ad8a645d0a07f7bbd8742cf02\"><!--Umbraco-Block--></umb-rte-block>",
                                    "blocks": {
                                        "layout": {
                                            "Umbraco.TinyMCE": [{
                                                    "contentUdi": "umb://element/36cc710ad8a645d0a07f7bbd8742cf02",
-                                                   "settingsUdi": "umb://element/d2eeef66411142f4a1647a523eaffbc2",
+                                                   "settingsUdi": "umb://element/d2eeef66411142f4a1647a523eaffbc2"
                                                }
                                            ]
                                        },

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Models/DataTypeTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Models/DataTypeTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using Newtonsoft.Json;
+using System.Text.Json;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Tests.Common.Builders;
@@ -54,6 +54,6 @@ public class DataTypeTests
     {
         var item = _builder.Build();
 
-        Assert.DoesNotThrow(() => JsonConvert.SerializeObject(item));
+        Assert.DoesNotThrow(() => JsonSerializer.Serialize(item));
     }
 }


### PR DESCRIPTION
This removes the dependency on `Newtonsoft.Json` from all tests and instead uses `System.Text.Json`.