### PR TITLE
v14: JSON schema tool improvements

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
@@ -78,13 +78,12 @@ public class GlobalSettings
     public int VersionCheckPeriod { get; set; } = StaticVersionCheckPeriod;
 
     /// <summary>
-    ///     Gets or sets a value for the Umbraco back-office path.
+    /// Gets or sets a value for the Umbraco back-office path.
     /// </summary>
+    [Obsolete($"UmbracoPath is no longer configurable, use Constants.System.DefaultUmbracoPath instead. This property is scheduled for removal in a future version.")]
     public string UmbracoPath
     {
         get => Constants.System.DefaultUmbracoPath;
-        [Obsolete($"{nameof(UmbracoPath)} is no longer configurable, this property setter is scheduled for removal in V12.")]
-        // NOTE: When removing this, also clean up the hardcoded removal of UmbracoPath in Umbraco.JsonSchema
         set { }
     }
 

--- a/tools/Umbraco.JsonSchema/Options.cs
+++ b/tools/Umbraco.JsonSchema/Options.cs
@@ -3,5 +3,5 @@ using CommandLine;
 internal class Options
 {
     [Option("outputFile", Default = "appsettings-schema.Umbraco.Cms.json", HelpText = "Output file to save the generated JSON schema for Umbraco CMS.")]
-    public string OutputFile { get; set; } = null!;
+    public required string OutputFile { get; set; }
 }

--- a/tools/Umbraco.JsonSchema/Program.cs
+++ b/tools/Umbraco.JsonSchema/Program.cs
@@ -1,14 +1,10 @@
 using CommandLine;
-using Umbraco.Cms.Core.Configuration.Models;
 
 await Parser.Default.ParseArguments<Options>(args).WithParsedAsync(async options =>
 {
     // Generate CMS schema
     var jsonSchemaGenerator = new UmbracoJsonSchemaGenerator();
     var jsonSchema = jsonSchemaGenerator.Generate(typeof(UmbracoCmsSchema));
-
-    // TODO: When the UmbracoPath setter is removed from GlobalSettings (scheduled for V12), remove this line as well
-    jsonSchema.Definitions[nameof(GlobalSettings)]?.Properties?.Remove(nameof(GlobalSettings.UmbracoPath));
 
     await File.WriteAllTextAsync(options.OutputFile, jsonSchema.ToJson());
 });

--- a/tools/Umbraco.JsonSchema/UmbracoCmsSchema.cs
+++ b/tools/Umbraco.JsonSchema/UmbracoCmsSchema.cs
@@ -3,14 +3,14 @@ using Umbraco.Cms.Core.Configuration.Models;
 
 internal class UmbracoCmsSchema
 {
-    public UmbracoDefinition Umbraco { get; set; } = null!;
+    public required UmbracoDefinition Umbraco { get; set; }
 
     /// <summary>
     /// Configuration container for all Umbraco products.
     /// </summary>
     public class UmbracoDefinition
     {
-        public UmbracoCmsDefinition CMS { get; set; } = null!;
+        public required UmbracoCmsDefinition CMS { get; set; }
     }
 
     /// <summary>
@@ -18,66 +18,66 @@ internal class UmbracoCmsSchema
     /// </summary>
     public class UmbracoCmsDefinition
     {
-        public ContentSettings Content { get; set; } = null!;
+        public required ContentSettings Content { get; set; }
 
-        public DeliveryApiSettings DeliveryApi { get; set; } = null!;
+        public required DeliveryApiSettings DeliveryApi { get; set; }
 
-        public CoreDebugSettings Debug { get; set; } = null!;
+        public required CoreDebugSettings Debug { get; set; }
 
-        public ExceptionFilterSettings ExceptionFilter { get; set; } = null!;
+        public required ExceptionFilterSettings ExceptionFilter { get; set; }
 
-        public ModelsBuilderSettings ModelsBuilder { get; set; } = null!;
+        public required ModelsBuilderSettings ModelsBuilder { get; set; }
 
-        public GlobalSettings Global { get; set; } = null!;
+        public required GlobalSettings Global { get; set; }
 
-        public HealthChecksSettings HealthChecks { get; set; } = null!;
+        public required HealthChecksSettings HealthChecks { get; set; }
 
-        public HostingSettings Hosting { get; set; } = null!;
+        public required HostingSettings Hosting { get; set; }
 
-        public ImagingSettings Imaging { get; set; } = null!;
+        public required ImagingSettings Imaging { get; set; }
 
-        public IndexCreatorSettings Examine { get; set; } = null!;
+        public required IndexCreatorSettings Examine { get; set; }
 
-        public IndexingSettings Indexing { get; set; } = null!;
+        public required IndexingSettings Indexing { get; set; }
 
-        public LoggingSettings Logging { get; set; } = null!;
+        public required LoggingSettings Logging { get; set; }
 
-        public NuCacheSettings NuCache { get; set; } = null!;
+        public required NuCacheSettings NuCache { get; set; }
 
-        public RequestHandlerSettings RequestHandler { get; set; } = null!;
+        public required RequestHandlerSettings RequestHandler { get; set; }
 
-        public RuntimeSettings Runtime { get; set; } = null!;
+        public required RuntimeSettings Runtime { get; set; }
 
-        public SecuritySettings Security { get; set; } = null!;
+        public required SecuritySettings Security { get; set; }
 
-        public TypeFinderSettings TypeFinder { get; set; } = null!;
+        public required TypeFinderSettings TypeFinder { get; set; }
 
-        public WebRoutingSettings WebRouting { get; set; } = null!;
+        public required WebRoutingSettings WebRouting { get; set; }
 
-        public UmbracoPluginSettings Plugins { get; set; } = null!;
+        public required UmbracoPluginSettings Plugins { get; set; }
 
-        public UnattendedSettings Unattended { get; set; } = null!;
+        public required UnattendedSettings Unattended { get; set; }
 
-        public RichTextEditorSettings RichTextEditor { get; set; } = null!;
+        public required RichTextEditorSettings RichTextEditor { get; set; }
 
-        public RuntimeMinificationSettings RuntimeMinification { get; set; } = null!;
+        public required RuntimeMinificationSettings RuntimeMinification { get; set; }
 
-        public BasicAuthSettings BasicAuth { get; set; } = null!;
+        public required BasicAuthSettings BasicAuth { get; set; }
 
-        public PackageMigrationSettings PackageMigration { get; set; } = null!;
+        public required PackageMigrationSettings PackageMigration { get; set; }
 
-        public LegacyPasswordMigrationSettings LegacyPasswordMigration { get; set; } = null!;
+        public required LegacyPasswordMigrationSettings LegacyPasswordMigration { get; set; }
 
-        public ContentDashboardSettings ContentDashboard { get; set; } = null!;
+        public required ContentDashboardSettings ContentDashboard { get; set; }
 
-        public HelpPageSettings HelpPage { get; set; } = null!;
+        public required HelpPageSettings HelpPage { get; set; }
 
-        public InstallDefaultDataSettings DefaultDataCreation { get; set; } = null!;
+        public required InstallDefaultDataSettings DefaultDataCreation { get; set; }
 
-        public DataTypesSettings DataTypes { get; set; } = null!;
+        public required DataTypesSettings DataTypes { get; set; }
 
-        public MarketplaceSettings Marketplace { get; set; } = null!;
+        public required MarketplaceSettings Marketplace { get; set; }
 
-        public WebhookSettings Webhook { get; set; } = null!;
+        public required WebhookSettings Webhook { get; set; }
     }
 }

--- a/tools/Umbraco.JsonSchema/UmbracoJsonSchemaGenerator.cs
+++ b/tools/Umbraco.JsonSchema/UmbracoJsonSchemaGenerator.cs
@@ -5,7 +5,7 @@ using NJsonSchema;
 using NJsonSchema.Generation;
 
 /// <inheritdoc />
-public class UmbracoJsonSchemaGenerator : JsonSchemaGenerator
+internal class UmbracoJsonSchemaGenerator : JsonSchemaGenerator
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="UmbracoJsonSchemaGenerator" /> class.
@@ -19,11 +19,8 @@ public class UmbracoJsonSchemaGenerator : JsonSchemaGenerator
             ReflectionService = new UmbracoSystemTextJsonReflectionService(),
             SerializerOptions = new JsonSerializerOptions()
             {
-                Converters =
-                {
-                    new JsonStringEnumConverter()
-                },
-                WriteIndented = true,
+                Converters = { new JsonStringEnumConverter() },
+                IgnoreReadOnlyProperties = true,
             },
         })
     { }
@@ -34,16 +31,20 @@ public class UmbracoJsonSchemaGenerator : JsonSchemaGenerator
         /// <inheritdoc />
         public override void GenerateProperties(JsonSchema schema, ContextualType contextualType, SystemTextJsonSchemaGeneratorSettings settings, JsonSchemaGenerator schemaGenerator, JsonSchemaResolver schemaResolver)
         {
+            // Populate schema properties
             base.GenerateProperties(schema, contextualType, settings, schemaGenerator, schemaResolver);
 
-            // Remove read-only properties
-            foreach (ContextualPropertyInfo property in contextualType.Properties)
+            if (settings.SerializerOptions.IgnoreReadOnlyProperties)
             {
-                if (property.CanWrite is false)
+                // Remove read-only properties (because this is not implemented by the base class)
+                foreach (ContextualPropertyInfo property in contextualType.Properties)
                 {
-                    string propertyName = GetPropertyName(property, settings);
+                    if (property.CanWrite is false)
+                    {
+                        string propertyName = GetPropertyName(property, settings);
 
-                    schema.Properties.Remove(propertyName);
+                        schema.Properties.Remove(propertyName);
+                    }
                 }
             }
         }


### PR DESCRIPTION
After updating the JsonSchema tool in PR https://github.com/umbraco/Umbraco-CMS/pull/16030, I copied over the same changes to our commercial products (because this tool isn't reusable yet, see PR https://github.com/umbraco/Umbraco-CMS/pull/13560). This required doing some adjustments, which can be brought back to the CMS.

The biggest change is that the JSON schema generator now checks the `IgnoreReadOnlyProperties` setting to conditionally remove read-only properties (which probably should be supported OOTB by `NJsonSchema`). All properties on the schema class now use the required modifier instead of setting null-suppressed default values and I've made the full `UmbracoPath` property obsolete, so the obsolete setter work-around can be removed as well.

To test, rebuild the Umbraco.Cms.Targets project (or remove the `appsettings-schema.Umbraco.Cms.json` file and start a build) and check whether the generated file is the same as before.