### PR TITLE
Clean up FIXMEs in security controllers

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/ConfigurationSecurityController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/ConfigurationSecurityController.cs
@@ -1,13 +1,15 @@
 ﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.Security;
+using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Security;
 
 [ApiVersion("1.0")]
-// FIXME: Add requiring password reset token policy when its implemented
+[Authorize(Policy = AuthorizationPolicies.DenyLocalLoginIfConfigured)]
 public class ConfigurationSecurityController : SecurityControllerBase
 {
     private readonly IPasswordConfigurationPresentationFactory _passwordConfigurationPresentationFactory;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/ResetPasswordController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/ResetPasswordController.cs
@@ -12,7 +12,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 namespace Umbraco.Cms.Api.Management.Controllers.Security;
 
 [ApiVersion("1.0")]
-// FIXME: Add requiring password reset token policy when its implemented
 [Authorize(Policy = AuthorizationPolicies.DenyLocalLoginIfConfigured)]
 public class ResetPasswordController : SecurityControllerBase
 {


### PR DESCRIPTION
### Description

This PR ensures that the security configuration endpoint mimics the "reset password" endpoints, disallowing access if "deny local login" is configured.

The other change is just a leftover, that was not removed. The controller (`ResetPasswordController`) already adheres to the same auth requirements as [the corresponding endpoint in V13](https://github.com/umbraco/Umbraco-CMS/blob/8a9e6ee82dc265dc86983fd1dcb5aec526252851/src/Umbraco.Web.BackOffice/Controllers/AuthenticationController.cs#L463).