### PR TITLE
Removed leftover System.Text.Json dependencies

### DIFF
--- a/src/Umbraco.Core/Serialization/IJsonSerializer.cs
+++ b/src/Umbraco.Core/Serialization/IJsonSerializer.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Umbraco.Cms.Core.Serialization;
 
 /// <summary>
@@ -24,4 +26,14 @@ public interface IJsonSerializer
     /// A <typeparamref name="T" /> representation of the JSON value.
     /// </returns>
     T? Deserialize<T>(string input);
+
+    /// <summary>
+    /// Attempts to parse an object that represents a JSON structure - i.e. a JSON object or a JSON array - to a strongly typed representation.
+    /// </summary>
+    /// <typeparam name="T">The target type of the JSON value.</typeparam>
+    /// <param name="input">The object input to parse.</param>
+    /// <param name="value">The parsed result, or null if the parsing fails.</param>
+    /// <returns>True if the parsing results in a non-null value, false otherwise.</returns>
+    bool TryDeserialize<T>(object input, [NotNullWhen(true)] out T? value)
+        where T : class;
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperPropertyValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperPropertyValueEditor.cs
@@ -222,20 +222,21 @@ internal class ImageCropperPropertyValueEditor : DataValueEditor // TODO: core v
 
     private ImageCropperValue? TryParseImageCropperValue(object? editorValue)
     {
-        // FIXME: consider creating an object deserialization method on IJsonSerializer instead of relying on deserializing serialized JSON here (and likely other places as well)
-        if (editorValue is JsonObject jsonObject)
+        try
         {
-            try
+            if (editorValue is null ||
+                _jsonSerializer.TryDeserialize(editorValue, out ImageCropperValue? imageCropperValue) is false)
             {
-                ImageCropperValue? imageCropperValue = _jsonSerializer.Deserialize<ImageCropperValue>(jsonObject.ToJsonString());
-                imageCropperValue?.Prune();
-                return imageCropperValue;
+                return null;
             }
-            catch (Exception ex)
-            {
-                // For some reason the value is invalid - log error and continue as if no value was saved
-                _logger.LogWarning(ex, "Could not parse editor value to an ImageCropperValue object.");
-            }
+
+            imageCropperValue.Prune();
+            return imageCropperValue;
+        }
+        catch (Exception ex)
+        {
+            // For some reason the value is invalid - log error and continue as if no value was saved
+            _logger.LogWarning(ex, "Could not parse editor value to an ImageCropperValue object.");
         }
 
         return null;

--- a/src/Umbraco.Infrastructure/PropertyEditors/MediaPicker3PropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MediaPicker3PropertyEditor.cs
@@ -1,4 +1,3 @@
-using System.Text.Json.Nodes;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
@@ -112,14 +111,8 @@ public class MediaPicker3PropertyEditor : DataEditor
 
         public override object? FromEditor(ContentPropertyData editorValue, object? currentValue)
         {
-            // FIXME: consider creating an object deserialization method on IJsonSerializer instead of relying on deserializing serialized JSON here (and likely other places as well)
-            if (editorValue.Value is not JsonArray jsonArray)
-            {
-                return base.FromEditor(editorValue, currentValue);
-            }
-
-            List<MediaWithCropsDto>? mediaWithCropsDtos = _jsonSerializer.Deserialize<List<MediaWithCropsDto>>(jsonArray.ToJsonString());
-            if (mediaWithCropsDtos is null)
+            if (editorValue.Value is null ||
+                _jsonSerializer.TryDeserialize(editorValue.Value, out List<MediaWithCropsDto>? mediaWithCropsDtos) is false)
             {
                 return base.FromEditor(editorValue, currentValue);
             }

--- a/src/Umbraco.Infrastructure/PropertyEditors/SliderPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/SliderPropertyEditor.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using System.Text.Json.Nodes;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Editors;
@@ -73,16 +72,9 @@ public class SliderPropertyEditor : DataEditor
         }
 
         public override object? FromEditor(ContentPropertyData editorValue, object? currentValue)
-        {
-            // FIXME: do not rely explicitly on concrete JSON implementation here - consider creating an object deserialization method on IJsonSerializer (see also MultiUrlPickerValueEditor)
-            if (editorValue.Value is not JsonNode jsonNode)
-            {
-                return null;
-            }
-
-            SliderRange? range = _jsonSerializer.Deserialize<SliderRange>(jsonNode.ToJsonString());
-            return range?.ToString();
-        }
+            => editorValue.Value is not null && _jsonSerializer.TryDeserialize(editorValue.Value, out SliderRange? sliderRange)
+                ? sliderRange.ToString()
+                : null;
 
         internal class SliderRange
         {

--- a/src/Umbraco.Infrastructure/Serialization/SystemTextConfigurationEditorJsonSerializer.cs
+++ b/src/Umbraco.Infrastructure/Serialization/SystemTextConfigurationEditorJsonSerializer.cs
@@ -5,7 +5,7 @@ using Umbraco.Cms.Core.Serialization;
 namespace Umbraco.Cms.Infrastructure.Serialization;
 
 /// <inheritdoc />
-public sealed class SystemTextConfigurationEditorJsonSerializer : IConfigurationEditorJsonSerializer
+public sealed class SystemTextConfigurationEditorJsonSerializer : SystemTextJsonSerializerBase, IConfigurationEditorJsonSerializer
 {
     private readonly JsonSerializerOptions _jsonSerializerOptions;
 
@@ -30,9 +30,5 @@ public sealed class SystemTextConfigurationEditorJsonSerializer : IConfiguration
             }
         };
 
-    /// <inheritdoc />
-    public string Serialize(object? input) => JsonSerializer.Serialize(input, _jsonSerializerOptions);
-
-    /// <inheritdoc />
-    public T? Deserialize<T>(string input) => JsonSerializer.Deserialize<T>(input, _jsonSerializerOptions);
+    protected override JsonSerializerOptions JsonSerializerOptions => _jsonSerializerOptions;
 }

--- a/src/Umbraco.Infrastructure/Serialization/SystemTextJsonSerializer.cs
+++ b/src/Umbraco.Infrastructure/Serialization/SystemTextJsonSerializer.cs
@@ -1,11 +1,10 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Umbraco.Cms.Core.Serialization;
 
 namespace Umbraco.Cms.Infrastructure.Serialization;
 
 /// <inheritdoc />
-public sealed class SystemTextJsonSerializer : IJsonSerializer
+public sealed class SystemTextJsonSerializer : SystemTextJsonSerializerBase
 {
     private readonly JsonSerializerOptions _jsonSerializerOptions;
 
@@ -26,9 +25,5 @@ public sealed class SystemTextJsonSerializer : IJsonSerializer
             }
         };
 
-    /// <inheritdoc />
-    public string Serialize(object? input) => JsonSerializer.Serialize(input, _jsonSerializerOptions);
-
-    /// <inheritdoc />
-    public T? Deserialize<T>(string input) => JsonSerializer.Deserialize<T>(input, _jsonSerializerOptions);
+    protected override JsonSerializerOptions JsonSerializerOptions => _jsonSerializerOptions;
 }

--- a/src/Umbraco.Infrastructure/Serialization/SystemTextJsonSerializerBase.cs
+++ b/src/Umbraco.Infrastructure/Serialization/SystemTextJsonSerializerBase.cs
@@ -1,0 +1,35 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Infrastructure.Serialization;
+
+public abstract class SystemTextJsonSerializerBase : IJsonSerializer
+{
+    protected abstract JsonSerializerOptions JsonSerializerOptions { get; }
+
+    /// <inheritdoc />
+    public string Serialize(object? input) => JsonSerializer.Serialize(input, JsonSerializerOptions);
+
+    /// <inheritdoc />
+    public T? Deserialize<T>(string input) => JsonSerializer.Deserialize<T>(input, JsonSerializerOptions);
+
+    /// <inheritdoc />
+    public bool TryDeserialize<T>(object input, [NotNullWhen(true)] out T? value)
+        where T : class
+    {
+        var jsonString = input switch
+        {
+            JsonNode jsonNodeValue => jsonNodeValue.ToJsonString(),
+            string stringValue when stringValue.DetectIsJson() => stringValue,
+            _ => null
+        };
+
+        value = jsonString.IsNullOrWhiteSpace()
+            ? null
+            : Deserialize<T>(jsonString);
+        return value != null;
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Serialization/SystemTextJsonSerializerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Serialization/SystemTextJsonSerializerTests.cs
@@ -1,0 +1,53 @@
+﻿using System.Text.Json.Nodes;
+using NUnit.Framework;
+using Umbraco.Cms.Infrastructure.Serialization;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Serialization;
+
+[TestFixture]
+public class SystemTextJsonSerializerTests
+{
+    [Test]
+    public void TryDeserialize_Can_Handle_JsonObject()
+    {
+        var json = JsonNode.Parse("{\"myProperty\":\"value\"}");
+        var subject = new SystemTextJsonSerializer();
+        Assert.IsTrue(subject.TryDeserialize(json!, out MyItem myItem));
+        Assert.AreEqual("value", myItem.MyProperty);
+    }
+
+    [Test]
+    public void TryDeserialize_Can_Handle_JsonArray()
+    {
+        var json = JsonNode.Parse("[{\"myProperty\":\"value1\"},{\"myProperty\":\"value2\"}]");
+        var subject = new SystemTextJsonSerializer();
+        Assert.IsTrue(subject.TryDeserialize(json!, out MyItem[] myItems));
+        Assert.AreEqual(2, myItems.Length);
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual("value1", myItems[0].MyProperty);
+            Assert.AreEqual("value2", myItems[1].MyProperty);
+        });
+    }
+
+    [Test]
+    public void TryDeserialize_Can_Handle_JsonString()
+    {
+        var json = "{\"myProperty\":\"value\"}";
+        var subject = new SystemTextJsonSerializer();
+        Assert.IsTrue(subject.TryDeserialize(json, out MyItem myItem));
+        Assert.AreEqual("value", myItem.MyProperty);
+    }
+
+    [Test]
+    public void TryDeserialize_Cannot_Handle_RandomString()
+    {
+        var subject = new SystemTextJsonSerializer();
+        Assert.IsFalse(subject.TryDeserialize<MyItem>("something something", out _));
+    }
+
+    private class MyItem
+    {
+        public required string MyProperty { get; set; }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

A few property value editors have a direct dependency on `System.Text.Json`. While this works just fine, they really should not have that dependency. But at this point they're forced to.

This PR introduces a new method on `IJsonSerializer`, which allows for attempting a deserialization of any (JSON) object, thus removing the need for direct dependencies on the concrete JSON implementation.

Unit tests included.

As the current `IJsonSerializer` and `IConfigurationEditorJsonSerializer` implementations are virtually identical apart from the JSON configurations, I have abstracted their implementation into a base class, so I didn't have to duplicate the implementation of the `TryDeserialize` method too.

### Testing this PR

Nothing should change functionality wise.

Verify that you are still able to save content with properties based on the affected property value editors (slider, image cropper, media picker).