### PR TITLE
V14: MediaPicker/MNTP - Changed `StartNodeId` from a `Udi` to `Guid`

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/MediaPicker3Configuration.cs
+++ b/src/Umbraco.Core/PropertyEditors/MediaPicker3Configuration.cs
@@ -15,7 +15,7 @@ public class MediaPicker3Configuration : IIgnoreUserStartNodesConfig
     public NumberRange ValidationLimit { get; set; } = new();
 
     [ConfigurationField("startNodeId")]
-    public Udi? StartNodeId { get; set; }
+    public Guid? StartNodeId { get; set; }
 
     [ConfigurationField("enableLocalFocalPoint")]
     public bool EnableLocalFocalPoint { get; set; }

--- a/src/Umbraco.Core/PropertyEditors/MultiNodePickerConfigurationTreeSource.cs
+++ b/src/Umbraco.Core/PropertyEditors/MultiNodePickerConfigurationTreeSource.cs
@@ -22,7 +22,7 @@ public class MultiNodePickerConfigurationTreeSource
 
     [JsonPropertyName("id")]
     [DataMember(Name = "id")]
-    public Udi? StartNodeId { get; set; }
+    public Guid? StartNodeId { get; set; }
 }
 
 [DataContract]

--- a/src/Umbraco.Infrastructure/PropertyEditors/MediaPicker3PropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MediaPicker3PropertyEditor.cs
@@ -215,7 +215,7 @@ public class MediaPicker3PropertyEditor : DataEditor
                     continue;
                 }
 
-                GuidUdi? startNodeGuid = configuration.StartNodeId as GuidUdi ?? null;
+                Guid? startNodeGuid = configuration.StartNodeId;
 
                 // make sure we'll clean up the temporary file if the scope completes
                 using IScope scope = _scopeProvider.CreateScope();
@@ -225,7 +225,7 @@ public class MediaPicker3PropertyEditor : DataEditor
                 // there are multiple allowed media types matching the file extension
                 using Stream fileStream = temporaryFile.OpenReadStream();
                 IMedia mediaFile = _mediaImportService
-                    .ImportAsync(temporaryFile.FileName, fileStream, startNodeGuid?.Guid, mediaWithCropsDto.MediaTypeAlias, userKey)
+                    .ImportAsync(temporaryFile.FileName, fileStream, startNodeGuid, mediaWithCropsDto.MediaTypeAlias, userKey)
                     .GetAwaiter()
                     .GetResult();
 


### PR DESCRIPTION
As discussed with @Migaroez, I suspect these were missed during the data type configuration migration work.

Strange thing is that the frontend (beta002) had been working with these fine until yesterday, when it started to throw errors about the MediaPicker and MNTP configurations, so I'm not sure if something else changed on the server-side, but correcting the object-type appears to fix this.