### PR TITLE
Only add a SQL in statement if there are keys to filter on

### DIFF
--- a/src/Umbraco.Core/Services/TemplateService.cs
+++ b/src/Umbraco.Core/Services/TemplateService.cs
@@ -139,11 +139,12 @@ public class TemplateService : RepositoryService, ITemplateService
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
 
-        IQuery<ITemplate> query = Query<ITemplate>();
-        if (keys.Any())
+        if (keys.Any() == false)
         {
-            query = query.Where(x => keys.Contains(x.Key));
+            return Task.FromResult((IEnumerable<ITemplate>)_templateRepository.GetAll().OrderBy(x => x.Name));
         }
+
+        IQuery<ITemplate> query = Query<ITemplate>().Where(x => keys.Contains(x.Key));
         IEnumerable<ITemplate> templates = _templateRepository.Get(query).OrderBy(x => x.Name);
 
         return Task.FromResult(templates);

--- a/src/Umbraco.Core/Services/TemplateService.cs
+++ b/src/Umbraco.Core/Services/TemplateService.cs
@@ -139,7 +139,11 @@ public class TemplateService : RepositoryService, ITemplateService
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
 
-        IQuery<ITemplate> query = Query<ITemplate>().Where(x => keys.Contains(x.Key));
+        IQuery<ITemplate> query = Query<ITemplate>();
+        if (keys.Any())
+        {
+            query = query.Where(x => keys.Contains(x.Key));
+        }
         IEnumerable<ITemplate> templates = _templateRepository.Get(query).OrderBy(x => x.Name);
 
         return Task.FromResult(templates);


### PR DESCRIPTION
### Description
Calling TemplateService.GetAll any keys in the array results in a sql error.
(backoffice usecase: template selection on a doctype with template)

Since this is a params object we can not supply null, so we check versus any