### PR TITLE
Fixed check to support unix/linux OS

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/BackOfficeLoginController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/BackOfficeLoginController.cs
@@ -54,7 +54,7 @@ public class BackOfficeLoginController : Controller
             model.UmbracoUrl = _hostingEnvironment.ToAbsolute(_globalSettings.UmbracoPath);
         }
 
-        if (Uri.TryCreate(model.ReturnUrl, UriKind.Absolute, out _))
+        if ( Uri.TryCreate(model.ReturnUrl, UriKind.Relative, out _) is false) // Needs to test for relative and not absolute, as /whatever/ is an absolute path on linux
         {
             return BadRequest("ReturnUrl must be a relative path.");
         }


### PR DESCRIPTION
Negated a check for relative path.

The reason is because `/asd/` is also an absolute path on Linux/Unix.