### PR TITLE
Respect backoffice login returnPath regression

### DIFF
--- a/src/Umbraco.Web.UI.Login/src/components/external-login-provider.element.ts
+++ b/src/Umbraco.Web.UI.Login/src/components/external-login-provider.element.ts
@@ -73,7 +73,7 @@ export class UmbExternalLoginProviderElement extends LitElement {
   @property({attribute: 'external-login-url'})
   set externalLoginUrl(value: string) {
     const tempUrl = new URL(value, window.location.origin);
-    const searchParams = new URLSearchParams(tempUrl.search);
+    const searchParams = new URLSearchParams(window.location.search);
     tempUrl.searchParams.append('redirectUrl', decodeURIComponent(searchParams.get('returnPath') ?? ''));
     this.#externalLoginUrl = tempUrl.pathname + tempUrl.search;
   }


### PR DESCRIPTION
### Prerequisites

Fixes #15686 (was originally fixed in 2022/2023)

### Description
See issue for detailed info and how to reproduce.

Looks like while implementing the new login screen a typo was made that means the redirect url is never carried on.

There is however another part to this: in some situations when you try to directly go to a protected backoffice page (e.g. `/umbraco#/settings`) while not being logged in and not using basic authentication as in the issue, you are redirected to the login page but without the `returnPath` query parm. The redirect itself is done here https://github.com/umbraco/Umbraco-CMS/blob/v13/contrib/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs#L141 but I'm not sure how/where the hash part of the query is carried on on the client.