### PR TITLE
V14 External login linking + Proposed error handling

### DIFF
--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/UmbracoBuilder.BackOffice.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/UmbracoBuilder.BackOffice.cs
@@ -24,6 +24,7 @@ public static partial class UmbracoBuilderExtensions
         .AddConfiguration()
         .AddUmbracoCore()
         .AddWebComponents()
+        .AddHelpers()
         .AddBackOfficeCore()
         .AddBackOfficeIdentity()
         .AddBackOfficeAuthentication()

--- a/src/Umbraco.Cms.Api.Management/Routing/BackOfficeAreaRoutes.cs
+++ b/src/Umbraco.Cms.Api.Management/Routing/BackOfficeAreaRoutes.cs
@@ -82,6 +82,6 @@ public sealed class BackOfficeAreaRoutes : IAreaRoutes
                 Controller = ControllerExtensions.GetControllerName<BackOfficeDefaultController>(),
                 Action = nameof(BackOfficeDefaultController.Index),
             },
-            constraints: new { slug = @"^(section.*|upgrade|install|logout)$" });
+            constraints: new { slug = @"^(section.*|upgrade|install|logout|error)$" });
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Security/BackOfficeAuthenticationBuilder.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/BackOfficeAuthenticationBuilder.cs
@@ -20,7 +20,7 @@ public class BackOfficeAuthenticationBuilder : AuthenticationBuilder
         : base(services)
         => _loginProviderOptions = loginProviderOptions ?? (x => { });
 
-    public string? SchemeForBackOffice(string scheme)
+    public static string? SchemeForBackOffice(string scheme)
         => scheme?.EnsureStartsWith(Constants.Security.BackOfficeExternalAuthenticationTypePrefix);
 
     /// <summary>

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Security/UnLinkLoginRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Security/UnLinkLoginRequestModel.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.Security;
+
+public class UnLinkLoginRequestModel
+{
+    [Required]
+    [DataMember(Name = "loginProvider", IsRequired = true)]
+    public required string LoginProvider { get; set; }
+
+    [Required]
+    [DataMember(Name = "providerKey", IsRequired = true)]
+    public required string ProviderKey { get; set; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Security/UnLinkLoginRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Security/UnLinkLoginRequestModel.cs
@@ -6,10 +6,8 @@ namespace Umbraco.Cms.Api.Management.ViewModels.Security;
 public class UnLinkLoginRequestModel
 {
     [Required]
-    [DataMember(Name = "loginProvider", IsRequired = true)]
     public required string LoginProvider { get; set; }
 
     [Required]
-    [DataMember(Name = "providerKey", IsRequired = true)]
     public required string ProviderKey { get; set; }
 }

--- a/src/Umbraco.Core/Configuration/Models/SecuritySettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/SecuritySettings.cs
@@ -26,6 +26,7 @@ public class SecuritySettings
     internal const int StaticMemberDefaultLockoutTimeInMinutes = 30 * 24 * 60;
     internal const int StaticUserDefaultLockoutTimeInMinutes = 30 * 24 * 60;
     internal const string StaticAuthorizeCallbackPathName = "/umbraco";
+    internal const string StaticAuthorizeCallbackErrorPathName = StaticAuthorizeCallbackPathName + "/error";
 
     /// <summary>
     ///     Gets or sets a value indicating whether to keep the user logged in.
@@ -116,4 +117,6 @@ public class SecuritySettings
     /// </summary>
     [DefaultValue(StaticAuthorizeCallbackPathName)]
     public string AuthorizeCallbackPathName { get; set; } = StaticAuthorizeCallbackPathName;
+
+    public string AuthorizeCallbackErrorPathName { get; set; } = StaticAuthorizeCallbackErrorPathName;
 }

--- a/src/Umbraco.Core/Configuration/Models/SecuritySettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/SecuritySettings.cs
@@ -26,7 +26,7 @@ public class SecuritySettings
     internal const int StaticMemberDefaultLockoutTimeInMinutes = 30 * 24 * 60;
     internal const int StaticUserDefaultLockoutTimeInMinutes = 30 * 24 * 60;
     internal const string StaticAuthorizeCallbackPathName = "/umbraco";
-    internal const string StaticAuthorizeCallbackErrorPathName = StaticAuthorizeCallbackPathName + "/error";
+    internal const string StaticAuthorizeCallbackErrorPathName = "/umbraco/error";
 
     /// <summary>
     ///     Gets or sets a value indicating whether to keep the user logged in.
@@ -118,5 +118,6 @@ public class SecuritySettings
     [DefaultValue(StaticAuthorizeCallbackPathName)]
     public string AuthorizeCallbackPathName { get; set; } = StaticAuthorizeCallbackPathName;
 
+    [DefaultValue(StaticAuthorizeCallbackErrorPathName)]
     public string AuthorizeCallbackErrorPathName { get; set; } = StaticAuthorizeCallbackErrorPathName;
 }

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -46,6 +46,7 @@ using Umbraco.Cms.Web.Common.Blocks;
 using Umbraco.Cms.Web.Common.Configuration;
 using Umbraco.Cms.Web.Common.DependencyInjection;
 using Umbraco.Cms.Web.Common.FileProviders;
+using Umbraco.Cms.Web.Common.Helpers;
 using Umbraco.Cms.Web.Common.Localization;
 using Umbraco.Cms.Web.Common.Middleware;
 using Umbraco.Cms.Web.Common.ModelBinders;
@@ -302,6 +303,13 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddScoped<IBackOfficeSecurity, BackOfficeSecurity>();
 
         builder.AddHttpClients();
+
+        return builder;
+    }
+
+    public static IUmbracoBuilder AddHelpers(this IUmbracoBuilder builder)
+    {
+        builder.Services.AddSingleton<OAuthOptionsHelper>();
 
         return builder;
     }

--- a/src/Umbraco.Web.Common/Extensions/OAuthOptionsExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/OAuthOptionsExtensions.cs
@@ -1,0 +1,73 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OAuth;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
+
+namespace Umbraco.Cms.Web.Common.Extensions;
+
+public static class OAuthOptionsExtensions
+{
+    /// <summary>
+    /// Applies SetUmbracoRedirectWithFilteredParams to both OnAccessDenied and OnRemoteFailure
+    /// on the OAuthOptions so Umbraco can do its best to nicely display the error messages
+    /// that are passed back from the external login provider on failure.
+    /// </summary>
+    /// <param name="oAuthOptions"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public static T SetDefaultErrorEventHandling<T>(this T oAuthOptions) where T : OAuthOptions
+    {
+        oAuthOptions.Events.OnAccessDenied = HandleResponseWithDefaultUmbracoRedirect;
+        oAuthOptions.Events.OnRemoteFailure = HandleResponseWithDefaultUmbracoRedirect;
+
+        return oAuthOptions;
+    }
+
+    private static Task HandleResponseWithDefaultUmbracoRedirect(HandleRequestContext<RemoteAuthenticationOptions> context)
+    {
+        context.SetUmbracoRedirectWithFilteredParams()
+            .HandleResponse();
+
+        return Task.FromResult(0);
+    }
+
+    /// <summary>
+    /// Sets the context to redirect to the <see cref="SecuritySettings.AuthorizeCallbackErrorPathName"/> path with all parameters, except state, that are passed to the initial server callback configured for the configured external login provider
+    /// </summary>
+    /// <returns></returns>
+    public static T SetUmbracoRedirectWithFilteredParams<T>(this T context)
+        where T : HandleRequestContext<RemoteAuthenticationOptions>
+    {
+        var callbackPath = StaticServiceProvider.Instance.GetRequiredService<IOptions<SecuritySettings>>().Value
+            .AuthorizeCallbackErrorPathName;
+        context.Response.Redirect($"{callbackPath}?" + string.Join(
+            '&',
+            context.Request.Query.Where(q =>
+                    q.Key.Equals("state", StringComparison.InvariantCultureIgnoreCase) == false)
+                .Select(q => q.Key + "=" + q.Value)));
+
+        return context;
+    }
+
+    /// <summary>
+    /// Sets the callbackPath for the RemoteAuthenticationOptions based on the configured Umbraco path and the path supplied.
+    /// By default this will result in "/umbraco/your-supplied-path".
+    /// </summary>
+    /// <param name="options">The options object to set the path on.</param>
+    /// <param name="path">The path that should go after the umbraco path, will add a leading slash if it's missing.</param>
+    /// <returns></returns>
+    public static RemoteAuthenticationOptions SetUmbracoBasedCallbackPath(this RemoteAuthenticationOptions options, string path)
+    {
+        var umbracoDallbackPath = StaticServiceProvider.Instance.GetRequiredService<IOptions<SecuritySettings>>().Value
+            .AuthorizeCallbackPathName;
+        if (path.StartsWith('/') == false)
+        {
+            path = "/" + path;
+        }
+
+        options.CallbackPath = umbracoDallbackPath + path;
+        return options;
+    }
+}

--- a/src/Umbraco.Web.Common/Helpers/OAuthOptionsHelper.cs
+++ b/src/Umbraco.Web.Common/Helpers/OAuthOptionsHelper.cs
@@ -1,25 +1,30 @@
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
-using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Extensions;
 
-namespace Umbraco.Cms.Web.Common.Extensions;
+namespace Umbraco.Cms.Web.Common.Helpers;
 
-public static class OAuthOptionsExtensions
+public class OAuthOptionsHelper
 {
     // https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1
     // we omit "state" and "error_uri" here as it hold no value in determining the message to display to the user
-    private static IReadOnlyCollection<string> oathCallbackErrorParams = new string[] { "error", "error_description" };
+    private static readonly IReadOnlyCollection<string> _oathCallbackErrorParams = new string[] { "error", "error_description" };
+
+    private readonly IOptions<SecuritySettings> _securitySettings;
+
+    public OAuthOptionsHelper(IOptions<SecuritySettings> securitySettings)
+    {
+        _securitySettings = securitySettings;
+    }
 
     /// <summary>
     /// Applies SetUmbracoRedirectWithFilteredParams to both OnAccessDenied and OnRemoteFailure
     /// on the OAuthOptions so Umbraco can do its best to nicely display the error messages
     /// that are passed back from the external login provider on failure.
     /// </summary>
-    public static T SetDefaultErrorEventHandling<T>(this T oAuthOptions, string providerFriendlyName) where T : OAuthOptions
+    public T SetDefaultErrorEventHandling<T>(T oAuthOptions, string providerFriendlyName) where T : OAuthOptions
     {
         oAuthOptions.Events.OnAccessDenied =
             context => HandleResponseWithDefaultUmbracoRedirect(context, providerFriendlyName, "OnAccessDenied");
@@ -29,9 +34,9 @@ public static class OAuthOptionsExtensions
         return oAuthOptions;
     }
 
-    private static Task HandleResponseWithDefaultUmbracoRedirect(HandleRequestContext<RemoteAuthenticationOptions> context, string providerFriendlyName, string eventName)
+    private Task HandleResponseWithDefaultUmbracoRedirect(HandleRequestContext<RemoteAuthenticationOptions> context, string providerFriendlyName, string eventName)
     {
-        context.SetUmbracoRedirectWithFilteredParams(providerFriendlyName,eventName)
+        SetUmbracoRedirectWithFilteredParams(context, providerFriendlyName, eventName)
             .HandleResponse();
 
         return Task.FromResult(0);
@@ -40,17 +45,16 @@ public static class OAuthOptionsExtensions
     /// <summary>
     /// Sets the context to redirect to the <see cref="SecuritySettings.AuthorizeCallbackErrorPathName"/> path with all parameters, except state, that are passed to the initial server callback configured for the configured external login provider
     /// </summary>
-    public static T SetUmbracoRedirectWithFilteredParams<T>(this T context, string providerFriendlyName, string eventName)
+    public T SetUmbracoRedirectWithFilteredParams<T>(T context, string providerFriendlyName, string eventName)
         where T : HandleRequestContext<RemoteAuthenticationOptions>
     {
-        var callbackPath = StaticServiceProvider.Instance.GetRequiredService<IOptions<SecuritySettings>>().Value
-            .AuthorizeCallbackErrorPathName;
+        var callbackPath = _securitySettings.Value.AuthorizeCallbackErrorPathName;
 
         callbackPath = callbackPath.AppendQueryStringToUrl("flow=external-login")
         .AppendQueryStringToUrl($"provider={providerFriendlyName}")
         .AppendQueryStringToUrl($"callback-event={eventName}");
 
-        foreach (var oathCallbackErrorParam in oathCallbackErrorParams)
+        foreach (var oathCallbackErrorParam in _oathCallbackErrorParams)
         {
             if (context.Request.Query.ContainsKey(oathCallbackErrorParam))
             {
@@ -69,10 +73,9 @@ public static class OAuthOptionsExtensions
     /// <param name="options">The options object to set the path on.</param>
     /// <param name="path">The path that should go after the umbraco path, will add a leading slash if it's missing.</param>
     /// <returns></returns>
-    public static RemoteAuthenticationOptions SetUmbracoBasedCallbackPath(this RemoteAuthenticationOptions options, string path)
+    public RemoteAuthenticationOptions SetUmbracoBasedCallbackPath(RemoteAuthenticationOptions options, string path)
     {
-        var umbracoCallbackPath = StaticServiceProvider.Instance.GetRequiredService<IOptions<SecuritySettings>>().Value
-            .AuthorizeCallbackPathName;
+        var umbracoCallbackPath = _securitySettings.Value.AuthorizeCallbackPathName;
 
         options.CallbackPath = umbracoCallbackPath + path.EnsureStartsWith("/");
         return options;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR introduces some proposed helper methods to uniformly communicate external login errors that come into the backend trough the configured callback methods to a specific frontend path.

### Example code
[ExampleGithubCode.zip](https://github.com/umbraco/Umbraco-CMS/files/14978456/ExampleGithubCode.zip) (requires installation of `AspNet.Security.OAuth.GitHub`)
This adds all the necessary bits to register github as an external login provider and some bad frontend code to link/unlink.

When starting the linking process from the backend, you will need to open your devtools and click on the CORS blocked link manually to continue, the Frontend team has a task to improve this behaviour

If you use the endpoints, make sure to set the Umbraco authentication cookie as it is needed to figure out what user the linking process should complete on when returning trough the callback.

Updated example registration code
```csharp
backOfficeAuthenticationBuilder.AddGitHub(
                        backOfficeAuthenticationBuilder.SchemeForBackOffice(GitHubBackOfficeExternalLoginProviderOptions
                            .SchemeName)!,
                        options =>
                        {
                            options.SetUmbracoBasedCallbackPath("signin-github");
                            options.ClientId = "d261ea94c7bf0255801d";
                            options.ClientSecret = "88e795ccb1050c2806dd9d87ec0c6e2048f1a6a4";
                            options.Scope.Add("user:email");
                            options.SetDefaultErrorEventHandling(GitHubBackOfficeExternalLoginProviderOptions
                                .SchemeName);
                        });
```