### PR TITLE
V14/feature/all segment endpoint

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Segment/AllSegmentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Segment/AllSegmentController.cs
@@ -34,7 +34,7 @@ public class AllSegmentController : SegmentControllerBase
     {
         Attempt<PagedModel<Core.Models.Segment>?, SegmentOperationStatus> pagedAttempt = await _segmentService.GetPagedSegmentsAsync(skip, take);
 
-        if (pagedAttempt.Success == false)
+        if (pagedAttempt.Success is false)
         {
             return MapFailure(pagedAttempt.Status);
         }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Segment/AllSegmentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Segment/AllSegmentController.cs
@@ -1,0 +1,50 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Common.ViewModels.Pagination;
+using Umbraco.Cms.Api.Management.ViewModels.Segment;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Mapping;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Web.Common.Authorization;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Segment;
+
+[ApiVersion("1.0")]
+[Authorize(Policy = AuthorizationPolicies.SectionAccessSettings)]
+public class AllSegmentController : SegmentControllerBase
+{
+    private readonly ISegmentService _segmentService;
+    private readonly IUmbracoMapper _umbracoMapper;
+
+    public AllSegmentController(ISegmentService segmentService, IUmbracoMapper umbracoMapper)
+    {
+        _segmentService = segmentService;
+        _umbracoMapper = umbracoMapper;
+    }
+
+    [HttpGet]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(PagedViewModel<SegmentResponseModel>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetAll(CancellationToken cancellationToken, int skip = 0, int take = 100)
+    {
+        Attempt<PagedModel<Core.Models.Segment>?, SegmentOperationStatus> pagedAttempt = await _segmentService.GetPagedSegmentsAsync(skip, take);
+
+        if (pagedAttempt.Success == false)
+        {
+            return MapFailure(pagedAttempt.Status);
+        }
+
+        var viewModel = new PagedViewModel<SegmentResponseModel>
+        {
+            Items = _umbracoMapper.MapEnumerable<Core.Models.Segment, SegmentResponseModel>(pagedAttempt.Result!.Items),
+            Total = pagedAttempt.Result!.Total,
+        };
+
+        return Ok(viewModel);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Segment/SegmentControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Segment/SegmentControllerBase.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Segment;
+
+[VersionedApiBackOfficeRoute("segment")]
+[ApiExplorerSettings(GroupName = "Segment")]
+public abstract class SegmentControllerBase : ManagementApiControllerBase
+{
+    protected IActionResult MapFailure(SegmentOperationStatus status)
+        => OperationStatusResult(status, problemDetailsBuilder => status switch
+        {
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
+                .WithTitle("Unknown segment operation status.")
+                .Build()),
+        });
+}

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/SegmentBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/SegmentBuilderExtensions.cs
@@ -1,0 +1,15 @@
+using Umbraco.Cms.Api.Management.Mapping.Segment;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Mapping;
+
+namespace Umbraco.Cms.Api.Management.DependencyInjection;
+
+internal static class SegmentBuilderExtensions
+{
+    internal static IUmbracoBuilder AddSegment(this IUmbracoBuilder builder)
+    {
+        builder.WithCollectionBuilder<MapDefinitionCollectionBuilder>().Add<SegmentMapDefinition>();
+
+        return builder;
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -67,7 +67,8 @@ public static partial class UmbracoBuilderExtensions
                 .AddPreview()
                 .AddPasswordConfiguration()
                 .AddSupplemenataryLocalizedTextFileSources()
-                .AddUserData();
+                .AddUserData()
+                .AddSegment();
 
             services
                 .ConfigureOptions<ConfigureApiBehaviorOptions>()

--- a/src/Umbraco.Cms.Api.Management/Mapping/Segment/SegmentMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Segment/SegmentMapDefinition.cs
@@ -5,10 +5,7 @@ namespace Umbraco.Cms.Api.Management.Mapping.Segment;
 
 public class SegmentMapDefinition : IMapDefinition
 {
-    public void DefineMaps(IUmbracoMapper mapper)
-    {
-        mapper.Define<Core.Models.Segment, SegmentResponseModel>((_, _) => new SegmentResponseModel(), Map);
-    }
+    public void DefineMaps(IUmbracoMapper mapper) => mapper.Define<Core.Models.Segment, SegmentResponseModel>((_, _) => new SegmentResponseModel { Name = string.Empty, Alias = string.Empty }, Map);
 
     // Umbraco.Code.MapAll
     private static void Map(Core.Models.Segment source, SegmentResponseModel target, MapperContext context)

--- a/src/Umbraco.Cms.Api.Management/Mapping/Segment/SegmentMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Segment/SegmentMapDefinition.cs
@@ -1,0 +1,19 @@
+using Umbraco.Cms.Api.Management.ViewModels.Segment;
+using Umbraco.Cms.Core.Mapping;
+
+namespace Umbraco.Cms.Api.Management.Mapping.Segment;
+
+public class SegmentMapDefinition : IMapDefinition
+{
+    public void DefineMaps(IUmbracoMapper mapper)
+    {
+        mapper.Define<Core.Models.Segment, SegmentResponseModel>((_, _) => new SegmentResponseModel(), Map);
+    }
+
+    // Umbraco.Code.MapAll
+    private static void Map(Core.Models.Segment source, SegmentResponseModel target, MapperContext context)
+    {
+        target.Name = source.Name;
+        target.Alias = source.Alias;
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -4270,6 +4270,54 @@
         ]
       }
     },
+    "/umbraco/management/api/v1/tree/document-blueprint/ancestors": {
+      "get": {
+        "tags": [
+          "Document Blueprint"
+        ],
+        "operationId": "GetTreeDocumentBlueprintAncestors",
+        "parameters": [
+          {
+            "name": "descendantId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DocumentBlueprintTreeItemResponseModel"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          },
+          "403": {
+            "description": "The authenticated user do not have access to this resource"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
     "/umbraco/management/api/v1/tree/document-blueprint/children": {
       "get": {
         "tags": [
@@ -4877,6 +4925,84 @@
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/PagedAllowedDocumentTypeModel"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ProblemDetails"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          },
+          "403": {
+            "description": "The authenticated user do not have access to this resource"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/document-type/{id}/blueprint": {
+      "get": {
+        "tags": [
+          "Document Type"
+        ],
+        "operationId": "GetDocumentTypeByIdBlueprint",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PagedDocumentTypeBlueprintItemResponseModel"
                     }
                   ]
                 }
@@ -9267,6 +9393,58 @@
                 }
               }
             }
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/document/urls": {
+      "get": {
+        "tags": [
+          "Document"
+        ],
+        "operationId": "GetDocumentUrls",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DocumentUrlInfoResponseModel"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          },
+          "403": {
+            "description": "The authenticated user do not have access to this resource"
           }
         },
         "security": [
@@ -15708,6 +15886,58 @@
                 }
               }
             }
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/media/urls": {
+      "get": {
+        "tags": [
+          "Media"
+        ],
+        "operationId": "GetMediaUrls",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/MediaUrlInfoResponseModel"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          },
+          "403": {
+            "description": "The authenticated user do not have access to this resource"
           }
         },
         "security": [
@@ -23739,6 +23969,75 @@
             }
           }
         }
+      }
+    },
+    "/umbraco/management/api/v1/segment": {
+      "get": {
+        "tags": [
+          "Segment"
+        ],
+        "operationId": "GetSegment",
+        "parameters": [
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PagedSegmentResponseModel"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ProblemDetails"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          },
+          "403": {
+            "description": "The authenticated user do not have access to this resource"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
       }
     },
     "/umbraco/management/api/v1/server/configuration": {
@@ -34254,8 +34553,7 @@
         "required": [
           "canBeChanged",
           "documentListViewId",
-          "mediaListViewId",
-          "memberListViewId"
+          "mediaListViewId"
         ],
         "type": "object",
         "properties": {
@@ -34267,10 +34565,6 @@
             "format": "uuid"
           },
           "mediaListViewId": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "memberListViewId": {
             "type": "string",
             "format": "uuid"
           }
@@ -34942,6 +35236,23 @@
         },
         "additionalProperties": false
       },
+      "DocumentTypeBlueprintItemResponseModel": {
+        "required": [
+          "id",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
       "DocumentTypeCleanupModel": {
         "required": [
           "preventCleanup"
@@ -35436,6 +35747,30 @@
           },
           "url": {
             "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "DocumentUrlInfoResponseModel": {
+        "required": [
+          "id",
+          "urlInfos"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "urlInfos": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DocumentUrlInfoModel"
+                }
+              ]
+            }
           }
         },
         "additionalProperties": false
@@ -37297,6 +37632,30 @@
         },
         "additionalProperties": false
       },
+      "MediaUrlInfoResponseModel": {
+        "required": [
+          "id",
+          "urlInfos"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "urlInfos": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/MediaUrlInfoModel"
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
+      },
       "MediaValueModel": {
         "required": [
           "alias"
@@ -38626,6 +38985,30 @@
         },
         "additionalProperties": false
       },
+      "PagedDocumentTypeBlueprintItemResponseModel": {
+        "required": [
+          "items",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DocumentTypeBlueprintItemResponseModel"
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
+      },
       "PagedDocumentTypeTreeItemResponseModel": {
         "required": [
           "items",
@@ -39537,6 +39920,30 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/SearcherResponseModel"
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedSegmentResponseModel": {
+        "required": [
+          "items",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/SegmentResponseModel"
                 }
               ]
             }
@@ -40515,6 +40922,24 @@
                 "$ref": "#/components/schemas/PasswordConfigurationResponseModel"
               }
             ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "SegmentResponseModel": {
+        "required": [
+          "alias",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "alias": {
+            "minLength": 1,
+            "type": "string"
           }
         },
         "additionalProperties": false

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Segment/SegmentResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Segment/SegmentResponseModel.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.Segment;
+
+public class SegmentResponseModel
+{
+    [Required]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    public string Alias { get; set; } = string.Empty;
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Segment/SegmentResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Segment/SegmentResponseModel.cs
@@ -4,9 +4,7 @@ namespace Umbraco.Cms.Api.Management.ViewModels.Segment;
 
 public class SegmentResponseModel
 {
-    [Required]
-    public string Name { get; set; } = string.Empty;
+    public required string Name { get; set; } = string.Empty;
 
-    [Required]
-    public string Alias { get; set; } = string.Empty;
+    public required string Alias { get; set; } = string.Empty;
 }

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -390,6 +390,9 @@ namespace Umbraco.Cms.Core.DependencyInjection
             Services.AddSingleton<IMediaPermissionAuthorizer, MediaPermissionAuthorizer>();
             Services.AddSingleton<IUserGroupPermissionAuthorizer, UserGroupPermissionAuthorizer>();
             Services.AddSingleton<IUserPermissionAuthorizer, UserPermissionAuthorizer>();
+
+            // Segments
+            Services.AddUnique<ISegmentService, NoopSegmentService>();
         }
     }
 }

--- a/src/Umbraco.Core/Models/Segment.cs
+++ b/src/Umbraco.Core/Models/Segment.cs
@@ -1,0 +1,8 @@
+namespace Umbraco.Cms.Core.Models;
+
+public class Segment
+{
+    public required string Name { get; set; }
+
+    public required string Alias { get; set; }
+}

--- a/src/Umbraco.Core/Services/ISegmentService.cs
+++ b/src/Umbraco.Core/Services/ISegmentService.cs
@@ -1,0 +1,9 @@
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Core.Services;
+
+public interface ISegmentService
+{
+    Task<Attempt<PagedModel<Segment>?, SegmentOperationStatus>> GetPagedSegmentsAsync(int skip = 0, int take = 100);
+}

--- a/src/Umbraco.Core/Services/NoopSegmentService.cs
+++ b/src/Umbraco.Core/Services/NoopSegmentService.cs
@@ -1,0 +1,14 @@
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Core.Services;
+
+public class NoopSegmentService : ISegmentService
+{
+    public async Task<Attempt<PagedModel<Segment>?, SegmentOperationStatus>> GetPagedSegmentsAsync(int skip = 0, int take = 100)
+    {
+        return await Task.FromResult(Attempt.SucceedWithStatus<PagedModel<Segment>?, SegmentOperationStatus>(
+            SegmentOperationStatus.Success,
+            new PagedModel<Segment> { Total = 0, Items = Enumerable.Empty<Segment>() }));
+    }
+}

--- a/src/Umbraco.Core/Services/OperationStatus/SegmentOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/SegmentOperationStatus.cs
@@ -1,0 +1,6 @@
+namespace Umbraco.Cms.Core.Services.OperationStatus;
+
+public enum SegmentOperationStatus
+{
+    Success,
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR adds the contractual stable endpoint to retrieve all "defined" (content) segments. Since Umbraco has no way (yet?) to define segments out of the box, we supply a noop implementation of the service behind the endpoint to just return an empty paged list.

### Testing
Consider basic Get endpoint testing including authorization with settings section
You can use the following code to quickly override the service to return something.
```csharp
using Umbraco.Cms.Core;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Services;
using Umbraco.Cms.Core.Services.OperationStatus;

namespace Umbraco.Cms.Web.UI;

public class SegmentService : ISegmentService
{
    private static readonly Segment[] segments = new Segment[] {
        new Segment
        {
            Alias = "segment-one",
            Name = "First Segment"
        },
        new Segment
        {
            Alias = "segment-two",
            Name = "Second Segment"
        },
        new Segment
        {
            Alias = "segment-three",
            Name = "Thrird Segment"
        },
    };

    public async Task<Attempt<PagedModel<Segment>?, SegmentOperationStatus>> GetPagedSegmentsAsync(int skip = 0, int take = 100)
    {
        return await Task.FromResult(Attempt.SucceedWithStatus<PagedModel<Segment>?, SegmentOperationStatus>(
            SegmentOperationStatus.Success,
            new PagedModel<Segment> { Total = segments.Length, Items = segments.Skip(0).Take(take) }));
    }
}

public class SegmentServiceOverrideComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder) => builder.Services.AddUnique<ISegmentService, SegmentService>();
}

```