### PR TITLE
Make the API content response builder extendable

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Json/DeliveryApiJsonTypeResolver.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Json/DeliveryApiJsonTypeResolver.cs
@@ -12,23 +12,36 @@ public class DeliveryApiJsonTypeResolver : DefaultJsonTypeInfoResolver
     {
         JsonTypeInfo jsonTypeInfo = base.GetTypeInfo(type, options);
 
-        if (jsonTypeInfo.Type == typeof(IApiContent))
+        Type[] derivedTypes = GetDerivedTypes(jsonTypeInfo);
+        if (derivedTypes.Length > 0)
         {
-            ConfigureJsonPolymorphismOptions(jsonTypeInfo, typeof(ApiContent));
-        }
-        else if (jsonTypeInfo.Type == typeof(IApiContentResponse))
-        {
-            ConfigureJsonPolymorphismOptions(jsonTypeInfo, typeof(ApiContentResponse));
-        }
-        else if (jsonTypeInfo.Type == typeof(IRichTextElement))
-        {
-            ConfigureJsonPolymorphismOptions(jsonTypeInfo, typeof(RichTextRootElement), typeof(RichTextGenericElement), typeof(RichTextTextElement));
+            ConfigureJsonPolymorphismOptions(jsonTypeInfo, derivedTypes);
         }
 
         return jsonTypeInfo;
     }
 
-    private void ConfigureJsonPolymorphismOptions(JsonTypeInfo jsonTypeInfo, params Type[] derivedTypes)
+    protected virtual Type[] GetDerivedTypes(JsonTypeInfo jsonTypeInfo)
+    {
+        if (jsonTypeInfo.Type == typeof(IApiContent))
+        {
+            return new[] { typeof(ApiContent) };
+        }
+
+        if (jsonTypeInfo.Type == typeof(IApiContentResponse))
+        {
+            return new[] { typeof(ApiContentResponse) };
+        }
+
+        if (jsonTypeInfo.Type == typeof(IRichTextElement))
+        {
+            return new[] { typeof(RichTextRootElement), typeof(RichTextGenericElement), typeof(RichTextTextElement) };
+        }
+
+        return Array.Empty<Type>();
+    }
+
+    protected void ConfigureJsonPolymorphismOptions(JsonTypeInfo jsonTypeInfo, params Type[] derivedTypes)
     {
         jsonTypeInfo.PolymorphismOptions = new JsonPolymorphismOptions
         {

--- a/src/Umbraco.Core/DeliveryApi/ApiContentResponseBuilder.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiContentResponseBuilder.cs
@@ -1,11 +1,10 @@
 ﻿using Umbraco.Cms.Core.Models.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
-using Umbraco.Cms.Core.Routing;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.DeliveryApi;
 
-public sealed class ApiContentResponseBuilder : ApiContentBuilderBase<IApiContentResponse>, IApiContentResponseBuilder
+public class ApiContentResponseBuilder : ApiContentBuilderBase<IApiContentResponse>, IApiContentResponseBuilder
 {
     private readonly IApiContentRouteBuilder _apiContentRouteBuilder;
 
@@ -14,6 +13,12 @@ public sealed class ApiContentResponseBuilder : ApiContentBuilderBase<IApiConten
         => _apiContentRouteBuilder = apiContentRouteBuilder;
 
     protected override IApiContentResponse Create(IPublishedContent content, string name, IApiContentRoute route, IDictionary<string, object?> properties)
+    {
+        IDictionary<string, IApiContentRoute> cultures = GetCultures(content);
+        return new ApiContentResponse(content.Key, name, content.ContentType.Alias, content.CreateDate, content.UpdateDate, route, properties, cultures);
+    }
+
+    protected virtual IDictionary<string, IApiContentRoute> GetCultures(IPublishedContent content)
     {
         var routesByCulture = new Dictionary<string, IApiContentRoute>();
 
@@ -35,6 +40,6 @@ public sealed class ApiContentResponseBuilder : ApiContentBuilderBase<IApiConten
             routesByCulture[publishedCultureInfo.Culture] = cultureRoute;
         }
 
-        return new ApiContentResponse(content.Key, name, content.ContentType.Alias, content.CreateDate, content.UpdateDate, route, properties, routesByCulture);
+        return routesByCulture;
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR makes the default API content response builder extendable, thus making it easier to customize the output of the Delivery API.

Due to how System.Text.Json handles polymorphism, the default JSON type resolver also needs to be extendable, in order to add custom response models to the allow-list for API responses.

### Testing this PR

Build a custom `IApiContentResponseBuilder` by extending the default `ApiContentResponseBuilder`. The custom API response builder should be able to:

1. Return its own content model (an extension of `ApiContentResponse`).
2. Manipulate the properties collection created by the `ApiContentResponseBuilder` base before they are returned by the API.

The following test code can be used, or at least serve as inspiration for testing 😉 

```cs
using System.Text.Json;
using System.Text.Json.Serialization.Metadata;
using Umbraco.Cms.Api.Common.DependencyInjection;
using Umbraco.Cms.Api.Delivery.Json;
using Umbraco.Cms.Core;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.DeliveryApi;
using Umbraco.Cms.Core.Models.DeliveryApi;
using Umbraco.Cms.Core.Models.PublishedContent;

namespace Umbraco.Cms.Web.UI.Custom;

public class MyApiContentResponseBuilder : ApiContentResponseBuilder
{
    public MyApiContentResponseBuilder(
        IApiContentNameProvider apiContentNameProvider,
        IApiContentRouteBuilder apiContentRouteBuilder,
        IOutputExpansionStrategyAccessor outputExpansionStrategyAccessor)
        : base(apiContentNameProvider, apiContentRouteBuilder, outputExpansionStrategyAccessor)
    {
    }

    protected override IApiContentResponse Create(
        IPublishedContent content,
        string name,
        IApiContentRoute route,
        IDictionary<string, object?> properties)
    {
        properties["title"] = properties.TryGetValue("title", out var value) && value is string titleValue
            ? $"I modified the title value: {titleValue}"
            : $"I added the title value";

        IDictionary<string, IApiContentRoute> cultures = GetCultures(content);
        return new MyApiContentResponse(
            content.Key,
            name,
            content.ContentType.Alias,
            content.CreateDate,
            content.UpdateDate,
            route,
            properties,
            cultures,
            DateTime.UtcNow.ToString("s"));
    }
}

public class MyApiContentResponse : ApiContentResponse
{
    public string MyExtraResponseData { get; }

    public MyApiContentResponse(
        Guid id,
        string name,
        string contentType,
        DateTime createDate,
        DateTime updateDate,
        IApiContentRoute route,
        IDictionary<string, object?> properties,
        IDictionary<string, IApiContentRoute> cultures,
        string myExtraResponseData)
        : base(id, name, contentType, createDate, updateDate, route, properties, cultures)
        => MyExtraResponseData = myExtraResponseData;
}

public class MyDeliveryApiJsonTypeResolver : DeliveryApiJsonTypeResolver
{
    protected override Type[] GetDerivedTypes(JsonTypeInfo jsonTypeInfo)
        => jsonTypeInfo.Type == typeof(IApiContentResponse)
            ? new[] { typeof(MyApiContentResponse), typeof(ApiContentResponse) }
            : base.GetDerivedTypes(jsonTypeInfo);
}

public class MyApiContentResponseComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.Services.AddSingleton<IApiContentResponseBuilder, MyApiContentResponseBuilder>();
        builder
            .Services
            .AddControllers()
            .AddJsonOptions(
                Constants.JsonOptionsNames.DeliveryApi,
                options => options.JsonSerializerOptions.TypeInfoResolver = new MyDeliveryApiJsonTypeResolver());
    }
}
```

The custom API response builder can be tested using swagger:

<img width="593" alt="image" src="https://github.com/umbraco/Umbraco-CMS/assets/7405322/7f46f2e7-53cf-4037-be32-89fadfdbf079">
