### PR TITLE
V13: Add webhook information to detailed telemetry

### DIFF
--- a/src/Umbraco.Core/Constants-Telemetry.cs
+++ b/src/Umbraco.Core/Constants-Telemetry.cs
@@ -32,5 +32,9 @@ public static partial class Constants
         public static string BackofficeExternalLoginProviderCount = "BackofficeExternalLoginProviderCount";
         public static string DeliverApiEnabled = "DeliverApiEnabled";
         public static string DeliveryApiPublicAccess = "DeliveryApiPublicAccess";
+        public static string WebhookPrefix = "WebhookCount_";
+        public static string WebhookTotal = $"{WebhookPrefix}Total";
+        public static string WebhookCustomHeaders = $"{WebhookPrefix}CustomHeaders";
+        public static string WebhookCustomEvent = $"{WebhookPrefix}CustomEvent";
     }
 }

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -3077,7 +3077,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="detailedLevelDescription"><![CDATA[We will send:
 <ul>
     <li>Anonymized site ID, Umbraco version, and packages installed.</li>
-    <li>Number of: Root nodes, Content nodes, Macros, Media, Document Types, Templates, Languages, Domains, User Group, Users, Members, Backoffice external login providers, and Property Editors in use.</li>
+    <li>Number of: Root nodes, Content nodes, Macros, Media, Document Types, Templates, Languages, Domains, User Group, Users, Members, Backoffice external login providers, Webhooks, and Property Editors in use.</li>
     <li>System information: Webserver, server OS, server framework, server OS language, and database provider.</li>
     <li>Configuration settings: Modelsbuilder mode, if custom Umbraco path exists, ASP environment, whether the delivery API is enabled, and allows public access, and if you are in debug mode.</li>
 </ul>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -2035,7 +2035,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="webhookKey">Webhook key</key>
     <key alias="retryCount">Retry count</key>
     <key alias="toggleDebug">Toggle debug mode for more information.</key>
-    <key alias="statusNotOk">Not OK status code</key>    
+    <key alias="statusNotOk">Not OK status code</key>
     <key alias="urlDescription">The url to call when the webhook is triggered.</key>
     <key alias="eventDescription">The events for which the webhook should be triggered.</key>
     <key alias="contentTypeDescription">Only trigger the webhook for a specific content type.</key>
@@ -3096,7 +3096,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
           We will send:
           <ul>
             <li>Anonymized site ID, Umbraco version, and packages installed.</li>
-            <li>Number of: Root nodes, Content nodes, Macros, Media, Document Types, Templates, Languages, Domains, User Group, Users, Members, Backoffice external login providers, and Property Editors in use.</li>
+            <li>Number of: Root nodes, Content nodes, Macros, Media, Document Types, Templates, Languages, Domains, User Group, Users, Members, Backoffice external login providers, Webhooks, and Property Editors in use.</li>
             <li>System information: Webserver, server OS, server framework, server OS language, and database provider.</li>
             <li>Configuration settings: Modelsbuilder mode, if custom Umbraco path exists, ASP environment, whether the delivery API is enabled, and allows public access, and if you are in debug mode.</li>
           </ul>

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ReportSiteJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ReportSiteJob.cs
@@ -17,18 +17,24 @@ namespace Umbraco.Cms.Infrastructure.BackgroundJobs.Jobs;
 public class ReportSiteJob : IRecurringBackgroundJob
 {
 
-    public TimeSpan Period { get => TimeSpan.FromDays(1); }
-    public TimeSpan Delay { get => TimeSpan.FromMinutes(5); }
-    public ServerRole[] ServerRoles { get => Enum.GetValues<ServerRole>(); }
+    public TimeSpan Period => TimeSpan.FromDays(1);
+
+    public TimeSpan Delay => TimeSpan.FromMinutes(5);
+
+    public ServerRole[] ServerRoles => Enum.GetValues<ServerRole>();
 
     // No-op event as the period never changes on this job
-    public event EventHandler PeriodChanged { add { } remove { } }
-
+    public event EventHandler PeriodChanged
+    {
+        add { } remove { }
+    }
 
     private static HttpClient _httpClient = new();
+
     private readonly ILogger<ReportSiteJob> _logger;
+
     private readonly ITelemetryService _telemetryService;
-    
+
 
     public ReportSiteJob(
         ILogger<ReportSiteJob> logger,
@@ -43,9 +49,8 @@ public class ReportSiteJob : IRecurringBackgroundJob
     /// Runs the background task to send the anonymous ID
     /// to telemetry service
     /// </summary>
-    public  async Task RunJobAsync()
+    public async Task RunJobAsync()
     {
-
         if (_telemetryService.TryGetTelemetryReportData(out TelemetryReportData? telemetryReportData) is false)
         {
             _logger.LogWarning("No telemetry marker found");

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.TelemetryProviders.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.TelemetryProviders.cs
@@ -20,6 +20,7 @@ public static class UmbracoBuilder_TelemetryProviders
         builder.Services.AddTransient<IDetailedTelemetryProvider, UserTelemetryProvider>();
         builder.Services.AddTransient<IDetailedTelemetryProvider, SystemInformationTelemetryProvider>();
         builder.Services.AddTransient<IDetailedTelemetryProvider, DeliveryApiTelemetryProvider>();
+        builder.Services.AddTransient<IDetailedTelemetryProvider, WebhookTelemetryProvider>();
         return builder;
     }
 }

--- a/src/Umbraco.Infrastructure/Telemetry/Providers/WebhookTelemetryProvider.cs
+++ b/src/Umbraco.Infrastructure/Telemetry/Providers/WebhookTelemetryProvider.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Cms.Core.Models;
+﻿using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Telemetry.Interfaces;
 
@@ -23,18 +24,18 @@ public class WebhookTelemetryProvider : IDetailedTelemetryProvider
     {
         IWebhook[] allWebhooks = _webhookService.GetAllAsync(0, int.MaxValue).GetAwaiter().GetResult().Items.ToArray();
 
-        yield return new UsageInformation("WebhookCount_Total", allWebhooks.Length);
+        yield return new UsageInformation(Constants.Telemetry.WebhookTotal, allWebhooks.Length);
 
         foreach (var eventType in _defaultEventTypes)
         {
             IWebhook[] webhooks = allWebhooks.Where(x => x.Events.Contains(eventType)).ToArray();
-            yield return new UsageInformation($"WebhookCount_{eventType}", webhooks.Length);
+            yield return new UsageInformation($"{Constants.Telemetry.WebhookPrefix}{eventType}", webhooks.Length);
         }
 
         IEnumerable<IWebhook> customWebhooks = allWebhooks.Where(x => x.Events.Except(_defaultEventTypes).Any());
-        yield return new UsageInformation("WebhookCount_CustomEvent", customWebhooks.Count());
+        yield return new UsageInformation(Constants.Telemetry.WebhookCustomEvent, customWebhooks.Count());
 
         IEnumerable<IWebhook> customHeaderWebhooks = allWebhooks.Where(x => x.Headers.Any());
-        yield return new UsageInformation("WebhookCount_CustomHeaders", customHeaderWebhooks.Count());
+        yield return new UsageInformation(Constants.Telemetry.WebhookCustomHeaders, customHeaderWebhooks.Count());
     }
 }

--- a/src/Umbraco.Infrastructure/Telemetry/Providers/WebhookTelemetryProvider.cs
+++ b/src/Umbraco.Infrastructure/Telemetry/Providers/WebhookTelemetryProvider.cs
@@ -1,0 +1,38 @@
+﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Telemetry.Interfaces;
+
+namespace Umbraco.Cms.Infrastructure.Telemetry.Providers;
+
+public class WebhookTelemetryProvider : IDetailedTelemetryProvider
+{
+    private readonly IWebhookService _webhookService;
+
+    public WebhookTelemetryProvider(IWebhookService webhookService) => _webhookService = webhookService;
+
+    private readonly string[] _defaultEventTypes =
+        [
+            "Umbraco.ContentDelete",
+            "Umbraco.ContentPublish",
+            "Umbraco.ContentUnpublish",
+            "Umbraco.MediaDelete",
+            "Umbraco.MediaSave"
+        ];
+
+    public IEnumerable<UsageInformation> GetInformation()
+    {
+        IWebhook[] allWebhooks = _webhookService.GetAllAsync(0, int.MaxValue).GetAwaiter().GetResult().Items.ToArray();
+
+        yield return new UsageInformation("WebhookCount_Total", allWebhooks.Length);
+
+        foreach (var eventType in _defaultEventTypes)
+        {
+            IWebhook[] webhooks = allWebhooks.Where(x => x.Events.Contains(eventType)).ToArray();
+            yield return new UsageInformation($"WebhookCount_{eventType}", webhooks.Length);
+        }
+
+        IEnumerable<IWebhook> customWebhooks = allWebhooks.Where(x => x.Events.Except(_defaultEventTypes).Any());
+
+        yield return new UsageInformation("WebhookCount_CustomEvent", customWebhooks.Count());
+    }
+}

--- a/src/Umbraco.Infrastructure/Telemetry/Providers/WebhookTelemetryProvider.cs
+++ b/src/Umbraco.Infrastructure/Telemetry/Providers/WebhookTelemetryProvider.cs
@@ -32,7 +32,9 @@ public class WebhookTelemetryProvider : IDetailedTelemetryProvider
         }
 
         IEnumerable<IWebhook> customWebhooks = allWebhooks.Where(x => x.Events.Except(_defaultEventTypes).Any());
-
         yield return new UsageInformation("WebhookCount_CustomEvent", customWebhooks.Count());
+
+        IEnumerable<IWebhook> customHeaderWebhooks = allWebhooks.Where(x => x.Headers.Any());
+        yield return new UsageInformation("WebhookCount_CustomHeaders", customHeaderWebhooks.Count());
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
@@ -1,12 +1,11 @@
-using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
-using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Telemetry;
+using Umbraco.Cms.Core.Webhooks;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
 
@@ -20,12 +19,15 @@ public class TelemetryServiceTests : UmbracoIntegrationTest
         builder.Services.Configure<GlobalSettings>(options => options.Id = Guid.NewGuid().ToString());
 
     private ITelemetryService TelemetryService => GetRequiredService<ITelemetryService>();
+
     private IMetricsConsentService MetricsConsentService => GetRequiredService<IMetricsConsentService>();
+
+    private WebhookEventCollection WebhookEventCollection => GetRequiredService<WebhookEventCollection>();
 
     [Test]
     public void Expected_Detailed_Telemetry_Exists()
     {
-        var expectedData = new[]
+        var expectedData = new List<string>
         {
             Constants.Telemetry.RootCount,
             Constants.Telemetry.DomainCount,
@@ -52,8 +54,14 @@ public class TelemetryServiceTests : UmbracoIntegrationTest
             Constants.Telemetry.BackofficeExternalLoginProviderCount,
             Constants.Telemetry.RuntimeMode,
             Constants.Telemetry.DeliverApiEnabled,
-            Constants.Telemetry.DeliveryApiPublicAccess
+            Constants.Telemetry.DeliveryApiPublicAccess,
+            Constants.Telemetry.WebhookTotal,
+            Constants.Telemetry.WebhookCustomHeaders,
+            Constants.Telemetry.WebhookCustomEvent,
         };
+
+        // Add the default webhook events.
+        expectedData.AddRange(WebhookEventCollection.Select(eventInfo => $"{Constants.Telemetry.WebhookPrefix}{eventInfo.Alias}"));
 
         MetricsConsentService.SetConsentLevel(TelemetryLevel.Detailed);
         var success = TelemetryService.TryGetTelemetryReportData(out var telemetryReportData);
@@ -63,7 +71,7 @@ public class TelemetryServiceTests : UmbracoIntegrationTest
         Assert.Multiple(() =>
         {
             Assert.IsNotNull(detailed);
-            Assert.AreEqual(expectedData.Length, detailed.Length);
+            Assert.AreEqual(expectedData.Count, detailed.Length);
 
             foreach (var expectedInfo in expectedData)
             {


### PR DESCRIPTION
Adds webhook information to detailed telemetry, a sample payload looks like the following: 


```
        {
            "name": "WebhookCount_Total",
            "data": 3
        },
        {
            "name": "WebhookCount_Umbraco.ContentDelete",
            "data": 1
        },
        {
            "name": "WebhookCount_Umbraco.ContentPublish",
            "data": 1
        },
        {
            "name": "WebhookCount_Umbraco.ContentUnpublish",
            "data": 1
        },
        {
            "name": "WebhookCount_Umbraco.MediaDelete",
            "data": 1
        },
        {
            "name": "WebhookCount_Umbraco.MediaSave",
            "data": 1
        },
        {
            "name": "WebhookCount_CustomEvent",
            "data": 1
        },
        {
            "name": "WebhookCount_CustomHeaders",
            "data": 1
        }
```


## Testing

Ensure that the payload is accurate, then can be achieved by setting a breakpoint in `ReportSiteJob` and ensure that the contents of `telemetryReportData` is as expected