### PR TITLE
v14: Update ImageSharp and MailKit dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -72,8 +72,8 @@
     <PackageVersion Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageVersion Include="Serilog.Sinks.Map" Version="1.0.2" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.3" />
-    <PackageVersion Include="SixLabors.ImageSharp.Web" Version="3.1.1" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.4" />
+    <PackageVersion Include="SixLabors.ImageSharp.Web" Version="3.1.2" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
   <!-- Transitive pinned versions (only required because our direct dependencies have vulnerable versions of transitive dependencies) -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,7 +49,7 @@
     <PackageVersion Include="HtmlAgilityPack" Version="1.11.60" />
     <PackageVersion Include="JsonPatch.Net" Version="3.0.0" />
     <PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />
-    <PackageVersion Include="MailKit" Version="4.4.0" />
+    <PackageVersion Include="MailKit" Version="4.5.0" />
     <PackageVersion Include="Markdown" Version="2.2.1" />
     <PackageVersion Include="MessagePack" Version="2.5.140" />
     <PackageVersion Include="MiniProfiler.AspNetCore.Mvc" Version="4.3.8" />

--- a/src/Umbraco.Cms.Imaging.ImageSharp2/Umbraco.Cms.Imaging.ImageSharp2.csproj
+++ b/src/Umbraco.Cms.Imaging.ImageSharp2/Umbraco.Cms.Imaging.ImageSharp2.csproj
@@ -7,8 +7,6 @@
   <ItemGroup>
     <PackageReference Include="SixLabors.ImageSharp" VersionOverride="[2.1.7, 3)" />
     <PackageReference Include="SixLabors.ImageSharp.Web" VersionOverride="[2.0.2, 3)" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.7" />
-    <PackageReference Include="SixLabors.ImageSharp.Web" Version="2.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Umbraco.Cms.Imaging.ImageSharp2/Umbraco.Cms.Imaging.ImageSharp2.csproj
+++ b/src/Umbraco.Cms.Imaging.ImageSharp2/Umbraco.Cms.Imaging.ImageSharp2.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" VersionOverride="[2.1.7, 3)" />
+    <PackageReference Include="SixLabors.ImageSharp" VersionOverride="[2.1.8, 3)" />
     <PackageReference Include="SixLabors.ImageSharp.Web" VersionOverride="[2.0.2, 3)" />
   </ItemGroup>
 


### PR DESCRIPTION
While building `v14/dev` I noticed getting a `NU1504` error: `Duplicate 'PackageReference' items found. Remove the duplicate items or use the Update functionality to ensure a consistent restore behavior. The duplicate 'PackageReference' items are: SixLabors.ImageSharp , SixLabors.ImageSharp 2.1.7; SixLabors.ImageSharp.Web , SixLabors.ImageSharp.Web 2.0.2.`.

This PR removes the duplicate PackageReference and also updated both ImageSharp (v2 and v3) and MailKit dependencies to the latest versions.