### PR TITLE
Fix Collection views with custom field ordering

### DIFF
--- a/src/Umbraco.Infrastructure/Services/ContentListViewServiceBase.cs
+++ b/src/Umbraco.Infrastructure/Services/ContentListViewServiceBase.cs
@@ -102,7 +102,7 @@ internal abstract class ContentListViewServiceBase<TContent, TContentType, TCont
         }
 
         var orderByCustomField = listViewProperties
-            .Any(p => p.Alias == orderBy && p.IsSystem);
+            .Any(p => p.Alias == orderBy && p.IsSystem is false);
 
         var ordering = Ordering.By(
             orderBy,


### PR DESCRIPTION
Fixed a small issue with collection views (List views) when ordering by a custom property, it was not determined as custom and did not work

### Test
- Test a collection view and order by one of the properties from the doc type.