### PR TITLE
Add JsonObjectConverter to the default serializer and make a safe check before adding index

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddGuidsToUsers.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddGuidsToUsers.cs
@@ -47,7 +47,11 @@ internal class AddGuidsToUsers : UnscopedMigrationBase
         AddColumnIfNotExists<UserDto>(columns, NewColumnName);
 
         var nodeDtoTrashedIndex = $"IX_umbracoUser_userKey";
-        CreateIndex<UserDto>(nodeDtoTrashedIndex);
+        if (IndexExists(nodeDtoTrashedIndex) is false)
+        {
+            CreateIndex<UserDto>(nodeDtoTrashedIndex);
+        }
+
 
         List<NewUserDto>? userDtos = Database.Fetch<NewUserDto>();
         if (userDtos is null)

--- a/src/Umbraco.Infrastructure/Serialization/SystemTextJsonSerializer.cs
+++ b/src/Umbraco.Infrastructure/Serialization/SystemTextJsonSerializer.cs
@@ -20,8 +20,7 @@ public sealed class SystemTextJsonSerializer : SystemTextJsonSerializerBase
                 new JsonStringEnumConverter(),
                 new JsonUdiConverter(),
                 new JsonUdiRangeConverter(),
-                // We may need to add JsonObjectConverter at some point, but for the time being things work fine without
-                //new JsonObjectConverter()
+                new JsonObjectConverter() // Required for block editor values
             }
         };
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Manifest/PackageManifestReaderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Manifest/PackageManifestReaderTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -93,15 +94,15 @@ public class PackageManifestReaderTests
         var first = result.First();
 
         // Ensure that the extensions are deserialized as JsonElement
-        Assert.IsTrue(first.Extensions.All(e => e is JsonElement));
+        Assert.IsTrue(first.Extensions.All(e => e is JsonObject));
 
         // Test the deserialization of the first extension to make sure we don't break the JSON parsing
-        JsonElement firstExtension = (JsonElement)first.Extensions.First();
-        Assert.AreEqual("tree", firstExtension.GetProperty("type").GetString());
-        var meta = firstExtension.GetProperty("meta");
-        Assert.AreEqual("My Tree", meta.GetProperty("label").GetString());
-        var someArray = meta.GetProperty("someArray");
-        Assert.AreEqual(1, someArray[0].GetInt32());
+        JsonObject firstExtension = (JsonObject)first.Extensions.First();
+         Assert.AreEqual("tree", firstExtension["type"].GetValue<string>());
+         var meta = firstExtension["meta"];
+         Assert.AreEqual("My Tree", meta["label"].GetValue<string>());
+         var someArray = meta["someArray"];
+         Assert.AreEqual(1, someArray[0].GetValue<int>());
     }
 
     [Test]


### PR DESCRIPTION
### Summary
This PR contains two small changes required.
1. Adding the JsonObjectConverter by default is required for the block editors to work
1. Adding a safety check around creating an index, so it is not created if it already exists.
 