### PR TITLE
V14: Optimise login screen javascript

### DIFF
--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoLogin/Index.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoLogin/Index.cshtml
@@ -47,7 +47,7 @@
     <title>Umbraco</title>
 
     <link rel="stylesheet" href="~/umbraco/login/user-defined.css" asp-append-version="true"/>
-    <link rel="stylesheet" href="~/umbraco/login/style.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/umbraco/backoffice/css/uui-css.css" asp-append-version="true" />
     <style>
       body {
         margin: 0;

--- a/src/Umbraco.Web.UI.Login/package-lock.json
+++ b/src/Umbraco.Web.UI.Login/package-lock.json
@@ -9,7 +9,6 @@
 				"msw": "^2.2.13"
 			},
 			"devDependencies": {
-				"@umbraco-ui/uui-css": "1.8.0-rc.0",
 				"typescript": "^5.3.3",
 				"vite": "^5.2.2",
 				"vite-tsconfig-paths": "^4.3.2"
@@ -460,23 +459,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/@lit-labs/ssr-dom-shim": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.0.tgz",
-			"integrity": "sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@lit/reactive-element": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
-			"integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@lit-labs/ssr-dom-shim": "^1.2.0"
-			}
-		},
 		"node_modules/@mswjs/cookies": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
@@ -721,26 +703,10 @@
 			"resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.4.tgz",
 			"integrity": "sha512-eqNDvZsCNY49OAXB0Firg/Sc2BgoWsntsLUdybGFOhAfCD6QJ2n9HXUIHGqt5qjrxmMv4wS8WLAw43ZkKcJ8Pw=="
 		},
-		"node_modules/@types/trusted-types": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/@types/wrap-ansi": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
 			"integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g=="
-		},
-		"node_modules/@umbraco-ui/uui-css": {
-			"version": "1.8.0-rc.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-css/-/uui-css-1.8.0-rc.0.tgz",
-			"integrity": "sha512-trwLCgJtT91iP2b20QlHWjuj44AF4lWCg4CqBZoT2Z8a5IedqflnQstXCZRYm/F5Re32YGTwlR9lF1rAXqq4gg==",
-			"dev": true,
-			"peerDependencies": {
-				"lit": ">=2.8.0"
-			}
 		},
 		"node_modules/ansi-escapes": {
 			"version": "4.3.2",
@@ -1011,40 +977,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
 			"integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw=="
-		},
-		"node_modules/lit": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/lit/-/lit-3.1.2.tgz",
-			"integrity": "sha512-VZx5iAyMtX7CV4K8iTLdCkMaYZ7ipjJZ0JcSdJ0zIdGxxyurjIn7yuuSxNBD7QmjvcNJwr0JS4cAdAtsy7gZ6w==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@lit/reactive-element": "^2.0.4",
-				"lit-element": "^4.0.4",
-				"lit-html": "^3.1.2"
-			}
-		},
-		"node_modules/lit-element": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.4.tgz",
-			"integrity": "sha512-98CvgulX6eCPs6TyAIQoJZBCQPo80rgXR+dVBs61cstJXqtI+USQZAbA4gFHh6L/mxBx9MrgPLHLsUgDUHAcCQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@lit-labs/ssr-dom-shim": "^1.2.0",
-				"@lit/reactive-element": "^2.0.4",
-				"lit-html": "^3.1.2"
-			}
-		},
-		"node_modules/lit-html": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.2.tgz",
-			"integrity": "sha512-3OBZSUrPnAHoKJ9AMjRL/m01YJxQMf+TMHanNtTHG68ubjnZxK0RFl102DPzsw4mWnHibfZIBJm3LWCZ/LmMvg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@types/trusted-types": "^2.0.2"
-			}
 		},
 		"node_modules/ms": {
 			"version": "2.1.2",

--- a/src/Umbraco.Web.UI.Login/package.json
+++ b/src/Umbraco.Web.UI.Login/package.json
@@ -16,7 +16,6 @@
 		"msw": "^2.2.13"
 	},
 	"devDependencies": {
-		"@umbraco-ui/uui-css": "1.8.0-rc.0",
 		"typescript": "^5.3.3",
 		"vite": "^5.2.2",
 		"vite-tsconfig-paths": "^4.3.2"

--- a/src/Umbraco.Web.UI.Login/src/controllers/slim-backoffice-initializer.ts
+++ b/src/Umbraco.Web.UI.Login/src/controllers/slim-backoffice-initializer.ts
@@ -1,6 +1,4 @@
 import {
-  UmbBundleExtensionInitializer,
-  UmbEntryPointExtensionInitializer,
   UmbServerExtensionRegistrator
 } from "@umbraco-cms/backoffice/extension-api";
 import { umbExtensionsRegistry } from "@umbraco-cms/backoffice/extension-registry";
@@ -23,8 +21,6 @@ export class UmbSlimBackofficeController extends UmbControllerBase {
 
   constructor(host: UmbElement) {
     super(host);
-    new UmbBundleExtensionInitializer(host, umbExtensionsRegistry);
-    new UmbEntryPointExtensionInitializer(host, umbExtensionsRegistry);
     new UmbServerExtensionRegistrator(host, umbExtensionsRegistry).registerPublicExtensions();
 
     this.#umbIconRegistry.attach(host);

--- a/src/Umbraco.Web.UI.Login/src/controllers/slim-backoffice-initializer.ts
+++ b/src/Umbraco.Web.UI.Login/src/controllers/slim-backoffice-initializer.ts
@@ -1,4 +1,5 @@
 import {
+  UmbBundleExtensionInitializer,
   UmbServerExtensionRegistrator
 } from "@umbraco-cms/backoffice/extension-api";
 import { umbExtensionsRegistry } from "@umbraco-cms/backoffice/extension-registry";
@@ -21,6 +22,7 @@ export class UmbSlimBackofficeController extends UmbControllerBase {
 
   constructor(host: UmbElement) {
     super(host);
+    new UmbBundleExtensionInitializer(host, umbExtensionsRegistry);
     new UmbServerExtensionRegistrator(host, umbExtensionsRegistry).registerPublicExtensions();
 
     this.#umbIconRegistry.attach(host);

--- a/src/Umbraco.Web.UI.Login/src/index.ts
+++ b/src/Umbraco.Web.UI.Login/src/index.ts
@@ -1,5 +1,3 @@
-import '@umbraco-ui/uui-css/dist/uui-css.css';
-
 export * from './auth.element.js';
 export * from './components/index.js';
 export * from './contexts/index.js';


### PR DESCRIPTION
- Do not load entrypoints on the login screen (the screen only supports simple extensions)
- Remove dependency on uui-css and load from the built backoffice client instead (we get the javascript through the importmap anyway)