### PR TITLE
V14: Fix npmjs.org publish

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -768,7 +768,7 @@ stages:
 
               # Find the first .tgz file in the current directory and publish it
               files=( ./*.tgz )
-              npm publish --access public "${files[0]}"
+              npm publish "${files[0]}"
             displayName: Push to npm (MyGet)
             workingDirectory: $(Pipeline.Workspace)/npm
 
@@ -822,7 +822,7 @@ stages:
 
               # Find the first .tgz file in the current directory and publish it
               files=( ./*.tgz )
-              npm publish --tag $npmTag --access public "${files[0]}"
+              npm publish "${files[0]}"
             displayName: Push to npm
             workingDirectory: $(Pipeline.Workspace)/npm
 


### PR DESCRIPTION
Do not refer to `$npmTag` which does not exist and `--access` is not required either since we now specify that in the package.json file.