### PR TITLE
Add blocks in RTE telemetry

### DIFF
--- a/src/Umbraco.Core/Constants-Telemetry.cs
+++ b/src/Umbraco.Core/Constants-Telemetry.cs
@@ -36,5 +36,7 @@ public static partial class Constants
         public static string WebhookTotal = $"{WebhookPrefix}Total";
         public static string WebhookCustomHeaders = $"{WebhookPrefix}CustomHeaders";
         public static string WebhookCustomEvent = $"{WebhookPrefix}CustomEvent";
+        public static string RichTextEditorCount = "RichTextEditorCount";
+        public static string RichTextBlockCount = "RichTextBlockCount";
     }
 }

--- a/src/Umbraco.Core/Constants-Telemetry.cs
+++ b/src/Umbraco.Core/Constants-Telemetry.cs
@@ -38,5 +38,8 @@ public static partial class Constants
         public static string WebhookCustomEvent = $"{WebhookPrefix}CustomEvent";
         public static string RichTextEditorCount = "RichTextEditorCount";
         public static string RichTextBlockCount = "RichTextBlockCount";
+        public static string TotalPropertyCount = "TotalPropertyCount";
+        public static string HighestPropertyCount = "HighestPropertyCount";
+        public static string TotalCompositions = "TotalCompositions";
     }
 }

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -3077,7 +3077,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="detailedLevelDescription"><![CDATA[We will send:
 <ul>
     <li>Anonymized site ID, Umbraco version, and packages installed.</li>
-    <li>Number of: Root nodes, Content nodes, Macros, Media, Document Types, Templates, Languages, Domains, User Group, Users, Members, Backoffice external login providers, Webhooks, and Property Editors in use.</li>
+    <li>Number of: Root nodes, Content nodes, Macros, Media, Document Types, Templates, Languages, Domains, User Group, Users, Members, Backoffice external login providers, Webhooks, rich text datatypes, blocks used in rich text datatypes and Property Editors in use.</li>
     <li>System information: Webserver, server OS, server framework, server OS language, and database provider.</li>
     <li>Configuration settings: Modelsbuilder mode, if custom Umbraco path exists, ASP environment, whether the delivery API is enabled, and allows public access, and if you are in debug mode.</li>
 </ul>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -3077,7 +3077,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="detailedLevelDescription"><![CDATA[We will send:
 <ul>
     <li>Anonymized site ID, Umbraco version, and packages installed.</li>
-    <li>Number of: Root nodes, Content nodes, Macros, Media, Document Types, Templates, Languages, Domains, User Group, Users, Members, Backoffice external login providers, Webhooks, rich text datatypes, blocks used in rich text datatypes and Property Editors in use.</li>
+    <li>Number of: Root nodes, Content nodes, Macros, Media, Document Types, Property Types, Compositions, Templates, Languages, Domains, User Group, Users, Members, Backoffice external login providers, Webhooks, rich text datatypes, blocks used in rich text datatypes, and Property Editors in use.</li>
     <li>System information: Webserver, server OS, server framework, server OS language, and database provider.</li>
     <li>Configuration settings: Modelsbuilder mode, if custom Umbraco path exists, ASP environment, whether the delivery API is enabled, and allows public access, and if you are in debug mode.</li>
 </ul>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -3096,7 +3096,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
           We will send:
           <ul>
             <li>Anonymized site ID, Umbraco version, and packages installed.</li>
-            <li>Number of: Root nodes, Content nodes, Macros, Media, Document Types, Templates, Languages, Domains, User Group, Users, Members, Backoffice external login providers, Webhooks, rich text datatypes, blocks used in rich text datatypes and Property Editors in use.</li>
+            <li>Number of: Root nodes, Content nodes, Macros, Media, Document Types, Property Types, Compositions, Templates, Languages, Domains, User Group, Users, Members, Backoffice external login providers, Webhooks, rich text datatypes, blocks used in rich text datatypes, and Property Editors in use.</li>
             <li>System information: Webserver, server OS, server framework, server OS language, and database provider.</li>
             <li>Configuration settings: Modelsbuilder mode, if custom Umbraco path exists, ASP environment, whether the delivery API is enabled, and allows public access, and if you are in debug mode.</li>
           </ul>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -3096,7 +3096,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
           We will send:
           <ul>
             <li>Anonymized site ID, Umbraco version, and packages installed.</li>
-            <li>Number of: Root nodes, Content nodes, Macros, Media, Document Types, Templates, Languages, Domains, User Group, Users, Members, Backoffice external login providers, Webhooks, and Property Editors in use.</li>
+            <li>Number of: Root nodes, Content nodes, Macros, Media, Document Types, Templates, Languages, Domains, User Group, Users, Members, Backoffice external login providers, Webhooks, rich text datatypes, blocks used in rich text datatypes and Property Editors in use.</li>
             <li>System information: Webserver, server OS, server framework, server OS language, and database provider.</li>
             <li>Configuration settings: Modelsbuilder mode, if custom Umbraco path exists, ASP environment, whether the delivery API is enabled, and allows public access, and if you are in debug mode.</li>
           </ul>

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.TelemetryProviders.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.TelemetryProviders.cs
@@ -21,6 +21,7 @@ public static class UmbracoBuilder_TelemetryProviders
         builder.Services.AddTransient<IDetailedTelemetryProvider, SystemInformationTelemetryProvider>();
         builder.Services.AddTransient<IDetailedTelemetryProvider, DeliveryApiTelemetryProvider>();
         builder.Services.AddTransient<IDetailedTelemetryProvider, WebhookTelemetryProvider>();
+        builder.Services.AddTransient<IDetailedTelemetryProvider, BlocksInRichTextTelemetryProvider>();
         return builder;
     }
 }

--- a/src/Umbraco.Infrastructure/Telemetry/Providers/BlocksInRichTextTelemetryProvider.cs
+++ b/src/Umbraco.Infrastructure/Telemetry/Providers/BlocksInRichTextTelemetryProvider.cs
@@ -1,0 +1,42 @@
+﻿using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Telemetry.Interfaces;
+
+namespace Umbraco.Cms.Infrastructure.Telemetry.Providers;
+
+public class BlocksInRichTextTelemetryProvider : IDetailedTelemetryProvider
+{
+    private readonly IDataTypeService _dataTypeService;
+
+    public BlocksInRichTextTelemetryProvider(IDataTypeService dataTypeService)
+    {
+        _dataTypeService = dataTypeService;
+    }
+
+    public IEnumerable<UsageInformation> GetInformation()
+    {
+        IEnumerable<IDataType> richTextDataTypes = _dataTypeService.GetByEditorAlias(Constants.PropertyEditors.Aliases.TinyMce).ToArray();
+        int registeredBlocks = 0;
+        yield return new UsageInformation("RichTextEditorCount", richTextDataTypes.Count());
+
+        foreach (IDataType richTextDataType in richTextDataTypes)
+        {
+            if (richTextDataType.Configuration is not RichTextConfiguration richTextConfiguration)
+            {
+                // Might be some custom data type, skip it
+                continue;
+            }
+
+            if (richTextConfiguration.Blocks is null)
+            {
+                continue;
+            }
+
+            registeredBlocks += richTextConfiguration.Blocks.Length;
+        }
+
+        yield return new UsageInformation("RichTextBlockCount", registeredBlocks);
+    }
+}

--- a/src/Umbraco.Infrastructure/Telemetry/Providers/BlocksInRichTextTelemetryProvider.cs
+++ b/src/Umbraco.Infrastructure/Telemetry/Providers/BlocksInRichTextTelemetryProvider.cs
@@ -19,7 +19,7 @@ public class BlocksInRichTextTelemetryProvider : IDetailedTelemetryProvider
     {
         IEnumerable<IDataType> richTextDataTypes = _dataTypeService.GetByEditorAlias(Constants.PropertyEditors.Aliases.TinyMce).ToArray();
         int registeredBlocks = 0;
-        yield return new UsageInformation("RichTextEditorCount", richTextDataTypes.Count());
+        yield return new UsageInformation(Constants.Telemetry.RichTextEditorCount, richTextDataTypes.Count());
 
         foreach (IDataType richTextDataType in richTextDataTypes)
         {
@@ -37,6 +37,6 @@ public class BlocksInRichTextTelemetryProvider : IDetailedTelemetryProvider
             registeredBlocks += richTextConfiguration.Blocks.Length;
         }
 
-        yield return new UsageInformation("RichTextBlockCount", registeredBlocks);
+        yield return new UsageInformation(Constants.Telemetry.RichTextBlockCount, registeredBlocks);
     }
 }

--- a/src/Umbraco.Infrastructure/Telemetry/Providers/PropertyEditorTelemetryProvider.cs
+++ b/src/Umbraco.Infrastructure/Telemetry/Providers/PropertyEditorTelemetryProvider.cs
@@ -16,11 +16,19 @@ public class PropertyEditorTelemetryProvider : IDetailedTelemetryProvider
     {
         IEnumerable<IContentType> contentTypes = _contentTypeService.GetAll();
         var propertyTypes = new HashSet<string>();
+        var propertyTypeCounts = new List<int>();
+        var totalCompositions = 0;
+
         foreach (IContentType contentType in contentTypes)
         {
             propertyTypes.UnionWith(contentType.PropertyTypes.Select(x => x.PropertyEditorAlias));
+            propertyTypeCounts.Add(contentType.CompositionPropertyTypes.Count());
+            totalCompositions += contentType.CompositionAliases().Count();
         }
 
         yield return new UsageInformation(Constants.Telemetry.Properties, propertyTypes);
+        yield return new UsageInformation(Constants.Telemetry.TotalPropertyCount, propertyTypeCounts.Sum());
+        yield return new UsageInformation(Constants.Telemetry.HighestPropertyCount, propertyTypeCounts.Count > 0 ? propertyTypeCounts.Max() : 0);
+        yield return new UsageInformation(Constants.Telemetry.TotalCompositions, totalCompositions);
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
@@ -59,7 +59,10 @@ public class TelemetryServiceTests : UmbracoIntegrationTest
             Constants.Telemetry.WebhookCustomHeaders,
             Constants.Telemetry.WebhookCustomEvent,
             Constants.Telemetry.RichTextEditorCount,
-            Constants.Telemetry.RichTextBlockCount
+            Constants.Telemetry.RichTextBlockCount,
+            Constants.Telemetry.TotalPropertyCount,
+            Constants.Telemetry.HighestPropertyCount,
+            Constants.Telemetry.TotalCompositions,
         };
 
         // Add the default webhook events.

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
@@ -58,6 +58,8 @@ public class TelemetryServiceTests : UmbracoIntegrationTest
             Constants.Telemetry.WebhookTotal,
             Constants.Telemetry.WebhookCustomHeaders,
             Constants.Telemetry.WebhookCustomEvent,
+            Constants.Telemetry.RichTextEditorCount,
+            Constants.Telemetry.RichTextBlockCount
         };
 
         // Add the default webhook events.


### PR DESCRIPTION
Adds a telemetry provider that reports on the total amount of registered rich text editors data types, and the amount of blocks used in rich text editors.

```json
{
      "name": "RichTextEditorCount",
      "data": 3
    },
    {
      "name": "RichTextBlockCount",
      "data": 3
    }
```