### PR TITLE
V14: Fix member mapping

### DIFF
--- a/src/Umbraco.Cms.Api.Management/ViewModels/Member/CreateMemberRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Member/CreateMemberRequestModel.cs
@@ -12,7 +12,7 @@ public class CreateMemberRequestModel : CreateContentRequestModelBase<MemberValu
 
     public required ReferenceByIdModel MemberType { get; set; }
 
-    public IEnumerable<string>? Groups { get; set; }
+    public IEnumerable<Guid>? Groups { get; set; }
 
     public bool IsApproved { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Member/MemberResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Member/MemberResponseModel.cs
@@ -25,5 +25,5 @@ public class MemberResponseModel : ContentResponseModelBase<MemberValueModel, Me
 
     public DateTime? LastPasswordChangeDate { get; set; }
 
-    public IEnumerable<string> Groups { get; set; } = [];
+    public IEnumerable<Guid> Groups { get; set; } = [];
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Member/UpdateMemberRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Member/UpdateMemberRequestModel.cs
@@ -12,7 +12,7 @@ public class UpdateMemberRequestModel : UpdateContentRequestModelBase<MemberValu
 
     public string? NewPassword { get; set; }
 
-    public IEnumerable<string>? Groups { get; set; }
+    public IEnumerable<Guid>? Groups { get; set; }
 
     public bool IsApproved { get; set; }
 

--- a/src/Umbraco.Core/Models/ContentEditing/MemberEditingModelBase.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/MemberEditingModelBase.cs
@@ -4,7 +4,7 @@ public abstract class MemberEditingModelBase : ContentEditingModelBase
 {
     public bool IsApproved { get; set; }
 
-    public IEnumerable<string>? Roles { get; set; }
+    public IEnumerable<Guid>? Roles { get; set; }
 
     public string Email { get; set; } = string.Empty;
 

--- a/src/Umbraco.Infrastructure/Services/MemberEditingService.cs
+++ b/src/Umbraco.Infrastructure/Services/MemberEditingService.cs
@@ -18,6 +18,7 @@ internal sealed class MemberEditingService : IMemberEditingService
     private readonly ITwoFactorLoginService _twoFactorLoginService;
     private readonly IPasswordChanger<MemberIdentityUser> _passwordChanger;
     private readonly ILogger<MemberEditingService> _logger;
+    private readonly IMemberGroupService _memberGroupService;
 
     public MemberEditingService(
         IMemberService memberService,
@@ -26,7 +27,8 @@ internal sealed class MemberEditingService : IMemberEditingService
         IMemberManager memberManager,
         ITwoFactorLoginService twoFactorLoginService,
         IPasswordChanger<MemberIdentityUser> passwordChanger,
-        ILogger<MemberEditingService> logger)
+        ILogger<MemberEditingService> logger,
+        IMemberGroupService memberGroupService)
     {
         _memberService = memberService;
         _memberTypeService = memberTypeService;
@@ -35,6 +37,7 @@ internal sealed class MemberEditingService : IMemberEditingService
         _twoFactorLoginService = twoFactorLoginService;
         _passwordChanger = passwordChanger;
         _logger = logger;
+        _memberGroupService = memberGroupService;
     }
 
     public async Task<IMember?> GetAsync(Guid key)
@@ -248,6 +251,22 @@ internal sealed class MemberEditingService : IMemberEditingService
 
     private async Task<bool> UpdateRoles(IEnumerable<string>? roles, MemberIdentityUser identityMember)
     {
+        // We have to convert the GUIDS to names here, as roles on a member are stored by name, not key.
+        var convertedRoles = new List<string>();
+        foreach (var role in roles ?? Enumerable.Empty<string>())
+        {
+            if (!Guid.TryParse(role, out Guid key))
+            {
+                continue;
+            }
+
+            IMemberGroup? group = await _memberGroupService.GetAsync(key);
+            if (group is not null)
+            {
+                convertedRoles.Add(group.Name!);
+            }
+        }
+
         // We're gonna look up the current roles now because the below code can cause
         // events to be raised and developers could be manually adding roles to members in
         // their handlers. If we don't look this up now there's a chance we'll just end up
@@ -255,7 +274,7 @@ internal sealed class MemberEditingService : IMemberEditingService
         IEnumerable<string> currentRoles = (await _memberManager.GetRolesAsync(identityMember)).ToList();
 
         // find the ones to remove and remove them
-        var rolesToRemove = currentRoles.Except(roles ?? Enumerable.Empty<string>()).ToArray();
+        var rolesToRemove = currentRoles.Except(convertedRoles).ToArray();
 
         // Now let's do the role provider stuff - now that we've saved the content item (that is important since
         // if we are changing the username, it must be persisted before looking up the member roles).
@@ -270,8 +289,8 @@ internal sealed class MemberEditingService : IMemberEditingService
         }
 
         // find the ones to add and add them
-        var rolesToAdd = roles?.Except(currentRoles).ToArray();
-        if (rolesToAdd?.Any() is true)
+        var rolesToAdd = convertedRoles.Except(currentRoles).ToArray();
+        if (rolesToAdd.Any())
         {
             // add the ones submitted
             IdentityResult identityResult = await _memberManager.AddToRolesAsync(identityMember, rolesToAdd);

--- a/src/Umbraco.Infrastructure/Services/MemberEditingService.cs
+++ b/src/Umbraco.Infrastructure/Services/MemberEditingService.cs
@@ -270,7 +270,8 @@ internal sealed class MemberEditingService : IMemberEditingService
         IEnumerable<string> currentRoles = (await _memberManager.GetRolesAsync(identityMember)).ToList();
 
         // find the ones to remove and remove them
-        var rolesToRemove = currentRoles.Except(memberGroups.Select(x => x.Name)).WhereNotNull().ToArray();
+        IEnumerable<string> memberGroupNames = memberGroups.Select(x => x.Name).WhereNotNull().ToArray();
+        var rolesToRemove = currentRoles.Except(memberGroupNames).ToArray();
 
         // Now let's do the role provider stuff - now that we've saved the content item (that is important since
         // if we are changing the username, it must be persisted before looking up the member roles).
@@ -285,7 +286,7 @@ internal sealed class MemberEditingService : IMemberEditingService
         }
 
         // find the ones to add and add them
-        var rolesToAdd = memberGroups.Select(x => x.Name).WhereNotNull().Except(currentRoles).ToArray();
+        var rolesToAdd = memberGroupNames.Except(currentRoles).ToArray();
         if (rolesToAdd.Any())
         {
             // add the ones submitted

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MemberEditingServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MemberEditingServiceTests.cs
@@ -25,6 +25,8 @@ public class MemberEditingServiceTests : UmbracoIntegrationTest
 
     private IUserService UserService => GetRequiredService<IUserService>();
 
+    private IMemberGroupService MemberGroupService => GetRequiredService<IMemberGroupService>();
+
     [Test]
     public async Task Can_Create_Member()
     {
@@ -129,6 +131,7 @@ public class MemberEditingServiceTests : UmbracoIntegrationTest
     {
         MemberService.AddRole("RoleTwo");
         MemberService.AddRole("RoleThree");
+        var grps = new[] { MemberGroupService.GetByName("RoleTwo"), MemberGroupService.GetByName("RoleThree") };
 
         var member = await CreateMemberAsync();
 
@@ -138,7 +141,7 @@ public class MemberEditingServiceTests : UmbracoIntegrationTest
             Username = member.Username,
             IsApproved = true,
             InvariantName = member.Name,
-            Roles = new [] { "RoleTwo", "RoleThree" }
+            Roles = grps.Select(x => x.Key),
         };
 
         var result = await MemberEditingService.UpdateAsync(member.Key, updateModel, SuperUser());
@@ -432,6 +435,7 @@ public class MemberEditingServiceTests : UmbracoIntegrationTest
         memberType.SetIsSensitiveProperty("title", titleIsSensitive);
         MemberTypeService.Save(memberType);
         MemberService.AddRole("RoleOne");
+        var group = MemberGroupService.GetByName("RoleOne");
 
         var createModel = new MemberCreateModel
         {
@@ -441,7 +445,7 @@ public class MemberEditingServiceTests : UmbracoIntegrationTest
             Password = "SuperSecret123",
             IsApproved = true,
             ContentTypeKey = memberType.Key,
-            Roles = new [] { "RoleOne" },
+            Roles = new [] { group.Key },
             InvariantName = "T. Est",
             InvariantProperties = new[]
             {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MemberEditingServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MemberEditingServiceTests.cs
@@ -131,7 +131,7 @@ public class MemberEditingServiceTests : UmbracoIntegrationTest
     {
         MemberService.AddRole("RoleTwo");
         MemberService.AddRole("RoleThree");
-        var grps = new[] { MemberGroupService.GetByName("RoleTwo"), MemberGroupService.GetByName("RoleThree") };
+        var groups = new[] { MemberGroupService.GetByName("RoleTwo"), MemberGroupService.GetByName("RoleThree") };
 
         var member = await CreateMemberAsync();
 
@@ -141,7 +141,7 @@ public class MemberEditingServiceTests : UmbracoIntegrationTest
             Username = member.Username,
             IsApproved = true,
             InvariantName = member.Name,
-            Roles = grps.Select(x => x.Key),
+            Roles = groups.Select(x => x.Key),
         };
 
         var result = await MemberEditingService.UpdateAsync(member.Key, updateModel, SuperUser());


### PR DESCRIPTION
# Notes
There was a bug, that when you created a member with a member group, an additional member group was created.

This comes down to do with how member groups are created, as these are created based by role (name).
In v14 however, these member groups are referenced by key, and thus a new member group with the key as name, was created.

This PR remedies that, by mapping the keys over to names when its inbound, and then mapping the names back to key when it's outbound

# How to test
- Via the UI, create a member group
- Create a member with that member group assigned.
- This should no longer create an extra member group

- Start on v13
- Create some members and member groups
- migrate to v14
- Assert that you can get the members without any errors