### PR TITLE
V13/feature/property type count

### DIFF
--- a/src/Umbraco.Core/Constants-Telemetry.cs
+++ b/src/Umbraco.Core/Constants-Telemetry.cs
@@ -38,5 +38,8 @@ public static partial class Constants
         public static string WebhookCustomEvent = $"{WebhookPrefix}CustomEvent";
         public static string RichTextEditorCount = "RichTextEditorCount";
         public static string RichTextBlockCount = "RichTextBlockCount";
+        public static string TotalPropertyCount = "TotalPropertyCount";
+        public static string HighestPropertyCount = "HighestPropertyCount";
+        public static string TotalCompositions = "TotalCompositions";
     }
 }

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -3077,7 +3077,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
     <key alias="detailedLevelDescription"><![CDATA[We will send:
 <ul>
     <li>Anonymized site ID, Umbraco version, and packages installed.</li>
-    <li>Number of: Root nodes, Content nodes, Macros, Media, Document Types, Templates, Languages, Domains, User Group, Users, Members, Backoffice external login providers, Webhooks, rich text datatypes, blocks used in rich text datatypes and Property Editors in use.</li>
+    <li>Number of: Root nodes, Content nodes, Macros, Media, Document Types, Property Types, Compositions, Templates, Languages, Domains, User Group, Users, Members, Backoffice external login providers, Webhooks, rich text datatypes, blocks used in rich text datatypes, and Property Editors in use.</li>
     <li>System information: Webserver, server OS, server framework, server OS language, and database provider.</li>
     <li>Configuration settings: Modelsbuilder mode, if custom Umbraco path exists, ASP environment, whether the delivery API is enabled, and allows public access, and if you are in debug mode.</li>
 </ul>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -3096,7 +3096,7 @@ To manage your website, simply open the Umbraco backoffice and start adding cont
           We will send:
           <ul>
             <li>Anonymized site ID, Umbraco version, and packages installed.</li>
-            <li>Number of: Root nodes, Content nodes, Macros, Media, Document Types, Templates, Languages, Domains, User Group, Users, Members, Backoffice external login providers, Webhooks, rich text datatypes, blocks used in rich text datatypes and Property Editors in use.</li>
+            <li>Number of: Root nodes, Content nodes, Macros, Media, Document Types, Property Types, Compositions, Templates, Languages, Domains, User Group, Users, Members, Backoffice external login providers, Webhooks, rich text datatypes, blocks used in rich text datatypes, and Property Editors in use.</li>
             <li>System information: Webserver, server OS, server framework, server OS language, and database provider.</li>
             <li>Configuration settings: Modelsbuilder mode, if custom Umbraco path exists, ASP environment, whether the delivery API is enabled, and allows public access, and if you are in debug mode.</li>
           </ul>

--- a/src/Umbraco.Infrastructure/Telemetry/Providers/PropertyEditorTelemetryProvider.cs
+++ b/src/Umbraco.Infrastructure/Telemetry/Providers/PropertyEditorTelemetryProvider.cs
@@ -27,8 +27,8 @@ public class PropertyEditorTelemetryProvider : IDetailedTelemetryProvider
         }
 
         yield return new UsageInformation(Constants.Telemetry.Properties, propertyTypes);
-        yield return new UsageInformation("TotalPropertyCount", propertyTypeCounts.Sum());
-        yield return new UsageInformation("HighestPropertyCount", propertyTypeCounts.Max());
-        yield return new UsageInformation("TotalCompositions", totalCompositions);
+        yield return new UsageInformation(Constants.Telemetry.TotalPropertyCount, propertyTypeCounts.Sum());
+        yield return new UsageInformation(Constants.Telemetry.HighestPropertyCount, propertyTypeCounts.Count > 0 ? propertyTypeCounts.Max() : 0);
+        yield return new UsageInformation(Constants.Telemetry.TotalCompositions, totalCompositions);
     }
 }

--- a/src/Umbraco.Infrastructure/Telemetry/Providers/PropertyEditorTelemetryProvider.cs
+++ b/src/Umbraco.Infrastructure/Telemetry/Providers/PropertyEditorTelemetryProvider.cs
@@ -16,11 +16,19 @@ public class PropertyEditorTelemetryProvider : IDetailedTelemetryProvider
     {
         IEnumerable<IContentType> contentTypes = _contentTypeService.GetAll();
         var propertyTypes = new HashSet<string>();
+        var propertyTypeCounts = new List<int>();
+        var totalCompositions = 0;
+
         foreach (IContentType contentType in contentTypes)
         {
             propertyTypes.UnionWith(contentType.PropertyTypes.Select(x => x.PropertyEditorAlias));
+            propertyTypeCounts.Add(contentType.CompositionPropertyTypes.Count());
+            totalCompositions += contentType.CompositionAliases().Count();
         }
 
         yield return new UsageInformation(Constants.Telemetry.Properties, propertyTypes);
+        yield return new UsageInformation("TotalPropertyCount", propertyTypeCounts.Sum());
+        yield return new UsageInformation("HighestPropertyCount", propertyTypeCounts.Max());
+        yield return new UsageInformation("TotalCompositions", totalCompositions);
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
@@ -59,7 +59,10 @@ public class TelemetryServiceTests : UmbracoIntegrationTest
             Constants.Telemetry.WebhookCustomHeaders,
             Constants.Telemetry.WebhookCustomEvent,
             Constants.Telemetry.RichTextEditorCount,
-            Constants.Telemetry.RichTextBlockCount
+            Constants.Telemetry.RichTextBlockCount,
+            Constants.Telemetry.TotalPropertyCount,
+            Constants.Telemetry.HighestPropertyCount,
+            Constants.Telemetry.TotalCompositions,
         };
 
         // Add the default webhook events.


### PR DESCRIPTION
Adds information about property type usage to telemetry, specifically: 

* Total amount of property types across all document types
* Highest amount of property types on a single document type
* Total amount of compositions across all document types: 

```json
    {
      "name": "TotalPropertyCount",
      "data": 4
    },
    {
      "name": "HighestPropertyCount",
      "data": 2
    },
    {
      "name": "TotalCompositions",
      "data": 1
    },
```