### PR TITLE
Since v13 properties can sometimes be of new type `RichTextEditorIntermediateValue`

### DIFF
--- a/src/Umbraco.Core/Xml/XPath/NavigableNavigator.cs
+++ b/src/Umbraco.Core/Xml/XPath/NavigableNavigator.cs
@@ -15,6 +15,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Xml;
 using System.Xml.XPath;
+using Umbraco.Cms.Core.PropertyEditors;
 
 namespace Umbraco.Cms.Core.Xml.XPath;
 
@@ -639,6 +640,11 @@ public class NavigableNavigator : XPathNavigator
             InternalState.Position = StatePosition.PropertyText;
             DebugState();
             return true;
+        }
+
+        if (valueForXPath is IRichTextEditorIntermediateValue)
+        {
+            return false;
         }
 
         throw new InvalidOperationException("XPathValue must be an XPathNavigator or a string.");


### PR DESCRIPTION
This was unexpected in the XPath navigator code, faulting it into the exception state.

Fixes #15582

The cause of the error is that there is a block list editor on the Error page that we're trying to select by XPath.
Since we're trying to find property values on content items to be able to match the XPath specified in appsettings, we need to  look at all the properties (which is also why it's inefficient and this code is removed in v14).
This works for most things but not for content items with an RTE any more. Since we added blocks to the RTE in v13, the RTE property is no longer a simple string, instead it is an `RichTextEditorIntermediateValue` (as per PR #15645). Our XPath navigator code is not expecting this value.

To test: 

- Install the Clean starterkit
- Set 404 error collection to:
```json
        "Error404Collection": [
          {
            "Culture": "default",
            "ContentXPath": "//error[@nodeName='Error']"
          }
        ]
```
- Set a breakpoint in `NavigableNavigator` line 649 - https://github.com/umbraco/Umbraco-CMS/blob/v13/dev/src/Umbraco.Core/Xml/XPath/NavigableNavigator.cs#L644
- Note that before this PR, you would get to this line, now inspect the variable `valueForXPath` and note that it is of type `RteMacroRenderingValueConverter.RichTextEditorIntermediateValue`
- You get to this line for on this error page `nav` is null, `valueForXpath` is not and `valueForXpath` is not a string

After this PR is applied, the error page returns just fine (see screenshot, it will not jump to the `throw` line). Returning `false` here means that a matching XPath value was not found, I think this is okay, we don't want to make it even less performant by selecting that an RTE property should have an exact text and that means this is the correct error page.

![image](https://github.com/umbraco/Umbraco-CMS/assets/304656/b30b3414-f27b-4309-bd77-008107f26cef)

