### PR TITLE
V14: Obsolete runtime minification settings

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/RuntimeMinificationSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/RuntimeMinificationSettings.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 
 namespace Umbraco.Cms.Core.Configuration.Models;
 
+[Obsolete("Runtime minification is no longer supported. Will be removed entirely in V16.")]
 [UmbracoOptions(Constants.Configuration.ConfigRuntimeMinification)]
 public class RuntimeMinificationSettings
 {

--- a/src/Umbraco.Core/Constants-Configuration.cs
+++ b/src/Umbraco.Core/Constants-Configuration.cs
@@ -48,6 +48,7 @@ public static partial class Constants
         public const string ConfigRequestHandler = ConfigPrefix + "RequestHandler";
         public const string ConfigRuntime = ConfigPrefix + "Runtime";
         public const string ConfigRuntimeMode = ConfigRuntime + ":Mode";
+        [Obsolete("Runtime minification is no longer supported. Will be removed entirely in V16.")]
         public const string ConfigRuntimeMinification = ConfigPrefix + "RuntimeMinification";
         public const string ConfigRuntimeMinificationVersion = ConfigRuntimeMinification + ":Version";
         public const string ConfigSecurity = ConfigPrefix + "Security";

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -93,7 +93,6 @@ public static partial class UmbracoBuilderExtensions
             .Add<JITOptimizerValidator>()
             .Add<UmbracoApplicationUrlValidator>()
             .Add<UseHttpsValidator>()
-            .Add<RuntimeMinificationValidator>()
             .Add<ModelsBuilderModeValidator>();
 
         // composers

--- a/src/Umbraco.Infrastructure/Runtime/RuntimeModeValidators/RuntimeMinificationValidator.cs
+++ b/src/Umbraco.Infrastructure/Runtime/RuntimeModeValidators/RuntimeMinificationValidator.cs
@@ -8,6 +8,7 @@ namespace Umbraco.Cms.Infrastructure.Runtime.RuntimeModeValidators;
 /// Validates whether the runtime minification cache buster is not set to <see cref="RuntimeMinificationCacheBuster.Timestamp" /> when in production runtime mode.
 /// </summary>
 /// <seealso cref="Umbraco.Cms.Infrastructure.Runtime.RuntimeModeValidators.RuntimeModeProductionValidatorBase" />
+[Obsolete("Runtime minification is no longer supported, so this is no longer relevant. Will be removed entirely in V16.")]
 public class RuntimeMinificationValidator : RuntimeModeProductionValidatorBase
 {
     private readonly IOptionsMonitor<RuntimeMinificationSettings> _runtimeMinificationSettings;

--- a/tools/Umbraco.JsonSchema/UmbracoCmsSchema.cs
+++ b/tools/Umbraco.JsonSchema/UmbracoCmsSchema.cs
@@ -60,6 +60,7 @@ internal class UmbracoCmsSchema
 
         public required RichTextEditorSettings RichTextEditor { get; set; }
 
+        [Obsolete("Runtime minification is no longer supported. Will be removed entirely in V16.")]
         public required RuntimeMinificationSettings RuntimeMinification { get; set; }
 
         public required BasicAuthSettings BasicAuth { get; set; }


### PR DESCRIPTION
`RuntimeMinificationSettings` are no longer required since runtime modification is not supported anymore. 

I've obsoleted the settings and not removed them entirely since this will make it show up as obsolete in the app settings.

I also haven't removed the config from DI either, just in case someone might have injected them, there's no reason to throw yet another error here, since we'll need to come back to this later and remove the config class later anyhow, we may as well wait with unregistering it until then. 

 Lastly I've obsoleted the `RuntimeMinificationValidator` and removed it from the list of checks, since it no longer makes sense. 