### PR TITLE
V14: Refactor items endpoint to return 0 items when ids/paths are empty

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Item/ItemDatatypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Item/ItemDatatypeItemController.cs
@@ -27,6 +27,11 @@ public class ItemDatatypeItemController : DatatypeItemControllerBase
         CancellationToken cancellationToken,
         [FromQuery(Name = "id")] HashSet<Guid> ids)
     {
+        if (ids.Count is 0)
+        {
+            return Ok(Enumerable.Empty<DataTypeItemResponseModel>());
+        }
+
         var dataTypes = new List<IDataType>();
         foreach (Guid id in ids)
         {

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Item/ItemDictionaryItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Item/ItemDictionaryItemController.cs
@@ -27,6 +27,11 @@ public class ItemDictionaryItemController : DictionaryItemControllerBase
         CancellationToken cancellationToken,
         [FromQuery(Name = "id")] HashSet<Guid> ids)
     {
+        if (ids.Count is 0)
+        {
+            return Ok(Enumerable.Empty<DictionaryItemItemResponseModel>());
+        }
+
         IEnumerable<IDictionaryItem> dictionaryItems = await _dictionaryItemService.GetManyAsync(ids.ToArray());
 
         List<DictionaryItemItemResponseModel> responseModels = _mapper.MapEnumerable<IDictionaryItem, DictionaryItemItemResponseModel>(dictionaryItems);

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/ItemDocumentItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/ItemDocumentItemController.cs
@@ -28,6 +28,11 @@ public class ItemDocumentItemController : DocumentItemControllerBase
         CancellationToken cancellationToken,
         [FromQuery(Name = "id")] HashSet<Guid> ids)
     {
+        if (ids.Count is 0)
+        {
+            return Ok(Enumerable.Empty<DocumentItemResponseModel>());
+        }
+
         IEnumerable<IDocumentEntitySlim> documents = _entityService
             .GetAll(UmbracoObjectTypes.Document, ids.ToArray())
             .OfType<IDocumentEntitySlim>();

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Item/ItemDocumentTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Item/ItemDocumentTypeItemController.cs
@@ -27,6 +27,11 @@ public class ItemDocumentTypeItemController : DocumentTypeItemControllerBase
         CancellationToken cancellationToken,
         [FromQuery(Name = "id")] HashSet<Guid> ids)
     {
+        if (ids.Count is 0)
+        {
+            return Ok(Enumerable.Empty<DocumentTypeItemResponseModel>());
+        }
+
         IEnumerable<IContentType> contentTypes = _contentTypeService.GetAll(ids);
         List<DocumentTypeItemResponseModel> responseModels = _mapper.MapEnumerable<IContentType, DocumentTypeItemResponseModel>(contentTypes);
         return await Task.FromResult(Ok(responseModels));

--- a/src/Umbraco.Cms.Api.Management/Controllers/Language/Item/ItemsLanguageEntityController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Language/Item/ItemsLanguageEntityController.cs
@@ -27,6 +27,11 @@ public class ItemsLanguageEntityController : LanguageEntityControllerBase
         CancellationToken cancellationToken,
         [FromQuery(Name = "isoCode")] HashSet<string> isoCodes)
     {
+        if (isoCodes.Count is 0)
+        {
+            return Ok(Enumerable.Empty<LanguageItemResponseModel>());
+        }
+
         IEnumerable<ILanguage> languages = await _languageService.GetMultipleAsync(isoCodes);
         List<LanguageItemResponseModel> entityResponseModels = _mapper.MapEnumerable<ILanguage, LanguageItemResponseModel>(languages);
         return Ok(entityResponseModels);

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/ItemMediaItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/ItemMediaItemController.cs
@@ -29,6 +29,11 @@ public class ItemMediaItemController : MediaItemControllerBase
         CancellationToken cancellationToken,
         [FromQuery(Name = "id")] HashSet<Guid> ids)
     {
+        if (ids.Count is 0)
+        {
+            return Ok(Enumerable.Empty<MediaItemResponseModel>());
+        }
+
         IEnumerable<IMediaEntitySlim> media = _entityService
             .GetAll(UmbracoObjectTypes.Media, ids.ToArray())
             .OfType<IMediaEntitySlim>();

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/ItemMediaTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/ItemMediaTypeItemController.cs
@@ -27,6 +27,11 @@ public class ItemMediaTypeItemController : MediaTypeItemControllerBase
         CancellationToken cancellationToken,
         [FromQuery(Name = "id")] HashSet<Guid> ids)
     {
+        if (ids.Count is 0)
+        {
+            return Ok(Enumerable.Empty<MediaTypeItemResponseModel>());
+        }
+
         IEnumerable<IMediaType> mediaTypes = _mediaTypeService.GetAll(ids);
         List<MediaTypeItemResponseModel> responseModels = _mapper.MapEnumerable<IMediaType, MediaTypeItemResponseModel>(mediaTypes);
         return await Task.FromResult(Ok(responseModels));

--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/Item/ItemMemberItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/Item/ItemMemberItemController.cs
@@ -29,6 +29,11 @@ public class ItemMemberItemController : MemberItemControllerBase
         CancellationToken cancellationToken,
         [FromQuery(Name = "id")] HashSet<Guid> ids)
     {
+        if (ids.Count is 0)
+        {
+            return Ok(Enumerable.Empty<MemberItemResponseModel>());
+        }
+
         IEnumerable<IMemberEntitySlim> members = _entityService
             .GetAll(UmbracoObjectTypes.Member, ids.ToArray())
             .OfType<IMemberEntitySlim>();

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberGroup/Item/ItemMemberGroupItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberGroup/Item/ItemMemberGroupItemController.cs
@@ -29,6 +29,11 @@ public class ItemMemberGroupItemController : MemberGroupItemControllerBase
         CancellationToken cancellationToken,
         [FromQuery(Name = "id")] HashSet<Guid> ids)
     {
+        if (ids.Count is 0)
+        {
+            return Ok(Enumerable.Empty<MemberGroupItemResponseModel>());
+        }
+
         IEnumerable<IEntitySlim> memberGroups = _entityService.GetAll(UmbracoObjectTypes.MemberGroup, ids.ToArray());
         List<MemberGroupItemResponseModel> responseModel = _mapper.MapEnumerable<IEntitySlim, MemberGroupItemResponseModel>(memberGroups);
         return Ok(responseModel);

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Item/ItemMemberTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Item/ItemMemberTypeItemController.cs
@@ -27,6 +27,11 @@ public class ItemMemberTypeItemController : MemberTypeItemControllerBase
         CancellationToken cancellationToken,
         [FromQuery(Name = "id")] HashSet<Guid> ids)
     {
+        if (ids.Count is 0)
+        {
+            return Ok(Enumerable.Empty<MemberTypeItemResponseModel>());
+        }
+
         IEnumerable<IMemberType> memberTypes = _memberTypeService.GetAll(ids);
         List<MemberTypeItemResponseModel> responseModels = _mapper.MapEnumerable<IMemberType, MemberTypeItemResponseModel>(memberTypes);
         return Ok(responseModels);

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Item/ItemPartialViewItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Item/ItemPartialViewItemController.cs
@@ -22,6 +22,11 @@ public class ItemPartialViewItemController : PartialViewItemControllerBase
         CancellationToken cancellationToken,
         [FromQuery(Name = "path")] HashSet<string> paths)
     {
+        if (paths.Count is 0)
+        {
+            return Ok(Enumerable.Empty<PartialViewItemResponseModel>());
+        }
+
         paths = paths.Select(path => path.VirtualPathToSystemPath()).ToHashSet();
         IEnumerable<PartialViewItemResponseModel> responseModels = _fileItemPresentationFactory.CreatePartialViewItemResponseModels(paths);
         return await Task.FromResult(Ok(responseModels));

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Item/ItemRelationTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Item/ItemRelationTypeItemController.cs
@@ -27,6 +27,11 @@ public class ItemRelationTypeItemController : RelationTypeItemControllerBase
         CancellationToken cancellationToken,
         [FromQuery(Name = "id")] HashSet<Guid> ids)
     {
+        if (ids.Count is 0)
+        {
+            return Ok(Enumerable.Empty<RelationTypeItemResponseModel>());
+        }
+
         // relation service does not allow fetching a collection of relation types by their ids; instead it relies
         // heavily on caching, which means this is as fast as it gets - even if it looks less than performant
         IRelationType[] relationTypes = _relationService

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/Item/ItemScriptItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/Item/ItemScriptItemController.cs
@@ -22,6 +22,11 @@ public class ItemScriptItemController : ScriptItemControllerBase
         CancellationToken cancellationToken,
         [FromQuery(Name = "path")] HashSet<string> paths)
     {
+        if (paths.Count is 0)
+        {
+            return Ok(Enumerable.Empty<ScriptItemResponseModel>());
+        }
+
         paths = paths.Select(path => path.VirtualPathToSystemPath()).ToHashSet();
         IEnumerable<ScriptItemResponseModel> responseModels = _fileItemPresentationFactory.CreateScriptItemResponseModels(paths);
         return await Task.FromResult(Ok(responseModels));

--- a/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Item/ItemStaticFileItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Item/ItemStaticFileItemController.cs
@@ -22,6 +22,11 @@ public class ItemStaticFileItemController : StaticFileItemControllerBase
         CancellationToken cancellationToken,
         [FromQuery(Name = "path")] HashSet<string> paths)
     {
+        if (paths.Count is 0)
+        {
+            return Ok(Enumerable.Empty<StaticFileItemResponseModel>());
+        }
+
         paths = paths.Select(path => path.VirtualPathToSystemPath()).ToHashSet();
         IEnumerable<StaticFileItemResponseModel> responseModels = _fileItemPresentationFactory.CreateStaticFileItemResponseModels(paths);
         return await Task.FromResult(Ok(responseModels));

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Item/ItemStylesheetItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Item/ItemStylesheetItemController.cs
@@ -22,6 +22,11 @@ public class ItemStylesheetItemController : StylesheetItemControllerBase
         CancellationToken cancellationToken,
         [FromQuery(Name = "path")] HashSet<string> paths)
     {
+        if (paths.Count is 0)
+        {
+            return Ok(Enumerable.Empty<StylesheetItemResponseModel>());
+        }
+
         paths = paths.Select(path => path.VirtualPathToSystemPath()).ToHashSet();
         IEnumerable<StylesheetItemResponseModel> responseModels = _fileItemPresentationFactory.CreateStylesheetItemResponseModels(paths);
         return await Task.FromResult(Ok(responseModels));

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Item/ItemTemplateItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Item/ItemTemplateItemController.cs
@@ -27,6 +27,11 @@ public class ItemTemplateItemController : TemplateItemControllerBase
         CancellationToken cancellationToken,
         [FromQuery(Name = "id")] HashSet<Guid> ids)
     {
+        if (ids.Count is 0)
+        {
+            return Ok(Enumerable.Empty<TemplateItemResponseModel>());
+        }
+
         // This is far from ideal, that we pick out the entire model, however, we must do this to get the alias.
         // This is (for one) needed for when specifying master template, since alias + .cshtml
         IEnumerable<ITemplate> templates = await _templateService.GetAllAsync(ids.ToArray());

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/Item/ItemUserItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/Item/ItemUserItemController.cs
@@ -25,6 +25,11 @@ public class ItemUserItemController : UserItemControllerBase
     [ProducesResponseType(typeof(IEnumerable<UserItemResponseModel>), StatusCodes.Status200OK)]
     public async Task<IActionResult> Item(CancellationToken cancellationToken, [FromQuery(Name = "id")] HashSet<Guid> ids)
     {
+        if (ids.Count is 0)
+        {
+            return Ok(Enumerable.Empty<UserItemResponseModel>());
+        }
+
         IEnumerable<IUser> users = await _userService.GetAsync(ids.ToArray());
         List<UserItemResponseModel> responseModels = _mapper.MapEnumerable<IUser, UserItemResponseModel>(users);
         return Ok(responseModels);

--- a/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/Item/ItemUserGroupItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/Item/ItemUserGroupItemController.cs
@@ -27,6 +27,11 @@ public class ItemUserGroupItemController : UserGroupItemControllerBase
         CancellationToken cancellationToken,
         [FromQuery(Name = "id")] HashSet<Guid> ids)
     {
+        if (ids.Count is 0)
+        {
+            return Ok(Enumerable.Empty<UserGroupItemResponseModel>());
+        }
+
         IEnumerable<IUserGroup> userGroups = await _userGroupService.GetAsync(ids);
         List<UserGroupItemResponseModel> responseModels = _mapper.MapEnumerable<IUserGroup, UserGroupItemResponseModel>(userGroups);
         return Ok(responseModels);

--- a/src/Umbraco.Cms.Api.Management/Controllers/Webhook/Item/ItemsWebhookEntityController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Webhook/Item/ItemsWebhookEntityController.cs
@@ -27,6 +27,11 @@ public class ItemsWebhookEntityController : WebhookEntityControllerBase
         CancellationToken cancellationToken,
         [FromQuery(Name = "ids")] HashSet<Guid> ids)
     {
+        if (ids.Count is 0)
+        {
+            return Ok(Enumerable.Empty<WebhookItemResponseModel>());
+        }
+
         IEnumerable<IWebhook?> webhooks = await _webhookService.GetMultipleAsync(ids);
         List<WebhookItemResponseModel> entityResponseModels = _mapper.MapEnumerable<IWebhook?, WebhookItemResponseModel>(webhooks);
         return Ok(entityResponseModels);


### PR DESCRIPTION
# Notes
This pr builds on https://github.com/umbraco/Umbraco-CMS/pull/16047, where we have started to return 0 items, on the `items` endpoint, if the ids / paths are 0.
- For consistency, I've added the count check to ALL the endpoints, although it isn't always neccesary.
- Lets take `ItemRelationTypeItemController` as an example, this will get out ALL the relation types, and then filter by ids, which will end up still return 0 items, so the behavior is the same. We do however save on performance, as we don't need to make a db/cache call to get out all the relation types

# How to test
- Test the 19 different endpoints, and assert when you send 0 ids/paths, you do not get any items