### PR TITLE
Fix RTEs stylesheet loading error

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Tree/StaticFileTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Tree/StaticFileTreeControllerBase.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Cms.Api.Management.Controllers.StaticFile.Tree;
 [ApiExplorerSettings(GroupName = "Static File")]
 public class StaticFileTreeControllerBase : FileSystemTreeControllerBase
 {
-    private static readonly string[] _allowedRootFolders = { "App_Plugins", "wwwroot" };
+    private static readonly string[] _allowedRootFolders = { $"{Path.DirectorySeparatorChar}App_Plugins", $"{Path.DirectorySeparatorChar}wwwroot" };
 
     public StaticFileTreeControllerBase(IPhysicalFileSystem physicalFileSystem)
         => FileSystem = physicalFileSystem;
@@ -35,7 +35,7 @@ public class StaticFileTreeControllerBase : FileSystemTreeControllerBase
             ? base.GetAncestorModels(path, includeSelf)
             : Array.Empty<FileSystemTreeItemPresentationModel>();
 
-    private bool IsTreeRootPath(string path) => string.IsNullOrWhiteSpace(path);
+    private bool IsTreeRootPath(string path) => path == Path.DirectorySeparatorChar.ToString();
 
     private bool IsAllowedPath(string path) => _allowedRootFolders.Contains(path) || _allowedRootFolders.Any(folder => path.StartsWith($"{folder}{Path.DirectorySeparatorChar}"));
 }

--- a/src/Umbraco.Cms.Api.Management/Extensions/StringPathExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/Extensions/StringPathExtensions.cs
@@ -6,5 +6,5 @@ internal static class StringPathExtensions
 {
     public static string SystemPathToVirtualPath(this string systemPath) => systemPath.Replace('\\', '/').TrimStart('~').EnsureStartsWith('/');
 
-    public static string VirtualPathToSystemPath(this string virtualPath) => virtualPath.TrimStart('/').Replace('/', Path.DirectorySeparatorChar);
+    public static string VirtualPathToSystemPath(this string virtualPath) => virtualPath.Replace('/', Path.DirectorySeparatorChar).EnsureStartsWith(Path.DirectorySeparatorChar);
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The Management API fails miserable at retrieving stylesheets for an RTE.

As it happens, our file system trees are not acting correctly. This PR fixes it.

### Testing this PR

1. An RTE with one or more stylesheets configured should _not_ fail in loading said stylesheets.
2. The "static files" API endpoints should still work (allowing access to "/App_Plugins" and "/wwwroot").