### PR TITLE
Fix data parsing error for dropdown and checkbox list

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/MultipleValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultipleValueEditor.cs
@@ -30,25 +30,6 @@ public class MultipleValueEditor : DataValueEditor
         _jsonSerializer = jsonSerializer;
 
     /// <summary>
-    ///     Override so that we can return an array to the editor for multi-select values
-    /// </summary>
-    /// <param name="property"></param>
-    /// <param name="culture"></param>
-    /// <param name="segment"></param>
-    /// <returns></returns>
-    public override object ToEditor(IProperty property, string? culture = null, string? segment = null)
-    {
-        var json = base.ToEditor(property, culture, segment)?.ToString();
-        string[]? result = null;
-        if (json is not null)
-        {
-            result = _jsonSerializer.Deserialize<string[]>(json);
-        }
-
-        return result ?? Array.Empty<string>();
-    }
-
-    /// <summary>
     ///     When multiple values are selected a json array will be posted back so we need to format for storage in
     ///     the database which is a comma separated string value
     /// </summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/16080

### Description

See linked issue for details.

**Note:** The issue does _not_ affect ratio button list as it is mentioned in the linked issue.

### Testing this PR

It should be possible to edit and reload documents with checkbox list and dropdown (single and multiple configurations).