### PR TITLE
Cleaned up V13 related and obsoleted system directory constants

### DIFF
--- a/src/Umbraco.Core/Constants-SystemDirectories.cs
+++ b/src/Umbraco.Core/Constants-SystemDirectories.cs
@@ -37,15 +37,11 @@ public static partial class Constants
 
         public const string TempFileUploads = TempData + "/FileUploads";
 
-        public const string TempImageUploads = TempFileUploads + "/rte";
-
         public const string Install = "~/install";
 
         public const string AppPlugins = "/App_Plugins";
 
         public const string BackOfficePath = "/umbraco/backoffice";
-
-        public const string PluginIcons = "/backoffice/icons";
 
         public const string MvcViews = "~/Views";
 
@@ -56,14 +52,5 @@ public static partial class Constants
         public const string CreatedPackages = Data + "/CreatedPackages";
 
         public const string Preview = Data + "/preview";
-
-        /// <summary>
-        ///     The default folder where Umbraco log files are stored
-        /// </summary>
-        [Obsolete("Use LoggingSettings.GetLoggingDirectory() instead, will be removed in Umbraco 13.")]
-        public const string LogFiles = Umbraco + "/Logs";
-
-        [Obsolete("Use PluginIcons instead")]
-        public static string AppPluginIcons => "/Backoffice/Icons";
     }
 }

--- a/src/Umbraco.Core/Constants-SystemDirectories.cs
+++ b/src/Umbraco.Core/Constants-SystemDirectories.cs
@@ -52,5 +52,11 @@ public static partial class Constants
         public const string CreatedPackages = Data + "/CreatedPackages";
 
         public const string Preview = Data + "/preview";
+
+        /// <summary>
+        ///     The default folder where Umbraco log files are stored
+        /// </summary>
+        [Obsolete("Use LoggingSettings.GetLoggingDirectory() instead, will be removed in Umbraco 13.")]
+        public const string LogFiles = Umbraco + "/Logs";
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

`Constants.SystemDirectories` contains a fair few constants that are related to the V13 implementation of the backoffice. This PR cleans up those constants.