### PR TITLE
Make public access endpoints work correctly

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/CreatePublicAccessDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/CreatePublicAccessDocumentController.cs
@@ -57,7 +57,7 @@ public class CreatePublicAccessDocumentController : DocumentControllerBase
         Attempt<PublicAccessEntry?, PublicAccessOperationStatus> saveAttempt = await _publicAccessService.CreateAsync(publicAccessEntrySlim);
 
         return saveAttempt.Success
-            ? CreatedAtId<GetPublicAccessDocumentController>(controller => nameof(controller.GetPublicAccess), saveAttempt.Result!.Key)
+            ? CreatedAtId<GetPublicAccessDocumentController>(controller => nameof(controller.GetPublicAccess), id)
             : PublicAccessOperationStatusResult(saveAttempt.Status);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/DocumentControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/DocumentControllerBase.cs
@@ -162,7 +162,7 @@ public abstract class DocumentControllerBase : ContentControllerBase
                 .WithTitle("Ambiguous Rule")
                 .WithDetail("The specified rule is ambiguous, because both member groups and member names were given.")
                 .Build()),
-            PublicAccessOperationStatus.EntryNotFound => BadRequest(problemDetailsBuilder
+            PublicAccessOperationStatus.EntryNotFound => NotFound(problemDetailsBuilder
                 .WithTitle("Entry not found")
                 .WithDetail("The specified entry was not found.")
                 .Build()),

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/GetPublicAccessDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/GetPublicAccessDocumentController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
-using Umbraco.Cms.Api.Management.Security.Authorization.Content;
 using Umbraco.Cms.Api.Management.ViewModels.PublicAccess;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Actions;
@@ -35,6 +34,7 @@ public class GetPublicAccessDocumentController : DocumentControllerBase
 
     [MapToApiVersion("1.0")]
     [HttpGet("{id:guid}/public-access")]
+    [ProducesResponseType(typeof(PublicAccessResponseModel), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetPublicAccess(CancellationToken cancellationToken, Guid id)
     {
@@ -51,14 +51,9 @@ public class GetPublicAccessDocumentController : DocumentControllerBase
         Attempt<PublicAccessEntry?, PublicAccessOperationStatus> accessAttempt =
             await _publicAccessService.GetEntryByContentKeyAsync(id);
 
-        if (accessAttempt.Success is false)
+        if (accessAttempt.Success is false || accessAttempt.Result is null)
         {
             return PublicAccessOperationStatusResult(accessAttempt.Status);
-        }
-
-        if (accessAttempt.Result is null)
-        {
-            return Ok();
         }
 
         Attempt<PublicAccessResponseModel?, PublicAccessOperationStatus> responseModelAttempt =

--- a/src/Umbraco.Cms.Api.Management/Factories/IMemberPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IMemberPresentationFactory.cs
@@ -1,7 +1,5 @@
-﻿using Umbraco.Cms.Api.Management.ViewModels.Content;
-using Umbraco.Cms.Api.Management.ViewModels.Member;
+﻿using Umbraco.Cms.Api.Management.ViewModels.Member;
 using Umbraco.Cms.Api.Management.ViewModels.Member.Item;
-using Umbraco.Cms.Api.Management.ViewModels.MemberType;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Models.Membership;
@@ -16,7 +14,5 @@ public interface IMemberPresentationFactory
 
     MemberItemResponseModel CreateItemResponseModel(IMemberEntitySlim entity);
 
-    IEnumerable<VariantItemResponseModel> CreateVariantsItemResponseModels(IMemberEntitySlim entity);
-
-    MemberTypeReferenceResponseModel CreateMemberTypeReferenceResponseModel(IMemberEntitySlim entity);
+    MemberItemResponseModel CreateItemResponseModel(IMember entity);
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/MemberPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/MemberPresentationFactory.cs
@@ -60,20 +60,21 @@ internal sealed class MemberPresentationFactory : IMemberPresentationFactory
     }
 
     public MemberItemResponseModel CreateItemResponseModel(IMemberEntitySlim entity)
-    {
-        var responseModel = new MemberItemResponseModel
+        => CreateItemResponseModel<IMemberEntitySlim>(entity);
+
+    public MemberItemResponseModel CreateItemResponseModel(IMember entity)
+        => CreateItemResponseModel<IMember>(entity);
+
+    private MemberItemResponseModel CreateItemResponseModel<T>(T entity)
+        where T : ITreeEntity
+        => new MemberItemResponseModel
         {
             Id = entity.Key,
+            MemberType = _umbracoMapper.Map<MemberTypeReferenceResponseModel>(entity)!,
+            Variants = CreateVariantsItemResponseModels(entity)
         };
 
-        responseModel.MemberType = _umbracoMapper.Map<MemberTypeReferenceResponseModel>(entity)!;
-
-        responseModel.Variants = CreateVariantsItemResponseModels(entity);
-
-        return responseModel;
-    }
-
-    public IEnumerable<VariantItemResponseModel> CreateVariantsItemResponseModels(IMemberEntitySlim entity)
+    private static IEnumerable<VariantItemResponseModel> CreateVariantsItemResponseModels(ITreeEntity entity)
         => new[]
         {
             new VariantItemResponseModel
@@ -82,9 +83,6 @@ internal sealed class MemberPresentationFactory : IMemberPresentationFactory
                 Culture = null
             }
         };
-
-    public MemberTypeReferenceResponseModel CreateMemberTypeReferenceResponseModel(IMemberEntitySlim entity)
-        => _umbracoMapper.Map<MemberTypeReferenceResponseModel>(entity)!;
 
     private async Task<MemberResponseModel> RemoveSensitiveDataAsync(IMember member, MemberResponseModel responseModel)
     {

--- a/src/Umbraco.Cms.Api.Management/Mapping/MemberType/MemberTypeMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/MemberType/MemberTypeMapDefinition.cs
@@ -14,7 +14,7 @@ public class MemberTypeMapDefinition : ContentTypeMapDefinition<IMemberType, Mem
         mapper.Define<IMemberType, MemberTypeResponseModel>((_, _) => new MemberTypeResponseModel(), Map);
         mapper.Define<IMemberType, MemberTypeReferenceResponseModel>((_, _) => new MemberTypeReferenceResponseModel(), Map);
         mapper.Define<IMemberEntitySlim, MemberTypeReferenceResponseModel>((_, _) => new MemberTypeReferenceResponseModel(), Map);
-        mapper.Define<IContentEntitySlim, MemberTypeReferenceResponseModel>((_, _) => new MemberTypeReferenceResponseModel(), Map);
+        mapper.Define<IMember, MemberTypeReferenceResponseModel>((_, _) => new MemberTypeReferenceResponseModel(), Map);
         mapper.Define<ISimpleContentType, MemberTypeReferenceResponseModel>((_, _) => new MemberTypeReferenceResponseModel(), Map);
     }
 
@@ -49,16 +49,18 @@ public class MemberTypeMapDefinition : ContentTypeMapDefinition<IMemberType, Mem
         target.Icon = source.Icon ?? string.Empty;
     }
 
+    // Umbraco.Code.MapAll -Collection
     private void Map(IMemberEntitySlim source, MemberTypeReferenceResponseModel target, MapperContext context)
     {
         target.Id = source.ContentTypeKey;
         target.Icon = source.ContentTypeIcon ?? string.Empty;
     }
 
-    private void Map(IContentEntitySlim source, MemberTypeReferenceResponseModel target, MapperContext context)
+    // Umbraco.Code.MapAll -Collection
+    private void Map(IMember source, MemberTypeReferenceResponseModel target, MapperContext context)
     {
-        target.Id = source.ContentTypeKey;
-        target.Icon = source.ContentTypeIcon ?? string.Empty;
+        target.Id = source.ContentType.Key;
+        target.Icon = source.ContentType.Icon ?? string.Empty;
     }
 
     // Umbraco.Code.MapAll -Collection

--- a/src/Umbraco.Core/Services/PublicAccessService.cs
+++ b/src/Umbraco.Core/Services/PublicAccessService.cs
@@ -375,7 +375,7 @@ internal class PublicAccessService : RepositoryService, IPublicAccessService
 
         if (entry is null)
         {
-            return Task.FromResult(Attempt.SucceedWithStatus<PublicAccessEntry?, PublicAccessOperationStatus>(PublicAccessOperationStatus.Success, null));
+            return Task.FromResult(Attempt.SucceedWithStatus<PublicAccessEntry?, PublicAccessOperationStatus>(PublicAccessOperationStatus.EntryNotFound, null));
         }
 
         return Task.FromResult(Attempt.SucceedWithStatus<PublicAccessEntry?, PublicAccessOperationStatus>(PublicAccessOperationStatus.Success, entry));


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

There are a few issues with the "get" and "create" endpoints for public access.

#### Create

1. Upon successful creation of a public access rule, the endpoint yields the wrong "created at" location. The correct location to retrieve the created rule is `/document/[document key]/public-access`.

#### GET
1. The HTTP 200 OK response is not documented towards OpenAPI.
2. When queried for a non-existing public access rule, the endpoint should return HTTP 404 NotFound.
3. When queried for a public access rule with one or more explicit members, the operation fails because the umbraco mapper does not know how to map `IMember` to `MemberItemResponseModel`.
4. Fixing the previous problem uncovers that public access rules with explicit members yields a `MemberItemResponseModel` that contains _all_ existing member groups instead of none.

### Testing this PR

Use Swagger to ensure that the public access endpoints work as expected.