### PR TITLE
RTE media folder config is stored as a GUID in V14

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/RichTextConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/RichTextConfiguration.cs
@@ -9,7 +9,7 @@ public class RichTextConfiguration : IIgnoreUserStartNodesConfig
     public RichTextBlockConfiguration[]? Blocks { get; set; } = null!;
 
     [ConfigurationField("mediaParentId")]
-    public GuidUdi? MediaParentId { get; set; }
+    public Guid? MediaParentId { get; set; }
 
     [ConfigurationField(Constants.DataTypes.ReservedPreValueKeys.IgnoreUserStartNodes)]
     public bool IgnoreUserStartNodes { get; set; }

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
@@ -214,8 +214,7 @@ public class RichTextPropertyEditor : DataEditor
                           Constants.Security.SuperUserKey;
 
             var config = editorValue.DataTypeConfiguration as RichTextConfiguration;
-            GuidUdi? mediaParent = config?.MediaParentId;
-            Guid mediaParentId = mediaParent == null ? Guid.Empty : mediaParent.Guid;
+            Guid mediaParentId = config?.MediaParentId ?? Guid.Empty;
 
             if (string.IsNullOrWhiteSpace(richTextEditorValue.Markup))
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #16083

### Description

The RTE config for default media upload folder has been migrated from an `Udi` in V13 to a `Guid` in V14 ([see migration here](https://github.com/umbraco/Umbraco-CMS/blob/v14/dev/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateDataTypeConfigurations.cs#L495)).

Unfortunately the implementation of the strongly typed RTE config `RichTextConfiguration` has not followed suit, which causes the config parsing error reported in the linked issue.

### Testing this PR

See the linked issue for details.