### PR TITLE
V14: Cache user by id

### DIFF
--- a/src/Umbraco.Core/Cache/DistributedCacheExtensions.cs
+++ b/src/Umbraco.Core/Cache/DistributedCacheExtensions.cs
@@ -22,22 +22,18 @@ public static class DistributedCacheExtensions
 
     #region UserCacheRefresher
 
-    public static void RemoveUserCache(this DistributedCache dc, int userId)
-        => dc.Remove(UserCacheRefresher.UniqueId, userId);
-
     public static void RemoveUserCache(this DistributedCache dc, IEnumerable<IUser> users)
         => dc.Remove(UserCacheRefresher.UniqueId, users.Select(x => x.Id).Distinct().ToArray());
 
-    public static void RefreshUserCache(this DistributedCache dc, int userId)
-        => dc.Refresh(UserCacheRefresher.UniqueId, userId);
-
     public static void RefreshUserCache(this DistributedCache dc, IEnumerable<IUser> users)
     {
-        foreach (IUser user in users)
+        IEnumerable<UserCacheRefresher.JsonPayload> payloads = users.Select(x => new UserCacheRefresher.JsonPayload()
         {
-            dc.Refresh(UserCacheRefresher.UniqueId, user.Key);
-            dc.Refresh(UserCacheRefresher.UniqueId, user.Id);
-        }
+            Id = x.Id,
+            Key = x.Key,
+        });
+
+        dc.RefreshByPayload(UserCacheRefresher.UniqueId, payloads);
     }
 
     public static void RefreshAllUserCache(this DistributedCache dc)

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/UserCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/UserCacheRefresher.cs
@@ -2,27 +2,29 @@ using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Serialization;
 
 namespace Umbraco.Cms.Core.Cache;
 
-public sealed class UserCacheRefresher : CacheRefresherBase<UserCacheRefresherNotification>
+public sealed class UserCacheRefresher : PayloadCacheRefresherBase<UserCacheRefresherNotification, UserCacheRefresher.JsonPayload>
 {
-    #region Define
-
-    public static readonly Guid UniqueId = Guid.Parse("E057AF6D-2EE6-41F4-8045-3694010F0AA6");
-
-    public UserCacheRefresher(AppCaches appCaches, IEventAggregator eventAggregator, ICacheRefresherNotificationFactory factory)
-        : base(appCaches, eventAggregator, factory)
+    public UserCacheRefresher(AppCaches appCaches, IJsonSerializer serializer, IEventAggregator eventAggregator, ICacheRefresherNotificationFactory factory)
+        : base(appCaches, serializer, eventAggregator, factory)
     {
     }
+
+    public static readonly Guid UniqueId = Guid.Parse("E057AF6D-2EE6-41F4-8045-3694010F0AA6");
 
     public override Guid RefresherUniqueId => UniqueId;
 
     public override string Name => "User Cache Refresher";
 
-    #endregion
+    public record JsonPayload
+    {
+        public int Id { get; init; }
 
-    #region Refresher
+        public Guid Key { get; init; }
+    }
 
     public override void RefreshAll()
     {
@@ -30,32 +32,28 @@ public sealed class UserCacheRefresher : CacheRefresherBase<UserCacheRefresherNo
         base.RefreshAll();
     }
 
-    public override void Refresh(Guid id)
+    public override void Refresh(JsonPayload[] payloads)
     {
-        Attempt<IAppPolicyCache?> userCache = AppCaches.IsolatedCaches.Get<IUser>();
-        if (userCache.Success)
+        ClearCache(payloads);
+        base.Refresh(payloads);
+    }
+
+    private void ClearCache(params JsonPayload[] payloads)
+    {
+        foreach (JsonPayload p in payloads)
         {
-            userCache.Result?.Clear(RepositoryCacheKeys.GetKey<IUser, Guid>(id));
-            userCache.Result?.ClearByKey(CacheKeys.UserContentStartNodePathsPrefix + id);
-            userCache.Result?.ClearByKey(CacheKeys.UserMediaStartNodePathsPrefix + id);
-            userCache.Result?.ClearByKey(CacheKeys.UserAllContentStartNodesPrefix + id);
-            userCache.Result?.ClearByKey(CacheKeys.UserAllMediaStartNodesPrefix + id);
+            Attempt<IAppPolicyCache?> userCache = AppCaches.IsolatedCaches.Get<IUser>();
+            if (!userCache.Success)
+            {
+                continue;
+            }
+
+            userCache.Result?.Clear(RepositoryCacheKeys.GetKey<IUser, Guid>(p.Key));
+            userCache.Result?.Clear(RepositoryCacheKeys.GetKey<IUser, int>(p.Id));
+            userCache.Result?.ClearByKey(CacheKeys.UserContentStartNodePathsPrefix + p.Key);
+            userCache.Result?.ClearByKey(CacheKeys.UserMediaStartNodePathsPrefix + p.Key);
+            userCache.Result?.ClearByKey(CacheKeys.UserAllContentStartNodesPrefix + p.Key);
+            userCache.Result?.ClearByKey(CacheKeys.UserAllMediaStartNodesPrefix + p.Key);
         }
-
-        base.Refresh(id);
     }
-
-    public override void Refresh(int id)
-    {
-        Remove(id);
-        base.Refresh(id);
-    }
-
-    public override void Remove(int id)
-    {
-        AppCaches.RuntimeCache.Clear(RepositoryCacheKeys.GetKey<IUser, int>(id));
-        base.Remove(id);
-    }
-
-    #endregion
 }

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/UserCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/UserCacheRefresher.cs
@@ -53,8 +53,7 @@ public sealed class UserCacheRefresher : CacheRefresherBase<UserCacheRefresherNo
 
     public override void Remove(int id)
     {
-        string cacheKey = $"uRepo_{typeof(IUser).Name}_" + id;
-        AppCaches.RuntimeCache.Clear(cacheKey);
+        AppCaches.RuntimeCache.Clear(RepositoryCacheKeys.GetKey<IUser, int>(id));
         base.Remove(id);
     }
 

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/UserCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/UserCacheRefresher.cs
@@ -45,5 +45,18 @@ public sealed class UserCacheRefresher : CacheRefresherBase<UserCacheRefresherNo
         base.Refresh(id);
     }
 
+    public override void Refresh(int id)
+    {
+        Remove(id);
+        base.Refresh(id);
+    }
+
+    public override void Remove(int id)
+    {
+        string cacheKey = $"uRepo_{typeof(IUser).Name}_" + id;
+        AppCaches.RuntimeCache.Clear(cacheKey);
+        base.Remove(id);
+    }
+
     #endregion
 }

--- a/src/Umbraco.Core/Persistence/Repositories/IUserRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IUserRepository.cs
@@ -21,6 +21,15 @@ public interface IUserRepository : IReadWriteQueryRepository<Guid, IUser>
     bool ExistsByUserName(string username);
 
     /// <summary>
+    ///     Returns a user by id
+    /// </summary>
+    /// <param name="id"></param>
+    /// <returns>
+    ///     A cached <see cref="IUser" /> instance
+    /// </returns>
+    IUser? Get(int id);
+
+    /// <summary>
     ///     Checks if a user with the login exists
     /// </summary>
     /// <param name="login"></param>

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
@@ -56,6 +56,7 @@ internal class UserRepository : EntityRepositoryBase<Guid, IUser>, IUserReposito
     /// <param name="jsonSerializer">The JSON serializer.</param>
     /// <param name="runtimeState">State of the runtime.</param>
     /// <param name="permissionMappers">The permission mappers.</param>
+    /// <param name="globalCache">The app policy cache.</param>
     /// <exception cref="System.ArgumentNullException">
     ///     mapperCollection
     ///     or
@@ -72,7 +73,8 @@ internal class UserRepository : EntityRepositoryBase<Guid, IUser>, IUserReposito
         IOptions<UserPasswordConfigurationSettings> passwordConfiguration,
         IJsonSerializer jsonSerializer,
         IRuntimeState runtimeState,
-        IEnumerable<IPermissionMapper> permissionMappers, IAppPolicyCache globalCache)
+        IEnumerable<IPermissionMapper> permissionMappers,
+        IAppPolicyCache globalCache)
         : base(scopeAccessor, appCaches, logger)
     {
         _scopeAccessor = scopeAccessor;

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
@@ -931,7 +931,7 @@ SELECT 4 AS [Key], COUNT(id) AS [Value] FROM umbracoUser WHERE userDisabled = 0 
     // TODO: Remove this once CreatorId gets migrated to a key.
     public IUser? Get(int id)
     {
-        string cacheKey = $"uRepo_{typeof(IUser).Name}_" + id;
+        string cacheKey = RepositoryCacheKeys.GetKey<IUser, int>(id);
         IUser? cachedUser = IsolatedCache.GetCacheItem<IUser>(cacheKey);
         if (cachedUser is not null)
         {

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
@@ -943,7 +943,10 @@ SELECT 4 AS [Key], COUNT(id) AS [Value] FROM umbracoUser WHERE userDisabled = 0 
         }
     }
 
-    // TODO: Remove this once only get user by key.
+    // This is a bit hacky, as we're stealing some of the cache implementation, so we also can cache user by id
+    // We do however need this, as all content have creatorId (as int) and thus when we index content
+    // this gets called for each content item, and we need to cache the user to avoid a lot of db calls
+    // TODO: Remove this once CreatorId gets migrated to a key.
     public IUser? Get(int id)
     {
         string cacheKey = $"uRepo_{typeof(IUser).Name}_" + id;

--- a/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
@@ -249,8 +249,7 @@ public class BackOfficeUserStore :
 
         try
         {
-            IQuery<IUser> query = _scopeProvider.CreateQuery<IUser>().Where(x => x.Id == id);
-            return Task.FromResult(_userRepository.Get(query).FirstOrDefault());
+            return Task.FromResult(_userRepository.Get(id));
         }
         catch (DbException)
         {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/UserRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/UserRepositoryTest.cs
@@ -40,6 +40,8 @@ public class UserRepositoryTest : UmbracoIntegrationTest
     private IMediaRepository MediaRepository => GetRequiredService<IMediaRepository>();
     private IEnumerable<IPermissionMapper> PermissionMappers => GetRequiredService<IEnumerable<IPermissionMapper>>();
 
+    private IAppPolicyCache AppPolicyCache => GetRequiredService<IAppPolicyCache>();
+
     private UserRepository CreateRepository(ICoreScopeProvider provider)
     {
         var accessor = (IScopeAccessor)provider;
@@ -54,7 +56,8 @@ public class UserRepositoryTest : UmbracoIntegrationTest
             Options.Create(new UserPasswordConfigurationSettings()),
             new SystemTextJsonSerializer(),
             mockRuntimeState.Object,
-            PermissionMappers);
+            PermissionMappers,
+            AppPolicyCache);
         return repository;
     }
 
@@ -161,7 +164,8 @@ public class UserRepositoryTest : UmbracoIntegrationTest
                 Options.Create(new UserPasswordConfigurationSettings()),
                 new SystemTextJsonSerializer(),
                 mockRuntimeState.Object,
-                PermissionMappers);
+                PermissionMappers,
+                AppPolicyCache);
 
             repository2.Delete(user);
 


### PR DESCRIPTION
# Notes
- We need to cache user by id aswell, because all content have creatorId (as int) and thus when we index content, user by id gets called for each content item, therefore we need to cache the user to avoid a lot of db calls.

# How to test
- Put a breakpoint in the `UserRepository.Get(int id)` method
- Assert that first time a user gets retrieved, the `GetCacheItem` should return null (not in the cache
- Assert that the second time the user gets retrieved `GetCacheItem` should now have a user.
- Update the users name (or something else, name is easiest)
- Get the user again, and assert that the `GetCacheItem` returns null (Updated user should NOT be in the cache)
- Get the user once last time, and assert that it is indeed cached again, with the updated name