### PR TITLE
[v14] backoffice user login providers endpoint

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/User/Current/ListExternalLoginProvidersCurrentUserController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/Current/ListExternalLoginProvidersCurrentUserController.cs
@@ -1,0 +1,41 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Services;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Api.Management.Controllers.User.Current;
+
+[ApiVersion("1.0")]
+public class ListExternalLoginProvidersCurrentUserController : CurrentUserControllerBase
+{
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+    private readonly IBackOfficeExternalLoginService _backOfficeExternalLoginService;
+
+    public ListExternalLoginProvidersCurrentUserController(
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
+        IBackOfficeExternalLoginService backOfficeExternalLoginService)
+    {
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+        _backOfficeExternalLoginService = backOfficeExternalLoginService;
+    }
+
+    [MapToApiVersion("1.0")]
+    [HttpGet("login-providers")]
+    [ProducesResponseType(typeof(IEnumerable<UserExternalLoginProviderModel>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> ListTwoFactorProvidersForCurrentUser(CancellationToken cancellationToken)
+    {
+        Guid userKey = CurrentUserKey(_backOfficeSecurityAccessor);
+
+        Attempt<IEnumerable<UserExternalLoginProviderModel>, ExternalLoginOperationStatus> result =
+            await _backOfficeExternalLoginService.ExternalLoginStatusForUser(userKey);
+
+        return result.Success
+            ? Ok(result.Result)
+            : ExternalLoginOperationStatusResult(result.Status);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/Current/ListExternalLoginProvidersCurrentUserController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/Current/ListExternalLoginProvidersCurrentUserController.cs
@@ -2,7 +2,9 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Services;
+using Umbraco.Cms.Api.Management.ViewModels.User.Current;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
@@ -15,13 +17,16 @@ public class ListExternalLoginProvidersCurrentUserController : CurrentUserContro
 {
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
     private readonly IBackOfficeExternalLoginService _backOfficeExternalLoginService;
+    private readonly IUmbracoMapper _mapper;
 
     public ListExternalLoginProvidersCurrentUserController(
         IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
-        IBackOfficeExternalLoginService backOfficeExternalLoginService)
+        IBackOfficeExternalLoginService backOfficeExternalLoginService,
+        IUmbracoMapper mapper)
     {
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
         _backOfficeExternalLoginService = backOfficeExternalLoginService;
+        _mapper = mapper;
     }
 
     [MapToApiVersion("1.0")]
@@ -35,7 +40,8 @@ public class ListExternalLoginProvidersCurrentUserController : CurrentUserContro
             await _backOfficeExternalLoginService.ExternalLoginStatusForUser(userKey);
 
         return result.Success
-            ? Ok(result.Result)
+            ? Ok(_mapper.MapEnumerable<UserExternalLoginProviderModel, UserExternalLoginProviderResponseModel>(
+                result.Result))
             : ExternalLoginOperationStatusResult(result.Status);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/UserOrCurrentUserControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/UserOrCurrentUserControllerBase.cs
@@ -153,4 +153,16 @@ public abstract class UserOrCurrentUserControllerBase : ManagementApiControllerB
                 .WithTitle("Unknown two factor operation status.")
                 .Build()),
         });
+
+    protected IActionResult ExternalLoginOperationStatusResult(ExternalLoginOperationStatus status) =>
+        OperationStatusResult(status, problemDetailsBuilder => status switch
+        {
+            ExternalLoginOperationStatus.UserNotFound => NotFound(problemDetailsBuilder
+                .WithTitle("User not found")
+                .WithDetail("The specified user id was not found.")
+                .Build()),
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
+                .WithTitle("Unknown two factor operation status.")
+                .Build()),
+        });
 }

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/UmbracoBuilder.BackOfficeIdentity.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/UmbracoBuilder.BackOfficeIdentity.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Api.Management.Security;
+using Umbraco.Cms.Api.Management.Services;
 using Umbraco.Cms.Api.Management.Telemetry;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration.Models;
@@ -69,6 +70,8 @@ public static partial class UmbracoBuilderExtensions
 
         // Configure the options specifically for the UmbracoBackOfficeIdentityOptions instance
         services.ConfigureOptions<ConfigureBackOfficeIdentityOptions>();
+
+        services.AddScoped<IBackOfficeExternalLoginService, BackOfficeExternalLoginService>();
 
         return builder;
     }

--- a/src/Umbraco.Cms.Api.Management/Mapping/Users/UsersViewModelsMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Users/UsersViewModelsMapDefinition.cs
@@ -1,5 +1,6 @@
 ﻿using Umbraco.Cms.Api.Management.ViewModels;
 using Umbraco.Cms.Api.Management.ViewModels.User;
+using Umbraco.Cms.Api.Management.ViewModels.User.Current;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Membership;
@@ -14,6 +15,8 @@ public class UsersViewModelsMapDefinition : IMapDefinition
         mapper.Define<PasswordChangedModel, ResetPasswordUserResponseModel>((_, _) => new ResetPasswordUserResponseModel(), Map);
         mapper.Define<UserCreationResult, CreateUserResponseModel>((_, _) => new CreateUserResponseModel { User = new() }, Map);
         mapper.Define<IIdentityUserLogin, LinkedLoginViewModel>((_, _) => new LinkedLoginViewModel { ProviderKey = string.Empty, ProviderName = string.Empty }, Map);
+        mapper.Define<UserExternalLoginProviderModel, UserExternalLoginProviderResponseModel>(
+            (_, _) => new UserExternalLoginProviderResponseModel{ ProviderSchemaName = string.Empty }, Map);
     }
 
     // Umbraco.Code.MapAll
@@ -37,5 +40,13 @@ public class UsersViewModelsMapDefinition : IMapDefinition
     private void Map(PasswordChangedModel source, ResetPasswordUserResponseModel target, MapperContext context)
     {
         target.ResetPassword = source.ResetPassword;
+    }
+
+// Umbraco.Code.MapAll
+    private void Map(UserExternalLoginProviderModel source, UserExternalLoginProviderResponseModel target, MapperContext context)
+    {
+        target.ProviderSchemaName = source.ProviderSchemaName;
+        target.HasManualLinkingEnabled = source.HasManualLinkingEnabled;
+        target.IsLinkedOnUser = source.IsLinkedOnUser;
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Services/BackOfficeExternalLoginService.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/BackOfficeExternalLoginService.cs
@@ -1,0 +1,57 @@
+using Umbraco.Cms.Api.Management.Security;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Api.Management.Services;
+
+public class BackOfficeExternalLoginService : IBackOfficeExternalLoginService
+{
+    private readonly IBackOfficeExternalLoginProviders _backOfficeExternalLoginProviders;
+    private readonly IUserService _userService;
+
+    public BackOfficeExternalLoginService(
+        IBackOfficeExternalLoginProviders backOfficeExternalLoginProviders,
+        IUserService userService)
+    {
+        _backOfficeExternalLoginProviders = backOfficeExternalLoginProviders;
+        _userService = userService;
+    }
+
+    public async Task<Attempt<IEnumerable<UserExternalLoginProviderModel>, ExternalLoginOperationStatus>>
+        ExternalLoginStatusForUser(Guid userid)
+    {
+        IEnumerable<BackOfficeExternaLoginProviderScheme> providers =
+            await _backOfficeExternalLoginProviders.GetBackOfficeProvidersAsync();
+
+        Attempt<ICollection<IIdentityUserLogin>, UserOperationStatus> linkedLoginsAttempt =
+            await _userService.GetLinkedLoginsAsync(userid);
+        if (linkedLoginsAttempt.Success is false)
+        {
+            return Attempt<IEnumerable<UserExternalLoginProviderModel>, ExternalLoginOperationStatus>.Fail(
+                FromUserOperationStatusFailure(linkedLoginsAttempt.Status),
+                Enumerable.Empty<UserExternalLoginProviderModel>());
+        }
+
+        IEnumerable<UserExternalLoginProviderModel> providerStatuses = providers.Select(
+            providerScheme => new UserExternalLoginProviderModel(
+                providerScheme.ExternalLoginProvider.AuthenticationType,
+                linkedLoginsAttempt.Result.Any(linkedLogin =>
+                    linkedLogin.LoginProvider == providerScheme.ExternalLoginProvider.AuthenticationType),
+                providerScheme.ExternalLoginProvider.Options.AutoLinkOptions.AllowManualLinking));
+
+        return Attempt<IEnumerable<UserExternalLoginProviderModel>, ExternalLoginOperationStatus>.Succeed(
+                ExternalLoginOperationStatus.Success, providerStatuses);
+    }
+
+    private ExternalLoginOperationStatus FromUserOperationStatusFailure(UserOperationStatus userOperationStatus)
+    {
+        return userOperationStatus switch
+        {
+            UserOperationStatus.MissingUser => ExternalLoginOperationStatus.UserNotFound,
+            _ => ExternalLoginOperationStatus.Unknown
+        };
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Services/IBackOfficeExternalLoginService.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/IBackOfficeExternalLoginService.cs
@@ -1,0 +1,10 @@
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Api.Management.Services;
+
+public interface IBackOfficeExternalLoginService
+{
+    Task<Attempt<IEnumerable<UserExternalLoginProviderModel>, ExternalLoginOperationStatus>> ExternalLoginStatusForUser(Guid userid);
+}

--- a/src/Umbraco.Cms.Api.Management/Services/IBackOfficeExternalLoginService.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/IBackOfficeExternalLoginService.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services.OperationStatus;
@@ -7,4 +8,5 @@ namespace Umbraco.Cms.Api.Management.Services;
 public interface IBackOfficeExternalLoginService
 {
     Task<Attempt<IEnumerable<UserExternalLoginProviderModel>, ExternalLoginOperationStatus>> ExternalLoginStatusForUser(Guid userid);
+    Task<Attempt<ExternalLoginOperationStatus>> UnLinkLogin(ClaimsPrincipal claimsPrincipal, string loginProvider, string providerKey);
 }

--- a/src/Umbraco.Cms.Api.Management/Services/IBackOfficeExternalLoginService.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/IBackOfficeExternalLoginService.cs
@@ -1,4 +1,6 @@
 using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services.OperationStatus;
@@ -8,5 +10,6 @@ namespace Umbraco.Cms.Api.Management.Services;
 public interface IBackOfficeExternalLoginService
 {
     Task<Attempt<IEnumerable<UserExternalLoginProviderModel>, ExternalLoginOperationStatus>> ExternalLoginStatusForUser(Guid userid);
-    Task<Attempt<ExternalLoginOperationStatus>> UnLinkLogin(ClaimsPrincipal claimsPrincipal, string loginProvider, string providerKey);
+    Task<Attempt<ExternalLoginOperationStatus>> UnLinkLoginAsync(ClaimsPrincipal claimsPrincipal, string loginProvider, string providerKey);
+    Task<Attempt<IEnumerable<IdentityError>, ExternalLoginOperationStatus>> HandleLoginCallbackAsync(HttpContext httpContext);
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/Current/UserExternalLoginProviderResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/Current/UserExternalLoginProviderResponseModel.cs
@@ -1,0 +1,10 @@
+namespace Umbraco.Cms.Api.Management.ViewModels.User.Current;
+
+public class UserExternalLoginProviderResponseModel
+{
+    public required string ProviderSchemaName { get; set; }
+
+    public bool IsLinkedOnUser { get; set; }
+
+    public bool HasManualLinkingEnabled { get; set; }
+}

--- a/src/Umbraco.Core/Models/UserExternalLoginProviderModel.cs
+++ b/src/Umbraco.Core/Models/UserExternalLoginProviderModel.cs
@@ -1,0 +1,19 @@
+using System.Runtime.Serialization;
+
+namespace Umbraco.Cms.Core.Models;
+
+public class UserExternalLoginProviderModel
+{
+    public UserExternalLoginProviderModel(string providerSchemaName, bool isLinkedOnUser, bool hasManualLinkingEnabled)
+    {
+        ProviderSchemaName = providerSchemaName;
+        IsLinkedOnUser = isLinkedOnUser;
+        HasManualLinkingEnabled = hasManualLinkingEnabled;
+    }
+
+    public string ProviderSchemaName { get; }
+
+    public bool IsLinkedOnUser { get; }
+
+    public bool HasManualLinkingEnabled { get; }
+}

--- a/src/Umbraco.Core/Services/OperationStatus/ExternalLoginOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/ExternalLoginOperationStatus.cs
@@ -9,5 +9,8 @@ public enum ExternalLoginOperationStatus
     AuthenticationOptionsNotFound,
     UnlinkingDisabled,
     InvalidProviderKey,
-    AuthenticationSchemeNotFound
+    AuthenticationSchemeNotFound,
+    Unauthorized,
+    ExternalInfoNotFound,
+    IdentityFailure
 }

--- a/src/Umbraco.Core/Services/OperationStatus/ExternalLoginOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/ExternalLoginOperationStatus.cs
@@ -1,0 +1,8 @@
+namespace Umbraco.Cms.Core.Services.OperationStatus;
+
+public enum ExternalLoginOperationStatus
+{
+    Success,
+    UserNotFound,
+    Unknown
+}

--- a/src/Umbraco.Core/Services/OperationStatus/ExternalLoginOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/ExternalLoginOperationStatus.cs
@@ -4,5 +4,10 @@ public enum ExternalLoginOperationStatus
 {
     Success,
     UserNotFound,
-    Unknown
+    Unknown,
+    IdentityNotFound,
+    AuthenticationOptionsNotFound,
+    UnlinkingDisabled,
+    InvalidProviderKey,
+    AuthenticationSchemeNotFound
 }

--- a/src/Umbraco.Web.Common/Helpers/OAuthOptionsHelper.cs
+++ b/src/Umbraco.Web.Common/Helpers/OAuthOptionsHelper.cs
@@ -48,7 +48,7 @@ public class OAuthOptionsHelper
     public T SetUmbracoRedirectWithFilteredParams<T>(T context, string providerFriendlyName, string eventName)
         where T : HandleRequestContext<RemoteAuthenticationOptions>
     {
-        var callbackPath = _securitySettings.Value.AuthorizeCallbackErrorPathName;
+        var callbackPath =_securitySettings.Value.BackOfficeHost + _securitySettings.Value.AuthorizeCallbackErrorPathName;
 
         callbackPath = callbackPath.AppendQueryStringToUrl("flow=external-login")
         .AppendQueryStringToUrl($"provider={providerFriendlyName}")
@@ -75,7 +75,7 @@ public class OAuthOptionsHelper
     /// <returns></returns>
     public RemoteAuthenticationOptions SetUmbracoBasedCallbackPath(RemoteAuthenticationOptions options, string path)
     {
-        var umbracoCallbackPath = _securitySettings.Value.AuthorizeCallbackPathName;
+        var umbracoCallbackPath = _securitySettings.Value.BackOfficeHost + _securitySettings.Value.AuthorizeCallbackPathName;
 
         options.CallbackPath = umbracoCallbackPath + path.EnsureStartsWith("/");
         return options;


### PR DESCRIPTION
### Prerequisites
- [ ] I have added steps to test this contribution in the description below

### Description
Added an endpoint to get a all available external login providers with status for the current user to show whether it is linked or not.

During tests and pair review, it was noted the methods in the backofficecontroller had to much logic, so I refactored methods that had to do with linking/unlinking into a seperate service as this logic was part of the test path for setting up the new endpoints.

## Testing
[ ] You can still link/unlink providers as described in https://github.com/umbraco/Umbraco-CMS/pull/16052
[ ] Using those registering and link/unlink steps, you should be able to manipulate the output of the new endpoint GET:/umbraco/management/api/v1/user/current/login-providers