### PR TITLE
V14: Migrate notify action from char to string 

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -78,6 +78,7 @@ public class UmbracoPlan : MigrationPlan
         To<V_14_0_0.DeleteMacroTables>("{0D82C836-96DD-480D-A924-7964E458BD34}");
         To<V_14_0_0.MoveDocumentBlueprintsToFolders>("{1A0FBC8A-6FC6-456C-805C-B94816B2E570}");
         To<V_14_0_0.MigrateTours>("{302DE171-6D83-4B6B-B3C0-AC8808A16CA1}");
+        To<V_14_0_0.MigrateUserGroup2PermissionPermissions>("{8184E61D-ECBA-4AAA-B61B-D7A82EB82EB7}");
         To<V_14_0_0.MigrateNotificationCharsToStrings>("{E261BF01-2C7F-4544-BAE7-49D545B21D68}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -78,7 +78,7 @@ public class UmbracoPlan : MigrationPlan
         To<V_14_0_0.DeleteMacroTables>("{0D82C836-96DD-480D-A924-7964E458BD34}");
         To<V_14_0_0.MoveDocumentBlueprintsToFolders>("{1A0FBC8A-6FC6-456C-805C-B94816B2E570}");
         To<V_14_0_0.MigrateTours>("{302DE171-6D83-4B6B-B3C0-AC8808A16CA1}");
-        To<V_14_0_0.MigrateUserGroup2PermissionPermissions>("{8184E61D-ECBA-4AAA-B61B-D7A82EB82EB7}");
+        To<V_14_0_0.MigrateUserGroup2PermissionPermissionColumnType>("{8184E61D-ECBA-4AAA-B61B-D7A82EB82EB7}");
         To<V_14_0_0.MigrateNotificationCharsToStrings>("{E261BF01-2C7F-4544-BAE7-49D545B21D68}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -78,5 +78,6 @@ public class UmbracoPlan : MigrationPlan
         To<V_14_0_0.DeleteMacroTables>("{0D82C836-96DD-480D-A924-7964E458BD34}");
         To<V_14_0_0.MoveDocumentBlueprintsToFolders>("{1A0FBC8A-6FC6-456C-805C-B94816B2E570}");
         To<V_14_0_0.MigrateTours>("{302DE171-6D83-4B6B-B3C0-AC8808A16CA1}");
+        To<V_14_0_0.MigrateNotificationCharsToStrings>("{E261BF01-2C7F-4544-BAE7-49D545B21D68}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateCharPermissionsToStrings.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateCharPermissionsToStrings.cs
@@ -14,7 +14,7 @@ internal class MigrateCharPermissionsToStrings : MigrationBase
 {
     private readonly IIdKeyMap _idKeyMap;
 
-    private static Dictionary<char, IEnumerable<string>> _charToStringPermissionDictionary =
+    internal static Dictionary<char, IEnumerable<string>> CharToStringPermissionDictionary { get; } =
         new()
         {
             ['I'] = new []{ActionAssignDomain.ActionLetter},
@@ -110,5 +110,5 @@ internal class MigrateCharPermissionsToStrings : MigrationBase
         Delete.Table(Constants.DatabaseSchema.Tables.UserGroup2Node).Do();
     }
 
-    private IEnumerable<string> ReplacePermissionValue(char oldPermission) => _charToStringPermissionDictionary.TryGetValue(oldPermission, out IEnumerable<string>? newPermission) ? newPermission : oldPermission.ToString().Yield();
+    private IEnumerable<string> ReplacePermissionValue(char oldPermission) => CharToStringPermissionDictionary.TryGetValue(oldPermission, out IEnumerable<string>? newPermission) ? newPermission : oldPermission.ToString().Yield();
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateNotificationCharsToStrings.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateNotificationCharsToStrings.cs
@@ -1,0 +1,82 @@
+﻿using NPoco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Infrastructure.Persistence.DatabaseAnnotations;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_14_0_0;
+
+[Obsolete("Remove in Umbraco 18.")]
+public class MigrateNotificationCharsToStrings : MigrationBase
+{
+    private static Dictionary<string, string> _charToStringPermissionDictionary =
+        new()
+        {
+            ["I"] = ActionAssignDomain.ActionLetter,
+            ["F"] = ActionBrowse.ActionLetter,
+            ["O"] = ActionCopy.ActionLetter,
+            ["ï"] = ActionCreateBlueprintFromContent.ActionLetter,
+            ["D"] = ActionDelete.ActionLetter,
+            ["M"] = ActionMove.ActionLetter,
+            ["C"] = ActionNew.ActionLetter,
+            ["N"] = ActionNotify.ActionLetter,
+            ["P"] = ActionProtect.ActionLetter,
+            ["U"] = ActionPublish.ActionLetter,
+            ["V"] = ActionRestore.ActionLetter,
+            ["R"] = ActionRights.ActionLetter,
+            ["K"] = ActionRollback.ActionLetter,
+            ["S"] = ActionSort.ActionLetter,
+            ["Z"] = ActionUnpublish.ActionLetter,
+            ["A"] = ActionUpdate.ActionLetter,
+        };
+
+    public MigrateNotificationCharsToStrings(IMigrationContext context) : base(context)
+    {
+    }
+
+    protected override void Migrate()
+    {
+        List<LegacyUser2NodeNotifyDto>? legacyNotifyDtos = Database.Fetch<LegacyUser2NodeNotifyDto>();
+        Delete.Table(Constants.DatabaseSchema.Tables.User2NodeNotify).Do();
+
+        Create.Table<User2NodeNotifyDto>().Do();
+        var notifyDtos = legacyNotifyDtos.Select(ReplaceAction).ToList();
+        Database.InsertBulk(notifyDtos);
+    }
+
+    private User2NodeNotifyDto ReplaceAction(LegacyUser2NodeNotifyDto dto)
+    {
+        // Action is non-nullable
+        // When we expanded the column it padded it with space, so we need to strip it.
+        dto.Action = _charToStringPermissionDictionary.TryGetValue(dto.Action!.StripWhitespace(), out var action) ? action : dto.Action?.StripWhitespace();
+
+        return new User2NodeNotifyDto
+        {
+            UserId = dto.UserId,
+            NodeId = dto.NodeId,
+            Action = dto.Action
+        };
+    }
+
+
+    [TableName(Constants.DatabaseSchema.Tables.User2NodeNotify)]
+    [PrimaryKey("userId", AutoIncrement = false)]
+    [ExplicitColumns]
+    private class LegacyUser2NodeNotifyDto
+    {
+        [Column("userId")]
+        [PrimaryKeyColumn(AutoIncrement = false, Name = "PK_umbracoUser2NodeNotify", OnColumns = "userId, nodeId, action")]
+        [ForeignKey(typeof(UserDto))]
+        public int UserId { get; set; }
+
+        [Column("nodeId")]
+        [ForeignKey(typeof(NodeDto))]
+        public int NodeId { get; set; }
+
+        [Column("action")]
+        [SpecialDbType(SpecialDbTypes.NCHAR)]
+        [Length(1)]
+        public string? Action { get; set; }
+    }
+}

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateNotificationCharsToStrings.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateNotificationCharsToStrings.cs
@@ -10,28 +10,7 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_14_0_0;
 [Obsolete("Remove in Umbraco 18.")]
 public class MigrateNotificationCharsToStrings : MigrationBase
 {
-    private static Dictionary<string, string> _charToStringPermissionDictionary =
-        new()
-        {
-            ["I"] = ActionAssignDomain.ActionLetter,
-            ["F"] = ActionBrowse.ActionLetter,
-            ["O"] = ActionCopy.ActionLetter,
-            ["ï"] = ActionCreateBlueprintFromContent.ActionLetter,
-            ["D"] = ActionDelete.ActionLetter,
-            ["M"] = ActionMove.ActionLetter,
-            ["C"] = ActionNew.ActionLetter,
-            ["N"] = ActionNotify.ActionLetter,
-            ["P"] = ActionProtect.ActionLetter,
-            ["U"] = ActionPublish.ActionLetter,
-            ["V"] = ActionRestore.ActionLetter,
-            ["R"] = ActionRights.ActionLetter,
-            ["K"] = ActionRollback.ActionLetter,
-            ["S"] = ActionSort.ActionLetter,
-            ["Z"] = ActionUnpublish.ActionLetter,
-            ["A"] = ActionUpdate.ActionLetter,
-        };
-
-    public MigrateNotificationCharsToStrings(IMigrationContext context) : base(context)
+   public MigrateNotificationCharsToStrings(IMigrationContext context) : base(context)
     {
     }
 
@@ -48,7 +27,7 @@ public class MigrateNotificationCharsToStrings : MigrationBase
     private User2NodeNotifyDto ReplaceAction(LegacyUser2NodeNotifyDto dto)
     {
         // Action is non-nullable
-        dto.Action = _charToStringPermissionDictionary.TryGetValue(dto.Action!, out var action) ? action : dto.Action;
+        dto.Action = MigrateCharPermissionsToStrings.CharToStringPermissionDictionary.TryGetValue(dto.Action!.ToCharArray().First(), out var action) ? string.Join(string.Empty, action) : dto.Action;
 
         return new User2NodeNotifyDto
         {
@@ -72,10 +51,10 @@ public class MigrateNotificationCharsToStrings : MigrationBase
         [Column("nodeId")]
         [ForeignKey(typeof(NodeDto))]
         public int NodeId { get; set; }
-
         [Column("action")]
         [SpecialDbType(SpecialDbTypes.NCHAR)]
         [Length(1)]
+
         public string? Action { get; set; }
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateNotificationCharsToStrings.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateNotificationCharsToStrings.cs
@@ -48,8 +48,7 @@ public class MigrateNotificationCharsToStrings : MigrationBase
     private User2NodeNotifyDto ReplaceAction(LegacyUser2NodeNotifyDto dto)
     {
         // Action is non-nullable
-        // When we expanded the column it padded it with space, so we need to strip it.
-        dto.Action = _charToStringPermissionDictionary.TryGetValue(dto.Action!.StripWhitespace(), out var action) ? action : dto.Action?.StripWhitespace();
+        dto.Action = _charToStringPermissionDictionary.TryGetValue(dto.Action!, out var action) ? action : dto.Action;
 
         return new User2NodeNotifyDto
         {

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateUserGroup2PermissionPermissionColumnType.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateUserGroup2PermissionPermissionColumnType.cs
@@ -5,9 +5,9 @@ using Umbraco.Cms.Infrastructure.Persistence.Dtos;
 namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_14_0_0;
 
 [Obsolete("Remove in Umbraco 18.")]
-public class MigrateUserGroup2PermissionPermissions : MigrationBase
+public class MigrateUserGroup2PermissionPermissionColumnType : MigrationBase
 {
-    public MigrateUserGroup2PermissionPermissions(IMigrationContext context) : base(context)
+    public MigrateUserGroup2PermissionPermissionColumnType(IMigrationContext context) : base(context)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateUserGroup2PermissionPermissions.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateUserGroup2PermissionPermissions.cs
@@ -1,0 +1,25 @@
+﻿using NPoco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_14_0_0;
+
+[Obsolete("Remove in Umbraco 18.")]
+public class MigrateUserGroup2PermissionPermissions : MigrationBase
+{
+    public MigrateUserGroup2PermissionPermissions(IMigrationContext context) : base(context)
+    {
+    }
+
+    protected override void Migrate()
+    {
+        // We don't need to update the column for SQLite since it just uses TEXT.
+        if (DatabaseType == DatabaseType.SQLite)
+        {
+            return;
+        }
+
+        // The action column is part of the primary key, so we must drop the constraint before we can alter the column.
+        AlterColumn<UserGroup2PermissionDto>(Constants.DatabaseSchema.Tables.UserGroup2Permission, "permission");
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/User2NodeNotifyDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/User2NodeNotifyDto.cs
@@ -19,7 +19,6 @@ internal class User2NodeNotifyDto
     public int NodeId { get; set; }
 
     [Column("action")]
-    [SpecialDbType(SpecialDbTypes.NCHAR)]
-    [Length(1)]
+    [Length(255)]
     public string? Action { get; set; }
 }

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/UserGroup2PermissionDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/UserGroup2PermissionDto.cs
@@ -18,6 +18,6 @@ public class UserGroup2PermissionDto
     public Guid UserGroupKey { get; set; }
 
     [Column("permission")]
-    [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
+    [Length(255)]
     public required string Permission { get; set; }
 }


### PR DESCRIPTION
Migrates the `umbracoUser2NodeNotify.action` column use the new action strings instead of the action letters. This involves changing the column type to `Nvarchar(255)`, and mapping the action letters to the new action strings. 

Additionally this also migrates the `umbracoUserGroup2Permission.permission` column to use `Nvarchar(255)`, partly just to align the two, since it's referencing the same thing, but this will also allow for a compound key in the future. 

## Testing

On both Sqlite and MSSQL: 

0. Ensure SMTP is configured
1. Create some content in v13
2. Enable notifications for the content 
3. Migrate the database to v14.
4. The values in the mentioned tables should now be updated (except for 'H', since that's a deploy thing) 
5. Content notifications should now work