### PR TITLE
V14: Fixup webhook endpoints

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Webhook/AllWebhookController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Webhook/AllWebhookController.cs
@@ -2,8 +2,8 @@ using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
+using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.Webhook;
-using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 
@@ -13,12 +13,12 @@ namespace Umbraco.Cms.Api.Management.Controllers.Webhook;
 public class AllWebhookController : WebhookControllerBase
 {
     private readonly IWebhookService _webhookService;
-    private readonly IUmbracoMapper _umbracoMapper;
+    private readonly IWebhookPresentationFactory _webhookPresentationFactory;
 
-    public AllWebhookController(IWebhookService webhookService, IUmbracoMapper umbracoMapper)
+    public AllWebhookController(IWebhookService webhookService, IWebhookPresentationFactory webhookPresentationFactory)
     {
         _webhookService = webhookService;
-        _umbracoMapper = umbracoMapper;
+        _webhookPresentationFactory = webhookPresentationFactory;
     }
 
     [HttpGet]
@@ -34,7 +34,7 @@ public class AllWebhookController : WebhookControllerBase
         var viewModel = new PagedViewModel<WebhookResponseModel>
         {
             Total = result.Total,
-            Items = _umbracoMapper.MapEnumerable<IWebhook, WebhookResponseModel>(webhooks)
+            Items = webhooks.Select(x => _webhookPresentationFactory.CreateResponseModel(x)),
         };
 
         return Ok(viewModel);

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/WebhookRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/WebhookRepository.cs
@@ -61,11 +61,9 @@ public class WebhookRepository : IWebhookRepository
     public async Task<PagedModel<IWebhook>> GetByIdsAsync(IEnumerable<Guid> keys)
     {
         Sql<ISqlContext>? sql = _scopeAccessor.AmbientScope?.Database.SqlContext.Sql()
-            .SelectAll()
+            .Select<WebhookDto>()
             .From<WebhookDto>()
-            .InnerJoin<Webhook2EventsDto>()
-            .On<WebhookDto, Webhook2EventsDto>(left => left.Id, right => right.WebhookId)
-            .WhereIn<Webhook2EventsDto>(x => x.WebhookId, keys);
+            .WhereIn<WebhookDto>(x => x.Key, keys);
 
         List<WebhookDto>? webhookDtos = await _scopeAccessor.AmbientScope?.Database.FetchAsync<WebhookDto>(sql)!;
 


### PR DESCRIPTION
# Notes
- The `webhook` get endpoint to get all webhooks did not work, as it would throw an error about not knowing how to map, this has been fixed by using the Presentation factory instead, as there is no `WebhookMapDefinition`
- The `item` endpoint would always return 0 items, as the `GetByIdsAsync` webhook repository method did not work, this has been remedied by refactoring the method to have similar functionality to `GetAsync`

# How to test
- Start on v13
- Create a couple of webhooks
- Migrate to v14 (this branch)
- Call the `webhook` get endpoint to get all webhooks, this should return the correct number.
- Call the `item` endpoint for webhook, with one or more ids (you can get these ids from the all endpoint you just called), and assert it returns the correct number of items
