### PR TITLE
Configured the swagger UI

### DIFF
--- a/src/Umbraco.Cms.Api.Common/OpenApi/SwaggerRouteTemplatePipelineFilter.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/SwaggerRouteTemplatePipelineFilter.cs
@@ -62,6 +62,10 @@ public class SwaggerRouteTemplatePipelineFilter : UmbracoPipelineFilter
             swaggerUiOptions.SwaggerEndpoint($"{name}/swagger.json", $"{apiInfo.Title}");
         }
 
+        // Add custom configuration from https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
+        swaggerUiOptions.ConfigObject.PersistAuthorization = true; // persists authorization data so it would not be lost on browser close/refresh
+        swaggerUiOptions.ConfigObject.Filter = string.Empty; // Enable the filter with an empty string as default filter.
+
         swaggerUiOptions.OAuthClientId(Constants.OAuthClientIds.Swagger);
         swaggerUiOptions.OAuthUsePkce();
     }


### PR DESCRIPTION
Configured the swagger UI  to persist the authentication token (still only valid for 5 minutes, as it cannot use refreshtoken) and added filtering.

![image](https://github.com/umbraco/Umbraco-CMS/assets/1561480/54fe4801-0a75-41f8-9ae0-ec1a8ff4af2c)

### Test
- [x] Test out the filtering
- [x] Open Swagger and authentize, and verify it is signed in by calling a protected endpoint. Close the window and reopen it, and verify you are still authenticated by calling a protected endpoint
