### PR TITLE
Support member saving Cancel

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/MemberControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/MemberControllerBase.cs
@@ -71,6 +71,9 @@ public class MemberControllerBase : ContentControllerBase
                 .WithTitle("Duplicate email detected")
                 .WithDetail("The supplied email is already in use by another member.")
                 .Build()),
+            MemberEditingOperationStatus.CancelledByNotificationHandler => BadRequest(problemDetailsBuilder
+                .WithTitle("Cancelled")
+                .Build()),
             MemberEditingOperationStatus.Unknown => StatusCode(
                 StatusCodes.Status500InternalServerError,
                 problemDetailsBuilder

--- a/src/Umbraco.Core/Services/OperationStatus/MemberEditingOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/MemberEditingOperationStatus.cs
@@ -15,5 +15,6 @@ public enum MemberEditingOperationStatus
     InvalidEmail,
     DuplicateUsername,
     DuplicateEmail,
+    CancelledByNotificationHandler,
     Unknown,
 }

--- a/src/Umbraco.Infrastructure/Services/MemberEditingService.cs
+++ b/src/Umbraco.Infrastructure/Services/MemberEditingService.cs
@@ -329,6 +329,9 @@ internal sealed class MemberEditingService : IMemberEditingService
                 case nameof(IdentityErrorDescriber.DuplicateEmail):
                     createStatus = MemberEditingOperationStatus.DuplicateEmail;
                     break;
+                case MemberUserStore.CancelledIdentityErrorCode:
+                    createStatus = MemberEditingOperationStatus.CancelledByNotificationHandler;
+                    break;
             }
 
             if (createStatus is not MemberEditingOperationStatus.Unknown)


### PR DESCRIPTION
### Description
Fixes https://github.com/umbraco/Umbraco-CMS/issues/15152

This PR adds support for cancelling a member saving operation. 

### Remarks
This is fixed on V14, as we already have updated the MemberService.Save to be able to communicate back the error messages. For earlier versions it is just a void method.

### Test
The error message is still not picked up by the frontend, but we know thats a general missing thing. To test follow the instructions on the issue, and note the "Umb-Notifications"  header in the request

<img width="1481" alt="image" src="https://github.com/umbraco/Umbraco-CMS/assets/1561480/b2cbad31-7115-4606-858d-283284de2b4e">
