### PR TITLE
Translate user picker property editor value to V14 compatible format (and back again)

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/UserPickerPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/UserPickerPropertyEditor.cs
@@ -1,3 +1,11 @@
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Editors;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Strings;
+using Umbraco.Extensions;
+
 namespace Umbraco.Cms.Core.PropertyEditors;
 
 [DataEditor(
@@ -9,4 +17,41 @@ public class UserPickerPropertyEditor : DataEditor
     public UserPickerPropertyEditor(IDataValueEditorFactory dataValueEditorFactory)
         : base(dataValueEditorFactory)
         => SupportsReadOnly = true;
+
+    protected override IDataValueEditor CreateValueEditor() =>
+        DataValueEditorFactory.Create<UserPickerPropertyValueEditor>(Attribute!);
+
+    private class UserPickerPropertyValueEditor : DataValueEditor
+    {
+        private readonly IUserService _userService;
+
+        public UserPickerPropertyValueEditor(
+            IShortStringHelper shortStringHelper,
+            IJsonSerializer jsonSerializer,
+            IIOHelper ioHelper,
+            DataEditorAttribute attribute,
+            IUserService userService)
+            : base(shortStringHelper, jsonSerializer, ioHelper, attribute)
+            => _userService = userService;
+
+        public override object? ToEditor(IProperty property, string? culture = null, string? segment = null)
+        {
+            // the stored value is the user ID - need to transform this into the corresponding user key
+            var value = base.ToEditor(property, culture, segment);
+            if (value is not string stringValue || stringValue.IsNullOrWhiteSpace())
+            {
+                return value;
+            }
+
+            return int.TryParse(stringValue, out var userId)
+                ? _userService.GetUserById(userId)?.Key
+                : null;
+        }
+
+        // the editor value is expected to be the user key - store it as the user ID
+        public override object? FromEditor(ContentPropertyData editorValue, object? currentValue)
+            => editorValue.Value is string stringValue && Guid.TryParse(stringValue, out Guid userKey)
+                ? _userService.GetAsync(userKey).GetAwaiter().GetResult()?.Id
+                : null;
+    }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

_This is the user equivalent of https://github.com/umbraco/Umbraco-CMS/pull/16149_

The user picker property editor stores the integer ID of the picked user. However, the V14 client needs the user key to resolve the user data in the editor UI, so we need to translate the value back and forth.

Note that we still need to retain the integer ID when storing data. Eventually we should migrate this, but a content migration is not desirable for V14.

### Testing this PR

The user picker property editor UI should work and should be able to store and retrieve a picked user.