### PR TITLE
V14: add authorized logout callback path

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Security/BackOfficeApplicationManager.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/BackOfficeApplicationManager.cs
@@ -16,6 +16,7 @@ public class BackOfficeApplicationManager : OpenIdDictApplicationManagerBase, IB
     private readonly IRuntimeState _runtimeState;
     private readonly Uri? _backOfficeHost;
     private readonly string _authorizeCallbackPathName;
+    private readonly string _authorizeCallbackLogoutPathName;
 
     public BackOfficeApplicationManager(
         IOpenIddictApplicationManager applicationManager,
@@ -28,6 +29,7 @@ public class BackOfficeApplicationManager : OpenIdDictApplicationManagerBase, IB
         _runtimeState = runtimeState;
         _backOfficeHost = securitySettings.Value.BackOfficeHost;
         _authorizeCallbackPathName = securitySettings.Value.AuthorizeCallbackPathName;
+        _authorizeCallbackLogoutPathName = securitySettings.Value.AuthorizeCallbackLogoutPathName;
     }
 
     public async Task EnsureBackOfficeApplicationAsync(Uri backOfficeUrl, CancellationToken cancellationToken = default)
@@ -112,7 +114,7 @@ public class BackOfficeApplicationManager : OpenIdDictApplicationManagerBase, IB
             PostLogoutRedirectUris =
             {
                 CallbackUrl(_authorizeCallbackPathName),
-                CallbackUrl($"{_authorizeCallbackPathName.EnsureEndsWith("/")}logout")
+                CallbackUrl(_authorizeCallbackLogoutPathName),
             },
             Permissions =
             {
@@ -122,8 +124,8 @@ public class BackOfficeApplicationManager : OpenIdDictApplicationManagerBase, IB
                 OpenIddictConstants.Permissions.Endpoints.Revocation,
                 OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode,
                 OpenIddictConstants.Permissions.GrantTypes.RefreshToken,
-                OpenIddictConstants.Permissions.ResponseTypes.Code
-            }
+                OpenIddictConstants.Permissions.ResponseTypes.Code,
+            },
         };
     }
 

--- a/src/Umbraco.Core/Configuration/Models/SecuritySettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/SecuritySettings.cs
@@ -26,6 +26,7 @@ public class SecuritySettings
     internal const int StaticMemberDefaultLockoutTimeInMinutes = 30 * 24 * 60;
     internal const int StaticUserDefaultLockoutTimeInMinutes = 30 * 24 * 60;
     internal const string StaticAuthorizeCallbackPathName = "/umbraco";
+    internal const string StaticAuthorizeCallbackLogoutPathName = "/umbraco/logout";
     internal const string StaticAuthorizeCallbackErrorPathName = "/umbraco/error";
 
     /// <summary>
@@ -113,11 +114,20 @@ public class SecuritySettings
     public Uri? BackOfficeHost { get; set; }
 
     /// <summary>
-    ///     The path to use for authorization callback. Will be appended to the BackOfficeHost.
+    ///     Gets or sets the path to use for authorization callback. Will be appended to the BackOfficeHost.
     /// </summary>
     [DefaultValue(StaticAuthorizeCallbackPathName)]
     public string AuthorizeCallbackPathName { get; set; } = StaticAuthorizeCallbackPathName;
 
+    /// <summary>
+    ///     Gets or sets the path to use for authorization callback logout. Will be appended to the BackOfficeHost.
+    /// </summary>
+    [DefaultValue(StaticAuthorizeCallbackLogoutPathName)]
+    public string AuthorizeCallbackLogoutPathName { get; set; } = StaticAuthorizeCallbackLogoutPathName;
+
+    /// <summary>
+    ///     Gets or sets the path to use for authorization callback error. Will be appended to the BackOfficeHost.
+    /// </summary>
     [DefaultValue(StaticAuthorizeCallbackErrorPathName)]
     public string AuthorizeCallbackErrorPathName { get; set; } = StaticAuthorizeCallbackErrorPathName;
 }


### PR DESCRIPTION
### Description

This adds an extra option to allow configuration of the authorized logout path, which enables any client to allow the user to get redirected back to a certain path following a successful logout. The default is `/umbraco/logout`.

We want the user to land on a dedicated logout page so that we know they were logged out and not. This allows us to let the user stay on the logout page rather than, say, redirect them to a login provider with automatic redirect setup.

Also, this was hardcoded before, which wasn't the nicest solution and didn't work when you accessed the Management API from another host. By moving this to a configuration option, we can allow developers to set the value specifically for their usecase.