### PR TITLE
V14: the login page only needs UUI icons

### DIFF
--- a/src/Umbraco.Web.UI.Login/src/controllers/slim-backoffice-initializer.ts
+++ b/src/Umbraco.Web.UI.Login/src/controllers/slim-backoffice-initializer.ts
@@ -5,7 +5,6 @@ import {
 import { umbExtensionsRegistry } from "@umbraco-cms/backoffice/extension-registry";
 import type { UmbElement } from "@umbraco-cms/backoffice/element-api";
 import { UmbControllerBase } from "@umbraco-cms/backoffice/class-api";
-import { UmbIconRegistry } from "@umbraco-cms/backoffice/icon";
 import { UUIIconRegistryEssential } from "@umbraco-cms/backoffice/external/uui";
 
 // We import what we need from the Backoffice app.
@@ -17,7 +16,6 @@ import '@umbraco-cms/backoffice/localization';
  * It is responsible for initializing the backoffice and only the extensions that is needed to run the login screen.
  */
 export class UmbSlimBackofficeController extends UmbControllerBase {
-  #umbIconRegistry = new UmbIconRegistry();
   #uuiIconRegistry = new UUIIconRegistryEssential();
 
   constructor(host: UmbElement) {
@@ -25,7 +23,6 @@ export class UmbSlimBackofficeController extends UmbControllerBase {
     new UmbBundleExtensionInitializer(host, umbExtensionsRegistry);
     new UmbServerExtensionRegistrator(host, umbExtensionsRegistry).registerPublicExtensions();
 
-    this.#umbIconRegistry.attach(host);
     this.#uuiIconRegistry.attach(host);
 
     host.classList.add('uui-text');


### PR DESCRIPTION
chore: remove import from backoffice icons since we now only have to rely on the ui library

this also fixes an issue where icons did not work anymore due to changes in the backoffice taking over

it can be tested by checking if the "check" or "cross" icons show up on the main login button.