### PR TITLE
Add member type icon to member type tree output

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Tree/RootMemberTypeTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Tree/RootMemberTypeTreeController.cs
@@ -10,15 +10,15 @@ namespace Umbraco.Cms.Api.Management.Controllers.MemberType.Tree;
 [ApiVersion("1.0")]
 public class RootMemberTypeTreeController : MemberTypeTreeControllerBase
 {
-    public RootMemberTypeTreeController(IEntityService entityService)
-        : base(entityService)
+    public RootMemberTypeTreeController(IEntityService entityService, IMemberTypeService memberTypeService)
+        : base(entityService, memberTypeService)
     {
     }
 
     [HttpGet("root")]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(typeof(PagedViewModel<NamedEntityTreeItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<PagedViewModel<NamedEntityTreeItemResponseModel>>> Root(
+    [ProducesResponseType(typeof(PagedViewModel<MemberTypeTreeItemResponseModel>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<PagedViewModel<MemberTypeTreeItemResponseModel>>> Root(
         CancellationToken cancellationToken,
         int skip = 0,
         int take = 100)

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -18265,7 +18265,7 @@
                 "schema": {
                   "oneOf": [
                     {
-                      "$ref": "#/components/schemas/PagedNamedEntityTreeItemResponseModel"
+                      "$ref": "#/components/schemas/PagedMemberTypeTreeItemResponseModel"
                     }
                   ]
                 }
@@ -38268,6 +38268,39 @@
         },
         "additionalProperties": false
       },
+      "MemberTypeTreeItemResponseModel": {
+        "required": [
+          "hasChildren",
+          "icon",
+          "id",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "hasChildren": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "parent": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ReferenceByIdModel"
+              }
+            ],
+            "nullable": true
+          },
+          "name": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
       "MemberValueModel": {
         "required": [
           "alias"
@@ -39441,6 +39474,30 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/MemberResponseModel"
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedMemberTypeTreeItemResponseModel": {
+        "required": [
+          "items",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/MemberTypeTreeItemResponseModel"
                 }
               ]
             }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Tree/MemberTypeTreeItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Tree/MemberTypeTreeItemResponseModel.cs
@@ -1,0 +1,6 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Tree;
+
+public class MemberTypeTreeItemResponseModel : NamedEntityTreeItemResponseModel
+{
+    public string Icon { get; set; } = string.Empty;
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The member types tree output does not contain the configured member type icons. That's a mistake, so this PR fixes it 😄 

### Testing this PR

Use Swagger to verify that the API output contains member type icons.