### PR TITLE
Persist claims from OnExternalLogin event

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeController.cs
@@ -405,6 +405,7 @@ public class BackOfficeController : SecurityControllerBase
 
         return new SignInResult(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme, backOfficePrincipal);
     }
+
     private async Task<IActionResult> SignInBackOfficeUser(BackOfficeIdentityUser backOfficeUser, OpenIddictRequest request)
     {
         ClaimsPrincipal backOfficePrincipal = await _backOfficeSignInManager.CreateUserPrincipalAsync(backOfficeUser);

--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeController.cs
@@ -374,7 +374,7 @@ public class BackOfficeController : SecurityControllerBase
                 // Update any authentication tokens if succeeded
                 await _backOfficeSignInManager.UpdateExternalAuthenticationTokensAsync(loginInfo);
 
-                // sign in the backoffice user associated with the login provider and unique provider id
+                // sign in the backoffice user from the HttpContext, as thas was set doing the ExternalLoginSignInAsync
                 ClaimsPrincipal backOfficePrincipal = HttpContext.User;
                 return await SignInBackOfficeUser(backOfficePrincipal, request);
             }


### PR DESCRIPTION
### Description
This PR Ensures claims added in the OnExternalLogin are actually persisted in the tokens we store.

The issue before was we did not use the same ClaimsPricipal when calling OpenIddict as the one used doing External Login