### PR TITLE
V14: Fix sorting by "creator" on collection view

### DIFF
--- a/src/Umbraco.Infrastructure/Services/ContentListViewServiceBase.cs
+++ b/src/Umbraco.Infrastructure/Services/ContentListViewServiceBase.cs
@@ -90,15 +90,16 @@ internal abstract class ContentListViewServiceBase<TContent, TContentType, TCont
             .Select(p => p.Alias)
             .WhereNotNull();
 
-        // Service layer expects "owner" instead of "creator", so make sure to pass in the correct field
-        if (orderBy.InvariantEquals("creator"))
-        {
-            orderBy = "owner";
-        }
 
         if (listViewPropertyAliases.Contains(orderBy) == false && orderBy.InvariantEquals("name") == false)
         {
             return Attempt.FailWithStatus<Ordering?, ContentCollectionOperationStatus>(ContentCollectionOperationStatus.OrderByNotPartOfCollectionConfiguration, null);
+        }
+
+        // Service layer expects "owner" instead of "creator", so make sure to pass in the correct field
+        if (orderBy.InvariantEquals("creator"))
+        {
+            orderBy = "owner";
         }
 
         var orderByCustomField = listViewProperties


### PR DESCRIPTION
## Details
- Allows for items in a collection view to be sortable by "creator", aka "Created by" field;
  - Changing the order of transforming "creator" to "owner" since we are performing a check against the collection view properties and there it is named "creator" => we need to do the check first.

## Test
- Create a root doc type with collection view enabled & a child doc type;
- Create some content to be able to sort items in the collection view;
  - **Use at least 2 users** when creating the content items, so that you can see a difference when sorting.
- Modify the "Columns Displayed" on the "List View - Content" data type to have the "Created by" property - _you can find it under "Document type" > the child doc type > "Created by"_ 
- In the Content section, navigate to the Collection app;
- Verify that by clicking on the "Created by", the items get sorted.