### PR TITLE
Add data type editor UI aliases on upgrade

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Mapping/DataType/DataTypeViewModelMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/DataType/DataTypeViewModelMapDefinition.cs
@@ -17,7 +17,7 @@ public class DataTypeViewModelMapDefinition : IMapDefinition
         target.Id = source.Key;
         target.Name = source.Name ?? string.Empty;
         target.EditorAlias = source.EditorAlias;
-        target.EditorUiAlias = source.EditorUiAlias;
+        target.EditorUiAlias = source.EditorUiAlias ?? source.EditorAlias;
         target.IsDeletable = source.IsDeletableDataType();
         target.CanIgnoreStartNodes = source.IsBuildInDataType() is false;
 

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -32592,6 +32592,7 @@
       "CreateDataTypeRequestModel": {
         "required": [
           "editorAlias",
+          "editorUiAlias",
           "name",
           "values"
         ],
@@ -32606,8 +32607,7 @@
             "type": "string"
           },
           "editorUiAlias": {
-            "type": "string",
-            "nullable": true
+            "type": "string"
           },
           "values": {
             "type": "array",
@@ -34394,6 +34394,7 @@
         "required": [
           "canIgnoreStartNodes",
           "editorAlias",
+          "editorUiAlias",
           "id",
           "isDeletable",
           "name",
@@ -34410,8 +34411,7 @@
             "type": "string"
           },
           "editorUiAlias": {
-            "type": "string",
-            "nullable": true
+            "type": "string"
           },
           "values": {
             "type": "array",
@@ -41704,6 +41704,7 @@
       "UpdateDataTypeRequestModel": {
         "required": [
           "editorAlias",
+          "editorUiAlias",
           "name",
           "values"
         ],
@@ -41718,8 +41719,7 @@
             "type": "string"
           },
           "editorUiAlias": {
-            "type": "string",
-            "nullable": true
+            "type": "string"
           },
           "values": {
             "type": "array",

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DataTypeModelBase.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DataTypeModelBase.cs
@@ -10,7 +10,7 @@ public abstract class DataTypeModelBase
     [Required]
     public string EditorAlias { get; set; } = string.Empty;
 
-    public string? EditorUiAlias { get; set; }
+    public string EditorUiAlias { get; set; } = string.Empty;
 
     public IEnumerable<DataTypePropertyPresentationModel> Values { get; set; } = Enumerable.Empty<DataTypePropertyPresentationModel>();
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -80,5 +80,6 @@ public class UmbracoPlan : MigrationPlan
         To<V_14_0_0.MigrateTours>("{302DE171-6D83-4B6B-B3C0-AC8808A16CA1}");
         To<V_14_0_0.MigrateUserGroup2PermissionPermissionColumnType>("{8184E61D-ECBA-4AAA-B61B-D7A82EB82EB7}");
         To<V_14_0_0.MigrateNotificationCharsToStrings>("{E261BF01-2C7F-4544-BAE7-49D545B21D68}");
+        To<V_14_0_0.AddEditorUiToDataType>("{5A2EF07D-37B4-49D5-8E9B-3ED01877263B}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddEditorUiToDataType.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddEditorUiToDataType.cs
@@ -1,0 +1,136 @@
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using NPoco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_14_0_0;
+
+public class AddEditorUiToDataType : MigrationBase
+{
+    private readonly IKeyValueService _keyValueService;
+    private readonly IJsonSerializer _jsonSerializer;
+    private readonly ILogger<AddEditorUiToDataType> _logger;
+
+    public AddEditorUiToDataType(IMigrationContext context, IKeyValueService keyValueService, IJsonSerializer jsonSerializer, ILogger<AddEditorUiToDataType> logger)
+        : base(context)
+    {
+        _keyValueService = keyValueService;
+        _jsonSerializer = jsonSerializer;
+        _logger = logger;
+    }
+
+    protected override void Migrate()
+    {
+        var dataEditorSplitCollectionData = _keyValueService.GetValue("migrateDataEditorSplitCollectionData");
+        if (dataEditorSplitCollectionData.IsNullOrWhiteSpace())
+        {
+            return;
+        }
+
+        DataTypeEditorAliasMigrationData[]? migrationData = _jsonSerializer.Deserialize<DataTypeEditorAliasMigrationData[]>(dataEditorSplitCollectionData);
+        if (migrationData?.Any() is not true)
+        {
+            _logger.LogError("No migration data was found for the data editor split. Please make sure you're upgrading from the latest V13. Any data types based on custom property editors may not work correctly.");
+            return;
+        }
+
+        Sql<ISqlContext> sql = Sql()
+            .Select<DataTypeDto>()
+            .AndSelect<NodeDto>()
+            .From<DataTypeDto>()
+            .InnerJoin<NodeDto>()
+            .On<DataTypeDto, NodeDto>(left => left.NodeId, right => right.NodeId)
+            .Where<DataTypeDto>(x => x.EditorUiAlias == null);
+
+        List<DataTypeDto> dataTypeDtos = Database.Fetch<DataTypeDto>(sql);
+        foreach (DataTypeDto dataTypeDto in dataTypeDtos)
+        {
+            dataTypeDto.EditorUiAlias = dataTypeDto.EditorAlias switch
+            {
+                Constants.PropertyEditors.Aliases.BlockList => "Umb.PropertyEditorUi.BlockList",
+                Constants.PropertyEditors.Aliases.BlockGrid => "Umb.PropertyEditorUi.BlockGrid",
+                Constants.PropertyEditors.Aliases.CheckBoxList => "Umb.PropertyEditorUi.CheckBoxList",
+                Constants.PropertyEditors.Aliases.ColorPicker => "Umb.PropertyEditorUi.ColorPicker",
+                Constants.PropertyEditors.Aliases.ColorPickerEyeDropper => "Umb.PropertyEditorUi.EyeDropper",
+                Constants.PropertyEditors.Aliases.ContentPicker => "Umb.PropertyEditorUi.DocumentPicker",
+                Constants.PropertyEditors.Aliases.DateTime => "Umb.PropertyEditorUi.DatePicker",
+                Constants.PropertyEditors.Aliases.DropDownListFlexible => "Umb.PropertyEditorUi.Dropdown",
+                Constants.PropertyEditors.Aliases.ImageCropper => "Umb.PropertyEditorUi.ImageCropper",
+                Constants.PropertyEditors.Aliases.Integer => "Umb.PropertyEditorUi.Integer",
+                Constants.PropertyEditors.Aliases.Decimal => "Umb.PropertyEditorUi.Decimal",
+                Constants.PropertyEditors.Aliases.ListView => "Umb.PropertyEditorUi.Collection",
+                Constants.PropertyEditors.Aliases.MediaPicker3 => "Umb.PropertyEditorUi.MediaPicker",
+                Constants.PropertyEditors.Aliases.MemberPicker => "Umb.PropertyEditorUi.MemberPicker",
+                Constants.PropertyEditors.Aliases.MemberGroupPicker => "Umb.PropertyEditorUi.MemberGroupPicker",
+                Constants.PropertyEditors.Aliases.MultiNodeTreePicker => "Umb.PropertyEditorUi.TreePicker",
+                Constants.PropertyEditors.Aliases.MultipleTextstring => "Umb.PropertyEditorUi.MultipleTextString",
+                Constants.PropertyEditors.Aliases.Label => "Umb.PropertyEditorUi.Label",
+                Constants.PropertyEditors.Aliases.RadioButtonList => "Umb.PropertyEditorUi.RadioButtonList",
+                Constants.PropertyEditors.Aliases.Slider => "Umb.PropertyEditorUi.Slider",
+                Constants.PropertyEditors.Aliases.Tags => "Umb.PropertyEditorUi.Tags",
+                Constants.PropertyEditors.Aliases.TextBox => "Umb.PropertyEditorUi.TextBox",
+                Constants.PropertyEditors.Aliases.TextArea => "Umb.PropertyEditorUi.TextArea",
+                Constants.PropertyEditors.Aliases.RichText => "Umb.PropertyEditorUi.TinyMCE",
+                Constants.PropertyEditors.Aliases.TinyMce => "Umb.PropertyEditorUi.TinyMCE",
+                Constants.PropertyEditors.Aliases.Boolean => "Umb.PropertyEditorUi.Toggle",
+                Constants.PropertyEditors.Aliases.MarkdownEditor => "Umb.PropertyEditorUi.MarkdownEditor",
+                Constants.PropertyEditors.Aliases.UserPicker => "Umb.PropertyEditorUi.UserPicker",
+                Constants.PropertyEditors.Aliases.UploadField => "Umb.PropertyEditorUi.UploadField",
+                Constants.PropertyEditors.Aliases.EmailAddress => "Umb.PropertyEditorUi.EmailAddress",
+                Constants.PropertyEditors.Aliases.MultiUrlPicker => "Umb.PropertyEditorUi.MultiUrlPicker",
+                _ => null
+            };
+
+            if (dataTypeDto.EditorUiAlias is null)
+            {
+                DataTypeEditorAliasMigrationData? dataTypeMigrationData = migrationData.FirstOrDefault(md => md.DataTypeId == dataTypeDto.NodeId);
+                if (dataTypeMigrationData is not null)
+                {
+                    // the V13 "data type split data collector" works like this:
+                    // - if .EditorUiAlias is set, the editor is based on manifests and should use one of the "Umbraco.Plain" options as .EditorAlias
+                    // - if .EditorUiAlias is not set, the editor is based on code and should use its own alias as .EditorUiAlias
+                    // unfortunately there is an issue with the migrator, in that it does not handle manifest based editors using valueType=TEXT,
+                    // but with the above logic in mind, we can work around that :)
+                    if (dataTypeMigrationData.EditorUiAlias.IsNullOrWhiteSpace())
+                    {
+                        // editor based on code
+                        dataTypeDto.EditorUiAlias = dataTypeDto.EditorAlias;
+                    }
+                    else
+                    {
+                        // editor based on manifests
+                        dataTypeDto.EditorUiAlias = dataTypeMigrationData.EditorUiAlias;
+                        dataTypeDto.EditorAlias = dataTypeMigrationData.EditorAlias?.NullOrWhiteSpaceAsNull()
+                                                  ?? "Umbraco.Plain.String";
+                    }
+                }
+                else
+                {
+                    _logger.LogWarning("No migration data was found for the data editor split for data type {name} ({editorAlias} - {id}). Please make sure you're upgrading from the latest V13. The affected data type may not work correctly.", dataTypeDto.NodeDto.Text, dataTypeDto.EditorAlias, dataTypeDto.NodeId);
+
+                    // we *need* an EditorUiAlias - default to the editor alias (let the client handle later)
+                    dataTypeDto.EditorUiAlias = dataTypeDto.EditorAlias;
+                }
+            }
+
+            Database.Update(dataTypeDto);
+        }
+    }
+
+    private class DataTypeEditorAliasMigrationData
+    {
+        [JsonPropertyName("DataTypeId")]
+        public int DataTypeId { get; set; }
+
+        [JsonPropertyName("EditorUiAlias")]
+        public string? EditorUiAlias { get; init; }
+
+        [JsonPropertyName("EditorAlias")]
+        public string? EditorAlias { get; init; }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

As of #15463 we have been tracking data type configurations with the intent of correctly migrating the split into "editor alias" and "editor UI alias". This PR performs the actual migration 😄 

The idea is:

1. All data types for core editors are migrated with their new editor UI aliases hardcoded.
2. All data types for custom editors are migrated based on the data collected by the [`DataTypeSplitDataCollector`](https://github.com/umbraco/Umbraco-CMS/blob/v13/dev/src/Umbraco.Infrastructure/Migrations/PreMigration/DataTypeSplitDataCollector.cs) in V13.

Note that there are different ways to build a property editor, thus we have been assuming the following:

1. If a property editor is declared by means of a manifest:
   - The V14 editor alias must be the "plain" `DataEditor` that corresponds to the property editor V13 value type.
   - The V14 editor UI alias must be set to the one collected by the `DataTypeSplitDataCollector` in V13 (corresponding to a custom view component in V14).
2. If a property editor is declared in code (as a `DataEditor`):
   - The V14 editor alias must must remain the same as in V13, so the `DataEditor` continues to do its work.
   - The V14 editor UI alias must be the V13 editor alias (corresponding to a custom view component in V14).

Lastly, this PR makes the editor UI alias non-nullable in the API contract, as it is now defacto a required piece of a data type configuration. This change will alleviate some pains on the clientside 😄 

### Testing this PR

This PR concerns itself purely with upgrading from V13. Thus you need a V13 database with data types based on custom property editors - both declared by manifest and by code. See #15463 for instructions on how to build these. Or reach out to @kjac for a test database.

After upgrading the DB to V14, verify that:
- All data types based on core property editors have proper icons in the data type tree (except from any leftover legacy editors like the old media picker):
![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/74b97b82-1f81-49d8-8f7b-5fe098594b69)
- All data types based on core property editors are well configured when you edit them (i.e. they have both an editor alias and an editor UI alias assigned):
![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/c05863be-b3bf-49fb-a91b-cb6dc5696a76)
- Data types based on custom property editors likely list with missing icons unless you port over views and whatnot 🤓 
![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/c6c0ae54-30c7-4463-8fd0-502421b402df)
- Data types based on custom property editors are well configured when you edit them:
![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/3d8cc8d9-5111-428b-b615-9231e3346f56)

Note that Umbraco treats unknown data types as using the property editor `Umbraco.Label`, which is why you'll see that as the configured one. The database, however, shows the correct configuration in the `umbracoDataType`:

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/5559a60a-55a7-4aee-b559-a1344bcda0f6)

Lastly, verify that _no_ data types have a `null` value in the `propertyEditorUiAlias` column of the `umbracoDataType` table.

☝️ This PR sets the list view editor UI alias to `"Umb.PropertyEditorUi.Collection"` as a preemptive measure, because this is what it _will_ be eventually on the client (it is currently `"Umb.PropertyEditorUi.CollectionView"`, which is wrong). Thus the list view icons might not show up correctly, depending on when you test this.
