### PR TITLE
Set the data type editor UI aliases at install time

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
@@ -1870,9 +1870,9 @@ internal class DatabaseDataCreator
 
     private void CreateDataTypeData()
     {
-        void InsertDataTypeDto(int id, string editorAlias, string dbType, string? configuration = null)
+        void InsertDataTypeDto(int id, string editorAlias, string editorUiAlias, string dbType, string? configuration)
         {
-            var dataTypeDto = new DataTypeDto { NodeId = id, EditorAlias = editorAlias, DbType = dbType };
+            var dataTypeDto = new DataTypeDto { NodeId = id, EditorAlias = editorAlias, EditorUiAlias = editorUiAlias, DbType = dbType };
 
             if (configuration != null)
             {
@@ -1901,6 +1901,7 @@ internal class DatabaseDataCreator
                 {
                     NodeId = Constants.DataTypes.Boolean,
                     EditorAlias = Constants.PropertyEditors.Aliases.Boolean,
+                    EditorUiAlias = "Umb.PropertyEditorUi.Toggle",
                     DbType = "Integer",
                 });
         }
@@ -1912,6 +1913,7 @@ internal class DatabaseDataCreator
                 {
                     NodeId = -51,
                     EditorAlias = Constants.PropertyEditors.Aliases.Integer,
+                    EditorUiAlias = "Umb.PropertyEditorUi.Integer",
                     DbType = "Integer",
                 });
         }
@@ -1926,6 +1928,7 @@ internal class DatabaseDataCreator
                 {
                     NodeId = -87,
                     EditorAlias = Constants.PropertyEditors.Aliases.RichText,
+                    EditorUiAlias = "Umb.PropertyEditorUi.TinyMCE",
                     DbType = "Ntext",
                     Configuration =
                         "{\"toolbar\":[\"ace\",\"styles\",\"bold\",\"italic\",\"alignleft\",\"aligncenter\",\"alignright\",\"bullist\",\"numlist\",\"outdent\",\"indent\",\"link\",\"umbmediapicker\",\"umbembeddialog\"],\"stylesheets\":[],\"maxImageSize\":500,\"mode\":\"classic\"}",
@@ -1939,6 +1942,7 @@ internal class DatabaseDataCreator
                 {
                     NodeId = Constants.DataTypes.Textbox,
                     EditorAlias = Constants.PropertyEditors.Aliases.TextBox,
+                    EditorUiAlias = "Umb.PropertyEditorUi.TextBox",
                     DbType = "Nvarchar",
                 });
         }
@@ -1950,6 +1954,7 @@ internal class DatabaseDataCreator
                 {
                     NodeId = Constants.DataTypes.Textarea,
                     EditorAlias = Constants.PropertyEditors.Aliases.TextArea,
+                    EditorUiAlias = "Umb.PropertyEditorUi.TextArea",
                     DbType = "Ntext",
                 });
         }
@@ -1961,22 +1966,23 @@ internal class DatabaseDataCreator
                 {
                     NodeId = Constants.DataTypes.Upload,
                     EditorAlias = Constants.PropertyEditors.Aliases.UploadField,
+                    EditorUiAlias = "Umb.PropertyEditorUi.UploadField",
                     DbType = "Nvarchar",
                 });
         }
 
-        InsertDataTypeDto(Constants.DataTypes.LabelString, Constants.PropertyEditors.Aliases.Label, "Nvarchar",
-            "{\"umbracoDataValueType\":\"STRING\"}");
-        InsertDataTypeDto(Constants.DataTypes.LabelInt, Constants.PropertyEditors.Aliases.Label, "Integer",
-            "{\"umbracoDataValueType\":\"INT\"}");
-        InsertDataTypeDto(Constants.DataTypes.LabelBigint, Constants.PropertyEditors.Aliases.Label, "Nvarchar",
-            "{\"umbracoDataValueType\":\"BIGINT\"}");
-        InsertDataTypeDto(Constants.DataTypes.LabelDateTime, Constants.PropertyEditors.Aliases.Label, "Date",
-            "{\"umbracoDataValueType\":\"DATETIME\"}");
-        InsertDataTypeDto(Constants.DataTypes.LabelDecimal, Constants.PropertyEditors.Aliases.Label, "Decimal",
-            "{\"umbracoDataValueType\":\"DECIMAL\"}");
-        InsertDataTypeDto(Constants.DataTypes.LabelTime, Constants.PropertyEditors.Aliases.Label, "Date",
-            "{\"umbracoDataValueType\":\"TIME\"}");
+        InsertDataTypeDto(Constants.DataTypes.LabelString, Constants.PropertyEditors.Aliases.Label,
+            "Umb.PropertyEditorUi.Label", "Nvarchar", "{\"umbracoDataValueType\":\"STRING\"}");
+        InsertDataTypeDto(Constants.DataTypes.LabelInt, Constants.PropertyEditors.Aliases.Label,
+            "Umb.PropertyEditorUi.Label", "Integer", "{\"umbracoDataValueType\":\"INT\"}");
+        InsertDataTypeDto(Constants.DataTypes.LabelBigint, Constants.PropertyEditors.Aliases.Label,
+            "Umb.PropertyEditorUi.Label", "Nvarchar", "{\"umbracoDataValueType\":\"BIGINT\"}");
+        InsertDataTypeDto(Constants.DataTypes.LabelDateTime, Constants.PropertyEditors.Aliases.Label,
+            "Umb.PropertyEditorUi.Label", "Date", "{\"umbracoDataValueType\":\"DATETIME\"}");
+        InsertDataTypeDto(Constants.DataTypes.LabelDecimal, Constants.PropertyEditors.Aliases.Label,
+            "Umb.PropertyEditorUi.Label", "Decimal", "{\"umbracoDataValueType\":\"DECIMAL\"}");
+        InsertDataTypeDto(Constants.DataTypes.LabelTime, Constants.PropertyEditors.Aliases.Label,
+            "Umb.PropertyEditorUi.Label", "Date", "{\"umbracoDataValueType\":\"TIME\"}");
 
         if (_database.Exists<NodeDto>(Constants.DataTypes.DateTime))
         {
@@ -1985,6 +1991,7 @@ internal class DatabaseDataCreator
                 {
                     NodeId = Constants.DataTypes.DateTime,
                     EditorAlias = Constants.PropertyEditors.Aliases.DateTime,
+                    EditorUiAlias = "Umb.PropertyEditorUi.DatePicker",
                     DbType = "Date",
                     Configuration = "{\"format\":\"YYYY-MM-DD HH:mm:ss\"}",
                 });
@@ -1997,12 +2004,13 @@ internal class DatabaseDataCreator
                 {
                     NodeId = -37,
                     EditorAlias = Constants.PropertyEditors.Aliases.ColorPicker,
+                    EditorUiAlias = "Umb.PropertyEditorUi.ColorPicker",
                     DbType = "Nvarchar",
                 });
         }
 
         InsertDataTypeDto(Constants.DataTypes.DropDownSingle, Constants.PropertyEditors.Aliases.DropDownListFlexible,
-            "Nvarchar", "{\"multiple\":false}");
+            "Umb.PropertyEditorUi.Dropdown", "Nvarchar", "{\"multiple\":false}");
 
         if (_database.Exists<NodeDto>(-40))
         {
@@ -2011,6 +2019,7 @@ internal class DatabaseDataCreator
                 {
                     NodeId = -40,
                     EditorAlias = Constants.PropertyEditors.Aliases.RadioButtonList,
+                    EditorUiAlias = "Umb.PropertyEditorUi.RadioButtonList",
                     DbType = "Nvarchar",
                 });
         }
@@ -2021,14 +2030,15 @@ internal class DatabaseDataCreator
                 new DataTypeDto
                 {
                     NodeId = -41,
-                    EditorAlias = "Umbraco.DateTime",
+                    EditorAlias = Constants.PropertyEditors.Aliases.DateTime,
+                    EditorUiAlias = "Umb.PropertyEditorUi.DatePicker",
                     DbType = "Date",
                     Configuration = "{\"format\":\"YYYY-MM-DD\"}",
                 });
         }
 
         InsertDataTypeDto(Constants.DataTypes.DropDownMultiple, Constants.PropertyEditors.Aliases.DropDownListFlexible,
-            "Nvarchar", "{\"multiple\":true}");
+            "Umb.PropertyEditorUi.Dropdown", "Nvarchar", "{\"multiple\":true}");
 
         if (_database.Exists<NodeDto>(-43))
         {
@@ -2037,6 +2047,7 @@ internal class DatabaseDataCreator
                 {
                     NodeId = -43,
                     EditorAlias = Constants.PropertyEditors.Aliases.CheckBoxList,
+                    EditorUiAlias = "Umb.PropertyEditorUi.CheckBoxList",
                     DbType = "Nvarchar",
                 });
         }
@@ -2051,6 +2062,7 @@ internal class DatabaseDataCreator
                 {
                     NodeId = Constants.DataTypes.Tags,
                     EditorAlias = Constants.PropertyEditors.Aliases.Tags,
+                    EditorUiAlias = "Umb.PropertyEditorUi.Tags",
                     DbType = "Ntext",
                     Configuration = "{\"group\":\"default\", \"storageType\":\"Json\"}",
                 });
@@ -2063,6 +2075,7 @@ internal class DatabaseDataCreator
                 {
                     NodeId = Constants.DataTypes.ImageCropper,
                     EditorAlias = Constants.PropertyEditors.Aliases.ImageCropper,
+                    EditorUiAlias = "Umb.PropertyEditorUi.ImageCropper",
                     DbType = "Ntext",
                 });
         }
@@ -2077,6 +2090,7 @@ internal class DatabaseDataCreator
                 {
                     NodeId = Constants.DataTypes.DefaultContentListView,
                     EditorAlias = Constants.PropertyEditors.Aliases.ListView,
+                    EditorUiAlias = "Umb.PropertyEditorUi.Collection",
                     DbType = "Nvarchar",
                     Configuration =
                         "{\"pageSize\":100, \"orderBy\":\"updateDate\", \"orderDirection\":\"desc\", \"layouts\":" +
@@ -2095,6 +2109,7 @@ internal class DatabaseDataCreator
                 {
                     NodeId = Constants.DataTypes.DefaultMediaListView,
                     EditorAlias = Constants.PropertyEditors.Aliases.ListView,
+                    EditorUiAlias = "Umb.PropertyEditorUi.Collection",
                     DbType = "Nvarchar",
                     Configuration =
                         "{\"pageSize\":100, \"orderBy\":\"updateDate\", \"orderDirection\":\"desc\", \"layouts\":" +
@@ -2113,6 +2128,7 @@ internal class DatabaseDataCreator
                 {
                     NodeId = Constants.DataTypes.DefaultMembersListView,
                     EditorAlias = Constants.PropertyEditors.Aliases.ListView,
+                    EditorUiAlias = "Umb.PropertyEditorUi.Collection",
                     DbType = "Nvarchar",
                     Configuration =
                         "{\"pageSize\":10, \"orderBy\":\"username\", \"orderDirection\":\"asc\", \"includeProperties\":[{\"alias\":\"username\",\"isSystem\":true},{\"alias\":\"email\",\"isSystem\":true},{\"alias\":\"updateDate\",\"header\":\"Last edited\",\"isSystem\":true}]}",
@@ -2127,6 +2143,7 @@ internal class DatabaseDataCreator
                 {
                     NodeId = 1046,
                     EditorAlias = Constants.PropertyEditors.Aliases.ContentPicker,
+                    EditorUiAlias = "Umb.PropertyEditorUi.DocumentPicker",
                     DbType = "Nvarchar",
                 });
         }
@@ -2138,6 +2155,7 @@ internal class DatabaseDataCreator
                 {
                     NodeId = 1047,
                     EditorAlias = Constants.PropertyEditors.Aliases.MemberPicker,
+                    EditorUiAlias = "Umb.PropertyEditorUi.MemberPicker",
                     DbType = "Nvarchar",
                 });
         }
@@ -2149,6 +2167,7 @@ internal class DatabaseDataCreator
                 {
                     NodeId = 1050,
                     EditorAlias = Constants.PropertyEditors.Aliases.MultiUrlPicker,
+                    EditorUiAlias = "Umb.PropertyEditorUi.MultiUrlPicker",
                     DbType = "Ntext",
                 });
         }
@@ -2160,6 +2179,7 @@ internal class DatabaseDataCreator
                 {
                     NodeId = Constants.DataTypes.UploadVideo,
                     EditorAlias = Constants.PropertyEditors.Aliases.UploadField,
+                    EditorUiAlias = "Umb.PropertyEditorUi.UploadField",
                     DbType = "Nvarchar",
                     Configuration =
                         "{\"fileExtensions\":[\"mp4\",\"webm\",\"ogv\"]}",
@@ -2173,6 +2193,7 @@ internal class DatabaseDataCreator
                 {
                     NodeId = Constants.DataTypes.UploadAudio,
                     EditorAlias = Constants.PropertyEditors.Aliases.UploadField,
+                    EditorUiAlias = "Umb.PropertyEditorUi.UploadField",
                     DbType = "Nvarchar",
                     Configuration =
                         "{\"fileExtensions\":[\"mp3\",\"weba\",\"oga\",\"opus\"]}",
@@ -2186,6 +2207,7 @@ internal class DatabaseDataCreator
                 {
                     NodeId = Constants.DataTypes.UploadArticle,
                     EditorAlias = Constants.PropertyEditors.Aliases.UploadField,
+                    EditorUiAlias = "Umb.PropertyEditorUi.UploadField",
                     DbType = "Nvarchar",
                     Configuration =
                         "{\"fileExtensions\":[\"pdf\",\"docx\",\"doc\"]}",
@@ -2199,6 +2221,7 @@ internal class DatabaseDataCreator
                 {
                     NodeId = Constants.DataTypes.UploadVectorGraphics,
                     EditorAlias = Constants.PropertyEditors.Aliases.UploadField,
+                    EditorUiAlias = "Umb.PropertyEditorUi.UploadField",
                     DbType = "Nvarchar",
                     Configuration = "{\"fileExtensions\":[\"svg\"]}",
                 });
@@ -2211,6 +2234,7 @@ internal class DatabaseDataCreator
                 {
                     NodeId = 1051,
                     EditorAlias = Constants.PropertyEditors.Aliases.MediaPicker3,
+                    EditorUiAlias = "Umb.PropertyEditorUi.MediaPicker",
                     DbType = "Ntext",
                     Configuration = "{\"multiple\": false, \"validationLimit\":{\"min\":0,\"max\":1}}",
                 });
@@ -2223,6 +2247,7 @@ internal class DatabaseDataCreator
                 {
                     NodeId = 1052,
                     EditorAlias = Constants.PropertyEditors.Aliases.MediaPicker3,
+                    EditorUiAlias = "Umb.PropertyEditorUi.MediaPicker",
                     DbType = "Ntext",
                     Configuration = "{\"multiple\": true}",
                 });
@@ -2235,6 +2260,7 @@ internal class DatabaseDataCreator
                 {
                     NodeId = 1053,
                     EditorAlias = Constants.PropertyEditors.Aliases.MediaPicker3,
+                    EditorUiAlias = "Umb.PropertyEditorUi.MediaPicker",
                     DbType = "Ntext",
                     Configuration = "{\"filter\":\"" + ImageMediaTypeKey +
                                     "\", \"multiple\": false, \"validationLimit\":{\"min\":0,\"max\":1}}",
@@ -2248,6 +2274,7 @@ internal class DatabaseDataCreator
                 {
                     NodeId = 1054,
                     EditorAlias = Constants.PropertyEditors.Aliases.MediaPicker3,
+                    EditorUiAlias = "Umb.PropertyEditorUi.MediaPicker",
                     DbType = "Ntext",
                     Configuration = "{\"filter\":\"" + ImageMediaTypeKey +
                                     "\", \"multiple\": true}",


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

_This is the install equivalent to #16183_

Currently, all data types have missing icons on a freshly installed V14:

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/06fd6e3c-75bf-44d1-bd6f-7aee545d1a62)

...despite them seemingly being correctly configured when edited:

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/886db4c0-702d-4489-ad66-57ca2b0755bd)

This PR ensures that all data types are created with their correct editor UI aliases, thus ensuring that the icons are correct from the get-go:

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/bcc7a403-08c0-4b7f-8bc2-6e005aff3bf1)

☝️ As with #16183, this PR sets also the list view editor UI alias to "Umb.PropertyEditorUi.Collection" as a preemptive measure, because this is what it will be eventually on the client (it is currently "Umb.PropertyEditorUi.CollectionView", which is wrong). Thus the list view icons might not show up correctly, depending on when you test this.

### Testing this PR

Spin up a brand new V14 database and verify that all data types (possibly except the list view ones) have correct icons in the tree.