### PR TITLE
Add avatarUrls to the userItem responsemodel

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/User/Item/ItemUserItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/Item/ItemUserItemController.cs
@@ -1,6 +1,7 @@
 ﻿using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.User.Item;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models.Membership;
@@ -12,12 +13,12 @@ namespace Umbraco.Cms.Api.Management.Controllers.User.Item;
 public class ItemUserItemController : UserItemControllerBase
 {
     private readonly IUserService _userService;
-    private readonly IUmbracoMapper _mapper;
+    private readonly IUserPresentationFactory _userPresentationFactory;
 
-    public ItemUserItemController(IUserService userService, IUmbracoMapper mapper)
+    public ItemUserItemController(IUserService userService, IUserPresentationFactory userPresentationFactory)
     {
         _userService = userService;
-        _mapper = mapper;
+        _userPresentationFactory = userPresentationFactory;
     }
 
     [HttpGet]
@@ -31,7 +32,7 @@ public class ItemUserItemController : UserItemControllerBase
         }
 
         IEnumerable<IUser> users = await _userService.GetAsync(ids.ToArray());
-        List<UserItemResponseModel> responseModels = _mapper.MapEnumerable<IUser, UserItemResponseModel>(users);
+        var responseModels = users.Select(_userPresentationFactory.CreateItemResponseModel).ToList();
         return Ok(responseModels);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/IUserPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IUserPresentationFactory.cs
@@ -1,5 +1,6 @@
 ﻿using Umbraco.Cms.Api.Management.ViewModels.User;
 using Umbraco.Cms.Api.Management.ViewModels.User.Current;
+using Umbraco.Cms.Api.Management.ViewModels.User.Item;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Membership;
 
@@ -22,4 +23,6 @@ public interface IUserPresentationFactory
     Task<UserConfigurationResponseModel> CreateUserConfigurationModelAsync();
 
     Task<CurrenUserConfigurationResponseModel> CreateCurrentUserConfigurationModelAsync();
+
+    UserItemResponseModel CreateItemResponseModel(IUser user);
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using Umbraco.Cms.Api.Management.Security;
 using Umbraco.Cms.Api.Management.ViewModels.User;
 using Umbraco.Cms.Api.Management.ViewModels.User.Current;
+using Umbraco.Cms.Api.Management.ViewModels.User.Item;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.IO;
@@ -79,6 +80,15 @@ public class UserPresentationFactory : IUserPresentationFactory
 
         return responseModel;
     }
+
+    public UserItemResponseModel CreateItemResponseModel(IUser user) =>
+        new()
+        {
+            Id = user.Key,
+            Name = user.Name ?? user.Username,
+            AvatarUrls = user.GetUserAvatarUrls(_appCaches.RuntimeCache, _mediaFileManager, _imageUrlGenerator)
+                .Select(url => _absoluteUrlBuilder.ToAbsoluteUrl(url).ToString()),
+        };
 
     public async Task<UserCreateModel> CreateCreationModelAsync(CreateUserRequestModel requestModel)
     {

--- a/src/Umbraco.Cms.Api.Management/Mapping/Item/ItemTypeMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Item/ItemTypeMapDefinition.cs
@@ -31,7 +31,6 @@ public class ItemTypeMapDefinition : IMapDefinition
         mapper.Define<ITemplate, TemplateItemResponseModel>((_, _) => new TemplateItemResponseModel { Alias = string.Empty }, Map);
         mapper.Define<IMemberType, MemberTypeItemResponseModel>((_, _) => new MemberTypeItemResponseModel(), Map);
         mapper.Define<IRelationType, RelationTypeItemResponseModel>((_, _) => new RelationTypeItemResponseModel(), Map);
-        mapper.Define<IUser, UserItemResponseModel>((_, _) => new UserItemResponseModel(), Map);
         mapper.Define<IUserGroup, UserGroupItemResponseModel>((_, _) => new UserGroupItemResponseModel(), Map);
         mapper.Define<IWebhook, WebhookItemResponseModel>((_, _) => new WebhookItemResponseModel(), Map);
     }
@@ -105,13 +104,6 @@ public class ItemTypeMapDefinition : IMapDefinition
         target.Id = source.Key;
         target.Name = source.Name ?? string.Empty;
         target.IsDeletable = source.IsDeletableRelationType();
-    }
-
-    // Umbraco.Code.MapAll
-    private static void Map(IUser source, UserItemResponseModel target, MapperContext context)
-    {
-        target.Id = source.Key;
-        target.Name = source.Name ?? source.Username;
     }
 
     // Umbraco.Code.MapAll

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/Item/UserItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/Item/UserItemResponseModel.cs
@@ -4,4 +4,5 @@ namespace Umbraco.Cms.Api.Management.ViewModels.User.Item;
 
 public class UserItemResponseModel : NamedItemResponseModelBase
 {
+    public IEnumerable<string> AvatarUrls { get; set; } = Enumerable.Empty<string>();
 }


### PR DESCRIPTION
### Description
Frontend needs avatarUrls on the item endpoint as it is a crucial aspect to display users in pickers.

### Testing
After setting an avatar on a user (you should be able to use the client), check that the item endpoint returns the crop urls for the avatar on the selected user.