### PR TITLE
V14: Unique OAuth callback route

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/SecuritySettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/SecuritySettings.cs
@@ -25,7 +25,7 @@ public class SecuritySettings
 
     internal const int StaticMemberDefaultLockoutTimeInMinutes = 30 * 24 * 60;
     internal const int StaticUserDefaultLockoutTimeInMinutes = 30 * 24 * 60;
-    internal const string StaticAuthorizeCallbackPathName = "/umbraco";
+    internal const string StaticAuthorizeCallbackPathName = "/umbraco/oauth_complete";
     internal const string StaticAuthorizeCallbackLogoutPathName = "/umbraco/logout";
     internal const string StaticAuthorizeCallbackErrorPathName = "/umbraco/error";
 

--- a/src/Umbraco.Web.Common/Helpers/OAuthOptionsHelper.cs
+++ b/src/Umbraco.Web.Common/Helpers/OAuthOptionsHelper.cs
@@ -65,19 +65,4 @@ public class OAuthOptionsHelper
         context.Response.Redirect(callbackPath);
         return context;
     }
-
-    /// <summary>
-    /// Sets the callbackPath for the RemoteAuthenticationOptions based on the configured Umbraco path and the path supplied.
-    /// By default this will result in "/umbraco/your-supplied-path".
-    /// </summary>
-    /// <param name="options">The options object to set the path on.</param>
-    /// <param name="path">The path that should go after the umbraco path, will add a leading slash if it's missing.</param>
-    /// <returns></returns>
-    public RemoteAuthenticationOptions SetUmbracoBasedCallbackPath(RemoteAuthenticationOptions options, string path)
-    {
-        var umbracoCallbackPath = _securitySettings.Value.AuthorizeCallbackPathName;
-
-        options.CallbackPath = umbracoCallbackPath + path.EnsureStartsWith("/");
-        return options;
-    }
 }


### PR DESCRIPTION
### Description

> [!WARNING]
> Should not be merged before https://github.com/umbraco/Umbraco.CMS.Backoffice/pull/1720 is merged

This allows the server to send the user back to a route on the backoffice client where nothing is loaded. This is useful in case the user is being logged in inside a popup, where you don't need to load the whole backoffice client, since the popup will be closed by itself.