### PR TITLE
V14: Lock out users

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeController.cs
@@ -66,12 +66,6 @@ public class BackOfficeController : SecurityControllerBase
     [Authorize(Policy = AuthorizationPolicies.DenyLocalLoginIfConfigured)]
     public async Task<IActionResult> Login(CancellationToken cancellationToken, LoginRequestModel model)
     {
-        var validated = await _backOfficeUserManager.ValidateCredentialsAsync(model.Username, model.Password);
-        if (validated is false)
-        {
-            return Unauthorized();
-        }
-
         IdentitySignInResult result = await _backOfficeSignInManager.PasswordSignInAsync(
             model.Username, model.Password, true, true);
 


### PR DESCRIPTION
# Notes
- Remove the validation of credentials first, as this is not needed.
Brif history on why: it's because deploy needed a way to validate credentials, without logging the user in, thus `ValidateCredentialsAsync` was created.
Thus it is safe to remove this validation, as `PasswordSignInAsync` will validate the password, increment the lockout count etc all on its own.

# How to test
- Create a new user (remember the email and password)
- Log in with the user just to activate it
- Log out again
- Try to log in with the WRONG password more than 5 times
- Try to log in with the right password, this should now fail as the user is locked out 😁 