### PR TITLE
[V14] Allow specifying ID on the create package endpoint

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Factories/PackagePresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/PackagePresentationFactory.cs
@@ -30,7 +30,7 @@ internal class PackagePresentationFactory : IPackagePresentationFactory
 
         // Temp Id, PackageId and PackagePath for the newly created package
         packageDefinition.Id = 0;
-        packageDefinition.PackageId = Guid.Empty;
+        packageDefinition.PackageId = createPackageRequestModel.Id ?? Guid.Empty;
         packageDefinition.PackagePath = string.Empty;
 
         return packageDefinition;

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -32356,6 +32356,58 @@
           }
         ]
       }
+    },
+    "/umbraco/management/api/v1/webhook/events": {
+      "get": {
+        "tags": [
+          "Webhook"
+        ],
+        "operationId": "GetWebhookEvents",
+        "parameters": [
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PagedWebhookResponseModel"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
     }
   },
   "components": {
@@ -33884,6 +33936,11 @@
             "items": {
               "type": "string"
             }
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -43461,6 +43518,7 @@
       },
       "UserItemResponseModel": {
         "required": [
+          "avatarUrls",
           "id",
           "name"
         ],
@@ -43472,6 +43530,12 @@
           },
           "name": {
             "type": "string"
+          },
+          "avatarUrls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "additionalProperties": false

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Package/CreatePackageRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Package/CreatePackageRequestModel.cs
@@ -2,4 +2,5 @@ namespace Umbraco.Cms.Api.Management.ViewModels.Package;
 
 public class CreatePackageRequestModel : PackageModelBase
 {
+    public Guid? Id { get; set; }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
Allowing to specify the ID on the create package endpoint aligns it with the rest of our create endpoints

### Testing
- Validate whether a chosen ID is respected in the response headers and the resource can be fetched.
- Validate the ID is optional and a random one will be assigned if not supplied