### PR TITLE
V14: The `/umbraco/oauth_complete` route should show the Backoffice client

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Routing/BackOfficeAreaRoutes.cs
+++ b/src/Umbraco.Cms.Api.Management/Routing/BackOfficeAreaRoutes.cs
@@ -82,6 +82,6 @@ public sealed class BackOfficeAreaRoutes : IAreaRoutes
                 Controller = ControllerExtensions.GetControllerName<BackOfficeDefaultController>(),
                 Action = nameof(BackOfficeDefaultController.Index),
             },
-            constraints: new { slug = @"^(section.*|upgrade|install|logout|error)$" });
+            constraints: new { slug = @"^(section.*|upgrade|install|oauth_complete|logout|error)$" });
     }
 }


### PR DESCRIPTION
Following the feature in #16194 we need to add the new "oauth_complete" path to the list of exemptions for the backoffice client.