### PR TITLE
V14: Webhook endpoint fixes

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Webhook/CreateWebhookController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Webhook/CreateWebhookController.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.Webhook;
 using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Webhook/CreateWebhookController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Webhook/CreateWebhookController.cs
@@ -2,6 +2,7 @@ using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.Webhook;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Mapping;
@@ -17,13 +18,13 @@ namespace Umbraco.Cms.Api.Management.Controllers.Webhook;
 public class CreateWebhookController : WebhookControllerBase
 {
     private readonly IWebhookService _webhookService;
-    private readonly IUmbracoMapper _umbracoMapper;
+    private readonly IWebhookPresentationFactory _webhookPresentationFactory;
 
     public CreateWebhookController(
-        IWebhookService webhookService, IUmbracoMapper umbracoMapper)
+        IWebhookService webhookService, IWebhookPresentationFactory webhookPresentationFactory)
     {
         _webhookService = webhookService;
-        _umbracoMapper = umbracoMapper;
+        _webhookPresentationFactory = webhookPresentationFactory;
     }
 
     [HttpPost]
@@ -35,7 +36,7 @@ public class CreateWebhookController : WebhookControllerBase
         CancellationToken cancellationToken,
         CreateWebhookRequestModel createWebhookRequestModel)
     {
-        IWebhook created = _umbracoMapper.Map<IWebhook>(createWebhookRequestModel)!;
+        IWebhook created = _webhookPresentationFactory.CreateWebhook(createWebhookRequestModel);
 
         Attempt<IWebhook, WebhookOperationStatus> result = await _webhookService.CreateAsync(created);
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Webhook/DeleteWebhookController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Webhook/DeleteWebhookController.cs
@@ -24,7 +24,7 @@ public class DeleteWebhookController : WebhookControllerBase
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
-    [HttpDelete($"{{{nameof(id)}}}")]
+    [HttpDelete("{id:guid}")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Webhook/UpdateWebhookController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Webhook/UpdateWebhookController.cs
@@ -5,12 +5,9 @@ using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.Webhook;
 using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
-using Umbraco.Cms.Core.Webhooks;
 using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Webhook;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Webhook/UpdateWebhookController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Webhook/UpdateWebhookController.cs
@@ -43,7 +43,7 @@ public class UpdateWebhookController : WebhookControllerBase
             return WebhookNotFound();
         }
 
-        IWebhook updated = _webhookPresentationFactory.CreateWebhook(updateWebhookRequestModel);
+        IWebhook updated = _webhookPresentationFactory.CreateWebhook(updateWebhookRequestModel, id);
 
         Attempt<IWebhook, WebhookOperationStatus> result = await _webhookService.UpdateAsync(updated);
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Webhook/UpdateWebhookController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Webhook/UpdateWebhookController.cs
@@ -2,6 +2,7 @@ using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.Webhook;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Mapping;
@@ -19,14 +20,14 @@ namespace Umbraco.Cms.Api.Management.Controllers.Webhook;
 public class UpdateWebhookController : WebhookControllerBase
 {
     private readonly IWebhookService _webhookService;
-    private readonly IUmbracoMapper _umbracoMapper;
+    private readonly IWebhookPresentationFactory _webhookPresentationFactory;
+
 
     public UpdateWebhookController(
-        IWebhookService webhookService,
-        IUmbracoMapper umbracoMapper)
+        IWebhookService webhookService, IWebhookPresentationFactory webhookPresentationFactory)
     {
         _webhookService = webhookService;
-        _umbracoMapper = umbracoMapper;
+        _webhookPresentationFactory = webhookPresentationFactory;
     }
 
     [HttpPut("{id:guid}")]
@@ -45,7 +46,7 @@ public class UpdateWebhookController : WebhookControllerBase
             return WebhookNotFound();
         }
 
-        IWebhook updated = _umbracoMapper.Map(updateWebhookRequestModel, current);
+        IWebhook updated = _webhookPresentationFactory.CreateWebhook(updateWebhookRequestModel);
 
         Attempt<IWebhook, WebhookOperationStatus> result = await _webhookService.UpdateAsync(updated);
 

--- a/src/Umbraco.Cms.Api.Management/Factories/IWebhookPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IWebhookPresentationFactory.cs
@@ -10,5 +10,5 @@ public interface IWebhookPresentationFactory
 
     IWebhook CreateWebhook(CreateWebhookRequestModel webhookRequestModel);
 
-    IWebhook CreateWebhook(UpdateWebhookRequestModel webhookRequestModel);
+    IWebhook CreateWebhook(UpdateWebhookRequestModel webhookRequestModel, Guid existingWebhookKey);
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/WebhookPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/WebhookPresentationFactory.cs
@@ -28,7 +28,10 @@ internal class WebhookPresentationFactory : IWebhookPresentationFactory
 
     public IWebhook CreateWebhook(CreateWebhookRequestModel webhookRequestModel)
     {
-        var target = new Webhook(webhookRequestModel.Url, webhookRequestModel.Enabled, webhookRequestModel.ContentTypeKeys, webhookRequestModel.Events, webhookRequestModel.Headers);
+        var target = new Webhook(webhookRequestModel.Url, webhookRequestModel.Enabled, webhookRequestModel.ContentTypeKeys, webhookRequestModel.Events, webhookRequestModel.Headers)
+        {
+            Key = webhookRequestModel.Id ?? Guid.NewGuid(),
+        };
         return target;
     }
 

--- a/src/Umbraco.Cms.Api.Management/Factories/WebhookPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/WebhookPresentationFactory.cs
@@ -35,9 +35,12 @@ internal class WebhookPresentationFactory : IWebhookPresentationFactory
         return target;
     }
 
-    public IWebhook CreateWebhook(UpdateWebhookRequestModel webhookRequestModel)
+    public IWebhook CreateWebhook(UpdateWebhookRequestModel webhookRequestModel, Guid existingWebhookkey)
     {
-        var target = new Webhook(webhookRequestModel.Url, webhookRequestModel.Enabled, webhookRequestModel.ContentTypeKeys, webhookRequestModel.Events, webhookRequestModel.Headers);
+        var target = new Webhook(webhookRequestModel.Url, webhookRequestModel.Enabled, webhookRequestModel.ContentTypeKeys, webhookRequestModel.Events, webhookRequestModel.Headers)
+        {
+            Key = existingWebhookkey,
+        };
         return target;
     }
 


### PR DESCRIPTION
# Notes
- Fixes various webhook endpoints, as they were using mapping definition and not presentation factory

# How to test
- Create and delete webhooks via swagger, this should now work