### PR TITLE
Use the correct editor UI for MNTP

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddEditorUiToDataType.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddEditorUiToDataType.cs
@@ -67,7 +67,7 @@ public class AddEditorUiToDataType : MigrationBase
                 Constants.PropertyEditors.Aliases.MediaPicker3 => "Umb.PropertyEditorUi.MediaPicker",
                 Constants.PropertyEditors.Aliases.MemberPicker => "Umb.PropertyEditorUi.MemberPicker",
                 Constants.PropertyEditors.Aliases.MemberGroupPicker => "Umb.PropertyEditorUi.MemberGroupPicker",
-                Constants.PropertyEditors.Aliases.MultiNodeTreePicker => "Umb.PropertyEditorUi.TreePicker",
+                Constants.PropertyEditors.Aliases.MultiNodeTreePicker => "Umb.PropertyEditorUi.ContentPicker",
                 Constants.PropertyEditors.Aliases.MultipleTextstring => "Umb.PropertyEditorUi.MultipleTextString",
                 Constants.PropertyEditors.Aliases.Label => "Umb.PropertyEditorUi.Label",
                 Constants.PropertyEditors.Aliases.RadioButtonList => "Umb.PropertyEditorUi.RadioButtonList",


### PR DESCRIPTION
### Description

The editor UI for MNTP has changed from `Umb.PropertyEditorUi.TreePicker` to `Umb.PropertyEditorUi.ContentPicker` - this change needs reflecting in the upgrade migration (we do not install a default MNTP, so _only_ the upgrade migration is affected).