### PR TITLE
V13: Optimize custom MVC routing

### DIFF
--- a/src/Umbraco.Core/Constants-Web.cs
+++ b/src/Umbraco.Core/Constants-Web.cs
@@ -62,6 +62,7 @@ public static partial class Constants
             public const string ControllerToken = "controller";
             public const string ActionToken = "action";
             public const string AreaToken = "area";
+            public const string DynamicRoutePattern = "/{**umbracoSlug}";
         }
 
         public static class RoutePath

--- a/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -64,6 +64,7 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddSingleton<IUmbracoVirtualPageRoute, UmbracoVirtualPageRoute>();
         builder.Services.AddSingleton<IUmbracoRouteValuesFactory, UmbracoRouteValuesFactory>();
         builder.Services.AddSingleton<IRoutableDocumentFilter, RoutableDocumentFilter>();
+        builder.Services.AddSingleton<MatcherPolicy, EagerMatcherPolicy>();
         builder.Services.AddSingleton<MatcherPolicy, SurfaceControllerMatcherPolicy>();
 
         builder.Services.AddSingleton<FrontEndRoutes>();

--- a/src/Umbraco.Web.Website/Extensions/UmbracoApplicationBuilder.Website.cs
+++ b/src/Umbraco.Web.Website/Extensions/UmbracoApplicationBuilder.Website.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Web.Common.ApplicationBuilder;
 using Umbraco.Cms.Web.Common.Middleware;
 using Umbraco.Cms.Web.Website.Routing;
@@ -39,7 +40,7 @@ public static class UmbracoApplicationBuilderExtensions
 
         FrontEndRoutes surfaceRoutes = builder.ApplicationServices.GetRequiredService<FrontEndRoutes>();
         surfaceRoutes.CreateRoutes(builder.EndpointRouteBuilder);
-        builder.EndpointRouteBuilder.MapDynamicControllerRoute<UmbracoRouteValueTransformer>("/{**slug}");
+        builder.EndpointRouteBuilder.MapDynamicControllerRoute<UmbracoRouteValueTransformer>(Constants.Web.Routing.DynamicRoutePattern);
 
         return builder;
     }

--- a/src/Umbraco.Web.Website/Routing/EagerMatcherPolicy.cs
+++ b/src/Umbraco.Web.Website/Routing/EagerMatcherPolicy.cs
@@ -193,30 +193,31 @@ internal class EagerMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy
         }
 
         // Check if maintenance page should be shown
-        if (_runtimeState.Level == RuntimeLevel.Upgrade && _globalSettings.ShowMaintenancePageWhenInUpgradeState)
+        if (_runtimeState.Level != RuntimeLevel.Upgrade || _globalSettings.ShowMaintenancePageWhenInUpgradeState is false)
         {
-            // When upgrading you get redirected to /umbraco, and the API calls are considered installer requests
-            // So we need to not mess with these.
-            // This check relatively expensive, however,
-            // since this is only done when in upgrade state and when the maintenance page is enabled
-            // I think it's fine, since the site is really not expected to be under load while in this state.
-            if (_umbracoRequestPaths.IsBackOfficeRequest(httpContext.Request.Path)
-                || _umbracoRequestPaths.IsInstallerRequest(httpContext.Request.Path))
-            {
-                return Task.FromResult(true);
-            }
+            return Task.FromResult(false);
+        }
 
-            // Otherwise we'll re-route to the render controller (this will in turn show the maintenance page through a filter)
-            // With this approach however this could really just be a plain old endpoint instead of a filter.
-            SetEndpoint(candidates, _renderEndpoint.Value, new RouteValueDictionary
-                {
-                    [Constants.Web.Routing.ControllerToken] = ControllerExtensions.GetControllerName<RenderController>(),
-                    [Constants.Web.Routing.ActionToken] = nameof(RenderController.Index),
-                });
-
+        // When upgrading you get redirected to /umbraco, and the API calls are considered installer requests
+        // So we need to not mess with these.
+        // This check relatively expensive, however,
+        // since this is only done when in upgrade state and when the maintenance page is enabled
+        // I think it's fine, since the site is really not expected to be under load while in this state.
+        if (_umbracoRequestPaths.IsBackOfficeRequest(httpContext.Request.Path)
+            || _umbracoRequestPaths.IsInstallerRequest(httpContext.Request.Path))
+        {
             return Task.FromResult(true);
         }
 
-        return Task.FromResult(false);
+        // Otherwise we'll re-route to the render controller (this will in turn show the maintenance page through a filter)
+        // With this approach however this could really just be a plain old endpoint instead of a filter.
+        SetEndpoint(candidates, _renderEndpoint.Value, new RouteValueDictionary
+        {
+            [Constants.Web.Routing.ControllerToken] = ControllerExtensions.GetControllerName<RenderController>(),
+            [Constants.Web.Routing.ActionToken] = nameof(RenderController.Index),
+        });
+
+        return Task.FromResult(true);
+
     }
 }

--- a/src/Umbraco.Web.Website/Routing/EagerMatcherPolicy.cs
+++ b/src/Umbraco.Web.Website/Routing/EagerMatcherPolicy.cs
@@ -110,6 +110,7 @@ internal class EagerMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy
                 lowestOrder = routeEndpoint.Order;
             }
 
+            // We only want to consider our dynamic route, this way it's still possible to register your own custom route before ours.
             if (routeEndpoint.DisplayName != Constants.Web.Routing.DynamicRoutePattern)
             {
                 continue;
@@ -183,7 +184,6 @@ internal class EagerMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy
 
             SetEndpoint(candidates, _installEndpoint.Value, new RouteValueDictionary
             {
-                //TODO: figure out constants
                 [Constants.Web.Routing.ControllerToken] = "Install",
                 [Constants.Web.Routing.ActionToken] = "Index",
                 [Constants.Web.Routing.AreaToken] = Constants.Web.Mvc.InstallArea,

--- a/src/Umbraco.Web.Website/Routing/EagerMatcherPolicy.cs
+++ b/src/Umbraco.Web.Website/Routing/EagerMatcherPolicy.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Matching;
+using Umbraco.Cms.Core;
+
+namespace Umbraco.Cms.Web.Website.Routing;
+
+public class EagerMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy
+{
+    // We want this to run as the very first policy, so we can discard the UmbracoRouteValueTransformer before the framework runs it.
+    public override int Order => int.MinValue + 10;
+
+    // We want to run this against all endpoints.
+    public bool AppliesToEndpoints(IReadOnlyList<Endpoint> endpoints) => true;
+
+    public Task ApplyAsync(HttpContext httpContext, CandidateSet candidates)
+    {
+        // If there's only one candidate, we don't need to do anything.
+        if (candidates.Count < 2)
+        {
+            return Task.CompletedTask;
+        }
+
+        // If there are multiple candidates, we want to discard the catch-all (slug)
+        // IF there is any candidates with a lower order. Since this will be a statically routed endpoint registered before the dynamic route.
+        // Which means that we don't have to run our UmbracoRouteValueTransformer to route dynamically (expensive).
+        var lowestOrder = int.MaxValue;
+        int? dynamicId = null;
+        RouteEndpoint? dynamicEndpoint = null;
+        for (var i = 0; i < candidates.Count; i++)
+        {
+            CandidateState candidate = candidates[i];
+
+            // If it's not a RouteEndpoint there's not much we can do to count it in the order.
+            if (candidate.Endpoint is not RouteEndpoint routeEndpoint)
+            {
+                continue;
+            }
+
+            if (routeEndpoint.Order < lowestOrder)
+            {
+                lowestOrder = routeEndpoint.Order;
+            }
+
+            if (routeEndpoint.DisplayName != Constants.Web.Routing.DynamicRoutePattern)
+            {
+                continue;
+            }
+
+            dynamicEndpoint = routeEndpoint;
+            dynamicId = i;
+        }
+
+        // Invalidate the dynamic route if a static route has a lower order.
+        if (dynamicEndpoint is not null && dynamicId is not null && dynamicEndpoint.Order > lowestOrder)
+        {
+            candidates.SetValidity(dynamicId.Value, false);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Umbraco.Web.Website/Routing/EagerMatcherPolicy.cs
+++ b/src/Umbraco.Web.Website/Routing/EagerMatcherPolicy.cs
@@ -2,7 +2,13 @@
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Matching;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Web.Common.Controllers;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Web.Website.Routing;
 
@@ -21,41 +27,46 @@ namespace Umbraco.Cms.Web.Website.Routing;
  * "
  * From: https://github.com/dotnet/aspnetcore/issues/45175#issuecomment-1322497958
  *
+ * This also handles rerouting under install/upgrade states.
  */
 
 internal class EagerMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy
 {
+    private readonly IRuntimeState _runtimeState;
+    private readonly EndpointDataSource _endpointDataSource;
+    private readonly UmbracoRequestPaths _umbracoRequestPaths;
+    private GlobalSettings _globalSettings;
+    private readonly Lazy<Endpoint> _installEndpoint;
+    private readonly Lazy<Endpoint> _renderEndpoint;
+
+    public EagerMatcherPolicy(
+        IRuntimeState runtimeState,
+        EndpointDataSource endpointDataSource,
+        UmbracoRequestPaths umbracoRequestPaths,
+        IOptionsMonitor<GlobalSettings> globalSettings)
+    {
+        _runtimeState = runtimeState;
+        _endpointDataSource = endpointDataSource;
+        _umbracoRequestPaths = umbracoRequestPaths;
+        _globalSettings = globalSettings.CurrentValue;
+        globalSettings.OnChange(settings => _globalSettings = settings);
+        _installEndpoint = new Lazy<Endpoint>(GetInstallEndpoint);
+        _renderEndpoint = new Lazy<Endpoint>(GetRenderEndpoint);
+    }
+
     // We want this to run as the very first policy, so we can discard the UmbracoRouteValueTransformer before the framework runs it.
     public override int Order => int.MinValue + 10;
 
     // We know we don't have to run this matcher against the backoffice endpoints.
-    public bool AppliesToEndpoints(IReadOnlyList<Endpoint> endpoints)
-    {
-        // If there's only one candidate it's the dynamic route
-        if (endpoints.Count < 2)
-        {
-            return true;
-        }
-
-        foreach (Endpoint endpoint in endpoints)
-        {
-            ControllerActionDescriptor? actionDescriptor = endpoint.Metadata.GetMetadata<ControllerActionDescriptor>();
-
-            var namespaceName = actionDescriptor?.ControllerTypeInfo.Namespace;
-
-            if (namespaceName is null || namespaceName.StartsWith("Umbraco.Cms") is false || namespaceName.StartsWith("Umbraco.Cms.Web.UI"))
-            {
-                continue;
-            }
-
-            return false;
-        }
-
-        return true;
-    }
+    public bool AppliesToEndpoints(IReadOnlyList<Endpoint> endpoints) => true;
 
     public Task ApplyAsync(HttpContext httpContext, CandidateSet candidates)
     {
+        if (_runtimeState.Level != RuntimeLevel.Run)
+        {
+            return HandleInstallUpgrade(httpContext, candidates);
+        }
+
         // If there's only one candidate, we don't need to do anything.
         if (candidates.Count < 2)
         {
@@ -110,6 +121,98 @@ internal class EagerMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy
         if (dynamicEndpoint is not null && dynamicId is not null && dynamicEndpoint.Order > lowestOrder)
         {
             candidates.SetValidity(dynamicId.Value, false);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Replaces the first endpoint candidate with the specified endpoint, invalidating all other candidates,
+    /// guaranteeing that the specified endpoint will be hit.
+    /// </summary>
+    /// <param name="candidates">The candidate set to manipulate.</param>
+    /// <param name="endpoint">The target endpoint that will be hit.</param>
+    /// <param name="routeValueDictionary"></param>
+    private static void SetEndpoint(CandidateSet candidates, Endpoint endpoint, RouteValueDictionary routeValueDictionary)
+    {
+        candidates.ReplaceEndpoint(0, endpoint, routeValueDictionary);
+
+        for (int i = 1; i < candidates.Count; i++)
+        {
+            candidates.SetValidity(1, false);
+        }
+    }
+
+    private Endpoint GetInstallEndpoint()
+    {
+        Endpoint endpoint = _endpointDataSource.Endpoints.First(x =>
+        {
+            ControllerActionDescriptor? descriptor = x.Metadata.GetMetadata<ControllerActionDescriptor>();
+            return descriptor?.ControllerTypeInfo.Name == "InstallController"
+                   && descriptor.ActionName == "Index";
+        });
+
+        return endpoint;
+    }
+
+    private Endpoint GetRenderEndpoint()
+    {
+        Endpoint endpoint = _endpointDataSource.Endpoints.First(x =>
+        {
+            ControllerActionDescriptor? descriptor = x.Metadata.GetMetadata<ControllerActionDescriptor>();
+            return descriptor?.ControllerTypeInfo == typeof(RenderController)
+                   && descriptor.ActionName == nameof(RenderController.Index);
+        });
+
+        return endpoint;
+    }
+
+    private Task HandleInstallUpgrade(HttpContext httpContext, CandidateSet candidates)
+    {
+        if (_runtimeState.Level != RuntimeLevel.Upgrade)
+        {
+            // We need to let the installer API requests through
+            // Currently we do this with a check for the installer path
+            // Ideally we should do this in a more robust way, for instance with a dedicated attribute we can then check for.
+            if (_umbracoRequestPaths.IsInstallerRequest(httpContext.Request.Path))
+            {
+                return Task.CompletedTask;
+            }
+
+            SetEndpoint(candidates, _installEndpoint.Value, new RouteValueDictionary
+            {
+                //TODO: figure out constants
+                [Constants.Web.Routing.ControllerToken] = "Install",
+                [Constants.Web.Routing.ActionToken] = "Index",
+                [Constants.Web.Routing.AreaToken] = Constants.Web.Mvc.InstallArea,
+            });
+
+            return Task.CompletedTask;
+        }
+
+        // Check if maintenance page should be shown
+        if (_runtimeState.Level == RuntimeLevel.Upgrade && _globalSettings.ShowMaintenancePageWhenInUpgradeState)
+        {
+            // When upgrading you get redirected to /umbraco, and the API calls are considered installer requests
+            // So we need to not mess with these.
+            // This check relatively expensive, however,
+            // since this is only done when in upgrade state and when the maintenance page is enabled
+            // I think it's fine, since the site is really not expected to be under load while in this state.
+            if (_umbracoRequestPaths.IsBackOfficeRequest(httpContext.Request.Path)
+                || _umbracoRequestPaths.IsInstallerRequest(httpContext.Request.Path))
+            {
+                return Task.CompletedTask;
+            }
+
+            // Otherwise we'll re-route to the render controller (this will in turn show the maintenance page through a filter)
+            // With this approach however this could really just be a plain old endpoint instead of a filter.
+            SetEndpoint(candidates, _renderEndpoint.Value, new RouteValueDictionary
+                {
+                    [Constants.Web.Routing.ControllerToken] = ControllerExtensions.GetControllerName<RenderController>(),
+                    [Constants.Web.Routing.ActionToken] = nameof(RenderController.Index),
+                });
+
+            return Task.CompletedTask;
         }
 
         return Task.CompletedTask;

--- a/src/Umbraco.Web.Website/Routing/EagerMatcherPolicy.cs
+++ b/src/Umbraco.Web.Website/Routing/EagerMatcherPolicy.cs
@@ -37,7 +37,6 @@ internal class EagerMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy
             return true;
         }
 
-        var applies = true;
         foreach (Endpoint endpoint in endpoints)
         {
             ControllerActionDescriptor? actionDescriptor = endpoint.Metadata.GetMetadata<ControllerActionDescriptor>();
@@ -49,11 +48,10 @@ internal class EagerMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy
                 continue;
             }
 
-            applies = false;
-            break;
+            return false;
         }
 
-        return applies;
+        return true;
     }
 
     public Task ApplyAsync(HttpContext httpContext, CandidateSet candidates)

--- a/src/Umbraco.Web.Website/Routing/EagerMatcherPolicy.cs
+++ b/src/Umbraco.Web.Website/Routing/EagerMatcherPolicy.cs
@@ -215,17 +215,6 @@ internal class EagerMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy
             return Task.FromResult(false);
         }
 
-        // When upgrading you get redirected to /umbraco, and the API calls are considered installer requests
-        // So we need to not mess with these.
-        // This check relatively expensive, however,
-        // since this is only done when in upgrade state and when the maintenance page is enabled
-        // I think it's fine, since the site is really not expected to be under load while in this state.
-        if (_umbracoRequestPaths.IsBackOfficeRequest(httpContext.Request.Path)
-            || _umbracoRequestPaths.IsInstallerRequest(httpContext.Request.Path))
-        {
-            return Task.FromResult(true);
-        }
-
         // Otherwise we'll re-route to the render controller (this will in turn show the maintenance page through a filter)
         // With this approach however this could really just be a plain old endpoint instead of a filter.
         SetEndpoint(candidates, _renderEndpoint.Value, new RouteValueDictionary

--- a/src/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformer.cs
+++ b/src/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformer.cs
@@ -139,23 +139,6 @@ public class UmbracoRouteValueTransformer : DynamicRouteValueTransformer
     public override async ValueTask<RouteValueDictionary> TransformAsync(
         HttpContext httpContext, RouteValueDictionary values)
     {
-        // If we aren't running, then we have nothing to route. We allow the frontend to continue while in upgrade mode.
-        if (_runtime.Level != RuntimeLevel.Run && _runtime.Level != RuntimeLevel.Upgrade)
-        {
-            if (_runtime.Level == RuntimeLevel.Install)
-            {
-                return new RouteValueDictionary()
-                {
-                    //TODO figure out constants
-                    [ControllerToken] = "Install",
-                    [ActionToken] = "Index",
-                    [AreaToken] = Constants.Web.Mvc.InstallArea,
-                };
-            }
-
-            return null!;
-        }
-
         // will be null for any client side requests like JS, etc...
         if (!_umbracoContextAccessor.TryGetUmbracoContext(out IUmbracoContext? umbracoContext))
         {
@@ -170,17 +153,6 @@ public class UmbracoRouteValueTransformer : DynamicRouteValueTransformer
         if (CheckActiveDynamicRoutingAndNoException(httpContext))
         {
             return null!;
-        }
-
-        // Check if the maintenance page should be shown
-        if (_runtime.Level == RuntimeLevel.Upgrade && _globalSettings.ShowMaintenancePageWhenInUpgradeState)
-        {
-            return new RouteValueDictionary
-            {
-                // Redirects to the RenderController who handles maintenance page in a filter, instead of having a dedicated controller
-                [ControllerToken] = ControllerExtensions.GetControllerName<RenderController>(),
-                [ActionToken] = nameof(RenderController.Index),
-            };
         }
 
         // Check if there is no existing content and return the no content controller


### PR DESCRIPTION
This optimizes the routing of custom MVC routes, both with and without `UmbracoPageController` by ensuring that the `UmbracoRouteValueTransformer` is only hit when needed, this fixes #16015.

This problem is caused by the behaviour of asp.net core as [explained in this comment:](https://github.com/dotnet/aspnetcore/issues/45175#issuecomment-1322497958)

"all routes get evaluated, they get to produce candidates and then the best candidate is selected. Since you have a dynamic route, it needs to run to produce the final endpoints and then those are ranked in along with the rest of the candidates to choose the final endpoint." 

This means that no matter what the `UmbracoRouteValueTransformer` would always be called, requiring it to run through **all** content finders. 

The fix for this is to implement our custom `MatcherPolicy` which will invalidate our dynamic route if another (usually static) route is configured before our dynamic route. This was complicated because our install/upgrade redirect handling was handled by the `UmbracoRouteValueTransformer`. This means that since we now skip the transformer for static routes you wouldn't get redirected to install/upgrade if you hit a static route. To fix this I've moved the install/upgrade redirect into the `MatcherPolicy` instead.


## Testing

It's hard to list a specific test procedure for this one, but see the issue #16015 for a good starting setup, and then try and test our different ways of routing, surface controller etc, and ensure they work as expected, additionally test that install/upgrade works as intended. 

I've tried to test every combination of routing I can come up with 😄 

