### PR TITLE
Combining OpenId and OfflineAccess scope

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Controllers/Security/MemberController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/Security/MemberController.cs
@@ -158,20 +158,13 @@ public class MemberController : DeliveryApiControllerBase
         {
             claim.SetDestinations(OpenIddictConstants.Destinations.AccessToken);
         }
-        var scopes = new List<string>();
 
-        if (request.GetScopes().Contains(OpenIddictConstants.Scopes.OpenId))
-        {
-            scopes.Add(OpenIddictConstants.Scopes.OpenId);
-        }
-
-        if (request.GetScopes().Contains(OpenIddictConstants.Scopes.OfflineAccess))
-        {
-            // "offline_access" scope is required to use refresh tokens
-            scopes.Add(OpenIddictConstants.Scopes.OfflineAccess);
-        }
-
-        memberPrincipal.SetScopes(scopes);
+        // "openid" and "offline_access" are the only scopes allowed for members; explicitly ensure we only add those
+        // NOTE: the "offline_access" scope is required to use refresh tokens
+        IEnumerable<string> allowedScopes = request
+            .GetScopes()
+            .Intersect(new[] { OpenIddictConstants.Scopes.OpenId, OpenIddictConstants.Scopes.OfflineAccess });
+        memberPrincipal.SetScopes(allowedScopes);
 
         return new SignInResult(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme, memberPrincipal);
     }

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/Security/MemberController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/Security/MemberController.cs
@@ -158,12 +158,20 @@ public class MemberController : DeliveryApiControllerBase
         {
             claim.SetDestinations(OpenIddictConstants.Destinations.AccessToken);
         }
+        var scopes = new List<string>();
+
+        if (request.GetScopes().Contains(OpenIddictConstants.Scopes.OpenId))
+        {
+            scopes.Add(OpenIddictConstants.Scopes.OpenId);
+        }
 
         if (request.GetScopes().Contains(OpenIddictConstants.Scopes.OfflineAccess))
         {
             // "offline_access" scope is required to use refresh tokens
-            memberPrincipal.SetScopes(OpenIddictConstants.Scopes.OfflineAccess);
+            scopes.Add(OpenIddictConstants.Scopes.OfflineAccess);
         }
+
+        memberPrincipal.SetScopes(scopes);
 
         return new SignInResult(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme, memberPrincipal);
     }


### PR DESCRIPTION
When the client scope is set to "openid offline_access", the returned scope only has the "offline_access" scope. The "openid" scope and the "id_token" are missing. By combining the OpenId and OfflineAccess as return scope, the refresh_token and id_token are returned.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
This change checks if the OpenId and/or OfflineAccess scope is set and combines them.
To test I've used the Client app of this repro from Jeroen Breuer: https://github.com/jbreuer/UmbracoDeliveryApiAuthDemo

Change https://github.com/jbreuer/UmbracoDeliveryApiAuthDemo/blob/a799b307302f7189d7ddd69b9554ae2b24612eb4/src/Client/src/App.js#L22 to `const scope = 'openid offline_access';`

Copy the "OpenIdConnect" section in the appsettings.json to your own installation.

    The token result looks like this:
![afbeelding](https://github.com/umbraco/Umbraco-CMS/assets/18614643/b13ec0e8-d9c3-4065-a5d9-c7eb706d0c05)
    Note that the id_token is missing and the scope is set to "offline_access" only.

   After applying this PR, te result looks like this:

![afbeelding](https://github.com/umbraco/Umbraco-CMS/assets/18614643/c371fbff-b54d-4769-b590-f22764d8dc80)







<!-- Thanks for contributing to Umbraco CMS! -->
