### PR TITLE
V14: Return the unhealthy error message from Examine index

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Factories/IndexPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IndexPresentationFactory.cs
@@ -26,7 +26,10 @@ public class IndexPresentationFactory : IIndexPresentationFactory
             return new IndexResponseModel
             {
                 Name = index.Name,
-                HealthStatus = HealthStatus.Rebuilding,
+                HealthStatus = new HealthStatusResponseModel
+                {
+                    Status = HealthStatus.Rebuilding,
+                },
                 SearcherName = index.Searcher.Name,
                 DocumentCount = 0,
                 FieldCount = 0,
@@ -36,6 +39,7 @@ public class IndexPresentationFactory : IIndexPresentationFactory
         IIndexDiagnostics indexDiag = _indexDiagnosticsFactory.Create(index);
 
         Attempt<string?> isHealthy = indexDiag.IsHealthy();
+        var healthResult = isHealthy.Result;
 
         var properties = new Dictionary<string, object?>();
 
@@ -55,7 +59,11 @@ public class IndexPresentationFactory : IIndexPresentationFactory
         var indexerModel = new IndexResponseModel
         {
             Name = index.Name,
-            HealthStatus = isHealthy.Success ? HealthStatus.Healthy : HealthStatus.Unhealthy,
+            HealthStatus = new HealthStatusResponseModel
+            {
+                Status = isHealthy.Success ? HealthStatus.Healthy : HealthStatus.Unhealthy,
+                Message = healthResult,
+            },
             CanRebuild = _indexRebuilder.CanRebuild(index.Name),
             SearcherName = index.Searcher.Name,
             DocumentCount = indexDiag.GetDocumentCount(),

--- a/src/Umbraco.Cms.Api.Management/Factories/IndexPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IndexPresentationFactory.cs
@@ -38,8 +38,7 @@ public class IndexPresentationFactory : IIndexPresentationFactory
 
         IIndexDiagnostics indexDiag = _indexDiagnosticsFactory.Create(index);
 
-        Attempt<string?> isHealthy = indexDiag.IsHealthy();
-        var healthResult = isHealthy.Result;
+        Attempt<string?> isHealthyAttempt = indexDiag.IsHealthy();
 
         var properties = new Dictionary<string, object?>();
 
@@ -61,8 +60,8 @@ public class IndexPresentationFactory : IIndexPresentationFactory
             Name = index.Name,
             HealthStatus = new HealthStatusResponseModel
             {
-                Status = isHealthy.Success ? HealthStatus.Healthy : HealthStatus.Unhealthy,
-                Message = healthResult,
+                Status = isHealthyAttempt.Success ? HealthStatus.Healthy : HealthStatus.Unhealthy,
+                Message = isHealthyAttempt.Result,
             },
             CanRebuild = _indexRebuilder.CanRebuild(index.Name),
             SearcherName = index.Searcher.Name,

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -32107,6 +32107,115 @@
           }
         ]
       },
+      "delete": {
+        "tags": [
+          "Webhook"
+        ],
+        "operationId": "DeleteWebhookById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ProblemDetails"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ProblemDetails"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Success",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          },
+          "403": {
+            "description": "The authenticated user do not have access to this resource",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      },
       "put": {
         "tags": [
           "Webhook"
@@ -32183,115 +32292,6 @@
           },
           "400": {
             "description": "Bad Request",
-            "headers": {
-              "Umb-Notifications": {
-                "description": "The list of notifications produced during the request.",
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/NotificationHeaderModel"
-                  },
-                  "nullable": true
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/ProblemDetails"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "Success",
-            "headers": {
-              "Umb-Notifications": {
-                "description": "The list of notifications produced during the request.",
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/NotificationHeaderModel"
-                  },
-                  "nullable": true
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "The resource is protected and requires an authentication token"
-          },
-          "403": {
-            "description": "The authenticated user do not have access to this resource",
-            "headers": {
-              "Umb-Notifications": {
-                "description": "The list of notifications produced during the request.",
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/NotificationHeaderModel"
-                  },
-                  "nullable": true
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "Backoffice User": [ ]
-          }
-        ]
-      },
-      "delete": {
-        "tags": [
-          "Webhook"
-        ],
-        "operationId": "DeleteWebhookById",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "400": {
-            "description": "Bad Request",
-            "headers": {
-              "Umb-Notifications": {
-                "description": "The list of notifications produced during the request.",
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/NotificationHeaderModel"
-                  },
-                  "nullable": true
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/ProblemDetails"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
             "headers": {
               "Umb-Notifications": {
                 "description": "The list of notifications produced during the request.",
@@ -36671,6 +36671,22 @@
         ],
         "type": "string"
       },
+      "HealthStatusResponseModel": {
+        "required": [
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/HealthStatusModel"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "HelpPageResponseModel": {
         "type": "object",
         "properties": {
@@ -36733,7 +36749,11 @@
             "type": "string"
           },
           "healthStatus": {
-            "$ref": "#/components/schemas/HealthStatusModel"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/HealthStatusResponseModel"
+              }
+            ]
           },
           "canRebuild": {
             "type": "boolean"
@@ -43456,11 +43476,12 @@
       "UserGroupResponseModel": {
         "required": [
           "alias",
+          "aliasCanBeChanged",
           "documentRootAccess",
           "fallbackPermissions",
           "hasAccessToAllLanguages",
           "id",
-          "isSystemGroup",
+          "isDeletable",
           "languages",
           "mediaRootAccess",
           "name",
@@ -43541,7 +43562,10 @@
             "type": "string",
             "format": "uuid"
           },
-          "isSystemGroup": {
+          "isDeletable": {
+            "type": "boolean"
+          },
+          "aliasCanBeChanged": {
             "type": "boolean"
           }
         },

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Indexer/HealthStatusResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Indexer/HealthStatusResponseModel.cs
@@ -1,0 +1,8 @@
+namespace Umbraco.Cms.Api.Management.ViewModels.Indexer;
+
+public class HealthStatusResponseModel
+{
+    public HealthStatus Status { get; init; }
+
+    public string? Message { get; init; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Indexer/IndexResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Indexer/IndexResponseModel.cs
@@ -7,7 +7,7 @@ public class IndexResponseModel
     [Required]
     public string Name { get; init; } = null!;
 
-    public HealthStatus HealthStatus { get; init; }
+    public HealthStatusResponseModel HealthStatus { get; set; } = new();
 
     [Required]
     public bool CanRebuild { get; init; }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Factories/IndexPresentationFactoryTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Factories/IndexPresentationFactoryTests.cs
@@ -1,0 +1,63 @@
+using System.Collections.ObjectModel;
+using Examine;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Examine;
+using Umbraco.Cms.Infrastructure.Services;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Api.Management.Factories;
+
+[TestFixture]
+public class IndexPresentationFactoryTests
+{
+    [Test]
+    public void Create_Should_Set_HealthStatusMessage_On_Diagnostics_Failure()
+    {
+        var indexDiagnosticsFailureMessage = "something is wrong";
+        // arrange
+        var indexMock = new Mock<IIndex>();
+        indexMock
+            .SetupGet(index => index.Name)
+            .Returns("testIndex");
+        indexMock
+            .SetupGet(index => index.Searcher)
+            .Returns(Mock.Of<ISearcher>());
+
+        var indexDiagnosticsMock = new Mock<IIndexDiagnostics>();
+        indexDiagnosticsMock
+            .Setup(diagnostic => diagnostic.IsHealthy())
+            .Returns(Attempt<string?>.Fail(indexDiagnosticsFailureMessage));
+        indexDiagnosticsMock
+            .SetupGet(diagnostic => diagnostic.Metadata)
+            .Returns(ReadOnlyDictionary<string, object?>.Empty);
+        indexDiagnosticsMock
+            .Setup(diagnostic => diagnostic.GetFieldNames())
+            .Returns(Enumerable.Empty<string>());
+
+        var indexDiagnosticsFactoryMock = new Mock<IIndexDiagnosticsFactory>();
+        indexDiagnosticsFactoryMock
+            .Setup(f => f.Create(It.IsAny<IIndex>()))
+            .Returns(indexDiagnosticsMock.Object);
+
+        var indexRebuilderMock = new Mock<IIndexRebuilder>();
+
+        var indexRebuilderServiceMock = new Mock<IIndexingRebuilderService>();
+        indexRebuilderServiceMock
+            .Setup(rebuilder => rebuilder.IsRebuilding(It.IsAny<string>()))
+            .Returns(false);
+
+        var factory = new IndexPresentationFactory(
+            indexDiagnosticsFactoryMock.Object,
+            indexRebuilderMock.Object,
+            indexRebuilderServiceMock.Object);
+
+
+        // act
+        var responseModel = factory.Create(indexMock.Object);
+
+        // assert
+        Assert.AreEqual(indexDiagnosticsFailureMessage, responseModel.HealthStatus.Message);
+    }
+}


### PR DESCRIPTION
## Details
- Fixes the backend part of the following issue, reported in https://github.com/umbraco/Umbraco-CMS/issues/16213:
> When the IIndexDiagnostics reports unhealthy, the dashboard not longer uses the Attempt<string> result to display the unhealthy error message. The string returned from this attempt should be displayed.

## Test
- Change [_this line_](https://github.com/umbraco/Umbraco-CMS/blob/v14/dev/src/Umbraco.Cms.Api.Management/Factories/IndexPresentationFactory.cs#L38) to the following:
```c#
Attempt<string?> isHealthy = Attempt.Fail("something went wrong");
```
- Verify that when an index is unhealthy, you get the `"something went wrong"` message using `GET /umbraco/management/api/v1/indexer` endpoint;
- Verify that the `healthStatus::message` (in the output) is null when there is no message, i.e. an index is healthy.