### PR TITLE
V14: The login page does not respect certain error codes

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Security/TwoFactorLoginViewOptions.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/TwoFactorLoginViewOptions.cs
@@ -8,5 +8,6 @@ public class TwoFactorLoginViewOptions
     /// <summary>
     ///     Gets or sets the path of the view to show when setting up this 2fa provider
     /// </summary>
+    [Obsolete("Register the view in the backoffice instead. This will be removed in version 15.")]
     public string? SetupViewPath { get; set; }
 }

--- a/src/Umbraco.Web.UI.Login/src/components/pages/login.page.element.ts
+++ b/src/Umbraco.Web.UI.Login/src/components/pages/login.page.element.ts
@@ -91,7 +91,6 @@ export default class UmbLoginPageElement extends UmbLitElement {
     }
 
     if (response.error) {
-      this.dispatchEvent(new CustomEvent('umb-login-failed', {bubbles: true, composed: true}));
       return;
     }
 
@@ -100,8 +99,6 @@ export default class UmbLoginPageElement extends UmbLitElement {
     if (returnPath) {
       location.href = returnPath;
     }
-
-    this.dispatchEvent(new CustomEvent('umb-login-success', {bubbles: true, composed: true, detail: response.data}));
   };
 
   get #greetingLocalizationKey() {

--- a/src/Umbraco.Web.UI.Login/src/components/pages/login.page.element.ts
+++ b/src/Umbraco.Web.UI.Login/src/components/pages/login.page.element.ts
@@ -42,6 +42,12 @@ export default class UmbLoginPageElement extends UmbLitElement {
 
     if (!this.#formElement) return;
 
+    // We need to listen for the enter key to submit the form, because the uui-button does not support the native input fields submit event
+    this.#formElement.addEventListener('keypress', (e) => {
+      if (e.key === 'Enter') {
+        this.#onSubmitClick();
+      }
+    });
     this.#formElement.onsubmit = this.#handleSubmit;
   }
 

--- a/src/Umbraco.Web.UI.Login/src/components/pages/mfa.page.element.ts
+++ b/src/Umbraco.Web.UI.Login/src/components/pages/mfa.page.element.ts
@@ -56,6 +56,7 @@ export default class UmbMfaPageElement extends UmbLitElement {
     if (codeInput) {
       codeInput.error = false;
       codeInput.errorMessage = '';
+      codeInput.setCustomValidity('');
     }
 
     if (!form.checkValidity()) return;
@@ -84,44 +85,30 @@ export default class UmbMfaPageElement extends UmbLitElement {
 
     this.buttonState = 'waiting';
 
-    try {
-      const response = await this.#authContext.validateMfaCode(code, provider);
-      if (response.error) {
-        if (codeInput) {
-          codeInput.error = true;
-          codeInput.errorMessage = response.error;
-        } else {
-          this.error = response.error;
-        }
-        this.buttonState = 'failed';
-        return;
-      }
-
-      this.buttonState = 'success';
-
-      const returnPath = this.#authContext.returnPath;
-      if (returnPath) {
-        location.href = returnPath;
-      }
-
-      this.dispatchEvent(
-        new CustomEvent('umb-login-success', {bubbles: true, composed: true})
-      );
-    } catch (e) {
-      if (e instanceof Error) {
-        this.error = e.message ?? 'Unknown error';
+    const response = await this.#authContext.validateMfaCode(code, provider);
+    if (response.error) {
+      if (codeInput) {
+        codeInput.error = true;
+        codeInput.errorMessage = response.error;
       } else {
-        this.error = 'Unknown error';
+        this.error = response.error;
       }
       this.buttonState = 'failed';
-      this.dispatchEvent(new CustomEvent('umb-login-failed', {bubbles: true, composed: true}));
+      return;
+    }
+
+    this.buttonState = 'success';
+
+    const returnPath = this.#authContext.returnPath;
+    if (returnPath) {
+      location.href = returnPath;
     }
   }
 
   protected renderDefaultView() {
     return html`
       <uui-form>
-        <form id="LoginForm" @submit=${this.#handleSubmit}>
+        <form id="LoginForm" @submit=${this.#handleSubmit} novalidate>
           <header id="header">
             <h1>
               <umb-localize key="auth_mfaTitle">One last step</umb-localize>

--- a/src/Umbraco.Web.UI.Login/src/components/pages/mfa.page.element.ts
+++ b/src/Umbraco.Web.UI.Login/src/components/pages/mfa.page.element.ts
@@ -128,7 +128,7 @@ export default class UmbMfaPageElement extends UmbLitElement {
                 <uui-label id="providerLabel" for="provider" slot="label" required>
                   <umb-localize key="auth_mfaMultipleText">Please choose a 2-factor provider</umb-localize>
                 </uui-label>
-                <uui-select id="provider" name="provider" .options=${this.providers} aria-required="true" required></uui-select>
+                <uui-select label=${this.localize.term('auth_mfaMultipleText')} id="provider" name="provider" .options=${this.providers} aria-required="true" required></uui-select>
               </uui-form-layout-item>
             `
             : nothing}
@@ -149,6 +149,7 @@ export default class UmbMfaPageElement extends UmbLitElement {
               aria-required="true"
               required
               required-message=${this.localize.term('auth_mfaCodeInputHelp')}
+              label=${this.localize.term('auth_mfaCodeInput')}
               style="width:100%;">
             </uui-input>
           </uui-form-layout-item>

--- a/src/Umbraco.Web.UI.Login/src/contexts/auth.repository.ts
+++ b/src/Umbraco.Web.UI.Login/src/contexts/auth.repository.ts
@@ -57,7 +57,7 @@ export class UmbAuthRepository extends UmbRepositoryBase {
     } catch (error) {
       return {
         status: 500,
-        error: error instanceof Error ? error.message : 'Unknown error',
+        error: error instanceof Error ? error.message : this.#localize.term('auth_receivedErrorFromServer'),
       };
     }
   }
@@ -207,6 +207,9 @@ export class UmbAuthRepository extends UmbRepositoryBase {
 
       case 402:
         return this.#localize.term('auth_mfaText');
+
+      case 403:
+        return this.#localize.term('auth_userLockedOut');
 
       case 500:
         return this.#localize.term('auth_receivedErrorFromServer');

--- a/src/Umbraco.Web.UI.Login/src/contexts/auth.repository.ts
+++ b/src/Umbraco.Web.UI.Login/src/contexts/auth.repository.ts
@@ -220,9 +220,6 @@ export class UmbAuthRepository extends UmbRepositoryBase {
       case 403:
         return this.#localize.term('auth_userLockedOut');
 
-      case 500:
-        return this.#localize.term('auth_receivedErrorFromServer');
-
       default:
         return (
           this.#localize.term('auth_receivedErrorFromServer')

--- a/src/Umbraco.Web.UI.Login/src/localization/lang/da-dk.ts
+++ b/src/Umbraco.Web.UI.Login/src/localization/lang/da-dk.ts
@@ -42,6 +42,7 @@ export default {
     mfaText: 'Du har aktiveret multi-faktor godkendelse. Du skal nu bekræfte din identitet.',
     mfaMultipleText: 'Vælg venligst en godkendelsesmetode',
     mfaCodeInput: 'Kode',
+    mfaInvalidCode: 'Forkert kode indtastet',
     signInWith: 'Log ind med {0}',
     returnToLogin: 'Tilbage til log ind',
     localLoginDisabled: 'Desværre er det ikke muligt at logge ind direkte. Det er blevet deaktiveret af en login-udbyder.',

--- a/src/Umbraco.Web.UI.Login/src/localization/lang/da-dk.ts
+++ b/src/Umbraco.Web.UI.Login/src/localization/lang/da-dk.ts
@@ -23,6 +23,7 @@ export default {
     passwordMinLength: 'Adgangskoden skal være mindst {0} tegn lang.',
     passwordIsBlank: 'Din nye adgangskode kan ikke være tom.',
     userFailedLogin: 'Ups! Vi kunne ikke logge dig ind. Tjek at dit brugernavn og adgangskode er korrekt og prøv igen.',
+    userLockedOut: 'Din konto er blevet låst. Prøv igen senere.',
     receivedErrorFromServer: 'Der skete en fejl på serveren',
     resetCodeExpired: 'Det link, du har klikket på, er ugyldigt eller udløbet',
     userInviteWelcomeMessage: 'Hej og velkommen til Umbraco! På bare 1 minut vil du være klar til at komme i gang, vi skal bare have dig til at oprette en adgangskode.',

--- a/src/Umbraco.Web.UI.Login/src/localization/lang/de-de.ts
+++ b/src/Umbraco.Web.UI.Login/src/localization/lang/de-de.ts
@@ -42,6 +42,7 @@ export default {
     mfaText: 'Sie haben die Multi-Faktor-Authentifizierung aktiviert und müssen Ihre Identität bestätigen.',
     mfaMultipleText: 'Bitte wählen Sie einen Multi-Faktor-Anbieter',
     mfaCodeInput: 'Bestätigungscode',
+    mfaInvalidCode: 'Ungültiger Code eingegeben',
     signInWith: 'Anmelden mit {0}',
     returnToLogin: 'Zurück zur Anmeldung',
     localLoginDisabled: 'Leider ist eine direkte Anmeldung nicht möglich. Sie wurde von einem Anbieter deaktiviert.',

--- a/src/Umbraco.Web.UI.Login/src/localization/lang/de-de.ts
+++ b/src/Umbraco.Web.UI.Login/src/localization/lang/de-de.ts
@@ -23,6 +23,7 @@ export default {
     passwordMinLength: 'Ihr Kennwort muss mindestens {0} Zeichen lang sein.',
     passwordIsBlank: 'Ihr neues Kennwort darf nicht leer sein!',
     userFailedLogin: 'Hoppla! Wir konnten Sie nicht anmelden. Bitte überprüfen Sie Ihre Anmeldeinformationen und versuchen Sie es erneut.',
+    userLockedOut: 'Ihr Konto wurde gesperrt. Bitte versuchen Sie es später erneut.',
     receivedErrorFromServer: 'Der Server hat einen Fehler gemeldet',
     resetCodeExpired: 'Der aufgerufene Link ist ungültig oder abgelaufen',
     userInviteWelcomeMessage: 'Hallo und Willkommen bei Umbraco! In nur einer Minute sind Sie bereit loszulegen, Sie müssen nur ein Kennwort festlegen.',

--- a/src/Umbraco.Web.UI.Login/src/localization/lang/en-us.ts
+++ b/src/Umbraco.Web.UI.Login/src/localization/lang/en-us.ts
@@ -42,6 +42,7 @@ export default {
     mfaText: 'You have enabled 2-factor authentication and must verify your identity.',
     mfaMultipleText: 'Please choose a 2-factor provider',
     mfaCodeInput: 'Verification code',
+    mfaInvalidCode: 'Invalid code entered',
     signInWith: 'Sign in with {0}',
     returnToLogin: 'Return to login',
     localLoginDisabled: 'Unfortunately, direct login is not possible. It has been disabled by a provider.',

--- a/src/Umbraco.Web.UI.Login/src/localization/lang/en-us.ts
+++ b/src/Umbraco.Web.UI.Login/src/localization/lang/en-us.ts
@@ -23,6 +23,7 @@ export default {
     passwordMinLength: 'The password must be at least {0} characters long.',
     passwordIsBlank: 'The password cannot be blank.',
     userFailedLogin: 'Oops! We couldn\'t log you in. Please check your credentials and try again.',
+    userLockedOut: 'Your account has been locked out. Please try again later.',
     receivedErrorFromServer: 'Received an error from the server',
     resetCodeExpired: 'The link you have clicked on is invalid or has expired',
     userInviteWelcomeMessage: 'Hello there and welcome to Umbraco! In just 1 minute you’ll be good to go, we just need you to setup a password.',

--- a/src/Umbraco.Web.UI.Login/src/localization/lang/en.ts
+++ b/src/Umbraco.Web.UI.Login/src/localization/lang/en.ts
@@ -42,6 +42,7 @@ export default {
     mfaText: 'You have enabled 2-factor authentication and must verify your identity.',
     mfaMultipleText: 'Please choose a 2-factor provider',
     mfaCodeInput: 'Verification code',
+    mfaInvalidCode: 'Invalid code entered',
     signInWith: 'Sign in with {0}',
     returnToLogin: 'Return to login',
     localLoginDisabled: 'Unfortunately, direct login is not possible. It has been disabled by a provider.',

--- a/src/Umbraco.Web.UI.Login/src/localization/lang/en.ts
+++ b/src/Umbraco.Web.UI.Login/src/localization/lang/en.ts
@@ -23,6 +23,7 @@ export default {
     passwordMinLength: 'The password must be at least {0} characters long.',
     passwordIsBlank: 'The password cannot be blank.',
     userFailedLogin: 'Oops! We couldn\'t log you in. Please check your credentials and try again.',
+    userLockedOut: 'Your account has been locked out. Please try again later.',
     receivedErrorFromServer: 'Received an error from the server',
     resetCodeExpired: 'The link you have clicked on is invalid or has expired',
     userInviteWelcomeMessage: 'Hello there and welcome to Umbraco! In just 1 minute you’ll be good to go, we just need you to setup a password.',

--- a/src/Umbraco.Web.UI.Login/src/localization/lang/nb-no.ts
+++ b/src/Umbraco.Web.UI.Login/src/localization/lang/nb-no.ts
@@ -23,6 +23,7 @@ export default {
     passwordMinLength: 'Passordet må være minst {0} tegn langt.',
     passwordIsBlank: 'Det nye passordet kan ikke være tomt!',
     userFailedLogin: 'Oops! Vi kunne ikke logge deg inn. Vennligst sjekk legitimasjonen din og prøv igjen.',
+    userLockedOut: 'Kontoen din er låst. Vennligst prøv igjen senere.',
     receivedErrorFromServer: 'Mottok en feil fra serveren',
     resetCodeExpired: 'Lenken du har klikket på er ugyldig eller har utløpt',
     userInviteWelcomeMessage: 'Hei og velkommen til Umbraco! Om bare 1 minutt er du klar til å starte, vi trenger bare at du setter et passord.',

--- a/src/Umbraco.Web.UI.Login/src/localization/lang/nb-no.ts
+++ b/src/Umbraco.Web.UI.Login/src/localization/lang/nb-no.ts
@@ -42,6 +42,7 @@ export default {
     mfaText: 'Du har aktivert tofaktorautentisering og må bekrefte identiteten din.',
     mfaMultipleText: 'Velg en tofaktorleverandør',
     mfaCodeInput: 'Bekreftelseskode',
+    mfaInvalidCode: 'Ugyldig kode angitt',
     signInWith: 'Logg inn med {0}',
     returnToLogin: 'Tilbake til innlogging',
     localLoginDisabled: 'Dessverre er direkte innlogging ikke mulig. Den er deaktivert av en leverandør.',

--- a/src/Umbraco.Web.UI.Login/src/localization/lang/nl-nl.ts
+++ b/src/Umbraco.Web.UI.Login/src/localization/lang/nl-nl.ts
@@ -23,6 +23,7 @@ export default {
     passwordMinLength: 'Je wachtwoord moet minstens {0} tekens lang zijn.',
     passwordIsBlank: 'Je nieuwe wachtwoord mag niet leeg zijn!',
     userFailedLogin: 'Oeps! We konden je niet inloggen. Controleer je inloggegevens en probeer het opnieuw.',
+    userLockedOut: 'Je account is geblokkeerd. Probeer het later opnieuw.',
     receivedErrorFromServer: 'Een error ontvangen van de server',
     resetCodeExpired: 'De link die je hebt aangeklikt is niet (meer) geldig.',
     userInviteWelcomeMessage: 'Hallo en welkom in Umbraco! Binnen ongeveer één minuut kan je aan de slag. Je moet enkel je wachtwoord instellen.',

--- a/src/Umbraco.Web.UI.Login/src/localization/lang/nl-nl.ts
+++ b/src/Umbraco.Web.UI.Login/src/localization/lang/nl-nl.ts
@@ -42,6 +42,7 @@ export default {
     mfaText: 'Je hebt tweestapsverificatie ingeschakeld en moet je identiteit verifiëren.',
     mfaMultipleText: 'Kies een tweestapsverificatie aanbieder',
     mfaCodeInput: 'Verificatiecode',
+    mfaInvalidCode: 'Ongeldige code ingevoerd',
     signInWith: 'Inloggen met {0}',
     returnToLogin: 'Terug naar loginformulier',
     localLoginDisabled: 'Helaas is direct inloggen niet mogelijk. Het is uitgeschakeld door een aanbieder.',

--- a/src/Umbraco.Web.UI.Login/src/localization/lang/sv-se.ts
+++ b/src/Umbraco.Web.UI.Login/src/localization/lang/sv-se.ts
@@ -23,6 +23,7 @@ export default {
     passwordMinLength: 'Lösenordet måste vara minst {0} tecken långt.',
     passwordIsBlank: 'Ditt nya lösenord kan inte vara tomt!',
     userFailedLogin: 'Hoppsan! Vi kunde inte logga in dig. Vänligen kontrollera dina uppgifter och försök igen.',
+    userLockedOut: 'Ditt konto har låsts. Vänligen försök igen senare.',
     receivedErrorFromServer: 'Ett fel uppstod på servern',
     resetCodeExpired: 'Länken du har klickat på är ogiltig eller har gått ut',
     userInviteWelcomeMessage: 'Hej och välkommen till Umbraco! Inom bara 1 minut är du redo att börja, vi behöver bara att du ställer in ett lösenord.',

--- a/src/Umbraco.Web.UI.Login/src/localization/lang/sv-se.ts
+++ b/src/Umbraco.Web.UI.Login/src/localization/lang/sv-se.ts
@@ -42,6 +42,7 @@ export default {
     mfaText: 'Du har aktiverat tvåfaktorsautentisering och måste verifiera din identitet.',
     mfaMultipleText: 'Vänligen välj en tvåfaktorsleverantör',
     mfaCodeInput: 'Verifieringskod',
+    mfaInvalidCode: 'Ogiltig kod angiven',
     signInWith: 'Logga in med {0}',
     returnToLogin: 'Återgå till inloggning',
     localLoginDisabled: 'Tyvärr är direktinloggning inte möjlig. Det har inaktiverats av en leverantör.',


### PR DESCRIPTION
### Description

Fixes #16240

The login page does not handle certain error codes coming from the API, nor does it allow to submit the form in certain circumstances.

**Login**
* 403 (user is locked out) - no error message to show the user, and the fallback error message did not work

**Two-Factor**
* 400 (wrong authorization code) - the error fell through and was considered as a success, but naturally, the user was not logged in and therefore stayed on the login page with no error message being shown
* 401-500 errors - the errors did not have appropriate error messages

### How to test

Setup a fake two-factor authenticator, or follow the [newly updated guide on the UmbracoDocs](https://docs.umbraco.com/umbraco-cms/v/14.latest-rc/reference/security/two-factor-authentication#two-factor-authentication-for-users).