### PR TITLE
TemplateService should return all templates from GetAllAsync if no keys are passed

### DIFF
--- a/src/Umbraco.Core/Services/TemplateService.cs
+++ b/src/Umbraco.Core/Services/TemplateService.cs
@@ -139,12 +139,12 @@ public class TemplateService : RepositoryService, ITemplateService
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
 
-        if (keys.Any() == false)
+        IQuery<ITemplate> query = Query<ITemplate>();
+        if (keys.Any())
         {
-            return Task.FromResult((IEnumerable<ITemplate>)_templateRepository.GetAll().OrderBy(x => x.Name));
+            query = query.Where(x => keys.Contains(x.Key));
         }
 
-        IQuery<ITemplate> query = Query<ITemplate>().Where(x => keys.Contains(x.Key));
         IEnumerable<ITemplate> templates = _templateRepository.Get(query).OrderBy(x => x.Name);
 
         return Task.FromResult(templates);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

_This is the `TemplateService` equivalent of #16230_

To align functionality of our services, `GetAllAsync(params Guid[] keys)` must return _all_ templates if _no_ keys have been passed to the method.

This is functionally breaking, but "only" towards the new V14 service methods.

I have verified that all consumers of this method are guarded by an explicit check for zero results, thus ensuring we don't accidentally return _all_ templates when we're in fact wanting to return _none_.

### Testing this PR

`GetAllAsync(params Guid[] keys)` is only used by the template "item" and "search" endpoints. Both should still work 😄 

- The "item" endpoint should return no templates if no item keys are passed.
- The "search" endpoint should return no templates if there are zero matches to the search query.
- The "search" endpoint should return no templates if paginating "past" the total number of results in a query that yields results.
