### PR TITLE
Use a fixed access token timeout for developer clients

### DIFF
--- a/src/Umbraco.Cms.Api.Common/OpenApi/SwaggerRouteTemplatePipelineFilter.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/SwaggerRouteTemplatePipelineFilter.cs
@@ -63,6 +63,7 @@ public class SwaggerRouteTemplatePipelineFilter : UmbracoPipelineFilter
         }
 
         // Add custom configuration from https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
+        swaggerUiOptions.ConfigObject.PersistAuthorization = true; // persists authorization data so it would not be lost on browser close/refresh
         swaggerUiOptions.ConfigObject.Filter = string.Empty; // Enable the filter with an empty string as default filter.
 
         swaggerUiOptions.OAuthClientId(Constants.OAuthClientIds.Swagger);

--- a/src/Umbraco.Cms.Api.Common/OpenApi/SwaggerRouteTemplatePipelineFilter.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/SwaggerRouteTemplatePipelineFilter.cs
@@ -63,7 +63,6 @@ public class SwaggerRouteTemplatePipelineFilter : UmbracoPipelineFilter
         }
 
         // Add custom configuration from https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
-        swaggerUiOptions.ConfigObject.PersistAuthorization = true; // persists authorization data so it would not be lost on browser close/refresh
         swaggerUiOptions.ConfigObject.Filter = string.Empty; // Enable the filter with an empty string as default filter.
 
         swaggerUiOptions.OAuthClientId(Constants.OAuthClientIds.Swagger);

--- a/src/Umbraco.Cms.Api.Management/Security/BackOfficeApplicationManager.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/BackOfficeApplicationManager.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Hosting;
+﻿using System.Globalization;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using OpenIddict.Abstractions;
@@ -6,7 +7,6 @@ using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Security;
-using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Security;
 
@@ -57,6 +57,8 @@ public class BackOfficeApplicationManager : OpenIdDictApplicationManagerBase, IB
         }
         else
         {
+            var developerClientTimeOutValue = new GlobalSettings().TimeOut.ToString("c", CultureInfo.InvariantCulture);
+
             await CreateOrUpdate(
                 new OpenIddictApplicationDescriptor
                 {
@@ -73,6 +75,11 @@ public class BackOfficeApplicationManager : OpenIdDictApplicationManagerBase, IB
                         OpenIddictConstants.Permissions.Endpoints.Token,
                         OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode,
                         OpenIddictConstants.Permissions.ResponseTypes.Code
+                    },
+                    Settings =
+                    {
+                        // use a fixed access token lifetime for tokens issued to the Swagger application.
+                        [OpenIddictConstants.Settings.TokenLifetimes.AccessToken] = developerClientTimeOutValue
                     }
                 },
                 cancellationToken);
@@ -93,6 +100,11 @@ public class BackOfficeApplicationManager : OpenIdDictApplicationManagerBase, IB
                         OpenIddictConstants.Permissions.Endpoints.Token,
                         OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode,
                         OpenIddictConstants.Permissions.ResponseTypes.Code
+                    },
+                    Settings =
+                    {
+                        // use a fixed access token lifetime for tokens issued to the Postman application.
+                        [OpenIddictConstants.Settings.TokenLifetimes.AccessToken] = developerClientTimeOutValue
                     }
                 },
                 cancellationToken);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Since #16028, the developer clients (Swagger, Postman) have been subject to very short-lived access tokens (five minutes by default). This is quite annoying when testing APIs 😞 

OpenIddict 5.0 introduced a solution for per-client token lifetimes (see this [reference article](https://kevinchalet.com/2023/10/20/introducing-native-applications-per-client-token-lifetimes-and-client-assertions-support-in-openiddict-5-0-preview1/))
. This PR utilizes that feature to set a fixed token lifetime (20 minutes at the time of writing) for the developer clients.

Also, the Swagger client is currently configured to persist auth, in part as a workaround for the short-lived access tokens. While well meant, this persistence far outlives the token lifetimes, which causes the Swagger UI to indicate successful authorization while in fact the token has long since expired. So I have removed the auth persistence in Swagger.

### Testing this PR

Use Swagger to verify that an auth session lasts longer than 5 minutes 😉 