### PR TITLE
Use parentElement instead of parent

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
@@ -126,7 +126,7 @@
                 else if(defaultFocusedElement === null ){
                     // If the first focusable elements are either items from the umb-sub-views-nav menu or the umb-button-ellipsis we most likely want to start the focus on the second item
                     // We don't want to focus the second button if it's in a tab otherwise the second tab is highlighted as well as the first tab
-                    var avoidStartElm = focusableElements.findIndex(elm => elm.classList.contains('umb-button-ellipsis') || elm.classList.contains('umb-sub-views-nav-item__action') || (elm.classList.contains('umb-tab-button') && !elm.parent?.classList.contains('umb-tab')));
+                    var avoidStartElm = focusableElements.findIndex(elm => elm.classList.contains('umb-button-ellipsis') || elm.classList.contains('umb-sub-views-nav-item__action') || (elm.classList.contains('umb-tab-button') && !elm.parentElement.classList.contains('umb-tab')));
 
                     if(avoidStartElm === 0) {
                         focusableElements[1].focus();

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
@@ -126,7 +126,7 @@
                 else if(defaultFocusedElement === null ){
                     // If the first focusable elements are either items from the umb-sub-views-nav menu or the umb-button-ellipsis we most likely want to start the focus on the second item
                     // We don't want to focus the second button if it's in a tab otherwise the second tab is highlighted as well as the first tab
-                    var avoidStartElm = focusableElements.findIndex(elm => elm.classList.contains('umb-button-ellipsis') || elm.classList.contains('umb-sub-views-nav-item__action') || (elm.classList.contains('umb-tab-button') && !elm.parent.classList.contains('umb-tab')));
+                    var avoidStartElm = focusableElements.findIndex(elm => elm.classList.contains('umb-button-ellipsis') || elm.classList.contains('umb-sub-views-nav-item__action') || (elm.classList.contains('umb-tab-button') && !elm.parent?.classList.contains('umb-tab')));
 
                     if(avoidStartElm === 0) {
                         focusableElements[1].focus();


### PR DESCRIPTION
Checking the [focusabeElements](https://github.com/umbraco/Umbraco-CMS/blob/v13/dev/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js#L49) object it contains the following fields:

![image](https://github.com/umbraco/Umbraco-CMS/assets/32614506/a7eb3d36-2c6a-4c06-a01d-501c76f57e14)

I didn't see any `parent` field, so used the `parentElement` instead.

This fixes #16256 