### PR TITLE
Return 401 in case the signin was not successfully

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeController.cs
@@ -94,7 +94,15 @@ public class BackOfficeController : SecurityControllerBase
                 EnabledTwoFactorProviderNames = enabledProviders
             });
         }
-        return Ok();
+
+        if (result.Succeeded)
+        {
+            return Ok();
+        }
+        return StatusCode(StatusCodes.Status401Unauthorized, new ProblemDetailsBuilder()
+            .WithTitle("Invalid credentials")
+            .WithDetail("The provided credentials are invalid. User has not been signed in.")
+            .Build());
     }
 
     [AllowAnonymous]


### PR DESCRIPTION
Return 401 in case the signin was not successfully, so the client can show a message