### PR TITLE
Exclude prereleases in upper version limit

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -47,9 +47,16 @@
 
   <!-- Use version range on project references (to limit on major version in generated packages) -->
   <Target Name="_GetProjectReferenceVersionRanges" AfterTargets="_GetProjectReferenceVersions">
+    <PropertyGroup>
+      <!--
+      Because we exclude prereleases in the upper version limit (by adding '-0' - the lowest possible prerelease tag),
+      NuGet incorrectly triggers the 'A stable release of a package should not have a prerelease dependency.' warning.
+      -->
+      <NoWarn>$(NoWarn);NU5104</NoWarn>
+    </PropertyGroup>
     <ItemGroup>
       <_ProjectReferencesWithVersions Condition="'%(ProjectVersion)' != ''">
-        <ProjectVersion>[%(ProjectVersion), $([MSBuild]::Add($([System.Text.RegularExpressions.Regex]::Match('%(ProjectVersion)', '^\d+').Value), 1)))</ProjectVersion>
+        <ProjectVersion>[%(ProjectVersion), $([MSBuild]::Add($([System.Text.RegularExpressions.Regex]::Match('%(ProjectVersion)', '^\d+').Value), 1))-0)</ProjectVersion>
       </_ProjectReferencesWithVersions>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Version 13 added a version range on project references by automatically adding the next major version, e.g. `[13.4.0, 14.0.0)` (see https://github.com/umbraco/Umbraco-CMS/pull/14719). This prevents users from installing CMS components/packages of different major versions and/or for transitive dependencies to upgrade them.

However, this NuGet version range doesn't exclude prereleases in the upper version limit. Most of the time this isn't an issue, because packages won't have a dependency on a CMS prerelease and NuGet won't update transitive dependencies to prerelease versions. With packages that target a new major CMS version though, this issue does become apparent, as mentioned in https://github.com/warrenbuckley/Examine-Peek/pull/4: you can install this v14-only package on a v13 site, which will upgrade some transitive CMS packages to the v14 prerelease (resulting in compilation errors).

The standard Semver range `>= 13.0.0 <14.0.0` does exclude pre-preleases, but NuGet uses its own syntax and implementation that doesn't exclude pre-releases when `[13.0.0, 14.0.0)` is used:

![Comparing Semver and NuGet.Versioning](https://github.com/umbraco/Umbraco-CMS/assets/1051287/21fffe7a-5803-4bbf-a93d-c933432ab591)

This can be fixed by appending `-0` to the upper version limit (the [lowest possible prerelease version](https://semver-nuget.org/v2.3.x/Semver.html#constructing-prerelease-ranges)), which is a nicer solution to using x.999999 like we did in v8:

https://github.com/umbraco/Umbraco-CMS/blob/82b5e0be02c3d2eac9fcab7ade4bb253ade585f7/build/NuSpecs/UmbracoCms.nuspec#L19-L24

With this applied, the version range excludes any prerelease version and thereby prevents you from installing any mixed CMS major version in a project:

![NuGet.Versioning updated version range](https://github.com/umbraco/Umbraco-CMS/assets/1051287/18d74c80-c508-4391-9be9-43252a974711)

If packages use a similar version range to limit the CMS version you can install it on, they should use the same syntax. So to only allow your package to be installed on a version 13 site, you should use: `[13.0.0, 14.0.0-0)`.

The only downside to this approach is that the NuGet build target will raise a [NU5104](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5104) warning about using a prerelease dependency when building a stable version of your own package. This is a false-positive, as it's not pulling in a prerelease version, but actually preventing you from installing it... I've added this to the `NoWarn` property to ignore it, although this might actually remove the warning for dependencies that are actually pulling in prereleases. We currently don't fail the build on these kind of warnings and the build contains too many warnings to be noticeable, so I think this is a fine trade-off to not add any more warnings.

Testing can be done by checking the NuGet packages in the build output and verifying whether the dependencies contain the `-0` postfix on the upper version limit. Additionally, you can upgrade a v13 project using this build output and check if you now get a [`NU1107` error](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1107) if ExaminePeek 1.0.0 (depending on v14.0.0-rc3) is installed:

```
❯ dotnet build
MSBuild version 17.9.8+b34f75857 for .NET
  Determining projects to restore...
Umbraco 13_4_0.csproj : error NU1107: Version conflict detected for Umbraco.Cms.Web.Common. Install/reference Umbraco.Cms.Web.Common 14.0.0-rc1 directly to project Umbraco 13_4_0 to resolve this issue.
Umbraco 13_4_0.csproj : error NU1107:  Umbraco 13_4_0 -> ExaminePeek 1.0.0 -> Umbraco.Cms.Web.Website 14.0.0-rc1 -> Umbraco.Cms.Web.Common (>= 14.0.0-rc1 && < 15.0.0)
Umbraco 13_4_0.csproj : error NU1107:  Umbraco 13_4_0 -> Umbraco.Cms 13.4.0--preview.6.gbc46017 -> Umbraco.Cms.Imaging.ImageSharp 13.4.0--preview.6.gbc46017 -> Umbraco.Cms.Web.Common (>= 13.4.0--preview.6.gbc46017 && < 14.0.0-0).
  Failed to restore Umbraco 13_4_0.csproj (in 746 ms).

Build FAILED.
```