### PR TITLE
Add GetAllAsync overload without parameter simplify getting all or by keys

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Tree/DataTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Tree/DataTypeTreeControllerBase.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Controllers.Tree;
 using Umbraco.Cms.Api.Management.Routing;
@@ -40,11 +40,9 @@ public class DataTypeTreeControllerBase : FolderTreeControllerBase<DataTypeTreeI
 
     protected override DataTypeTreeItemResponseModel[] MapTreeItemViewModels(Guid? parentId, IEntitySlim[] entities)
     {
-        Dictionary<int, IDataType> dataTypes = entities.Any()
-            ? _dataTypeService
-                .GetAllAsync(entities.Select(entity => entity.Key).ToArray()).GetAwaiter().GetResult()
-                .ToDictionary(contentType => contentType.Id)
-            : new Dictionary<int, IDataType>();
+        var dataTypes = _dataTypeService
+            .GetAllAsync(entities.Select(entity => entity.Key).ToArray()).GetAwaiter().GetResult()
+            .ToDictionary(contentType => contentType.Id);
 
         return entities.Select(entity =>
         {

--- a/src/Umbraco.Core/Services/ContentTypeEditing/ContentTypeEditingServiceBase.cs
+++ b/src/Umbraco.Core/Services/ContentTypeEditing/ContentTypeEditingServiceBase.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentTypeEditing;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Services.OperationStatus;
@@ -658,12 +658,7 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
         => model.Properties.Select(property => property.DataTypeKey).Distinct().ToArray();
 
     private async Task<IDataType[]> GetDataTypesAsync(ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model)
-    {
-        Guid[] dataTypeKeys = GetDataTypeKeys(model);
-        return dataTypeKeys.Any()
-            ? (await _dataTypeService.GetAllAsync(GetDataTypeKeys(model))).ToArray()
-            : Array.Empty<IDataType>();
-    }
+        => (await _dataTypeService.GetAllAsync(GetDataTypeKeys(model))).ToArray();
 
     private int? GetParentId(ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model, Guid? containerKey)
     {

--- a/src/Umbraco.Core/Services/DataTypeService.cs
+++ b/src/Umbraco.Core/Services/DataTypeService.cs
@@ -232,17 +232,20 @@ namespace Umbraco.Cms.Core.Services.Implement
         }
 
         /// <inheritdoc />
+        public Task<IEnumerable<IDataType>> GetAllAsync()
+        {
+            using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
+            IDataType[] dataTypes = _dataTypeRepository.GetMany().ToArray();
+            ConvertMissingEditorsOfDataTypesToLabels(dataTypes);
+
+            return Task.FromResult<IEnumerable<IDataType>>(dataTypes);
+        }
+
+        /// <inheritdoc />
         public Task<IEnumerable<IDataType>> GetAllAsync(params Guid[] keys)
         {
             using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
-
-            IQuery<IDataType> query = Query<IDataType>();
-            if (keys.Length > 0)
-            {
-                query = query.Where(x => keys.Contains(x.Key));
-            }
-
-            IDataType[] dataTypes = _dataTypeRepository.Get(query).ToArray();
+            IDataType[] dataTypes = _dataTypeRepository.Get(Query<IDataType>().Where(x => keys.Contains(x.Key))).ToArray();
             ConvertMissingEditorsOfDataTypesToLabels(dataTypes);
 
             return Task.FromResult<IEnumerable<IDataType>>(dataTypes);

--- a/src/Umbraco.Core/Services/IDataTypeService.cs
+++ b/src/Umbraco.Core/Services/IDataTypeService.cs
@@ -105,10 +105,16 @@ public interface IDataTypeService : IService
     Task<IDataType?> GetAsync(Guid id);
 
     /// <summary>
+    /// Gets all <see cref="IDataType"/> objects.
+    /// </summary>
+    /// <returns>All data types.</returns>
+    Task<IEnumerable<IDataType>> GetAllAsync();
+
+    /// <summary>
     /// Gets multiple <see cref="IDataType"/> objects by their unique keys.
     /// </summary>
     /// <param name="keys">The keys to get datatypes by.</param>
-    /// <returns>An attempt with the requested data types.</returns>
+    /// <returns>The data types with the specified keys.</returns>
     Task<IEnumerable<IDataType>> GetAllAsync(params Guid[] keys);
 
     /// <summary>


### PR DESCRIPTION
As mentioned in https://github.com/umbraco/Umbraco-CMS/pull/16230#issuecomment-2104496917, changing `GetAllAsync()` to return all data types if no keys are specified requires conditional checks when supplying a dynamic list of keys (as an empty list of keys would now return all data types, instead of 0).

To avoid having to manually check the length of the list of keys, this PR adds an overload without the parameter that returns all data types and reverts the previous method to only return data types for the specified keys (so an empty list of keys results in an empty list of data types again).

This should also prevent similar bugs in the future (or in packages). The only discrepancy would be that `GetAll(params int[] ids)` still returns all data types if an empty list of IDs is specified), but this methods has already been obsoleted.