### PR TITLE
Do not expose culture we do not accept for languages

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Culture/AllCultureController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Culture/AllCultureController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Api.Management.ViewModels.Culture;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
+using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Culture;
 
@@ -12,8 +13,13 @@ namespace Umbraco.Cms.Api.Management.Controllers.Culture;
 public class AllCultureController : CultureControllerBase
 {
     private readonly IUmbracoMapper _umbracoMapper;
+    private readonly ICultureService _cultureService;
 
-    public AllCultureController(IUmbracoMapper umbracoMapper) => _umbracoMapper = umbracoMapper;
+    public AllCultureController(IUmbracoMapper umbracoMapper, ICultureService cultureService)
+    {
+        _umbracoMapper = umbracoMapper;
+        _cultureService = cultureService;
+    }
 
     /// <summary>
     ///     Returns all cultures available for creating languages.
@@ -24,10 +30,7 @@ public class AllCultureController : CultureControllerBase
     [ProducesResponseType(typeof(PagedViewModel<CultureReponseModel>), StatusCodes.Status200OK)]
     public async Task<PagedViewModel<CultureReponseModel>> GetAll(CancellationToken cancellationToken, int skip = 0, int take = 100)
     {
-        CultureInfo[] all = CultureInfo.GetCultures(CultureTypes.AllCultures)
-            .DistinctBy(x => x.Name)
-            .OrderBy(x => x.EnglishName)
-            .ToArray();
+        CultureInfo[] all = _cultureService.GetValidCultureInfos();
 
         var viewModel = new PagedViewModel<CultureReponseModel>
         {

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -286,6 +286,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
             Services.AddUnique<IMediaTypeContainerService, MediaTypeContainerService>();
             Services.AddUnique<IContentBlueprintContainerService, ContentBlueprintContainerService>();
             Services.AddUnique<IIsoCodeValidator, IsoCodeValidator>();
+            Services.AddUnique<ICultureService, CultureService>();
             Services.AddUnique<ILanguageService, LanguageService>();
             Services.AddUnique<IMemberGroupService, MemberGroupService>();
             Services.AddUnique<IRedirectUrlService, RedirectUrlService>();

--- a/src/Umbraco.Core/Services/CultureService.cs
+++ b/src/Umbraco.Core/Services/CultureService.cs
@@ -1,0 +1,20 @@
+using System.Globalization;
+
+namespace Umbraco.Cms.Core.Services;
+
+public class CultureService : ICultureService
+{
+    private readonly IIsoCodeValidator _isoCodeValidator;
+
+    public CultureService(IIsoCodeValidator isoCodeValidator) => _isoCodeValidator = isoCodeValidator;
+
+    public CultureInfo[] GetValidCultureInfos()
+    {
+        CultureInfo[] all = CultureInfo.GetCultures(CultureTypes.AllCultures)
+            .Where(x=> _isoCodeValidator.IsValid(x))
+            .DistinctBy(x => x.Name)
+            .OrderBy(x => x.EnglishName)
+            .ToArray();
+        return all;
+    }
+}

--- a/src/Umbraco.Core/Services/ICultureService.cs
+++ b/src/Umbraco.Core/Services/ICultureService.cs
@@ -1,0 +1,8 @@
+using System.Globalization;
+
+namespace Umbraco.Cms.Core.Services;
+
+public interface ICultureService
+{
+    CultureInfo[] GetValidCultureInfos();
+}

--- a/src/Umbraco.Core/Services/IIsoCodeValidator.cs
+++ b/src/Umbraco.Core/Services/IIsoCodeValidator.cs
@@ -1,4 +1,6 @@
-﻿namespace Umbraco.Cms.Core.Services;
+﻿using System.Globalization;
+
+namespace Umbraco.Cms.Core.Services;
 
 /// <summary>
 /// A validator for validating if an ISO code string can be is valid.
@@ -10,5 +12,23 @@ public interface IIsoCodeValidator
     /// </summary>
     /// <param name="isoCode">The string to validate.</param>
     /// <returns>True if the string is a valid ISO code.</returns>
-    bool IsValid(string isoCode);
+    bool IsValid(string isoCode)
+    {
+        try
+        {
+            var culture = CultureInfo.GetCultureInfo(isoCode);
+            return culture.Name.Equals(isoCode, StringComparison.InvariantCultureIgnoreCase) && IsValid(culture);
+        }
+        catch (CultureNotFoundException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Validates that a cultureInfo is a valid culture info in Umbraco.
+    /// </summary>
+    /// <param name="culture">The culture info to validate.</param>
+    /// <returns>True if the CultureInfo is valid in Umbraco.</returns>
+    bool IsValid(CultureInfo culture);
 }

--- a/src/Umbraco.Core/Services/IsoCodeValidator.cs
+++ b/src/Umbraco.Core/Services/IsoCodeValidator.cs
@@ -6,16 +6,5 @@ namespace Umbraco.Cms.Core.Services;
 public class IsoCodeValidator : IIsoCodeValidator
 {
     /// <inheritdoc />
-    public bool IsValid(string isoCode)
-    {
-        try
-        {
-            var culture = CultureInfo.GetCultureInfo(isoCode);
-            return culture.Name.Equals(isoCode, StringComparison.InvariantCultureIgnoreCase) && culture.CultureTypes.HasFlag(CultureTypes.UserCustomCulture) == false;
-        }
-        catch (CultureNotFoundException)
-        {
-            return false;
-        }
-    }
+    public bool IsValid(CultureInfo culture) => culture.CultureTypes.HasFlag(CultureTypes.UserCustomCulture) is false;
 }


### PR DESCRIPTION
### Description
This PR ensures we do not expose any cultures we do not accept in languages.

Furthermore, I moved it to a service to people can replace the logic

### Test 
- [ ]  Ensure you cannot create custom cultures
- [ ] Ensure what is returned from the culture endpoint actually works for languages