### PR TITLE
DX: Add `BlockValue` constructors to force correct property editor alias and layout item type

### DIFF
--- a/src/Umbraco.Core/Models/Blocks/BlockEditorData.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockEditorData.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Core.Models.Blocks;
 /// </summary>
 public class BlockEditorData<TValue, TLayout>
     where TValue : BlockValue<TLayout>, new()
-    where TLayout : class, IBlockLayoutItem, new()
+    where TLayout : IBlockLayoutItem
 {
     private readonly string _propertyEditorAlias;
 

--- a/src/Umbraco.Core/Models/Blocks/BlockEditorData.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockEditorData.cs
@@ -10,19 +10,8 @@ public class BlockEditorData<TValue, TLayout>
     where TValue : BlockValue<TLayout>, new()
     where TLayout : IBlockLayoutItem
 {
-    private readonly string _propertyEditorAlias;
-
-    public BlockEditorData(
-        string propertyEditorAlias,
-        IEnumerable<ContentAndSettingsReference> references,
-        TValue blockValue)
+    public BlockEditorData(IEnumerable<ContentAndSettingsReference> references, TValue blockValue)
     {
-        if (string.IsNullOrWhiteSpace(propertyEditorAlias))
-        {
-            throw new ArgumentException($"'{nameof(propertyEditorAlias)}' cannot be null or whitespace", nameof(propertyEditorAlias));
-        }
-
-        _propertyEditorAlias = propertyEditorAlias;
         BlockValue = blockValue ?? throw new ArgumentNullException(nameof(blockValue));
         References = references != null
             ? new List<ContentAndSettingsReference>(references)
@@ -30,17 +19,14 @@ public class BlockEditorData<TValue, TLayout>
     }
 
     private BlockEditorData()
-    {
-        _propertyEditorAlias = string.Empty;
-        BlockValue = new TValue();
-    }
+        => BlockValue = new TValue();
 
     public static BlockEditorData<TValue, TLayout> Empty { get; } = new();
 
     /// <summary>
     ///     Returns the layout for this specific property editor
     /// </summary>
-    public IEnumerable<TLayout>? Layout => BlockValue.GetLayouts(_propertyEditorAlias);
+    public IEnumerable<TLayout>? Layout => BlockValue.GetLayouts();
 
     /// <summary>
     ///     Returns the reference to the original BlockValue

--- a/src/Umbraco.Core/Models/Blocks/BlockEditorDataConverter.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockEditorDataConverter.cs
@@ -62,13 +62,13 @@ public abstract class BlockEditorDataConverter<TValue, TLayout>
 
     public BlockEditorData<TValue, TLayout> Convert(TValue? value)
     {
-        if (value is null || value.GetLayouts() is not IEnumerable<TLayout> layouts)
+        if (value?.GetLayouts() is not IEnumerable<TLayout> layouts)
         {
             return BlockEditorData<TValue, TLayout>.Empty;
         }
 
         IEnumerable<ContentAndSettingsReference> references = GetBlockReferences(layouts);
 
-        return new BlockEditorData<TValue, TLayout>(value.PropertyEditorAlias, references, value);
+        return new BlockEditorData<TValue, TLayout>(references, value);
     }
 }

--- a/src/Umbraco.Core/Models/Blocks/BlockEditorDataConverter.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockEditorDataConverter.cs
@@ -13,7 +13,7 @@ namespace Umbraco.Cms.Core.Models.Blocks;
 /// </summary>
 public abstract class BlockEditorDataConverter<TValue, TLayout>
     where TValue : BlockValue<TLayout>, new()
-    where TLayout : class, IBlockLayoutItem, new()
+    where TLayout : IBlockLayoutItem
 {
     private readonly IJsonSerializer _jsonSerializer;
 
@@ -42,7 +42,7 @@ public abstract class BlockEditorDataConverter<TValue, TLayout>
         }
         catch (Exception)
         {
-            blockEditorData = null;
+            blockEditorData = default;
             return false;
         }
     }

--- a/src/Umbraco.Core/Models/Blocks/BlockEditorDataConverter.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockEditorDataConverter.cs
@@ -62,15 +62,13 @@ public abstract class BlockEditorDataConverter<TValue, TLayout>
 
     public BlockEditorData<TValue, TLayout> Convert(TValue? value)
     {
-        var propertyEditorAlias = new TValue().PropertyEditorAlias;
-        IEnumerable<TLayout>? layouts = value?.GetLayouts(propertyEditorAlias);
-        if (layouts is null)
+        if (value is null || value.GetLayouts() is not IEnumerable<TLayout> layouts)
         {
             return BlockEditorData<TValue, TLayout>.Empty;
         }
 
         IEnumerable<ContentAndSettingsReference> references = GetBlockReferences(layouts);
 
-        return new BlockEditorData<TValue, TLayout>(propertyEditorAlias, references, value!);
+        return new BlockEditorData<TValue, TLayout>(value.PropertyEditorAlias, references, value);
     }
 }

--- a/src/Umbraco.Core/Models/Blocks/BlockGridLayoutAreaItem.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockGridLayoutAreaItem.cs
@@ -1,8 +1,14 @@
-﻿namespace Umbraco.Cms.Core.Models.Blocks;
+namespace Umbraco.Cms.Core.Models.Blocks;
 
 public class BlockGridLayoutAreaItem
 {
     public Guid Key { get; set; } = Guid.Empty;
 
     public BlockGridLayoutItem[] Items { get; set; } = Array.Empty<BlockGridLayoutItem>();
+
+    public BlockGridLayoutAreaItem()
+    { }
+
+    public BlockGridLayoutAreaItem(Guid key)
+        => Key = key;
 }

--- a/src/Umbraco.Core/Models/Blocks/BlockGridLayoutItem.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockGridLayoutItem.cs
@@ -17,4 +17,14 @@ public class BlockGridLayoutItem : IBlockLayoutItem
     public int? RowSpan { get; set; }
 
     public BlockGridLayoutAreaItem[] Areas { get; set; } = Array.Empty<BlockGridLayoutAreaItem>();
+
+    public BlockGridLayoutItem()
+    { }
+
+    public BlockGridLayoutItem(Udi contentUdi)
+        => ContentUdi = contentUdi;
+
+    public BlockGridLayoutItem(Udi contentUdi, Udi settingsUdi)
+        : this(contentUdi)
+        => SettingsUdi = settingsUdi;
 }

--- a/src/Umbraco.Core/Models/Blocks/BlockGridValue.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockGridValue.cs
@@ -1,6 +1,23 @@
-﻿namespace Umbraco.Cms.Core.Models.Blocks;
+namespace Umbraco.Cms.Core.Models.Blocks;
 
+/// <summary>
+/// Represents a block grid value.
+/// </summary>
 public class BlockGridValue : BlockValue<BlockGridLayoutItem>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BlockGridValue" /> class.
+    /// </summary>
+    public BlockGridValue()
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BlockGridValue" /> class.
+    /// </summary>
+    /// <param name="layouts">The layouts.</param>
+    public BlockGridValue(IEnumerable<BlockGridLayoutItem> layouts)
+        => Layout[PropertyEditorAlias] = layouts;
+
+    /// <inheritdoc />
     public override string PropertyEditorAlias => Constants.PropertyEditors.Aliases.BlockGrid;
 }

--- a/src/Umbraco.Core/Models/Blocks/BlockItemData.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockItemData.cs
@@ -10,6 +10,17 @@ namespace Umbraco.Cms.Core.Models.Blocks;
 /// </summary>
 public class BlockItemData
 {
+    public BlockItemData()
+    {
+    }
+
+    public BlockItemData(Udi udi, Guid contentTypeKey, string contentTypeAlias)
+    {
+        ContentTypeAlias = contentTypeAlias;
+        Udi = udi;
+        ContentTypeKey = contentTypeKey;
+    }
+
     public Guid ContentTypeKey { get; set; }
 
     /// <summary>

--- a/src/Umbraco.Core/Models/Blocks/BlockListLayoutItem.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockListLayoutItem.cs
@@ -11,4 +11,14 @@ public class BlockListLayoutItem : IBlockLayoutItem
     public Udi? ContentUdi { get; set; }
 
     public Udi? SettingsUdi { get; set; }
+
+    public BlockListLayoutItem()
+    { }
+
+    public BlockListLayoutItem(Udi contentUdi)
+        => ContentUdi = contentUdi;
+
+    public BlockListLayoutItem(Udi contentUdi, Udi settingsUdi)
+        : this(contentUdi)
+        => SettingsUdi = settingsUdi;
 }

--- a/src/Umbraco.Core/Models/Blocks/BlockListValue.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockListValue.cs
@@ -1,6 +1,23 @@
-﻿namespace Umbraco.Cms.Core.Models.Blocks;
+namespace Umbraco.Cms.Core.Models.Blocks;
 
+/// <summary>
+/// Represents a block list value.
+/// </summary>
 public class BlockListValue : BlockValue<BlockListLayoutItem>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BlockListValue" /> class.
+    /// </summary>
+    public BlockListValue()
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BlockListValue" /> class.
+    /// </summary>
+    /// <param name="layouts">The layouts.</param>
+    public BlockListValue(IEnumerable<BlockListLayoutItem> layouts)
+        => Layout[PropertyEditorAlias] = layouts;
+
+    /// <inheritdoc />
     public override string PropertyEditorAlias => Constants.PropertyEditors.Aliases.BlockList;
 }

--- a/src/Umbraco.Core/Models/Blocks/BlockValue.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockValue.cs
@@ -3,22 +3,66 @@
 
 namespace Umbraco.Cms.Core.Models.Blocks;
 
+/// <summary>
+/// Represents a block value.
+/// </summary>
+public abstract class BlockValue
+{
+    /// <summary>
+    /// Gets or sets the layout for specific property editors.
+    /// </summary>
+    /// <value>
+    /// The layout.
+    /// </value>
+    public IDictionary<string, IEnumerable<IBlockLayoutItem>> Layout { get; set; } = new Dictionary<string, IEnumerable<IBlockLayoutItem>>();
+
+    /// <summary>
+    /// Gets or sets the content data.
+    /// </summary>
+    /// <value>
+    /// The content data.
+    /// </value>
+    public List<BlockItemData> ContentData { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the settings data.
+    /// </summary>
+    /// <value>
+    /// The settings data.
+    /// </value>
+    public List<BlockItemData> SettingsData { get; set; } = [];
+
+    /// <summary>
+    /// Gets the property editor alias of the current layout.
+    /// </summary>
+    /// <value>
+    /// The property editor alias of the current layout.
+    /// </value>
+    public abstract string PropertyEditorAlias { get; }
+}
+
+/// <inheritdoc />
 public abstract class BlockValue<TLayout> : BlockValue
     where TLayout : IBlockLayoutItem
 {
+    /// <summary>
+    /// Gets the layouts of the current property editor.
+    /// </summary>
+    /// <returns>
+    /// The layouts.
+    /// </returns>
+    public IEnumerable<TLayout>? GetLayouts()
+        => GetLayouts(PropertyEditorAlias);
+
+    /// <summary>
+    /// Gets the layouts of the specified property editor.
+    /// </summary>
+    /// <param name="propertyEditorAlias">The property editor alias.</param>
+    /// <returns>
+    /// The layouts.
+    /// </returns>
     public IEnumerable<TLayout>? GetLayouts(string propertyEditorAlias)
-        => Layout.TryGetValue(propertyEditorAlias, out IEnumerable<IBlockLayoutItem>? layouts) is true
+        => Layout.TryGetValue(propertyEditorAlias, out IEnumerable<IBlockLayoutItem>? layouts)
             ? layouts.OfType<TLayout>()
             : null;
-}
-
-public abstract class BlockValue
-{
-    public IDictionary<string, IEnumerable<IBlockLayoutItem>> Layout { get; set; } = new Dictionary<string, IEnumerable<IBlockLayoutItem>>();
-
-    public List<BlockItemData> ContentData { get; set; } = new();
-
-    public List<BlockItemData> SettingsData { get; set; } = new();
-
-    public abstract string PropertyEditorAlias { get; }
 }

--- a/src/Umbraco.Core/Models/Blocks/BlockValue.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockValue.cs
@@ -52,17 +52,7 @@ public abstract class BlockValue<TLayout> : BlockValue
     /// The layouts.
     /// </returns>
     public IEnumerable<TLayout>? GetLayouts()
-        => GetLayouts(PropertyEditorAlias);
-
-    /// <summary>
-    /// Gets the layouts of the specified property editor.
-    /// </summary>
-    /// <param name="propertyEditorAlias">The property editor alias.</param>
-    /// <returns>
-    /// The layouts.
-    /// </returns>
-    public IEnumerable<TLayout>? GetLayouts(string propertyEditorAlias)
-        => Layout.TryGetValue(propertyEditorAlias, out IEnumerable<IBlockLayoutItem>? layouts)
+        => Layout.TryGetValue(PropertyEditorAlias, out IEnumerable<IBlockLayoutItem>? layouts)
             ? layouts.OfType<TLayout>()
             : null;
 }

--- a/src/Umbraco.Core/Models/Blocks/RichTextBlockLayoutItem.cs
+++ b/src/Umbraco.Core/Models/Blocks/RichTextBlockLayoutItem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 namespace Umbraco.Cms.Core.Models.Blocks;
@@ -11,4 +11,14 @@ public class RichTextBlockLayoutItem : IBlockLayoutItem
     public Udi? ContentUdi { get; set; }
 
     public Udi? SettingsUdi { get; set; }
+
+    public RichTextBlockLayoutItem()
+    { }
+
+    public RichTextBlockLayoutItem(Udi contentUdi)
+        => ContentUdi = contentUdi;
+
+    public RichTextBlockLayoutItem(Udi contentUdi, Udi settingsUdi)
+        : this(contentUdi)
+        => SettingsUdi = settingsUdi;
 }

--- a/src/Umbraco.Core/Models/Blocks/RichTextBlockValue.cs
+++ b/src/Umbraco.Core/Models/Blocks/RichTextBlockValue.cs
@@ -1,6 +1,23 @@
 namespace Umbraco.Cms.Core.Models.Blocks;
 
+/// <summary>
+/// Represents a rich text block value.
+/// </summary>
 public class RichTextBlockValue : BlockValue<RichTextBlockLayoutItem>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RichTextBlockValue" /> class.
+    /// </summary>
+    public RichTextBlockValue()
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RichTextBlockValue" /> class.
+    /// </summary>
+    /// <param name="layouts">The layouts.</param>
+    public RichTextBlockValue(IEnumerable<RichTextBlockLayoutItem> layouts)
+        => Layout[PropertyEditorAlias] = layouts;
+
+    /// <inheritdoc />
     public override string PropertyEditorAlias => Constants.PropertyEditors.Aliases.TinyMce;
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
@@ -254,7 +254,8 @@ public class RichTextPropertyEditor : DataEditor
                 handleMapping(blockEditorData.BlockValue);
                 return new RichTextEditorValue
                 {
-                    Markup = richTextEditorValue.Markup, Blocks = blockEditorData.BlockValue
+                    Markup = richTextEditorValue.Markup,
+                    Blocks = blockEditorData.BlockValue,
                 };
             }
 
@@ -263,7 +264,8 @@ public class RichTextPropertyEditor : DataEditor
 
             RichTextEditorValue MarkupWithEmptyBlocks() => new()
             {
-                Markup = richTextEditorValue.Markup, Blocks = new RichTextBlockValue()
+                Markup = richTextEditorValue.Markup,
+                Blocks = new RichTextBlockValue(),
             };
         }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/PropertyIndexValueFactoryTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/PropertyIndexValueFactoryTests.cs
@@ -1,4 +1,4 @@
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Blocks;
@@ -178,11 +178,8 @@ public class PropertyIndexValueFactoryTests : UmbracoIntegrationTest
         {
             ContentData =
             [
-                new()
+                new(contentElementUdi, elementType.Key, elementType.Alias)
                 {
-                    Udi = contentElementUdi,
-                    ContentTypeAlias = elementType.Alias,
-                    ContentTypeKey = elementType.Key,
                     RawPropertyValues = new Dictionary<string, object?>
                     {
                         {"singleLineText", "The single line of text in the block"},
@@ -302,22 +299,16 @@ public class PropertyIndexValueFactoryTests : UmbracoIntegrationTest
         {
             ContentData =
             [
-                new()
+                new(contentElementUdi, elementType.Key, elementType.Alias)
                 {
-                    Udi = contentElementUdi,
-                    ContentTypeAlias = elementType.Alias,
-                    ContentTypeKey = elementType.Key,
                     RawPropertyValues = new()
                     {
                         { "singleLineText", "The single line of text in the grid root" },
                         { "bodyText", "<p>The body text in the grid root</p>" },
                     },
                 },
-                new()
+                new(contentAreaElementUdi, elementType.Key, elementType.Alias)
                 {
-                    Udi = contentAreaElementUdi,
-                    ContentTypeAlias = elementType.Alias,
-                    ContentTypeKey = elementType.Key,
                     RawPropertyValues = new()
                     {
                         { "singleLineText", "The single line of text in the grid area" },

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/PropertyIndexValueFactoryTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/PropertyIndexValueFactoryTests.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Blocks;
@@ -171,21 +171,11 @@ public class PropertyIndexValueFactoryTests : UmbracoIntegrationTest
         var editor = dataType.Editor!;
 
         var contentElementUdi = new GuidUdi(Constants.UdiEntityType.Element, Guid.NewGuid());
-        var blockListValue = new BlockListValue
+        var blockListValue = new BlockListValue(
+        [
+            new BlockListLayoutItem(contentElementUdi)
+        ])
         {
-            Layout = new Dictionary<string, IEnumerable<IBlockLayoutItem>>
-            {
-                {
-                    Constants.PropertyEditors.Aliases.BlockList,
-                    new IBlockLayoutItem[]
-                    {
-                        new BlockListLayoutItem()
-                        {
-                            ContentUdi = contentElementUdi
-                        }
-                    }
-                }
-            },
             ContentData =
             [
                 new()
@@ -287,39 +277,29 @@ public class PropertyIndexValueFactoryTests : UmbracoIntegrationTest
 
         var contentElementUdi = new GuidUdi(Constants.UdiEntityType.Element, Guid.NewGuid());
         var contentAreaElementUdi = new GuidUdi(Constants.UdiEntityType.Element, Guid.NewGuid());
-        var blockGridValue = new BlockGridValue
-        {
-            Layout = new Dictionary<string, IEnumerable<IBlockLayoutItem>>
+        var blockGridValue = new BlockGridValue(
+        [
+            new BlockGridLayoutItem(contentElementUdi)
             {
-                {
-                    Constants.PropertyEditors.Aliases.BlockGrid,
-                    new IBlockLayoutItem[]
+                ColumnSpan = 12,
+                RowSpan = 1,
+                Areas =
+                [
+                    new BlockGridLayoutAreaItem(Guid.NewGuid())
                     {
-                        new BlockGridLayoutItem
-                        {
-                            ColumnSpan = 12,
-                            RowSpan = 1,
-                            ContentUdi = contentElementUdi,
-                            Areas = new []
+                        Items =
+                        [
+                            new BlockGridLayoutItem(contentAreaElementUdi)
                             {
-                                new BlockGridLayoutAreaItem
-                                {
-                                    Key = Guid.NewGuid(),
-                                    Items = new []
-                                    {
-                                        new BlockGridLayoutItem
-                                        {
-                                            ContentUdi = contentAreaElementUdi,
-                                            ColumnSpan = 12,
-                                            RowSpan = 1
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                                ColumnSpan = 12,
+                                RowSpan = 1,
+                            },
+                        ],
+                    },
+                ],
             },
+        ])
+        {
             ContentData =
             [
                 new()
@@ -327,25 +307,24 @@ public class PropertyIndexValueFactoryTests : UmbracoIntegrationTest
                     Udi = contentElementUdi,
                     ContentTypeAlias = elementType.Alias,
                     ContentTypeKey = elementType.Key,
-                    RawPropertyValues = new Dictionary<string, object?>
+                    RawPropertyValues = new()
                     {
-                        {"singleLineText", "The single line of text in the grid root"},
-                        {"bodyText", "<p>The body text in the grid root</p>"}
-                    }
+                        { "singleLineText", "The single line of text in the grid root" },
+                        { "bodyText", "<p>The body text in the grid root</p>" },
+                    },
                 },
                 new()
                 {
                     Udi = contentAreaElementUdi,
                     ContentTypeAlias = elementType.Alias,
                     ContentTypeKey = elementType.Key,
-                    RawPropertyValues = new Dictionary<string, object?>
+                    RawPropertyValues = new()
                     {
-                        {"singleLineText", "The single line of text in the grid area"},
-                        {"bodyText", "<p>The body text in the grid area</p>"}
-                    }
-                }
+                        { "singleLineText", "The single line of text in the grid area" },
+                        { "bodyText", "<p>The body text in the grid area</p>" },
+                    },
+                },
             ],
-            SettingsData = []
         };
         var propertyValue = JsonSerializer.Serialize(blockGridValue);
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Serialization/JsonBlockValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Serialization/JsonBlockValueConverterTests.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Infrastructure.Serialization;
@@ -25,65 +25,48 @@ public class JsonBlockValueConverterTests
         var elementType3Key = Guid.NewGuid();
         var elementType4Key = Guid.NewGuid();
 
-        var blockGridValue = new BlockGridValue
-        {
-            Layout = new Dictionary<string, IEnumerable<IBlockLayoutItem>>
+        var blockGridValue = new BlockGridValue(
+        [
+            new BlockGridLayoutItem(contentElementUdi1, settingsElementUdi1)
             {
-                {
-                    Constants.PropertyEditors.Aliases.BlockGrid,
-                    new IBlockLayoutItem[]
+                ColumnSpan = 123,
+                RowSpan = 456,
+                Areas =
+                [
+                    new BlockGridLayoutAreaItem(Guid.NewGuid())
                     {
-                        new BlockGridLayoutItem
-                        {
-                            ColumnSpan = 123,
-                            RowSpan = 456,
-                            ContentUdi = contentElementUdi1,
-                            SettingsUdi = settingsElementUdi1,
-                            Areas = new []
+                        Items =
+                        [
+                            new BlockGridLayoutItem(contentElementUdi3, settingsElementUdi3)
                             {
-                                new BlockGridLayoutAreaItem
-                                {
-                                    Key = Guid.NewGuid(),
-                                    Items = new []
+                                ColumnSpan = 12,
+                                RowSpan = 34,
+                                Areas =
+                                [
+                                    new BlockGridLayoutAreaItem(Guid.NewGuid())
                                     {
-                                        new BlockGridLayoutItem
-                                        {
-                                            ColumnSpan = 12,
-                                            RowSpan = 34,
-                                            ContentUdi = contentElementUdi3,
-                                            SettingsUdi = settingsElementUdi3,
-                                            Areas = new []
+                                        Items =
+                                        [
+                                            new BlockGridLayoutItem(contentElementUdi4, settingsElementUdi4)
                                             {
-                                                new BlockGridLayoutAreaItem
-                                                {
-                                                    Key = Guid.NewGuid(),
-                                                    Items = new []
-                                                    {
-                                                        new BlockGridLayoutItem
-                                                        {
-                                                            ColumnSpan = 56,
-                                                            RowSpan = 78,
-                                                            ContentUdi = contentElementUdi4,
-                                                            SettingsUdi = settingsElementUdi4
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        new BlockGridLayoutItem
-                        {
-                            ColumnSpan = 789,
-                            RowSpan = 123,
-                            ContentUdi = contentElementUdi2,
-                            SettingsUdi = settingsElementUdi2
-                        }
-                    }
-                }
+                                                ColumnSpan = 56,
+                                                RowSpan = 78,
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
             },
+            new BlockGridLayoutItem(contentElementUdi2, settingsElementUdi2)
+            {
+                ColumnSpan = 789,
+                RowSpan = 123,
+            }
+        ])
+        {
             ContentData =
             [
                 new() { Udi = contentElementUdi1, ContentTypeAlias = "elementType1", ContentTypeKey = elementType1Key },
@@ -189,13 +172,7 @@ public class JsonBlockValueConverterTests
     [Test]
     public void Can_Serialize_BlockGrid_Without_Blocks()
     {
-        var blockGridValue = new BlockGridValue
-        {
-            Layout = new Dictionary<string, IEnumerable<IBlockLayoutItem>>(),
-            ContentData = [],
-            SettingsData = []
-        };
-
+        var blockGridValue = new BlockGridValue();
         var serializer = new SystemTextJsonSerializer();
         var serialized = serializer.Serialize(blockGridValue);
         var deserialized = serializer.Deserialize<BlockGridValue>(serialized);
@@ -222,27 +199,12 @@ public class JsonBlockValueConverterTests
         var elementType3Key = Guid.NewGuid();
         var elementType4Key = Guid.NewGuid();
 
-        var blockListValue = new BlockListValue
+        var blockListValue = new BlockListValue(
+        [
+            new BlockListLayoutItem(contentElementUdi1, settingsElementUdi1),
+            new BlockListLayoutItem(contentElementUdi2, settingsElementUdi2),
+        ])
         {
-            Layout = new Dictionary<string, IEnumerable<IBlockLayoutItem>>
-            {
-                {
-                    Constants.PropertyEditors.Aliases.BlockList,
-                    new IBlockLayoutItem[]
-                    {
-                        new BlockListLayoutItem()
-                        {
-                            ContentUdi = contentElementUdi1,
-                            SettingsUdi = settingsElementUdi1
-                        },
-                        new BlockListLayoutItem
-                        {
-                            ContentUdi = contentElementUdi2,
-                            SettingsUdi = settingsElementUdi2
-                        }
-                    }
-                }
-            },
             ContentData =
             [
                 new() { Udi = contentElementUdi1, ContentTypeAlias = "elementType1", ContentTypeKey = elementType1Key },
@@ -302,13 +264,7 @@ public class JsonBlockValueConverterTests
     [Test]
     public void Can_Serialize_BlockList_Without_Blocks()
     {
-        var blockListValue = new BlockListValue
-        {
-            Layout = new Dictionary<string, IEnumerable<IBlockLayoutItem>>(),
-            ContentData = [],
-            SettingsData = []
-        };
-
+        var blockListValue = new BlockListValue();
         var serializer = new SystemTextJsonSerializer();
         var serialized = serializer.Serialize(blockListValue);
         var deserialized = serializer.Deserialize<BlockListValue>(serialized);
@@ -335,27 +291,12 @@ public class JsonBlockValueConverterTests
         var elementType3Key = Guid.NewGuid();
         var elementType4Key = Guid.NewGuid();
 
-        var richTextBlockValue = new RichTextBlockValue
+        var richTextBlockValue = new RichTextBlockValue(
+        [
+            new RichTextBlockLayoutItem(contentElementUdi1, settingsElementUdi1),
+            new RichTextBlockLayoutItem(contentElementUdi2, settingsElementUdi2),
+        ])
         {
-            Layout = new Dictionary<string, IEnumerable<IBlockLayoutItem>>
-            {
-                {
-                    Constants.PropertyEditors.Aliases.TinyMce,
-                    new IBlockLayoutItem[]
-                    {
-                        new RichTextBlockLayoutItem
-                        {
-                            ContentUdi = contentElementUdi1,
-                            SettingsUdi = settingsElementUdi1
-                        },
-                        new RichTextBlockLayoutItem
-                        {
-                            ContentUdi = contentElementUdi2,
-                            SettingsUdi = settingsElementUdi2
-                        }
-                    }
-                }
-            },
             ContentData =
             [
                 new() { Udi = contentElementUdi1, ContentTypeAlias = "elementType1", ContentTypeKey = elementType1Key },
@@ -426,12 +367,7 @@ public class JsonBlockValueConverterTests
     {
         var richTextEditorValue = new RichTextEditorValue
         {
-            Blocks = new RichTextBlockValue
-            {
-                Layout = new Dictionary<string, IEnumerable<IBlockLayoutItem>>(),
-                ContentData = new List<BlockItemData>(),
-                SettingsData = new List<BlockItemData>()
-            },
+            Blocks = new RichTextBlockValue(),
             Markup = "<p>This is some markup</p>"
         };
 
@@ -459,54 +395,25 @@ public class JsonBlockValueConverterTests
         var elementType1Key = Guid.NewGuid();
         var elementType2Key = Guid.NewGuid();
 
-        var blockListValue = new BlockListValue
+        var blockListValue = new BlockListValue(
+        [
+            new BlockListLayoutItem(contentElementUdi1, settingsElementUdi1),
+        ])
         {
-            Layout = new Dictionary<string, IEnumerable<IBlockLayoutItem>>
+            Layout =
             {
-                {
-                    Constants.PropertyEditors.Aliases.TinyMce,
-                    new IBlockLayoutItem[]
-                    {
-                        new RichTextBlockLayoutItem
-                        {
-                            ContentUdi = contentElementUdi1,
-                            SettingsUdi = settingsElementUdi1
-                        }
-                    }
-                },
-                {
-                    Constants.PropertyEditors.Aliases.BlockList,
-                    new IBlockLayoutItem[]
-                    {
-                        new BlockListLayoutItem
-                        {
-                            ContentUdi = contentElementUdi1,
-                            SettingsUdi = settingsElementUdi1
-                        }
-                    }
-                },
-                {
-                    Constants.PropertyEditors.Aliases.BlockGrid,
-                    new IBlockLayoutItem[]
-                    {
-                        new BlockGridLayoutItem
-                        {
-                            ContentUdi = contentElementUdi1,
-                            SettingsUdi = settingsElementUdi1
-                        }
-                    }
-                },
-                {
-                    "Some.Custom.Block.Editor",
-                    new IBlockLayoutItem[]
-                    {
-                        new BlockListLayoutItem
-                        {
-                            ContentUdi = contentElementUdi1,
-                            SettingsUdi = settingsElementUdi1
-                        }
-                    }
-                }
+                [Constants.PropertyEditors.Aliases.TinyMce] =
+                [
+                    new RichTextBlockLayoutItem(contentElementUdi1, settingsElementUdi1)
+                ],
+                [Constants.PropertyEditors.Aliases.BlockGrid] =
+                [
+                    new BlockGridLayoutItem(contentElementUdi1, settingsElementUdi1),
+                ],
+                ["Some.Custom.Block.Editor"] =
+                [
+                    new BlockListLayoutItem(contentElementUdi1, settingsElementUdi1),
+                ]
             },
             ContentData =
             [

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Serialization/JsonBlockValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Serialization/JsonBlockValueConverterTests.cs
@@ -69,17 +69,17 @@ public class JsonBlockValueConverterTests
         {
             ContentData =
             [
-                new() { Udi = contentElementUdi1, ContentTypeAlias = "elementType1", ContentTypeKey = elementType1Key },
-                new() { Udi = contentElementUdi2, ContentTypeAlias = "elementType2", ContentTypeKey = elementType2Key },
-                new() { Udi = contentElementUdi3, ContentTypeAlias = "elementType3", ContentTypeKey = elementType3Key },
-                new() { Udi = contentElementUdi4, ContentTypeAlias = "elementType¤", ContentTypeKey = elementType4Key },
+                new(contentElementUdi1, elementType1Key, "elementType1"),
+                new(contentElementUdi2, elementType2Key, "elementType2"),
+                new(contentElementUdi3, elementType3Key, "elementType3"),
+                new(contentElementUdi4, elementType4Key, "elementType4"),
             ],
             SettingsData =
             [
-                new() { Udi = settingsElementUdi1, ContentTypeAlias = "elementType3", ContentTypeKey = elementType3Key },
-                new() { Udi = settingsElementUdi2, ContentTypeAlias = "elementType4", ContentTypeKey = elementType4Key },
-                new() { Udi = settingsElementUdi3, ContentTypeAlias = "elementType1", ContentTypeKey = elementType1Key },
-                new() { Udi = settingsElementUdi4, ContentTypeAlias = "elementType2", ContentTypeKey = elementType2Key }
+                new(settingsElementUdi1, elementType3Key, "elementType3"),
+                new(settingsElementUdi2, elementType4Key, "elementType4"),
+                new(settingsElementUdi3, elementType1Key, "elementType1"),
+                new(settingsElementUdi4, elementType2Key, "elementType2")
             ]
         };
 
@@ -207,13 +207,13 @@ public class JsonBlockValueConverterTests
         {
             ContentData =
             [
-                new() { Udi = contentElementUdi1, ContentTypeAlias = "elementType1", ContentTypeKey = elementType1Key },
-                new() { Udi = contentElementUdi2, ContentTypeAlias = "elementType2", ContentTypeKey = elementType2Key }
+                new(contentElementUdi1, elementType1Key, "elementType1"),
+                new(contentElementUdi2, elementType2Key, "elementType2")
             ],
             SettingsData =
             [
-                new() { Udi = settingsElementUdi1, ContentTypeAlias = "elementType3", ContentTypeKey = elementType3Key },
-                new() { Udi = settingsElementUdi2, ContentTypeAlias = "elementType4", ContentTypeKey = elementType4Key }
+                new(settingsElementUdi1, elementType3Key, "elementType3"),
+                new(settingsElementUdi2, elementType4Key, "elementType4")
             ]
         };
 
@@ -299,13 +299,13 @@ public class JsonBlockValueConverterTests
         {
             ContentData =
             [
-                new() { Udi = contentElementUdi1, ContentTypeAlias = "elementType1", ContentTypeKey = elementType1Key },
-                new() { Udi = contentElementUdi2, ContentTypeAlias = "elementType2", ContentTypeKey = elementType2Key }
+                new(contentElementUdi1, elementType1Key, "elementType1"),
+                new(contentElementUdi2, elementType2Key, "elementType2")
             ],
             SettingsData =
             [
-                new() { Udi = settingsElementUdi1, ContentTypeAlias = "elementType3", ContentTypeKey = elementType3Key },
-                new() { Udi = settingsElementUdi2, ContentTypeAlias = "elementType4", ContentTypeKey = elementType4Key }
+                new(settingsElementUdi1, elementType3Key, "elementType3"),
+                new(settingsElementUdi2, elementType4Key, "elementType4")
             ]
         };
 
@@ -417,11 +417,11 @@ public class JsonBlockValueConverterTests
             },
             ContentData =
             [
-                new() { Udi = contentElementUdi1, ContentTypeAlias = "elementType1", ContentTypeKey = elementType1Key },
+                new(contentElementUdi1, elementType1Key, "elementType1"),
             ],
             SettingsData =
             [
-                new() { Udi = settingsElementUdi1, ContentTypeAlias = "elementType2", ContentTypeKey = elementType2Key },
+                new(settingsElementUdi1, elementType2Key, "elementType2")
             ]
         };
 


### PR DESCRIPTION
PR https://github.com/umbraco/Umbraco-CMS/pull/16184 fixed the `BlockValue` implementation when serializing/deserializing, but creating a new value still required you to use the correct property editor alias and layout item type. For example, it was easy to get the following wrong:

```c#
var blockListValue = new BlockListValue()
{
    Layout =
    {
        // This won't store the layout, because it's not the correct one for BlockListValue
        [Constants.PropertyEditors.Aliases.BlockGrid] =
        [
            // Even if the type got updated to BlockGridValue, this layout item shouldn't be allowed
            new BlockListLayoutItem()
        ]
    }
};
````

Although the CMS codebase only manually creates these values in tests, users might want to programmatically create them. One use case is the Deploy artifact migrators, e.g. if you want to migrate Nested Content to Block List.

With this PR applied, you can use the new constructor overloads to specify the layout, which automatically uses the correct property editor alias (from the abstract property) and forces you to use the correct layout item type:

```c#
var blockListValue = new BlockListValue(
[
    new BlockListLayoutItem()
]);
```