### PR TITLE
Property source level variation should only be applied when configured

### DIFF
--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Published/PublishedContentVarianceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Published/PublishedContentVarianceTests.cs
@@ -76,6 +76,28 @@ public class PublishedContentVarianceTests
         Assert.AreEqual(expectedValue, value);
     }
 
+    [TestCase(DaCulture, Segment1, "DaDk property value")]
+    [TestCase(DaCulture, Segment2, "DaDk property value")]
+    [TestCase(EnCulture, Segment1, "EnUs property value")]
+    [TestCase(EnCulture, Segment2, "EnUs property value")]
+    public void Content_Culture_And_Segment_Variation_Can_Get_Culture_Variant_Property(string culture, string segment, string expectedValue)
+    {
+        var content = CreatePublishedContent(ContentVariation.CultureAndSegment, ContentVariation.Culture, variationContextCulture: culture, variationContextSegment: segment);
+        var value = GetPropertyValue(content);
+        Assert.AreEqual(expectedValue, value);
+    }
+
+    [TestCase(DaCulture, Segment1, "Segment1 property value")]
+    [TestCase(DaCulture, Segment2, "Segment2 property value")]
+    [TestCase(EnCulture, Segment1, "Segment1 property value")]
+    [TestCase(EnCulture, Segment2, "Segment2 property value")]
+    public void Content_Culture_And_Segment_Variation_Can_Get_Segment_Variant_Property(string culture, string segment, string expectedValue)
+    {
+        var content = CreatePublishedContent(ContentVariation.CultureAndSegment, ContentVariation.Segment, variationContextCulture: culture, variationContextSegment: segment);
+        var value = GetPropertyValue(content);
+        Assert.AreEqual(expectedValue, value);
+    }
+
     private object? GetPropertyValue(IPublishedContent content) => content.GetProperty(PropertyTypeAlias)!.GetValue();
 
     private IPublishedContent CreatePublishedContent(ContentVariation contentTypeVariation, ContentVariation propertyTypeVariation, string? variationContextCulture = null, string? variationContextSegment = null)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #16186

### Description

This PR fixes #16186

The property level variance has been a problem child for a while now. These issues are related to the same thing:

- https://github.com/umbraco/Umbraco-CMS/issues/15117
- https://github.com/umbraco/Umbraco-CMS/issues/14758

### Testing this PR

First and foremost, make sure everything works in respect to the original issue (#16186). I have attached testing resources at the end of this PR description, so you don't have to set everything up from scratch. The "Home" item is setup for testing #16186.

Second make sure that property level expansion still works (see #14758 for details). Remember to enable the Content Delivery API 😉 If you're using the test DB attached below, this content item (`f9f25aed-4a73-4ed2-aa6e-efb4359a39ce`) can be used to verify:

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/f31f25d5-7013-42ec-8b21-07d083e2d617)

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/6ab3335b-8933-498d-8125-4e9fb256dc5b)

#### Database

This DB has everything setup for testing:

[Umbraco.sqlite.16186.db.zip](https://github.com/umbraco/Umbraco-CMS/files/15290601/Umbraco.sqlite.16186.db.zip)

Admin login: admin@localhost / SuperSecret123

> [!NOTE]
> You may have to republish everything in all cultures and segments.

#### Segments setup

Include this code to enable the "customer" and "visitor" segments:

<details>
<summary>Issue16186.cs</summary>

```cs
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Models.ContentEditing;
using Umbraco.Cms.Core.Notifications;
using Umbraco.Cms.Core.Services;

namespace Umbraco.Cms.Web.UI.Custom;

public class VariantsComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.AddNotificationHandler<ServerVariablesParsingNotification, VariantsServerVariablesParser>();
        builder.AddNotificationHandler<SendingContentNotification, CreateSegmentsEvent>();
    }

    public class CreateSegmentsEvent : INotificationHandler<SendingContentNotification>
    {
        private readonly IContentTypeService contentTypeService;

        public CreateSegmentsEvent(IContentTypeService contentTypeService)
        {
            this.contentTypeService = contentTypeService;
        }

        public void Handle(SendingContentNotification notification)
        {
            /* There are several rules for segmentation
                *  - For each original version, we should have additional versions for each segment
             *  - A segment should be added if no version already exists on the content model
             */


            var segments = new List<string>() { "customer", "visitor" };

            var contentType = this.contentTypeService.Get(notification.Content.ContentTypeId ?? -1);
            if (contentType is null) return;

            var props = contentType.PropertyTypes.Where(p => p.VariesBySegment()).Select(p => p.Alias).ToHashSet();
            props.UnionWith(contentType.CompositionPropertyGroups.SelectMany(p => p.PropertyTypes ?? Enumerable.Empty<IPropertyType>()).Where(p => p.VariesBySegment()).Select(p => p.Alias));

            if (!props.Any()) return;

            // The frontend depends on the order of the segments,
            //   therefore it is important to ensure a consistent order of all different variations.
            var newVariants = new List<ContentVariantDisplay>(notification.Content.Variants);
            newVariants = EnsureProperDisplayNames(newVariants, segments);
            newVariants = EnsureSegmentForEachVariant(newVariants, segments, props);
            notification.Content.Variants = newVariants
                .OrderBy(v => IsDefaultLanguage(v) ? 0 : 1)
                .ThenBy(v => IsDefaultSegment(v) ? 0 : 1)
                .ThenBy(v => v?.Language?.Name)
                .ThenBy(v => v.Segment)
                .ToList();
        }

        private static bool IsDefaultLanguage(ContentVariantDisplay variant) =>
            variant.Language == null || variant.Language.IsDefault;

        private static bool IsDefaultSegment(ContentVariantDisplay variant) => variant.Segment == null;

        private List<ContentVariantDisplay> EnsureSegmentForEachVariant(List<ContentVariantDisplay> newVariants, IEnumerable<string> segments, ISet<string> variantProps)
        {
            var additionalVariants = new List<ContentVariantDisplay>();

            // A variant is original if the value for segment is empty
            foreach (var variant in newVariants.Where(v => string.IsNullOrWhiteSpace(v.Segment)))
            {
                // A variant is the same if their language and segment are equal.
                foreach (var segment in segments.Where(s => !newVariants.Any(v => v.Language?.Id == variant.Language?.Id && v.Segment == s)))
                {
                    var newVariant = new ContentVariantDisplay
                    {
                        AllowedActions = new List<string>(variant.AllowedActions),
                        DisplayName = segment,
                        Language = variant.Language,
                        Segment = segment,
                        State = ContentSavedState.NotCreated,
                        Tabs = variant.Tabs.Select(x => new Tab<ContentPropertyDisplay>
                        {
                            Alias = x.Alias,
                            IsActive = x.IsActive,
                            Expanded = x.Expanded,
                            Id = x.Id,
                            Key = x.Key,
                            Label = x.Label,
                            Type = x.Type,
                            Properties = x.Properties?.Select(p => new ContentPropertyDisplay
                            {
                                Alias = p.Alias,
                                Config = p.Config,
                                ConfigNullable = p.ConfigNullable,
                                Culture = p.Culture,
                                DataTypeKey = p.DataTypeKey,
                                Description = p.Description,
                                Editor = p.Editor,
                                HideLabel = p.HideLabel,
                                Id = p.Id,
                                IsSensitive = p.IsSensitive,
                                Label = p.Label,
                                LabelOnTop = p.LabelOnTop,
                                PropertyEditor = p.PropertyEditor,
                                Readonly = p.Readonly,
                                Segment = variantProps.Contains(p.Alias) ? segment : null,
                                SupportsReadOnly = p.SupportsReadOnly,
                                Validation = p.Validation,
                                Value = variantProps.Contains(p.Alias) ? null : p.Value,
                                Variations = p.Variations,
                                View = p.View,
                            }),
                        })
                    };

                    additionalVariants.Add(newVariant);
                }
            }

            newVariants.AddRange(additionalVariants);
            return newVariants;
        }

        private List<ContentVariantDisplay> EnsureProperDisplayNames(List<ContentVariantDisplay> newVariants, IEnumerable<string> segments)
        {
            // Always assign the current name of the segment to the displayname to ensure that the frontend always shows an up-to-date name
            foreach (var variant in newVariants)
            {
                if (string.IsNullOrWhiteSpace(variant.Segment)) continue;
                var segment = segments.FirstOrDefault(s => s == variant.Segment);
                if (segment is null) continue;

                variant.DisplayName = segment;
            }

            return newVariants;
        }
    }

    public class VariantsServerVariablesParser : INotificationHandler<ServerVariablesParsingNotification>
    {
        public void Handle(ServerVariablesParsingNotification notification)
        {
            if (!notification.ServerVariables.TryGetValue("umbracoSettings", out object? umbracoSettingsObject)
                || umbracoSettingsObject is not IDictionary<string, object> umbracoSettings)
            {
                umbracoSettings = new Dictionary<string, object>();
                notification.ServerVariables.Add("umbracoSettings", umbracoSettings);
            }

            umbracoSettings["showAllowSegmentationForDocumentTypes"] = true;
        }
    }
}
```
</details>

#### Template

Use this template to test the PR:

<details>
<summary>home.cshtml</summary>

```html
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<IPublishedContent>
@inject IVariationContextAccessor VariationContextAccessor
@inject IPublishedValueFallback PublishedValueFallback
@{
    Layout = null;

    var segment = Context.Request.Query["s"].ToString();

    if (string.IsNullOrWhiteSpace(segment) == false)
    {
        VariationContextAccessor.VariationContext = new VariationContext(VariationContextAccessor.VariationContext?.Culture, segment);
    }

    var cultureAlias = "cultureOnlyText";
    var segmentAlias = "segmentOnlyText";
    var cultureAndSegmentAlias = "segmentAndCultureText";
    var invariantAlias = "invariantText";
}

<h2>Specifiying culture and segment for getting values</h2>

<ul>
    <li>Invariant text :  @Model.Value(invariantAlias, VariationContextAccessor.VariationContext?.Culture, segment)</li>
    <li>Culture text :  @Model.Value(cultureAlias, VariationContextAccessor.VariationContext?.Culture, segment)</li>
    <li>Segment text :  @Model.Value(segmentAlias, VariationContextAccessor.VariationContext?.Culture, segment)</li>
    <li>Culture and segment text : @Model.Value(cultureAndSegmentAlias, VariationContextAccessor.VariationContext?.Culture, segment)</li>
</ul>

<h2>Getting values without specifying anything</h2>

<ul>
    <li>Invariant text :  @Model.Value(invariantAlias)</li>
    <li>Culture text :  @Model.Value(cultureAlias)</li>
    <li>Segment text :  @Model.Value(segmentAlias)</li>
    <li>Culture and segment text : @Model.Value(cultureAndSegmentAlias)</li>
</ul>

<h2>Using publishedFallback (the modelsbuilder way)</h2>

<ul>
    <li>Invariant text :  @Model.Value(PublishedValueFallback, invariantAlias)</li>
    <li>Culture text :  @Model.Value(PublishedValueFallback, cultureAlias)</li>
    <li>Segment text :  @Model.Value(PublishedValueFallback, segmentAlias)</li>
    <li>Culture and segment text : @Model.Value(PublishedValueFallback, cultureAndSegmentAlias)</li>
</ul>
```
</details>
