### PR TITLE
V14: Backend changes to facilitate Preview mode in Bellissimma

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Preview/IPreviewHub.cs
+++ b/src/Umbraco.Cms.Api.Management/Preview/IPreviewHub.cs
@@ -5,7 +5,7 @@ public interface IPreviewHub
     // define methods implemented by client
     // ReSharper disable InconsistentNaming
 
-    Task refreshed(int id);
+    Task refreshed(Guid key);
 
     // ReSharper restore InconsistentNaming
 }

--- a/src/Umbraco.Cms.Api.Management/Preview/PreviewHubUpdater.cs
+++ b/src/Umbraco.Cms.Api.Management/Preview/PreviewHubUpdater.cs
@@ -26,8 +26,13 @@ public class PreviewHubUpdater : INotificationAsyncHandler<ContentCacheRefresher
         IHubContext<PreviewHub, IPreviewHub> hubContextInstance = _hubContext.Value;
         foreach (ContentCacheRefresher.JsonPayload payload in payloads)
         {
-            var id = payload.Id; // keep it simple for now, ignore ChangeTypes
-            await hubContextInstance.Clients.All.refreshed(id);
+            var key = payload.Key; // keep it simple for now, ignore ChangeTypes
+            if (key.HasValue is false)
+            {
+                throw new InvalidOperationException($"No key is set for payload with id {payload.Id}");
+            }
+
+            await hubContextInstance.Clients.All.refreshed(key.Value);
         }
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Routing/BackOfficeAreaRoutes.cs
+++ b/src/Umbraco.Cms.Api.Management/Routing/BackOfficeAreaRoutes.cs
@@ -88,6 +88,6 @@ public sealed class BackOfficeAreaRoutes : IAreaRoutes
                 Controller = ControllerExtensions.GetControllerName<BackOfficeDefaultController>(),
                 Action = nameof(BackOfficeDefaultController.Index),
             },
-            constraints: new { slug = @"^(section.*|upgrade|install|oauth_complete|logout|error)$" });
+            constraints: new { slug = @"^(section.*|preview|upgrade|install|oauth_complete|logout|error)$" });
     }
 }

--- a/src/Umbraco.Core/Configuration/Models/WebRoutingSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/WebRoutingSettings.cs
@@ -18,6 +18,7 @@ public class WebRoutingSettings
     internal const bool StaticDisableAlternativeTemplates = false;
     internal const bool StaticValidateAlternativeTemplates = false;
     internal const bool StaticDisableFindContentByIdPath = false;
+    internal const bool StaticDisableFindContentByIdentifierPath = false;
     internal const bool StaticDisableRedirectUrlTracking = false;
     internal const string StaticUrlProviderMode = "Auto";
 
@@ -59,13 +60,12 @@ public class WebRoutingSettings
     [DefaultValue(StaticValidateAlternativeTemplates)]
     public bool ValidateAlternativeTemplates { get; set; } = StaticValidateAlternativeTemplates;
 
-    /// <summary>
-    ///     Gets or sets a value indicating whether finding content by ID path or key path is disabled.
-    /// </summary>
-    // TODO: Rename setting to DisableFindContentByIdentifierPath to reflect the usage in both <see cref="ContentFinderByIdPath" /> and <see cref="ContentFinderByKeyPath" />.
+    [Obsolete("Use DisableFindContentByIdentifierPath instead. This will be removed in Umbraco 15." )]
     [DefaultValue(StaticDisableFindContentByIdPath)]
     public bool DisableFindContentByIdPath { get; set; } = StaticDisableFindContentByIdPath;
 
+    [DefaultValue(StaticDisableFindContentByIdentifierPath)]
+    public bool DisableFindContentByIdentifierPath { get; set; } = StaticDisableFindContentByIdentifierPath;
     /// <summary>
     ///     Gets or sets a value indicating whether redirect URL tracking is disabled.
     /// </summary>

--- a/src/Umbraco.Core/Configuration/Models/WebRoutingSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/WebRoutingSettings.cs
@@ -60,8 +60,9 @@ public class WebRoutingSettings
     public bool ValidateAlternativeTemplates { get; set; } = StaticValidateAlternativeTemplates;
 
     /// <summary>
-    ///     Gets or sets a value indicating whether find content ID by path is disabled.
+    ///     Gets or sets a value indicating whether finding content by ID path or key path is disabled.
     /// </summary>
+    // TODO: Rename setting to DisableFindContentByIdentifierPath to reflect the usage in both <see cref="ContentFinderByIdPath" /> and <see cref="ContentFinderByKeyPath" />.
     [DefaultValue(StaticDisableFindContentByIdPath)]
     public bool DisableFindContentByIdPath { get; set; } = StaticDisableFindContentByIdPath;
 

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
@@ -38,6 +38,7 @@ public static partial class UmbracoBuilderExtensions
             .Append<ContentFinderByPageIdQuery>()
             .Append<ContentFinderByUrl>()
             .Append<ContentFinderByIdPath>()
+            .Append<ContentFinderByKeyPath>()
             /*.Append<ContentFinderByUrlAndTemplate>() // disabled, this is an odd finder */
             .Append<ContentFinderByUrlAlias>()
             .Append<ContentFinderByRedirectUrl>();

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
@@ -37,8 +37,8 @@ public static partial class UmbracoBuilderExtensions
         builder.ContentFinders()
             .Append<ContentFinderByPageIdQuery>()
             .Append<ContentFinderByUrl>()
-            .Append<ContentFinderByIdPath>()
             .Append<ContentFinderByKeyPath>()
+            .Append<ContentFinderByIdPath>()
             /*.Append<ContentFinderByUrlAndTemplate>() // disabled, this is an odd finder */
             .Append<ContentFinderByUrlAlias>()
             .Append<ContentFinderByRedirectUrl>();

--- a/src/Umbraco.Core/Routing/ContentFinderByIdPath.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByIdPath.cs
@@ -13,6 +13,7 @@ namespace Umbraco.Cms.Core.Routing;
 /// <remarks>
 ///     <para>Handles <c>/1234</c> where <c>1234</c> is the identified of a document.</para>
 /// </remarks>
+[Obsolete("Use ContentFinderByKeyPath instead. This will be removed in Umbraco 15.")]
 public class ContentFinderByIdPath : ContentFinderByIdentifierPathBase, IContentFinder
 {
     private readonly ILogger<ContentFinderByIdPath> _logger;
@@ -52,7 +53,7 @@ public class ContentFinderByIdPath : ContentFinderByIdentifierPathBase, IContent
             return Task.FromResult(false);
         }
 
-        if (umbracoContext.InPreviewMode == false && _webRoutingSettings.DisableFindContentByIdPath)
+        if (umbracoContext.InPreviewMode == false && (_webRoutingSettings.DisableFindContentByIdPath || _webRoutingSettings.DisableFindContentByIdentifierPath))
         {
             return Task.FromResult(false);
         }

--- a/src/Umbraco.Core/Routing/ContentFinderByIdPath.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByIdPath.cs
@@ -13,12 +13,13 @@ namespace Umbraco.Cms.Core.Routing;
 /// <remarks>
 ///     <para>Handles <c>/1234</c> where <c>1234</c> is the identified of a document.</para>
 /// </remarks>
-public class ContentFinderByIdPath : IContentFinder
+public class ContentFinderByIdPath : ContentFinderByIdentifierPathBase, IContentFinder
 {
     private readonly ILogger<ContentFinderByIdPath> _logger;
-    private readonly IRequestAccessor _requestAccessor;
     private readonly IUmbracoContextAccessor _umbracoContextAccessor;
     private WebRoutingSettings _webRoutingSettings;
+
+    protected override string FailureLogMessageTemplate => "Not a node id";
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="ContentFinderByIdPath" /> class.
@@ -28,11 +29,11 @@ public class ContentFinderByIdPath : IContentFinder
         ILogger<ContentFinderByIdPath> logger,
         IRequestAccessor requestAccessor,
         IUmbracoContextAccessor umbracoContextAccessor)
+        : base(requestAccessor, logger)
     {
         _webRoutingSettings = webRoutingSettings.CurrentValue ??
                               throw new ArgumentNullException(nameof(webRoutingSettings));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _requestAccessor = requestAccessor ?? throw new ArgumentNullException(nameof(requestAccessor));
         _umbracoContextAccessor =
             umbracoContextAccessor ?? throw new ArgumentNullException(nameof(umbracoContextAccessor));
 
@@ -89,14 +90,7 @@ public class ContentFinderByIdPath : IContentFinder
             return LogAndReturnFailure();
         }
 
-        var cultureFromQuerystring = _requestAccessor.GetQueryStringValue("culture");
-
-        // if we have a node, check if we have a culture in the query string
-        if (!string.IsNullOrEmpty(cultureFromQuerystring))
-        {
-            // we're assuming it will match a culture, if an invalid one is passed in, an exception will throw (there is no TryGetCultureInfo method), i think this is ok though
-            frequest.SetCulture(cultureFromQuerystring);
-        }
+        ResolveAndSetCultureOnRequest(frequest);
 
         frequest.SetPublishedContent(node);
         if (_logger.IsEnabled(LogLevel.Debug))
@@ -105,15 +99,5 @@ public class ContentFinderByIdPath : IContentFinder
         }
 
         return Task.FromResult(true);
-    }
-
-    private Task<bool> LogAndReturnFailure()
-    {
-        if (_logger.IsEnabled(LogLevel.Debug))
-        {
-            _logger.LogDebug("Not a node id");
-        }
-
-        return Task.FromResult(false);
     }
 }

--- a/src/Umbraco.Core/Routing/ContentFinderByIdentifierPathBase.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByIdentifierPathBase.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Web;
+
+namespace Umbraco.Cms.Core.Routing;
+
+public abstract class ContentFinderByIdentifierPathBase
+{
+    private readonly IRequestAccessor _requestAccessor;
+    private readonly ILogger<ContentFinderByIdentifierPathBase> _logger;
+
+    /// <remark>
+    ///     Used as the log message inside <see cref="LogAndReturnFailure()"/>>.
+    /// </remark>
+    protected abstract string FailureLogMessageTemplate { get; }
+
+    protected ContentFinderByIdentifierPathBase(IRequestAccessor requestAccessor, ILogger<ContentFinderByIdentifierPathBase> logger)
+    {
+        _requestAccessor = requestAccessor;
+        _logger = logger;
+    }
+
+    protected void ResolveAndSetCultureOnRequest(IPublishedRequestBuilder frequest)
+    {
+        var cultureFromQuerystring = _requestAccessor.GetQueryStringValue("culture");
+
+        // if we have a node, check if we have a culture in the query string
+        if (!string.IsNullOrEmpty(cultureFromQuerystring))
+        {
+            // we're assuming it will match a culture, if an invalid one is passed in, an exception will throw (there is no TryGetCultureInfo method), i think this is ok though
+            frequest.SetCulture(cultureFromQuerystring);
+        }
+    }
+
+    protected Task<bool> LogAndReturnFailure()
+    {
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug(FailureLogMessageTemplate);
+        }
+
+        return Task.FromResult(false);
+    }
+}

--- a/src/Umbraco.Core/Routing/ContentFinderByIdentifierPathBase.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByIdentifierPathBase.cs
@@ -23,10 +23,11 @@ public abstract class ContentFinderByIdentifierPathBase
     {
         var cultureFromQuerystring = _requestAccessor.GetQueryStringValue("culture");
 
-        // if we have a node, check if we have a culture in the query string
+        // Check if we have a culture in the query string
         if (!string.IsNullOrEmpty(cultureFromQuerystring))
         {
-            // we're assuming it will match a culture, if an invalid one is passed in, an exception will throw (there is no TryGetCultureInfo method), i think this is ok though
+            // We're assuming it will match a culture, if an invalid one is passed in,
+            // an exception will throw (there is no TryGetCultureInfo method)
             frequest.SetCulture(cultureFromQuerystring);
         }
     }

--- a/src/Umbraco.Core/Routing/ContentFinderByKeyPath.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByKeyPath.cs
@@ -1,0 +1,120 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Web;
+
+namespace Umbraco.Cms.Core.Routing;
+
+/// <summary>
+///     Provides an implementation of <see cref="IContentFinder" /> that handles page key identifiers.
+/// </summary>
+/// <remarks>
+///     <para>Handles <c>/e7b65017-c6b3-4c11-b7c7-7ea1d0404c9a</c> where <c>e7b65017-c6b3-4c11-b7c7-7ea1d0404c9a</c> is the key of a document.</para>
+/// </remarks>
+public class ContentFinderByKeyPath : IContentFinder
+{
+    private readonly ILogger<ContentFinderByKeyPath> _logger;
+    private readonly IRequestAccessor _requestAccessor;
+    private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+    private WebRoutingSettings _webRoutingSettings;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="ContentFinderByKeyPath" /> class.
+    /// </summary>
+    public ContentFinderByKeyPath(
+        IOptionsMonitor<WebRoutingSettings> webRoutingSettings,
+        ILogger<ContentFinderByKeyPath> logger,
+        IRequestAccessor requestAccessor,
+        IUmbracoContextAccessor umbracoContextAccessor)
+    {
+        _webRoutingSettings = webRoutingSettings.CurrentValue ??
+                              throw new ArgumentNullException(nameof(webRoutingSettings));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _requestAccessor = requestAccessor ?? throw new ArgumentNullException(nameof(requestAccessor));
+        _umbracoContextAccessor =
+            umbracoContextAccessor ?? throw new ArgumentNullException(nameof(umbracoContextAccessor));
+
+        webRoutingSettings.OnChange(x => _webRoutingSettings = x);
+    }
+
+    /// <summary>
+    ///     Tries to find and assign an Umbraco document to a <c>PublishedRequest</c>.
+    /// </summary>
+    /// <param name="frequest">The <c>PublishedRequest</c>.</param>
+    /// <returns>A value indicating whether an Umbraco document was found and assigned.</returns>
+    public Task<bool> TryFindContent(IPublishedRequestBuilder frequest)
+    {
+        if (!_umbracoContextAccessor.TryGetUmbracoContext(out IUmbracoContext? umbracoContext))
+        {
+            return Task.FromResult(false);
+        }
+
+        // Reusing DisableFindContentByIdPath configuration as if people have disabled content finders by ids,
+        // the same should apply for keys
+        if (umbracoContext.InPreviewMode == false && _webRoutingSettings.DisableFindContentByIdPath)
+        {
+            return Task.FromResult(false);
+        }
+
+        var path = frequest.AbsolutePathDecoded;
+
+        // no id if "/"
+        if (path == "/")
+        {
+            return LogAndReturnFailure();
+        }
+
+        var noSlashPath = path.Substring(1);
+
+        if (Guid.TryParse(noSlashPath, out var nodeKey) == false)
+        {
+            return LogAndReturnFailure();
+        }
+
+        // We shouldn't be persisting empty Guids
+        if (nodeKey.Equals(Guid.Empty))
+        {
+            return LogAndReturnFailure();
+        }
+
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug("Key={NodeKey}", nodeKey);
+        }
+
+        IPublishedContent? node = umbracoContext.Content?.GetById(nodeKey);
+
+        if (node is null)
+        {
+            return LogAndReturnFailure();
+        }
+
+        var cultureFromQuerystring = _requestAccessor.GetQueryStringValue("culture");
+
+        // if we have a node, check if we have a culture in the query string
+        if (!string.IsNullOrEmpty(cultureFromQuerystring))
+        {
+            // we're assuming it will match a culture, if an invalid one is passed in, an exception will throw (there is no TryGetCultureInfo method), i think this is ok though
+            frequest.SetCulture(cultureFromQuerystring);
+        }
+
+        frequest.SetPublishedContent(node);
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug("Found node with key={PublishedContentKey}", node.Key);
+        }
+
+        return Task.FromResult(true);
+    }
+
+    private Task<bool> LogAndReturnFailure()
+    {
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug("Not a node key");
+        }
+
+        return Task.FromResult(false);
+    }
+}

--- a/src/Umbraco.Core/Routing/ContentFinderByKeyPath.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByKeyPath.cs
@@ -51,9 +51,7 @@ public class ContentFinderByKeyPath : ContentFinderByIdentifierPathBase, IConten
             return Task.FromResult(false);
         }
 
-        // Reusing DisableFindContentByIdPath configuration as if people have disabled content finders by ids,
-        // the same should apply for keys
-        if (umbracoContext.InPreviewMode == false && _webRoutingSettings.DisableFindContentByIdPath)
+        if (umbracoContext.InPreviewMode == false && _webRoutingSettings.DisableFindContentByIdentifierPath)
         {
             return Task.FromResult(false);
         }

--- a/src/Umbraco.Core/Services/PreviewService.cs
+++ b/src/Umbraco.Core/Services/PreviewService.cs
@@ -8,7 +8,7 @@ public class PreviewService : IPreviewService
 
     public PreviewService(ICookieManager cookieManager) => _cookieManager = cookieManager;
 
-    public void EnterPreview() => _cookieManager.SetCookieValue(Constants.Web.PreviewCookieName, "preview");
+    public void EnterPreview() => _cookieManager.SetCookieValue(Constants.Web.PreviewCookieName, "preview", true);
 
 
     public void EndPreview() => _cookieManager.ExpireCookie(Constants.Web.PreviewCookieName);

--- a/src/Umbraco.Core/Web/ICookieManager.cs
+++ b/src/Umbraco.Core/Web/ICookieManager.cs
@@ -6,7 +6,7 @@ public interface ICookieManager
 
     string? GetCookieValue(string cookieName);
 
-    void SetCookieValue(string cookieName, string value);
+    void SetCookieValue(string cookieName, string value, bool httpOnly = false);
 
     bool HasCookie(string cookieName);
 }

--- a/src/Umbraco.Core/Web/ICookieManager.cs
+++ b/src/Umbraco.Core/Web/ICookieManager.cs
@@ -6,7 +6,10 @@ public interface ICookieManager
 
     string? GetCookieValue(string cookieName);
 
-    void SetCookieValue(string cookieName, string value, bool httpOnly = false);
+    [Obsolete("Use overload with the httpOnly parameter instead. Scheduled for removal in V16.")]
+    void SetCookieValue(string cookieName, string value) => SetCookieValue(cookieName, value, false);
+
+    void SetCookieValue(string cookieName, string value, bool httpOnly);
 
     bool HasCookie(string cookieName);
 }

--- a/src/Umbraco.Infrastructure/Install/InstallHelper.cs
+++ b/src/Umbraco.Infrastructure/Install/InstallHelper.cs
@@ -61,7 +61,7 @@ namespace Umbraco.Cms.Infrastructure.Install
                 {
                     installId = Guid.NewGuid();
 
-                    _cookieManager.SetCookieValue(Constants.Web.InstallerCookieName, installId.ToString());
+                    _cookieManager.SetCookieValue(Constants.Web.InstallerCookieName, installId.ToString(), false);
                 }
 
                 var dbProvider = string.Empty;

--- a/src/Umbraco.Web.Common/AspNetCore/AspNetCoreCookieManager.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/AspNetCoreCookieManager.cs
@@ -27,7 +27,7 @@ public class AspNetCoreCookieManager : ICookieManager
 
     public string? GetCookieValue(string cookieName) => _httpContextAccessor.HttpContext?.Request.Cookies[cookieName];
 
-    public void SetCookieValue(string cookieName, string value, bool httpOnly = false) =>
+    public void SetCookieValue(string cookieName, string value, bool httpOnly) =>
         _httpContextAccessor.HttpContext?.Response.Cookies.Append(cookieName, value, new CookieOptions { HttpOnly = httpOnly });
 
     public bool HasCookie(string cookieName) => !(GetCookieValue(cookieName) is null);

--- a/src/Umbraco.Web.Common/AspNetCore/AspNetCoreCookieManager.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/AspNetCoreCookieManager.cs
@@ -27,8 +27,8 @@ public class AspNetCoreCookieManager : ICookieManager
 
     public string? GetCookieValue(string cookieName) => _httpContextAccessor.HttpContext?.Request.Cookies[cookieName];
 
-    public void SetCookieValue(string cookieName, string value) =>
-        _httpContextAccessor.HttpContext?.Response.Cookies.Append(cookieName, value, new CookieOptions());
+    public void SetCookieValue(string cookieName, string value, bool httpOnly = false) =>
+        _httpContextAccessor.HttpContext?.Response.Cookies.Append(cookieName, value, new CookieOptions { HttpOnly = httpOnly });
 
     public bool HasCookie(string cookieName) => !(GetCookieValue(cookieName) is null);
 }

--- a/src/Umbraco.Web.Common/Profiler/WebProfiler.cs
+++ b/src/Umbraco.Web.Common/Profiler/WebProfiler.cs
@@ -109,7 +109,7 @@ public class WebProfiler : IProfiler
                     && !location.Contains("://"))
                 {
                     MiniProfilerContext.Value.Root.Name = "Before Redirect";
-                    cookieManager.SetCookieValue(WebProfileCookieKey, MiniProfilerContext.Value.ToJson());
+                    cookieManager.SetCookieValue(WebProfileCookieKey, MiniProfilerContext.Value.ToJson(), false);
                 }
             }
         }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByIdentifierTestsBase.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByIdentifierTestsBase.cs
@@ -1,0 +1,58 @@
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+using Umbraco.Cms.Tests.UnitTests.TestHelpers;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing;
+
+public abstract class ContentFinderByIdentifierTestsBase : PublishedSnapshotServiceTestBase
+{
+    protected void PopulateCache(int nodeId, Guid nodeKey)
+    {
+        var dataTypes = GetDefaultDataTypes().Select(dt => dt as IDataType).ToArray();
+        var propertyDataTypes = new Dictionary<string, IDataType>
+        {
+            // we only have one data type for this test which will be resolved with string empty.
+            [string.Empty] = dataTypes[0],
+        };
+        IContentType contentType1 = new ContentType(ShortStringHelper, -1);
+
+        var rootData = new ContentDataBuilder()
+            .WithName("Page" + Guid.NewGuid())
+            .Build(ShortStringHelper, propertyDataTypes, contentType1, "alias");
+
+        var root = ContentNodeKitBuilder.CreateWithContent(
+            contentType1.Id,
+            9876,
+            "-1,9876",
+            draftData: rootData,
+            publishedData: rootData);
+
+        var parentData = new ContentDataBuilder()
+            .WithName("Page" + Guid.NewGuid())
+            .Build();
+
+        var parent = ContentNodeKitBuilder.CreateWithContent(
+            contentType1.Id,
+            5432,
+            "-1,9876,5432",
+            parentContentId: 9876,
+            draftData: parentData,
+            publishedData: parentData);
+
+        var contentData = new ContentDataBuilder()
+            .WithName("Page" + Guid.NewGuid())
+            .Build();
+
+        var content = ContentNodeKitBuilder.CreateWithContent(
+            contentType1.Id,
+            nodeId,
+            "-1,9876,5432," + nodeId,
+            parentContentId: 5432,
+            draftData: contentData,
+            publishedData: contentData,
+            uid: nodeKey);
+
+        InitializedCache(new[] { root, parent, content }, [contentType1], dataTypes);
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByKeyTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByKeyTests.cs
@@ -10,7 +10,7 @@ using Umbraco.Extensions;
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing;
 
 [TestFixture]
-public class ContentFinderByIdTests : ContentFinderByIdentifierTestsBase
+public class ContentFinderByKeyTests : ContentFinderByIdentifierTestsBase
 {
     [SetUp]
     public override void Setup()
@@ -18,20 +18,22 @@ public class ContentFinderByIdTests : ContentFinderByIdentifierTestsBase
         base.Setup();
     }
 
-    [TestCase("/1046", 1046, true)]
-    [TestCase("/1046", 1047, false)]
-    public async Task Lookup_By_Id(string urlAsString, int nodeId, bool shouldSucceed)
+    [TestCase("/1598901d-ebbe-4996-b7fb-6a6cbac13a62", "1598901d-ebbe-4996-b7fb-6a6cbac13a62", true)]
+    [TestCase("/1598901d-ebbe-4996-b7fb-6a6cbac13a62", "a383f6ed-cc54-46f1-a577-33f42e7214de", false)]
+    public async Task Lookup_By_Key(string urlAsString, string nodeKeyString, bool shouldSucceed)
     {
-        PopulateCache(nodeId, Guid.NewGuid());
+        var nodeKey = Guid.Parse(nodeKeyString);
+
+        PopulateCache(9999, nodeKey);
 
         var umbracoContextAccessor = GetUmbracoContextAccessor(urlAsString);
         var umbracoContext = umbracoContextAccessor.GetRequiredUmbracoContext();
         var publishedRouter = CreatePublishedRouter(umbracoContextAccessor);
         var frequest = await publishedRouter.CreateRequestAsync(umbracoContext.CleanedUmbracoUrl);
         var webRoutingSettings = new WebRoutingSettings();
-        var lookup = new ContentFinderByIdPath(
+        var lookup = new ContentFinderByKeyPath(
             Mock.Of<IOptionsMonitor<WebRoutingSettings>>(x => x.CurrentValue == webRoutingSettings),
-            Mock.Of<ILogger<ContentFinderByIdPath>>(),
+            Mock.Of<ILogger<ContentFinderByKeyPath>>(),
             Mock.Of<IRequestAccessor>(),
             umbracoContextAccessor);
 
@@ -40,7 +42,7 @@ public class ContentFinderByIdTests : ContentFinderByIdentifierTestsBase
         Assert.AreEqual(shouldSucceed, result);
         if (shouldSucceed)
         {
-            Assert.AreEqual(frequest.PublishedContent!.Id, nodeId);
+            Assert.AreEqual(frequest.PublishedContent!.Key, nodeKey);
         }
         else
         {


### PR DESCRIPTION
## Details
- Updating SignalR Preview Hub to send Guid instead of int id;
- Make `UMB_PREVIEW` cookie HttpOnly so that we are able to make a request to the server from a client on a different host;
- Enable routing for the preview feature based on a Guid since we no longer expose integer ids by creating a new `ContentFinderByKeyPath`.
  - Creating a base class for common logic between `ContentFinderByIdPath` and `ContentFinderByKeyPath`;
  - Refactoring content finder tests.

## Test
- Make sure tests pass ✅ ;
- Enable preview mode and verify that `UMB_PREVIEW` cookie is HttpOnly (_see appendix*_)
- Create a simple content node with a template saying "Hello, World!";
  - Find its int id and guid key.
- Verify that visiting `https://localhost:44339/<nodeKey>` and `https://localhost:44339/<nodeId>`:
  - Resolves to the same content node when using a valid key and a valid id of the same content node;
  - Resolves to 404 when using a random guid or -1 as int id;
  - Resolves to 404 when using valid int id or Guid key and setting `Umbraco::CMS::WebRouting::DisableFindContentByIdPath` to `true` (_and you don't have the `UMB_PREVIEW` cookie_).

## Appendix
\* Use the following endpoint in Swagger to enable preview mode and delete the cookie to disable it:
```c#
using Asp.Versioning;
using Microsoft.AspNetCore.Mvc;
using Umbraco.Cms.Api.Management.Controllers;
using Umbraco.Cms.Core.Services;

namespace Umbraco.Cms.Web.UI;

[Route("api/v{version:apiVersion}/myApi")]
[ApiVersion("1.0")]
[ApiExplorerSettings(GroupName = "A new API")]
public class MyApiController : ManagementApiControllerBase
{
    private readonly IPreviewService _previewService;

    public MyApiController(IPreviewService previewService)
    {
        _previewService = previewService;
    }

    [HttpGet]
    [Route("preview")]
    public IActionResult EnterPreview()
    {
        _previewService.EnterPreview();
        return Ok("In preview mode");
    }
}
```