### PR TITLE
V13/bugfix/fix infinite editor stuck in create action 15945

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -512,7 +512,7 @@
                 init();
 
                 //needs to be manually set for infinite editing mode
-                $scope.page.isNew = false;
+                $scope.isNew = false;
 
                 syncTreeNode($scope.content, data.path, false, args.reloadChildren);
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/forms/umbfocuslock.directive.js
@@ -88,26 +88,27 @@
 
                 // If an infinite editor is being closed then we reset the focus to the element that triggered the the overlay
                 if(closingEditor){
-
                     // If there is only one editor open, search for the "editor-info" inside it and set focus on it
                     // This is relevant when a property editor has been selected and the editor where we selected it from
                     // is closed taking us back to the first layer
                     // Otherwise set it to the last element in the lastKnownFocusedElements array
-                    if(infiniteEditors && infiniteEditors.length === 1){
-                        var editorInfo = infiniteEditors[0].querySelector('.editor-info');
-                        if(infiniteEditors && infiniteEditors.length === 1 && editorInfo !== null) {
-                            lastKnownElement = editorInfo;
 
-                            // Clear the array
-                            clearLastKnownFocusedElements();
-                        }
+                    var editorInfo = (infiniteEditors && infiniteEditors.length === 1)
+                      ? infiniteEditors[0].querySelector('.editor-info')
+                      : null;
+
+                    if(editorInfo !== null){
+                      lastKnownElement = editorInfo;
+
+                      // Clear the array
+                      clearLastKnownFocusedElements();
                     }
-                    else {
-                        var lastItemIndex = $rootScope.lastKnownFocusableElements.length - 1;
-                        lastKnownElement = $rootScope.lastKnownFocusableElements[lastItemIndex];
+                    else{
+                      var lastIndex = $rootScope.lastKnownFocusableElements.length - 1;
+                      lastKnownElement = $rootScope.lastKnownFocusableElements[lastIndex];
 
-                        // Remove the last item from the array so we always set the correct lastKnowFocus for each layer
-                        $rootScope.lastKnownFocusableElements.splice(lastItemIndex, 1);
+                      // Remove the last item from the array so we always set the correct lastKnowFocus for each layer
+                      $rootScope.lastKnownFocusableElements.splice(lastIndex, 1);
                     }
 
                     // Update the lastknowelement variable here


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [#15945](https://github.com/umbraco/Umbraco-CMS/issues/15945)

### Description

Since the merge of issue [#15032](https://github.com/umbraco/Umbraco-CMS/pull/15032), a new item was created with every save action within an infinite editor.

The problem was that now the `$scope.page.isNew` was set to false instead of the `$scope.isNew = false;`
and that it was later overwritten by the wrong value.