### PR TITLE
V14: Add JsonDocumentOptions skipping comments in appsettings

### DIFF
--- a/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
+++ b/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
@@ -19,6 +19,7 @@ internal class JsonConfigManipulator : IConfigManipulator
     private const string GlobalIdPath = $"{CmsObjectPath}:Global:Id";
     private const string DisableRedirectUrlTrackingPath = $"{CmsObjectPath}:WebRouting:DisableRedirectUrlTracking";
 
+    private readonly JsonDocumentOptions _jsonDocumentOptions = new() { CommentHandling = JsonCommentHandling.Skip };
     private readonly IConfiguration _configuration;
     private readonly ILogger<JsonConfigManipulator> _logger;
     private readonly SemaphoreSlim _lock = new(1, 1);
@@ -238,7 +239,7 @@ internal class JsonConfigManipulator : IConfigManipulator
         try
         {
             using var streamReader = new StreamReader(jsonFilePath);
-            return await JsonNode.ParseAsync(streamReader.BaseStream);
+            return await JsonNode.ParseAsync(streamReader.BaseStream, documentOptions: _jsonDocumentOptions);
         }
         catch (IOException exception)
         {


### PR DESCRIPTION
We'll explode if you try to install while there are comments in the `appsettings.json`

To fix this I've added some `JsonDocumentOptions` to skip comments, unfortunately, this means that any comments will be removed, because they're not read in when manipulating the JSON. 

The reason for this is that since .NET Core 3.1 the `JsonDocument` and `JsonSerializer` do not support allowing comments, you'll just get an error if you try. 

The underlying reason is that the JSON spec does not support comments, and the dotnet team seems to feel very strongly about adhering to the spec, which is fair enough but means we cannot support having the comments in the app settings JSON document. For more information see the following discussion https://github.com/dotnet/runtime/issues/35251 (Warning: It's a ***very*** heated debate).


## Testing

Try installing while there is a comment in the `appsettings.json` it should no longer explode, but the comment will disappear. 

 