### PR TITLE
V14: Fix null ref exception in current user permission endpoint

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/User/UserOrCurrentUserControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/UserOrCurrentUserControllerBase.cs
@@ -116,6 +116,10 @@ public abstract class UserOrCurrentUserControllerBase : ManagementApiControllerB
                 .WithTitle("Content node not found")
                 .WithDetail("The specified content node was not found.")
                 .Build()),
+            UserOperationStatus.NodeNotFound => NotFound(problemDetailsBuilder
+                .WithTitle("Node not found")
+                .WithDetail("The specified node was not found.")
+                .Build()),
             UserOperationStatus.NotInInviteState => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid user state")
                 .WithDetail("The target user is not in the invite state.")

--- a/src/Umbraco.Core/Services/OperationStatus/UserOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/UserOperationStatus.cs
@@ -34,6 +34,7 @@ public enum UserOperationStatus
     MediaStartNodeNotFound,
     ContentNodeNotFound,
     MediaNodeNotFound,
+    NodeNotFound,
     UnknownFailure,
     CannotPasswordReset,
     NotInInviteState,

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -2347,15 +2347,10 @@ internal class UserService : RepositoryService, IUserService
 
             if (entity is null)
             {
-                continue;
+                return Attempt.FailWithStatus(UserOperationStatus.NodeNotFound, Enumerable.Empty<NodePermissions>());
             }
 
             idKeyMap[entity.Id] = key;
-        }
-
-        if (idKeyMap.Count < 1)
-        {
-            return Attempt.SucceedWithStatus(UserOperationStatus.Success, Enumerable.Empty<NodePermissions>());
         }
 
         EntityPermissionCollection permissionCollection = _userGroupRepository.GetPermissions(user.Groups.ToArray(), true, idKeyMap.Keys.ToArray());


### PR DESCRIPTION
Given an invalid content key, the current user endpoint currently throws a null ref exception, this is because the entity gotten from the entity service is null, I've added a guard that prevents this, and instead returns a 404, aligning with the document and media versions of the endpoint. 

## Testing

The `/umbraco/management/api/v1/user/current/permissions` should not throw a null ref exception when given an invalid guide, but instead a not found. 