### PR TITLE
Fix the editor UI alias migration and re-run it

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -81,5 +81,7 @@ public class UmbracoPlan : MigrationPlan
         To<V_14_0_0.MigrateUserGroup2PermissionPermissionColumnType>("{8184E61D-ECBA-4AAA-B61B-D7A82EB82EB7}");
         To<V_14_0_0.MigrateNotificationCharsToStrings>("{E261BF01-2C7F-4544-BAE7-49D545B21D68}");
         To<V_14_0_0.AddEditorUiToDataType>("{5A2EF07D-37B4-49D5-8E9B-3ED01877263B}");
+        // we need to re-run this migration, as it was flawed for V14 RC3 (the migration can run twice without any issues)
+        To<V_14_0_0.AddEditorUiToDataType>("{6FB5CA9E-C823-473B-A14C-FE760D75943C}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddEditorUiToDataType.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddEditorUiToDataType.cs
@@ -27,17 +27,9 @@ public class AddEditorUiToDataType : MigrationBase
     protected override void Migrate()
     {
         var dataEditorSplitCollectionData = _keyValueService.GetValue("migrateDataEditorSplitCollectionData");
-        if (dataEditorSplitCollectionData.IsNullOrWhiteSpace())
-        {
-            return;
-        }
-
-        DataTypeEditorAliasMigrationData[]? migrationData = _jsonSerializer.Deserialize<DataTypeEditorAliasMigrationData[]>(dataEditorSplitCollectionData);
-        if (migrationData?.Any() is not true)
-        {
-            _logger.LogError("No migration data was found for the data editor split. Please make sure you're upgrading from the latest V13. Any data types based on custom property editors may not work correctly.");
-            return;
-        }
+        DataTypeEditorAliasMigrationData[]? migrationData = dataEditorSplitCollectionData.IsNullOrWhiteSpace() is false
+            ? _jsonSerializer.Deserialize<DataTypeEditorAliasMigrationData[]>(dataEditorSplitCollectionData)
+            : null;
 
         Sql<ISqlContext> sql = Sql()
             .Select<DataTypeDto>()
@@ -88,7 +80,7 @@ public class AddEditorUiToDataType : MigrationBase
 
             if (dataTypeDto.EditorUiAlias is null)
             {
-                DataTypeEditorAliasMigrationData? dataTypeMigrationData = migrationData.FirstOrDefault(md => md.DataTypeId == dataTypeDto.NodeId);
+                DataTypeEditorAliasMigrationData? dataTypeMigrationData = migrationData?.FirstOrDefault(md => md.DataTypeId == dataTypeDto.NodeId);
                 if (dataTypeMigrationData is not null)
                 {
                     // the V13 "data type split data collector" works like this:


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The editor UI alias migration is flawed - it does not run unless there are custom property editors in the source (V13) database. The result is that a default V13 database is upgraded to V14 with _no_ editor UI aliases, which causes havoc in the UI.

This PR ensures that the migration _always_ runs.

As the flawed migration has already run on RC3, I have opted to re-run it during upgrade. Other than potential duplicate warning messages for any misconfigured/missing data types, it is entirely harmless to run the migration twice (in all likelihood there will be no warnings).

### Testing this PR

Create a blank V13 site and migrate it to V14. The data types should be migrated to have the correct editor UI aliases; if the data type icons show correctly in V14, the migration worked as it should.