### PR TITLE
V14: fix user set user group endpoint

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/User/UpdateUserGroupsUserController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/UpdateUserGroupsUserController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Controllers.UserGroup;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Api.Management.ViewModels.User;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Security.Authorization;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
@@ -48,10 +49,12 @@ public class UpdateUserGroupsUserController : UserGroupControllerBase
             return Forbidden();
         }
 
-        UserGroupOperationStatus status = await _userGroupService.UpdateUserGroupsOnUsersAsync(
+        Attempt<UserGroupOperationStatus> result = await _userGroupService.UpdateUserGroupsOnUsersAsync(
             requestModel.UserGroupIds.Select(x => x.Id).ToHashSet(),
             requestModel.UserIds.Select(x => x.Id).ToHashSet());
 
-        return UserGroupOperationStatusResult(status);
+        return result.Success
+            ? Ok()
+            : UserGroupOperationStatusResult(result.Result);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/AddUsersToUserGroupController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/AddUsersToUserGroupController.cs
@@ -51,11 +51,11 @@ public class AddUsersToUserGroupController : UserGroupControllerBase
             return Forbidden();
         }
 
-        UserGroupOperationStatus result = await _userGroupService.AddUsersToUserGroupAsync(
+        Attempt<UserGroupOperationStatus> result = await _userGroupService.AddUsersToUserGroupAsync(
             new UsersToUserGroupManipulationModel(id, userIds.Select(x => x.Id).ToArray()), CurrentUserKey(_backOfficeSecurityAccessor));
 
-        return result == UserGroupOperationStatus.Success
+        return result.Success
             ? Ok()
-            : UserGroupOperationStatusResult(result);
+            : UserGroupOperationStatusResult(result.Result);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/RemoveUsersFromUserGroupController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/UserGroup/RemoveUsersFromUserGroupController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Security.Authorization;
@@ -46,11 +47,11 @@ public class RemoveUsersFromUserGroupController : UserGroupControllerBase
             return Forbidden();
         }
 
-        UserGroupOperationStatus result = await _userGroupService.RemoveUsersFromUserGroupAsync(
+        Attempt<UserGroupOperationStatus> result = await _userGroupService.RemoveUsersFromUserGroupAsync(
             new UsersToUserGroupManipulationModel(id, userIds.Select(x => x.Id).ToArray()), CurrentUserKey(_backOfficeSecurityAccessor));
 
-        return result == UserGroupOperationStatus.Success
+        return result.Success
             ? Ok()
-            : UserGroupOperationStatusResult(result);
+            : UserGroupOperationStatusResult(result.Result);
     }
 }

--- a/src/Umbraco.Core/Services/IUserGroupService.cs
+++ b/src/Umbraco.Core/Services/IUserGroupService.cs
@@ -107,8 +107,8 @@ public interface IUserGroupService
     /// <param name="userGroupKeys">The user groups the users should be part of.</param>
     /// <param name="userKeys">The user whose groups we want to alter.</param>
     /// <returns>An attempt indicating if the operation was a success as well as a more detailed <see cref="UserGroupOperationStatus"/>.</returns>
-    Task<UserGroupOperationStatus> UpdateUserGroupsOnUsersAsync(ISet<Guid> userGroupKeys, ISet<Guid> userKeys);
+    Task<Attempt<UserGroupOperationStatus>> UpdateUserGroupsOnUsersAsync(ISet<Guid> userGroupKeys, ISet<Guid> userKeys);
 
-    Task<UserGroupOperationStatus> AddUsersToUserGroupAsync(UsersToUserGroupManipulationModel addUsersModel, Guid performingUserKey);
-    Task<UserGroupOperationStatus> RemoveUsersFromUserGroupAsync(UsersToUserGroupManipulationModel removeUsersModel, Guid performingUserKey);
+    Task<Attempt<UserGroupOperationStatus>> AddUsersToUserGroupAsync(UsersToUserGroupManipulationModel addUsersModel, Guid performingUserKey);
+    Task<Attempt<UserGroupOperationStatus>> RemoveUsersFromUserGroupAsync(UsersToUserGroupManipulationModel removeUsersModel, Guid performingUserKey);
 }

--- a/src/Umbraco.Core/Services/UserGroupService.cs
+++ b/src/Umbraco.Core/Services/UserGroupService.cs
@@ -210,7 +210,7 @@ internal sealed class UserGroupService : RepositoryService, IUserGroupService
         return Attempt.Succeed(UserGroupOperationStatus.Success);
     }
 
-    public async Task<UserGroupOperationStatus> UpdateUserGroupsOnUsersAsync(
+    public async Task<Attempt<UserGroupOperationStatus>> UpdateUserGroupsOnUsersAsync(
         ISet<Guid> userGroupKeys,
         ISet<Guid> userKeys)
     {
@@ -233,7 +233,7 @@ internal sealed class UserGroupService : RepositoryService, IUserGroupService
                 if (adminGroup is not null && adminGroup.UserCount <= usersToDeAdmin.Length)
                 {
                     scope.Complete();
-                    return UserGroupOperationStatus.AdminGroupCannotBeEmpty;
+                    return Attempt.Fail(UserGroupOperationStatus.AdminGroupCannotBeEmpty);
                 }
             }
         }
@@ -251,7 +251,7 @@ internal sealed class UserGroupService : RepositoryService, IUserGroupService
 
         scope.Complete();
 
-        return UserGroupOperationStatus.Success;
+        return Attempt.Succeed(UserGroupOperationStatus.Success);
     }
 
     private Attempt<UserGroupOperationStatus> ValidateUserGroupDeletion(IUserGroup? userGroup)
@@ -393,7 +393,7 @@ internal sealed class UserGroupService : RepositoryService, IUserGroupService
         return Attempt.SucceedWithStatus(UserGroupOperationStatus.Success, userGroup);
     }
 
-    public async Task<UserGroupOperationStatus> AddUsersToUserGroupAsync(UsersToUserGroupManipulationModel addUsersModel, Guid performingUserKey)
+    public async Task<Attempt<UserGroupOperationStatus>> AddUsersToUserGroupAsync(UsersToUserGroupManipulationModel addUsersModel, Guid performingUserKey)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope();
 
@@ -401,7 +401,7 @@ internal sealed class UserGroupService : RepositoryService, IUserGroupService
 
         if (resolveAttempt.Success is false)
         {
-            return resolveAttempt.Status;
+            return Attempt.Fail(resolveAttempt.Status);
         }
 
         ResolvedUserToUserGroupManipulationModel? resolvedModel = resolveAttempt.Result;
@@ -423,10 +423,10 @@ internal sealed class UserGroupService : RepositoryService, IUserGroupService
 
         scope.Complete();
 
-        return UserGroupOperationStatus.Success;
+        return Attempt.Succeed(UserGroupOperationStatus.Success);
     }
 
-    public async Task<UserGroupOperationStatus> RemoveUsersFromUserGroupAsync(UsersToUserGroupManipulationModel removeUsersModel, Guid performingUserKey)
+    public async Task<Attempt<UserGroupOperationStatus>> RemoveUsersFromUserGroupAsync(UsersToUserGroupManipulationModel removeUsersModel, Guid performingUserKey)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope();
 
@@ -434,7 +434,7 @@ internal sealed class UserGroupService : RepositoryService, IUserGroupService
 
         if (resolveAttempt.Success is false)
         {
-            return resolveAttempt.Status;
+            return Attempt.Fail(resolveAttempt.Status);
         }
 
         ResolvedUserToUserGroupManipulationModel? resolvedModel = resolveAttempt.Result;
@@ -450,7 +450,7 @@ internal sealed class UserGroupService : RepositoryService, IUserGroupService
             // We can't remove a user from a group they're not part of.
             if (user.Groups.Select(x => x.Key).Contains(resolvedModel.UserGroup.Key) is false)
             {
-                return UserGroupOperationStatus.UserNotInGroup;
+                return Attempt.Fail(UserGroupOperationStatus.UserNotInGroup);
             }
 
             user.RemoveGroup(resolvedModel.UserGroup.Alias);
@@ -461,14 +461,14 @@ internal sealed class UserGroupService : RepositoryService, IUserGroupService
         if (resolvedModel.UserGroup.Key == Constants.Security.AdminGroupKey
             && resolvedModel.UserGroup.UserCount <= resolvedModel.Users.Length)
         {
-            return UserGroupOperationStatus.AdminGroupCannotBeEmpty;
+            return Attempt.Fail(UserGroupOperationStatus.AdminGroupCannotBeEmpty);
         }
 
         _userService.Save(resolvedModel.Users);
 
         scope.Complete();
 
-        return UserGroupOperationStatus.Success;
+        return Attempt.Succeed(UserGroupOperationStatus.Success);
     }
 
     /// <summary>


### PR DESCRIPTION
# Notes
- Fixes the `umbraco/management/api/v1/user/set-user-groups`, as it did not know how to map success status code (we didn't check for succeed first)
- Refactored a few methods to use attempt so it lines up with the rest of the API 👍

# How to test
- Use the `umbraco/management/api/v1/user/set-user-groups`, to set groups for a user
- It should now work