### PR TITLE
V14 QA Apply new syntax for adding smoke tags

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/DataType.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/DataType.spec.ts
@@ -15,7 +15,7 @@ test.describe('Data Types basic functionalities tests', () => {
     await umbracoApi.dataType.ensureNameNotExists(dataTypeName);
   });
 
-  test('can create a data type @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can create a data type', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Act
     await umbracoUi.dataType.clickActionsMenuAtRoot();
     await umbracoUi.dataType.clickCreateButton();
@@ -28,7 +28,7 @@ test.describe('Data Types basic functionalities tests', () => {
     expect(await umbracoApi.dataType.doesNameExist(dataTypeName)).toBeTruthy();
   });
 
-  test('can update a data type name @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can update a data type name', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     const wrongDataTypeName = 'Wrong Data Type';
     await umbracoApi.dataType.ensureNameNotExists(wrongDataTypeName);
@@ -45,7 +45,7 @@ test.describe('Data Types basic functionalities tests', () => {
     expect(await umbracoApi.dataType.doesNameExist(wrongDataTypeName)).toBeFalsy();
   });
 
-  test.skip('can delete a data type @smoke', async ({umbracoApi, umbracoUi}) => {
+  test.skip('can delete a data type', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     await umbracoApi.dataType.create(dataTypeName, editorAlias, []);
     expect(await umbracoApi.dataType.doesNameExist(dataTypeName)).toBeTruthy();
@@ -59,7 +59,7 @@ test.describe('Data Types basic functionalities tests', () => {
     expect(await umbracoApi.dataType.doesNameExist(dataTypeName)).toBeFalsy();
   });
 
-  test.skip('can change Property Editor in a data type @smoke', async ({umbracoApi, umbracoUi}) => {
+  test.skip('can change Property Editor in a data type', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     const updatedEditorName = 'Text Area';
     const updatedEditorAlias = 'Umbraco.TextArea';

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/DataTypeFolder.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/DataTypeFolder.spec.ts
@@ -48,7 +48,7 @@ test.describe('Data Types Folder tests', () => {
     expect(await umbracoApi.dataType.doesNameExist(wrongDataTypeFolderName)).toBeFalsy();
   });
 
-  test('can delete a data type folder @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can delete a data type folder', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     await umbracoApi.dataType.createFolder(dataTypeFolderName);
     expect(await umbracoApi.dataType.doesNameExist(dataTypeFolderName)).toBeTruthy();

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/LogViewer/LogViewer.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/LogViewer/LogViewer.spec.ts
@@ -14,7 +14,7 @@ test.describe('Log Viewer tests', () => {
     await umbracoApi.telemetry.setLevel(startTelemetryLevel);
   });
 
-  test('can search @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can search', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     const telemetryLevel = 'Minimal';
     await umbracoApi.telemetry.setLevel(telemetryLevel);
@@ -46,7 +46,7 @@ test.describe('Log Viewer tests', () => {
     await umbracoUi.logViewer.doesLogLevelIndicatorDisplay(logLevel);
   });
 
-  test('can create a saved search @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can create a saved search', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     const searchName = 'TestSavedSearch';
     const search = 'test saved search';

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Packages/CreatedPackages.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Packages/CreatedPackages.spec.ts
@@ -16,7 +16,7 @@ test.describe('Created packages tests', () => {
     await umbracoApi.package.ensureNameNotExists(packageName);
   });
 
-  test.skip('can create a empty package @smoke', async ({umbracoUi}) => {
+  test.skip('can create a empty package', {tag: '@smoke'}, async ({umbracoUi}) => {
     // Act
     await umbracoUi.package.clickCreatePackageButton();
     await umbracoUi.package.enterPackageName(packageName);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Language/Language.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Language/Language.spec.ts
@@ -16,7 +16,7 @@ test.describe('Language tests', () => {
     await umbracoApi.language.ensureNameNotExists(languageName);
   });
   
-  test('can add language @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can add language', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     await umbracoUi.language.goToSettingsTreeItem('Language');
 
@@ -32,7 +32,7 @@ test.describe('Language tests', () => {
     await umbracoUi.language.isLanguageNameVisible(languageName, true);
   });
 
-  test('can update default language option @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can update default language option', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     await umbracoApi.language.create(languageName, false, false, isoCode);
     expect(await umbracoApi.language.doesExist(isoCode)).toBeTruthy();
@@ -70,7 +70,7 @@ test.describe('Language tests', () => {
     expect(languageData.isMandatory).toBe(true);
   });
 
-  test('can delete language @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can delete language', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     await umbracoApi.language.create(languageName, false, false, isoCode);
     expect(await umbracoApi.language.doesExist(isoCode)).toBeTruthy();

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/PartialView/PartialView.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/PartialView/PartialView.spec.ts
@@ -18,7 +18,7 @@ test.describe('Partial View tests', () => {
     await umbracoApi.dictionary.ensureNameNotExists(dictionaryName);
   });
 
-  test('can create an empty partial view @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can create an empty partial view', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Act
     await umbracoUi.partialView.clickActionsMenuAtRoot();
     await umbracoUi.partialView.clickCreateButton();
@@ -66,7 +66,7 @@ test.describe('Partial View tests', () => {
     await umbracoUi.partialView.isPartialViewRootTreeItemVisibile(partialViewFileName);
   });
 
-  test('can rename a partial view @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can rename a partial view', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     const wrongPartialViewName = 'WrongName';
     const wrongPartialViewFileName = wrongPartialViewName + '.cshtml';
@@ -90,7 +90,7 @@ test.describe('Partial View tests', () => {
     await umbracoUi.partialView.isPartialViewRootTreeItemVisibile(partialViewFileName);
   });
 
-  test('can update a partial view content @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can update a partial view content', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     const updatedPartialViewContent = defaultPartialViewContent +
       '@{\r\n' +
@@ -234,7 +234,7 @@ test.describe('Partial View tests', () => {
     expect(partialViewData.content).toBe(partialViewContent);
   });
 
-  test('can delete a partial view @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can delete a partial view', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     //Arrange
     await umbracoApi.partialView.create(partialViewFileName, partialViewFileName, '/');
     expect(await umbracoApi.partialView.doesExist(partialViewFileName)).toBeTruthy();

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/PartialView/PartialViewFolder.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/PartialView/PartialViewFolder.spec.ts
@@ -29,7 +29,7 @@ test.describe('Partial View Folder tests', () => {
     await umbracoUi.partialView.isPartialViewRootTreeItemVisibile(folderName);  
   });
 
-  test('can delete a folder @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can delete a folder', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     //Arrange
     await umbracoApi.partialView.createFolder(folderName);
     expect(await umbracoApi.partialView.doesFolderExist(folderName)).toBeTruthy();
@@ -93,7 +93,7 @@ test.describe('Partial View Folder tests', () => {
     await umbracoUi.partialView.isPartialViewRootTreeItemVisibile(childFolderName); 
   });
 
-  test('can create a folder in a folder in a folder @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can create a folder in a folder in a folder', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     const childFolderName = 'ChildFolderName';
     const childOfChildFolderName = 'ChildOfChildFolderName';

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Script/Script.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Script/Script.spec.ts
@@ -14,7 +14,7 @@ test.describe('Script tests', () => {
     await umbracoApi.script.ensureNameNotExists(scriptName);
   });
 
-  test('can create a empty script @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can create a empty script', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Act
     await umbracoUi.script.goToSection(ConstantHelper.sections.settings);
     await umbracoUi.script.clickActionsMenuAtRoot();
@@ -50,7 +50,7 @@ test.describe('Script tests', () => {
     await umbracoUi.script.isScriptRootTreeItemVisible(scriptName);
   });
 
-  test('can update a script @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can update a script', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     await umbracoApi.script.create(scriptName, 'test');
     const updatedScriptContent = 'const test = {\r\n    script = \u0022Test\u0022,\r\n    extension = \u0022.js\u0022,\r\n    scriptPath: function() {\r\n        return this.script \u002B this.extension;\r\n    }\r\n};\r\n';
@@ -67,7 +67,7 @@ test.describe('Script tests', () => {
     expect(updatedScript.content).toBe(updatedScriptContent);
   });
 
-  test('can delete a script @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can delete a script', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     await umbracoApi.script.create(scriptName, '');
 

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Script/ScriptFolder.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Script/ScriptFolder.spec.ts
@@ -14,7 +14,7 @@ test.describe('Script tests', () => {
     await umbracoApi.script.ensureNameNotExists(scriptFolderName);
   });
 
-  test('can create a folder @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can create a folder', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Act
     await umbracoUi.script.goToSection(ConstantHelper.sections.settings);
     await umbracoUi.script.clickActionsMenuAtRoot();
@@ -28,7 +28,7 @@ test.describe('Script tests', () => {
     await umbracoUi.script.isScriptRootTreeItemVisible(scriptFolderName);
   });
 
-  test('can delete a folder @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can delete a folder', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     await umbracoApi.script.createFolder(scriptFolderName);
 
@@ -90,7 +90,7 @@ test.describe('Script tests', () => {
     await umbracoUi.script.isScriptRootTreeItemVisible(childFolderName);
   });
 
-  test('can create a folder in a folder in a folder @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can create a folder in a folder in a folder', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     const childFolderName = 'ChildFolderName';
     const childOfChildFolderName = 'ChildOfChildFolderName';

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Stylesheet/Stylesheet.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Stylesheet/Stylesheet.spec.ts
@@ -16,7 +16,7 @@ test.describe('Stylesheets tests', () => {
     await umbracoApi.stylesheet.ensureNameNotExists(stylesheetName);
   });
 
-  test('can create a empty stylesheet @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can create a empty stylesheet', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Act
     await umbracoUi.stylesheet.goToSection(ConstantHelper.sections.settings);
     await umbracoUi.stylesheet.clickActionsMenuAtRoot();
@@ -52,7 +52,7 @@ test.describe('Stylesheets tests', () => {
     await umbracoUi.stylesheet.isStylesheetRootTreeItemVisible(stylesheetName);
   });
 
-  test.skip('can create a new Rich Text Editor stylesheet file @smoke', async ({umbracoApi, umbracoUi}) => {
+  test.skip('can create a new Rich Text Editor stylesheet file', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     const stylesheetContent = '/**umb_name:' + styleName + '*/\n' + styleSelector + ' {\n\t' +  styleStyles + '\n}';
 
@@ -73,7 +73,7 @@ test.describe('Stylesheets tests', () => {
     await umbracoUi.stylesheet.isStylesheetRootTreeItemVisible(stylesheetName);
   });
 
-  test.skip('can update a stylesheet @smoke', async ({umbracoApi, umbracoUi}) => {
+  test.skip('can update a stylesheet', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     const stylesheetContent = '/**umb_name:' + styleName + '*/\n' + styleSelector + ' {\n\t' +  styleStyles + '\n}';
     await umbracoApi.stylesheet.create(stylesheetName, '', '/');
@@ -91,7 +91,7 @@ test.describe('Stylesheets tests', () => {
     expect(stylesheetData.content).toEqual(stylesheetContent);
   });
 
-  test('can delete a stylesheet @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can delete a stylesheet', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     await umbracoApi.stylesheet.create(stylesheetName, '', '/');
 
@@ -107,7 +107,7 @@ test.describe('Stylesheets tests', () => {
     await umbracoUi.stylesheet.isStylesheetRootTreeItemVisible(stylesheetName, false);
   });
 
-  test('can rename a stylesheet @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can rename a stylesheet', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     const wrongStylesheetName = 'WrongStylesheetName.css';
     await umbracoApi.stylesheet.ensureNameNotExists(wrongStylesheetName);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Stylesheet/StylesheetFolder.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Stylesheet/StylesheetFolder.spec.ts
@@ -28,7 +28,7 @@ test.describe('Stylesheets tests', () => {
     await umbracoUi.stylesheet.isStylesheetRootTreeItemVisible(stylesheetFolderName);
   });
 
-  test('can delete a folder @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can delete a folder', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     await umbracoApi.stylesheet.createFolder(stylesheetFolderName, '');
 
@@ -64,7 +64,7 @@ test.describe('Stylesheets tests', () => {
     await umbracoUi.stylesheet.isStylesheetRootTreeItemVisible(childFolderName);
   });
 
-  test('can create a folder in a folder in a folder @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can create a folder in a folder in a folder', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     const childFolderName = 'ChildFolderName';
     const childOfChildFolderName = 'ChildOfChildFolderName';

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Template/Templates.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Template/Templates.spec.ts
@@ -14,7 +14,7 @@ test.describe('Template tests', () => {
     await umbracoApi.template.ensureNameNotExists(templateName);
   });
 
-  test('can create a template @smoke', async ({page, umbracoApi, umbracoUi}) => {
+  test('can create a template', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     await umbracoUi.template.goToSection(ConstantHelper.sections.settings);
 
@@ -30,7 +30,7 @@ test.describe('Template tests', () => {
     await umbracoUi.template.isTemplateRootTreeItemVisible(templateName);
   });
 
-  test('can update content of a template @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can update content of a template', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     const updatedTemplateContent =
       defaultTemplateContent + '\r\n' + '<p>AcceptanceTests</p>';

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Translation/Translation.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Translation/Translation.spec.ts
@@ -52,7 +52,7 @@ test.describe('Translation tests', () => {
     //expect(await umbracoUi.translation.doesDictionaryListHaveText(dictionaryName)).toBeFalsy();
   });
 
-  test('can create a dictionary item in a dictionary @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can create a dictionary item in a dictionary', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     await umbracoApi.dictionary.ensureNameNotExists(parentDictionaryName);
     let parentDictionaryId = await umbracoApi.dictionary.create(parentDictionaryName);
@@ -94,7 +94,7 @@ test.describe('Translation tests', () => {
     expect(exportData).toEqual(dictionaryId + '.udt');
   });
 
-  test('can export a dictionary item with descendants @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can export a dictionary item with descendants', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     await umbracoApi.dictionary.ensureNameNotExists(parentDictionaryName);
     let parentDictionaryId = await umbracoApi.dictionary.create(parentDictionaryName);
@@ -136,7 +136,7 @@ test.describe('Translation tests', () => {
     //expect(await umbracoUi.translation.doesDictionaryListHaveText(importDictionaryName)).toBeTruthy();
   });
 
-  test('can import a dictionary item with descendants @smoke', async ({umbracoApi, umbracoUi}) => {
+  test('can import a dictionary item with descendants', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
     // Arrange
     const udtFilePath = './fixtures/dictionary/TestDictionaryWithDescendants.udt';
     // This variable must not be changed as it is declared in the file TestDictionaryWithDescendants.udt


### PR DESCRIPTION
With the current syntax, the tags are visible in the HTML report in the title as well as a label. This can be confusing and unclear.
So in this PR, I tried to apply new syntax for adding smoke tags to the tests.
