### PR TITLE
Block settings unavailable element type

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/blockgrid.blockconfiguration.overlay.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/blockgrid.blockconfiguration.overlay.controller.js
@@ -77,7 +77,7 @@
                 vm.elementTypes = elementTypes;
 
                 vm.contentPreview = vm.getElementTypeByKey(vm.block.contentElementTypeKey);
-                vm.settingsPreview = vm.getElementTypeByKey(vm.block.settingsElementTypeKey);
+                vm.settingsPreview = vm.getElementTypeByKey(vm.block.settingsElementTypeKey) || { icon: "icon-science", name: "(Unavailable ElementType)" };
             });
         }
 
@@ -170,7 +170,7 @@
         vm.requestRemoveSettingsForBlock = function(block) {
             localizationService.localizeMany(["general_remove", "defaultdialogs_confirmremoveusageof"]).then(function (data) {
 
-                var settingsElementType = vm.getElementTypeByKey(block.settingsElementTypeKey);
+                const settingsElementType = vm.getElementTypeByKey(block.settingsElementTypeKey);
 
                 overlayService.confirmRemove({
                     title: data[0],

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/blockgrid.blockconfiguration.overlay.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/prevalue/blockgrid.blockconfiguration.overlay.html
@@ -41,7 +41,11 @@
                                     <label class="control-label"><localize key="blockEditor_labelContentElementType">Content ElementType</localize></label>
                                     <div class="controls">
                                         <div class="__settings-input --hasValue" ng-if="vm.block.contentElementTypeKey !== null" >
-                                            <umb-node-preview icon="vm.contentPreview.icon" name="vm.contentPreview.name" alias="vm.contentPreview.alias"></umb-node-preview>
+                                            <umb-node-preview
+                                                icon="vm.contentPreview.icon"
+                                                name="vm.contentPreview.name"
+                                                alias="vm.contentPreview.alias">
+                                            </umb-node-preview>
                                             <div class="__control-actions">
                                                 <button type="button" class="btn-reset __control-actions-btn --open umb-outline" ng-click="vm.openElementType(vm.block.contentElementTypeKey)">
                                                     <umb-icon icon="icon-edit" class="icon"></umb-icon>
@@ -58,9 +62,13 @@
                                     <label class="control-label"><localize key="blockEditor_labelSettingsElementType">Settings Element Type</localize></label>
                                     <div class="controls">
                                         <div class="__settings-input --hasValue" ng-if="vm.block.settingsElementTypeKey !== null">
-                                            <umb-node-preview icon="vm.settingsPreview.icon" name="vm.settingsPreview.name" alias="vm.settingsPreview.alias"></umb-node-preview>
+                                            <umb-node-preview
+                                                icon="vm.settingsPreview.icon"
+                                                name="vm.settingsPreview.name"
+                                                alias="vm.settingsPreview.alias">
+                                            </umb-node-preview>
                                             <div class="__control-actions">
-                                                <button type="button" class="btn-reset __control-actions-btn --open umb-outline" ng-click="vm.openElementType(vm.block.settingsElementTypeKey)">
+                                                <button type="button" class="btn-reset __control-actions-btn --open umb-outline" ng-click="vm.openElementType(vm.block.settingsElementTypeKey)" ng-if="vm.settingsPreview && vm.settingsPreview.alias">
                                                     <umb-icon icon="icon-edit" class="icon"></umb-icon>
                                                 </button>
                                                 <button type="button" class="btn-reset __control-actions-btn --remove umb-outline" ng-click="vm.requestRemoveSettingsForBlock(vm.block)">

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.controller.js
@@ -30,7 +30,7 @@
                 vm.elementTypes = elementTypes;
 
                 vm.contentPreview = vm.getElementTypeByKey(vm.block.contentElementTypeKey);
-                vm.settingsPreview = vm.getElementTypeByKey(vm.block.settingsElementTypeKey);
+                vm.settingsPreview = vm.getElementTypeByKey(vm.block.settingsElementTypeKey) || { icon: "icon-science", name: "(Unavailable ElementType)" };
             });
         }
 
@@ -123,7 +123,7 @@
         vm.requestRemoveSettingsForBlock = function(block) {
             localizationService.localizeMany(["general_remove", "defaultdialogs_confirmremoveusageof"]).then(function (data) {
 
-                var settingsElementType = vm.getElementTypeByKey(block.settingsElementTypeKey);
+                const settingsElementType = vm.getElementTypeByKey(block.settingsElementTypeKey);
 
                 overlayService.confirmRemove({
                     title: data[0],

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blocklist/prevalue/blocklist.blockconfiguration.overlay.html
@@ -110,7 +110,11 @@
                                     <label class="control-label" for="blockContentElemenType"><localize key="blockEditor_labelContentElementType">Content ElementType</localize></label>
                                     <div class="controls">
                                         <div class="__settings-input --hasValue" ng-if="vm.block.contentElementTypeKey !== null" >
-                                            <umb-node-preview icon="vm.contentPreview.icon" name="vm.contentPreview.name" alias="vm.contentPreview.alias"></umb-node-preview>
+                                            <umb-node-preview
+                                                icon="vm.contentPreview.icon"
+                                                name="vm.contentPreview.name"
+                                                alias="vm.contentPreview.alias">
+                                            </umb-node-preview>
                                             <div class="__control-actions">
                                                 <button type="button" id="blockContentElemenType" class="btn-reset __control-actions-btn --open umb-outline" ng-click="vm.openElementType(vm.block.contentElementTypeKey)">
                                                     <umb-icon icon="icon-edit" class="icon"></umb-icon>
@@ -127,9 +131,13 @@
                                     <label class="control-label" for="blockSettingsElemenType"><localize key="blockEditor_labelSettingsElementType">Settings Element Type</localize></label>
                                     <div class="controls">
                                         <div class="__settings-input --hasValue" ng-if="vm.block.settingsElementTypeKey !== null">
-                                            <umb-node-preview icon="vm.settingsPreview.icon" name="vm.settingsPreview.name" alias="vm.settingsPreview.alias"></umb-node-preview>
+                                            <umb-node-preview
+                                                icon="vm.settingsPreview.icon"
+                                                name="vm.settingsPreview.name"
+                                                alias="vm.settingsPreview.alias">
+                                            </umb-node-preview>
                                             <div class="__control-actions">
-                                                <button type="button" class="btn-reset __control-actions-btn --open umb-outline" ng-click="vm.openElementType(vm.block.settingsElementTypeKey)">
+                                                <button type="button" class="btn-reset __control-actions-btn --open umb-outline" ng-click="vm.openElementType(vm.block.settingsElementTypeKey)" ng-if="vm.settingsPreview && vm.settingsPreview.alias">
                                                     <umb-icon icon="icon-edit" class="icon"></umb-icon>
                                                 </button>
                                                 <button type="button" class="btn-reset __control-actions-btn --remove umb-outline" ng-click="vm.requestRemoveSettingsForBlock(vm.block)">


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/16303

### Description

Since settings element type can be nullable, but deleting (settings) element type, doesn't remove reference in block configuration itself, we should use a fallback value if element type isn't found.

I used `icon-science` as fallback icon as this is the default element type icon and to align text at content/setting element type node previews.

Besides that it also just show the edit button only if the settings element type is found (the alias has a value as we add a fallback for name and icon), as opening an element type that doesn't exists would fail anyway.

As the new backoffice in Umbraco 14 it close to release, this is just a simple fix for current backoffice, but we should probably check it also has a fallback in the new backoffice in Umbraco 14.

Before

![chrome_StpmPp3a5c](https://github.com/umbraco/Umbraco-CMS/assets/2919859/7728a343-6207-419e-b146-13339710f769)



**Block Grid**

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/bfe7ce63-7c17-454b-87dc-22310125a34c)

**Block List**

![image](https://github.com/umbraco/Umbraco-CMS/assets/2919859/d0553f4a-b20b-42bb-8318-0203c5c2de20)
