### PR TITLE
The preview hub throws an exception during DB upgrade

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Preview/PreviewHubUpdater.cs
+++ b/src/Umbraco.Cms.Api.Management/Preview/PreviewHubUpdater.cs
@@ -2,7 +2,9 @@ using Microsoft.AspNetCore.SignalR;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services.Changes;
 using Umbraco.Cms.Core.Sync;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Preview;
 
@@ -26,13 +28,17 @@ public class PreviewHubUpdater : INotificationAsyncHandler<ContentCacheRefresher
         IHubContext<PreviewHub, IPreviewHub> hubContextInstance = _hubContext.Value;
         foreach (ContentCacheRefresher.JsonPayload payload in payloads)
         {
-            var key = payload.Key; // keep it simple for now, ignore ChangeTypes
-            if (key.HasValue is false)
+            if (payload.ChangeTypes.HasType(TreeChangeTypes.RefreshNode) is false)
+            {
+                continue;
+            }
+
+            if (payload.Key.HasValue is false)
             {
                 throw new InvalidOperationException($"No key is set for payload with id {payload.Id}");
             }
 
-            await hubContextInstance.Clients.All.refreshed(key.Value);
+            await hubContextInstance.Clients.All.refreshed(payload.Key.Value);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The preview hub sometimes throws an exception when upgrading a DB:

```
An unhandled exception has occurred while executing the request.
Umbraco.Cms.Core.Exceptions.BootFailedException: Boot failed: Umbraco cannot run. See Umbraco's log file for more details.

-> Umbraco.Cms.Core.Exceptions.BootFailedException: An error occurred while running the unattended upgrade.
The database configuration failed with the following message: One or more errors occurred. (No key is set for payload with id 0)
 Please check log file for additional information (can be found in 'LoggingSettings.Directory')
```

I can't entirely put my finger on when and why, but it has to do with content cache refreshing at the end of the upgrade process:

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/43b9b7ed-cf61-4871-949a-378edf43e821)

This PR adds a little extra logic to the preview hub, so it strictly only handles "refresh node" notifications.

### Testing this PR

To test that the upgrade works, get in touch with @kjac for a test DB which will trigger the cache refresh during upgrade.

Also test that the preview hub actually triggers updates when saving content. It's likely easiest to verify this using a debugger.
