### PR TITLE
V13: Fix routing with string parameter

### DIFF
--- a/src/Umbraco.Web.Website/Routing/EagerMatcherPolicy.cs
+++ b/src/Umbraco.Web.Website/Routing/EagerMatcherPolicy.cs
@@ -72,7 +72,8 @@ internal class EagerMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy
         }
 
         // If there's only one candidate, we don't need to do anything.
-        if (candidates.Count < 2)
+        var candidateCount = candidates.Count;
+        if (candidateCount < 2)
         {
             return;
         }
@@ -85,6 +86,14 @@ internal class EagerMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy
         RouteEndpoint? dynamicEndpoint = null;
         for (var i = 0; i < candidates.Count; i++)
         {
+            if (candidates.IsValidCandidate(i) is false)
+            {
+                // If the candidate is not valid we reduce the candidate count so we can later ensure that there is always
+                // at least 1 candidate.
+                candidateCount -= 1;
+                continue;
+            }
+
             CandidateState candidate = candidates[i];
 
             // If it's not a RouteEndpoint there's not much we can do to count it in the order.
@@ -123,7 +132,7 @@ internal class EagerMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy
         // Invalidate the dynamic route if another route has a lower order.
         // This means that if you register your static route after the dynamic route, the dynamic route will take precedence
         // This more closely resembles the existing behaviour.
-        if (dynamicEndpoint is not null && dynamicId is not null && dynamicEndpoint.Order > lowestOrder)
+        if (dynamicEndpoint is not null && dynamicId is not null && dynamicEndpoint.Order > lowestOrder && candidateCount > 1)
         {
             candidates.SetValidity(dynamicId.Value, false);
         }


### PR DESCRIPTION
Fixes routing when a string parameter is used

This was caused by #16218 not considering invalid candidates

Fixes #16332 and #16341 

Teting: 

Create a site with a URL with more than one segment I.E

* Root
    * Child
        * Grandchild

Add an attribute routed endpoint with a string I.E.: 

```
[HttpGet("sitemap-{group}-xml")]
    public IActionResult AttributeRoute(string group)
    {
        _logger.LogInformation("Got request: {GroupValue}", group);
        return Ok();
    }
```

Ensure you can request both `/child/grandchild` and  `/sitemap-something-xml`