### PR TITLE
V14: login should autofocus

### DIFF
--- a/src/Umbraco.Web.UI.Login/src/auth.element.ts
+++ b/src/Umbraco.Web.UI.Login/src/auth.element.ts
@@ -19,6 +19,7 @@ const createInput = (opts: {
   autocomplete: AutoFill;
   label: string;
   inputmode: string;
+  autofocus?: boolean;
 }) => {
   const input = document.createElement('input');
   input.type = opts.type;
@@ -28,6 +29,7 @@ const createInput = (opts: {
   input.required = true;
   input.inputMode = opts.inputmode;
   input.ariaLabel = opts.label;
+  input.autofocus = opts.autofocus || false;
 
   return input;
 };
@@ -171,6 +173,7 @@ export default class UmbAuthElement extends UmbLitElement {
       autocomplete: 'username',
       label: labelUsername,
       inputmode: this.usernameIsEmail ? 'email' : '',
+      autofocus: true,
     });
     this._passwordInput = createInput({
       id: 'password-input',


### PR DESCRIPTION
### Description

The login username/email field should have autofocus.

This field will be automatically focused when the user sees the login screen, and it should be valid according to a11y best practices as this is the first and main element on the page ([source](https://www.boia.org/blog/accessibility-tips-be-cautious-when-using-autofocus)).

Fixes #16276