### PR TITLE
Fix issues with initial creation of external users

### DIFF
--- a/src/Umbraco.Core/Extensions/ClaimsIdentityExtensions.cs
+++ b/src/Umbraco.Core/Extensions/ClaimsIdentityExtensions.cs
@@ -65,7 +65,7 @@ public static class ClaimsIdentityExtensions
         if (identity is ClaimsIdentity claimsIdentity)
         {
             userId = claimsIdentity.FindFirstValue(ClaimTypes.NameIdentifier)
-                     ?? claimsIdentity.FindFirstValue("sub");
+                     ?? claimsIdentity.FindFirstValue(Constants.Security.OpenIdDictSubClaimType);
         }
 
         return userId;
@@ -88,7 +88,7 @@ public static class ClaimsIdentityExtensions
         string? userKey = null;
         if (identity is ClaimsIdentity claimsIdentity)
         {
-            userKey = claimsIdentity.FindFirstValue("sub");
+            userKey = claimsIdentity.FindFirstValue(Constants.Security.OpenIdDictSubClaimType);
         }
 
         return Guid.TryParse(userKey, out Guid result)

--- a/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
@@ -157,8 +157,9 @@ public class BackOfficeUserStore :
             throw new DataException("Could not create the user, check logs for details");
         }
 
-        // re-assign id
+        // re-assign id and key
         user.Id = UserIdToString(userEntity.Id);
+        user.Key = userEntity.Key;
 
         if (isLoginsPropertyDirty)
         {


### PR DESCRIPTION
### Description

After logging in with an external user for the first time, the Management API is unable to resolve the current user. Turns out we are mapping an empty user key in the "sub" claim.

### Testing

Setup external auth on a fresh DB. Log in with an external user. It should work.