### PR TITLE
Fixes a NullReferenceException bug when the ValueSetValidator is null

### DIFF
--- a/src/Umbraco.Examine.Lucene/UmbracoContentIndex.cs
+++ b/src/Umbraco.Examine.Lucene/UmbracoContentIndex.cs
@@ -70,9 +70,13 @@ public class UmbracoContentIndex : UmbracoExamineIndex, IUmbracoContentIndex
                 return ValueSetValidationStatus.Failed;
             }
 
-            ValueSetValidationResult validationResult = ValueSetValidator.Validate(v);
+            if (ValueSetValidator is not null)
+            {
+                ValueSetValidationResult validationResult = ValueSetValidator.Validate(v);
+                return validationResult.Status;
+            }
 
-            return validationResult.Status;
+            return ValueSetValidationStatus.Valid;
         }).ToArray();
 
         var hasDeletes = false;


### PR DESCRIPTION
Fixes a bug where the ValueSetValidator is null which will cause a NullReferenceException.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
When creating a custom index based on Umbraco content/media via this code:

```cs
services.AddExamineLuceneIndex<UmbracoContentIndex, ConfigurationEnabledDirectoryFactory>("TestIndex");
```

It will mean that this index's `LuceneDirectoryIndexOptions.ValueSetValidator` will be null and when rebuilding the index, a null reference exception will occur.

To resolve this, it is required that an explicit value set validator is applied to the options, like:

```cs
public class LuceneEditorialIndexOptions : IConfigureNamedOptions<LuceneDirectoryIndexOptions>
{
    private readonly IUmbracoIndexConfig _umbracoIndexConfig;

    public LuceneEditorialIndexOptions(IUmbracoIndexConfig umbracoIndexConfig)
    {
        _umbracoIndexConfig = umbracoIndexConfig;
    }

    public void Configure(string? name, LuceneDirectoryIndexOptions options)
    {
        if (name?.Equals("EditorialIndex") is false)
        {
            return;
        }

        options.Validator = _umbracoIndexConfig.GetContentValueSetValidator();
    }

    // not used
    public void Configure(LuceneDirectoryIndexOptions options) => throw new NotImplementedException();
}
```

However, it is not clear that this is a requirement but either way, a null reference exception shouldn't be thrown.

A reference: https://github.com/SDKits/ExamineX/issues/103#issuecomment-2127447324