### PR TITLE
Added apostrophe to allowed characters for username.

### DIFF
--- a/src/Umbraco.Web.UI/appsettings.template.json
+++ b/src/Umbraco.Web.UI/appsettings.template.json
@@ -41,7 +41,7 @@
         "KeepUserLoggedIn": false,
         "UsernameIsEmail": true,
         "HideDisabledUsersInBackoffice": false,
-        "AllowedUserNameCharacters": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+\\",
+        "AllowedUserNameCharacters": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-'._@+\\",
         "UserPassword": {
           "RequiredLength": 10,
           "RequireNonLetterOrDigit": false,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/16201

### Description
Steps:

1. Log into the backoffice and go to the users section.
2. Select the "Create user" button.
3. Complete the fields on the form that appears and enter an email address with an apostrophe (') in it.
4. Select the "Create user" form submission button.

[umbraco-16201.webm](https://github.com/umbraco/Umbraco-CMS/assets/11333925/c34422f0-7de4-4745-b1bd-fa1b351c1843)


<!-- Thanks for contributing to Umbraco CMS! -->
