### PR TITLE
Enrich the datatype references output with content type data

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Factories/DataTypeReferencePresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DataTypeReferencePresentationFactory.cs
@@ -47,8 +47,13 @@ public class DataTypeReferencePresentationFactory : IDataTypeReferencePresentati
                 IEnumerable<string> propertyAliases = propertyAliasesByGuid[contentType.Key];
                 yield return new DataTypeReferenceResponseModel
                 {
-                    Id = contentType.Key,
-                    Type = usagesByEntityType.Key,
+                    ContentType = new DataTypeContentTypeReferenceModel
+                    {
+                        Id = contentType.Key,
+                        Name = contentType.Name,
+                        Icon = contentType.Icon,
+                        Type = usagesByEntityType.Key,
+                    },
                     Properties = contentType
                         .PropertyTypes
                         .Where(propertyType => propertyAliases.InvariantContains(propertyType.Alias))

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -35399,6 +35399,34 @@
         ],
         "type": "string"
       },
+      "DataTypeContentTypeReferenceModel": {
+        "required": [
+          "icon",
+          "id",
+          "name",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "icon": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "DataTypeItemResponseModel": {
         "required": [
           "id",
@@ -35457,18 +35485,17 @@
       },
       "DataTypeReferenceResponseModel": {
         "required": [
-          "id",
-          "properties",
-          "type"
+          "contentType",
+          "properties"
         ],
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "type": {
-            "type": "string"
+          "contentType": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/DataTypeContentTypeReferenceModel"
+              }
+            ]
           },
           "properties": {
             "type": "array",

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DataTypeContentTypeReferenceModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DataTypeContentTypeReferenceModel.cs
@@ -1,0 +1,12 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.DataType;
+
+public class DataTypeContentTypeReferenceModel
+{
+    public required Guid Id { get; set; }
+
+    public required string? Type { get; set; }
+
+    public required string? Name { get; set; }
+
+    public required string? Icon { get; set; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DataTypeReferenceResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DataType/DataTypeReferenceResponseModel.cs
@@ -2,9 +2,7 @@
 
 public class DataTypeReferenceResponseModel
 {
-    public required Guid Id { get; init; }
-
-    public required string Type { get; init; }
+    public required DataTypeContentTypeReferenceModel ContentType { get; init; }
 
     public required IEnumerable<DataTypePropertyReferenceViewModel> Properties { get; init; }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

🚨 **Do not merge this until the client is ready** 🚨 

The datatype references output is very limited. If it is to be utilized as-is, it will require a lot of additional API requests to create meaningful UI on top.

The corresponding references outputs for document and media types have been enriched with these data, so it seems fitting to do it for datatypes also.

**NOTE:** The `type` property in the datatype references output has moved into the new `contentType` property.

### Testing this PR

Fetch references for a datatype that is used on a doc/media/member type. Verify that the new output format contains the doc/media/member type name and icon.