### PR TITLE
Make sure listviews are initialized correctly in a new DB

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
@@ -1062,6 +1062,7 @@ internal class DatabaseDataCreator
                     Thumbnail = Constants.Icons.MediaFolder,
                     AllowAtRoot = true,
                     Variations = (byte)ContentVariation.Nothing,
+                    ListView = Constants.DataTypes.Guids.ListViewMediaGuid
                 });
         }
 
@@ -1886,11 +1887,13 @@ internal class DatabaseDataCreator
         }
 
         // layouts for the list view
-        const string cardLayout =
-            "{\"name\": \"Grid\",\"path\": \"views/propertyeditors/listview/layouts/grid/grid.html\", \"icon\": \"icon-thumbnails-small\", \"isSystem\": true, \"selected\": true}";
-        const string listLayout =
-            "{\"name\": \"List\",\"path\": \"views/propertyeditors/listview/layouts/list/list.html\",\"icon\": \"icon-list\", \"isSystem\": true,\"selected\": true}";
-        const string layouts = "[" + cardLayout + "," + listLayout + "]";
+        string TableCollectionView(string collectionViewType) =>
+            $"{{\"name\": \"List\",\"collectionView\": \"Umb.CollectionView.{collectionViewType}.Table\", \"icon\": \"icon-list\", \"isSystem\": true, \"selected\": true}}";
+
+        string GridCollectionView(string collectionViewType) =>
+            $"{{\"name\": \"Grid\",\"collectionView\": \"Umb.CollectionView.{collectionViewType}.Grid\",\"icon\": \"icon-thumbnails-small\", \"isSystem\": true,\"selected\": true}}";
+
+        string Layouts(string collectionViewType) => $"[{GridCollectionView(collectionViewType)},{TableCollectionView(collectionViewType)}]";
 
         // Insert data types only if the corresponding Node record exists (which may or may not have been created depending on configuration
         // of data types to create).
@@ -2094,7 +2097,7 @@ internal class DatabaseDataCreator
                     DbType = "Nvarchar",
                     Configuration =
                         "{\"pageSize\":100, \"orderBy\":\"updateDate\", \"orderDirection\":\"desc\", \"layouts\":" +
-                        layouts +
+                        Layouts("Document") +
                         ", \"includeProperties\":[{\"alias\":\"updateDate\",\"header\":\"Last edited\",\"isSystem\":true},{\"alias\":\"creator\",\"header\":\"Updated by\",\"isSystem\":true}]}",
                 });
         }
@@ -2113,7 +2116,7 @@ internal class DatabaseDataCreator
                     DbType = "Nvarchar",
                     Configuration =
                         "{\"pageSize\":100, \"orderBy\":\"updateDate\", \"orderDirection\":\"desc\", \"layouts\":" +
-                        layouts +
+                        Layouts("Media") +
                         ", \"includeProperties\":[{\"alias\":\"updateDate\",\"header\":\"Last edited\",\"isSystem\":true},{\"alias\":\"creator\",\"header\":\"Updated by\",\"isSystem\":true}]}",
                 });
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The default listviews are not created correctly - they still use the V13 format 🤦 this PR fixes them.

### Testing

Initialize a fresh DB and verify that the list views have the correct view components listed in the backoffice UI:

#### Document list view

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/849f88b8-2341-4cf9-a586-f616e4a2d353)

#### Media list view

![image](https://github.com/umbraco/Umbraco-CMS/assets/7405322/53d099f0-2e00-454b-a336-147d3e4e7bc9)
