### PR TITLE
v14: Validate file name to return correct error

### DIFF
--- a/src/Umbraco.Core/Services/FileServiceOperationBase.cs
+++ b/src/Umbraco.Core/Services/FileServiceOperationBase.cs
@@ -82,6 +82,11 @@ public abstract class FileServiceOperationBase<TRepository, TEntity, TOperationS
 
     protected async Task<Attempt<TEntity?, TOperationStatus>> HandleCreateAsync(string name, string? parentPath, string? content, Guid userKey)
     {
+        if (name.Contains("/"))
+        {
+            return Attempt.FailWithStatus<TEntity?, TOperationStatus>(InvalidName, default);
+        }
+
         using ICoreScope scope = ScopeProvider.CreateCoreScope();
 
         var path = GetFilePath(parentPath, name);

--- a/src/Umbraco.Core/Services/FileServiceOperationBase.cs
+++ b/src/Umbraco.Core/Services/FileServiceOperationBase.cs
@@ -82,7 +82,7 @@ public abstract class FileServiceOperationBase<TRepository, TEntity, TOperationS
 
     protected async Task<Attempt<TEntity?, TOperationStatus>> HandleCreateAsync(string name, string? parentPath, string? content, Guid userKey)
     {
-        if (name.Contains("/"))
+        if (name.Contains('/'))
         {
             return Attempt.FailWithStatus<TEntity?, TOperationStatus>(InvalidName, default);
         }
@@ -153,6 +153,11 @@ public abstract class FileServiceOperationBase<TRepository, TEntity, TOperationS
 
     protected async Task<Attempt<TEntity?, TOperationStatus>> HandleRenameAsync(string path, string newName, Guid userKey)
     {
+        if (newName.Contains('/'))
+        {
+            return Attempt.FailWithStatus<TEntity?, TOperationStatus>(InvalidName, default);
+        }
+
         using ICoreScope scope = ScopeProvider.CreateCoreScope();
 
         TEntity? entity = Repository.Get(path);


### PR DESCRIPTION
# Notes
- If the file name contains `/`, it is invalid, as we do have `parenpath`, it would make no sense to have a `/` in a filename

# How to test
- call the `umbraco/management/api/v1/script` endpoint with:
```
{
  "name": "hell/o.js",
  "content": "<string>"
}
```
- This should now yield a `InvalidName` error, not a `ParentNotFound` error