### PR TITLE
Add editor ui alias to package xml

### DIFF
--- a/src/Umbraco.Core/Services/EntityXmlSerializer.cs
+++ b/src/Umbraco.Core/Services/EntityXmlSerializer.cs
@@ -211,6 +211,7 @@ internal class EntityXmlSerializer : IEntityXmlSerializer
 
         // The 'ID' when exporting is actually the property editor alias (in pre v7 it was the IDataType GUID id)
         xml.Add(new XAttribute("Id", dataType.EditorAlias));
+        xml.Add(new XAttribute("EditorUiAlias", dataType.EditorUiAlias ?? dataType.EditorAlias));
         xml.Add(new XAttribute("Definition", dataType.Key));
         xml.Add(new XAttribute("DatabaseType", dataType.DatabaseType.ToString()));
         xml.Add(new XAttribute("Configuration", _configurationEditorJsonSerializer.Serialize(dataType.ConfigurationObject)));

--- a/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
+++ b/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
@@ -1257,12 +1257,16 @@ namespace Umbraco.Cms.Infrastructure.Packaging
                         editor = new VoidEditor(_dataValueEditorFactory) {Alias = editorAlias ?? string.Empty};
                     }
 
+                    var editorUiAlias = dataTypeElement.Attribute("EditorUiAlias")?.Value?.Trim() ?? editorAlias;
+
+
                     var dataType = new DataType(editor, _serializer)
                     {
                         Key = dataTypeDefinitionId,
                         Name = dataTypeDefinitionName,
                         DatabaseType = databaseType,
-                        ParentId = parentId
+                        ParentId = parentId,
+                        EditorUiAlias = editorUiAlias,
                     };
 
                     var configurationAttributeValue = dataTypeElement.Attribute("Configuration")?.Value;


### PR DESCRIPTION
Adds the `EditorUiAlias` to the package.xml and uses it when importing, otherwise the editor will not work in the backoffice