### PR TITLE
Update ApiRichTextParserBase.cs

### DIFF
--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextParserBase.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextParserBase.cs
@@ -52,7 +52,7 @@ internal abstract partial class ApiRichTextParserBase
                 if (media != null)
                 {
                     handled = true;
-                    handleMediaUrl(_publishedUrlProvider.GetMediaUrl(media, UrlMode.Absolute));
+                    handleMediaUrl(_publishedUrlProvider.GetMediaUrl(media, UrlMode.Default));
                 }
 
                 break;
@@ -77,7 +77,7 @@ internal abstract partial class ApiRichTextParserBase
             return;
         }
 
-        handleMediaUrl(_publishedUrlProvider.GetMediaUrl(media, UrlMode.Absolute));
+        handleMediaUrl(_publishedUrlProvider.GetMediaUrl(media, UrlMode.Default));
     }
 
     [GeneratedRegex("{localLink:(?<udi>umb:.+)}")]


### PR DESCRIPTION
Changed Url UrlMode.Absolute to UrlMode.Default
For return mediaurl in content delivery api based on the configuration provided

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

Related issue: [ #16416](https://github.com/umbraco/Umbraco-CMS/issues/16416)

### Description
Based on the linked issue, we need to ensure that we:
The content delivery api response for the  image URLs inside Rich Text Editor With will be loaded based on the WebRouting configuration set for the UrlProviderMode in the AppSettings.Json.

