### PR TITLE
Fix issue when FileUpload exists on a document, it cannot publish

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/FileUploadPropertyValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/FileUploadPropertyValueEditor.cs
@@ -154,6 +154,14 @@ internal class FileUploadPropertyValueEditor : DataValueEditor
             return null;
         }
 
+        if (editorValue is string sourceString && sourceString.DetectIsJson() is false)
+        {
+            return new FileUploadValue()
+            {
+                Src = sourceString
+            };
+        }
+
         return _jsonSerializer.TryDeserialize(editorValue, out FileUploadValue? modelValue)
             ? modelValue
             : throw new ArgumentException($"Could not parse editor value to a {nameof(FileUploadValue)} object.");


### PR DESCRIPTION
### Description
This PR fixes an issue with the FileUpload when used on documents, it could only save, but not publish.

The reason is because the value from the DB is just the path and we did not handle that case when doing validation before publish.

### Test
- Verify you can create a document type with a file upload property editor and publish that document