### PR TITLE
Include umbraco-package.json manifests in telemetry data

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Mapping/Manifest/ManifestViewModelMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Manifest/ManifestViewModelMapDefinition.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Api.Management.ViewModels.Manifest;
+using Umbraco.Cms.Api.Management.ViewModels.Manifest;
 using Umbraco.Cms.Core.Manifest;
 using Umbraco.Cms.Core.Mapping;
 
@@ -13,6 +13,7 @@ public class ManifestViewModelMapDefinition : IMapDefinition
     private static void Map(PackageManifest source, ManifestResponseModel target, MapperContext context)
     {
         target.Name = source.Name;
+        target.Id = source.Id;
         target.Version = source.Version;
         target.Extensions = source.Extensions;
     }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Manifest/ManifestResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Manifest/ManifestResponseModel.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 
 namespace Umbraco.Cms.Api.Management.ViewModels.Manifest;
 
@@ -6,6 +6,8 @@ public class ManifestResponseModel
 {
     [Required]
     public string Name { get; set; } = string.Empty;
+
+    public string? Id { get; set; }
 
     public string? Version { get; set; }
 

--- a/src/Umbraco.Core/Manifest/PackageManifest.cs
+++ b/src/Umbraco.Core/Manifest/PackageManifest.cs
@@ -1,8 +1,10 @@
-﻿namespace Umbraco.Cms.Core.Manifest;
+namespace Umbraco.Cms.Core.Manifest;
 
 public class PackageManifest
 {
     public required string Name { get; set; }
+
+    public string? Id { get; set; }
 
     public string? Version { get; set; }
 

--- a/src/Umbraco.Core/Services/IPackagingService.cs
+++ b/src/Umbraco.Core/Services/IPackagingService.cs
@@ -29,7 +29,14 @@ public interface IPackagingService : IService
     ///     Returns the advertised installed packages
     /// </summary>
     /// <returns></returns>
+    [Obsolete("Use GetAllInstalledPackagesAsync instead. Scheduled for removal in Umbraco 15.")]
     IEnumerable<InstalledPackage> GetAllInstalledPackages();
+
+    /// <summary>
+    ///     Returns the advertised installed packages
+    /// </summary>
+    /// <returns></returns>
+    Task<IEnumerable<InstalledPackage>> GetAllInstalledPackagesAsync();
 
     /// <summary>
     ///     Returns installed packages collected from the package migration plans.

--- a/src/Umbraco.Core/Services/IPackagingService.cs
+++ b/src/Umbraco.Core/Services/IPackagingService.cs
@@ -36,7 +36,10 @@ public interface IPackagingService : IService
     ///     Returns the advertised installed packages
     /// </summary>
     /// <returns></returns>
-    Task<IEnumerable<InstalledPackage>> GetAllInstalledPackagesAsync();
+    Task<IEnumerable<InstalledPackage>> GetAllInstalledPackagesAsync()
+#pragma warning disable CS0618 // Type or member is obsolete
+        => Task.FromResult(GetAllInstalledPackages());
+#pragma warning restore CS0618 // Type or member is obsolete
 
     /// <summary>
     ///     Returns installed packages collected from the package migration plans.

--- a/src/Umbraco.Core/Telemetry/TelemetryService.cs
+++ b/src/Umbraco.Core/Telemetry/TelemetryService.cs
@@ -1,10 +1,7 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.Configuration;
-using Umbraco.Cms.Core.DependencyInjection;
-using Umbraco.Cms.Core.Manifest;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Packaging;
 using Umbraco.Cms.Core.Services;
@@ -43,6 +40,7 @@ internal class TelemetryService : ITelemetryService
     public bool TryGetTelemetryReportData(out TelemetryReportData? telemetryReportData)
     {
         telemetryReportData = GetTelemetryReportDataAsync().GetAwaiter().GetResult();
+
         return telemetryReportData != null;
     }
 
@@ -58,7 +56,7 @@ internal class TelemetryService : ITelemetryService
         {
             Id = telemetryId,
             Version = GetVersion(),
-            Packages = await GetPackageTelemetryAsync(),
+            Packages = await GetPackageTelemetryAsync().ConfigureAwait(false),
             Detailed = _usageInformationService.GetDetailed(),
         };
     }
@@ -66,8 +64,6 @@ internal class TelemetryService : ITelemetryService
     private string? GetVersion() => _metricsConsentService.GetConsentLevel() == TelemetryLevel.Minimal
         ? null
         : _umbracoVersion.SemanticVersion.ToSemanticStringWithoutBuild();
-
-
 
     private async Task<IEnumerable<PackageTelemetry>?> GetPackageTelemetryAsync()
     {
@@ -77,7 +73,7 @@ internal class TelemetryService : ITelemetryService
         }
 
         List<PackageTelemetry> packages = new();
-        IEnumerable<InstalledPackage> installedPackages = _packagingService.GetAllInstalledPackages();
+        IEnumerable<InstalledPackage> installedPackages = await _packagingService.GetAllInstalledPackagesAsync().ConfigureAwait(false);
 
         foreach (InstalledPackage installedPackage in installedPackages)
         {

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ReportSiteJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ReportSiteJob.cs
@@ -9,7 +9,6 @@ namespace Umbraco.Cms.Infrastructure.BackgroundJobs.Jobs;
 
 public class ReportSiteJob : IRecurringBackgroundJob
 {
-
     public TimeSpan Period => TimeSpan.FromDays(1);
 
     public TimeSpan Delay => TimeSpan.FromMinutes(5);
@@ -19,25 +18,25 @@ public class ReportSiteJob : IRecurringBackgroundJob
     // No-op event as the period never changes on this job
     public event EventHandler PeriodChanged
     {
-        add { } remove { }
+        add { }
+        remove { }
     }
 
-    private static HttpClient _httpClient = new();
-
     private readonly ILogger<ReportSiteJob> _logger;
-
     private readonly ITelemetryService _telemetryService;
-private readonly IJsonSerializer _jsonSerializer;
+    private readonly IJsonSerializer _jsonSerializer;
+    private readonly IHttpClientFactory _httpClientFactory;
 
     public ReportSiteJob(
         ILogger<ReportSiteJob> logger,
         ITelemetryService telemetryService,
-        IJsonSerializer jsonSerializer)
+        IJsonSerializer jsonSerializer,
+        IHttpClientFactory httpClientFactory)
     {
         _logger = logger;
         _telemetryService = telemetryService;
         _jsonSerializer = jsonSerializer;
-        _httpClient = new HttpClient();
+        _httpClientFactory = httpClientFactory;
     }
 
     /// <summary>
@@ -46,7 +45,8 @@ private readonly IJsonSerializer _jsonSerializer;
     /// </summary>
     public async Task RunJobAsync()
     {
-        if (_telemetryService.TryGetTelemetryReportData(out TelemetryReportData? telemetryReportData) is false)
+        TelemetryReportData? telemetryReportData = await _telemetryService.GetTelemetryReportDataAsync().ConfigureAwait(false);
+        if (telemetryReportData is null)
         {
             _logger.LogWarning("No telemetry marker found");
 
@@ -55,31 +55,28 @@ private readonly IJsonSerializer _jsonSerializer;
 
         try
         {
-            if (_httpClient.BaseAddress is null)
+            HttpClient httpClient = _httpClientFactory.CreateClient();
+            if (httpClient.BaseAddress is null)
             {
                 // Send data to LIVE telemetry
-                _httpClient.BaseAddress = new Uri("https://telemetry.umbraco.com/");
+                httpClient.BaseAddress = new Uri("https://telemetry.umbraco.com/");
 
 #if DEBUG
                 // Send data to DEBUG telemetry service
-                _httpClient.BaseAddress = new Uri("https://telemetry.rainbowsrock.net/");
+                httpClient.BaseAddress = new Uri("https://telemetry.rainbowsrock.net/");
 #endif
             }
 
-            _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
+            httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
 
-            using (var request = new HttpRequestMessage(HttpMethod.Post, "installs/"))
-            {
-                request.Content = new StringContent(_jsonSerializer.Serialize(telemetryReportData), Encoding.UTF8,
-                    "application/json");
+            using var request = new HttpRequestMessage(HttpMethod.Post, "installs/");
+            request.Content = new StringContent(_jsonSerializer.Serialize(telemetryReportData), Encoding.UTF8, "application/json");
 
-                // Make a HTTP Post to telemetry service
-                // https://telemetry.umbraco.com/installs/
-                // Fire & Forget, do not need to know if its a 200, 500 etc
-                using (await _httpClient.SendAsync(request))
-                {
-                }
-            }
+            // Make a HTTP Post to telemetry service
+            // https://telemetry.umbraco.com/installs/
+            // Fire & Forget, do not need to know if its a 200, 500 etc
+            using (await httpClient.SendAsync(request))
+            { }
         }
         catch
         {

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ReportSiteJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ReportSiteJob.cs
@@ -1,5 +1,7 @@
 using System.Text;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Core.Telemetry;
@@ -26,6 +28,18 @@ public class ReportSiteJob : IRecurringBackgroundJob
     private readonly ITelemetryService _telemetryService;
     private readonly IJsonSerializer _jsonSerializer;
     private readonly IHttpClientFactory _httpClientFactory;
+
+    [Obsolete("Use the constructor with IHttpClientFactory instead.")]
+    public ReportSiteJob(
+        ILogger<ReportSiteJob> logger,
+        ITelemetryService telemetryService,
+        IJsonSerializer jsonSerializer)
+        : this(
+            logger,
+            telemetryService,
+            jsonSerializer,
+            StaticServiceProvider.Instance.GetRequiredService<IHttpClientFactory>())
+    { }
 
     public ReportSiteJob(
         ILogger<ReportSiteJob> logger,

--- a/src/Umbraco.Infrastructure/Services/Implement/PackagingService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/PackagingService.cs
@@ -1,10 +1,6 @@
 using System.Xml.Linq;
-using Microsoft.Extensions.DependencyInjection;
-using Umbraco.Cms.Core.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
-using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Extensions;
 using Umbraco.Cms.Core.Manifest;
@@ -14,6 +10,7 @@ using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Packaging;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Infrastructure.Manifest;
 using Umbraco.Extensions;
 using File = System.IO.File;
 
@@ -31,6 +28,7 @@ public class PackagingService : IPackagingService
     private readonly IKeyValueService _keyValueService;
     private readonly IPackageInstallation _packageInstallation;
     private readonly PackageMigrationPlanCollection _packageMigrationPlans;
+    private readonly IPackageManifestReader _packageManifestReader;
     private readonly ICoreScopeProvider _coreScopeProvider;
     private readonly IHostEnvironment _hostEnvironment;
     private readonly IUserService _userService;
@@ -43,6 +41,7 @@ public class PackagingService : IPackagingService
         IKeyValueService keyValueService,
         ICoreScopeProvider coreScopeProvider,
         PackageMigrationPlanCollection packageMigrationPlans,
+        IPackageManifestReader packageManifestReader,
         IHostEnvironment hostEnvironment,
         IUserService userService)
     {
@@ -52,6 +51,7 @@ public class PackagingService : IPackagingService
         _eventAggregator = eventAggregator;
         _keyValueService = keyValueService;
         _packageMigrationPlans = packageMigrationPlans;
+        _packageManifestReader = packageManifestReader;
         _coreScopeProvider = coreScopeProvider;
         _hostEnvironment = hostEnvironment;
         _userService = userService;
@@ -61,9 +61,7 @@ public class PackagingService : IPackagingService
 
     public CompiledPackage GetCompiledPackageInfo(XDocument? xml) => _packageInstallation.ReadPackage(xml);
 
-    public InstallationSummary InstallCompiledPackageData(
-        XDocument? packageXml,
-        int userId = Constants.Security.SuperUserId)
+    public InstallationSummary InstallCompiledPackageData(XDocument? packageXml, int userId = Constants.Security.SuperUserId)
     {
         CompiledPackage compiledPackage = GetCompiledPackageInfo(packageXml);
 
@@ -89,9 +87,7 @@ public class PackagingService : IPackagingService
         return summary;
     }
 
-    public InstallationSummary InstallCompiledPackageData(
-        FileInfo packageXmlFile,
-        int userId = Constants.Security.SuperUserId)
+    public InstallationSummary InstallCompiledPackageData(FileInfo packageXmlFile, int userId = Constants.Security.SuperUserId)
     {
         XDocument xml;
         using (StreamReader streamReader = File.OpenText(packageXmlFile.FullName))
@@ -109,10 +105,14 @@ public class PackagingService : IPackagingService
     [Obsolete("Use DeleteCreatedPackageAsync instead. Scheduled for removal in Umbraco 15.")]
     public void DeleteCreatedPackage(int id, int userId = Constants.Security.SuperUserId)
     {
-        using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
-        PackageDefinition? package = GetCreatedPackageById(id);
-        Guid key = package?.PackageId ?? Guid.Empty;
-        Guid currentUserKey = _userService.GetUserById(id)?.Key ?? Constants.Security.SuperUserKey;
+        Guid key, currentUserKey;
+
+        using (ICoreScope scope = _coreScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            PackageDefinition? package = GetCreatedPackageById(id);
+            key = package?.PackageId ?? Guid.Empty;
+            currentUserKey = _userService.GetUserById(id)?.Key ?? Constants.Security.SuperUserKey;
+        }
 
         DeleteCreatedPackageAsync(key, currentUserKey).GetAwaiter().GetResult();
     }
@@ -139,6 +139,7 @@ public class PackagingService : IPackagingService
     public IEnumerable<PackageDefinition?> GetAllCreatedPackages()
     {
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope(autoComplete: true);
+
         return _createdPackages.GetAll();
     }
 
@@ -146,6 +147,7 @@ public class PackagingService : IPackagingService
     public PackageDefinition? GetCreatedPackageById(int id)
     {
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope(autoComplete: true);
+
         return _createdPackages.GetById(id);
     }
 
@@ -155,7 +157,8 @@ public class PackagingService : IPackagingService
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope(autoComplete: true);
         PackageDefinition[] packages = _createdPackages.GetAll().WhereNotNull().ToArray();
         var pagedModel = new PagedModel<PackageDefinition>(packages.Length, packages.Skip(skip).Take(take));
-        return await Task.FromResult(pagedModel);
+
+        return pagedModel;
     }
 
     /// <inheritdoc/>
@@ -173,6 +176,7 @@ public class PackagingService : IPackagingService
 
         var success = _createdPackages.SavePackage(definition);
         scope.Complete();
+
         return success;
     }
 
@@ -192,9 +196,10 @@ public class PackagingService : IPackagingService
 
         int currentUserId = (await _userService.GetRequiredUserAsync(userKey)).Id;
         _auditService.Add(AuditType.New, currentUserId, -1, "Package", $"Created package '{package.Name}' created. Package key: {package.PackageId}");
-        scope.Complete();
-        return await Task.FromResult(Attempt.SucceedWithStatus(PackageOperationStatus.Success, package));
 
+        scope.Complete();
+
+        return Attempt.SucceedWithStatus(PackageOperationStatus.Success, package);
     }
 
     /// <inheritdoc/>
@@ -208,20 +213,27 @@ public class PackagingService : IPackagingService
 
         int currentUserId = (await _userService.GetRequiredUserAsync(userKey)).Id;
         _auditService.Add(AuditType.New, currentUserId, -1, "Package", $"Created package '{package.Name}' updated. Package key: {package.PackageId}");
+
         scope.Complete();
-        return await Task.FromResult(Attempt.SucceedWithStatus(PackageOperationStatus.Success, package));
+
+        return Attempt.SucceedWithStatus(PackageOperationStatus.Success, package);
     }
 
     public string ExportCreatedPackage(PackageDefinition definition)
     {
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope(autoComplete: true);
+
         return _createdPackages.ExportPackage(definition);
     }
 
     public InstalledPackage? GetInstalledPackageByName(string packageName)
         => GetAllInstalledPackages().Where(x => x.PackageName?.InvariantEquals(packageName) ?? false).FirstOrDefault();
 
+    [Obsolete("Use GetAllInstalledPackagesAsync instead. Scheduled for removal in Umbraco 15.")]
     public IEnumerable<InstalledPackage> GetAllInstalledPackages()
+        => GetAllInstalledPackagesAsync().GetAwaiter().GetResult();
+
+    public async Task<IEnumerable<InstalledPackage>> GetAllInstalledPackagesAsync()
     {
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope(autoComplete: true);
 
@@ -277,14 +289,57 @@ public class PackagingService : IPackagingService
             installedPackage.PackageMigrationPlans = currentPlans;
         }
 
-        // Return all packages with an ID or name in the package.manifest or package migrations
+        // Collect and merge the packages from the manifests
+        foreach (PackageManifest packageManifest in await _packageManifestReader.ReadPackageManifestsAsync().ConfigureAwait(false))
+        {
+            if (packageManifest.Id is null && string.IsNullOrEmpty(packageManifest.Name))
+            {
+                continue;
+            }
+
+            InstalledPackage installedPackage;
+            if (packageManifest.Id is not null && installedPackages.FirstOrDefault(x => x.PackageId == packageManifest.Id) is InstalledPackage installedPackageById)
+            {
+                installedPackage = installedPackageById;
+
+                // Always use package name from manifest
+                installedPackage.PackageName = packageManifest.Name;
+            }
+            else if (installedPackages.FirstOrDefault(x => x.PackageName == packageManifest.Name) is InstalledPackage installedPackageByName)
+            {
+                installedPackage = installedPackageByName;
+
+                // Ensure package ID is set
+                installedPackage.PackageId ??= packageManifest.Id;
+            }
+            else
+            {
+                installedPackage = new InstalledPackage
+                {
+                    PackageId = packageManifest.Id,
+                    PackageName = packageManifest.Name,
+                };
+
+                installedPackages.Add(installedPackage);
+            }
+
+            // Set additional values
+            installedPackage.AllowPackageTelemetry = packageManifest.AllowTelemetry;
+
+            if (!string.IsNullOrEmpty(packageManifest.Version))
+            {
+                installedPackage.Version = packageManifest.Version;
+            }
+        }
+
+        // Return all packages with an ID or name in the package manifest or package migrations
         return installedPackages;
     }
 
     #endregion
 
     /// <inheritdoc/>
-    public async Task<PagedModel<InstalledPackage>> GetInstalledPackagesFromMigrationPlansAsync(int skip, int take)
+    public Task<PagedModel<InstalledPackage>> GetInstalledPackagesFromMigrationPlansAsync(int skip, int take)
     {
         IReadOnlyDictionary<string, string?>? keyValues =
             _keyValueService.FindByKeyPrefix(Constants.Conventions.Migrations.KeyValuePrefix);
@@ -311,7 +366,7 @@ public class PackagingService : IPackagingService
                 return package;
             }).ToArray();
 
-        return await Task.FromResult(new PagedModel<InstalledPackage>
+        return Task.FromResult(new PagedModel<InstalledPackage>
         {
             Total = installedPackages.Count(),
             Items = installedPackages.Skip(skip).Take(take),

--- a/src/Umbraco.Infrastructure/Services/Implement/PackagingService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/PackagingService.cs
@@ -1,6 +1,8 @@
 using System.Xml.Linq;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Extensions;
 using Umbraco.Cms.Core.Manifest;
@@ -32,6 +34,30 @@ public class PackagingService : IPackagingService
     private readonly ICoreScopeProvider _coreScopeProvider;
     private readonly IHostEnvironment _hostEnvironment;
     private readonly IUserService _userService;
+
+    [Obsolete("Use the constructor with IPackageManifestReader instead.")]
+    public PackagingService(
+        IAuditService auditService,
+        ICreatedPackagesRepository createdPackages,
+        IPackageInstallation packageInstallation,
+        IEventAggregator eventAggregator,
+        IKeyValueService keyValueService,
+        ICoreScopeProvider coreScopeProvider,
+        PackageMigrationPlanCollection packageMigrationPlans,
+        IHostEnvironment hostEnvironment,
+        IUserService userService)
+        : this(
+            auditService,
+            createdPackages,
+            packageInstallation,
+            eventAggregator,
+            keyValueService,
+            coreScopeProvider,
+            packageMigrationPlans,
+            StaticServiceProvider.Instance.GetRequiredService<IPackageManifestReader>(),
+            hostEnvironment,
+            userService)
+    { }
 
     public PackagingService(
         IAuditService auditService,

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Telemetry/TelemetryServiceTests.cs
@@ -1,7 +1,6 @@
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Configuration;
-using Umbraco.Cms.Core.Manifest;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Packaging;
 using Umbraco.Cms.Core.Semver;
@@ -139,7 +138,7 @@ public class TelemetryServiceTests
     private IPackagingService CreatePackagingService(IEnumerable<InstalledPackage> installedPackages)
     {
         var packagingServiceMock = new Mock<IPackagingService>();
-        packagingServiceMock.Setup(x => x.GetAllInstalledPackages()).Returns(installedPackages);
+        packagingServiceMock.Setup(x => x.GetAllInstalledPackagesAsync()).ReturnsAsync(installedPackages);
         return packagingServiceMock.Object;
     }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
PR https://github.com/umbraco/Umbraco-CMS/pull/15744 removed the legacy package manifest parser, but also removed the code from `PackagingService` that returned the combined the package migrations _and manifests_. This data is used in the telemetry service to report the installed packages (if the consent level of the installation is set to Basic or Detailed and the package hasn't opted-out), which is mainly used in the Marketplace to sort the packages by most active installs.

Another important detail that was missing, is being able to specify the (NuGet) package ID in the manifest, so the Marketplace can do a 1:1 match when aggregating the data.

Besides re-introducing the package manifests as installed packages and adding the package ID, I've ensured the ID is also exposed in the Management API endpoints. E.g. the `umbraco/management/api/v1/manifest/manifest` endpoint now returns:
```json
[
  {
    "name": "@umbraco-cms/backoffice",
    "id": null,
    "version": "14.0.0-rc2",
    "extensions": []
  },
  {
    "name": "Test",
    "id": "Umbraco.Cms.Test",
    "version": "14.0.0",
    "extensions": []
  }
]
```

Testing can be done by adding a `umbraco-package.json` file to e.g. `wwwroot\App_Plugins\Test`:
```json
{
  "name": "Test",
  "id": "Umbraco.Cms.Test",
  "version": "14.0.0",
  "extensions": []
}
```

And then making sure this is included in `ReportSiteJob.RunJobAsync()` (update Delay to 0 and add a breakpoint to this method) and the package ID is exposed in the Management API (all Manifest endpoints).