### PR TITLE
Handle master template not found as bad request

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/TemplateControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/TemplateControllerBase.cs
@@ -34,6 +34,10 @@ public class TemplateControllerBase : ManagementApiControllerBase
                 .WithTitle("Invalid master template")
                 .WithDetail("The master template referenced in the template leads to a circular reference.")
                 .Build()),
+            TemplateOperationStatus.MasterTemplateNotFound => BadRequest(problemDetailsBuilder
+                .WithTitle("Master template not found")
+                .WithDetail("The master template referenced in the template was not found.")
+                .Build()),
             _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown template operation status.")
                 .Build()),


### PR DESCRIPTION
### Description
Handle the case, where a master template (layout) is references that do not exist.

Before
![image](https://github.com/umbraco/Umbraco-CMS/assets/1561480/fed78eac-6bec-44c2-8e75-af45ca613c57)
 after
![image](https://github.com/umbraco/Umbraco-CMS/assets/1561480/b41bc8ea-aeb1-4401-8e66-2b99e4c2b1b4)

### Test
- Create a template and reference a master that do not exist