### PR TITLE
V14: Handle embedded media providers returning dimensions as string values in their oEmbed JSON response

### DIFF
--- a/src/Umbraco.Core/Media/EmbedProviders/OEmbedResponse.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/OEmbedResponse.cs
@@ -1,68 +1,10 @@
-using System.Net;
 using System.Runtime.Serialization;
 
 namespace Umbraco.Cms.Core.Media.EmbedProviders;
 
 /// <summary>
-///     Wrapper class for OEmbed response
+///     Wrapper class for OEmbed response.
 /// </summary>
 [DataContract]
-public class OEmbedResponse
-{
-    [DataMember(Name = "type")]
-    public string? Type { get; set; }
+public class OEmbedResponse : OEmbedResponseBase<double>;
 
-    [DataMember(Name = "version")]
-    public string? Version { get; set; }
-
-    [DataMember(Name = "title")]
-    public string? Title { get; set; }
-
-    [DataMember(Name = "author_name")]
-    public string? AuthorName { get; set; }
-
-    [DataMember(Name = "author_url")]
-    public string? AuthorUrl { get; set; }
-
-    [DataMember(Name = "provider_name")]
-    public string? ProviderName { get; set; }
-
-    [DataMember(Name = "provider_url")]
-    public string? ProviderUrl { get; set; }
-
-    [DataMember(Name = "thumbnail_url")]
-    public string? ThumbnailUrl { get; set; }
-
-    [DataMember(Name = "thumbnail_height")]
-    public double? ThumbnailHeight { get; set; }
-
-    [DataMember(Name = "thumbnail_width")]
-    public double? ThumbnailWidth { get; set; }
-
-    [DataMember(Name = "html")]
-    public string? Html { get; set; }
-
-    [DataMember(Name = "url")]
-    public string? Url { get; set; }
-
-    [DataMember(Name = "height")]
-    public double? Height { get; set; }
-
-    [DataMember(Name = "width")]
-    public double? Width { get; set; }
-
-    /// <summary>
-    ///     Gets the HTML.
-    /// </summary>
-    /// <returns>The response HTML</returns>
-    public string GetHtml()
-    {
-        if (Type == "photo")
-        {
-            return "<img src=\"" + Url + "\" width=\"" + Width + "\" height=\"" + Height + "\" alt=\"" +
-                   WebUtility.HtmlEncode(Title) + "\" />";
-        }
-
-        return string.IsNullOrEmpty(Html) == false ? Html : string.Empty;
-    }
-}

--- a/src/Umbraco.Core/Media/EmbedProviders/OEmbedResponseBase.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/OEmbedResponseBase.cs
@@ -1,0 +1,68 @@
+using System.Net;
+using System.Runtime.Serialization;
+
+namespace Umbraco.Cms.Core.Media.EmbedProviders;
+
+/// <summary>
+///     Base class for OEmbed response.
+/// </summary>
+[DataContract]
+public abstract class OEmbedResponseBase<T>
+{
+    [DataMember(Name = "type")]
+    public string? Type { get; set; }
+
+    [DataMember(Name = "version")]
+    public string? Version { get; set; }
+
+    [DataMember(Name = "title")]
+    public string? Title { get; set; }
+
+    [DataMember(Name = "author_name")]
+    public string? AuthorName { get; set; }
+
+    [DataMember(Name = "author_url")]
+    public string? AuthorUrl { get; set; }
+
+    [DataMember(Name = "provider_name")]
+    public string? ProviderName { get; set; }
+
+    [DataMember(Name = "provider_url")]
+    public string? ProviderUrl { get; set; }
+
+    [DataMember(Name = "thumbnail_url")]
+    public string? ThumbnailUrl { get; set; }
+
+    [DataMember(Name = "thumbnail_height")]
+    public T? ThumbnailHeight { get; set; }
+
+    [DataMember(Name = "thumbnail_width")]
+    public T? ThumbnailWidth { get; set; }
+
+    [DataMember(Name = "html")]
+    public string? Html { get; set; }
+
+    [DataMember(Name = "url")]
+    public string? Url { get; set; }
+
+    [DataMember(Name = "height")]
+    public T? Height { get; set; }
+
+    [DataMember(Name = "width")]
+    public T? Width { get; set; }
+
+    /// <summary>
+    ///     Gets the HTML.
+    /// </summary>
+    /// <returns>The response HTML</returns>
+    public string GetHtml()
+    {
+        if (Type == "photo")
+        {
+            return "<img src=\"" + Url + "\" width=\"" + Width + "\" height=\"" + Height + "\" alt=\"" +
+                   WebUtility.HtmlEncode(Title) + "\" />";
+        }
+
+        return string.IsNullOrEmpty(Html) == false ? Html : string.Empty;
+    }
+}

--- a/src/Umbraco.Core/Media/EmbedProviders/OEmbedResponseWithStringDimensions.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/OEmbedResponseWithStringDimensions.cs
@@ -1,0 +1,9 @@
+using System.Runtime.Serialization;
+
+namespace Umbraco.Cms.Core.Media.EmbedProviders;
+
+/// <summary>
+///     Wrapper class for OEmbed response with width and height as string values.
+/// </summary>
+[DataContract]
+public class OEmbedResponseWithStringDimensions : OEmbedResponseBase<string>;


### PR DESCRIPTION
## Details
- Adding a base class of `OEmbedResponse`, so we can add an implementation handling string values in the JSON response for dimensions (width and height).
  - This wasn't necessary before when using `Newtonsoft.Json`, but `System.Text.Json` is more strict in this case.

## Test
- Create a doc type with RTE;
  - Make sure you have "**Embed**" option included in the toolbar.
- Create a content node from that document type;
- Insert an embedded media by clicking on the "**Embed**" button in the RTE;
- Verify that `https://www.youtube.com/watch?v=3bSHnMZF9xI` renders;
- Configure a new provider by adding the following classes:
```c#
using Umbraco.Cms.Core.Media.EmbedProviders;
using Umbraco.Cms.Core.Serialization;

namespace Umbraco.Cms.Web.UI;

public class DeviantArtEmbedProvider : OEmbedProviderBase
{
    public DeviantArtEmbedProvider(IJsonSerializer jsonSerializer)
        : base(jsonSerializer)
    {
    }

    public override string ApiEndpoint => "https://backend.deviantart.com/oembed?url=";

    public override string[] UrlSchemeRegex => new[]
    {
        @"fav\.me/*",
        @"\w+\.deviantart.com\/\w+\/art\/*",
        @"\w+\.deviantart.com\/art\/*",
        @"sta\.sh/*",
        @"\w+\.deviantart.com\/\w+#\/d*"
    };

    public override Dictionary<string, string> RequestParams => new();

    public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
    {
        return GeOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
    }

    public override async Task<string?> GeOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
    {
        var requestUrl = base.GetEmbedProviderUrl(url, maxWidth, maxHeight);
        OEmbedResponseWithStringDimensions? oembed = await base.GetJsonResponseAsync<OEmbedResponseWithStringDimensions>(requestUrl, cancellationToken);

        return oembed?.GetHtml();
    }
}
```

</br>

```c#
using Umbraco.Cms.Core.Composing;

namespace Umbraco.Cms.Web.UI;

public class RegisterEmbedProvidersComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
        => builder.EmbedProviders().Append< DeviantArtEmbedProvider >();
}
```

- Verify that `http://fav.me/darrsfo` renders now as well;