### PR TITLE
Added "git submodule update --init" command to the documentation

### DIFF
--- a/.github/BUILD.md
+++ b/.github/BUILD.md
@@ -15,7 +15,7 @@ If the answer is yes, please read on. Otherwise, make sure to head on over [to t
 
 ## Getting Started:
 To run umbraco, we first need to initialize the client git submodule:
-* Execute `git submodule init` and then `git submodule update` to get the files into Umbraco.Web.UI.Client project
+* Execute `git submodule update --init` to get the files into Umbraco.Web.UI.Client project
 * If you are going to work on the Backoffice, you can either go to the Umbraco.Web.UI.Client folder and check out a new branch or set it up in your IDE, which will allow you to commit to each repository simultaneously:
   * **Rider**: Preferences -> Version Control -> Directory Mappings -> Click the '+' sign
 * If you get a white page delete Umbraco.Cms.StaticAssets\wwwroot\umbraco folder and run `npm ci && npm run build:for:cms` inside Umbraco.Web.UI.Client folder to clear out any leftover files from older versions.


### PR DESCRIPTION
### Description
**Before**

- Try with an older git version.

- In my case, it was git version - 2.32.0.windows.2

![Screenshot 2024-05-31 115849](https://github.com/umbraco/Umbraco-CMS/assets/3594697/968f3122-351e-4fa8-a1aa-195ac862d73e)

**After**

- Works with any git version

- Submodule path 'src/Umbraco.Web.UI.Client': checked out