### PR TITLE
V14: Add clearer error for invalid property type

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/DocumentTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/DocumentTypeControllerBase.cs
@@ -41,6 +41,10 @@ public abstract class DocumentTypeControllerBase : ManagementApiControllerBase
                     .WithTitle("Invalid property type alias")
                     .WithDetail("One or more property type aliases are invalid")
                     .Build()),
+                ContentTypeOperationStatus.PropertyTypeAliasCannotEqualContentTypeAlias => new BadRequestObjectResult(problemDetailsBuilder
+                    .WithTitle("Invalid property type alias")
+                    .WithDetail("The property type alias cannot be the same as the content type alias")
+                    .Build()),
                 ContentTypeOperationStatus.InvalidContainerName => new BadRequestObjectResult(problemDetailsBuilder
                     .WithTitle("Invalid container name")
                     .WithDetail("One or more container names are invalid")

--- a/src/Umbraco.Core/Services/ContentTypeEditing/ContentTypeEditingServiceBase.cs
+++ b/src/Umbraco.Core/Services/ContentTypeEditing/ContentTypeEditingServiceBase.cs
@@ -200,6 +200,12 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
             return ContentTypeOperationStatus.InvalidAlias;
         }
 
+        // Validate content type alias is not in use.
+        if (model.Properties.Any(propertyType => propertyType.Alias.Equals(model.Alias, StringComparison.OrdinalIgnoreCase)))
+        {
+            return ContentTypeOperationStatus.PropertyTypeAliasCannotEqualContentTypeAlias;
+        }
+
         // Validate properties for reserved aliases.
         if (ContainsReservedPropertyTypeAlias(model))
         {
@@ -410,8 +416,7 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
             .Union(typeof(IPublishedContent).GetPublicMethods().Select(x => x.Name))
             .ToArray();
 
-        return model.Properties.Any(propertyType => propertyType.Alias.Equals(model.Alias, StringComparison.OrdinalIgnoreCase)
-                                                   || reservedPropertyTypeNames.InvariantContains(propertyType.Alias));
+        return model.Properties.Any(propertyType => reservedPropertyTypeNames.InvariantContains(propertyType.Alias));
     }
 
     private bool IsUnsafeAlias(string alias) => alias.IsNullOrWhiteSpace()

--- a/src/Umbraco.Core/Services/OperationStatus/ContentTypeOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/ContentTypeOperationStatus.cs
@@ -6,6 +6,7 @@ public enum ContentTypeOperationStatus
     DuplicateAlias,
     InvalidAlias,
     InvalidPropertyTypeAlias,
+    PropertyTypeAliasCannotEqualContentTypeAlias,
     DuplicatePropertyTypeAlias,
     DataTypeNotFound,
     InvalidInheritance,

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentTypeEditingServiceTests.Create.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentTypeEditingServiceTests.Create.cs
@@ -774,7 +774,7 @@ public partial class ContentTypeEditingServiceTests
 
         var result = await ContentTypeEditingService.CreateAsync(createModel, Constants.Security.SuperUserKey);
         Assert.IsFalse(result.Success);
-        Assert.AreEqual(ContentTypeOperationStatus.InvalidPropertyTypeAlias, result.Status);
+        Assert.AreEqual(ContentTypeOperationStatus.PropertyTypeAliasCannotEqualContentTypeAlias, result.Status);
     }
 
     [Test]


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/16502

# Notes
- Adds new OperationStatus to give clearer error, when you have the same property type alias, as the doc type alias.
![image](https://github.com/umbraco/Umbraco-CMS/assets/70372949/e5c29a73-39e3-4f44-ab9f-27f2e69d90cf)


# How to test
- Create a document type
- Add a property with the same alias as the content type
- You should now see a better error, telling you that it cannot have the same alias as the doc type