### PR TITLE
V14: Add required dependency to management api

### DIFF
--- a/src/Umbraco.Cms.Api.Common/DependencyInjection/UmbracoBuilderApiExtensions.cs
+++ b/src/Umbraco.Cms.Api.Common/DependencyInjection/UmbracoBuilderApiExtensions.cs
@@ -11,6 +11,11 @@ public static class UmbracoBuilderApiExtensions
 {
     public static IUmbracoBuilder AddUmbracoApiOpenApiUI(this IUmbracoBuilder builder)
     {
+        if(builder.Services.Any(x => x.ImplementationType == typeof(OperationIdSelector)))
+        {
+            return builder;
+        }
+
         builder.Services.AddSwaggerGen();
         builder.Services.ConfigureOptions<ConfigureUmbracoSwaggerGenOptions>();
         builder.Services.AddSingleton<IUmbracoJsonTypeInfoResolver, UmbracoJsonTypeInfoResolver>();

--- a/src/Umbraco.Cms.Api.Common/DependencyInjection/UmbracoBuilderApiExtensions.cs
+++ b/src/Umbraco.Cms.Api.Common/DependencyInjection/UmbracoBuilderApiExtensions.cs
@@ -11,7 +11,7 @@ public static class UmbracoBuilderApiExtensions
 {
     public static IUmbracoBuilder AddUmbracoApiOpenApiUI(this IUmbracoBuilder builder)
     {
-        if(builder.Services.Any(x => x.ImplementationType == typeof(OperationIdSelector)))
+        if (builder.Services.Any(x => x.ImplementationType == typeof(OperationIdSelector)))
         {
             return builder;
         }

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -22,6 +22,7 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddSingleton<BackOfficeAreaRoutes>();
         builder.Services.AddSingleton<BackOfficeExternalLoginProviderErrorMiddleware>();
         builder.Services.AddUnique<IConflictingRouteService, ConflictingRouteService>();
+        builder.AddUmbracoApiOpenApiUI();
 
         if (!services.Any(x => x.ImplementationType == typeof(JsonPatchService)))
         {


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/16516

# Notes
- Adds registration to management API aswell
- Adds check to see if we have already registered, to not register again

# How to test
- Remove `.AddDeliveryApi()` from `Program.cs`
- Program should be able to run