### PR TITLE
Add `IAsyncComponent` to allow async initialize/terminate

### DIFF
--- a/src/Umbraco.Core/Composing/AsyncComponentBase.cs
+++ b/src/Umbraco.Core/Composing/AsyncComponentBase.cs
@@ -1,0 +1,55 @@
+﻿namespace Umbraco.Cms.Core.Composing;
+
+/// <inheritdoc />
+/// <remarks>
+/// By default, the component will not execute if Umbraco is restarting.
+/// </remarks>
+public abstract class AsyncComponentBase : IAsyncComponent
+{
+    /// <inheritdoc />
+    public async Task InitializeAsync(bool isRestarting, CancellationToken cancellationToken)
+    {
+        if (CanExecute(isRestarting))
+        {
+            await InitializeAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task TerminateAsync(bool isRestarting, CancellationToken cancellationToken)
+    {
+        if (CanExecute(isRestarting))
+        {
+            await TerminateAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Determines whether the component can execute.
+    /// </summary>
+    /// <param name="isRestarting">If set to <c>true</c> indicates Umbraco is restarting.</param>
+    /// <returns>
+    ///   <c>true</c> if the component can execute; otherwise, <c>false</c>.
+    /// </returns>
+    protected virtual bool CanExecute(bool isRestarting)
+        => isRestarting is false;
+
+    /// <summary>
+    /// Initializes the component.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token. Cancellation indicates that the start process has been aborted.</param>
+    /// <returns>
+    /// A <see cref="Task" /> representing the asynchronous operation.
+    /// </returns>
+    protected abstract Task InitializeAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Terminates the component.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token. Cancellation indicates that the shutdown process should no longer be graceful.</param>
+    /// <returns>
+    /// A <see cref="Task" /> representing the asynchronous operation.
+    /// </returns>
+    protected virtual Task TerminateAsync(CancellationToken cancellationToken)
+        => Task.CompletedTask;
+}

--- a/src/Umbraco.Core/Composing/ComponentCollection.cs
+++ b/src/Umbraco.Core/Composing/ComponentCollection.cs
@@ -59,7 +59,6 @@ public class ComponentCollection : BuilderCollectionBase<IAsyncComponent>
                     try
                     {
                         await component.TerminateAsync(isRestarting, cancellationToken);
-                        await component.DisposeAsyncIfDisposable();
                     }
                     catch (Exception ex)
                     {

--- a/src/Umbraco.Core/Composing/ComponentCollection.cs
+++ b/src/Umbraco.Core/Composing/ComponentCollection.cs
@@ -5,59 +5,61 @@ using Umbraco.Extensions;
 namespace Umbraco.Cms.Core.Composing;
 
 /// <summary>
-///     Represents the collection of <see cref="IComponent" /> implementations.
+/// Represents the collection of <see cref="IAsyncComponent" /> implementations.
 /// </summary>
-public class ComponentCollection : BuilderCollectionBase<IComponent>
+public class ComponentCollection : BuilderCollectionBase<IAsyncComponent>
 {
     private const int LogThresholdMilliseconds = 100;
-    private readonly ILogger<ComponentCollection> _logger;
 
     private readonly IProfilingLogger _profilingLogger;
+    private readonly ILogger<ComponentCollection> _logger;
 
-    public ComponentCollection(Func<IEnumerable<IComponent>> items, IProfilingLogger profilingLogger, ILogger<ComponentCollection> logger)
+    public ComponentCollection(Func<IEnumerable<IAsyncComponent>> items, IProfilingLogger profilingLogger, ILogger<ComponentCollection> logger)
         : base(items)
     {
         _profilingLogger = profilingLogger;
         _logger = logger;
     }
 
-    public void Initialize()
+    public async Task InitializeAsync(bool isRestarting, CancellationToken cancellationToken)
     {
-        using (!_profilingLogger.IsEnabled(Logging.LogLevel.Debug) ? null : _profilingLogger.DebugDuration<ComponentCollection>(
-                   $"Initializing. (log components when >{LogThresholdMilliseconds}ms)", "Initialized."))
+        using (_profilingLogger.IsEnabled(Logging.LogLevel.Debug) is false
+            ? null
+            : _profilingLogger.DebugDuration<ComponentCollection>($"Initializing. (log components when >{LogThresholdMilliseconds}ms)", "Initialized."))
         {
-            foreach (IComponent component in this)
+            foreach (IAsyncComponent component in this)
             {
                 Type componentType = component.GetType();
-                using (!_profilingLogger.IsEnabled(Logging.LogLevel.Debug) ? null : _profilingLogger.DebugDuration<ComponentCollection>(
-                    $"Initializing {componentType.FullName}.",
-                    $"Initialized {componentType.FullName}.",
-                    thresholdMilliseconds: LogThresholdMilliseconds))
+
+                using (_profilingLogger.IsEnabled(Logging.LogLevel.Debug) is false
+                    ? null :
+                    _profilingLogger.DebugDuration<ComponentCollection>($"Initializing {componentType.FullName}.", $"Initialized {componentType.FullName}.", thresholdMilliseconds: LogThresholdMilliseconds))
                 {
-                    component.Initialize();
+                    await component.InitializeAsync(isRestarting, cancellationToken);
                 }
             }
         }
     }
 
-    public void Terminate()
+    public async Task TerminateAsync(bool isRestarting, CancellationToken cancellationToken)
     {
-        using (!_profilingLogger.IsEnabled(Logging.LogLevel.Debug) ? null : _profilingLogger.DebugDuration<ComponentCollection>(
-                   $"Terminating. (log components when >{LogThresholdMilliseconds}ms)", "Terminated."))
+        using (!_profilingLogger.IsEnabled(Logging.LogLevel.Debug)
+            ? null
+            : _profilingLogger.DebugDuration<ComponentCollection>($"Terminating. (log components when >{LogThresholdMilliseconds}ms)", "Terminated."))
         {
             // terminate components in reverse order
-            foreach (IComponent component in this.Reverse())
+            foreach (IAsyncComponent component in this.Reverse())
             {
                 Type componentType = component.GetType();
-                using (!_profilingLogger.IsEnabled(Logging.LogLevel.Debug) ? null : _profilingLogger.DebugDuration<ComponentCollection>(
-                    $"Terminating {componentType.FullName}.",
-                    $"Terminated {componentType.FullName}.",
-                    thresholdMilliseconds: LogThresholdMilliseconds))
+
+                using (_profilingLogger.IsEnabled(Logging.LogLevel.Debug) is false
+                    ? null
+                    : _profilingLogger.DebugDuration<ComponentCollection>($"Terminating {componentType.FullName}.", $"Terminated {componentType.FullName}.", thresholdMilliseconds: LogThresholdMilliseconds))
                 {
                     try
                     {
-                        component.Terminate();
-                        component.DisposeIfDisposable();
+                        await component.TerminateAsync(isRestarting, cancellationToken);
+                        await component.DisposeAsyncIfDisposable();
                     }
                     catch (Exception ex)
                     {

--- a/src/Umbraco.Core/Composing/ComponentCollectionBuilder.cs
+++ b/src/Umbraco.Core/Composing/ComponentCollectionBuilder.cs
@@ -4,35 +4,33 @@ using Umbraco.Cms.Core.Logging;
 namespace Umbraco.Cms.Core.Composing;
 
 /// <summary>
-///     Builds a <see cref="ComponentCollection" />.
+/// Builds a <see cref="ComponentCollection" />.
 /// </summary>
-public class
-    ComponentCollectionBuilder : OrderedCollectionBuilderBase<ComponentCollectionBuilder, ComponentCollection,
-        IComponent>
+public class ComponentCollectionBuilder : OrderedCollectionBuilderBase<ComponentCollectionBuilder, ComponentCollection, IAsyncComponent>
 {
     private const int LogThresholdMilliseconds = 100;
 
     protected override ComponentCollectionBuilder This => this;
 
-    protected override IEnumerable<IComponent> CreateItems(IServiceProvider factory)
+    protected override IEnumerable<IAsyncComponent> CreateItems(IServiceProvider factory)
     {
         IProfilingLogger logger = factory.GetRequiredService<IProfilingLogger>();
 
-        using (!logger.IsEnabled(Logging.LogLevel.Debug) ? null : logger.DebugDuration<ComponentCollectionBuilder>(
-                   $"Creating components. (log when >{LogThresholdMilliseconds}ms)", "Created."))
+        using (logger.IsEnabled(Logging.LogLevel.Debug) is false
+            ? null
+            : logger.DebugDuration<ComponentCollectionBuilder>($"Creating components. (log when >{LogThresholdMilliseconds}ms)", "Created."))
         {
             return base.CreateItems(factory);
         }
     }
 
-    protected override IComponent CreateItem(IServiceProvider factory, Type itemType)
+    protected override IAsyncComponent CreateItem(IServiceProvider factory, Type itemType)
     {
         IProfilingLogger logger = factory.GetRequiredService<IProfilingLogger>();
 
-        using (!logger.IsEnabled(Logging.LogLevel.Debug) ? null : logger.DebugDuration<ComponentCollectionBuilder>(
-            $"Creating {itemType.FullName}.",
-            $"Created {itemType.FullName}.",
-            thresholdMilliseconds: LogThresholdMilliseconds))
+        using (logger.IsEnabled(Logging.LogLevel.Debug) is false
+            ? null :
+            logger.DebugDuration<ComponentCollectionBuilder>($"Creating {itemType.FullName}.", $"Created {itemType.FullName}.", thresholdMilliseconds: LogThresholdMilliseconds))
         {
             return base.CreateItem(factory, itemType);
         }

--- a/src/Umbraco.Core/Composing/ComponentComposer.cs
+++ b/src/Umbraco.Core/Composing/ComponentComposer.cs
@@ -1,18 +1,23 @@
-﻿using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
 
 namespace Umbraco.Cms.Core.Composing;
 
 /// <summary>
-///     Provides a base class for composers which compose a component.
+/// Provides a composer that appends a component.
 /// </summary>
-/// <typeparam name="TComponent">The type of the component</typeparam>
+/// <typeparam name="TComponent">The type of the component.</typeparam>
+/// <remarks>
+/// Thanks to this class, a component that does not compose anything can be registered with one line:
+/// <code>
+/// <![CDATA[
+/// public class MyComponentComposer : ComponentComposer<MyComponent> { }
+/// ]]>
+/// </code>
+/// </remarks>
 public abstract class ComponentComposer<TComponent> : IComposer
-    where TComponent : IComponent
+    where TComponent : IAsyncComponent
 {
     /// <inheritdoc />
-    public virtual void Compose(IUmbracoBuilder builder) => builder.Components().Append<TComponent>();
-
-    // note: thanks to this class, a component that does not compose anything can be
-    // registered with one line:
-    // public class MyComponentComposer : ComponentComposer<MyComponent> { }
+    public virtual void Compose(IUmbracoBuilder builder)
+        => builder.Components().Append<TComponent>();
 }

--- a/src/Umbraco.Core/Composing/IAsyncComponent.cs
+++ b/src/Umbraco.Core/Composing/IAsyncComponent.cs
@@ -10,9 +10,6 @@ namespace Umbraco.Cms.Core.Composing;
 /// <para>
 /// All components are terminated in reverse order when Umbraco terminates, and disposable components are disposed.
 /// </para>
-/// <para>
-/// The Dispose method may be invoked more than once, and components should ensure they support this.
-/// </para>
 /// </remarks>
 public interface IAsyncComponent
 {

--- a/src/Umbraco.Core/Composing/IAsyncComponent.cs
+++ b/src/Umbraco.Core/Composing/IAsyncComponent.cs
@@ -1,0 +1,38 @@
+namespace Umbraco.Cms.Core.Composing;
+
+/// <summary>
+/// Represents a component.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Components are created by DI and therefore must have a public constructor.
+/// </para>
+/// <para>
+/// All components are terminated in reverse order when Umbraco terminates, and disposable components are disposed.
+/// </para>
+/// <para>
+/// The Dispose method may be invoked more than once, and components should ensure they support this.
+/// </para>
+/// </remarks>
+public interface IAsyncComponent
+{
+    /// <summary>
+    /// Initializes the component.
+    /// </summary>
+    /// <param name="isRestarting">If set to <c>true</c> indicates Umbraco is restarting.</param>
+    /// <param name="cancellationToken">The cancellation token. Cancellation indicates that the start process has been aborted.</param>
+    /// <returns>
+    /// A <see cref="Task" /> representing the asynchronous operation.
+    /// </returns>
+    Task InitializeAsync(bool isRestarting, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Terminates the component.
+    /// </summary>
+    /// <param name="isRestarting">If set to <c>true</c> indicates Umbraco is restarting.</param>
+    /// <param name="cancellationToken">The cancellation token. Cancellation indicates that the shutdown process should no longer be graceful.</param>
+    /// <returns>
+    /// A <see cref="Task" /> representing the asynchronous operation.
+    /// </returns>
+    Task TerminateAsync(bool isRestarting, CancellationToken cancellationToken);
+}

--- a/src/Umbraco.Core/Composing/IComponent.cs
+++ b/src/Umbraco.Core/Composing/IComponent.cs
@@ -1,19 +1,6 @@
 namespace Umbraco.Cms.Core.Composing;
 
-/// <summary>
-/// Represents a component.
-/// </summary>
-/// <remarks>
-/// <para>
-/// Components are created by DI and therefore must have a public constructor.
-/// </para>
-/// <para>
-/// All components are terminated in reverse order when Umbraco terminates, and disposable components are disposed.
-/// </para>
-/// <para>
-/// The Dispose method may be invoked more than once, and components should ensure they support this.
-/// </para>
-/// </remarks>
+/// <inheritdoc />
 [Obsolete("Use IAsyncComponent instead. This interface will be removed in a future version.")]
 public interface IComponent : IAsyncComponent
 {

--- a/src/Umbraco.Core/Composing/IComponent.cs
+++ b/src/Umbraco.Core/Composing/IComponent.cs
@@ -1,28 +1,45 @@
 namespace Umbraco.Cms.Core.Composing;
 
 /// <summary>
-///     Represents a component.
+/// Represents a component.
 /// </summary>
 /// <remarks>
-///     <para>Components are created by DI and therefore must have a public constructor.</para>
-///     <para>
-///         All components are terminated in reverse order when Umbraco terminates, and
-///         disposable components are disposed.
-///     </para>
-///     <para>
-///         The Dispose method may be invoked more than once, and components
-///         should ensure they support this.
-///     </para>
+/// <para>
+/// Components are created by DI and therefore must have a public constructor.
+/// </para>
+/// <para>
+/// All components are terminated in reverse order when Umbraco terminates, and disposable components are disposed.
+/// </para>
+/// <para>
+/// The Dispose method may be invoked more than once, and components should ensure they support this.
+/// </para>
 /// </remarks>
-public interface IComponent
+[Obsolete("Use IAsyncComponent instead. This interface will be removed in a future version.")]
+public interface IComponent : IAsyncComponent
 {
     /// <summary>
-    ///     Initializes the component.
+    /// Initializes the component.
     /// </summary>
     void Initialize();
 
     /// <summary>
-    ///     Terminates the component.
+    /// Terminates the component.
     /// </summary>
     void Terminate();
+
+    /// <inheritdoc />
+    Task IAsyncComponent.InitializeAsync(bool isRestarting, CancellationToken cancellationToken)
+    {
+        Initialize();
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    Task IAsyncComponent.TerminateAsync(bool isRestarting, CancellationToken cancellationToken)
+    {
+        Terminate();
+
+        return Task.CompletedTask;
+    }
 }

--- a/src/Umbraco.Core/Composing/RuntimeAsyncComponentBase.cs
+++ b/src/Umbraco.Core/Composing/RuntimeAsyncComponentBase.cs
@@ -1,0 +1,23 @@
+﻿using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Core.Composing;
+
+/// <inheritdoc />
+/// <remarks>
+/// By default, the component will not execute if Umbraco is restarting or the runtime level is not <see cref="RuntimeLevel.Run" />.
+/// </remarks>
+public abstract class RuntimeAsyncComponentBase : AsyncComponentBase
+{
+    private readonly IRuntimeState _runtimeState;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RuntimeAsyncComponentBase" /> class.
+    /// </summary>
+    /// <param name="runtimeState">State of the Umbraco runtime.</param>
+    protected RuntimeAsyncComponentBase(IRuntimeState runtimeState)
+        => _runtimeState = runtimeState;
+
+    /// <inheritdoc />
+    protected override bool CanExecute(bool isRestarting)
+        => base.CanExecute(isRestarting) && _runtimeState.Level == RuntimeLevel.Run;
+}

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
@@ -21,7 +21,7 @@ public static partial class UmbracoBuilderExtensions
     /// The builder.
     /// </returns>
     public static IUmbracoBuilder AddComponent<T>(this IUmbracoBuilder builder)
-        where T : IComponent
+        where T : IAsyncComponent
     {
         builder.Components().Append<T>();
 

--- a/src/Umbraco.Core/Extensions/ObjectExtensions.cs
+++ b/src/Umbraco.Core/Extensions/ObjectExtensions.cs
@@ -53,22 +53,6 @@ public static class ObjectExtensions
     }
 
     /// <summary>
-    /// Disposes the object if it implements <see cref="IAsyncDisposable" /> or <see cref="IDisposable" />.
-    /// </summary>
-    /// <param name="input">The object.</param>
-    public static async Task DisposeAsyncIfDisposable(this object input)
-    {
-        if (input is IAsyncDisposable disposable)
-        {
-            await disposable.DisposeAsync();
-        }
-        else
-        {
-            input.DisposeIfDisposable();
-        }
-    }
-
-    /// <summary>
     ///     Provides a shortcut way of safely casting an input when you cannot guarantee the <typeparamref name="T" /> is
     ///     an instance type (i.e., when the C# AS keyword is not applicable).
     /// </summary>

--- a/src/Umbraco.Core/Extensions/ObjectExtensions.cs
+++ b/src/Umbraco.Core/Extensions/ObjectExtensions.cs
@@ -41,13 +41,30 @@ public static class ObjectExtensions
     public static IEnumerable<T> AsEnumerableOfOne<T>(this T input) => Enumerable.Repeat(input, 1);
 
     /// <summary>
+    /// Disposes the object if it implements <see cref="IDisposable" />.
     /// </summary>
-    /// <param name="input"></param>
+    /// <param name="input">The object.</param>
     public static void DisposeIfDisposable(this object input)
     {
         if (input is IDisposable disposable)
         {
             disposable.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Disposes the object if it implements <see cref="IAsyncDisposable" /> or <see cref="IDisposable" />.
+    /// </summary>
+    /// <param name="input">The object.</param>
+    public static async Task DisposeAsyncIfDisposable(this object input)
+    {
+        if (input is IAsyncDisposable disposable)
+        {
+            await disposable.DisposeAsync();
+        }
+        else
+        {
+            input.DisposeIfDisposable();
         }
     }
 

--- a/src/Umbraco.Core/Notifications/UmbracoApplicationStartingNotification.cs
+++ b/src/Umbraco.Core/Notifications/UmbracoApplicationStartingNotification.cs
@@ -1,28 +1,26 @@
 namespace Umbraco.Cms.Core.Notifications;
 
 /// <summary>
-///     Notification that occurs at the very end of the Umbraco boot process (after all <see cref="Composing.IComponent" />s are
-/// initialized).
+/// Notification that occurs at the very end of the Umbraco boot process (after all components are initialized).
+/// </summary>
+public class UmbracoApplicationStartingNotification : IUmbracoApplicationLifetimeNotification
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UmbracoApplicationStartingNotification" /> class.
     /// </summary>
-    /// <seealso cref="IUmbracoApplicationLifetimeNotification" />
-    public class UmbracoApplicationStartingNotification : IUmbracoApplicationLifetimeNotification
+    /// <param name="runtimeLevel">The runtime level</param>
+    /// <param name="isRestarting">Indicates whether Umbraco is restarting.</param>
+    public UmbracoApplicationStartingNotification(RuntimeLevel runtimeLevel, bool isRestarting)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UmbracoApplicationStartingNotification" /> class.
-        /// </summary>
-        /// <param name="runtimeLevel">The runtime level</param>
-        /// <param name="isRestarting">Indicates whether Umbraco is restarting.</param>
-        public UmbracoApplicationStartingNotification(RuntimeLevel runtimeLevel, bool isRestarting)
-        {
-            RuntimeLevel = runtimeLevel;
-            IsRestarting = isRestarting;
-        }
+        RuntimeLevel = runtimeLevel;
+        IsRestarting = isRestarting;
+    }
 
     /// <summary>
-    ///     Gets the runtime level.
+    /// Gets the runtime level.
     /// </summary>
     /// <value>
-    ///     The runtime level.
+    /// The runtime level.
     /// </value>
     public RuntimeLevel RuntimeLevel { get; }
 

--- a/src/Umbraco.Core/Notifications/UmbracoApplicationStoppingNotification.cs
+++ b/src/Umbraco.Core/Notifications/UmbracoApplicationStoppingNotification.cs
@@ -1,17 +1,16 @@
 namespace Umbraco.Cms.Core.Notifications;
 
-
+/// <summary>
+/// Notification that occurs when Umbraco is shutting down (after all components are terminated).
+/// </summary>
+public class UmbracoApplicationStoppingNotification : IUmbracoApplicationLifetimeNotification
+{
     /// <summary>
-    /// Notification that occurs when Umbraco is shutting down (after all <see cref="Composing.IComponent" />s are terminated).
+    /// Initializes a new instance of the <see cref="UmbracoApplicationStoppingNotification" /> class.
     /// </summary>
-    /// <seealso cref="IUmbracoApplicationLifetimeNotification" />
-    public class UmbracoApplicationStoppingNotification : IUmbracoApplicationLifetimeNotification
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UmbracoApplicationStoppingNotification" /> class.
-        /// </summary>
-        /// <param name="isRestarting">Indicates whether Umbraco is restarting.</param>
-        public UmbracoApplicationStoppingNotification(bool isRestarting) => IsRestarting = isRestarting;
+    /// <param name="isRestarting">Indicates whether Umbraco is restarting.</param>
+    public UmbracoApplicationStoppingNotification(bool isRestarting)
+        => IsRestarting = isRestarting;
 
     /// <inheritdoc />
     public bool IsRestarting { get; }

--- a/src/Umbraco.Infrastructure/Runtime/CoreRuntime.cs
+++ b/src/Umbraco.Infrastructure/Runtime/CoreRuntime.cs
@@ -222,7 +222,7 @@ public class CoreRuntime : IRuntime
         }
 
         // Initialize the components
-        _components.Initialize();
+        await _components.InitializeAsync(isRestarting, cancellationToken);
 
         await _eventAggregator.PublishAsync(new UmbracoApplicationStartingNotification(State.Level, isRestarting), cancellationToken);
 
@@ -236,7 +236,7 @@ public class CoreRuntime : IRuntime
 
     private async Task StopAsync(CancellationToken cancellationToken, bool isRestarting)
     {
-        _components.Terminate();
+        await _components.TerminateAsync(isRestarting, cancellationToken);
         await _eventAggregator.PublishAsync(new UmbracoApplicationStoppingNotification(isRestarting), cancellationToken);
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Components/ComponentTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Components/ComponentTests.cs
@@ -80,7 +80,9 @@ public class ComponentTests
             Options.Create(new ContentSettings()));
         var eventAggregator = Mock.Of<IEventAggregator>();
         var scopeProvider = new ScopeProvider(
-            new AmbientScopeStack(), new AmbientScopeContextStack(),Mock.Of<IDistributedLockingMechanismFactory>(),
+            new AmbientScopeStack(),
+            new AmbientScopeContextStack(),
+            Mock.Of<IDistributedLockingMechanismFactory>(),
             f,
             fs,
             new TestOptionsMonitor<CoreDebugSettings>(coreDebug),
@@ -113,7 +115,7 @@ public class ComponentTests
         Mock.Of<IProfiler>());
 
     [Test]
-    public void Boot1A()
+    public async Task Boot1A()
     {
         var register = MockRegister();
         var composition = new UmbracoBuilder(register, Mock.Of<IConfiguration>(), TestHelper.GetMockedTypeLoader());
@@ -157,7 +159,7 @@ public class ComponentTests
                 {
                     return Mock.Of<ILogger<ComponentCollection>>();
                 }
-                
+
                 if (type == typeof(ILogger<ComponentCollection>))
                 {
                     return Mock.Of<ILogger<ComponentCollection>>();
@@ -176,9 +178,9 @@ public class ComponentTests
         var components = builder.CreateCollection(factory);
 
         Assert.IsEmpty(components);
-        components.Initialize();
+        await components.InitializeAsync(false, default);
         Assert.IsEmpty(Initialized);
-        components.Terminate();
+        await components.TerminateAsync(false, default);
         Assert.IsEmpty(Terminated);
     }
 
@@ -277,7 +279,7 @@ public class ComponentTests
     }
 
     [Test]
-    public void Initialize()
+    public async Task Initialize()
     {
         Composed.Clear();
         Initialized.Clear();
@@ -324,7 +326,7 @@ public class ComponentTests
                 {
                     return Mock.Of<ILogger<ComponentCollection>>();
                 }
-                
+
                 if (type == typeof(IServiceProviderIsService))
                 {
                     return Mock.Of<IServiceProviderIsService>();
@@ -347,11 +349,11 @@ public class ComponentTests
         var components = builder.CreateCollection(factory);
 
         Assert.IsEmpty(Initialized);
-        components.Initialize();
+        await components.InitializeAsync(false, default);
         AssertTypeArray(TypeArray<Component5, Component5a>(), Initialized);
 
         Assert.IsEmpty(Terminated);
-        components.Terminate();
+        await components.TerminateAsync(false, default);
         AssertTypeArray(TypeArray<Component5a, Component5>(), Terminated);
     }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
As mentioned in https://github.com/umbraco/Umbraco-CMS/pull/16430#issuecomment-2139162134, it's currently not possible to (correctly) use async methods in components. This adds `IAsyncComponent` and refactors the code to call the `InitializeAsync()`/`TerminateAsync()` methods instead, which does mean a breaking change in the `ComponentCollection` (the item type and methods have changed). I did make `IComponent` inherit from `IAsyncComponent` and added default interface methods, so any existing (synchronous) components are still backwards compatible.

I've also added 2 base classes to make usage easier:
- `AsyncComponentBase` - this only initializes/terminates when the application isn't restarting (aka the actual start/stop of the application) and implements a no-op `TerminateAsync()` method (as most implementations only require initialization);
- `RuntimeAsyncComponentBase` - inheriting from `AsyncComponentBase` and also takes the runtime level into account, so it only initializes/terminates when the application is running normally.

_I'll add some example components to help test later..._