### PR TITLE
V13: Update to sqlraw query

### DIFF
--- a/src/Umbraco.Cms.Persistence.EFCore/Locking/SqlServerEFCoreDistributedLockingMechanism.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/Locking/SqlServerEFCoreDistributedLockingMechanism.cs
@@ -170,7 +170,7 @@ internal class SqlServerEFCoreDistributedLockingMechanism<T> : IDistributedLocki
                         "A transaction with minimum ReadCommitted isolation level is required.");
                 }
 
-                var rowsAffected = await dbContext.Database.ExecuteSqlAsync(@$"SET LOCK_TIMEOUT {(int)_timeout.TotalMilliseconds};UPDATE umbracoLock WITH (REPEATABLEREAD) SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id={LockId}");
+                var rowsAffected = await dbContext.Database.ExecuteSqlRawAsync(@$"SET LOCK_TIMEOUT {(int)_timeout.TotalMilliseconds};UPDATE umbracoLock WITH (REPEATABLEREAD) SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id={LockId}");
 
                 if (rowsAffected == 0)
                 {


### PR DESCRIPTION
# Notes
- Updates `ExecuteSqlAsync` query to `ExecuteSqlRawAsync`, as that was what the timeout query was before, and there is luckily no chance of SqlInjection, as we're only interpolating integers.
- Sidenote: I have no idea why the syntax does not work with `ExecuteSqlAsync` 😕 

# How to test
- In the `Umbraco.Tests.Integration` project, change your `appsettings.Tests.json` file to run local db:

```
"Tests": {
    "Database": {
      "DatabaseType": "LocalDb",
      "PrepareThreadCount": 4,
      "SchemaDatabaseCount": 4,
      "EmptyDatabasesCount": 2,
      "SQLServerMasterConnectionString": ""
    }
  },
```

- run the `Can_Reacquire_Write_Lock` test, it should now pass 🙌 