### PR TITLE
Add custom mvc setup method to testserver base class

### DIFF
--- a/tests/Umbraco.Tests.Integration/TestServerTest/UmbracoTestServerTestBase.cs
+++ b/tests/Umbraco.Tests.Integration/TestServerTest/UmbracoTestServerTestBase.cs
@@ -278,6 +278,8 @@ namespace Umbraco.Cms.Tests.Integration.TestServerTest
 
                     // Adds Umbraco.Tests.Integration
                     mvcBuilder.AddApplicationPart(typeof(UmbracoTestServerTestBase).Assembly);
+
+                    CustomMvcSetup(mvcBuilder);
                 })
                 .AddWebServer()
                 .AddWebsite()
@@ -292,6 +294,11 @@ namespace Umbraco.Cms.Tests.Integration.TestServerTest
 
 
             builder.Build();
+        }
+
+        protected virtual void CustomMvcSetup(IMvcBuilder mvcBuilder)
+        {
+            
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description
In order to use `UmbracoTestServerTestBase` with view files outside the test project, we need to be able to customize the `IMvcBuilder` setup. This addition opens up the setup so that the builder can be modified during setup.

For instance:

![image](https://github.com/umbraco/Umbraco-CMS/assets/350918/472525d0-8246-48fa-9a5f-3c8109a18115)

I would love for this to be backported to 13 as well.
(Here's to hoping all the bugs aren't found yet) 
