### PR TITLE
POC: Feat/make indexing more resiliant

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/IndexingSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/IndexingSettings.cs
@@ -15,4 +15,8 @@ public class IndexingSettings
     /// </summary>
     [DefaultValue(StaticExplicitlyIndexEachNestedProperty)]
     public bool ExplicitlyIndexEachNestedProperty { get; set; } = StaticExplicitlyIndexEachNestedProperty;
+    /// <summary>
+    /// Defines how many items to index in a single page
+    /// </summary>
+    public int IndexingPageSize { get; set; } = 10000;
 }

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Examine.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Examine.cs
@@ -57,7 +57,7 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddUnique<IDeliveryApiContentIndexFieldDefinitionBuilder, DeliveryApiContentIndexFieldDefinitionBuilder>();
         builder.Services.AddUnique<IDeliveryApiContentIndexHelper, DeliveryApiContentIndexHelper>();
         builder.Services.AddSingleton<IDeliveryApiIndexingHandler, DeliveryApiIndexingHandler>();
-
+        builder.Services.AddSingleton<IIndexRebuildStatusManager, IndexRebuildStatusManager>();
         builder.Services.AddSingleton<ExamineIndexRebuilder>();  //TODO remove in Umbraco 15. Only the interface should be in the service provider
 
         builder.Services.AddUnique<IDeliveryApiCompositeIdHandler, DeliveryApiCompositeIdHandler>();

--- a/src/Umbraco.Infrastructure/Examine/ContentIndexPopulator.cs
+++ b/src/Umbraco.Infrastructure/Examine/ContentIndexPopulator.cs
@@ -1,5 +1,9 @@
 using Examine;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Querying;
 using Umbraco.Cms.Core.Services;
@@ -14,6 +18,7 @@ public class ContentIndexPopulator : IndexPopulator<IUmbracoContentIndex>
 {
     private readonly IContentService _contentService;
     private readonly IValueSetBuilder<IContent> _contentValueSetBuilder;
+    private IndexingSettings _indexingSettings;
     private readonly ILogger<ContentIndexPopulator> _logger;
     private readonly int? _parentId;
 
@@ -28,6 +33,7 @@ public class ContentIndexPopulator : IndexPopulator<IUmbracoContentIndex>
     /// <summary>
     ///     Default constructor to lookup all content data
     /// </summary>
+    [Obsolete("Use the constructor with IOptionsMonitor<IndexingSettings>")]
     public ContentIndexPopulator(
         ILogger<ContentIndexPopulator> logger,
         IContentService contentService,
@@ -40,13 +46,14 @@ public class ContentIndexPopulator : IndexPopulator<IUmbracoContentIndex>
     /// <summary>
     ///     Optional constructor allowing specifying custom query parameters
     /// </summary>
+    [Obsolete("Use the constructor with IOptionsMonitor<IndexingSettings>")]
     public ContentIndexPopulator(
         ILogger<ContentIndexPopulator> logger,
         bool publishedValuesOnly,
         int? parentId,
         IContentService contentService,
         IUmbracoDatabaseFactory umbracoDatabaseFactory,
-        IValueSetBuilder<IContent> contentValueSetBuilder)
+        IValueSetBuilder<IContent> contentValueSetBuilder) : this(logger, publishedValuesOnly, parentId, contentService, umbracoDatabaseFactory, contentValueSetBuilder, StaticServiceProvider.Instance.GetRequiredService<IOptionsMonitor<IndexingSettings>>())
     {
         _contentService = contentService ?? throw new ArgumentNullException(nameof(contentService));
         _umbracoDatabaseFactory = umbracoDatabaseFactory ?? throw new ArgumentNullException(nameof(umbracoDatabaseFactory));
@@ -55,7 +62,37 @@ public class ContentIndexPopulator : IndexPopulator<IUmbracoContentIndex>
         _publishedValuesOnly = publishedValuesOnly;
         _parentId = parentId;
     }
+    public ContentIndexPopulator(
+        ILogger<ContentIndexPopulator> logger,
+        IContentService contentService,
+        IUmbracoDatabaseFactory umbracoDatabaseFactory,
+        IContentValueSetBuilder contentValueSetBuilder,
+        IOptionsMonitor<IndexingSettings> indexingSettings)
+        : this(logger, false, null, contentService, umbracoDatabaseFactory, contentValueSetBuilder,indexingSettings)
+    {
+    }
+    public ContentIndexPopulator(
+        ILogger<ContentIndexPopulator> logger,
+        bool publishedValuesOnly,
+        int? parentId,
+        IContentService contentService,
+        IUmbracoDatabaseFactory umbracoDatabaseFactory,
+        IValueSetBuilder<IContent> contentValueSetBuilder,
+        IOptionsMonitor<IndexingSettings> indexingSettings)
+    {
+        _contentService = contentService ?? throw new ArgumentNullException(nameof(contentService));
+        _umbracoDatabaseFactory = umbracoDatabaseFactory ?? throw new ArgumentNullException(nameof(umbracoDatabaseFactory));
+        _contentValueSetBuilder = contentValueSetBuilder ?? throw new ArgumentNullException(nameof(contentValueSetBuilder));
+        _indexingSettings = indexingSettings.CurrentValue;
+        indexingSettings.OnChange(change =>
+        {
+            _indexingSettings = change;
+        });
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _publishedValuesOnly = publishedValuesOnly;
+        _parentId = parentId;
 
+    }
     private IQuery<IContent> PublishedQuery => _publishedQuery ??=
         _umbracoDatabaseFactory.SqlContext.Query<IContent>().Where(x => x.Published);
 
@@ -75,7 +112,7 @@ public class ContentIndexPopulator : IndexPopulator<IUmbracoContentIndex>
             return;
         }
 
-        const int pageSize = 10000;
+
         var pageIndex = 0;
 
         var contentParentId = -1;
@@ -86,11 +123,11 @@ public class ContentIndexPopulator : IndexPopulator<IUmbracoContentIndex>
 
         if (_publishedValuesOnly)
         {
-            IndexPublishedContent(contentParentId, pageIndex, pageSize, indexes);
+            IndexPublishedContent(contentParentId, pageIndex, _indexingSettings.IndexingPageSize, indexes);
         }
         else
         {
-            IndexAllContent(contentParentId, pageIndex, pageSize, indexes);
+            IndexAllContent(contentParentId, pageIndex, _indexingSettings.IndexingPageSize, indexes);
         }
     }
 

--- a/src/Umbraco.Infrastructure/Examine/IIndexRebuildStatusManager.cs
+++ b/src/Umbraco.Infrastructure/Examine/IIndexRebuildStatusManager.cs
@@ -1,0 +1,7 @@
+﻿namespace Umbraco.Cms.Infrastructure.Examine;
+
+public interface IIndexRebuildStatusManager
+{
+    void SetRebuildingIndexStatus(IEnumerable<string> indexes, bool b);
+    bool GetRebuildingIndexStatus(string index);
+}

--- a/src/Umbraco.Infrastructure/Examine/IndexRebuildStatusManager.cs
+++ b/src/Umbraco.Infrastructure/Examine/IndexRebuildStatusManager.cs
@@ -1,0 +1,28 @@
+using Examine;
+
+namespace Umbraco.Cms.Infrastructure.Examine;
+
+/// <summary>
+///
+/// </summary>
+public class IndexRebuildStatusManager : IIndexRebuildStatusManager
+{
+    IDictionary<string,bool> _rebuildingStatus = new Dictionary<string, bool>();
+    public IndexRebuildStatusManager(IExamineManager examineManager)
+    {
+        foreach (var index in examineManager.Indexes)
+        {
+            _rebuildingStatus.Add(index.Name, false);
+        }
+    }
+
+    public void SetRebuildingIndexStatus(IEnumerable<string> indexes, bool isRebuilding)
+    {
+        foreach (var index in indexes)
+        {
+            _rebuildingStatus[index] = isRebuilding;
+        }
+    }
+
+    public bool GetRebuildingIndexStatus(string index) => _rebuildingStatus.TryGetValue(index, out var isRebuilding) && isRebuilding;
+}


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [<!-- link to the issue here! -->](https://github.com/umbraco/Umbraco-CMS/issues/13498)

### Description
This Pr is POC for  solving issue with rebuilding of indexes on startup. Also adding small flexibility around page size when reindexing as current we pulled 10k nodes, which if they have more than 100 properties might cause really slow indexing when we pull more than 1k. I am making it as POC as won't spend more time on this pr unless HQ confirm this is the way and I should improve code in this pr.

<!-- Thanks for contributing to Umbraco CMS! -->
