### PR TITLE
OpenIddict should only handle `/umbraco/` requests

### DIFF
--- a/src/Umbraco.Cms.Api.Common/DependencyInjection/ProcessRequestContextHandler.cs
+++ b/src/Umbraco.Cms.Api.Common/DependencyInjection/ProcessRequestContextHandler.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.AspNetCore.Http;
+using OpenIddict.Server;
+using OpenIddict.Validation;
+using Umbraco.Cms.Core;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Common.DependencyInjection;
+
+public class ProcessRequestContextHandler
+    : IOpenIddictServerHandler<OpenIddictServerEvents.ProcessRequestContext>, IOpenIddictValidationHandler<OpenIddictValidationEvents.ProcessRequestContext>
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly string _backOfficePathSegment;
+
+    public ProcessRequestContextHandler(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+        _backOfficePathSegment = Constants.System.DefaultUmbracoPath.TrimStart(Constants.CharArrays.Tilde)
+            .EnsureStartsWith('/')
+            .EnsureEndsWith('/');
+    }
+
+    public ValueTask HandleAsync(OpenIddictServerEvents.ProcessRequestContext context)
+    {
+        if (SkipOpenIddictHandlingForRequest())
+        {
+            context.SkipRequest();
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask HandleAsync(OpenIddictValidationEvents.ProcessRequestContext context)
+    {
+        if (SkipOpenIddictHandlingForRequest())
+        {
+            context.SkipRequest();
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    private bool SkipOpenIddictHandlingForRequest()
+    {
+        var requestPath = _httpContextAccessor.HttpContext?.Request.Path.Value;
+        if (requestPath.IsNullOrWhiteSpace())
+        {
+            return false;
+        }
+
+        return requestPath.StartsWith(_backOfficePathSegment) is false;
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

OpenIddict performs initial request context processing for every last request to the server - including front-end requests. While this handling is not terribly costly, there really is no reason for it unless a `/umbraco/` request is in progress.

### Testing this PR

1. First and foremost, the backoffice should work as per usual 😄 
2. Enable verbose logging and verify that the OpenIddict request processing is only invoked for `/umbraco/` requests.
3. Setup [member auth](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api) for the Delivery API and verify that this still works.

Particularly the last point is a little tricky to get right. Get in touch with @kjac for a pair testing session 👍 