### PR TITLE
RTE and media picker should route medias the same way in the Delivery API

### DIFF
--- a/src/Umbraco.Core/DeliveryApi/ApiMediaUrlProvider.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiMediaUrlProvider.cs
@@ -17,6 +17,6 @@ public sealed class ApiMediaUrlProvider : IApiMediaUrlProvider
             throw new ArgumentException("Media URLs can only be generated from Media items.", nameof(media));
         }
 
-        return _publishedUrlProvider.GetMediaUrl(media, UrlMode.Relative);
+        return _publishedUrlProvider.GetMediaUrl(media);
     }
 }

--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs
@@ -22,28 +22,13 @@ internal sealed class ApiRichTextElementParser : ApiRichTextParserBase, IApiRich
     private const string TextNodeName = "#text";
     private const string CommentNodeName = "#comment";
 
-    [Obsolete($"Please use the constructor that accepts {nameof(IApiElementBuilder)}. Will be removed in V15.")]
     public ApiRichTextElementParser(
         IApiContentRouteBuilder apiContentRouteBuilder,
-        IPublishedUrlProvider publishedUrlProvider,
-        IPublishedSnapshotAccessor publishedSnapshotAccessor,
-        ILogger<ApiRichTextElementParser> logger)
-        : this(
-            apiContentRouteBuilder,
-            publishedUrlProvider,
-            publishedSnapshotAccessor,
-            StaticServiceProvider.Instance.GetRequiredService<IApiElementBuilder>(),
-            logger)
-    {
-    }
-
-    public ApiRichTextElementParser(
-        IApiContentRouteBuilder apiContentRouteBuilder,
-        IPublishedUrlProvider publishedUrlProvider,
+        IApiMediaUrlProvider mediaUrlProvider,
         IPublishedSnapshotAccessor publishedSnapshotAccessor,
         IApiElementBuilder apiElementBuilder,
         ILogger<ApiRichTextElementParser> logger)
-        : base(apiContentRouteBuilder, publishedUrlProvider)
+        : base(apiContentRouteBuilder, mediaUrlProvider)
     {
         _publishedSnapshotAccessor = publishedSnapshotAccessor;
         _apiElementBuilder = apiElementBuilder;

--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextMarkupParser.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextMarkupParser.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.PublishedCache;
-using Umbraco.Cms.Core.Routing;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.DeliveryApi;
@@ -15,10 +14,10 @@ internal sealed class ApiRichTextMarkupParser : ApiRichTextParserBase, IApiRichT
 
     public ApiRichTextMarkupParser(
         IApiContentRouteBuilder apiContentRouteBuilder,
-        IPublishedUrlProvider publishedUrlProvider,
+        IApiMediaUrlProvider mediaUrlProvider,
         IPublishedSnapshotAccessor publishedSnapshotAccessor,
         ILogger<ApiRichTextMarkupParser> logger)
-        : base(apiContentRouteBuilder, publishedUrlProvider)
+        : base(apiContentRouteBuilder, mediaUrlProvider)
     {
         _publishedSnapshotAccessor = publishedSnapshotAccessor;
         _logger = logger;

--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextParserBase.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextParserBase.cs
@@ -4,19 +4,18 @@ using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Models.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
-using Umbraco.Cms.Core.Routing;
 
 namespace Umbraco.Cms.Infrastructure.DeliveryApi;
 
 internal abstract partial class ApiRichTextParserBase
 {
     private readonly IApiContentRouteBuilder _apiContentRouteBuilder;
-    private readonly IPublishedUrlProvider _publishedUrlProvider;
+    private readonly IApiMediaUrlProvider _apiMediaUrlProvider;
 
-    protected ApiRichTextParserBase(IApiContentRouteBuilder apiContentRouteBuilder, IPublishedUrlProvider publishedUrlProvider)
+    protected ApiRichTextParserBase(IApiContentRouteBuilder apiContentRouteBuilder, IApiMediaUrlProvider apiMediaUrlProvider)
     {
         _apiContentRouteBuilder = apiContentRouteBuilder;
-        _publishedUrlProvider = publishedUrlProvider;
+        _apiMediaUrlProvider = apiMediaUrlProvider;
     }
 
     protected void ReplaceLocalLinks(IPublishedSnapshot publishedSnapshot, string href, Action<IApiContentRoute> handleContentRoute, Action<string> handleMediaUrl, Action handleInvalidLink)
@@ -52,7 +51,7 @@ internal abstract partial class ApiRichTextParserBase
                 if (media != null)
                 {
                     handled = true;
-                    handleMediaUrl(_publishedUrlProvider.GetMediaUrl(media, UrlMode.Absolute));
+                    handleMediaUrl(_apiMediaUrlProvider.GetUrl(media));
                 }
 
                 break;
@@ -77,7 +76,7 @@ internal abstract partial class ApiRichTextParserBase
             return;
         }
 
-        handleMediaUrl(_publishedUrlProvider.GetMediaUrl(media, UrlMode.Absolute));
+        handleMediaUrl(_apiMediaUrlProvider.GetUrl(media));
     }
 
     [GeneratedRegex("{localLink:(?<udi>umb:.+)}")]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ApiMediaUrlProviderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ApiMediaUrlProviderTests.cs
@@ -21,7 +21,7 @@ public class ApiMediaUrlProviderTests : PropertyValueConverterTests
 
         var publishedUrlProvider = new Mock<IPublishedUrlProvider>();
         publishedUrlProvider
-            .Setup(p => p.GetMediaUrl(content.Object, UrlMode.Relative, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<Uri?>()))
+            .Setup(p => p.GetMediaUrl(content.Object, UrlMode.Default, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<Uri?>()))
             .Returns(publishedUrl);
 
         var apiMediaUrlProvider = new ApiMediaUrlProvider(publishedUrlProvider.Object);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/RichTextParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/RichTextParserTests.cs
@@ -9,7 +9,6 @@ using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 using Umbraco.Cms.Core.PublishedCache;
-using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Infrastructure.DeliveryApi;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.DeliveryApi;
@@ -474,7 +473,7 @@ public class RichTextParserTests : PropertyValueConverterTests
             Mock.Of<ILogger<ApiRichTextMarkupParser>>());
     }
 
-    private void SetupTestContent(out IApiContentRouteBuilder routeBuilder, out IPublishedSnapshotAccessor snapshotAccessor, out IPublishedUrlProvider urlProvider)
+    private void SetupTestContent(out IApiContentRouteBuilder routeBuilder, out IPublishedSnapshotAccessor snapshotAccessor, out IApiMediaUrlProvider apiMediaUrlProvider)
     {
         var contentMock = new Mock<IPublishedContent>();
         contentMock.SetupGet(m => m.Key).Returns(_contentKey);
@@ -502,14 +501,14 @@ public class RichTextParserTests : PropertyValueConverterTests
             .Setup(m => m.Build(contentMock.Object, null))
             .Returns(new ApiContentRoute("/some-content-path", new ApiContentStartItem(_contentRootKey, "the-root-path")));
 
-        var urlProviderMock = new Mock<IPublishedUrlProvider>();
-        urlProviderMock
-            .Setup(m => m.GetMediaUrl(mediaMock.Object, It.IsAny<UrlMode>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<Uri?>()))
+        var apiMediaUrlProviderMock = new Mock<IApiMediaUrlProvider>();
+        apiMediaUrlProviderMock
+            .Setup(m => m.GetUrl(mediaMock.Object))
             .Returns("/some-media-url");
 
         routeBuilder = routeBuilderMock.Object;
         snapshotAccessor = snapshotAccessorMock.Object;
-        urlProvider = urlProviderMock.Object;
+        apiMediaUrlProvider = apiMediaUrlProviderMock.Object;
     }
 
     private IPublishedElement CreateElement(Guid id, int propertyValue)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #16416

### Description

As described in #16416, the Delivery API outputs different media routes for the media picker and medias in RTE. This PR ensures that:

1. Media picker and RTE uses the same implementation (`IApiMediaUrlProvider`) to calculate media routes in the Delivery API.
2. The Delivery API respects `WebRoutingSettings.UrlProviderMode`.

### Testing this PR

Given a document with a media picker and an RTE (with a media inside), verify that the Delivery API output:

1. Contains the same media route (URL) for both properties.
2. Respects `WebRoutingSettings.UrlProviderMode` - e.g. setting it to explicitly render absolute URLs.
3. Also works when outputting RTE as JSON.

### Breaking change

This PR is behaviourally breaking. But the current behaviour is a bug - it should not behave like that. 