### PR TITLE
Do not rely on claims to figure out user access + prepare for claims removal

### DIFF
--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeAuthBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeAuthBuilderExtensions.cs
@@ -29,7 +29,6 @@ public static class BackOfficeAuthBuilderExtensions
     {
         builder.AddNotificationAsyncHandler<UserSavedNotification, RevokeUserAuthenticationTokensNotificationHandler>();
         builder.AddNotificationAsyncHandler<UserDeletedNotification, RevokeUserAuthenticationTokensNotificationHandler>();
-        builder.AddNotificationAsyncHandler<UserGroupDeletingNotification, RevokeUserAuthenticationTokensNotificationHandler>();
         builder.AddNotificationAsyncHandler<UserLoginSuccessNotification, RevokeUserAuthenticationTokensNotificationHandler>();
 
         return builder;

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeAuthBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeAuthBuilderExtensions.cs
@@ -27,11 +27,9 @@ public static class BackOfficeAuthBuilderExtensions
 
     public static IUmbracoBuilder AddTokenRevocation(this IUmbracoBuilder builder)
     {
-        builder.AddNotificationAsyncHandler<UserSavingNotification, RevokeUserAuthenticationTokensNotificationHandler>();
         builder.AddNotificationAsyncHandler<UserSavedNotification, RevokeUserAuthenticationTokensNotificationHandler>();
         builder.AddNotificationAsyncHandler<UserDeletedNotification, RevokeUserAuthenticationTokensNotificationHandler>();
         builder.AddNotificationAsyncHandler<UserGroupDeletingNotification, RevokeUserAuthenticationTokensNotificationHandler>();
-        builder.AddNotificationAsyncHandler<UserGroupDeletedNotification, RevokeUserAuthenticationTokensNotificationHandler>();
         builder.AddNotificationAsyncHandler<UserLoginSuccessNotification, RevokeUserAuthenticationTokensNotificationHandler>();
 
         return builder;

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeAuthPolicyBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeAuthPolicyBuilderExtensions.cs
@@ -28,6 +28,7 @@ internal static class BackOfficeAuthPolicyBuilderExtensions
         builder.Services.AddSingleton<IAuthorizationHandler, MediaPermissionHandler>();
         builder.Services.AddSingleton<IAuthorizationHandler, UserGroupPermissionHandler>();
         builder.Services.AddSingleton<IAuthorizationHandler, UserPermissionHandler>();
+        builder.Services.AddSingleton<IAuthorizationHandler, AllowedApplicationHandler>();
 
         builder.Services.AddAuthorization(CreatePolicies);
         return builder;
@@ -35,14 +36,12 @@ internal static class BackOfficeAuthPolicyBuilderExtensions
 
     private static void CreatePolicies(AuthorizationOptions options)
     {
-        void AddPolicy(string policyName, string claimType, params string[] allowedClaimValues)
-        {
-            options.AddPolicy(policyName, policy =>
+        void AddAllowedApplicationsPolicy(string policyName, params string[] allowedClaimValues)
+            => options.AddPolicy(policyName, policy =>
             {
                 policy.AuthenticationSchemes.Add(OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme);
-                policy.RequireClaim(claimType, allowedClaimValues);
+                policy.Requirements.Add(new AllowedApplicationRequirement(allowedClaimValues));
             });
-        }
 
         options.AddPolicy(AuthorizationPolicies.BackOfficeAccess, policy =>
         {
@@ -56,39 +55,39 @@ internal static class BackOfficeAuthPolicyBuilderExtensions
             policy.RequireRole(Constants.Security.AdminGroupAlias);
         });
 
-        AddPolicy(AuthorizationPolicies.SectionAccessContent, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Content);
-        AddPolicy(AuthorizationPolicies.SectionAccessContentOrMedia, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Content, Constants.Applications.Media);
-        AddPolicy(AuthorizationPolicies.SectionAccessForContentTree, Constants.Security.AllowedApplicationsClaimType,
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.SectionAccessContent, Constants.Applications.Content);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.SectionAccessContentOrMedia, Constants.Applications.Content, Constants.Applications.Media);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.SectionAccessForContentTree,
             Constants.Applications.Content, Constants.Applications.Media, Constants.Applications.Users,
             Constants.Applications.Settings, Constants.Applications.Packages, Constants.Applications.Members);
-        AddPolicy(AuthorizationPolicies.SectionAccessForMediaTree, Constants.Security.AllowedApplicationsClaimType,
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.SectionAccessForMediaTree,
             Constants.Applications.Content, Constants.Applications.Media, Constants.Applications.Users,
             Constants.Applications.Settings, Constants.Applications.Packages, Constants.Applications.Members);
-        AddPolicy(AuthorizationPolicies.SectionAccessForMemberTree, Constants.Security.AllowedApplicationsClaimType,
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.SectionAccessForMemberTree,
             Constants.Applications.Content, Constants.Applications.Media, Constants.Applications.Members);
-        AddPolicy(AuthorizationPolicies.SectionAccessMedia, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Media);
-        AddPolicy(AuthorizationPolicies.SectionAccessMembers, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Members);
-        AddPolicy(AuthorizationPolicies.SectionAccessPackages, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Packages);
-        AddPolicy(AuthorizationPolicies.SectionAccessSettings, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Settings);
-        AddPolicy(AuthorizationPolicies.SectionAccessUsers, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Users);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.SectionAccessMedia, Constants.Applications.Media);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.SectionAccessMembers, Constants.Applications.Members);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.SectionAccessPackages, Constants.Applications.Packages);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.SectionAccessSettings, Constants.Applications.Settings);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.SectionAccessUsers, Constants.Applications.Users);
 
-        AddPolicy(AuthorizationPolicies.TreeAccessDataTypes, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Settings);
-        AddPolicy(AuthorizationPolicies.TreeAccessDictionary, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Translation);
-        AddPolicy(AuthorizationPolicies.TreeAccessDictionaryOrTemplates, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Translation, Constants.Applications.Settings);
-        AddPolicy(AuthorizationPolicies.TreeAccessDocuments, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Content);
-        AddPolicy(AuthorizationPolicies.TreeAccessDocumentsOrDocumentTypes, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Content, Constants.Applications.Settings);
-        AddPolicy(AuthorizationPolicies.TreeAccessDocumentTypes, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Settings);
-        AddPolicy(AuthorizationPolicies.TreeAccessLanguages, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Settings);
-        AddPolicy(AuthorizationPolicies.TreeAccessMediaTypes, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Settings);
-        AddPolicy(AuthorizationPolicies.TreeAccessMediaOrMediaTypes, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Media, Constants.Applications.Settings);
-        AddPolicy(AuthorizationPolicies.TreeAccessMemberGroups, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Members);
-        AddPolicy(AuthorizationPolicies.TreeAccessMemberTypes, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Settings);
-        AddPolicy(AuthorizationPolicies.TreeAccessPartialViews, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Settings);
-        AddPolicy(AuthorizationPolicies.TreeAccessRelationTypes, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Settings);
-        AddPolicy(AuthorizationPolicies.TreeAccessScripts, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Settings);
-        AddPolicy(AuthorizationPolicies.TreeAccessStylesheets, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Settings);
-        AddPolicy(AuthorizationPolicies.TreeAccessTemplates, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Settings);
-        AddPolicy(AuthorizationPolicies.TreeAccessWebhooks, Constants.Security.AllowedApplicationsClaimType, Constants.Applications.Settings);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessDataTypes, Constants.Applications.Settings);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessDictionary, Constants.Applications.Translation);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessDictionaryOrTemplates, Constants.Applications.Translation, Constants.Applications.Settings);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessDocuments, Constants.Applications.Content);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessDocumentsOrDocumentTypes, Constants.Applications.Content, Constants.Applications.Settings);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessDocumentTypes, Constants.Applications.Settings);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessLanguages, Constants.Applications.Settings);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessMediaTypes, Constants.Applications.Settings);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessMediaOrMediaTypes, Constants.Applications.Media, Constants.Applications.Settings);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessMemberGroups, Constants.Applications.Members);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessMemberTypes, Constants.Applications.Settings);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessPartialViews, Constants.Applications.Settings);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessRelationTypes, Constants.Applications.Settings);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessScripts, Constants.Applications.Settings);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessStylesheets, Constants.Applications.Settings);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessTemplates, Constants.Applications.Settings);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessWebhooks, Constants.Applications.Settings);
 
         // Contextual permissions
         options.AddPolicy(AuthorizationPolicies.ContentPermissionByResource, policy =>

--- a/src/Umbraco.Cms.Api.Management/Handlers/RevokeUserAuthenticationTokensNotificationHandler.cs
+++ b/src/Umbraco.Cms.Api.Management/Handlers/RevokeUserAuthenticationTokensNotificationHandler.cs
@@ -3,8 +3,10 @@ using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OpenIddict.Abstractions;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -13,18 +15,15 @@ using Umbraco.Extensions;
 namespace Umbraco.Cms.Api.Management.Handlers;
 
 internal sealed class RevokeUserAuthenticationTokensNotificationHandler :
-        INotificationAsyncHandler<UserSavingNotification>,
         INotificationAsyncHandler<UserSavedNotification>,
         INotificationAsyncHandler<UserDeletedNotification>,
         INotificationAsyncHandler<UserGroupDeletingNotification>,
-        INotificationAsyncHandler<UserGroupDeletedNotification>,
         INotificationAsyncHandler<UserLoginSuccessNotification>
 {
-    private const string NotificationStateKey = "Umbraco.Cms.Api.Management.Handlers.RevokeUserAuthenticationTokensNotificationHandler";
-
     private readonly IUserService _userService;
     private readonly IUserGroupService _userGroupService;
     private readonly IOpenIddictTokenManager _tokenManager;
+    private readonly AppCaches _appCaches;
     private readonly ILogger<RevokeUserAuthenticationTokensNotificationHandler> _logger;
     private readonly SecuritySettings _securitySettings;
 
@@ -32,60 +31,27 @@ internal sealed class RevokeUserAuthenticationTokensNotificationHandler :
         IUserService userService,
         IUserGroupService userGroupService,
         IOpenIddictTokenManager tokenManager,
+        AppCaches appCaches,
         ILogger<RevokeUserAuthenticationTokensNotificationHandler> logger,
         IOptions<SecuritySettings> securitySettingsOptions)
     {
         _userService = userService;
         _userGroupService = userGroupService;
         _tokenManager = tokenManager;
+        _appCaches = appCaches;
         _logger = logger;
         _securitySettings = securitySettingsOptions.Value;
-    }
-
-    // We need to know the pre-saving state of the saved users in order to compare if their access has changed
-    public async Task HandleAsync(UserSavingNotification notification, CancellationToken cancellationToken)
-    {
-        try
-        {
-            var usersAccess = new Dictionary<Guid, UserStartNodesAndGroupAccess>();
-            foreach (IUser user in notification.SavedEntities)
-            {
-                UserStartNodesAndGroupAccess? priorUserAccess = await GetRelevantUserAccessDataByUserKeyAsync(user.Key);
-                if (priorUserAccess == null)
-                {
-                    continue;
-                }
-
-                usersAccess.Add(user.Key, priorUserAccess);
-            }
-
-            notification.State[NotificationStateKey] = usersAccess;
-        }
-        catch (DbException e)
-        {
-            _logger.LogWarning(e, "This is expected when we upgrade from < Umbraco 14. Otherwise it should not happen");
-        }
     }
 
     public async Task HandleAsync(UserSavedNotification notification, CancellationToken cancellationToken)
     {
         try
         {
-            Dictionary<Guid, UserStartNodesAndGroupAccess>? preSavingUsersState = null;
-
-            if (notification.State.TryGetValue(NotificationStateKey, out var value))
-            {
-                preSavingUsersState = value as Dictionary<Guid, UserStartNodesAndGroupAccess>;
-            }
-
-            // If we have a new user, there is no token
-            if (preSavingUsersState is null || preSavingUsersState.Count == 0)
-            {
-                return;
-            }
-
             foreach (IUser user in notification.SavedEntities)
             {
+                // Flush the start node caches when editing a user
+                user.FlushStartNodeCaches(_appCaches);
+
                 if (user.IsSuper())
                 {
                     continue;
@@ -95,23 +61,6 @@ internal sealed class RevokeUserAuthenticationTokensNotificationHandler :
                 if (user.IsLockedOut || user.IsApproved is false)
                 {
                     await RevokeTokensAsync(user);
-                    continue;
-                }
-
-                // Don't revoke admin tokens to prevent log out when accidental changes
-                if (user.IsAdmin())
-                {
-                    continue;
-                }
-
-                // Check if the user access has changed - we also need to revoke all tokens in this case
-                if (preSavingUsersState.TryGetValue(user.Key, out UserStartNodesAndGroupAccess? preSavingState))
-                {
-                    UserStartNodesAndGroupAccess postSavingState = MapToUserStartNodesAndGroupAccess(user);
-                    if (preSavingState.CompareAccess(postSavingState) == false)
-                    {
-                        await RevokeTokensAsync(user);
-                    }
                 }
             }
         }
@@ -131,46 +80,21 @@ internal sealed class RevokeUserAuthenticationTokensNotificationHandler :
         }
     }
 
-    // We need to know the pre-deleting state of the users part of the deleted group to revoke their tokens
     public async Task HandleAsync(UserGroupDeletingNotification notification, CancellationToken cancellationToken)
     {
-        var usersInGroups = new Dictionary<Guid, IEnumerable<IUser>>();
         foreach (IUserGroup userGroup in notification.DeletedEntities)
         {
-            var users = await GetUsersByGroupKeyAsync(userGroup.Key);
-            if (users == null)
+            IEnumerable<IUser>? users = await GetUsersByGroupKeyAsync(userGroup.Key);
+            if (users is null)
             {
                 continue;
             }
 
-            usersInGroups.Add(userGroup.Key, users);
-        }
-
-        notification.State[NotificationStateKey] = usersInGroups;
-    }
-
-    public async Task HandleAsync(UserGroupDeletedNotification notification, CancellationToken cancellationToken)
-    {
-        Dictionary<Guid, IEnumerable<IUser>>? preDeletingUsersInGroups = null;
-
-        if (notification.State.TryGetValue(NotificationStateKey, out var value))
-        {
-            preDeletingUsersInGroups = value as Dictionary<Guid, IEnumerable<IUser>>;
-        }
-
-        if (preDeletingUsersInGroups is null)
-        {
-            return;
-        }
-
-        // since the user group was deleted, we can only use the information we collected before the deletion
-        // this means that we will not be able to detect users in any groups that were eventually deleted (due to implementor/3th party supplier interference)
-        // that were not in the initial to be deleted list
-        foreach (IUser user in preDeletingUsersInGroups
-                     .Where(group => notification.DeletedEntities.Any(entity => group.Key == entity.Key))
-                     .SelectMany(group => group.Value))
-        {
-            await RevokeTokensAsync(user);
+            // Flush the start node caches for all affected users when editing a group
+            foreach (IUser user in users)
+            {
+                user.FlushStartNodeCaches(_appCaches);
+            }
         }
     }
 
@@ -189,19 +113,6 @@ internal sealed class RevokeUserAuthenticationTokensNotificationHandler :
             await RevokeTokensAsync(user);
         }
     }
-
-    // Get data about the user before saving
-    private async Task<UserStartNodesAndGroupAccess?> GetRelevantUserAccessDataByUserKeyAsync(Guid userKey)
-    {
-        IUser? user = await _userService.GetAsync(userKey);
-
-        return user is null
-            ? null
-            : MapToUserStartNodesAndGroupAccess(user);
-    }
-
-    private UserStartNodesAndGroupAccess MapToUserStartNodesAndGroupAccess(IUser user)
-        => new(user.Groups.Select(g => g.Key), user.StartContentIds, user.StartMediaIds);
 
     // Get data about the users part of a group before deleting it
     private async Task<IEnumerable<IUser>?> GetUsersByGroupKeyAsync(Guid userGroupKey)
@@ -235,36 +146,5 @@ internal sealed class RevokeUserAuthenticationTokensNotificationHandler :
         }
 
         return null;
-    }
-
-    private class UserStartNodesAndGroupAccess
-    {
-        public IEnumerable<Guid> GroupKeys { get; }
-
-        public int[]? StartContentIds { get; }
-
-        public int[]? StartMediaIds { get; }
-
-        public UserStartNodesAndGroupAccess(IEnumerable<Guid> groupKeys, int[]? startContentIds, int[]? startMediaIds)
-        {
-            GroupKeys = groupKeys;
-            StartContentIds = startContentIds;
-            StartMediaIds = startMediaIds;
-        }
-
-        public bool CompareAccess(UserStartNodesAndGroupAccess other)
-        {
-            var areContentStartNodesEqual = (StartContentIds == null && other.StartContentIds == null) ||
-                                            (StartContentIds != null && other.StartContentIds != null &&
-                                            StartContentIds.SequenceEqual(other.StartContentIds));
-
-            var areMediaStartNodesEqual = (StartMediaIds == null && other.StartMediaIds == null) ||
-                                          (StartMediaIds != null && other.StartMediaIds != null &&
-                                          StartMediaIds.SequenceEqual(other.StartMediaIds));
-
-            return areContentStartNodesEqual &&
-                   areMediaStartNodesEqual &&
-                   GroupKeys.SequenceEqual(other.GroupKeys);
-        }
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Security/Authorization/User/AllowedApplicationHandler.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/Authorization/User/AllowedApplicationHandler.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Authorization;
+using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Security.Authorization;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.Security.Authorization.User;
+
+/// <summary>
+///     Authorizes that the current user has the correct permission access to the applications listed in the requirement.
+/// </summary>
+internal sealed class AllowedApplicationHandler : MustSatisfyRequirementAuthorizationHandler<AllowedApplicationRequirement>
+{
+    private readonly IAuthorizationHelper _authorizationHelper;
+
+    public AllowedApplicationHandler(IAuthorizationHelper authorizationHelper)
+        => _authorizationHelper = authorizationHelper;
+
+    protected override Task<bool> IsAuthorized(AuthorizationHandlerContext context, AllowedApplicationRequirement requirement)
+    {
+        IUser user = _authorizationHelper.GetUmbracoUser(context.User);
+        var allowed = user.AllowedSections.ContainsAny(requirement.Applications);
+        return Task.FromResult(allowed);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Security/Authorization/User/AllowedApplicationRequirement.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/Authorization/User/AllowedApplicationRequirement.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace Umbraco.Cms.Api.Management.Security.Authorization.User;
+
+/// <summary>
+///     Authorization requirement for the <see cref="AllowedApplicationHandler" />.
+/// </summary>
+internal sealed class AllowedApplicationRequirement : IAuthorizationRequirement
+{
+    public string[] Applications { get; }
+
+    public AllowedApplicationRequirement(params string[] applications)
+        => Applications = applications;
+}

--- a/src/Umbraco.Core/Constants-Security.cs
+++ b/src/Umbraco.Core/Constants-Security.cs
@@ -93,12 +93,15 @@ public static partial class Constants
 
         public const string MemberExternalAuthenticationTypePrefix = "UmbracoMembers.";
 
+        [Obsolete("Please use the UserExtensions class to access user start node info. Will be removed in V15.")]
         public const string StartContentNodeIdClaimType =
             "http://umbraco.org/2015/02/identity/claims/backoffice/startcontentnode";
 
+        [Obsolete("Please use the UserExtensions class to access user start node info. Will be removed in V15.")]
         public const string StartMediaNodeIdClaimType =
             "http://umbraco.org/2015/02/identity/claims/backoffice/startmedianode";
 
+        [Obsolete("Please use IUser.AllowedSections instead. Will be removed in V15.")]
         public const string AllowedApplicationsClaimType =
             "http://umbraco.org/2015/02/identity/claims/backoffice/allowedapp";
 

--- a/src/Umbraco.Core/Extensions/ClaimsIdentityExtensions.cs
+++ b/src/Umbraco.Core/Extensions/ClaimsIdentityExtensions.cs
@@ -34,8 +34,6 @@ public static class ClaimsIdentityExtensions
         ClaimTypes.Name, // username
         ClaimTypes.GivenName,
 
-        // Constants.Security.StartContentNodeIdClaimType, These seem to be able to be null...
-        // Constants.Security.StartMediaNodeIdClaimType,
         ClaimTypes.Locality, Constants.Security.SecurityStampClaimType,
     };
 
@@ -250,6 +248,7 @@ public static class ClaimsIdentityExtensions
                 identity));
         }
 
+        // NOTe: this can be removed when the obsolete claim type has been deleted
         if (identity.HasClaim(x => x.Type == Constants.Security.StartContentNodeIdClaimType) == false &&
             startContentNodes != null)
         {
@@ -265,6 +264,7 @@ public static class ClaimsIdentityExtensions
             }
         }
 
+        // NOTe: this can be removed when the obsolete claim type has been deleted
         if (identity.HasClaim(x => x.Type == Constants.Security.StartMediaNodeIdClaimType) == false &&
             startMediaNodes != null)
         {
@@ -304,6 +304,7 @@ public static class ClaimsIdentityExtensions
         }
 
         // Add each app as a separate claim
+        // NOTe: this can be removed when the obsolete claim type has been deleted
         if (identity.HasClaim(x => x.Type == Constants.Security.AllowedApplicationsClaimType) == false && allowedApps != null)
         {
             foreach (var application in allowedApps)
@@ -343,6 +344,7 @@ public static class ClaimsIdentityExtensions
     /// </summary>
     /// <param name="identity"></param>
     /// <returns>Array of start content nodes</returns>
+    [Obsolete("Please use the UserExtensions class to access user start node info. Will be removed in V15.")]
     public static int[] GetStartContentNodes(this ClaimsIdentity identity) =>
         identity.FindAll(x => x.Type == Constants.Security.StartContentNodeIdClaimType)
             .Select(node => int.TryParse(node.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var i)
@@ -355,6 +357,7 @@ public static class ClaimsIdentityExtensions
     /// </summary>
     /// <param name="identity"></param>
     /// <returns>Array of start media nodes</returns>
+    [Obsolete("Please use the UserExtensions class to access user start node info. Will be removed in V15.")]
     public static int[] GetStartMediaNodes(this ClaimsIdentity identity) =>
         identity.FindAll(x => x.Type == Constants.Security.StartMediaNodeIdClaimType)
             .Select(node => int.TryParse(node.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var i)
@@ -367,6 +370,7 @@ public static class ClaimsIdentityExtensions
     /// </summary>
     /// <param name="identity"></param>
     /// <returns></returns>
+    [Obsolete("Please use IUser.AllowedSections instead. Will be removed in V15.")]
     public static string[] GetAllowedApplications(this ClaimsIdentity identity) => identity
         .FindAll(x => x.Type == Constants.Security.AllowedApplicationsClaimType).Select(app => app.Value).ToArray();
 

--- a/src/Umbraco.Core/Extensions/ClaimsIdentityExtensions.cs
+++ b/src/Umbraco.Core/Extensions/ClaimsIdentityExtensions.cs
@@ -248,7 +248,7 @@ public static class ClaimsIdentityExtensions
                 identity));
         }
 
-        // NOTe: this can be removed when the obsolete claim type has been deleted
+        // NOTE: this can be removed when the obsolete claim type has been deleted
         if (identity.HasClaim(x => x.Type == Constants.Security.StartContentNodeIdClaimType) == false &&
             startContentNodes != null)
         {
@@ -264,7 +264,7 @@ public static class ClaimsIdentityExtensions
             }
         }
 
-        // NOTe: this can be removed when the obsolete claim type has been deleted
+        // NOTE: this can be removed when the obsolete claim type has been deleted
         if (identity.HasClaim(x => x.Type == Constants.Security.StartMediaNodeIdClaimType) == false &&
             startMediaNodes != null)
         {
@@ -304,7 +304,7 @@ public static class ClaimsIdentityExtensions
         }
 
         // Add each app as a separate claim
-        // NOTe: this can be removed when the obsolete claim type has been deleted
+        // NOTE: this can be removed when the obsolete claim type has been deleted
         if (identity.HasClaim(x => x.Type == Constants.Security.AllowedApplicationsClaimType) == false && allowedApps != null)
         {
             foreach (var application in allowedApps)

--- a/src/Umbraco.Core/Models/UserExtensions.cs
+++ b/src/Umbraco.Core/Models/UserExtensions.cs
@@ -1,5 +1,3 @@
-using System.Net;
-using System.Security.Cryptography;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Media;
@@ -155,8 +153,8 @@ public static class UserExtensions
 
     public static int[]? CalculateContentStartNodeIds(this IUser user, IEntityService entityService, AppCaches appCaches)
     {
-        var cacheKey = CacheKeys.UserAllContentStartNodesPrefix + user.Key;
-        IAppPolicyCache runtimeCache = appCaches.IsolatedCaches.GetOrCreate<IUser>();
+        var cacheKey = user.UserCacheKey(CacheKeys.UserAllContentStartNodesPrefix);
+        IAppPolicyCache runtimeCache = GetUserCache(appCaches);
         var result = runtimeCache.GetCacheItem(
             cacheKey,
             () =>
@@ -189,8 +187,8 @@ public static class UserExtensions
     /// <returns></returns>
     public static int[]? CalculateMediaStartNodeIds(this IUser user, IEntityService entityService, AppCaches appCaches)
     {
-        var cacheKey = CacheKeys.UserAllMediaStartNodesPrefix + user.Id;
-        IAppPolicyCache runtimeCache = appCaches.IsolatedCaches.GetOrCreate<IUser>();
+        var cacheKey = user.UserCacheKey(CacheKeys.UserAllMediaStartNodesPrefix);
+        IAppPolicyCache runtimeCache = GetUserCache(appCaches);
         var result = runtimeCache.GetCacheItem(
             cacheKey,
             () =>
@@ -214,8 +212,8 @@ public static class UserExtensions
 
     public static string[]? GetMediaStartNodePaths(this IUser user, IEntityService entityService, AppCaches appCaches)
     {
-        var cacheKey = CacheKeys.UserMediaStartNodePathsPrefix + user.Id;
-        IAppPolicyCache runtimeCache = appCaches.IsolatedCaches.GetOrCreate<IUser>();
+        var cacheKey = user.UserCacheKey(CacheKeys.UserMediaStartNodePathsPrefix);
+        IAppPolicyCache runtimeCache = GetUserCache(appCaches);
         var result = runtimeCache.GetCacheItem(
             cacheKey,
             () =>
@@ -232,8 +230,8 @@ public static class UserExtensions
 
     public static string[]? GetContentStartNodePaths(this IUser user, IEntityService entityService, AppCaches appCaches)
     {
-        var cacheKey = CacheKeys.UserContentStartNodePathsPrefix + user.Id;
-        IAppPolicyCache runtimeCache = appCaches.IsolatedCaches.GetOrCreate<IUser>();
+        var cacheKey = user.UserCacheKey(CacheKeys.UserContentStartNodePathsPrefix);
+        IAppPolicyCache runtimeCache = GetUserCache(appCaches);
         var result = runtimeCache.GetCacheItem(
             cacheKey,
             () =>
@@ -247,6 +245,15 @@ public static class UserExtensions
             true);
 
         return result;
+    }
+
+    public static void FlushStartNodeCaches(this IUser user, AppCaches appCaches)
+    {
+        IAppPolicyCache runtimeCache = GetUserCache(appCaches);
+        runtimeCache.Clear(user.UserCacheKey(CacheKeys.UserAllContentStartNodesPrefix));
+        runtimeCache.Clear(user.UserCacheKey(CacheKeys.UserAllMediaStartNodesPrefix));
+        runtimeCache.Clear(user.UserCacheKey(CacheKeys.UserContentStartNodePathsPrefix));
+        runtimeCache.Clear(user.UserCacheKey(CacheKeys.UserMediaStartNodePathsPrefix));
     }
 
     internal static int[] CombineStartNodes(UmbracoObjectTypes objectType, int[] groupSn, int[] userSn, IEntityService entityService)
@@ -316,6 +323,12 @@ public static class UserExtensions
 
         return lsn.ToArray();
     }
+
+    private static IAppPolicyCache GetUserCache(AppCaches appCaches)
+        => appCaches.IsolatedCaches.GetOrCreate<IUser>();
+
+    private static string UserCacheKey(this IUser user, string cacheKey)
+        => $"{cacheKey}{user.Key}";
 
     private static bool StartsWithPath(string test, string path) =>
         test.StartsWith(path) && test.Length > path.Length && test[path.Length] == ',';

--- a/src/Umbraco.Core/Models/UserExtensions.cs
+++ b/src/Umbraco.Core/Models/UserExtensions.cs
@@ -247,15 +247,6 @@ public static class UserExtensions
         return result;
     }
 
-    public static void FlushStartNodeCaches(this IUser user, AppCaches appCaches)
-    {
-        IAppPolicyCache runtimeCache = GetUserCache(appCaches);
-        runtimeCache.Clear(user.UserCacheKey(CacheKeys.UserAllContentStartNodesPrefix));
-        runtimeCache.Clear(user.UserCacheKey(CacheKeys.UserAllMediaStartNodesPrefix));
-        runtimeCache.Clear(user.UserCacheKey(CacheKeys.UserContentStartNodePathsPrefix));
-        runtimeCache.Clear(user.UserCacheKey(CacheKeys.UserMediaStartNodePathsPrefix));
-    }
-
     internal static int[] CombineStartNodes(UmbracoObjectTypes objectType, int[] groupSn, int[] userSn, IEntityService entityService)
     {
         // assume groupSn and userSn each don't contain duplicates


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

We're currently challenged by our claims and how they're tied to the tokens. Specifically, whenever we change something on a user or a user group, we need to revoke all issued tokens. But we won't revoke admin tokens, because we don't want to risk logging the current admin out.

This PR addresses these challenges by obsoleting the claims for user start nodes and "allowed apps" (sections). These are now resolved directly from the user instance, not from the token bound claims.

Eventually these claims will be removed. There will be a separate announcement for this, as it is potentially quite breaking for some.

### What about the role claims?

We _could_ in principle also remove the role claims (`ClaimsIdentity.DefaultRoleClaimType`). At this point I'm a little weary about doing that, though. 

In effect this means an access token will carry over roles for the duration of its lifetime, even if a user is removed from one role and added to another. 

### Testing this PR

The backoffice should function as per usual - auth and endpoint protection based on "allowed apps" (sections) should still work.

Changes in user start nodes or "allowed apps" should be immediately visible for all users.