### PR TITLE
V14: Add missing action parameters mapping

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Mapping/HealthCheck/HealthCheckViewModelsMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/HealthCheck/HealthCheckViewModelsMapDefinition.cs
@@ -23,7 +23,7 @@ public class HealthCheckViewModelsMapDefinition : IMapDefinition
         mapper.Define<IGrouping<string?, Core.HealthChecks.HealthCheck>, HealthCheckGroupResponseModel>((_, _) => new HealthCheckGroupResponseModel { Name = string.Empty }, Map);
     }
 
-    // Umbraco.Code.MapAll -ActionParameters
+    // Umbraco.Code.MapAll
     private static void Map(HealthCheckActionRequestModel source, HealthCheckAction target, MapperContext context)
     {
         target.Alias = source.Alias;

--- a/src/Umbraco.Cms.Api.Management/Mapping/HealthCheck/HealthCheckViewModelsMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/HealthCheck/HealthCheckViewModelsMapDefinition.cs
@@ -34,6 +34,7 @@ public class HealthCheckViewModelsMapDefinition : IMapDefinition
         target.ProvidedValueValidation = source.ProvidedValueValidation;
         target.ProvidedValueValidationRegex = source.ProvidedValueValidationRegex;
         target.ProvidedValue = source.ProvidedValue;
+        target.ActionParameters = source.ActionParameters;
     }
 
     // Umbraco.Code.MapAll
@@ -50,6 +51,7 @@ public class HealthCheckViewModelsMapDefinition : IMapDefinition
         target.ProvidedValue = source.ProvidedValue;
         target.ProvidedValueValidation = source.ProvidedValueValidation;
         target.ProvidedValueValidationRegex = source.ProvidedValueValidationRegex;
+        target.ActionParameters = source.ActionParameters;
     }
 
     // Umbraco.Code.MapAll

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -37432,6 +37432,11 @@
           "providedValueValidationRegex": {
             "type": "string",
             "nullable": true
+          },
+          "actionParameters": {
+            "type": "object",
+            "additionalProperties": { },
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -38041,6 +38046,10 @@
           "name": {
             "minLength": 1,
             "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "nullable": true
           },
           "version": {
             "type": "string",

--- a/src/Umbraco.Cms.Api.Management/ViewModels/HealthCheck/HealthCheckActionRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/HealthCheck/HealthCheckActionRequestModel.cs
@@ -47,4 +47,9 @@ public class HealthCheckActionRequestModel
     ///     Gets or sets the regex to use when validating the provided value (if the value can be validated by a regex).
     /// </summary>
     public string? ProvidedValueValidationRegex { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the action parameters.
+    /// </summary>
+    public Dictionary<string, object>? ActionParameters { get; set; }
 }


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/16477

# Notes
- Adds missing mapping for `ActionParameter`, I suspect this mapping was missing, because we had trouble mapping Dictionary<string, object> earlier on in the development process.

# How to test
- Implement the following healthcheck:
```
using Umbraco.Cms.Core.Extensions;
using Umbraco.Cms.Core.HealthChecks;
using Umbraco.Cms.Core.Services;

namespace Umbraco.Cms.Web.UI;

[HealthCheck("3A482719-3D90-4BC1-B9F8-910CD9CF5B32", "Tests the healthchecks",
    Description = "Runs a tests of the healthchecks for a PR", Group = "TestingGroup")]
public class HealthCheckNotifier : HealthCheck
{
    private readonly IHostEnvironment _hostEnvironment;
    private readonly ILogger<HealthCheckNotifier> _logger;
    private readonly ILocalizedTextService _textService;

    public HealthCheckNotifier(ILocalizedTextService textService, IHostEnvironment hostEnvironment,
        ILogger<HealthCheckNotifier> logger)
    {
        _textService = textService;
        _hostEnvironment = hostEnvironment;
        _logger = logger;
    }

    public override Task<IEnumerable<HealthCheckStatus>> GetStatus() =>
        Task.FromResult((IEnumerable<HealthCheckStatus>)new[] {GetHealthCheckStatus()});

    private HealthCheckStatus GetHealthCheckStatus()
    {
        var actions = new List<HealthCheckAction>();

        actions.Add(new HealthCheckAction($"action 1", Id)
        {
            Name = $"This will be action #1",
            ActionParameters = new Dictionary<string, object>()
            {
                { "folder", "my" },
            },
            Description = $"This is action number 1, it does awesome stuff",
        });

        actions.Add(new HealthCheckAction($"action 2", Id)
        {
            Name = $"This will be action #2",
            ActionParameters = new Dictionary<string, object>()
            {
                { "folder", "my" },
            },
            Description = $"This is action number 2, it does awesome stuff",
        });

        return
            new HealthCheckStatus("Wow that was awesome")
            {
                ResultType = StatusResultType.Success, Actions = actions
            };
    }

    public override HealthCheckStatus ExecuteAction(HealthCheckAction action)
    {
        switch (action.Alias)
        {
            case "removeFolders":
                if (action.ActionParameters?.ContainsKey("folder") is true)
                {
                    string? folder = action.ActionParameters["folder"].ToString();
                    return
                        new HealthCheckStatus("It worked )")
                        {
                            ResultType = StatusResultType.Success, Actions = new List<HealthCheckAction>()
                        };
                }
                else
                {
                    throw new ArgumentOutOfRangeException(nameof(action), $"No Folder for {action.Alias}");
                }
            default:
                throw new ArgumentOutOfRangeException(nameof(action));
        }
    }
}
```

- Set a breakpoint in the `ExecuteAction` method
- Run umbraco
- Go to Settings -> Health Check -> TestingGroup and click `Run checks`
- 2 actions should show, click either one
- You should now hit your breakpoint
- Assert that `ActionParameters` is no longer null