### PR TITLE
Fix unguarded calls to ServiceDescriptor.ImplementationType for keyed services

### DIFF
--- a/src/Umbraco.Cms.Api.Common/DependencyInjection/UmbracoBuilderApiExtensions.cs
+++ b/src/Umbraco.Cms.Api.Common/DependencyInjection/UmbracoBuilderApiExtensions.cs
@@ -11,7 +11,7 @@ public static class UmbracoBuilderApiExtensions
 {
     public static IUmbracoBuilder AddUmbracoApiOpenApiUI(this IUmbracoBuilder builder)
     {
-        if (builder.Services.Any(x => x.ImplementationType == typeof(OperationIdSelector)))
+        if (builder.Services.Any(x => !x.IsKeyedService && x.ImplementationType == typeof(OperationIdSelector)))
         {
             return builder;
         }

--- a/src/Umbraco.Cms.Api.Common/DependencyInjection/UmbracoBuilderAuthExtensions.cs
+++ b/src/Umbraco.Cms.Api.Common/DependencyInjection/UmbracoBuilderAuthExtensions.cs
@@ -17,7 +17,7 @@ public static class UmbracoBuilderAuthExtensions
 {
     public static IUmbracoBuilder AddUmbracoOpenIddict(this IUmbracoBuilder builder)
     {
-        if (builder.Services.Any(x=>x.ImplementationType == typeof(OpenIddictCleanupJob)) is false)
+        if (builder.Services.Any(x => !x.IsKeyedService && x.ImplementationType == typeof(OpenIddictCleanupJob)) is false)
         {
             ConfigureOpenIddict(builder);
         }

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -24,7 +24,7 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddUnique<IConflictingRouteService, ConflictingRouteService>();
         builder.AddUmbracoApiOpenApiUI();
 
-        if (!services.Any(x => x.ImplementationType == typeof(JsonPatchService)))
+        if (!services.Any(x => !x.IsKeyedService && x.ImplementationType == typeof(JsonPatchService)))
         {
             ModelsBuilderBuilderExtensions.AddModelsBuilder(builder)
                 .AddJson()

--- a/tests/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTest.cs
+++ b/tests/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTest.cs
@@ -136,6 +136,12 @@ public abstract class UmbracoIntegrationTest : UmbracoIntegrationTestBase
 
         services.AddLogger(webHostEnvironment, Configuration);
 
+        // Register a keyed service to verify that all calls to ServiceDescriptor.ImplementationType
+        // are guarded by checking IsKeyedService first.
+        // Failure to check this when accessing a keyed service descriptor's ImplementationType property
+        // throws a InvalidOperationException.
+        services.AddKeyedSingleton<object>("key");
+
         // Add it!
         var hostingEnvironment = TestHelper.GetHostingEnvironment();
         var typeLoader = services.AddTypeLoader(

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/LocksTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/LocksTests.cs
@@ -36,7 +36,7 @@ public class LocksTests : UmbracoIntegrationTest
 
     protected override void ConfigureTestServices(IServiceCollection services) =>
         // SQLite + retry policy makes tests fail, we retry before throwing distributed locking timeout.
-        services.RemoveAll(x => x.ImplementationType == typeof(SqliteAddRetryPolicyInterceptor));
+        services.RemoveAll(x => !x.IsKeyedService && x.ImplementationType == typeof(SqliteAddRetryPolicyInterceptor));
 
     [Test]
     public void SingleReadLockTest()

--- a/tests/Umbraco.Tests.Integration/Umbraco.Persistence.EFCore/Scoping/EFCoreLockTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Persistence.EFCore/Scoping/EFCoreLockTests.cs
@@ -23,7 +23,7 @@ public class EFCoreLockTests : UmbracoIntegrationTest
     protected override void ConfigureTestServices(IServiceCollection services)
     {
         // SQLite + retry policy makes tests fail, we retry before throwing distributed locking timeout.
-        services.RemoveAll(x => x.ImplementationType == typeof(SqliteAddRetryPolicyInterceptor));
+        services.RemoveAll(x => !x.IsKeyedService && x.ImplementationType == typeof(SqliteAddRetryPolicyInterceptor));
 
         // Remove all locking implementations to ensure we only use EFCoreDistributedLockingMechanisms
         services.RemoveAll(x => x.ServiceType == typeof(IDistributedLockingMechanism));


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

No known existing issue that I could find.

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
This PR updates the calls to ServiceDescriptor.ImplementationType by checking IsKeyedService first.

Currently, if you register a keyed service before UmbracoBuilder does its work, you'll get an exception like below (running the ComponentRuntimeTests.Start_And_Stop_Umbraco_With_Components_Enabled test):
```csharp
System.InvalidOperationException : This service descriptor is keyed. Your service provider may not support keyed services.
TearDown : System.NullReferenceException : Object reference not set to an instance of an object.
   at Microsoft.Extensions.DependencyInjection.ServiceDescriptor.ThrowKeyedDescriptor()
   at Microsoft.Extensions.DependencyInjection.ServiceDescriptor.get_ImplementationType()
   at Umbraco.Cms.Api.Common.DependencyInjection.UmbracoBuilderAuthExtensions.<>c.<AddUmbracoOpenIddict>b__0_0(ServiceDescriptor x) in F:\repos\umbraco\Umbraco-CMS\src\Umbraco.Cms.Api.Common\DependencyInjection\UmbracoBuilderAuthExtensions.cs:line 20
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
   at Umbraco.Cms.Api.Common.DependencyInjection.UmbracoBuilderAuthExtensions.AddUmbracoOpenIddict(IUmbracoBuilder builder) in F:\repos\umbraco\Umbraco-CMS\src\Umbraco.Cms.Api.Common\DependencyInjection\UmbracoBuilderAuthExtensions.cs:line 20
   at Umbraco.Cms.Api.Management.DependencyInjection.BackOfficeAuthBuilderExtensions.AddBackOfficeAuthentication(IUmbracoBuilder builder) in F:\repos\umbraco\Umbraco-CMS\src\Umbraco.Cms.Api.Management\DependencyInjection\BackOfficeAuthBuilderExtensions.cs:line 20
   at Umbraco.Cms.Tests.Integration.Testing.UmbracoIntegrationTest.ConfigureServices(IServiceCollection services) in F:\repos\umbraco\Umbraco-CMS\tests\Umbraco.Tests.Integration\Testing\UmbracoIntegrationTest.cs:line 156
   at Umbraco.Cms.Tests.Integration.Testing.UmbracoIntegrationTest.<CreateHostBuilder>b__27_1(HostBuilderContext _, IServiceCollection services) in F:\repos\umbraco\Umbraco-CMS\tests\Umbraco.Tests.Integration\Testing\UmbracoIntegrationTest.cs:line 112
   at Microsoft.Extensions.Hosting.HostBuilder.InitializeServiceProvider()
   at Microsoft.Extensions.Hosting.HostBuilder.Build()
   at Umbraco.Cms.Web.Common.Hosting.UmbracoHostBuilderDecorator.Build() in F:\repos\umbraco\Umbraco-CMS\src\Umbraco.Web.Common\Hosting\UmbracoHostBuilderDecorator.cs:line 63
   at Umbraco.Cms.Tests.Integration.Testing.UmbracoIntegrationTest.Setup() in F:\repos\umbraco\Umbraco-CMS\tests\Umbraco.Tests.Integration\Testing\UmbracoIntegrationTest.cs:line 76
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
--TearDown
   at Umbraco.Cms.Tests.Integration.Testing.UmbracoIntegrationTest.TearDownAsync() in F:\repos\umbraco\Umbraco-CMS\tests\Umbraco.Tests.Integration\Testing\UmbracoIntegrationTest.cs:line 87
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
```

To test & verify against this, I've registered a keyed service in the UmbracoIntegrationTest base class before UmbracoBuilder is created & used.

<!-- Thanks for contributing to Umbraco CMS! -->
