### PR TITLE
Add endpoint for calculating effective user start nodes

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/User/CalculateStartNodesUserController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/CalculateStartNodesUserController.cs
@@ -32,7 +32,7 @@ public class CalculatedStartNodesUserController : UserControllerBase
 
     [HttpGet("{id:guid}/calculate-start-nodes")]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(typeof(UserResponseModel), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(CalculatedUserStartNodesResponseModel), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> CalculatedStartNodes(CancellationToken cancellationToken, Guid id)
     {

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/CalculateStartNodesUserController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/CalculateStartNodesUserController.cs
@@ -1,0 +1,59 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.ViewModels.User;
+using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Security.Authorization;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Web.Common.Authorization;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.Controllers.User;
+
+[ApiVersion("1.0")]
+public class CalculatedStartNodesUserController : UserControllerBase
+{
+    private readonly IAuthorizationService _authorizationService;
+    private readonly IUserService _userService;
+    private readonly IUserPresentationFactory _userPresentationFactory;
+
+    public CalculatedStartNodesUserController(
+        IAuthorizationService authorizationService,
+        IUserService userService,
+        IUserPresentationFactory userPresentationFactory)
+    {
+        _authorizationService = authorizationService;
+        _userService = userService;
+        _userPresentationFactory = userPresentationFactory;
+    }
+
+    [HttpGet("{id:guid}/calculate-start-nodes")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(UserResponseModel), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> CalculatedStartNodes(CancellationToken cancellationToken, Guid id)
+    {
+        AuthorizationResult authorizationResult = await _authorizationService.AuthorizeResourceAsync(
+            User,
+            UserPermissionResource.WithKeys(id),
+            AuthorizationPolicies.UserPermissionByResource);
+
+        if (!authorizationResult.Succeeded)
+        {
+            return Forbidden();
+        }
+
+        IUser? user = await _userService.GetAsync(id);
+
+        if (user is null)
+        {
+            return UserOperationStatusResult(UserOperationStatus.UserNotFound);
+        }
+
+        CalculatedUserStartNodesResponseModel responseModel = await _userPresentationFactory.CreateCalculatedUserStartNodesResponseModelAsync(user);
+        return Ok(responseModel);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Factories/IUserPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IUserPresentationFactory.cs
@@ -25,4 +25,6 @@ public interface IUserPresentationFactory
     Task<CurrenUserConfigurationResponseModel> CreateCurrentUserConfigurationModelAsync();
 
     UserItemResponseModel CreateItemResponseModel(IUser user);
+
+    Task<CalculatedUserStartNodesResponseModel> CreateCalculatedUserStartNodesResponseModelAsync(IUser user);
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
@@ -212,6 +212,23 @@ public class UserPresentationFactory : IUserPresentationFactory
         });
     }
 
+    public async Task<CalculatedUserStartNodesResponseModel> CreateCalculatedUserStartNodesResponseModelAsync(IUser user)
+    {
+        var mediaStartNodeIds = user.CalculateMediaStartNodeIds(_entityService, _appCaches);
+        ISet<ReferenceByIdModel> mediaStartNodeKeys = GetKeysFromIds(mediaStartNodeIds, UmbracoObjectTypes.Media);
+        var contentStartNodeIds = user.CalculateContentStartNodeIds(_entityService, _appCaches);
+        ISet<ReferenceByIdModel> documentStartNodeKeys = GetKeysFromIds(contentStartNodeIds, UmbracoObjectTypes.Document);
+
+        return await Task.FromResult(new CalculatedUserStartNodesResponseModel()
+        {
+            Id = user.Key,
+            MediaStartNodeIds = mediaStartNodeKeys,
+            HasMediaRootAccess = HasRootAccess(mediaStartNodeIds),
+            DocumentStartNodeIds = documentStartNodeKeys,
+            HasDocumentRootAccess = HasRootAccess(contentStartNodeIds),
+        });
+    }
+
     private ISet<ReferenceByIdModel> GetKeysFromIds(IEnumerable<int>? ids, UmbracoObjectTypes type)
     {
         IEnumerable<ReferenceByIdModel>? models = ids?

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -30298,6 +30298,66 @@
         ]
       }
     },
+    "/umbraco/management/api/v1/user/{id}/calculate-start-nodes": {
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "operationId": "GetUserByIdCalculateStartNodes",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/CalculatedUserStartNodesResponseModel"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ProblemDetails"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          },
+          "403": {
+            "description": "The authenticated user do not have access to this resource"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
     "/umbraco/management/api/v1/user/{id}/change-password": {
       "post": {
         "tags": [
@@ -33442,6 +33502,51 @@
             }
           },
           "isCompatible": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CalculatedUserStartNodesResponseModel": {
+        "required": [
+          "documentStartNodeIds",
+          "hasDocumentRootAccess",
+          "hasMediaRootAccess",
+          "id",
+          "mediaStartNodeIds"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "documentStartNodeIds": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ReferenceByIdModel"
+                }
+              ]
+            }
+          },
+          "hasDocumentRootAccess": {
+            "type": "boolean"
+          },
+          "mediaStartNodeIds": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ReferenceByIdModel"
+                }
+              ]
+            }
+          },
+          "hasMediaRootAccess": {
             "type": "boolean"
           }
         },

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/CalculatedUserStartNodesResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/CalculatedUserStartNodesResponseModel.cs
@@ -1,0 +1,14 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.User;
+
+public class CalculatedUserStartNodesResponseModel
+{
+    public required Guid Id { get; init; }
+
+    public ISet<ReferenceByIdModel> DocumentStartNodeIds { get; set; } = new HashSet<ReferenceByIdModel>();
+
+    public bool HasDocumentRootAccess { get; set; }
+
+    public ISet<ReferenceByIdModel> MediaStartNodeIds { get; set; } = new HashSet<ReferenceByIdModel>();
+
+    public bool HasMediaRootAccess { get; set; }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

We need to list the effective user start nodes (directly applied to the user + inherited via group membership). Instead of cluttering the existing "get user" endpoint, I have decided to add a new endpoint for this calculation.

### Testing this PR

First and foremost, be aware that we have a few caching issues with users and start nodes (see https://github.com/umbraco/Umbraco-CMS/pull/16552). When making chances to user start nodes, the only really reliable way to have these reflected is currently to restart the site.

1. Create some users with different start node setups - both direct and inherited.
2. Verify that the effective start nodes are calculated correctly with this new endpoint.