### PR TITLE
Allow http for openiddict

### DIFF
--- a/src/Umbraco.Cms.Api.Common/Configuration/PostConfigureOpenIddict.cs
+++ b/src/Umbraco.Cms.Api.Common/Configuration/PostConfigureOpenIddict.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OpenIddict.Server;
+using OpenIddict.Server.AspNetCore;
+using Umbraco.Cms.Core.Configuration.Models;
+
+namespace Umbraco.Cms.Api.Common.Configuration;
+
+internal class PostConfigureOpenIddict : IPostConfigureOptions<OpenIddictServerOptions>
+{
+    private readonly IOptions<GlobalSettings> _globalSettings;
+
+    public PostConfigureOpenIddict(IOptions<GlobalSettings> globalSettings)
+    {
+        _globalSettings = globalSettings;
+    }
+
+    public void PostConfigure(string? name, OpenIddictServerOptions options)
+    {
+        EnsureHttpsIsNotRequiredWhenConfigAllowHttp(options);
+    }
+
+    /// <summary>
+    /// Ensures OpenIddict is configured to allow Http requrest, if and only if, the global settings are configured to allow Http.
+    /// </summary>
+    /// <remarks>
+    /// The logic actually allowing http by removing the ValidateTransportSecurityRequirement Descriptor is borrowed from <see cref="OpenIddictServerBuilder.RemoveEventHandler"/>
+    /// </remarks>
+    private void EnsureHttpsIsNotRequiredWhenConfigAllowHttp(OpenIddictServerOptions options)
+    {
+        if (_globalSettings.Value.UseHttps is false)
+        {
+            OpenIddictServerHandlerDescriptor descriptor = OpenIddictServerAspNetCoreHandlers.ValidateTransportSecurityRequirement.Descriptor;
+
+            for (var index = options.Handlers.Count - 1; index >= 0; index--)
+            {
+                if (options.Handlers[index].ServiceDescriptor.ServiceType == descriptor.ServiceDescriptor.ServiceType)
+                {
+                    options.Handlers.RemoveAt(index);
+                }
+            }
+        }
+    }
+}

--- a/src/Umbraco.Cms.Api.Common/DependencyInjection/UmbracoBuilderAuthExtensions.cs
+++ b/src/Umbraco.Cms.Api.Common/DependencyInjection/UmbracoBuilderAuthExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using OpenIddict.Server;
 using OpenIddict.Validation;
+using Umbraco.Cms.Api.Common.Configuration;
 using Umbraco.Cms.Api.Common.Security;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
@@ -132,5 +133,6 @@ public static class UmbracoBuilderAuthExtensions
             });
 
         builder.Services.AddRecurringBackgroundJob<OpenIddictCleanupJob>();
+        builder.Services.ConfigureOptions<PostConfigureOpenIddict>();
     }
 }


### PR DESCRIPTION
### Description
Added post configuration of OpenIddictServerOptions that removes the `ValidateTransportSecurityRequirement` iff `GlobalSettings.UseHttps` is `false`.

Fixing: https://github.com/umbraco/Umbraco-CMS/issues/16605

### Test
Please note that openiddict only allow connections from the host that first attempted to access backoffice. It can make it easier to set `launchBrowser` to `false` in `launchSettings.json`

- Set `Umbraco:CMS:Global:UseHttps` = `false`
    - Boot solution and verify you **_can_** sign-in using http: http://localhost:11000/umbraco/
    - Reboot solution and verify you _**can**_ sign-in using https: https://localhost:44339/umbraco/
- Set `Umbraco:CMS:Global:UseHttps` = `true`
    - Boot solution and verify you **_cannot_** sign-in using http: http://localhost:11000/umbraco/
    - Reboot solution and verify you **_can_** sign-in using https: https://localhost:44339/umbraco/