### PR TITLE
V13 QA Decreased to 1 retry for the tour file 

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Tour/tours.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Tour/tours.spec.ts
@@ -3,6 +3,7 @@ import {test} from '@umbraco/playwright-testhelpers';
 
 test.describe('Tours', () => {
   const timeout = 60000;
+  test.describe.configure({ retries: 1 });
   test.beforeEach(async ({ page, umbracoApi }, testInfo) => {
     await umbracoApi.report.report(testInfo);
     await umbracoApi.login();


### PR DESCRIPTION
The tours test run for quite a bit of time since there are a lot of steps involved. We are updating the retry count to 1 as it could result in failing the E2E stage on the pipeline. 