### PR TITLE
V15: Update to dotnet 9

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>13.0</LangVersion>
     <Company>Umbraco HQ</Company>
     <Authors>Umbraco</Authors>
     <Copyright>Copyright © Umbraco $([System.DateTime]::Today.ToString('yyyy'))</Copyright>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,6 @@
 <Project>
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
     <Company>Umbraco HQ</Company>
     <Authors>Umbraco</Authors>
     <Copyright>Copyright © Umbraco $([System.DateTime]::Today.ToString('yyyy'))</Copyright>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
     <Company>Umbraco HQ</Company>
     <Authors>Umbraco</Authors>
     <Copyright>Copyright © Umbraco $([System.DateTime]::Today.ToString('yyyy'))</Copyright>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,27 +12,27 @@
   </ItemGroup>
   <!-- Microsoft packages -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="9.0.0-preview.5.24306.11" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.5" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.5" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.5" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="8.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="8.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.0-preview.5.24306.3" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0-preview.5.24306.3" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0-preview.5.24306.3" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0-preview.5.24306.3" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.0-preview.5.24306.7" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0-preview.5.24306.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0-preview.5.24306.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0-preview.5.24306.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0-preview.5.24306.7" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.0-preview.5.24306.11" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="9.0.0-preview.5.24306.7" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0-preview.5.24306.7" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.0-preview.5.24306.7" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="9.0.0-preview.5.24306.11" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="9.0.0-preview.5.24306.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0-preview.5.24306.7" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.0-preview.5.24306.7" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0-preview.5.24306.7" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.0-preview.5.24306.7" />
   </ItemGroup>
   <!-- Umbraco packages -->
   <ItemGroup>
@@ -83,7 +83,7 @@
     <!-- Dazinator.Extensions.FileProviders brings in a vulnerable version of System.Net.Http -->
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <!-- Examine brings in a vulnerable version of System.Security.Cryptography.Xml -->
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.1" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="9.0.0-preview.5.24306.7" />
     <!-- Both Dazinator.Extensions.FileProviders and MiniProfiler.AspNetCore.Mvc bring in a vulnerable version of System.Text.RegularExpressions -->
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,17 +7,17 @@
   <ItemGroup>
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" />
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
-    <GlobalPackageReference Include="Umbraco.Code" Version="2.1.0" />
+    <GlobalPackageReference Include="Umbraco.Code" Version="2.2.0" />
     <GlobalPackageReference Include="Umbraco.GitVersioning.Extensions" Version="0.2.0" />
   </ItemGroup>
   <!-- Microsoft packages -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="9.0.0-preview.5.24306.11" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.0-preview.5.24306.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0-preview.5.24306.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0-preview.5.24306.3" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0-preview.5.24306.3" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.0-preview.5.24306.7" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0-preview.5.24306.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0-preview.5.24306.7" />

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -105,6 +105,7 @@ stages:
             displayName: Use .NET SDK from global.json
             inputs:
               useGlobalJson: true
+              includePreviewVersions: true
           - task: DotNetCoreCLI@2
             displayName: Run dotnet restore
             inputs:
@@ -163,6 +164,7 @@ stages:
             displayName: Use .NET SDK from global.json
             inputs:
               useGlobalJson: true
+              includePreviewVersions: true
           - task: PowerShell@2
             displayName: Install DocFX
             inputs:
@@ -280,6 +282,7 @@ stages:
             displayName: Use .NET SDK from global.json
             inputs:
               useGlobalJson: true
+              includePreviewVersions: true
           - task: DotNetCoreCLI@2
             displayName: Run dotnet test
             inputs:
@@ -321,6 +324,7 @@ stages:
             displayName: Use .NET SDK from global.json
             inputs:
               useGlobalJson: true
+              includePreviewVersions: true
 
           # Test
           - task: DotNetCoreCLI@2
@@ -369,6 +373,7 @@ stages:
             displayName: Use .NET SDK from global.json
             inputs:
               useGlobalJson: true
+              includePreviewVersions: true
 
           # Start SQL Server
           - powershell: docker run --name mssql -d -p 1433:1433 -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=$(SA_PASSWORD)" mcr.microsoft.com/mssql/server:2022-latest
@@ -462,6 +467,7 @@ stages:
             displayName: Use .NET SDK from global.json
             inputs:
               useGlobalJson: true
+              includePreviewVersions: true
 
           - pwsh: |
               "UMBRACO_USER_LOGIN=$(UMBRACO__CMS__UNATTENDED__UNATTENDEDUSEREMAIL)
@@ -528,7 +534,7 @@ stages:
           - ${{ if eq(parameters.isNightly, true) }}:
               pwsh: npm run test --ignore-certificate-errors
             ${{ else }}:
-              pwsh: npm run smokeTest --ignore-certificate-errors           
+              pwsh: npm run smokeTest --ignore-certificate-errors
             displayName: Run Playwright tests
             continueOnError: true
             workingDirectory: tests/Umbraco.Tests.AcceptanceTest
@@ -597,6 +603,7 @@ stages:
             displayName: Use .NET SDK from global.json
             inputs:
               useGlobalJson: true
+              includePreviewVersions: true
 
           - pwsh: |
               "UMBRACO_USER_LOGIN=$(UMBRACO__CMS__UNATTENDED__UNATTENDEDUSEREMAIL)

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -105,7 +105,6 @@ stages:
             displayName: Use .NET SDK from global.json
             inputs:
               useGlobalJson: true
-              includePreviewVersions: true
           - task: DotNetCoreCLI@2
             displayName: Run dotnet restore
             inputs:
@@ -164,7 +163,6 @@ stages:
             displayName: Use .NET SDK from global.json
             inputs:
               useGlobalJson: true
-              includePreviewVersions: true
           - task: PowerShell@2
             displayName: Install DocFX
             inputs:
@@ -282,7 +280,6 @@ stages:
             displayName: Use .NET SDK from global.json
             inputs:
               useGlobalJson: true
-              includePreviewVersions: true
           - task: DotNetCoreCLI@2
             displayName: Run dotnet test
             inputs:
@@ -324,7 +321,6 @@ stages:
             displayName: Use .NET SDK from global.json
             inputs:
               useGlobalJson: true
-              includePreviewVersions: true
 
           # Test
           - task: DotNetCoreCLI@2
@@ -373,7 +369,6 @@ stages:
             displayName: Use .NET SDK from global.json
             inputs:
               useGlobalJson: true
-              includePreviewVersions: true
 
           # Start SQL Server
           - powershell: docker run --name mssql -d -p 1433:1433 -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=$(SA_PASSWORD)" mcr.microsoft.com/mssql/server:2022-latest
@@ -467,7 +462,6 @@ stages:
             displayName: Use .NET SDK from global.json
             inputs:
               useGlobalJson: true
-              includePreviewVersions: true
 
           - pwsh: |
               "UMBRACO_USER_LOGIN=$(UMBRACO__CMS__UNATTENDED__UNATTENDEDUSEREMAIL)
@@ -603,7 +597,6 @@ stages:
             displayName: Use .NET SDK from global.json
             inputs:
               useGlobalJson: true
-              includePreviewVersions: true
 
           - pwsh: |
               "UMBRACO_USER_LOGIN=$(UMBRACO__CMS__UNATTENDED__UNATTENDEDUSEREMAIL)

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "9.0.100-preview.5.24307.3",
     "rollForward": "latestFeature",
     "allowPrerelease": true
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
-    "version": "8.0.100",
-    "rollForward": "latestFeature"
+    "version": "9.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": true
   }
 }

--- a/src/Umbraco.Cms.Api.Common/OpenApi/SchemaIdHandler.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/SchemaIdHandler.cs
@@ -36,7 +36,7 @@ public class SchemaIdHandler : ISchemaIdHandler
         // first grab the "non-generic" part of any generic type name (i.e. "PagedViewModel`1" becomes "PagedViewModel")
         .Split('`').First()
         // then remove the "ViewModel" postfix from type names
-        .TrimEndOfString("ViewModel");
+        .TrimEndExact("ViewModel");
 
     private string HandleGenerics(string name, Type type)
     {

--- a/src/Umbraco.Cms.Api.Common/OpenApi/SchemaIdHandler.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/SchemaIdHandler.cs
@@ -36,7 +36,7 @@ public class SchemaIdHandler : ISchemaIdHandler
         // first grab the "non-generic" part of any generic type name (i.e. "PagedViewModel`1" becomes "PagedViewModel")
         .Split('`').First()
         // then remove the "ViewModel" postfix from type names
-        .TrimEnd("ViewModel");
+        .TrimEndOfString("ViewModel");
 
     private string HandleGenerics(string name, Type type)
     {

--- a/src/Umbraco.Cms.Api.Delivery/Services/ApiMediaQueryService.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/ApiMediaQueryService.cs
@@ -85,7 +85,7 @@ internal sealed class ApiMediaQueryService : IApiMediaQueryService
             return null;
         }
 
-        var childrenOf = fetch.TrimStart(childrenOfParameter);
+        var childrenOf = fetch.TrimStartOfString(childrenOfParameter);
         if (childrenOf.IsNullOrWhiteSpace())
         {
             // this mirrors the current behavior of the Content Delivery API :-)

--- a/src/Umbraco.Cms.Api.Delivery/Services/ApiMediaQueryService.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/ApiMediaQueryService.cs
@@ -85,7 +85,7 @@ internal sealed class ApiMediaQueryService : IApiMediaQueryService
             return null;
         }
 
-        var childrenOf = fetch.TrimStartOfString(childrenOfParameter);
+        var childrenOf = fetch.TrimStartExact(childrenOfParameter);
         if (childrenOf.IsNullOrWhiteSpace())
         {
             // this mirrors the current behavior of the Content Delivery API :-)

--- a/src/Umbraco.Cms.Api.Delivery/Services/RequestRedirectService.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/RequestRedirectService.cs
@@ -66,7 +66,7 @@ internal sealed class RequestRedirectService : RoutingServiceBase, IRequestRedir
         }
 
         // important: redirect URLs are always tracked without trailing slashes
-        IRedirectUrl? redirectUrl = _redirectUrlService.GetMostRecentRedirectUrl(requestedPath.TrimEnd("/"), culture);
+        IRedirectUrl? redirectUrl = _redirectUrlService.GetMostRecentRedirectUrl(requestedPath.TrimEndOfString("/"), culture);
         IPublishedContent? content = redirectUrl != null
             ? _apiPublishedContentCache.GetById(redirectUrl.ContentKey)
             : null;

--- a/src/Umbraco.Cms.Api.Delivery/Services/RequestRedirectService.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/RequestRedirectService.cs
@@ -66,7 +66,7 @@ internal sealed class RequestRedirectService : RoutingServiceBase, IRequestRedir
         }
 
         // important: redirect URLs are always tracked without trailing slashes
-        IRedirectUrl? redirectUrl = _redirectUrlService.GetMostRecentRedirectUrl(requestedPath.TrimEndOfString("/"), culture);
+        IRedirectUrl? redirectUrl = _redirectUrlService.GetMostRecentRedirectUrl(requestedPath.TrimEndExact("/"), culture);
         IPublishedContent? content = redirectUrl != null
             ? _apiPublishedContentCache.GetById(redirectUrl.ContentKey)
             : null;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Indexer/AllIndexerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Indexer/AllIndexerController.cs
@@ -37,7 +37,7 @@ public class AllIndexerController : IndexerControllerBase
     {
         IndexResponseModel[] indexes = _examineManager.Indexes
             .Select(_indexPresentationFactory.Create)
-            .OrderBy(indexModel => indexModel.Name.TrimEnd("Indexer")).ToArray();
+            .OrderBy(indexModel => indexModel.Name.TrimEndOfString("Indexer")).ToArray();
 
         var viewModel = new PagedViewModel<IndexResponseModel> { Items = indexes.Skip(skip).Take(take), Total = indexes.Length };
         return Task.FromResult(viewModel);

--- a/src/Umbraco.Cms.Api.Management/Controllers/Indexer/AllIndexerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Indexer/AllIndexerController.cs
@@ -37,7 +37,7 @@ public class AllIndexerController : IndexerControllerBase
     {
         IndexResponseModel[] indexes = _examineManager.Indexes
             .Select(_indexPresentationFactory.Create)
-            .OrderBy(indexModel => indexModel.Name.TrimEndOfString("Indexer")).ToArray();
+            .OrderBy(indexModel => indexModel.Name.TrimEndExact("Indexer")).ToArray();
 
         var viewModel = new PagedViewModel<IndexResponseModel> { Items = indexes.Skip(skip).Take(take), Total = indexes.Length };
         return Task.FromResult(viewModel);

--- a/src/Umbraco.Cms.Api.Management/Controllers/Searcher/AllSearcherController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Searcher/AllSearcherController.cs
@@ -30,7 +30,7 @@ public class AllSearcherController : SearcherControllerBase
         var searchers = new List<SearcherResponse>(
             _examineManager.RegisteredSearchers.Select(searcher => new SearcherResponse { Name = searcher.Name })
                 .OrderBy(x =>
-                    x.Name.TrimEndOfString("Searcher"))); // order by name , but strip the "Searcher" from the end if it exists
+                    x.Name.TrimEndExact("Searcher"))); // order by name , but strip the "Searcher" from the end if it exists
         var viewModel = new PagedViewModel<SearcherResponse>
         {
             Items = searchers.Skip(skip).Take(take),

--- a/src/Umbraco.Cms.Api.Management/Controllers/Searcher/AllSearcherController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Searcher/AllSearcherController.cs
@@ -30,7 +30,7 @@ public class AllSearcherController : SearcherControllerBase
         var searchers = new List<SearcherResponse>(
             _examineManager.RegisteredSearchers.Select(searcher => new SearcherResponse { Name = searcher.Name })
                 .OrderBy(x =>
-                    x.Name.TrimEnd("Searcher"))); // order by name , but strip the "Searcher" from the end if it exists
+                    x.Name.TrimEndOfString("Searcher"))); // order by name , but strip the "Searcher" from the end if it exists
         var viewModel = new PagedViewModel<SearcherResponse>
         {
             Items = searchers.Skip(skip).Take(take),

--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoWebsite/Maintenance.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoWebsite/Maintenance.cshtml
@@ -17,7 +17,7 @@
 
     <title>Website is Under Maintainance</title>
 
-    <link rel="stylesheet" href="@WebPath.Combine(backOfficePath.TrimStartOfString("~") , "website", "/nonodes.css")" />
+    <link rel="stylesheet" href="@WebPath.Combine(backOfficePath.TrimStartExact("~") , "website", "/nonodes.css")" />
     <style type="text/css">
         body {
             color:initial;

--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoWebsite/Maintenance.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoWebsite/Maintenance.cshtml
@@ -17,7 +17,7 @@
 
     <title>Website is Under Maintainance</title>
 
-    <link rel="stylesheet" href="@WebPath.Combine(backOfficePath.TrimStart("~") , "website", "/nonodes.css")" />
+    <link rel="stylesheet" href="@WebPath.Combine(backOfficePath.TrimStartOfString("~") , "website", "/nonodes.css")" />
     <style type="text/css">
         body {
             color:initial;

--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoWebsite/NoNodes.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoWebsite/NoNodes.cshtml
@@ -18,7 +18,7 @@
 
     <title>Umbraco: No Published Content</title>
 
-    <link rel="stylesheet" href="@WebPath.Combine(backOfficePath.TrimStartOfString("~") , "website", "/nonodes.css")" />
+    <link rel="stylesheet" href="@WebPath.Combine(backOfficePath.TrimStartExact("~") , "website", "/nonodes.css")" />
 </head>
 <body>
 

--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoWebsite/NoNodes.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoWebsite/NoNodes.cshtml
@@ -18,7 +18,7 @@
 
     <title>Umbraco: No Published Content</title>
 
-    <link rel="stylesheet" href="@WebPath.Combine(backOfficePath.TrimStart("~") , "website", "/nonodes.css")" />
+    <link rel="stylesheet" href="@WebPath.Combine(backOfficePath.TrimStartOfString("~") , "website", "/nonodes.css")" />
 </head>
 <body>
 

--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoWebsite/NotFound.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoWebsite/NotFound.cshtml
@@ -17,7 +17,7 @@
 
     <title>Page Not Found</title>
 
-    <link rel="stylesheet" href="@WebPath.Combine(backOfficePath.TrimStartOfString("~") , "website", "/nonodes.css")" />
+    <link rel="stylesheet" href="@WebPath.Combine(backOfficePath.TrimStartExact("~") , "website", "/nonodes.css")" />
     <style type="text/css">
         body {
             color:initial;

--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoWebsite/NotFound.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoWebsite/NotFound.cshtml
@@ -17,7 +17,7 @@
 
     <title>Page Not Found</title>
 
-    <link rel="stylesheet" href="@WebPath.Combine(backOfficePath.TrimStart("~") , "website", "/nonodes.css")" />
+    <link rel="stylesheet" href="@WebPath.Combine(backOfficePath.TrimStartOfString("~") , "website", "/nonodes.css")" />
     <style type="text/css">
         body {
             color:initial;

--- a/src/Umbraco.Core/Configuration/ModelsBuilderConfigExtensions.cs
+++ b/src/Umbraco.Core/Configuration/ModelsBuilderConfigExtensions.cs
@@ -35,7 +35,7 @@ public static class ModelsBuilderConfigExtensions
 
         if (config.StartsWith("~/"))
         {
-            var dir = Path.Combine(root, config.TrimStart("~/"));
+            var dir = Path.Combine(root, config.TrimStartOfString("~/"));
 
             // sanitize - GetFullPath will take care of any relative
             // segments in path, eg '../../foo.tmp' - it may throw a SecurityException

--- a/src/Umbraco.Core/Configuration/ModelsBuilderConfigExtensions.cs
+++ b/src/Umbraco.Core/Configuration/ModelsBuilderConfigExtensions.cs
@@ -35,7 +35,7 @@ public static class ModelsBuilderConfigExtensions
 
         if (config.StartsWith("~/"))
         {
-            var dir = Path.Combine(root, config.TrimStartOfString("~/"));
+            var dir = Path.Combine(root, config.TrimStartExact("~/"));
 
             // sanitize - GetFullPath will take care of any relative
             // segments in path, eg '../../foo.tmp' - it may throw a SecurityException

--- a/src/Umbraco.Core/DeliveryApi/ApiContentRouteBuilder.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiContentRouteBuilder.cs
@@ -83,7 +83,7 @@ public sealed class ApiContentRouteBuilder : IApiContentRouteBuilder
 
         if (_globalSettings.HideTopLevelNodeFromPath == false)
         {
-            contentPath = contentPath.TrimStartOfString(rootPath.EnsureStartsWith("/")).EnsureStartsWith("/");
+            contentPath = contentPath.TrimStartExact(rootPath.EnsureStartsWith("/")).EnsureStartsWith("/");
         }
 
         return new ApiContentRoute(contentPath, new ApiContentStartItem(root.Key, rootPath));

--- a/src/Umbraco.Core/DeliveryApi/ApiContentRouteBuilder.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiContentRouteBuilder.cs
@@ -83,7 +83,7 @@ public sealed class ApiContentRouteBuilder : IApiContentRouteBuilder
 
         if (_globalSettings.HideTopLevelNodeFromPath == false)
         {
-            contentPath = contentPath.TrimStart(rootPath.EnsureStartsWith("/")).EnsureStartsWith("/");
+            contentPath = contentPath.TrimStartOfString(rootPath.EnsureStartsWith("/")).EnsureStartsWith("/");
         }
 
         return new ApiContentRoute(contentPath, new ApiContentStartItem(root.Key, rootPath));

--- a/src/Umbraco.Core/Extensions/StringExtensions.cs
+++ b/src/Umbraco.Core/Extensions/StringExtensions.cs
@@ -287,7 +287,7 @@ public static class StringExtensions
     /// <param name="value">The value.</param>
     /// <param name="forRemoving">For removing.</param>
     /// <returns></returns>
-    public static string Trim(this string value, string forRemoving)
+    public static string TrimExact(this string value, string forRemoving)
     {
         if (string.IsNullOrEmpty(value))
         {

--- a/src/Umbraco.Core/Extensions/StringExtensions.cs
+++ b/src/Umbraco.Core/Extensions/StringExtensions.cs
@@ -294,7 +294,7 @@ public static class StringExtensions
             return value;
         }
 
-        return value.TrimEnd(forRemoving).TrimStart(forRemoving);
+        return value.TrimEndOfString(forRemoving).TrimStartOfString(forRemoving);
     }
 
     public static string EncodeJsString(this string s)
@@ -343,7 +343,7 @@ public static class StringExtensions
         return sb.ToString();
     }
 
-    public static string TrimEnd(this string value, string forRemoving)
+    public static string TrimEndOfString(this string value, string forRemoving)
     {
         if (string.IsNullOrEmpty(value))
         {
@@ -363,7 +363,7 @@ public static class StringExtensions
         return value;
     }
 
-    public static string TrimStart(this string value, string forRemoving)
+    public static string TrimStartOfString(this string value, string forRemoving)
     {
         if (string.IsNullOrEmpty(value))
         {
@@ -390,7 +390,7 @@ public static class StringExtensions
             return input;
         }
 
-        return toStartWith + input.TrimStart(toStartWith);
+        return toStartWith + input.TrimStartOfString(toStartWith);
     }
 
     public static string EnsureStartsWith(this string input, char value) =>

--- a/src/Umbraco.Core/Extensions/StringExtensions.cs
+++ b/src/Umbraco.Core/Extensions/StringExtensions.cs
@@ -294,7 +294,7 @@ public static class StringExtensions
             return value;
         }
 
-        return value.TrimEndOfString(forRemoving).TrimStartOfString(forRemoving);
+        return value.TrimEndExact(forRemoving).TrimStartExact(forRemoving);
     }
 
     public static string EncodeJsString(this string s)
@@ -343,7 +343,7 @@ public static class StringExtensions
         return sb.ToString();
     }
 
-    public static string TrimEndOfString(this string value, string forRemoving)
+    public static string TrimEndExact(this string value, string forRemoving)
     {
         if (string.IsNullOrEmpty(value))
         {
@@ -363,7 +363,7 @@ public static class StringExtensions
         return value;
     }
 
-    public static string TrimStartOfString(this string value, string forRemoving)
+    public static string TrimStartExact(this string value, string forRemoving)
     {
         if (string.IsNullOrEmpty(value))
         {
@@ -390,7 +390,7 @@ public static class StringExtensions
             return input;
         }
 
-        return toStartWith + input.TrimStartOfString(toStartWith);
+        return toStartWith + input.TrimStartExact(toStartWith);
     }
 
     public static string EnsureStartsWith(this string input, char value) =>

--- a/src/Umbraco.Core/Models/Content.cs
+++ b/src/Umbraco.Core/Models/Content.cs
@@ -353,19 +353,19 @@ public class Content : ContentBase, IContent
         // Special check here since we want to check if the request is for changed cultures
         if (propertyName.StartsWith(ChangeTrackingPrefix.PublishedCulture))
         {
-            var culture = propertyName.TrimStartOfString(ChangeTrackingPrefix.PublishedCulture);
+            var culture = propertyName.TrimStartExact(ChangeTrackingPrefix.PublishedCulture);
             return _currentPublishCultureChanges.addedCultures?.Contains(culture) ?? false;
         }
 
         if (propertyName.StartsWith(ChangeTrackingPrefix.UnpublishedCulture))
         {
-            var culture = propertyName.TrimStartOfString(ChangeTrackingPrefix.UnpublishedCulture);
+            var culture = propertyName.TrimStartExact(ChangeTrackingPrefix.UnpublishedCulture);
             return _currentPublishCultureChanges.removedCultures?.Contains(culture) ?? false;
         }
 
         if (propertyName.StartsWith(ChangeTrackingPrefix.ChangedCulture))
         {
-            var culture = propertyName.TrimStartOfString(ChangeTrackingPrefix.ChangedCulture);
+            var culture = propertyName.TrimStartExact(ChangeTrackingPrefix.ChangedCulture);
             return _currentPublishCultureChanges.updatedCultures?.Contains(culture) ?? false;
         }
 
@@ -379,19 +379,19 @@ public class Content : ContentBase, IContent
         // Special check here since we want to check if the request is for changed cultures
         if (propertyName.StartsWith(ChangeTrackingPrefix.PublishedCulture))
         {
-            var culture = propertyName.TrimStartOfString(ChangeTrackingPrefix.PublishedCulture);
+            var culture = propertyName.TrimStartExact(ChangeTrackingPrefix.PublishedCulture);
             return _previousPublishCultureChanges.addedCultures?.Contains(culture) ?? false;
         }
 
         if (propertyName.StartsWith(ChangeTrackingPrefix.UnpublishedCulture))
         {
-            var culture = propertyName.TrimStartOfString(ChangeTrackingPrefix.UnpublishedCulture);
+            var culture = propertyName.TrimStartExact(ChangeTrackingPrefix.UnpublishedCulture);
             return _previousPublishCultureChanges.removedCultures?.Contains(culture) ?? false;
         }
 
         if (propertyName.StartsWith(ChangeTrackingPrefix.ChangedCulture))
         {
-            var culture = propertyName.TrimStartOfString(ChangeTrackingPrefix.ChangedCulture);
+            var culture = propertyName.TrimStartExact(ChangeTrackingPrefix.ChangedCulture);
             return _previousPublishCultureChanges.updatedCultures?.Contains(culture) ?? false;
         }
 

--- a/src/Umbraco.Core/Models/Content.cs
+++ b/src/Umbraco.Core/Models/Content.cs
@@ -353,19 +353,19 @@ public class Content : ContentBase, IContent
         // Special check here since we want to check if the request is for changed cultures
         if (propertyName.StartsWith(ChangeTrackingPrefix.PublishedCulture))
         {
-            var culture = propertyName.TrimStart(ChangeTrackingPrefix.PublishedCulture);
+            var culture = propertyName.TrimStartOfString(ChangeTrackingPrefix.PublishedCulture);
             return _currentPublishCultureChanges.addedCultures?.Contains(culture) ?? false;
         }
 
         if (propertyName.StartsWith(ChangeTrackingPrefix.UnpublishedCulture))
         {
-            var culture = propertyName.TrimStart(ChangeTrackingPrefix.UnpublishedCulture);
+            var culture = propertyName.TrimStartOfString(ChangeTrackingPrefix.UnpublishedCulture);
             return _currentPublishCultureChanges.removedCultures?.Contains(culture) ?? false;
         }
 
         if (propertyName.StartsWith(ChangeTrackingPrefix.ChangedCulture))
         {
-            var culture = propertyName.TrimStart(ChangeTrackingPrefix.ChangedCulture);
+            var culture = propertyName.TrimStartOfString(ChangeTrackingPrefix.ChangedCulture);
             return _currentPublishCultureChanges.updatedCultures?.Contains(culture) ?? false;
         }
 
@@ -379,19 +379,19 @@ public class Content : ContentBase, IContent
         // Special check here since we want to check if the request is for changed cultures
         if (propertyName.StartsWith(ChangeTrackingPrefix.PublishedCulture))
         {
-            var culture = propertyName.TrimStart(ChangeTrackingPrefix.PublishedCulture);
+            var culture = propertyName.TrimStartOfString(ChangeTrackingPrefix.PublishedCulture);
             return _previousPublishCultureChanges.addedCultures?.Contains(culture) ?? false;
         }
 
         if (propertyName.StartsWith(ChangeTrackingPrefix.UnpublishedCulture))
         {
-            var culture = propertyName.TrimStart(ChangeTrackingPrefix.UnpublishedCulture);
+            var culture = propertyName.TrimStartOfString(ChangeTrackingPrefix.UnpublishedCulture);
             return _previousPublishCultureChanges.removedCultures?.Contains(culture) ?? false;
         }
 
         if (propertyName.StartsWith(ChangeTrackingPrefix.ChangedCulture))
         {
-            var culture = propertyName.TrimStart(ChangeTrackingPrefix.ChangedCulture);
+            var culture = propertyName.TrimStartOfString(ChangeTrackingPrefix.ChangedCulture);
             return _previousPublishCultureChanges.updatedCultures?.Contains(culture) ?? false;
         }
 

--- a/src/Umbraco.Core/Models/ContentBase.cs
+++ b/src/Umbraco.Core/Models/ContentBase.cs
@@ -578,19 +578,19 @@ public abstract class ContentBase : TreeEntityBase, IContentBase
         // Special check here since we want to check if the request is for changed cultures
         if (propertyName.StartsWith(ChangeTrackingPrefix.AddedCulture))
         {
-            var culture = propertyName.TrimStartOfString(ChangeTrackingPrefix.AddedCulture);
+            var culture = propertyName.TrimStartExact(ChangeTrackingPrefix.AddedCulture);
             return _currentCultureChanges.addedCultures?.Contains(culture) ?? false;
         }
 
         if (propertyName.StartsWith(ChangeTrackingPrefix.RemovedCulture))
         {
-            var culture = propertyName.TrimStartOfString(ChangeTrackingPrefix.RemovedCulture);
+            var culture = propertyName.TrimStartExact(ChangeTrackingPrefix.RemovedCulture);
             return _currentCultureChanges.removedCultures?.Contains(culture) ?? false;
         }
 
         if (propertyName.StartsWith(ChangeTrackingPrefix.UpdatedCulture))
         {
-            var culture = propertyName.TrimStartOfString(ChangeTrackingPrefix.UpdatedCulture);
+            var culture = propertyName.TrimStartExact(ChangeTrackingPrefix.UpdatedCulture);
             return _currentCultureChanges.updatedCultures?.Contains(culture) ?? false;
         }
 
@@ -609,19 +609,19 @@ public abstract class ContentBase : TreeEntityBase, IContentBase
         // Special check here since we want to check if the request is for changed cultures
         if (propertyName.StartsWith(ChangeTrackingPrefix.AddedCulture))
         {
-            var culture = propertyName.TrimStartOfString(ChangeTrackingPrefix.AddedCulture);
+            var culture = propertyName.TrimStartExact(ChangeTrackingPrefix.AddedCulture);
             return _previousCultureChanges.addedCultures?.Contains(culture) ?? false;
         }
 
         if (propertyName.StartsWith(ChangeTrackingPrefix.RemovedCulture))
         {
-            var culture = propertyName.TrimStartOfString(ChangeTrackingPrefix.RemovedCulture);
+            var culture = propertyName.TrimStartExact(ChangeTrackingPrefix.RemovedCulture);
             return _previousCultureChanges.removedCultures?.Contains(culture) ?? false;
         }
 
         if (propertyName.StartsWith(ChangeTrackingPrefix.UpdatedCulture))
         {
-            var culture = propertyName.TrimStartOfString(ChangeTrackingPrefix.UpdatedCulture);
+            var culture = propertyName.TrimStartExact(ChangeTrackingPrefix.UpdatedCulture);
             return _previousCultureChanges.updatedCultures?.Contains(culture) ?? false;
         }
 

--- a/src/Umbraco.Core/Models/ContentBase.cs
+++ b/src/Umbraco.Core/Models/ContentBase.cs
@@ -578,19 +578,19 @@ public abstract class ContentBase : TreeEntityBase, IContentBase
         // Special check here since we want to check if the request is for changed cultures
         if (propertyName.StartsWith(ChangeTrackingPrefix.AddedCulture))
         {
-            var culture = propertyName.TrimStart(ChangeTrackingPrefix.AddedCulture);
+            var culture = propertyName.TrimStartOfString(ChangeTrackingPrefix.AddedCulture);
             return _currentCultureChanges.addedCultures?.Contains(culture) ?? false;
         }
 
         if (propertyName.StartsWith(ChangeTrackingPrefix.RemovedCulture))
         {
-            var culture = propertyName.TrimStart(ChangeTrackingPrefix.RemovedCulture);
+            var culture = propertyName.TrimStartOfString(ChangeTrackingPrefix.RemovedCulture);
             return _currentCultureChanges.removedCultures?.Contains(culture) ?? false;
         }
 
         if (propertyName.StartsWith(ChangeTrackingPrefix.UpdatedCulture))
         {
-            var culture = propertyName.TrimStart(ChangeTrackingPrefix.UpdatedCulture);
+            var culture = propertyName.TrimStartOfString(ChangeTrackingPrefix.UpdatedCulture);
             return _currentCultureChanges.updatedCultures?.Contains(culture) ?? false;
         }
 
@@ -609,19 +609,19 @@ public abstract class ContentBase : TreeEntityBase, IContentBase
         // Special check here since we want to check if the request is for changed cultures
         if (propertyName.StartsWith(ChangeTrackingPrefix.AddedCulture))
         {
-            var culture = propertyName.TrimStart(ChangeTrackingPrefix.AddedCulture);
+            var culture = propertyName.TrimStartOfString(ChangeTrackingPrefix.AddedCulture);
             return _previousCultureChanges.addedCultures?.Contains(culture) ?? false;
         }
 
         if (propertyName.StartsWith(ChangeTrackingPrefix.RemovedCulture))
         {
-            var culture = propertyName.TrimStart(ChangeTrackingPrefix.RemovedCulture);
+            var culture = propertyName.TrimStartOfString(ChangeTrackingPrefix.RemovedCulture);
             return _previousCultureChanges.removedCultures?.Contains(culture) ?? false;
         }
 
         if (propertyName.StartsWith(ChangeTrackingPrefix.UpdatedCulture))
         {
-            var culture = propertyName.TrimStart(ChangeTrackingPrefix.UpdatedCulture);
+            var culture = propertyName.TrimStartOfString(ChangeTrackingPrefix.UpdatedCulture);
             return _previousCultureChanges.updatedCultures?.Contains(culture) ?? false;
         }
 

--- a/src/Umbraco.Core/Routing/UmbracoRequestPaths.cs
+++ b/src/Umbraco.Core/Routing/UmbracoRequestPaths.cs
@@ -30,7 +30,7 @@ public class UmbracoRequestPaths
         _appPath = hostingEnvironment.ApplicationVirtualPath;
 
         _backOfficePath = globalSettings.Value.GetBackOfficePath(hostingEnvironment)
-            .EnsureStartsWith('/').TrimStart(_appPath).EnsureStartsWith('/');
+            .EnsureStartsWith('/').TrimStartOfString(_appPath).EnsureStartsWith('/');
 
         string mvcArea = globalSettings.Value.GetUmbracoMvcArea(hostingEnvironment);
 
@@ -73,7 +73,7 @@ public class UmbracoRequestPaths
     /// </remarks>
     public bool IsBackOfficeRequest(string absPath)
     {
-        string urlPath = absPath.TrimStart(_appPath).EnsureStartsWith('/');
+        string urlPath = absPath.TrimStartOfString(_appPath).EnsureStartsWith('/');
 
         // check if this is in the umbraco back office
         if (!urlPath.InvariantStartsWith(_backOfficePath))

--- a/src/Umbraco.Core/Routing/UmbracoRequestPaths.cs
+++ b/src/Umbraco.Core/Routing/UmbracoRequestPaths.cs
@@ -30,7 +30,7 @@ public class UmbracoRequestPaths
         _appPath = hostingEnvironment.ApplicationVirtualPath;
 
         _backOfficePath = globalSettings.Value.GetBackOfficePath(hostingEnvironment)
-            .EnsureStartsWith('/').TrimStartOfString(_appPath).EnsureStartsWith('/');
+            .EnsureStartsWith('/').TrimStartExact(_appPath).EnsureStartsWith('/');
 
         string mvcArea = globalSettings.Value.GetUmbracoMvcArea(hostingEnvironment);
 
@@ -73,7 +73,7 @@ public class UmbracoRequestPaths
     /// </remarks>
     public bool IsBackOfficeRequest(string absPath)
     {
-        string urlPath = absPath.TrimStartOfString(_appPath).EnsureStartsWith('/');
+        string urlPath = absPath.TrimStartExact(_appPath).EnsureStartsWith('/');
 
         // check if this is in the umbraco back office
         if (!urlPath.InvariantStartsWith(_backOfficePath))

--- a/src/Umbraco.Examine.Lucene/BackOfficeExamineSearcher.cs
+++ b/src/Umbraco.Examine.Lucene/BackOfficeExamineSearcher.cs
@@ -246,7 +246,7 @@ public class BackOfficeExamineSearcher : IBackOfficeExamineSearcher
                         for (var index = 0; index < querywords.Length; index++)
                         {
                             queryWordsReplaced[index] =
-                                querywords[index].Replace("\\-", " ").Replace("_", " ").Trim(" ");
+                                querywords[index].Replace("\\-", " ").Replace("_", " ").TrimExact(" ");
                         }
                     }
                     else

--- a/src/Umbraco.Examine.Lucene/LuceneIndexDiagnostics.cs
+++ b/src/Umbraco.Examine.Lucene/LuceneIndexDiagnostics.cs
@@ -64,7 +64,7 @@ public class LuceneIndexDiagnostics : IIndexDiagnostics
             {
                 var rootDir = _hostingEnvironment.ApplicationPhysicalPath;
                 d["LuceneIndexFolder"] = fsDir.Directory.ToString().ToLowerInvariant()
-                    .TrimStart(rootDir.ToLowerInvariant()).Replace("\\", " /").EnsureStartsWith('/');
+                    .TrimStartOfString(rootDir.ToLowerInvariant()).Replace("\\", " /").EnsureStartsWith('/');
             }
 
             if (_indexOptions != null)

--- a/src/Umbraco.Examine.Lucene/LuceneIndexDiagnostics.cs
+++ b/src/Umbraco.Examine.Lucene/LuceneIndexDiagnostics.cs
@@ -64,7 +64,7 @@ public class LuceneIndexDiagnostics : IIndexDiagnostics
             {
                 var rootDir = _hostingEnvironment.ApplicationPhysicalPath;
                 d["LuceneIndexFolder"] = fsDir.Directory.ToString().ToLowerInvariant()
-                    .TrimStartOfString(rootDir.ToLowerInvariant()).Replace("\\", " /").EnsureStartsWith('/');
+                    .TrimStartExact(rootDir.ToLowerInvariant()).Replace("\\", " /").EnsureStartsWith('/');
             }
 
             if (_indexOptions != null)

--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs
@@ -197,7 +197,7 @@ internal sealed class ApiRichTextElementParser : ApiRichTextParserBase, IApiRich
 
         foreach (KeyValuePair<string, object> dataAttribute in dataAttributes)
         {
-            var actualKey = dataAttribute.Key.TrimStart("data-");
+            var actualKey = dataAttribute.Key.TrimStartOfString("data-");
             attributes.TryAdd(actualKey, dataAttribute.Value);
 
             attributes.Remove(dataAttribute.Key);

--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs
@@ -197,7 +197,7 @@ internal sealed class ApiRichTextElementParser : ApiRichTextParserBase, IApiRich
 
         foreach (KeyValuePair<string, object> dataAttribute in dataAttributes)
         {
-            var actualKey = dataAttribute.Key.TrimStartOfString("data-");
+            var actualKey = dataAttribute.Key.TrimStartExact("data-");
             attributes.TryAdd(actualKey, dataAttribute.Value);
 
             attributes.Remove(dataAttribute.Key);

--- a/src/Umbraco.Infrastructure/Install/FilePermissionHelper.cs
+++ b/src/Umbraco.Infrastructure/Install/FilePermissionHelper.cs
@@ -97,7 +97,7 @@ public class FilePermissionHelper : IFilePermissionHelper
                 temp = new List<string>();
             }
 
-            temp.Add(dir.TrimStart(_basePath));
+            temp.Add(dir.TrimStartOfString(_basePath));
             success = false;
         }
 
@@ -122,7 +122,7 @@ public class FilePermissionHelper : IFilePermissionHelper
                 temp = new List<string>();
             }
 
-            temp.Add(file.TrimStart(_basePath));
+            temp.Add(file.TrimStartOfString(_basePath));
             success = false;
         }
 

--- a/src/Umbraco.Infrastructure/Install/FilePermissionHelper.cs
+++ b/src/Umbraco.Infrastructure/Install/FilePermissionHelper.cs
@@ -97,7 +97,7 @@ public class FilePermissionHelper : IFilePermissionHelper
                 temp = new List<string>();
             }
 
-            temp.Add(dir.TrimStartOfString(_basePath));
+            temp.Add(dir.TrimStartExact(_basePath));
             success = false;
         }
 
@@ -122,7 +122,7 @@ public class FilePermissionHelper : IFilePermissionHelper
                 temp = new List<string>();
             }
 
-            temp.Add(file.TrimStartOfString(_basePath));
+            temp.Add(file.TrimStartExact(_basePath));
             success = false;
         }
 

--- a/src/Umbraco.Infrastructure/Logging/Serilog/LoggerConfigExtensions.cs
+++ b/src/Umbraco.Infrastructure/Logging/Serilog/LoggerConfigExtensions.cs
@@ -95,7 +95,7 @@ namespace Umbraco.Extensions
 
             //Set this environment variable - so that it can be used in external config file
             //add key="serilog:write-to:RollingFile.pathFormat" value="%BASEDIR%\logs\log.txt" />
-            Environment.SetEnvironmentVariable("BASEDIR", hostEnvironment.MapPathContentRoot("/").TrimEndOfString("\\"), EnvironmentVariableTarget.Process);
+            Environment.SetEnvironmentVariable("BASEDIR", hostEnvironment.MapPathContentRoot("/").TrimEndExact("\\"), EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable("UMBLOGDIR", loggingConfiguration.LogDirectory, EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable("MACHINENAME", Environment.MachineName, EnvironmentVariableTarget.Process);
 

--- a/src/Umbraco.Infrastructure/Logging/Serilog/LoggerConfigExtensions.cs
+++ b/src/Umbraco.Infrastructure/Logging/Serilog/LoggerConfigExtensions.cs
@@ -95,7 +95,7 @@ namespace Umbraco.Extensions
 
             //Set this environment variable - so that it can be used in external config file
             //add key="serilog:write-to:RollingFile.pathFormat" value="%BASEDIR%\logs\log.txt" />
-            Environment.SetEnvironmentVariable("BASEDIR", hostEnvironment.MapPathContentRoot("/").TrimEnd("\\"), EnvironmentVariableTarget.Process);
+            Environment.SetEnvironmentVariable("BASEDIR", hostEnvironment.MapPathContentRoot("/").TrimEndOfString("\\"), EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable("UMBLOGDIR", loggingConfiguration.LogDirectory, EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable("MACHINENAME", Environment.MachineName, EnvironmentVariableTarget.Process);
 

--- a/src/Umbraco.Infrastructure/Persistence/NPocoSqlExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/NPocoSqlExtensions.cs
@@ -193,7 +193,7 @@ namespace Umbraco.Extensions
 
                 var temp = new Sql<ISqlContext>(sql.SqlContext);
                 temp = predicates[i](temp);
-                wsql.Append(temp.SQL.TrimStart("WHERE "), temp.Arguments);
+                wsql.Append(temp.SQL.TrimStartOfString("WHERE "), temp.Arguments);
             }
             wsql.Append(")");
 
@@ -582,7 +582,7 @@ namespace Umbraco.Extensions
         {
             var sql = new Sql<ISqlContext>(sqlJoin.SqlContext);
             sql = on(sql);
-            var text = sql.SQL.Trim().TrimStart("WHERE").Trim();
+            var text = sql.SQL.Trim().TrimStartOfString("WHERE").Trim();
             return sqlJoin.On(text, sql.Arguments);
         }
 

--- a/src/Umbraco.Infrastructure/Persistence/NPocoSqlExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/NPocoSqlExtensions.cs
@@ -193,7 +193,7 @@ namespace Umbraco.Extensions
 
                 var temp = new Sql<ISqlContext>(sql.SqlContext);
                 temp = predicates[i](temp);
-                wsql.Append(temp.SQL.TrimStartOfString("WHERE "), temp.Arguments);
+                wsql.Append(temp.SQL.TrimStartExact("WHERE "), temp.Arguments);
             }
             wsql.Append(")");
 
@@ -582,7 +582,7 @@ namespace Umbraco.Extensions
         {
             var sql = new Sql<ISqlContext>(sqlJoin.SqlContext);
             sql = on(sql);
-            var text = sql.SQL.Trim().TrimStartOfString("WHERE").Trim();
+            var text = sql.SQL.Trim().TrimStartExact("WHERE").Trim();
             return sqlJoin.On(text, sql.Arguments);
         }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
@@ -1179,7 +1179,7 @@ SELECT 4 AS [Key], COUNT(id) AS [Value] FROM umbracoUser WHERE userDisabled = 0 
         var args = filterSql.Arguments;
         var sqlFilter = hasWhereClause
             ? filterSql.SQL
-            : " WHERE " + filterSql.SQL.TrimStartOfString("AND ");
+            : " WHERE " + filterSql.SQL.TrimStartExact("AND ");
 
         sql.Append(SqlContext.Sql(sqlFilter, args));
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
@@ -1179,7 +1179,7 @@ SELECT 4 AS [Key], COUNT(id) AS [Value] FROM umbracoUser WHERE userDisabled = 0 
         var args = filterSql.Arguments;
         var sqlFilter = hasWhereClause
             ? filterSql.SQL
-            : " WHERE " + filterSql.SQL.TrimStart("AND ");
+            : " WHERE " + filterSql.SQL.TrimStartOfString("AND ");
 
         sql.Append(SqlContext.Sql(sqlFilter, args));
 

--- a/src/Umbraco.Infrastructure/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
@@ -303,7 +303,7 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
             sb.Append(Format(column) + ",\n");
         }
 
-        return sb.ToString().TrimEndOfString(",\n");
+        return sb.ToString().TrimEndExact(",\n");
     }
 
     public virtual string Format(ColumnDefinition column) =>

--- a/src/Umbraco.Infrastructure/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
@@ -303,7 +303,7 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
             sb.Append(Format(column) + ",\n");
         }
 
-        return sb.ToString().TrimEnd(",\n");
+        return sb.ToString().TrimEndOfString(",\n");
     }
 
     public virtual string Format(ColumnDefinition column) =>

--- a/src/Umbraco.Web.Common/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/ApplicationBuilderExtensions.cs
@@ -192,7 +192,7 @@ public static class ApplicationBuilderExtensions
     public static IApplicationBuilder UseUmbracoBackOfficeRewrites(this IApplicationBuilder builder)
     {
         IBackOfficePathGenerator backOfficePathGenerator = builder.ApplicationServices.GetRequiredService<IBackOfficePathGenerator>();
-        var backOfficeAssetsPath = backOfficePathGenerator.BackOfficeAssetsPath.TrimStart("/").EnsureEndsWith("/");
+        var backOfficeAssetsPath = backOfficePathGenerator.BackOfficeAssetsPath.TrimStartOfString("/").EnsureEndsWith("/");
 
         builder.UseRewriter(new RewriteOptions()
             // The destination needs to be hardcoded to "/umbraco/backoffice" because this is where they are located in the Umbraco.Cms.StaticAssets RCL

--- a/src/Umbraco.Web.Common/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/ApplicationBuilderExtensions.cs
@@ -192,7 +192,7 @@ public static class ApplicationBuilderExtensions
     public static IApplicationBuilder UseUmbracoBackOfficeRewrites(this IApplicationBuilder builder)
     {
         IBackOfficePathGenerator backOfficePathGenerator = builder.ApplicationServices.GetRequiredService<IBackOfficePathGenerator>();
-        var backOfficeAssetsPath = backOfficePathGenerator.BackOfficeAssetsPath.TrimStartOfString("/").EnsureEndsWith("/");
+        var backOfficeAssetsPath = backOfficePathGenerator.BackOfficeAssetsPath.TrimStartExact("/").EnsureEndsWith("/");
 
         builder.UseRewriter(new RewriteOptions()
             // The destination needs to be hardcoded to "/umbraco/backoffice" because this is where they are located in the Umbraco.Cms.StaticAssets RCL

--- a/src/Umbraco.Web.Common/Extensions/LinkGeneratorExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/LinkGeneratorExtensions.cs
@@ -40,7 +40,7 @@ public static class LinkGeneratorExtensions
                                              " or the result ");
         }
 
-        return linkGenerator.GetUmbracoApiService<T>(method.Name)?.TrimEnd(method.Name);
+        return linkGenerator.GetUmbracoApiService<T>(method.Name)?.TrimEndOfString(method.Name);
     }
 
     /// <summary>

--- a/src/Umbraco.Web.Common/Extensions/LinkGeneratorExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/LinkGeneratorExtensions.cs
@@ -40,7 +40,7 @@ public static class LinkGeneratorExtensions
                                              " or the result ");
         }
 
-        return linkGenerator.GetUmbracoApiService<T>(method.Name)?.TrimEndOfString(method.Name);
+        return linkGenerator.GetUmbracoApiService<T>(method.Name)?.TrimEndExact(method.Name);
     }
 
     /// <summary>

--- a/src/Umbraco.Web.Common/Extensions/UrlHelperExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/UrlHelperExtensions.cs
@@ -197,7 +197,7 @@ public static class UrlHelperExtensions
         UmbracoApiControllerTypeCollection umbracoApiControllerTypeCollection,
         string actionName)
         where T : UmbracoApiController =>
-        url.GetUmbracoApiService<T>(umbracoApiControllerTypeCollection, actionName)?.TrimEndOfString(actionName);
+        url.GetUmbracoApiService<T>(umbracoApiControllerTypeCollection, actionName)?.TrimEndExact(actionName);
 
     [Obsolete("This will be removed in Umbraco 15.")]
     public static string? GetUmbracoApiServiceBaseUrl<T>(
@@ -213,7 +213,7 @@ public static class UrlHelperExtensions
                                              " or the result ");
         }
 
-        return url.GetUmbracoApiService<T>(umbracoApiControllerTypeCollection, method.Name)?.TrimEndOfString(method.Name);
+        return url.GetUmbracoApiService<T>(umbracoApiControllerTypeCollection, method.Name)?.TrimEndExact(method.Name);
     }
 
     /// <summary>

--- a/src/Umbraco.Web.Common/Extensions/UrlHelperExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/UrlHelperExtensions.cs
@@ -197,7 +197,7 @@ public static class UrlHelperExtensions
         UmbracoApiControllerTypeCollection umbracoApiControllerTypeCollection,
         string actionName)
         where T : UmbracoApiController =>
-        url.GetUmbracoApiService<T>(umbracoApiControllerTypeCollection, actionName)?.TrimEnd(actionName);
+        url.GetUmbracoApiService<T>(umbracoApiControllerTypeCollection, actionName)?.TrimEndOfString(actionName);
 
     [Obsolete("This will be removed in Umbraco 15.")]
     public static string? GetUmbracoApiServiceBaseUrl<T>(
@@ -213,7 +213,7 @@ public static class UrlHelperExtensions
                                              " or the result ");
         }
 
-        return url.GetUmbracoApiService<T>(umbracoApiControllerTypeCollection, method.Name)?.TrimEnd(method.Name);
+        return url.GetUmbracoApiService<T>(umbracoApiControllerTypeCollection, method.Name)?.TrimEndOfString(method.Name);
     }
 
     /// <summary>

--- a/templates/UmbracoPackage/.template.config/template.json
+++ b/templates/UmbracoPackage/.template.config/template.json
@@ -28,13 +28,13 @@
       "datatype": "choice",
       "choices": [
         {
-          "displayName": ".NET 8.0",
-          "description": "Target net8.0",
-          "choice": "net8.0"
+          "displayName": ".NET 9.0",
+          "description": "Target net9.0",
+          "choice": "net9.0"
         }
       ],
-      "defaultValue": "net8.0",
-      "replaces": "net8.0"
+      "defaultValue": "net9.0",
+      "replaces": "net9.0"
     },
     "UmbracoVersion": {
       "displayName": "Umbraco version",

--- a/templates/UmbracoPackage/UmbracoPackage.csproj
+++ b/templates/UmbracoPackage/UmbracoPackage.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <ContentTargetFolders>.</ContentTargetFolders>

--- a/templates/UmbracoPackageRcl/.template.config/template.json
+++ b/templates/UmbracoPackageRcl/.template.config/template.json
@@ -29,13 +29,13 @@
       "datatype": "choice",
       "choices": [
         {
-          "displayName": ".NET 8.0",
-          "description": "Target net8.0",
-          "choice": "net8.0"
+          "displayName": ".NET 9.0",
+          "description": "Target net9.0",
+          "choice": "net9.0"
         }
       ],
-      "defaultValue": "net8.0",
-      "replaces": "net8.0"
+      "defaultValue": "net9.0",
+      "replaces": "net9.0"
     },
     "UmbracoVersion": {
       "displayName": "Umbraco version",

--- a/templates/UmbracoPackageRcl/UmbracoPackage.csproj
+++ b/templates/UmbracoPackageRcl/UmbracoPackage.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AddRazorSupportForMvc Condition="'$(SupportPagesAndViews)' == 'True'">true</AddRazorSupportForMvc>

--- a/templates/UmbracoProject/.template.config/template.json
+++ b/templates/UmbracoProject/.template.config/template.json
@@ -38,13 +38,13 @@
       "datatype": "choice",
       "choices": [
         {
-          "displayName": ".NET 8.0",
-          "description": "Target net8.0",
-          "choice": "net8.0"
+          "displayName": ".NET 9.0",
+          "description": "Target net9.0",
+          "choice": "net9.0"
         }
       ],
-      "defaultValue": "net8.0",
-      "replaces": "net8.0"
+      "defaultValue": "net9.0",
+      "replaces": "net9.0"
     },
     "UmbracoVersion": {
       "displayName": "Umbraco version",

--- a/templates/UmbracoProject/UmbracoProject.csproj
+++ b/templates/UmbracoProject/UmbracoProject.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Umbraco.Cms.Web.UI</RootNamespace>

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -5,12 +5,12 @@
   <ItemGroup>
     <!-- Microsoft packages -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-preview.5.24306.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0-preview.5.24306.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageVersion Include="System.Data.Odbc" Version="8.0.0" />
-    <PackageVersion Include="System.Data.OleDb" Version="8.0.0" />
+    <PackageVersion Include="System.Data.Odbc" Version="9.0.0-preview.5.24306.7" />
+    <PackageVersion Include="System.Data.OleDb" Version="9.0.0-preview.5.24306.7" />
     <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Umbraco.Tests.Integration/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/tests/Umbraco.Tests.Integration/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -132,7 +132,7 @@ public static class UmbracoBuilderExtensions
                     uiProject.Create();
                 }
 
-                var mainLangFolder = new DirectoryInfo(Path.Combine(uiProject.FullName, globalSettings.Value.UmbracoPath.TrimStart("~/"), "config", "lang"));
+                var mainLangFolder = new DirectoryInfo(Path.Combine(uiProject.FullName, globalSettings.Value.UmbracoPath.TrimStartOfString("~/"), "config", "lang"));
 
                 return new LocalizedTextServiceFileSources(
                     loggerFactory.CreateLogger<LocalizedTextServiceFileSources>(),

--- a/tests/Umbraco.Tests.Integration/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/tests/Umbraco.Tests.Integration/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -132,7 +132,7 @@ public static class UmbracoBuilderExtensions
                     uiProject.Create();
                 }
 
-                var mainLangFolder = new DirectoryInfo(Path.Combine(uiProject.FullName, globalSettings.Value.UmbracoPath.TrimStartOfString("~/"), "config", "lang"));
+                var mainLangFolder = new DirectoryInfo(Path.Combine(uiProject.FullName, globalSettings.Value.UmbracoPath.TrimStartExact("~/"), "config", "lang"));
 
                 return new LocalizedTextServiceFileSources(
                     loggerFactory.CreateLogger<LocalizedTextServiceFileSources>(),

--- a/tests/Umbraco.Tests.Integration/ManagementApi/ManagementApiTest.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/ManagementApiTest.cs
@@ -111,7 +111,7 @@ public abstract class ManagementApiTest<T> : UmbracoTestServerTestBase
 
         var codeVerifier = "12345"; // Just a dummy value we use in tests
         var codeChallange = Convert.ToBase64String(SHA256.Create().ComputeHash(Encoding.UTF8.GetBytes(codeVerifier)))
-            .TrimEnd("=");
+            .TrimEndOfString("=");
 
         var authorizationUrl = GetManagementApiUrl<BackOfficeController>(x => x.Authorize(CancellationToken.None)) +
                   $"?client_id={backofficeOpenIddictApplicationDescriptor.ClientId}&response_type=code&redirect_uri={WebUtility.UrlEncode(backofficeOpenIddictApplicationDescriptor.RedirectUris.FirstOrDefault()?.AbsoluteUri)}&code_challenge_method=S256&code_challenge={codeChallange}";

--- a/tests/Umbraco.Tests.Integration/ManagementApi/ManagementApiTest.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/ManagementApiTest.cs
@@ -111,7 +111,7 @@ public abstract class ManagementApiTest<T> : UmbracoTestServerTestBase
 
         var codeVerifier = "12345"; // Just a dummy value we use in tests
         var codeChallange = Convert.ToBase64String(SHA256.Create().ComputeHash(Encoding.UTF8.GetBytes(codeVerifier)))
-            .TrimEndOfString("=");
+            .TrimEndExact("=");
 
         var authorizationUrl = GetManagementApiUrl<BackOfficeController>(x => x.Authorize(CancellationToken.None)) +
                   $"?client_id={backofficeOpenIddictApplicationDescriptor.ClientId}&response_type=code&redirect_uri={WebUtility.UrlEncode(backofficeOpenIddictApplicationDescriptor.RedirectUris.FirstOrDefault()?.AbsoluteUri)}&code_challenge_method=S256&code_challenge={codeChallange}";

--- a/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/ExamineExternalIndexSearcherTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/ExamineExternalIndexSearcherTest.cs
@@ -240,7 +240,7 @@ public class ExamineExternalIndexSearcherTest : IExamineExternalIndexSearcherTes
                         for (var index = 0; index < querywords.Length; index++)
                         {
                             queryWordsReplaced[index] =
-                                querywords[index].Replace("\\-", " ").Replace("_", " ").Trim(" ");
+                                querywords[index].Replace("\\-", " ").Replace("_", " ").TrimExact(" ");
                         }
                     }
                     else

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ShortStringHelper/StringExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ShortStringHelper/StringExtensionsTests.cs
@@ -88,7 +88,7 @@ public class StringExtensionsTests
     [TestCase("Hello this is my string string", "Hello this is my string string", "")]
     public void TrimEnd(string input, string forTrimming, string shouldBe)
     {
-        var trimmed = input.TrimEndOfString(forTrimming);
+        var trimmed = input.TrimEndExact(forTrimming);
         Assert.AreEqual(shouldBe, trimmed);
     }
 
@@ -98,7 +98,7 @@ public class StringExtensionsTests
     [TestCase("Hello this is my string", "Hello this is my string", "")]
     public void TrimStart(string input, string forTrimming, string shouldBe)
     {
-        var trimmed = input.TrimStartOfString(forTrimming);
+        var trimmed = input.TrimStartExact(forTrimming);
         Assert.AreEqual(shouldBe, trimmed);
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ShortStringHelper/StringExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ShortStringHelper/StringExtensionsTests.cs
@@ -88,7 +88,7 @@ public class StringExtensionsTests
     [TestCase("Hello this is my string string", "Hello this is my string string", "")]
     public void TrimEnd(string input, string forTrimming, string shouldBe)
     {
-        var trimmed = input.TrimEnd(forTrimming);
+        var trimmed = input.TrimEndOfString(forTrimming);
         Assert.AreEqual(shouldBe, trimmed);
     }
 
@@ -98,7 +98,7 @@ public class StringExtensionsTests
     [TestCase("Hello this is my string", "Hello this is my string", "")]
     public void TrimStart(string input, string forTrimming, string shouldBe)
     {
-        var trimmed = input.TrimStart(forTrimming);
+        var trimmed = input.TrimStartOfString(forTrimming);
         Assert.AreEqual(shouldBe, trimmed);
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/NPocoTests/NPocoSqlTemplateTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/NPocoTests/NPocoSqlTemplateTests.cs
@@ -203,7 +203,7 @@ public class NPocoSqlTemplateTests
             .Append("AND whatever=@0", SqlTemplate.Arg("k")));
 
         sql = template.Sql(new { j = new[] { 1, 2, 3 }, k = "oops" });
-        Assert.AreEqual(sqlBase.TrimEnd("WHERE ") + "AND whatever=@0,@1,@2 AND whatever=@3", sql.SQL.NoCrLf());
+        Assert.AreEqual(sqlBase.TrimEndOfString("WHERE ") + "AND whatever=@0,@1,@2 AND whatever=@3", sql.SQL.NoCrLf());
         Assert.AreEqual(4, sql.Arguments.Length);
         Assert.AreEqual(1, sql.Arguments[0]);
         Assert.AreEqual(2, sql.Arguments[1]);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/NPocoTests/NPocoSqlTemplateTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/NPocoTests/NPocoSqlTemplateTests.cs
@@ -203,7 +203,7 @@ public class NPocoSqlTemplateTests
             .Append("AND whatever=@0", SqlTemplate.Arg("k")));
 
         sql = template.Sql(new { j = new[] { 1, 2, 3 }, k = "oops" });
-        Assert.AreEqual(sqlBase.TrimEndOfString("WHERE ") + "AND whatever=@0,@1,@2 AND whatever=@3", sql.SQL.NoCrLf());
+        Assert.AreEqual(sqlBase.TrimEndExact("WHERE ") + "AND whatever=@0,@1,@2 AND whatever=@3", sql.SQL.NoCrLf());
         Assert.AreEqual(4, sql.Arguments.Length);
         Assert.AreEqual(1, sql.Arguments[0]);
         Assert.AreEqual(2, sql.Arguments[1]);

--- a/tools/Umbraco.JsonSchema/Umbraco.JsonSchema.csproj
+++ b/tools/Umbraco.JsonSchema/Umbraco.JsonSchema.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" VersionOverride="2.9.1" />
-    <PackageReference Include="NJsonSchema" VersionOverride="11.0.0" />
+    <PackageReference Include="NJsonSchema" VersionOverride="11.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "14.1.0-rc",
+  "version": "15.0.0-rc1",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
# Notes
- Had to rename `TrimStart` & `TrimEnd`, as they are now implemented by Microsoft, and the behavior differs from ours.
- Updates dotnet verison to dotnet9
- Updates nuget packages to their respective dotnet 9 version
- Had to update Umbraco.Code to 2.2 aswell, as it used the `Microsoft.CodeAnalysis` package, and thus we couldn't update that.

# How to test
Ensure both templates & source code work with dotnet 9
- Download dotnet 9 preview here: https://dotnet.microsoft.com/en-us/download/dotnet/9.0
- In the root of the project, run `dotnet pack -o nuget`
- Go to the nuget folder `cd nuget`
- Copy the path of that folder, and then run `dotnet nuget add source [PATH TO NUGET FOLDER HERE]`
- Install the templates, take note of the version of the templates nupkg in the nuget folder `dotnet new install Umbraco.Templates::[version of templates here]`
- Create a new umbraco project with the new template `dotnet new umbraco -n "MyTestProject"`
- Run the project and assert it works 👍 