### PR TITLE
V13: Eaglery route domains for virtual page controllers

### DIFF
--- a/src/Umbraco.Web.Website/Routing/EagerMatcherPolicy.cs
+++ b/src/Umbraco.Web.Website/Routing/EagerMatcherPolicy.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Matching;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;

--- a/src/Umbraco.Web.Website/Routing/EagerMatcherPolicy.cs
+++ b/src/Umbraco.Web.Website/Routing/EagerMatcherPolicy.cs
@@ -128,7 +128,7 @@ internal class EagerMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy
 
             // If it's an UmbracoPageController we need to do some domain routing.
             // We need to do this in oder to handle cultures for our Dictionary.
-            // This is because UmbracoPublishedContentCultureProvider is ued to set the Thread.CurrentThread.CurrentCulture
+            // This is because UmbracoPublishedContentCultureProvider is ued to set the Thread.CurrentThread.CurrentUICulture
             // The CultureProvider is run before the actual routing, this means that our UmbracoVirtualPageFilterAttribute is hit AFTER the culture is set.
             // Meaning we have to route the domain part already now, this is not pretty, but it beats having to look for content we know doesn't exist.
             if (controllerTypeInfo is not null && controllerTypeInfo.IsType<UmbracoPageController>())


### PR DESCRIPTION
Fixes #16626 

This was caused because the `Thread.CurrentThread.CurrentUICulture` is set by `UmbracoPublishedContentCultureProvider` which runs before any of the filters, meaning that `CurrentUICulture` was never set correctly, so to fix this I've made the `EagerMatcherPolicy` detect if it's a `UmbracoPageController` and then do the domain routing and setting a dummy `UmbracoRouteValues` which is then used to assign the correct `CurrentUICulture` by the `UmbracoPublishedContentCultureProvider`. 

