### PR TITLE
fix: uploaded item not selected in media picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -271,6 +271,8 @@ angular.module("umbraco")
                     $scope.path = [];
                     performGotoFolder(folder);
                 }
+
+              return getChildren(folder.id);
             }
 
             function performGotoFolder(folder) {
@@ -280,8 +282,6 @@ angular.module("umbraco")
                 $scope.currentFolder = folder;
 
                 localStorageService.set("umbLastOpenedMediaNodeId", folder.id);
-
-                getChildren(folder.id);
             }
 
             function toggleListView() {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Since the merge of issue [#15115](https://github.com/umbraco/Umbraco-CMS/pull/15115), uploaded items are not selected anymore. 

Steps to test: 
* Create an Media Picker (Pick multiple items should be off) and upload an image into the media picker. 
Latest uploaded file should be selected.

With the option "Pick multiple items" no item is selected, but this functionality did not do this before the bug was introduced either. That is why no change has been made to this behaviour.

Extra remark:
issue [#15115](https://github.com/umbraco/Umbraco-CMS/pull/15115) does not appear to have resolved the problem either. I can still produce the bug.
