### PR TITLE
V13: Update url scheme for Twitter OEmbedProvider

### DIFF
--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
@@ -126,7 +126,6 @@ public static partial class UmbracoBuilderExtensions
         // register OEmbed providers - no type scanning - all explicit opt-in of adding types, IEmbedProvider is not IDiscoverable
         builder.EmbedProviders()
             .Append<YouTube>()
-            .Append<Twitter>()
             .Append<Vimeo>()
             .Append<DailyMotion>()
             .Append<Flickr>()
@@ -138,7 +137,8 @@ public static partial class UmbracoBuilderExtensions
             .Append<Issuu>()
             .Append<Hulu>()
             .Append<Giphy>()
-            .Append<LottieFiles>();
+            .Append<LottieFiles>()
+            .Append<X>();
         builder.SearchableTrees().Add(() => builder.TypeLoader.GetTypes<ISearchableTree>());
         builder.BackOfficeAssets();
         builder.SelectorHandlers().Add(() => builder.TypeLoader.GetTypes<ISelectorHandler>());

--- a/src/Umbraco.Core/Media/EmbedProviders/Twitter.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Twitter.cs
@@ -5,6 +5,7 @@ namespace Umbraco.Cms.Core.Media.EmbedProviders;
 /// <summary>
 ///     Embed Provider for Twitter the popular online service for microblogging and social networking.
 /// </summary>
+[Obsolete("Please use the X instead, scheduled for removal in v16")]
 public class Twitter : OEmbedProviderBase
 {
     public Twitter(IJsonSerializer jsonSerializer)
@@ -14,7 +15,7 @@ public class Twitter : OEmbedProviderBase
 
     public override string ApiEndpoint => "http://publish.twitter.com/oembed";
 
-    public override string[] UrlSchemeRegex => new[] { @"(?:https?:\/\/)(?:www\.)?(twitter|x)\.com\/.*\/status\/.*" };
+    public override string[] UrlSchemeRegex => new[] { @"twitter.com/.*/status/.*" };
 
     public override Dictionary<string, string> RequestParams => new();
 

--- a/src/Umbraco.Core/Media/EmbedProviders/Twitter.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Twitter.cs
@@ -14,7 +14,7 @@ public class Twitter : OEmbedProviderBase
 
     public override string ApiEndpoint => "http://publish.twitter.com/oembed";
 
-    public override string[] UrlSchemeRegex => new[] { @"(twitter|x).com/.*/status/.*" };
+    public override string[] UrlSchemeRegex => new[] { @"(?:https?:\/\/)(?:www\.)?(twitter|x)\.com\/.*\/status\/.*" };
 
     public override Dictionary<string, string> RequestParams => new();
 

--- a/src/Umbraco.Core/Media/EmbedProviders/Twitter.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Twitter.cs
@@ -14,7 +14,7 @@ public class Twitter : OEmbedProviderBase
 
     public override string ApiEndpoint => "http://publish.twitter.com/oembed";
 
-    public override string[] UrlSchemeRegex => new[] { @"twitter.com/.*/status/.*" };
+    public override string[] UrlSchemeRegex => new[] { @"(twitter|x).com/.*/status/.*" };
 
     public override Dictionary<string, string> RequestParams => new();
 

--- a/src/Umbraco.Core/Media/EmbedProviders/Twitter.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Twitter.cs
@@ -5,7 +5,7 @@ namespace Umbraco.Cms.Core.Media.EmbedProviders;
 /// <summary>
 ///     Embed Provider for Twitter the popular online service for microblogging and social networking.
 /// </summary>
-[Obsolete("Please use the X instead, scheduled for removal in v16")]
+[Obsolete("Please use X instead, scheduled for removal in v16")]
 public class Twitter : OEmbedProviderBase
 {
     public Twitter(IJsonSerializer jsonSerializer)

--- a/src/Umbraco.Core/Media/EmbedProviders/X.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/X.cs
@@ -1,0 +1,28 @@
+using Umbraco.Cms.Core.Serialization;
+
+namespace Umbraco.Cms.Core.Media.EmbedProviders;
+
+/// <summary>
+///     Embed Provider for X the popular online service for microblogging and social networking.
+/// </summary>
+public class X : OEmbedProviderBase
+{
+    public X(IJsonSerializer jsonSerializer)
+        : base(jsonSerializer)
+    {
+    }
+
+    public override string ApiEndpoint => "http://publish.twitter.com/oembed";
+
+    public override string[] UrlSchemeRegex => new[] { @"(https?:\/\/(www\.)?)(twitter|x)\.com\/.*\/status\/.*" };
+
+    public override Dictionary<string, string> RequestParams => new();
+
+    public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
+    {
+        var requestUrl = base.GetEmbedProviderUrl(url, maxWidth, maxHeight);
+        OEmbedResponse? oembed = base.GetJsonResponse<OEmbedResponse>(requestUrl);
+
+        return oembed?.GetHtml();
+    }
+}


### PR DESCRIPTION
## Details
- Fixes: #16645

## Test
- Create a doc type with RTE;
  - Make sure you have "**Embed**" option included in the toolbar.
- Create a content node from that document type;
- Insert an embedded media by clicking on the "**Embed**" button in the RTE;
- Verify that both `https://x.com/SpaceX/status/1732824684683784516` and `https://twitter.com/SpaceX/status/1732824684683784516` render;