### PR TITLE
Make GetHeaderValue support HttpContext unavailable

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Services/RequestHeaderHandler.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/RequestHeaderHandler.cs
@@ -8,11 +8,5 @@ internal abstract class RequestHeaderHandler
 
     protected RequestHeaderHandler(IHttpContextAccessor httpContextAccessor) => _httpContextAccessor = httpContextAccessor;
 
-    protected string? GetHeaderValue(string headerName)
-    {
-        HttpContext httpContext = _httpContextAccessor.HttpContext ??
-                                  throw new InvalidOperationException("Could not obtain an HTTP context");
-
-        return httpContext.Request.Headers[headerName];
-    }
+    protected string? GetHeaderValue(string headerName) => _httpContextAccessor.HttpContext?.Request.Headers[headerName];
 }


### PR DESCRIPTION
### Description
Makes the GetHeaderValue tolerant to work, when http context is not available. Now it just returns null.

Fixes #16638

