### PR TITLE
V14: Fix source code editor not showing on fresh install / upgrade

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
@@ -1934,7 +1934,7 @@ internal class DatabaseDataCreator
                     EditorUiAlias = "Umb.PropertyEditorUi.TinyMCE",
                     DbType = "Ntext",
                     Configuration =
-                        "{\"toolbar\":[\"ace\",\"styles\",\"bold\",\"italic\",\"alignleft\",\"aligncenter\",\"alignright\",\"bullist\",\"numlist\",\"outdent\",\"indent\",\"link\",\"umbmediapicker\",\"umbembeddialog\"],\"stylesheets\":[],\"maxImageSize\":500,\"mode\":\"classic\"}",
+                        "{\"toolbar\":[\"sourcecode\",\"styles\",\"bold\",\"italic\",\"alignleft\",\"aligncenter\",\"alignright\",\"bullist\",\"numlist\",\"outdent\",\"indent\",\"link\",\"umbmediapicker\",\"umbembeddialog\"],\"stylesheets\":[],\"maxImageSize\":500,\"mode\":\"classic\"}",
                 });
         }
 

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -84,5 +84,6 @@ public class UmbracoPlan : MigrationPlan
         // we need to re-run this migration, as it was flawed for V14 RC3 (the migration can run twice without any issues)
         To<V_14_0_0.AddEditorUiToDataType>("{6FB5CA9E-C823-473B-A14C-FE760D75943C}");
         To<V_14_0_0.CleanUpDataTypeConfigurations>("{827360CA-0855-42A5-8F86-A51F168CB559}");
+        To<V_14_0_0.MigrateRichTextConfiguration>("{FEF2DAF4-5408-4636-BB0E-B8798DF8F095}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateRichTextConfiguration.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateRichTextConfiguration.cs
@@ -1,0 +1,39 @@
+﻿using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_14_0_0;
+
+public class MigrateRichTextConfiguration : MigrationBase
+{
+    private readonly IDataTypeService _dataTypeService;
+
+    public MigrateRichTextConfiguration(IMigrationContext context, IDataTypeService dataTypeService) : base(context) => _dataTypeService = dataTypeService;
+
+    protected override void Migrate()
+    {
+        IEnumerable<IDataType> richTextEditors = _dataTypeService.GetByEditorAliasAsync(Constants.PropertyEditors.Aliases.RichText).GetAwaiter().GetResult();
+        foreach (IDataType richTextEditor in richTextEditors)
+        {
+            if (!richTextEditor.ConfigurationData.TryGetValue("toolbar", out var configurationValue))
+            {
+                continue;
+            }
+
+            if (configurationValue is not List<string> toolbar)
+            {
+                continue;
+            }
+
+            if (toolbar.Contains("ace"))
+            {
+                toolbar.Remove("ace");
+                toolbar.Add("sourcecode");
+            }
+
+            richTextEditor.ConfigurationData.Remove("toolbar");
+            richTextEditor.ConfigurationData.Add("toolbar", toolbar);
+            _dataTypeService.UpdateAsync(richTextEditor, Constants.Security.SuperUserKey);
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/16579

# Notes
- Seems that in v14, we have changed the source code editor in the toolbar, so now the alias is "sourcecode" instead of "ace"
- This PR changes the default when installing to sourcecode
- Also creates a migration to migrate the "ace" value to "sourcecode", so it again will show after migrating 👍 

# How to test
- Fresh install
- Create a document type with the default rich text editor (allow as root).
- Create some content with that document type
- Assert that the source code editor now shows.