### PR TITLE
Use configured backoffice route if available

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Middleware/BackOfficeAuthorizationInitializationMiddleware.cs
+++ b/src/Umbraco.Cms.Api.Management/Middleware/BackOfficeAuthorizationInitializationMiddleware.cs
@@ -1,10 +1,15 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Security;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Middleware;
 
@@ -16,15 +21,40 @@ public class BackOfficeAuthorizationInitializationMiddleware : IMiddleware
     private readonly UmbracoRequestPaths _umbracoRequestPaths;
     private readonly IServiceProvider _serviceProvider;
     private readonly IRuntimeState _runtimeState;
+    private readonly IOptions<GlobalSettings> _globalSettings;
+    private readonly IOptions<WebRoutingSettings> _webRoutingSettings;
+    private readonly IHostingEnvironment _hostingEnvironment;
 
+    [Obsolete("Use the non-obsolete constructor. This will be removed in Umbraco 16.")]
     public BackOfficeAuthorizationInitializationMiddleware(
         UmbracoRequestPaths umbracoRequestPaths,
         IServiceProvider serviceProvider,
         IRuntimeState runtimeState)
+    : this(
+        umbracoRequestPaths,
+        serviceProvider,
+        runtimeState,
+        StaticServiceProvider.Instance.GetRequiredService<IOptions<GlobalSettings>>(),
+        StaticServiceProvider.Instance.GetRequiredService<IOptions<WebRoutingSettings>>(),
+        StaticServiceProvider.Instance.GetRequiredService<IHostingEnvironment>()
+        )
+    {
+    }
+
+    public BackOfficeAuthorizationInitializationMiddleware(
+        UmbracoRequestPaths umbracoRequestPaths,
+        IServiceProvider serviceProvider,
+        IRuntimeState runtimeState,
+        IOptions<GlobalSettings> globalSettings,
+        IOptions<WebRoutingSettings> webRoutingSettings,
+        IHostingEnvironment hostingEnvironment)
     {
         _umbracoRequestPaths = umbracoRequestPaths;
         _serviceProvider = serviceProvider;
         _runtimeState = runtimeState;
+        _globalSettings = globalSettings;
+        _webRoutingSettings = webRoutingSettings;
+        _hostingEnvironment = hostingEnvironment;
     }
 
     public async Task InvokeAsync(HttpContext context, RequestDelegate next)
@@ -47,6 +77,7 @@ public class BackOfficeAuthorizationInitializationMiddleware : IMiddleware
             return;
         }
 
+
         if (_umbracoRequestPaths.IsBackOfficeRequest(context.Request.Path) == false)
         {
             return;
@@ -55,9 +86,13 @@ public class BackOfficeAuthorizationInitializationMiddleware : IMiddleware
         await _firstBackOfficeRequestLocker.WaitAsync();
         if (_firstBackOfficeRequest == false)
         {
+            Uri? backOfficeUrl = string.IsNullOrWhiteSpace(_webRoutingSettings.Value.UmbracoApplicationUrl) is false
+                ? new Uri($"{_webRoutingSettings.Value.UmbracoApplicationUrl.TrimEnd('/')}{_globalSettings.Value.GetBackOfficePath(_hostingEnvironment).EnsureStartsWith('/')}")
+                : null;
+
             using IServiceScope scope = _serviceProvider.CreateScope();
             IBackOfficeApplicationManager backOfficeApplicationManager = scope.ServiceProvider.GetRequiredService<IBackOfficeApplicationManager>();
-            await backOfficeApplicationManager.EnsureBackOfficeApplicationAsync(new Uri(context.Request.GetDisplayUrl()));
+            await backOfficeApplicationManager.EnsureBackOfficeApplicationAsync(backOfficeUrl ?? new Uri(context.Request.GetDisplayUrl()));
             _firstBackOfficeRequest = true;
         }
 


### PR DESCRIPTION
### Description
Use the application url from configuration to initialise openiddict. If it is not available, it will fallback to the requested path (like before)

This fixes issues where umbraco is behind a proxy.

 Fixes #16179


### Test
- Ensure login works with the configured application url
- Ensure login works without a configured application url