### PR TITLE
[V14] Make the backend work with the new localLinks format

### DIFF
--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs
@@ -132,9 +132,15 @@ internal sealed class ApiRichTextElementParser : ApiRichTextParserBase, IApiRich
             return;
         }
 
+        if (attributes["type"] is not string type)
+        {
+            type = "unknown";
+        }
+
         ReplaceLocalLinks(
             publishedSnapshot,
             href,
+            type,
             route =>
             {
                 attributes["route"] = route;

--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs
@@ -132,7 +132,7 @@ internal sealed class ApiRichTextElementParser : ApiRichTextParserBase, IApiRich
             return;
         }
 
-        if (attributes["type"] is not string type)
+        if (attributes.ContainsKey("type") is false || attributes["type"] is not string type)
         {
             type = "unknown";
         }

--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextMarkupParser.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextMarkupParser.cs
@@ -52,8 +52,9 @@ internal sealed class ApiRichTextMarkupParser : ApiRichTextParserBase, IApiRichT
         foreach (HtmlNode link in links)
         {
             ReplaceLocalLinks(
-                publishedSnapshot,
+                    publishedSnapshot,
                 link.GetAttributeValue("href", string.Empty),
+                link.GetAttributeValue("type", "unknown"),
                 route =>
                 {
                     link.SetAttributeValue("href", route.Path);

--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextParserBase.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextParserBase.cs
@@ -4,6 +4,7 @@ using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Models.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Templates;
 
 namespace Umbraco.Cms.Infrastructure.DeliveryApi;
 
@@ -18,20 +19,35 @@ internal abstract partial class ApiRichTextParserBase
         _apiMediaUrlProvider = apiMediaUrlProvider;
     }
 
-    protected void ReplaceLocalLinks(IPublishedSnapshot publishedSnapshot, string href, Action<IApiContentRoute> handleContentRoute, Action<string> handleMediaUrl, Action handleInvalidLink)
+    protected void ReplaceLocalLinks(IPublishedSnapshot publishedSnapshot, string href, string type, Action<IApiContentRoute> handleContentRoute, Action<string> handleMediaUrl, Action handleInvalidLink)
+    {
+        ReplaceStatus replaceAttempt = ReplaceLocalLink(publishedSnapshot, href, type, handleContentRoute, handleMediaUrl);
+        if (replaceAttempt == ReplaceStatus.Success)
+        {
+            return;
+        }
+
+        if (replaceAttempt == ReplaceStatus.InvalidEntityType || ReplaceLegacyLocalLink(publishedSnapshot, href, handleContentRoute, handleMediaUrl) == ReplaceStatus.InvalidEntityType)
+        {
+            handleInvalidLink();
+        }
+    }
+
+    private ReplaceStatus ReplaceLocalLink(IPublishedSnapshot publishedSnapshot, string href, string type, Action<IApiContentRoute> handleContentRoute, Action<string> handleMediaUrl)
     {
         Match match = LocalLinkRegex().Match(href);
         if (match.Success is false)
         {
-            return;
+            return ReplaceStatus.NoMatch;
         }
 
-        if (UdiParser.TryParse(match.Groups["udi"].Value, out Udi? udi) is false)
+        if (Guid.TryParse(match.Groups["guid"].Value, out Guid guid) is false)
         {
-            return;
+            return ReplaceStatus.NoMatch;
         }
 
-        bool handled = false;
+        var udi = new GuidUdi(type, guid);
+
         switch (udi.EntityType)
         {
             case Constants.UdiEntityType.Document:
@@ -41,8 +57,8 @@ internal abstract partial class ApiRichTextParserBase
                     : null;
                 if (route != null)
                 {
-                    handled = true;
                     handleContentRoute(route);
+                    return ReplaceStatus.Success;
                 }
 
                 break;
@@ -50,17 +66,56 @@ internal abstract partial class ApiRichTextParserBase
                 IPublishedContent? media = publishedSnapshot.Media?.GetById(udi);
                 if (media != null)
                 {
-                    handled = true;
                     handleMediaUrl(_apiMediaUrlProvider.GetUrl(media));
+                    return ReplaceStatus.Success;
                 }
 
                 break;
         }
 
-        if(handled is false)
+        return ReplaceStatus.InvalidEntityType;
+    }
+
+    private ReplaceStatus ReplaceLegacyLocalLink(IPublishedSnapshot publishedSnapshot, string href, Action<IApiContentRoute> handleContentRoute, Action<string> handleMediaUrl)
+    {
+        Match match = LegacyLocalLinkRegex().Match(href);
+        if (match.Success is false)
         {
-            handleInvalidLink();
+            return ReplaceStatus.NoMatch;
         }
+
+        if (UdiParser.TryParse(match.Groups["udi"].Value, out Udi? udi) is false)
+        {
+            return ReplaceStatus.NoMatch;
+        }
+
+
+        switch (udi.EntityType)
+        {
+            case Constants.UdiEntityType.Document:
+                IPublishedContent? content = publishedSnapshot.Content?.GetById(udi);
+                IApiContentRoute? route = content != null
+                    ? _apiContentRouteBuilder.Build(content)
+                    : null;
+                if (route != null)
+                {
+                    handleContentRoute(route);
+                    return ReplaceStatus.Success;
+                }
+
+                break;
+            case Constants.UdiEntityType.Media:
+                IPublishedContent? media = publishedSnapshot.Media?.GetById(udi);
+                if (media != null)
+                {
+                    handleMediaUrl(_apiMediaUrlProvider.GetUrl(media));
+                    return ReplaceStatus.Success;
+                }
+
+                break;
+        }
+
+        return ReplaceStatus.InvalidEntityType;
     }
 
     protected void ReplaceLocalImages(IPublishedSnapshot publishedSnapshot, string udi, Action<string> handleMediaUrl)
@@ -80,5 +135,15 @@ internal abstract partial class ApiRichTextParserBase
     }
 
     [GeneratedRegex("{localLink:(?<udi>umb:.+)}")]
+    private static partial Regex LegacyLocalLinkRegex();
+
+    [GeneratedRegex("{localLink:(?<guid>.+)}")]
     private static partial Regex LocalLinkRegex();
+
+    private enum ReplaceStatus
+    {
+        NoMatch,
+        Success,
+        InvalidEntityType
+    }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/DeliveryApi/ApiRichTextMarkupParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/DeliveryApi/ApiRichTextMarkupParserTests.cs
@@ -1,0 +1,200 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Core.Models.DeliveryApi;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Infrastructure.DeliveryApi;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.DeliveryApi;
+
+[TestFixture]
+public class ApiRichTextMarkupParserTests
+{
+    private Mock<IApiContentRouteBuilder> _apiContentRouteBuilder;
+    private Mock<IApiMediaUrlProvider> _apiMediaUrlProvider;
+    private Mock<IPublishedSnapshotAccessor> _publishedSnapshotAccessor;
+
+    [Test]
+    public void Can_Parse_Legacy_LocalLinks()
+    {
+        var key1 = Guid.Parse("a1c5d649977f4ea59b1cb26055f3eed3");
+        var data1 = new MockData()
+            .WithKey(key1)
+            .WithRoutePath("/inline/")
+            .WithRouteStartPath("inline");
+
+        var mockData = new Dictionary<Guid, MockData>
+        {
+            { key1, data1 },
+        };
+
+        var parser = BuildDefaultSut(mockData);
+
+        var legacyHtml =
+            "<p><a href=\"/{localLink:umb://document/a1c5d649977f4ea59b1cb26055f3eed3}\" title=\"Inline\">link </a>to another page</p>";
+
+        var expectedOutput =
+            "<p><a href=\"/inline/\" title=\"Inline\" data-start-item-path=\"inline\" data-start-item-id=\"a1c5d649-977f-4ea5-9b1c-b26055f3eed3\">link </a>to another page</p>";
+
+        var parsedHtml = parser.Parse(legacyHtml);
+
+        Assert.AreEqual(expectedOutput, parsedHtml);
+    }
+
+    [Test]
+    public void Can_Parse_LocalLinks()
+    {
+        var key1 = Guid.Parse("eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f");
+        var data1 = new MockData()
+            .WithKey(key1)
+            .WithRoutePath("/self/")
+            .WithRouteStartPath("self");
+
+        var key2 = Guid.Parse("cc143afe-4cbf-46e5-b399-c9f451384373");
+        var data2 = new MockData()
+            .WithKey(key2)
+            .WithRoutePath("/other/")
+            .WithRouteStartPath("other");
+
+        var mockData = new Dictionary<Guid, MockData>
+        {
+            { key1, data1 },
+            { key2, data2 },
+        };
+
+        var parser = BuildDefaultSut(mockData);
+
+        var html =
+            @"<p>Rich text outside of the blocks with a link to <a type=""document"" href=""/{localLink:eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f}"" title=""itself"">itself</a><br><br></p>
+<p>and to the <a type=""document"" href=""/{localLink:cc143afe-4cbf-46e5-b399-c9f451384373}"" title=""other page"">other page</a></p>";
+
+        var expectedOutput =
+            @"<p>Rich text outside of the blocks with a link to <a type=""document"" href=""/self/"" title=""itself"" data-start-item-path=""self"" data-start-item-id=""eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f"">itself</a><br><br></p>
+<p>and to the <a type=""document"" href=""/other/"" title=""other page"" data-start-item-path=""other"" data-start-item-id=""cc143afe-4cbf-46e5-b399-c9f451384373"">other page</a></p>";
+
+        var parsedHtml = parser.Parse(html);
+
+        Assert.AreEqual(expectedOutput, parsedHtml);
+    }
+
+    [Test]
+    public void Can_Parse_Legacy_LocalImages()
+    {
+        var key1 = Guid.Parse("395bdc0e8f4d4ad4af7f3a3f6265651e");
+        var data1 = new MockData()
+            .WithKey(key1)
+            .WithMediaUrl("https://localhost:44331/media/bdofwokn/77gtp8fbrxmgkefatp10aw.webp");
+
+        var mockData = new Dictionary<Guid, MockData>
+        {
+            { key1, data1 },
+        };
+        var parser = BuildDefaultSut(mockData);
+
+        var legacyHtml =
+            @"<p>An image</p>\n<p><img src=""/media/bdofwokn/77gtp8fbrxmgkefatp10aw.webp?rmode=max&amp;width=500&amp;height=500"" alt="""" width=""500"" height=""500"" data-udi=""umb://media/395bdc0e8f4d4ad4af7f3a3f6265651e""></p>";
+
+        var expectedOutput =
+            @"<p>An image</p>\n<p><img src=""https://localhost:44331/media/bdofwokn/77gtp8fbrxmgkefatp10aw.webp?rmode=max&amp;width=500&amp;height=500"" alt="""" width=""500"" height=""500""></p>";
+
+        var parsedHtml = parser.Parse(legacyHtml);
+
+        Assert.AreEqual(expectedOutput, parsedHtml);
+    }
+
+    private ApiRichTextMarkupParser BuildDefaultSut(Dictionary<Guid, MockData> mockData)
+    {
+        var contentCacheMock = new Mock<IPublishedContentCache>();
+
+        contentCacheMock.Setup(cc => cc.GetById(It.IsAny<bool>(), It.IsAny<Guid>()))
+            .Returns<bool, Guid>((preview, key) => mockData[key].PublishedContent);
+        contentCacheMock.Setup(cc => cc.GetById(It.IsAny<Guid>()))
+            .Returns<Guid>(key => mockData[key].PublishedContent);
+        contentCacheMock.Setup(cc => cc.GetById(It.IsAny<bool>(), It.IsAny<Udi>()))
+            .Returns<bool, Udi>((preview, udi) => mockData[((GuidUdi)udi).Guid].PublishedContent);
+        contentCacheMock.Setup(cc => cc.GetById(It.IsAny<Udi>()))
+            .Returns<Udi>(udi => mockData[((GuidUdi)udi).Guid].PublishedContent);
+
+        var mediaCacheMock = new Mock<IPublishedMediaCache>();
+        mediaCacheMock.Setup(cc => cc.GetById(It.IsAny<bool>(), It.IsAny<Guid>()))
+            .Returns<bool, Guid>((preview, key) => mockData[key].PublishedContent);
+        mediaCacheMock.Setup(cc => cc.GetById(It.IsAny<Guid>()))
+            .Returns<Guid>(key => mockData[key].PublishedContent);
+        mediaCacheMock.Setup(cc => cc.GetById(It.IsAny<bool>(), It.IsAny<Udi>()))
+            .Returns<bool, Udi>((preview, udi) => mockData[((GuidUdi)udi).Guid].PublishedContent);
+        mediaCacheMock.Setup(cc => cc.GetById(It.IsAny<Udi>()))
+            .Returns<Udi>(udi => mockData[((GuidUdi)udi).Guid].PublishedContent);
+
+        var snapshotMock = new Mock<IPublishedSnapshot>();
+        snapshotMock.SetupGet(ss => ss.Content)
+            .Returns(contentCacheMock.Object);
+        snapshotMock.SetupGet(ss => ss.Media)
+            .Returns(mediaCacheMock.Object);
+
+        var snapShot = snapshotMock.Object;
+
+        _publishedSnapshotAccessor = new Mock<IPublishedSnapshotAccessor>();
+        _publishedSnapshotAccessor.Setup(psa => psa.TryGetPublishedSnapshot(out snapShot))
+            .Returns(true);
+
+        _apiMediaUrlProvider = new Mock<IApiMediaUrlProvider>();
+        _apiMediaUrlProvider.Setup(mup => mup.GetUrl(It.IsAny<IPublishedContent>()))
+            .Returns<IPublishedContent>(ipc => mockData[ipc.Key].MediaUrl);
+
+        _apiContentRouteBuilder = new Mock<IApiContentRouteBuilder>();
+        _apiContentRouteBuilder.Setup(acrb => acrb.Build(It.IsAny<IPublishedContent>(), It.IsAny<string>()))
+            .Returns<IPublishedContent, string>((content, culture) => mockData[content.Key].ApiContentRoute);
+
+        return new ApiRichTextMarkupParser(
+            _apiContentRouteBuilder.Object,
+            _apiMediaUrlProvider.Object,
+            _publishedSnapshotAccessor.Object,
+            Mock.Of<ILogger<ApiRichTextMarkupParser>>());
+    }
+
+    private class MockData
+    {
+        private Mock<IPublishedContent> _publishedContentMock = new Mock<IPublishedContent>();
+        private Mock<IApiContentRoute> _apiContentRouteMock = new Mock<IApiContentRoute>();
+        private Mock<IApiContentStartItem> _apiContentStartItem = new Mock<IApiContentStartItem>();
+
+        public IPublishedContent PublishedContent => _publishedContentMock.Object;
+
+        public IApiContentRoute ApiContentRoute => _apiContentRouteMock.Object;
+
+        public string MediaUrl { get; set; } = string.Empty;
+
+        public MockData()
+        {
+            _apiContentRouteMock.SetupGet(r => r.StartItem).Returns(_apiContentStartItem.Object);
+        }
+
+        public MockData WithKey(Guid key)
+        {
+            _publishedContentMock.SetupGet(i => i.Key).Returns(key);
+            _apiContentStartItem.SetupGet(rsi => rsi.Id).Returns(key);
+            return this;
+        }
+
+        public MockData WithRoutePath(string path)
+        {
+            _apiContentRouteMock.SetupGet(r => r.Path).Returns(path);
+            return this;
+        }
+
+        public MockData WithRouteStartPath(string path)
+        {
+            _apiContentStartItem.SetupGet(rsi => rsi.Path).Returns(path);
+            return this;
+        }
+
+        public MockData WithMediaUrl(string url)
+        {
+            MediaUrl = url;
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
### Description
The new backoffice has removed UDI notation from the locallinks format in RTE <a> tags and split up the type and key into 2 attributes (href and type).

The backend was not fully updated and so when rendering the content trough razor pages, or retrieving trough the content delivery api, the locallink notation was not properly replaced by the actual content/media urls.

This PR aims to fix this and update/improve the unittests along the way.

The old format was not migrated to the new format in the v14 migration and this is currently not changing as the backend can handle both.

### Testing
Consider both RTEs on a document type and RTEs in block
Both migrated and new data should work as expected
Both Razor rendering and delivery api parsing should create similar output when comparing v13 and v14 data, both migrated and new, when it comes to v14.
The backoffice should allow editing of both old and new formatted data.
Non Local links should still work.

### Notes
There is a decent amount of duplicated code, I chose not to refactor this as we should obsolete/remove it at some point anyway. This will require some form of migrating the old formatted data.