### PR TITLE
[V14] Fix old rte seed value causing the toolbar not to appear

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -84,6 +84,9 @@ public class UmbracoPlan : MigrationPlan
         // we need to re-run this migration, as it was flawed for V14 RC3 (the migration can run twice without any issues)
         To<V_14_0_0.AddEditorUiToDataType>("{6FB5CA9E-C823-473B-A14C-FE760D75943C}");
         To<V_14_0_0.CleanUpDataTypeConfigurations>("{827360CA-0855-42A5-8F86-A51F168CB559}");
-        To<V_14_0_0.MigrateRichTextConfiguration>("{FEF2DAF4-5408-4636-BB0E-B8798DF8F095}");
+
+        // To 14.1.0
+        To<V_14_1_0.MigrateRichTextConfiguration>("{FEF2DAF4-5408-4636-BB0E-B8798DF8F095}");
+        To<V_14_1_0.MigrateOldRichTextSeedConfiguration>("{A385C5DF-48DC-46B4-A742-D5BB846483BC}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_1_0/MigrateOldRichTextSeedConfiguration.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_1_0/MigrateOldRichTextSeedConfiguration.cs
@@ -1,0 +1,38 @@
+﻿using NPoco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_14_1_0;
+
+public class MigrateOldRichTextSeedConfiguration : MigrationBase
+{
+    private const string OldSeedValue =
+        "{\"value\":\",code,undo,redo,cut,copy,mcepasteword,stylepicker,bold,italic,bullist,numlist,outdent,indent,mcelink,unlink,mceinsertanchor,mceimage,umbracomacro,mceinserttable,umbracoembed,mcecharmap,|1|1,2,3,|0|500,400|1049,|true|\"}";
+
+    private const string NewDefaultValue =
+        "{\"toolbar\":[\"styles\",\"bold\",\"italic\",\"alignleft\",\"aligncenter\",\"alignright\",\"bullist\",\"numlist\",\"outdent\",\"indent\",\"sourcecode\",\"link\",\"umbmediapicker\",\"umbembeddialog\"],\"mode\":\"Classic\",\"maxImageSize\":500}";
+    public MigrateOldRichTextSeedConfiguration(IMigrationContext context) : base(context)
+    {
+    }
+
+    protected override void Migrate()
+    {
+        Sql<ISqlContext> sql = Sql()
+            .Select<DataTypeDto>()
+            .From<DataTypeDto>()
+            .Where<DataTypeDto>(x =>
+                x.EditorAlias.Equals(Constants.PropertyEditors.Aliases.RichText)
+                && x.Configuration == OldSeedValue);
+
+        List<DataTypeDto> dataTypeDtos = Database.Fetch<DataTypeDto>(sql);
+
+        foreach (DataTypeDto dataTypeDto in dataTypeDtos)
+        {
+            // Update the configuration
+            dataTypeDto.Configuration = NewDefaultValue;
+            Database.Update(dataTypeDto);
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_1_0/MigrateRichTextConfiguration.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_1_0/MigrateRichTextConfiguration.cs
@@ -4,7 +4,7 @@ using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Infrastructure.Persistence.Dtos;
 using Umbraco.Extensions;
 
-namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_14_0_0;
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_14_1_0;
 
 public class MigrateRichTextConfiguration : MigrationBase
 {


### PR DESCRIPTION
### Description
There is a chance that a seeded RTE datatype configuration from the early days of v13 (or before) was never touched and thus its configuration data never upgraded to a newer format. This results in new backoffice not being able to read that configuration and simply not display a toolbar, when editing the configuration all checkboxes for the different tools are unchecked.

This PR introduces a migration that looks for that exact seed value and relaces it with the value that a newly created default RTE datatype would have.

### Testing
- Create a new v13 project, add a document type with the default RTE datatype and add some content for good measure
- Update the project to v14 => when editing the content, the RTE toolbar should be visible
- Custom RTE's from v13 with other options should not be affected, i.e. there should be no change in the toolbar buttons available for those editors when upgrading from v13 to v14