### PR TITLE
Add Health Check for Runtime mode

### DIFF
--- a/src/Umbraco.Core/Constants-HealthChecks.cs
+++ b/src/Umbraco.Core/Constants-HealthChecks.cs
@@ -22,6 +22,7 @@ public static partial class Constants
             public static class LiveEnvironment
             {
                 public const string CompilationDebugCheck = "https://umbra.co/healthchecks-compilation-debug";
+                public const string RuntimeModeCheck = "https://docs.umbraco.com/umbraco-cms/fundamentals/setup/server-setup/runtime-modes";
             }
 
             public static class Configuration

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
   <creator>
     <name>The Umbraco community</name>
@@ -428,6 +428,8 @@
     <key alias="compilationDebugCheckErrorMessage">Debug compilation mode is currently enabled. It is recommended to
       disable this setting before go live.
     </key>
+    <key alias="runtimeModeCheckSuccessMessage">Runtime mode is set to production.</key>
+    <key alias="runtimeModeCheckErrorMessage">Runtime mode is not set to production. It is recommended to change this setting to Production before go live.</key>
     <!-- The following keys get these tokens passed in:
 	    0: Path to the file not found
   	-->

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -429,7 +429,7 @@
       disable this setting before go live.
     </key>
     <key alias="runtimeModeCheckSuccessMessage">Runtime mode is set to production.</key>
-    <key alias="runtimeModeCheckErrorMessage">Runtime mode is not set to production. It is recommended to change this setting to Production before go live.</key>
+    <key alias="runtimeModeCheckErrorMessage">Runtime mode is not set to Production. It is recommended to set the Runtime Mode to Production for live/production environments.</key>
     <!-- The following keys get these tokens passed in:
 	    0: Path to the file not found
   	-->

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -420,7 +420,7 @@
       disable this setting before go live.
     </key>
     <key alias="runtimeModeCheckSuccessMessage">Runtime mode is set to production.</key>
-    <key alias="runtimeModeCheckErrorMessage">Runtime mode is not set to production. It is recommended to change this setting to Production before go live.</key>
+    <key alias="runtimeModeCheckErrorMessage">Runtime mode is not set to Production. It is recommended to set the Runtime Mode to Production for live/production environments.</key>
     <!-- The following keys get these tokens passed in:
 	    0: Comma delimitted list of failed folder paths
   	-->

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -419,6 +419,8 @@
     <key alias="compilationDebugCheckErrorMessage">Debug compilation mode is currently enabled. It is recommended to
       disable this setting before go live.
     </key>
+    <key alias="runtimeModeCheckSuccessMessage">Runtime mode is set to production.</key>
+    <key alias="runtimeModeCheckErrorMessage">Runtime mode is not set to production. It is recommended to change this setting to Production before go live.</key>
     <!-- The following keys get these tokens passed in:
 	    0: Comma delimitted list of failed folder paths
   	-->

--- a/src/Umbraco.Core/HealthChecks/Checks/LiveEnvironment/RuntimeModeCheck.cs
+++ b/src/Umbraco.Core/HealthChecks/Checks/LiveEnvironment/RuntimeModeCheck.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Cms.Core.HealthChecks.Checks.LiveEnvironment;
 [HealthCheck(
     "8E31E5C9-7A1D-4ACB-A3A8-6495F3EDB932",
     "Runtime Mode",
-    Description = "The Production Runtime Mode disables development features and checks that settings are configured optimally for production.
+    Description = "The Production Runtime Mode disables development features and checks that settings are configured optimally for production.",
     Group = "Live Environment")]
 public class RuntimeModeCheck : AbstractSettingsCheck
 {

--- a/src/Umbraco.Core/HealthChecks/Checks/LiveEnvironment/RuntimeModeCheck.cs
+++ b/src/Umbraco.Core/HealthChecks/Checks/LiveEnvironment/RuntimeModeCheck.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Cms.Core.HealthChecks.Checks.LiveEnvironment;
 [HealthCheck(
     "8E31E5C9-7A1D-4ACB-A3A8-6495F3EDB932",
     "Runtime Mode",
-    Description = "Health check for the recommended production configuration for runtime mode.",
+    Description = "The Production Runtime Mode disables development features and checks that settings are configured optimally for production.
     Group = "Live Environment")]
 public class RuntimeModeCheck : AbstractSettingsCheck
 {

--- a/src/Umbraco.Core/HealthChecks/Checks/LiveEnvironment/RuntimeModeCheck.cs
+++ b/src/Umbraco.Core/HealthChecks/Checks/LiveEnvironment/RuntimeModeCheck.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Core.HealthChecks.Checks.LiveEnvironment;
+
+/// <summary>
+///     Health check for the recommended production configuration for the runtime mode.
+/// </summary>
+[HealthCheck(
+    "8E31E5C9-7A1D-4ACB-A3A8-6495F3EDB932",
+    "Runtime Mode",
+    Description = "Health check for the recommended production configuration for runtime mode.",
+    Group = "Live Environment")]
+public class RuntimeModeCheck : AbstractSettingsCheck
+{
+    private readonly IOptionsMonitor<RuntimeSettings> _runtimeSettings;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="RuntimeModeCheck" /> class.
+    /// </summary>
+    public RuntimeModeCheck(ILocalizedTextService textService, IOptionsMonitor<RuntimeSettings> runtimeSettings)
+        : base(textService) =>
+        _runtimeSettings = runtimeSettings;
+
+    /// <inheritdoc />
+    public override string ItemPath => Constants.Configuration.ConfigRuntimeMode;
+
+    /// <inheritdoc />
+    public override ValueComparisonType ValueComparisonType => ValueComparisonType.ShouldEqual;
+
+    /// <inheritdoc />
+    public override IEnumerable<AcceptableConfiguration> Values => new List<AcceptableConfiguration>
+    {
+        new() { IsRecommended = true, Value = RuntimeMode.Production.ToString() },
+    };
+
+    /// <inheritdoc />
+    public override string CurrentValue => _runtimeSettings.CurrentValue.Mode.ToString();
+
+    /// <inheritdoc />
+    public override string CheckSuccessMessage => LocalizedTextService.Localize("healthcheck", "runtimeModeCheckSuccessMessage");
+
+    /// <inheritdoc />
+    public override string CheckErrorMessage => LocalizedTextService.Localize("healthcheck", "runtimeModeCheckErrorMessage");
+
+    /// <inheritdoc />
+    public override string ReadMoreLink => Constants.HealthChecks.DocumentationLinks.LiveEnvironment.RuntimeModeCheck;
+}


### PR DESCRIPTION
I thought it might be a good idea to add a health check to make sure the runtime mode is set to Production. 😄 



![image](https://github.com/umbraco/Umbraco-CMS/assets/7831614/68952d78-655d-42af-8fee-b8988845cc0d)
