### PR TITLE
v14: Implement backoffice signalR hub

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Routing/BackOfficeAreaRoutes.cs
+++ b/src/Umbraco.Cms.Api.Management/Routing/BackOfficeAreaRoutes.cs
@@ -7,8 +7,6 @@ using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Core.Web.Mvc;
-using Umbraco.Cms.Web.Common.Controllers;
 using Umbraco.Cms.Web.Common.Routing;
 using Umbraco.Extensions;
 
@@ -54,7 +52,7 @@ public sealed class BackOfficeAreaRoutes : IAreaRoutes
             case RuntimeLevel.Install:
             case RuntimeLevel.Upgrade:
             case RuntimeLevel.Run:
-
+                endpoints.MapHub<BackofficeHub>(_umbracoPathSegment + Constants.Web.BackofficeSignalRHub);
                 MapMinimalBackOffice(endpoints);
                 break;
             case RuntimeLevel.BootFailed:

--- a/src/Umbraco.Cms.Api.Management/Routing/BackOfficeAreaRoutes.cs
+++ b/src/Umbraco.Cms.Api.Management/Routing/BackOfficeAreaRoutes.cs
@@ -52,8 +52,8 @@ public sealed class BackOfficeAreaRoutes : IAreaRoutes
             case RuntimeLevel.Install:
             case RuntimeLevel.Upgrade:
             case RuntimeLevel.Run:
-                endpoints.MapHub<BackofficeHub>(_umbracoPathSegment + Constants.Web.BackofficeSignalRHub);
                 MapMinimalBackOffice(endpoints);
+                endpoints.MapHub<BackofficeHub>(_umbracoPathSegment + Constants.Web.BackofficeSignalRHub);
                 break;
             case RuntimeLevel.BootFailed:
             case RuntimeLevel.Unknown:

--- a/src/Umbraco.Cms.Api.Management/Routing/BackofficeHub.cs
+++ b/src/Umbraco.Cms.Api.Management/Routing/BackofficeHub.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+using Umbraco.Cms.Web.Common.Authorization;
+
+namespace Umbraco.Cms.Api.Management.Routing;
+
+[Authorize(Policy = AuthorizationPolicies.BackOfficeAccess)]
+public class BackofficeHub : Hub
+{
+    public async Task SendMessage(string message) => await Clients.All.SendAsync("receiveMessage", message);
+}

--- a/src/Umbraco.Cms.Api.Management/Routing/BackofficeHub.cs
+++ b/src/Umbraco.Cms.Api.Management/Routing/BackofficeHub.cs
@@ -4,5 +4,5 @@ namespace Umbraco.Cms.Api.Management.Routing;
 
 public class BackofficeHub : Hub
 {
-    public async Task SendMessage(object payload) => await Clients.All.SendAsync("receiveMessage", payload);
+    public async Task SendPayload(object payload) => await Clients.All.SendAsync("payloadReceived", payload);
 }

--- a/src/Umbraco.Cms.Api.Management/Routing/BackofficeHub.cs
+++ b/src/Umbraco.Cms.Api.Management/Routing/BackofficeHub.cs
@@ -1,11 +1,8 @@
-﻿using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.SignalR;
-using Umbraco.Cms.Web.Common.Authorization;
+﻿using Microsoft.AspNetCore.SignalR;
 
 namespace Umbraco.Cms.Api.Management.Routing;
 
-[Authorize(Policy = AuthorizationPolicies.BackOfficeAccess)]
 public class BackofficeHub : Hub
 {
-    public async Task SendMessage(string message) => await Clients.All.SendAsync("receiveMessage", message);
+    public async Task SendMessage(object payload) => await Clients.All.SendAsync("receiveMessage", payload);
 }

--- a/src/Umbraco.Core/Constants-Web.cs
+++ b/src/Umbraco.Core/Constants-Web.cs
@@ -56,6 +56,7 @@ public static partial class Constants
         ///     The "base" path to the Management API
         /// </summary>
         public const string ManagementApiPath = "/management/api/";
+        public const string BackofficeSignalRHub = "/backofficeHub";
 
         public static class Routing
         {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Routing/BackOfficeAreaRoutesTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Routing/BackOfficeAreaRoutesTests.cs
@@ -45,7 +45,7 @@ public class BackOfficeAreaRoutesTests
         var endpoints = new TestRouteBuilder();
         routes.CreateRoutes(endpoints);
 
-        Assert.AreEqual(1, endpoints.DataSources.Count);
+        Assert.AreEqual(2, endpoints.DataSources.Count);
         var route = endpoints.DataSources.First();
         Assert.AreEqual(2, route.Endpoints.Count);
 


### PR DESCRIPTION
# Notes
- This PR implements a new SignalR hub for the backoffice, with route `/umbraco/backofficeHub`
- This is basically just a relay hub, that takes in a message, and sends it to all current connections. We could in the future implement `OnConnect` & `OnDisconnect` to notify clients that they are in offline mode.

# How to test
- Unpack the following in your wwwroot folder
[js.zip](https://github.com/user-attachments/files/16052321/js.zip)
- Run umbraco
- Create a doctype with a template, remember to allow as root
- In the template, paste the following:
```
@using Umbraco.Cms.Web.Common.PublishedModels;
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
@{
	Layout = null;
}

<div class="container">
    <div class="row p-1">
        <div class="col-1">User</div>
        <div class="col-5"><input type="text" id="userInput" /></div>
    </div>
    <div class="row p-1">
        <div class="col-1">Message</div>
        <div class="col-5"><input type="text" class="w-100" id="messageInput" /></div>
    </div>
    <div class="row p-1">
        <div class="col-6 text-end">
            <input type="button" id="sendButton" value="Send Message" />
        </div>
    </div>
    <div class="row p-1">
        <div class="col-6">
            <hr />
        </div>
    </div>
    <div class="row p-1">
        <div class="col-6">
            <ul id="messagesList"></ul>
        </div>
    </div>
</div>
<script src="~/js/signalr/dist/browser/signalr.js"></script>
<script src="~/js/chat.js"></script>

```

- Create some content with that doctype and navigate to that content (in the frontend, so for example `https://localhost:44339/`
- Note that the send message button is greyed out, as we are not authorized
- With swagger, authorize yourself
- From local storage, you can get your auth token: 
![image](https://github.com/umbraco/Umbraco-CMS/assets/70372949/6af8be49-e814-486f-a776-b1c6bc5a9c27)
- copy that auth token into the `chat.js` file, on line three, replace `hyPO9Z-9VY8ml_bdoS4cirmwiT-z088JvANpziJ1-b0`
- Go to your content again (IE: ``https://localhost:44339/`), the send message button should no longer be greyed out
- You can now open multiple browsers and send messages back and forth 🚀 

