### PR TITLE
V14: Build and publish Typedoc docs

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -227,6 +227,20 @@ stages:
             inputs:
               targetPath: $(Build.ArtifactStagingDirectory)/ui-docs.zip
               artifact: ui-docs
+          - script: npm run generate:ui-api-docs
+            displayName: Generate API Docs
+            workingDirectory: $(Build.SourcesDirectory)/src/Umbraco.Web.UI.Client
+          - task: ArchiveFiles@2
+            displayName: Archive UI API Docs
+            inputs:
+              rootFolderOrFile: $(Build.SourcesDirectory)/src/Umbraco.Web.UI.Client/ui-api
+              includeRootFolder: false
+              archiveFile: $(Build.ArtifactStagingDirectory)/ui-api-docs.zip
+          - task: PublishPipelineArtifact@1
+            displayName: Publish UI API Docs
+            inputs:
+              targetPath: $(Build.ArtifactStagingDirectory)/ui-api-docs.zip
+              artifact: ui-api-docs
 
   ###############################################
   ## Test
@@ -867,4 +881,27 @@ stages:
               storage: umbracoapidocs
               ContainerName: '$web'
               BlobPrefix: v$(umbracoMajorVersion)/ui
+              CleanTargetBeforeCopy: true
+      - job:
+        displayName: Upload UI API Docs
+        steps:
+          - checkout: none
+          - task: DownloadPipelineArtifact@2
+            displayName: Download artifact
+            inputs:
+              artifact: ui-api-docs
+              path: $(Build.SourcesDirectory)
+          - task: ExtractFiles@1
+            inputs:
+              archiveFilePatterns: $(Build.SourcesDirectory)/ui-api-docs.zip
+              destinationFolder: $(Build.ArtifactStagingDirectory)/ui-api-docs
+          - task: AzureFileCopy@4
+            displayName: 'Copy UI API Docs to blob storage'
+            inputs:
+              SourcePath: '$(Build.ArtifactStagingDirectory)/ui-api-docs/*'
+              azureSubscription: umbraco-storage
+              Destination: AzureBlob
+              storage: umbracoapidocs
+              ContainerName: '$web'
+              BlobPrefix: v$(umbracoMajorVersion)/ui-api
               CleanTargetBeforeCopy: true

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -217,13 +217,13 @@ stages:
             displayName: Replace BASE_PATH on assets
             workingDirectory: $(Build.SourcesDirectory)/src/Umbraco.Web.UI.Client/storybook-static
           - task: ArchiveFiles@2
-            displayName: Archive js Docs
+            displayName: Archive Storybook
             inputs:
               rootFolderOrFile: $(Build.SourcesDirectory)/src/Umbraco.Web.UI.Client/storybook-static
               includeRootFolder: false
               archiveFile: $(Build.ArtifactStagingDirectory)/ui-docs.zip
           - task: PublishPipelineArtifact@1
-            displayName: Publish js Docs
+            displayName: Publish Storybook
             inputs:
               targetPath: $(Build.ArtifactStagingDirectory)/ui-docs.zip
               artifact: ui-docs
@@ -846,7 +846,7 @@ stages:
               BlobPrefix: v$(umbracoMajorVersion)/csharp
               CleanTargetBeforeCopy: true
       - job:
-        displayName: Upload js Docs
+        displayName: Upload Storybook
         steps:
           - checkout: none
           - task: DownloadPipelineArtifact@2
@@ -859,7 +859,7 @@ stages:
               archiveFilePatterns: $(Build.SourcesDirectory)/ui-docs.zip
               destinationFolder: $(Build.ArtifactStagingDirectory)/ui-docs
           - task: AzureFileCopy@4
-            displayName: 'Copy UI Docs to blob storage'
+            displayName: 'Copy Storybook to blob storage'
             inputs:
               SourcePath: '$(Build.ArtifactStagingDirectory)/ui-docs/*'
               azureSubscription: umbraco-storage


### PR DESCRIPTION
### Description

Automates the build and publication of the typedoc docs available at https://apidocs.umbraco.com/v14/ui-api/

### How to test

A successful run can be seen here: https://dev.azure.com/umbraco/Umbraco%20Cms/_build/results?buildId=172681&view=results

With the artifact published as [ui-api-docs](https://artprodsu6weu.artifacts.visualstudio.com/A1efe4343-f52d-4f92-995c-ba5b2f46070d/0fe81d3e-adbd-40f4-af17-796887948029/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL3VtYnJhY28vcHJvamVjdElkLzBmZTgxZDNlLWFkYmQtNDBmNC1hZjE3LTc5Njg4Nzk0ODAyOS9idWlsZElkLzE3MjY4MS9hcnRpZmFjdE5hbWUvdWktYXBpLWRvY3M1/content?format=file&subPath=%2Fui-api-docs.zip).