### PR TITLE
V14: Expose `Umb-Notifications` HTTP header

### DIFF
--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeCorsPolicyBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeCorsPolicyBuilderExtensions.cs
@@ -34,7 +34,7 @@ internal static class BackOfficeCorsPolicyBuilderExtensions
                 {
                     policy
                         .WithOrigins(customOrigin)
-                        .WithExposedHeaders(Constants.Headers.Location, Constants.Headers.GeneratedResource)
+                        .WithExposedHeaders(Constants.Headers.Location, Constants.Headers.GeneratedResource, Constants.Headers.Notifications)
                         .AllowAnyHeader()
                         .AllowAnyMethod()
                         .AllowCredentials();


### PR DESCRIPTION
### Description

Adds the `Umb-Notifications` HTTP header to the `"Access-Control-Expose-Headers"` list.

This is to enable the client-side development environment to access the custom `Umb-Notifications` HTTP header.

