### PR TITLE
V14: OpenAPI: Explicitly set `ByRelationTypeKey` endpoint name

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Relation/ByRelationTypeKeyRelationController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Relation/ByRelationTypeKeyRelationController.cs
@@ -1,4 +1,4 @@
-﻿using Asp.Versioning;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -29,7 +29,7 @@ public class ByRelationTypeKeyRelationController : RelationControllerBase
     /// <remarks>
     /// Use case: On a relation type page you can see all created relations of this type.
     /// </remarks>
-    [HttpGet("type/{id:guid}")]
+    [HttpGet("type/{id:guid}", Name = "GetRelationByRelationTypeId")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<RelationResponseModel>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(PagedViewModel<ProblemDetails>), StatusCodes.Status404NotFound)]

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -53,7 +53,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -199,7 +199,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -259,7 +259,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -368,7 +368,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -508,7 +508,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -639,7 +639,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -695,7 +695,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -811,7 +811,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -874,7 +874,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -909,7 +909,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -1055,7 +1055,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -1115,7 +1115,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -1224,7 +1224,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -1364,7 +1364,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -1441,7 +1441,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -1490,7 +1490,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -1549,7 +1549,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -1597,7 +1597,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -1668,7 +1668,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -1731,7 +1731,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -1793,7 +1793,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -1963,7 +1963,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -2023,7 +2023,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -2132,7 +2132,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -2272,7 +2272,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -2341,7 +2341,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -2483,7 +2483,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -2629,7 +2629,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -2678,7 +2678,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -2726,7 +2726,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -2789,7 +2789,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -2844,7 +2844,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -2990,7 +2990,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -3050,7 +3050,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -3159,7 +3159,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -3299,7 +3299,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -3415,7 +3415,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -3561,7 +3561,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -3621,7 +3621,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -3730,7 +3730,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -3870,7 +3870,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -3990,7 +3990,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -4039,7 +4039,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -4087,7 +4087,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -4158,7 +4158,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -4221,7 +4221,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -4367,7 +4367,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -4427,7 +4427,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -4510,7 +4510,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -4650,7 +4650,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -4728,7 +4728,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -4806,7 +4806,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -4883,7 +4883,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -5040,7 +5040,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -5101,7 +5101,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -5243,7 +5243,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -5385,7 +5385,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -5440,7 +5440,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -5533,7 +5533,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -5568,7 +5568,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -5714,7 +5714,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -5774,7 +5774,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -5883,7 +5883,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -6023,7 +6023,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -6169,7 +6169,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -6218,7 +6218,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -6277,7 +6277,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -6325,7 +6325,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -6396,7 +6396,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -6459,7 +6459,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -6558,7 +6558,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -6632,7 +6632,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -6750,7 +6750,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -6868,7 +6868,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -6997,7 +6997,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -7143,7 +7143,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -7203,7 +7203,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -7312,7 +7312,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -7452,7 +7452,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -7531,7 +7531,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -7662,7 +7662,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -7722,7 +7722,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -7888,7 +7888,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -8004,7 +8004,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -8115,7 +8115,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -8178,7 +8178,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -8292,7 +8292,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -8423,7 +8423,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -8506,7 +8506,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -8564,7 +8564,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -8678,7 +8678,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -8820,7 +8820,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -8962,7 +8962,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -9026,7 +9026,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -9090,7 +9090,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -9232,7 +9232,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -9374,7 +9374,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -9441,7 +9441,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -9476,7 +9476,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -9607,7 +9607,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -9659,7 +9659,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -9790,7 +9790,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -9839,7 +9839,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -9898,7 +9898,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -9972,7 +9972,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -10083,7 +10083,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -10157,7 +10157,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -10299,7 +10299,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -10362,7 +10362,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -10417,7 +10417,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -10465,7 +10465,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -10536,7 +10536,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -10599,7 +10599,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -10689,7 +10689,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -10723,7 +10723,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -10778,7 +10778,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -10837,7 +10837,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -10932,7 +10932,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -11048,7 +11048,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -11136,7 +11136,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -11213,7 +11213,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -11283,7 +11283,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -11335,7 +11335,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -11391,7 +11391,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -11512,7 +11512,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -11762,7 +11762,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -11794,7 +11794,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -11846,7 +11846,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -11990,7 +11990,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -12046,7 +12046,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -12154,7 +12154,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -12293,7 +12293,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -12348,7 +12348,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -12415,7 +12415,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -12510,7 +12510,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -12595,7 +12595,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -12650,7 +12650,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -12768,7 +12768,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -12827,7 +12827,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -12909,7 +12909,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -12965,7 +12965,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -13003,7 +13003,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -13041,7 +13041,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -13117,7 +13117,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -13176,7 +13176,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -13228,7 +13228,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -13287,7 +13287,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -13433,7 +13433,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -13493,7 +13493,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -13576,7 +13576,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -13716,7 +13716,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -13794,7 +13794,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -13871,7 +13871,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -14028,7 +14028,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -14089,7 +14089,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -14231,7 +14231,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -14373,7 +14373,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -14428,7 +14428,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -14521,7 +14521,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -14667,7 +14667,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -14727,7 +14727,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -14836,7 +14836,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -14976,7 +14976,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -15122,7 +15122,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -15170,7 +15170,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -15241,7 +15241,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -15304,7 +15304,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -15425,7 +15425,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -15474,7 +15474,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -15533,7 +15533,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -15679,7 +15679,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -15739,7 +15739,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -15848,7 +15848,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -15988,7 +15988,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -16067,7 +16067,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -16183,7 +16183,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -16294,7 +16294,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -16358,7 +16358,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -16422,7 +16422,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -16564,7 +16564,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -16631,7 +16631,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -16666,7 +16666,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -16797,7 +16797,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -16849,7 +16849,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -16980,7 +16980,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -17054,7 +17054,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -17165,7 +17165,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -17239,7 +17239,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -17381,7 +17381,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -17444,7 +17444,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -17499,7 +17499,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -17547,7 +17547,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -17618,7 +17618,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -17681,7 +17681,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -17730,7 +17730,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -17785,7 +17785,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -17903,7 +17903,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -17952,7 +17952,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -18061,7 +18061,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -18201,7 +18201,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -18256,7 +18256,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -18305,7 +18305,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -18364,7 +18364,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -18510,7 +18510,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -18570,7 +18570,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -18653,7 +18653,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -18793,7 +18793,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -18870,7 +18870,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -18996,7 +18996,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -19089,7 +19089,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -19144,7 +19144,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -19264,7 +19264,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -19313,7 +19313,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -19372,7 +19372,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -19518,7 +19518,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -19578,7 +19578,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -19687,7 +19687,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -19827,7 +19827,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -19969,7 +19969,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -20004,7 +20004,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -20135,7 +20135,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -20209,7 +20209,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -20244,7 +20244,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -20279,7 +20279,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -20331,7 +20331,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -20392,7 +20392,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -20502,7 +20502,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -20537,7 +20537,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -20592,7 +20592,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -20736,7 +20736,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -20796,7 +20796,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -20879,7 +20879,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -20993,7 +20993,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -21054,7 +21054,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -21109,7 +21109,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -21157,7 +21157,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -21303,7 +21303,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -21362,7 +21362,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -21470,7 +21470,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -21609,7 +21609,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -21765,7 +21765,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -21911,7 +21911,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -21970,7 +21970,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -22078,7 +22078,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -22133,7 +22133,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -22192,7 +22192,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -22239,7 +22239,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -22301,7 +22301,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -22356,7 +22356,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -22412,7 +22412,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -22447,7 +22447,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -22524,7 +22524,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -22586,7 +22586,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -22619,7 +22619,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -22652,7 +22652,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -22685,7 +22685,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -22713,7 +22713,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -22789,7 +22789,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -22853,7 +22853,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -22910,7 +22910,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -22945,7 +22945,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -23000,7 +23000,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -23049,7 +23049,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -23104,7 +23104,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -23164,7 +23164,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -23174,7 +23174,7 @@
         "tags": [
           "Relation"
         ],
-        "operationId": "GetRelationTypeById",
+        "operationId": "GetRelationByRelationTypeId",
         "parameters": [
           {
             "name": "id",
@@ -23242,7 +23242,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -23290,7 +23290,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -23436,7 +23436,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -23495,7 +23495,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -23603,7 +23603,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -23742,7 +23742,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -23898,7 +23898,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -24044,7 +24044,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -24103,7 +24103,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -24211,7 +24211,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -24258,7 +24258,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -24320,7 +24320,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -24375,7 +24375,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -24427,7 +24427,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -24508,7 +24508,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -24543,7 +24543,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -24648,7 +24648,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -24779,7 +24779,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -24967,7 +24967,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -24999,7 +24999,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -25031,7 +25031,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -25101,7 +25101,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -25149,7 +25149,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -25193,7 +25193,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -25252,7 +25252,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -25304,7 +25304,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -25352,7 +25352,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -25498,7 +25498,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -25557,7 +25557,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -25665,7 +25665,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -25804,7 +25804,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -25960,7 +25960,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -26106,7 +26106,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -26165,7 +26165,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -26273,7 +26273,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -26320,7 +26320,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -26382,7 +26382,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -26437,7 +26437,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -26510,7 +26510,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -26565,7 +26565,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -26600,7 +26600,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -26703,7 +26703,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -26752,7 +26752,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -26811,7 +26811,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -26957,7 +26957,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -27017,7 +27017,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -27126,7 +27126,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -27266,7 +27266,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -27301,7 +27301,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -27391,7 +27391,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -27426,7 +27426,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -27474,7 +27474,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -27537,7 +27537,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -27592,7 +27592,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -27697,7 +27697,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -27768,7 +27768,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -27862,7 +27862,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -27894,7 +27894,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -27994,7 +27994,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -28043,7 +28043,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -28166,7 +28166,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -28236,7 +28236,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -28342,7 +28342,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -28388,7 +28388,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -28479,7 +28479,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -28528,7 +28528,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -28633,7 +28633,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -28751,7 +28751,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -28804,7 +28804,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -28864,7 +28864,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -28947,7 +28947,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -29061,7 +29061,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -29186,7 +29186,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -29309,7 +29309,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -29437,7 +29437,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -29486,7 +29486,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -29632,7 +29632,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -29735,7 +29735,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -29802,7 +29802,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -29862,7 +29862,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -29971,7 +29971,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -30111,7 +30111,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -30174,7 +30174,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -30293,7 +30293,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -30353,7 +30353,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -30495,7 +30495,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -30617,7 +30617,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -30728,7 +30728,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -30868,7 +30868,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -30903,7 +30903,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -30935,7 +30935,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -30970,7 +30970,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -31072,7 +31072,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -31207,7 +31207,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -31275,7 +31275,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -31365,7 +31365,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -31455,7 +31455,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -31490,7 +31490,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -31525,7 +31525,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -31585,7 +31585,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -31648,7 +31648,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -31708,7 +31708,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -31839,7 +31839,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -31970,7 +31970,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -32116,7 +32116,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -32370,7 +32370,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -32583,7 +32583,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -32688,7 +32688,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -32737,7 +32737,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -32789,7 +32789,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -32933,7 +32933,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -32990,7 +32990,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -33099,7 +33099,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       },
@@ -33239,7 +33239,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -33291,7 +33291,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice User": []
           }
         ]
       }
@@ -37540,7 +37540,7 @@
           },
           "actionParameters": {
             "type": "object",
-            "additionalProperties": { },
+            "additionalProperties": {},
             "nullable": true
           }
         },
@@ -37827,7 +37827,7 @@
           },
           "providerProperties": {
             "type": "object",
-            "additionalProperties": { },
+            "additionalProperties": {},
             "nullable": true
           }
         },
@@ -38162,7 +38162,7 @@
           },
           "extensions": {
             "type": "array",
-            "items": { }
+            "items": {}
           }
         },
         "additionalProperties": false
@@ -41591,7 +41591,7 @@
             "nullable": true
           }
         },
-        "additionalProperties": { }
+        "additionalProperties": {}
       },
       "ProblemDetailsBuilderModel": {
         "type": "object",
@@ -45151,7 +45151,7 @@
           "authorizationCode": {
             "authorizationUrl": "/umbraco/management/api/v1/security/back-office/authorize",
             "tokenUrl": "/umbraco/management/api/v1/security/back-office/token",
-            "scopes": { }
+            "scopes": {}
           }
         }
       }


### PR DESCRIPTION
### Description

It was noticed that in the [OpenAPI.json (Swagger) file](https://github.com/umbraco/Umbraco-CMS/blob/release-14.0.0/src/Umbraco.Cms.Api.Management/OpenApi.json), there were two `operationId` values for `"GetRelationTypeById"`.

1. https://github.com/umbraco/Umbraco-CMS/blob/release-14.0.0/src/Umbraco.Cms.Api.Management/OpenApi.json#L23186
2. https://github.com/umbraco/Umbraco-CMS/blob/release-14.0.0/src/Umbraco.Cms.Api.Management/OpenApi.json#L23246

Given that the `operationId` value should be unique across the OpenAPI spec file, one of these endpoints would need to be named explicitly.

I have opted to rename 

[`ByRelationTypeKeyRelationController.ByRelationTypeKey`](https://github.com/umbraco/Umbraco-CMS/blob/release-14.0.0/src/Umbraco.Cms.Api.Management/Controllers/Relation/ByRelationTypeKeyRelationController.cs#L36) from `"GetRelationTypeById"` to `"GetRelationByRelationTypeId"`.

As far as I'm aware, this shouldn't be a breaking-change to the Management API.
