### PR TITLE
V14: Adding the ability to conditionally serialize version bound properties for the Delivery API

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Json/DeliveryApiJsonTypeResolver.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Json/DeliveryApiJsonTypeResolver.cs
@@ -1,18 +1,11 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
-using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Models.DeliveryApi;
 
 namespace Umbraco.Cms.Api.Delivery.Json;
 
-/// <summary>
-///     Custom resolver for JSON type information in the Delivery API serialization.
-///     Handles both polymorphism and filters out properties based on API versioning rules.
-/// </summary>
-/// <remarks>
-///     see https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/polymorphism?pivots=dotnet-7-0.
-/// </remarks>
+// see https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/polymorphism?pivots=dotnet-7-0
 public class DeliveryApiJsonTypeResolver : DefaultJsonTypeInfoResolver
 {
     public override JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options)
@@ -24,10 +17,6 @@ public class DeliveryApiJsonTypeResolver : DefaultJsonTypeInfoResolver
         {
             ConfigureJsonPolymorphismOptions(jsonTypeInfo, derivedTypes);
         }
-
-        // Filters out properties based on API versioning rules
-        var tempVersion = 3;
-        FilterOutVersionedProperties(jsonTypeInfo, tempVersion);
 
         return jsonTypeInfo;
     }
@@ -63,43 +52,5 @@ public class DeliveryApiJsonTypeResolver : DefaultJsonTypeInfoResolver
         {
             jsonTypeInfo.PolymorphismOptions.DerivedTypes.Add(new JsonDerivedType(derivedType));
         }
-    }
-
-    protected void FilterOutVersionedProperties(JsonTypeInfo jsonTypeInfo, int apiVersion)
-    {
-        var propertiesToRemove = jsonTypeInfo
-            .Properties
-            .Where(prop => ShouldIncludeProperty(prop, apiVersion) is false)
-            .ToArray();
-
-        foreach (JsonPropertyInfo prop in propertiesToRemove)
-        {
-            jsonTypeInfo.Properties.Remove(prop);
-        }
-    }
-
-    private bool ShouldIncludeProperty(JsonPropertyInfo prop, int version)
-    {
-        var attribute = prop
-            .AttributeProvider?
-            .GetCustomAttributes(typeof(IncludeInApiVersionAttribute), false)
-            .FirstOrDefault();
-
-        if (attribute is not IncludeInApiVersionAttribute apiVersionAttribute)
-        {
-            return true; // No attribute means include the property
-        }
-
-        // Check if the version is in the specified versions
-        if (apiVersionAttribute.Versions.Length > 0)
-        {
-            return apiVersionAttribute.Versions.Contains(version);
-        }
-
-        // Check if the version is within the specified bounds
-        var isWithinMinVersion = apiVersionAttribute.MinVersion.HasValue is false || version >= apiVersionAttribute.MinVersion.Value;
-        var isWithinMaxVersion = apiVersionAttribute.MaxVersion.HasValue is false || version <= apiVersionAttribute.MaxVersion.Value;
-
-        return isWithinMinVersion && isWithinMaxVersion;
     }
 }

--- a/src/Umbraco.Cms.Api.Delivery/Json/DeliveryApiJsonTypeResolver.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Json/DeliveryApiJsonTypeResolver.cs
@@ -1,11 +1,18 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
+using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Models.DeliveryApi;
 
 namespace Umbraco.Cms.Api.Delivery.Json;
 
-// see https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/polymorphism?pivots=dotnet-7-0
+/// <summary>
+///     Custom resolver for JSON type information in the Delivery API serialization.
+///     Handles both polymorphism and filters out properties based on API versioning rules.
+/// </summary>
+/// <remarks>
+///     see https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/polymorphism?pivots=dotnet-7-0.
+/// </remarks>
 public class DeliveryApiJsonTypeResolver : DefaultJsonTypeInfoResolver
 {
     public override JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options)
@@ -17,6 +24,10 @@ public class DeliveryApiJsonTypeResolver : DefaultJsonTypeInfoResolver
         {
             ConfigureJsonPolymorphismOptions(jsonTypeInfo, derivedTypes);
         }
+
+        // Filters out properties based on API versioning rules
+        var tempVersion = 3;
+        FilterOutVersionedProperties(jsonTypeInfo, tempVersion);
 
         return jsonTypeInfo;
     }
@@ -52,5 +63,43 @@ public class DeliveryApiJsonTypeResolver : DefaultJsonTypeInfoResolver
         {
             jsonTypeInfo.PolymorphismOptions.DerivedTypes.Add(new JsonDerivedType(derivedType));
         }
+    }
+
+    protected void FilterOutVersionedProperties(JsonTypeInfo jsonTypeInfo, int apiVersion)
+    {
+        var propertiesToRemove = jsonTypeInfo
+            .Properties
+            .Where(prop => ShouldIncludeProperty(prop, apiVersion) is false)
+            .ToArray();
+
+        foreach (JsonPropertyInfo prop in propertiesToRemove)
+        {
+            jsonTypeInfo.Properties.Remove(prop);
+        }
+    }
+
+    private bool ShouldIncludeProperty(JsonPropertyInfo prop, int version)
+    {
+        var attribute = prop
+            .AttributeProvider?
+            .GetCustomAttributes(typeof(IncludeInApiVersionAttribute), false)
+            .FirstOrDefault();
+
+        if (attribute is not IncludeInApiVersionAttribute apiVersionAttribute)
+        {
+            return true; // No attribute means include the property
+        }
+
+        // Check if the version is in the specified versions
+        if (apiVersionAttribute.Versions.Length > 0)
+        {
+            return apiVersionAttribute.Versions.Contains(version);
+        }
+
+        // Check if the version is within the specified bounds
+        var isWithinMinVersion = apiVersionAttribute.MinVersion.HasValue is false || version >= apiVersionAttribute.MinVersion.Value;
+        var isWithinMaxVersion = apiVersionAttribute.MaxVersion.HasValue is false || version <= apiVersionAttribute.MaxVersion.Value;
+
+        return isWithinMinVersion && isWithinMaxVersion;
     }
 }

--- a/src/Umbraco.Cms.Api.Delivery/Json/DeliveryApiVersionAwareJsonConverterBase.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Json/DeliveryApiVersionAwareJsonConverterBase.cs
@@ -23,13 +23,13 @@ public abstract class DeliveryApiVersionAwareJsonConverterBase<T> : JsonConverte
     public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
     {
         Type type = typeof(T);
-        PropertyInfo[] properties = type.GetProperties();
+        PropertyInfo[] properties = type.GetProperties().OrderBy(GetPropertyOrder).ToArray();
         var apiVersion = GetApiVersion();
 
         writer.WriteStartObject();
 
         // Serialize properties in the specified order
-        foreach (PropertyInfo property in properties.OrderBy(GetPropertyOrder))
+        foreach (PropertyInfo property in properties)
         {
             // Filter out properties based on the API version
             var include = apiVersion is null || ShouldIncludeProperty(property, apiVersion.Value);

--- a/src/Umbraco.Cms.Api.Delivery/Json/DeliveryApiVersionAwareJsonConverterBase.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Json/DeliveryApiVersionAwareJsonConverterBase.cs
@@ -61,21 +61,21 @@ public abstract class DeliveryApiVersionAwareJsonConverterBase<T> : JsonConverte
         return attribute?.Order ?? 0;
     }
 
-    private bool ShouldIncludeProperty(PropertyInfo prop, int version)
+    /// <summary>
+    ///     Determines whether a property should be included based on version bounds.
+    /// </summary>
+    /// <param name="propertyInfo">The property info.</param>
+    /// <param name="version">An integer representing an API version.</param>
+    /// <returns><c>true</c> if the property should be included; otherwise, <c>false</c>.</returns>
+    private bool ShouldIncludeProperty(PropertyInfo propertyInfo, int version)
     {
-        var attribute = prop
+        var attribute = propertyInfo
             .GetCustomAttributes(typeof(IncludeInApiVersionAttribute), false)
             .FirstOrDefault();
 
         if (attribute is not IncludeInApiVersionAttribute apiVersionAttribute)
         {
             return true; // No attribute means include the property
-        }
-
-        // Check if the version is in the specified versions
-        if (apiVersionAttribute.Versions.Length > 0)
-        {
-            return apiVersionAttribute.Versions.Contains(version);
         }
 
         // Check if the version is within the specified bounds

--- a/src/Umbraco.Cms.Api.Delivery/Json/DeliveryApiVersionAwareJsonConverterBase.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Json/DeliveryApiVersionAwareJsonConverterBase.cs
@@ -1,0 +1,73 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Umbraco.Cms.Core.DeliveryApi;
+
+namespace Umbraco.Cms.Api.Delivery.Json;
+
+public abstract class DeliveryApiVersionAwareJsonConverterBase<T> : JsonConverter<T>
+{
+    private readonly JsonConverter<T> _defaultConverter = (JsonConverter<T>)JsonSerializerOptions.Default.GetConverter(typeof(T));
+
+    private const int ApiVersion = 4; // TODO: remove
+
+    /// <inheritdoc />
+    public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        => _defaultConverter.Read(ref reader, typeToConvert, options);
+
+    public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+    {
+        Type type = typeof(T);
+        PropertyInfo[] properties = type.GetProperties();
+
+        writer.WriteStartObject();
+
+        // Serialize properties in the specified order
+        foreach (PropertyInfo property in properties.OrderBy(GetPropertyOrder))
+        {
+            // Filter out properties based on the API version
+            var include = ShouldIncludeProperty(property, ApiVersion);
+
+            if (include is false)
+            {
+                continue;
+            }
+
+            var propertyName = property.Name;
+            writer.WritePropertyName(options.PropertyNamingPolicy?.ConvertName(propertyName) ?? propertyName);
+            JsonSerializer.Serialize(writer, property.GetValue(value), options);
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private int GetPropertyOrder(PropertyInfo prop)
+    {
+        var attribute = prop.GetCustomAttribute<JsonPropertyOrderAttribute>();
+        return attribute?.Order ?? 0;
+    }
+
+    private bool ShouldIncludeProperty(PropertyInfo prop, int version)
+    {
+        var attribute = prop
+            .GetCustomAttributes(typeof(IncludeInApiVersionAttribute), false)
+            .FirstOrDefault();
+
+        if (attribute is not IncludeInApiVersionAttribute apiVersionAttribute)
+        {
+            return true; // No attribute means include the property
+        }
+
+        // Check if the version is in the specified versions
+        if (apiVersionAttribute.Versions.Length > 0)
+        {
+            return apiVersionAttribute.Versions.Contains(version);
+        }
+
+        // Check if the version is within the specified bounds
+        var isWithinMinVersion = apiVersionAttribute.MinVersion.HasValue is false || version >= apiVersionAttribute.MinVersion.Value;
+        var isWithinMaxVersion = apiVersionAttribute.MaxVersion.HasValue is false || version <= apiVersionAttribute.MaxVersion.Value;
+
+        return isWithinMinVersion && isWithinMaxVersion;
+    }
+}

--- a/src/Umbraco.Cms.Api.Delivery/Json/DeliveryApiVersionAwareJsonConverterBase.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Json/DeliveryApiVersionAwareJsonConverterBase.cs
@@ -23,12 +23,13 @@ public abstract class DeliveryApiVersionAwareJsonConverterBase<T> : JsonConverte
     public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
     {
         Type type = typeof(T);
-        PropertyInfo[] properties = type.GetProperties().OrderBy(GetPropertyOrder).ToArray();
         var apiVersion = GetApiVersion();
+
+        // Get the properties in the specified order
+        PropertyInfo[] properties = type.GetProperties().OrderBy(GetPropertyOrder).ToArray();
 
         writer.WriteStartObject();
 
-        // Serialize properties in the specified order
         foreach (PropertyInfo property in properties)
         {
             // Filter out properties based on the API version

--- a/src/Umbraco.Core/DeliveryApi/IncludeInApiVersionAttribute.cs
+++ b/src/Umbraco.Core/DeliveryApi/IncludeInApiVersionAttribute.cs
@@ -1,0 +1,36 @@
+namespace Umbraco.Cms.Core.DeliveryApi;
+
+[AttributeUsage(AttributeTargets.Property)]
+public class IncludeInApiVersionAttribute : Attribute
+{
+    public int[] Versions { get; }
+
+    public int? MinVersion { get; }
+
+    public int? MaxVersion { get; }
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="IncludeInApiVersionAttribute"/> class.
+    ///     Specifies that the property should be included in the API response for the specified versions.
+    /// </summary>
+    /// <param name="versions">The API versions for which the property should be included.</param>
+    public IncludeInApiVersionAttribute(params int[] versions)
+    {
+        Versions = versions;
+        MinVersion = null;
+        MaxVersion = null;
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="IncludeInApiVersionAttribute"/> class.
+    ///     Specifies that the property should be included in the API response if the API version falls within the specified bounds.
+    /// </summary>
+    /// <param name="minVersion">The minimum API version (inclusive) for which the property should be included.</param>
+    /// <param name="maxVersion">The maximum API version (inclusive) for which the property should be included.</param>
+    public IncludeInApiVersionAttribute(int? minVersion = null, int? maxVersion = null)
+    {
+        Versions = [];
+        MinVersion = minVersion;
+        MaxVersion = maxVersion;
+    }
+}

--- a/src/Umbraco.Core/DeliveryApi/IncludeInApiVersionAttribute.cs
+++ b/src/Umbraco.Core/DeliveryApi/IncludeInApiVersionAttribute.cs
@@ -3,23 +3,9 @@ namespace Umbraco.Cms.Core.DeliveryApi;
 [AttributeUsage(AttributeTargets.Property)]
 public class IncludeInApiVersionAttribute : Attribute
 {
-    public int[] Versions { get; }
-
     public int? MinVersion { get; }
 
     public int? MaxVersion { get; }
-
-    /// <summary>
-    ///     Initializes a new instance of the <see cref="IncludeInApiVersionAttribute"/> class.
-    ///     Specifies that the property should be included in the API response for the specified versions.
-    /// </summary>
-    /// <param name="versions">The API versions for which the property should be included.</param>
-    public IncludeInApiVersionAttribute(params int[] versions)
-    {
-        Versions = versions;
-        MinVersion = null;
-        MaxVersion = null;
-    }
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="IncludeInApiVersionAttribute"/> class.
@@ -27,10 +13,9 @@ public class IncludeInApiVersionAttribute : Attribute
     /// </summary>
     /// <param name="minVersion">The minimum API version (inclusive) for which the property should be included.</param>
     /// <param name="maxVersion">The maximum API version (inclusive) for which the property should be included.</param>
-    public IncludeInApiVersionAttribute(int? minVersion = null, int? maxVersion = null)
+    public IncludeInApiVersionAttribute(int minVersion = -1, int maxVersion = -1)
     {
-        Versions = [];
-        MinVersion = minVersion;
-        MaxVersion = maxVersion;
+        MinVersion = minVersion >= 0 ? minVersion : null;
+        MaxVersion = maxVersion >= 0 ? maxVersion : null;
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Delivery/Json/DeliveryApiVersionAwareJsonConverterBaseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Delivery/Json/DeliveryApiVersionAwareJsonConverterBaseTests.cs
@@ -64,10 +64,7 @@ public class DeliveryApiVersionAwareJsonConverterBaseTests
         var output = reader.ReadToEnd();
 
         // Assert
-        Assert.Multiple(() =>
-        {
-            Assert.That(expectedPropertyNames.All(v => output.Contains(v, StringComparison.InvariantCulture)), Is.True);
-        });
+        Assert.That(expectedPropertyNames.All(v => output.Contains(v, StringComparison.InvariantCulture)), Is.True);
     }
 
     [Test]
@@ -96,19 +93,16 @@ public class DeliveryApiVersionAwareJsonConverterBaseTests
         var jsonOptions = new JsonSerializerOptions();
         var output = GetJsonOutput(apiVersion, jsonOptions);
 
-        // Assert
-        Assert.Multiple(() =>
-        {
-            // Verify values correspond to properties
-            var jsonDoc = JsonDocument.Parse(output);
-            var root = jsonDoc.RootElement;
+        // Verify values correspond to properties
+        var jsonDoc = JsonDocument.Parse(output);
+        var root = jsonDoc.RootElement;
 
-            foreach (var propertyName in expectedPropertyNames)
-            {
-                var expectedValue = GetPropertyValue(propertyName);
-                Assert.AreEqual(expectedValue, root.GetProperty(propertyName).GetString());
-            }
-        });
+        // Assert
+        foreach (var propertyName in expectedPropertyNames)
+        {
+            var expectedValue = GetPropertyValue(propertyName);
+            Assert.AreEqual(expectedValue, root.GetProperty(propertyName).GetString());
+        }
     }
 
     [Test]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Delivery/Json/DeliveryApiVersionAwareJsonConverterBaseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Delivery/Json/DeliveryApiVersionAwareJsonConverterBaseTests.cs
@@ -1,0 +1,248 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Delivery.Json;
+using Umbraco.Cms.Core.DeliveryApi;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Api.Delivery.Json;
+
+[TestFixture]
+public class DeliveryApiVersionAwareJsonConverterBaseTests
+{
+    private Mock<IHttpContextAccessor> _httpContextAccessorMock;
+    private Mock<IApiVersioningFeature> _apiVersioningFeatureMock;
+
+    private void SetUpMocks(int apiVersion)
+    {
+        _httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+        _apiVersioningFeatureMock = new Mock<IApiVersioningFeature>();
+
+        _apiVersioningFeatureMock
+            .SetupGet(feature => feature.RequestedApiVersion)
+            .Returns(new ApiVersion(apiVersion));
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Features.Set(_apiVersioningFeatureMock.Object);
+
+        _httpContextAccessorMock
+            .SetupGet(accessor => accessor.HttpContext)
+            .Returns(httpContext);
+    }
+
+    [Test]
+    [TestCase(1, new[] { "PropertyAll", "PropertyV1Max", "PropertyV2Max", "PropertyV2Only", "PropertyV2Min" })]
+    [TestCase(2, new[] { "PropertyAll", "PropertyV1Max", "PropertyV2Max", "PropertyV2Only", "PropertyV2Min" })]
+    [TestCase(3, new[] { "PropertyAll", "PropertyV1Max", "PropertyV2Max", "PropertyV2Only", "PropertyV2Min" })]
+    public void Can_Include_All_Properties_When_No_HttpContext(int apiVersion, string[] expectedPropertyNames)
+    {
+        // Arrange
+        using var memoryStream = new MemoryStream();
+        using var jsonWriter = new Utf8JsonWriter(memoryStream);
+
+        _httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+        _apiVersioningFeatureMock = new Mock<IApiVersioningFeature>();
+
+        _apiVersioningFeatureMock
+            .SetupGet(feature => feature.RequestedApiVersion)
+            .Returns(new ApiVersion(apiVersion));
+
+        _httpContextAccessorMock
+            .SetupGet(accessor => accessor.HttpContext)
+            .Returns((HttpContext)null);
+
+        var sut = new TestJsonConverter(_httpContextAccessorMock.Object);
+
+        // Act
+        sut.Write(jsonWriter, new TestResponseModel(), new JsonSerializerOptions());
+        jsonWriter.Flush();
+
+        memoryStream.Seek(0, SeekOrigin.Begin);
+        using var reader = new StreamReader(memoryStream);
+        var output = reader.ReadToEnd();
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(expectedPropertyNames.All(v => output.Contains(v, StringComparison.InvariantCulture)), Is.True);
+        });
+    }
+
+    [Test]
+    [TestCase(1, new[] { "PropertyAll", "PropertyV1Max", "PropertyV2Max" }, new[] { "PropertyV2Min", "PropertyV2Only" })]
+    [TestCase(2, new[] { "PropertyAll", "PropertyV2Min", "PropertyV2Only", "PropertyV2Max" }, new[] { "PropertyV1Max" })]
+    [TestCase(3, new[] { "PropertyAll", "PropertyV2Min" }, new[] { "PropertyV1Max", "PropertyV2Only", "PropertyV2Max" })]
+    public void Can_Include_Correct_Properties_Based_On_Version_Attribute(int apiVersion, string[] expectedPropertyNames, string[] expectedDisallowedPropertyNames)
+    {
+        // Arrange
+        using var memoryStream = new MemoryStream();
+        using var jsonWriter = new Utf8JsonWriter(memoryStream);
+
+        SetUpMocks(apiVersion);
+        var sut = new TestJsonConverter(_httpContextAccessorMock.Object);
+
+        // Act
+        sut.Write(jsonWriter, new TestResponseModel(), new JsonSerializerOptions());
+        jsonWriter.Flush();
+
+        memoryStream.Seek(0, SeekOrigin.Begin);
+        using var reader = new StreamReader(memoryStream);
+        var output = reader.ReadToEnd();
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(expectedPropertyNames.All(v => output.Contains(v, StringComparison.InvariantCulture)), Is.True);
+            Assert.That(expectedDisallowedPropertyNames.All(v => output.Contains(v, StringComparison.InvariantCulture) is false), Is.True);
+        });
+    }
+
+    [Test]
+    [TestCase(1, new[] { "PropertyAll", "PropertyV1Max", "PropertyV2Max" })]
+    [TestCase(2, new[] { "PropertyAll", "PropertyV2Min", "PropertyV2Only", "PropertyV2Max" })]
+    [TestCase(3, new[] { "PropertyAll", "PropertyV2Min" })]
+    public void Can_Serialize_Properties_Correctly_Based_On_Version_Attribute(int apiVersion, string[] expectedPropertyNames)
+    {
+        // Arrange
+        using var memoryStream = new MemoryStream();
+        using var jsonWriter = new Utf8JsonWriter(memoryStream);
+
+        SetUpMocks(apiVersion);
+        var sut = new TestJsonConverter(_httpContextAccessorMock.Object);
+
+        // Act
+        sut.Write(jsonWriter, new TestResponseModel(), new JsonSerializerOptions());
+        jsonWriter.Flush();
+
+        memoryStream.Seek(0, SeekOrigin.Begin);
+        using var reader = new StreamReader(memoryStream);
+        var output = reader.ReadToEnd();
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            // Verify values correspond to properties
+            var jsonDoc = JsonDocument.Parse(output);
+            var root = jsonDoc.RootElement;
+
+            foreach (var propertyName in expectedPropertyNames)
+            {
+                var expectedValue = GetPropertyValue(propertyName);
+                Assert.AreEqual(expectedValue, root.GetProperty(propertyName).GetString());
+            }
+        });
+    }
+
+    [Test]
+    [TestCase(1, new[] { "propertyAll", "propertyV1Max", "propertyV2Max" }, new[] { "propertyV2Min", "propertyV2Only" })]
+    [TestCase(2, new[] { "propertyAll", "propertyV2Min", "propertyV2Only", "propertyV2Max" }, new[] { "propertyV1Max" })]
+    [TestCase(3, new[] { "propertyAll", "propertyV2Min" }, new[] { "propertyV1Max", "propertyV2Only", "propertyV2Max" })]
+    public void Can_Respect_Property_Naming_Policy_On_Json_Options(int apiVersion, string[] expectedPropertyNames, string[] expectedDisallowedPropertyNames)
+    {
+        // Arrange
+        using var memoryStream = new MemoryStream();
+        using var jsonWriter = new Utf8JsonWriter(memoryStream);
+
+        SetUpMocks(apiVersion);
+        var sut = new TestJsonConverter(_httpContextAccessorMock.Object);
+
+        // Set up CamelCase naming policy
+        var jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+
+        // Act
+        sut.Write(jsonWriter, new TestResponseModel(), jsonOptions);
+        jsonWriter.Flush();
+
+        memoryStream.Seek(0, SeekOrigin.Begin);
+        using var reader = new StreamReader(memoryStream);
+        var output = reader.ReadToEnd();
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(expectedPropertyNames.All(v => output.Contains(v, StringComparison.InvariantCulture)), Is.True);
+            Assert.That(expectedDisallowedPropertyNames.All(v => output.Contains(v, StringComparison.InvariantCulture) is false), Is.True);
+        });
+    }
+
+    [Test]
+    [TestCase(1, "PropertyV1Max", "PropertyAll")]
+    [TestCase(2, "PropertyV2Min", "PropertyAll")]
+    public void Can_Respect_Property_Order(int apiVersion, string expectedFirstPropertyName, string expectedLastPropertyName)
+    {
+        // Arrange
+        using var memoryStream = new MemoryStream();
+        using var jsonWriter = new Utf8JsonWriter(memoryStream);
+
+        SetUpMocks(apiVersion);
+        var sut = new TestJsonConverter(_httpContextAccessorMock.Object);
+
+        // Act
+        sut.Write(jsonWriter, new TestResponseModel(), new JsonSerializerOptions());
+        jsonWriter.Flush();
+
+        memoryStream.Seek(0, SeekOrigin.Begin);
+        using var reader = new StreamReader(memoryStream);
+        var output = reader.ReadToEnd();
+
+        // Parse the JSON to verify the order of properties
+        using var jsonDocument = JsonDocument.Parse(output);
+        var rootElement = jsonDocument.RootElement;
+
+        var properties = rootElement.EnumerateObject().ToList();
+        var firstProperty = properties.First();
+        var lastProperty = properties.Last();
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(expectedFirstPropertyName, firstProperty.Name);
+            Assert.AreEqual(expectedLastPropertyName, lastProperty.Name);
+        });
+    }
+
+    private string GetPropertyValue(string propertyName)
+    {
+        var model = new TestResponseModel();
+        return propertyName switch
+        {
+            nameof(TestResponseModel.PropertyAll) => model.PropertyAll,
+            nameof(TestResponseModel.PropertyV1Max) => model.PropertyV1Max,
+            nameof(TestResponseModel.PropertyV2Max) => model.PropertyV2Max,
+            nameof(TestResponseModel.PropertyV2Min) => model.PropertyV2Min,
+            nameof(TestResponseModel.PropertyV2Only) => model.PropertyV2Only,
+            _ => throw new ArgumentException($"Unknown property name: {propertyName}"),
+        };
+    }
+}
+
+internal class TestJsonConverter : DeliveryApiVersionAwareJsonConverterBase<TestResponseModel>
+{
+    public TestJsonConverter(IHttpContextAccessor httpContextAccessor)
+        : base(httpContextAccessor)
+    {
+    }
+}
+
+internal class TestResponseModel
+{
+    [JsonPropertyOrder(100)]
+    public string PropertyAll { get; init; } = "all";
+
+    [IncludeInApiVersion(maxVersion: 1)]
+    public string PropertyV1Max { get; init; } = "v1";
+
+    [IncludeInApiVersion(2)]
+    public string PropertyV2Min { get; init; } = "v2+";
+
+    [IncludeInApiVersion(2, 2)]
+    public string PropertyV2Only { get; init; } = "v2";
+
+    [IncludeInApiVersion(maxVersion: 2)]
+    public string PropertyV2Max { get; init; } = "up to v2";
+}


### PR DESCRIPTION
## Details
- Adding support for property-level versioning for the Delivery API;
  - Introducing `IncludeInApiVersionAttribute` to define API version bounds for properties. It supports both an inclusive minimum and maximum API version;
    - Properties annotated with this attribute will be included in the Delivery API response only if the API version falls within the specified bounds. 
  - Adding a base converter class that you can inherit from in your custom JsonConverters. It handles the System.Text.Json serialization of properties based on the Delivery API version bounds.
    - Uses `IHttpContextAccessor` to access and act upon the current API version.

</br>

> Example:
```c#
public class MyModel
{
    [IncludeInApiVersion(3)] // Only available from version 3 onwards
    public string Property1 { get; set; }

    [IncludeInApiVersion(2, 5)] // Available from version 2 to 5 (inclusive)
    public int Property2 { get; set; }

    [IncludeInApiVersion(maxVersion: 4)] // Available until version 4 (inclusive)
    public bool Property3 { get; set; }
}
```
_Now, properties in `MyModel` will be included in the Delivery API response based on the specified version bounds._


## Test
> Setup
1. Enable the Delivery API is **appsettings.json**:
```json
{
  . . .
  "Umbraco": {
    "CMS": {
      "DeliveryApi": {
        "Enabled": true
      },
      . . .
}
```
</br>

2. Set up some content, like:
- Products
  - Item 1
  - Item 2

</br>

> Baseline
3. Verify that the output is the same from both:
- GET <code>/umbraco/delivery/api/<b>v2</b>/content</code> and GET <code>/umbraco/delivery/api/<b>v1</b>/content</code> endpoints;
- and GET <code>/umbraco/delivery/api/<b>v2</b>/content/item/{id}</code> and GET <code>/umbraco/delivery/api/<b>v1</b>/content/item/{id}</code> endpoints;
  - so we have an example from both multiple and single item serialization ❗  
4. Keep the JSON from `/content` and `/item` endpoints in a text comparison tool, like https://www.diffchecker.com/text-compare/ to compare next.

</br>

> Custom converter and application of `[IncludeInApiVersion]` attribute
5. Modify [ApiContentResponse.cs](https://github.com/umbraco/Umbraco-CMS/blob/v14/dev/src/Umbraco.Core/Models/DeliveryApi/ApiContentResponse.cs) (or use your own Delivery API custom endpoints and models):

```c#
public class ApiContentResponse : ApiContent, IApiContentResponse
{
    . . .
    [JsonPropertyOrder(100)]
    [IncludeInApiVersion(maxVersion: 1)] // <--- ADD THIS
    public IDictionary<string, IApiContentRoute> Cultures { get; }
}
```

6. Modify [ApiContent.cs](https://github.com/umbraco/Umbraco-CMS/blob/v14/dev/src/Umbraco.Core/Models/DeliveryApi/ApiContent.cs) (or use your own Delivery API custom endpoints and models):

```c#
public class ApiContent : ApiElement, IApiContent
{
    . . .

    [IncludeInApiVersion(1, 2)] // <--- ADD THIS
    public DateTime CreateDate { get; }

    [IncludeInApiVersion(2)] // <--- ADD THIS
    public DateTime UpdateDate { get; }

    public IApiContentRoute Route { get; }
}
```

7. Create a custom JSON converter and configure additional JSON options for the DeliveryAPI:

```c#
using Microsoft.AspNetCore.Mvc;
using Microsoft.Extensions.Options;
using Umbraco.Cms.Api.Delivery.Json;
using Umbraco.Cms.Core;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Models.DeliveryApi;

namespace Umbraco.Cms.Web.UI;

public class MyComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        // Configure additional Delivery API JSON options
        builder.Services.ConfigureOptions<ConfigureDeliveryApiVersionAwareNamedOptions>();
    }
}

/// <summary>
///     Configures JSON options for the Delivery API based on API version awareness.
///     Passes on IHttpContextAccessor to access and act upon the current API version.
/// </summary>
public class ConfigureDeliveryApiVersionAwareNamedOptions : IConfigureNamedOptions<JsonOptions>
{
    private readonly IHttpContextAccessor _httpContextAccessor;

    public ConfigureDeliveryApiVersionAwareNamedOptions(IHttpContextAccessor httpContextAccessor)
        => _httpContextAccessor = httpContextAccessor;

    /// <inheritdoc />
    public void Configure(string? name, JsonOptions options)
    {
        if (name is Constants.JsonOptionsNames.DeliveryApi)
        {
            Configure(options);
        }
    }

    /// <summary>
    ///     Configures JSON options by adding a custom JSON converter.
    /// </summary>
    public void Configure(JsonOptions options)
    {
        options.JsonSerializerOptions.Converters.Add(new MyJsonConverter(_httpContextAccessor));
    }
}

/// <summary>
///     Custom JSON converter for the Delivery API to apply custom logic based on the API version.
/// </summary>
public class MyJsonConverter : DeliveryApiVersionAwareJsonConverterBase<ApiContentResponse>
{
    public MyJsonConverter(IHttpContextAccessor httpContextAccessor)
        : base(httpContextAccessor)
    {
    }
}
```

</br>

> Verification:
8. Compare first the output from <code>/umbraco/delivery/api/<b>v1</b></code> and then <code>/umbraco/delivery/api/<b>v2</b></code> of `/content` and `/item` endpoints with the complete output from before (_**step: 4**_) and verify that the following properties are there or not based on ✅ and ❌ indicators:

|           | v1         | v2         | v3         |
|-----------|------------|------------|------------|
| "createDate"| :white_check_mark: | :white_check_mark: | :x:        |
| "updateDate"| :x:        | :white_check_mark: | :white_check_mark: |
| "cultures"  | :white_check_mark: | :x:        | :x:        |

9. _Bonus:_ You can create v3 endpoint and verify that v3 column is correct 😊 

