### PR TITLE
Support JSON parsing object to DateTimeOffset and preserve timezone offset in `JsonObjectConverter`

### DIFF
--- a/src/Umbraco.Infrastructure/Serialization/JsonObjectConverter.cs
+++ b/src/Umbraco.Infrastructure/Serialization/JsonObjectConverter.cs
@@ -101,8 +101,9 @@ public sealed class JsonObjectConverter : JsonConverter<object>
             JsonTokenType.Number when reader.TryGetInt32(out int i) => i,
             JsonTokenType.Number when reader.TryGetInt64(out long l) => l,
             JsonTokenType.Number => reader.GetDouble(),
+            JsonTokenType.String when reader.TryGetDateTimeOffset(out DateTimeOffset datetime) => datetime,
             JsonTokenType.String when reader.TryGetDateTime(out DateTime datetime) => datetime,
-            JsonTokenType.String => reader.GetString()!,
+            JsonTokenType.String => reader.GetString(),
             _ => JsonDocument.ParseValue(ref reader).RootElement.Clone()
         };
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/16587.

### Description
Although [I initially thought](https://github.com/umbraco/Umbraco-CMS/issues/16587#issuecomment-2194236383) the CMS data type configuration migration (executed when upgrading v13 to v14) caused Deploy to write updated UDA files, it is actually due to the `JsonObjectConverter` (that's used by the `IConfigurationEditorJsonSerializer` for reading and writing data type configuration) not correctly parsing `DataTimeOffset` values.

This custom JsonConverter takes care of deserializing JSON values into `object` instances to their simple/primitive types (boolean, integer, date or string), instead of a boxed `JsonElement` (see https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/migrate-from-newtonsoft?pivots=dotnet-9-0#deserialization-of-object-properties). I assume this has been copied from the [example in the Microsoft documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/converters-how-to?pivots=dotnet-8-0#deserialize-inferred-types-to-object-properties), which clearly isn't really suitable to be used in production 🫤 Removing this converter would be a massive breaking change, as values will be parsed differently when deserializing, but I would suggest looking into thing for a future major release, as this also contains multiple performance issues (loading everything into lists, casting, creating generic types and new instances via reflection, etc.)...