### PR TITLE
Move ReservedFieldNames to type configuration endpoints

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/ConfigurationMediaTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/ConfigurationMediaTypeController.cs
@@ -1,0 +1,31 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.ViewModels.MediaType;
+using Umbraco.Cms.Web.Common.Authorization;
+
+namespace Umbraco.Cms.Api.Management.Controllers.MediaType;
+
+[ApiVersion("1.0")]
+[Authorize(Policy = AuthorizationPolicies.TreeAccessMediaTypes)]
+public class ConfigurationMediaTypeController : MediaTypeControllerBase
+{
+    private readonly IConfigurationPresentationFactory _configurationPresentationFactory;
+
+    public ConfigurationMediaTypeController(IConfigurationPresentationFactory configurationPresentationFactory)
+    {
+        _configurationPresentationFactory = configurationPresentationFactory;
+    }
+
+    [HttpGet("configuration")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(MediaTypeConfigurationResponseModel), StatusCodes.Status200OK)]
+    public Task<IActionResult> Configuration(CancellationToken cancellationToken)
+    {
+        MediaTypeConfigurationResponseModel responseModel = _configurationPresentationFactory.CreateMediaTypeConfigurationResponseModel();
+
+        return Task.FromResult<IActionResult>(Ok(responseModel));
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/ConfigurationMemberTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/ConfigurationMemberTypeController.cs
@@ -1,0 +1,31 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.ViewModels.MemberType;
+using Umbraco.Cms.Web.Common.Authorization;
+
+namespace Umbraco.Cms.Api.Management.Controllers.MemberType;
+
+[ApiVersion("1.0")]
+[Authorize(Policy = AuthorizationPolicies.TreeAccessMemberTypes)]
+public class ConfigurationMemberTypeController : MemberTypeControllerBase
+{
+    private readonly IConfigurationPresentationFactory _configurationPresentationFactory;
+
+    public ConfigurationMemberTypeController(IConfigurationPresentationFactory configurationPresentationFactory)
+    {
+        _configurationPresentationFactory = configurationPresentationFactory;
+    }
+
+    [HttpGet("configuration")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(MemberTypeConfigurationResponseModel), StatusCodes.Status200OK)]
+    public Task<IActionResult> Configuration(CancellationToken cancellationToken)
+    {
+        MemberTypeConfigurationResponseModel responseModel = _configurationPresentationFactory.CreateMemberTypeConfigurationResponseModel();
+
+        return Task.FromResult<IActionResult>(Ok(responseModel));
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/ConfigurationMemberTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/ConfigurationMemberTypeController.cs
@@ -9,7 +9,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 namespace Umbraco.Cms.Api.Management.Controllers.MemberType;
 
 [ApiVersion("1.0")]
-[Authorize(Policy = AuthorizationPolicies.TreeAccessMemberTypes)]
 public class ConfigurationMemberTypeController : MemberTypeControllerBase
 {
     private readonly IConfigurationPresentationFactory _configurationPresentationFactory;

--- a/src/Umbraco.Cms.Api.Management/Factories/ConfigurationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/ConfigurationPresentationFactory.cs
@@ -1,8 +1,14 @@
-﻿using Microsoft.Extensions.Options;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Api.Management.ViewModels.Document;
+using Umbraco.Cms.Api.Management.ViewModels.DocumentType;
 using Umbraco.Cms.Api.Management.ViewModels.Media;
+using Umbraco.Cms.Api.Management.ViewModels.MediaType;
 using Umbraco.Cms.Api.Management.ViewModels.Member;
+using Umbraco.Cms.Api.Management.ViewModels.MemberType;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Features;
 using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.Factories;
@@ -10,17 +16,38 @@ namespace Umbraco.Cms.Api.Management.Factories;
 public class ConfigurationPresentationFactory : IConfigurationPresentationFactory
 {
     private readonly IReservedFieldNamesService _reservedFieldNamesService;
+    private readonly UmbracoFeatures _umbracoFeatures;
+    private readonly DataTypesSettings _dataTypesSettings;
     private readonly ContentSettings _contentSettings;
     private readonly SegmentSettings _segmentSettings;
 
     public ConfigurationPresentationFactory(
         IReservedFieldNamesService reservedFieldNamesService,
         IOptions<ContentSettings> contentSettings,
-        IOptions<SegmentSettings> segmentSettings)
+        IOptions<SegmentSettings> segmentSettings,
+        IOptions<DataTypesSettings> dataTypesSettings,
+        UmbracoFeatures umbracoFeatures)
     {
         _reservedFieldNamesService = reservedFieldNamesService;
+        _umbracoFeatures = umbracoFeatures;
+        _dataTypesSettings = dataTypesSettings.Value;
         _contentSettings = contentSettings.Value;
         _segmentSettings = segmentSettings.Value;
+    }
+
+    [Obsolete("Use the constructor with all dependencies")]
+    public ConfigurationPresentationFactory(
+        IReservedFieldNamesService reservedFieldNamesService,
+        IOptions<ContentSettings> contentSettings,
+        IOptions<SegmentSettings> segmentSettings)
+    : this(
+        reservedFieldNamesService,
+        contentSettings,
+        segmentSettings,
+        StaticServiceProvider.Instance.GetRequiredService<IOptions<DataTypesSettings>>(),
+        StaticServiceProvider.Instance.GetRequiredService<UmbracoFeatures>()
+            )
+    {
     }
 
     public DocumentConfigurationResponseModel CreateDocumentConfigurationResponseModel() =>
@@ -33,7 +60,22 @@ public class ConfigurationPresentationFactory : IConfigurationPresentationFactor
             ReservedFieldNames = _reservedFieldNamesService.GetDocumentReservedFieldNames(),
         };
 
+    public DocumentTypeConfigurationResponseModel CreateDocumentTypeConfigurationResponseModel() =>
+        new()
+        {
+            DataTypesCanBeChanged = _dataTypesSettings.CanBeChanged,
+            DisableTemplates = _umbracoFeatures.Disabled.DisableTemplates,
+            UseSegments = _segmentSettings.Enabled,
+            ReservedFieldNames = _reservedFieldNamesService.GetDocumentReservedFieldNames(),
+        };
+
     public MemberConfigurationResponseModel CreateMemberConfigurationResponseModel() =>
+        new()
+        {
+            ReservedFieldNames = _reservedFieldNamesService.GetMemberReservedFieldNames(),
+        };
+
+    public MemberTypeConfigurationResponseModel CreateMemberTypeConfigurationResponseModel() =>
         new()
         {
             ReservedFieldNames = _reservedFieldNamesService.GetMemberReservedFieldNames(),
@@ -44,6 +86,12 @@ public class ConfigurationPresentationFactory : IConfigurationPresentationFactor
         {
             DisableDeleteWhenReferenced = _contentSettings.DisableDeleteWhenReferenced,
             DisableUnpublishWhenReferenced = _contentSettings.DisableUnpublishWhenReferenced,
+            ReservedFieldNames = _reservedFieldNamesService.GetMediaReservedFieldNames(),
+        };
+
+    public MediaTypeConfigurationResponseModel CreateMediaTypeConfigurationResponseModel() =>
+        new()
+        {
             ReservedFieldNames = _reservedFieldNamesService.GetMediaReservedFieldNames(),
         };
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/IConfigurationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IConfigurationPresentationFactory.cs
@@ -1,6 +1,9 @@
 ﻿using Umbraco.Cms.Api.Management.ViewModels.Document;
+using Umbraco.Cms.Api.Management.ViewModels.DocumentType;
 using Umbraco.Cms.Api.Management.ViewModels.Media;
+using Umbraco.Cms.Api.Management.ViewModels.MediaType;
 using Umbraco.Cms.Api.Management.ViewModels.Member;
+using Umbraco.Cms.Api.Management.ViewModels.MemberType;
 
 namespace Umbraco.Cms.Api.Management.Factories;
 
@@ -8,7 +11,16 @@ public interface IConfigurationPresentationFactory
 {
     DocumentConfigurationResponseModel CreateDocumentConfigurationResponseModel();
 
+    DocumentTypeConfigurationResponseModel CreateDocumentTypeConfigurationResponseModel()
+        => throw new NotImplementedException();
+
     MemberConfigurationResponseModel CreateMemberConfigurationResponseModel();
 
+    MemberTypeConfigurationResponseModel CreateMemberTypeConfigurationResponseModel()
+        => throw new NotImplementedException();
+
     MediaConfigurationResponseModel CreateMediaConfigurationResponseModel();
+
+    MediaTypeConfigurationResponseModel CreateMediaTypeConfigurationResponseModel()
+        => throw new NotImplementedException();
 }

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -14526,6 +14526,41 @@
         ]
       }
     },
+    "/umbraco/management/api/v1/media-type/configuration": {
+      "get": {
+        "tags": [
+          "Media Type"
+        ],
+        "operationId": "GetMediaTypeConfiguration",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/MediaTypeConfigurationResponseModel"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          },
+          "403": {
+            "description": "The authenticated user do not have access to this resource"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": []
+          }
+        ]
+      }
+    },
     "/umbraco/management/api/v1/media-type/folder": {
       "post": {
         "tags": [
@@ -19085,6 +19120,41 @@
                 }
               }
             }
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": []
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/member-type/configuration": {
+      "get": {
+        "tags": [
+          "Member Type"
+        ],
+        "operationId": "GetMemberTypeConfiguration",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/MemberTypeConfigurationResponseModel"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          },
+          "403": {
+            "description": "The authenticated user do not have access to this resource"
           }
         },
         "security": [
@@ -36124,7 +36194,8 @@
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "deprecated": true
           }
         },
         "additionalProperties": false
@@ -36551,6 +36622,7 @@
         "required": [
           "dataTypesCanBeChanged",
           "disableTemplates",
+          "reservedFieldNames",
           "useSegments"
         ],
         "type": "object",
@@ -36563,6 +36635,13 @@
           },
           "useSegments": {
             "type": "boolean"
+          },
+          "reservedFieldNames": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "additionalProperties": false
@@ -37540,7 +37619,7 @@
           },
           "actionParameters": {
             "type": "object",
-            "additionalProperties": {},
+            "additionalProperties": { },
             "nullable": true
           }
         },
@@ -37827,7 +37906,7 @@
           },
           "providerProperties": {
             "type": "object",
-            "additionalProperties": {},
+            "additionalProperties": { },
             "nullable": true
           }
         },
@@ -38162,7 +38241,7 @@
           },
           "extensions": {
             "type": "array",
-            "items": {}
+            "items": { }
           }
         },
         "additionalProperties": false
@@ -38238,7 +38317,8 @@
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "deprecated": true
           }
         },
         "additionalProperties": false
@@ -38544,6 +38624,22 @@
           },
           "icon": {
             "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MediaTypeConfigurationResponseModel": {
+        "required": [
+          "reservedFieldNames"
+        ],
+        "type": "object",
+        "properties": {
+          "reservedFieldNames": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "additionalProperties": false
@@ -38999,7 +39095,8 @@
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "deprecated": true
           }
         },
         "additionalProperties": false
@@ -39226,6 +39323,22 @@
           },
           "icon": {
             "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MemberTypeConfigurationResponseModel": {
+        "required": [
+          "reservedFieldNames"
+        ],
+        "type": "object",
+        "properties": {
+          "reservedFieldNames": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "additionalProperties": false
@@ -41591,7 +41704,7 @@
             "nullable": true
           }
         },
-        "additionalProperties": {}
+        "additionalProperties": { }
       },
       "ProblemDetailsBuilderModel": {
         "type": "object",
@@ -45151,7 +45264,7 @@
           "authorizationCode": {
             "authorizationUrl": "/umbraco/management/api/v1/security/back-office/authorize",
             "tokenUrl": "/umbraco/management/api/v1/security/back-office/token",
-            "scopes": {}
+            "scopes": { }
           }
         }
       }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentConfigurationResponseModel.cs
@@ -10,5 +10,6 @@ public class DocumentConfigurationResponseModel
 
     public required bool AllowNonExistingSegmentsCreation { get; set; }
 
+    [Obsolete("Use DocumentTypeConfigurationResponseModel.ReservedFieldNames from the DocumentTypeConfiguration endpoint instead.")]
     public required ISet<string> ReservedFieldNames { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentConfigurationResponseModel.cs
@@ -10,6 +10,6 @@ public class DocumentConfigurationResponseModel
 
     public required bool AllowNonExistingSegmentsCreation { get; set; }
 
-    [Obsolete("Use DocumentTypeConfigurationResponseModel.ReservedFieldNames from the DocumentTypeConfiguration endpoint instead.")]
+    [Obsolete("Use DocumentTypeConfigurationResponseModel.ReservedFieldNames from the ConfigurationDocumentTypeController endpoint instead.")]
     public required ISet<string> ReservedFieldNames { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/DocumentTypeConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/DocumentTypeConfigurationResponseModel.cs
@@ -9,4 +9,6 @@ public class DocumentTypeConfigurationResponseModel
     public required bool DisableTemplates { get; set; }
 
     public required bool UseSegments { get; set; }
+
+    public required ISet<string> ReservedFieldNames { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Media/MediaConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Media/MediaConfigurationResponseModel.cs
@@ -6,5 +6,6 @@ public class MediaConfigurationResponseModel
 
     public required bool DisableUnpublishWhenReferenced { get; set; }
 
+    [Obsolete("Use MediaTypeConfigurationResponseModel.ReservedFieldNames from the MediaTypeConfiguration endpoint instead.")]
     public required ISet<string> ReservedFieldNames { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Media/MediaConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Media/MediaConfigurationResponseModel.cs
@@ -6,6 +6,6 @@ public class MediaConfigurationResponseModel
 
     public required bool DisableUnpublishWhenReferenced { get; set; }
 
-    [Obsolete("Use MediaTypeConfigurationResponseModel.ReservedFieldNames from the MediaTypeConfiguration endpoint instead.")]
+    [Obsolete("Use MediaTypeConfigurationResponseModel.ReservedFieldNames from the ConfigurationMediaTypeController endpoint instead.")]
     public required ISet<string> ReservedFieldNames { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/MediaType/MediaTypeConfigurationModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/MediaType/MediaTypeConfigurationModel.cs
@@ -1,0 +1,6 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.MediaType;
+
+public class MediaTypeConfigurationResponseModel
+{
+    public required ISet<string> ReservedFieldNames { get; set; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Member/MemberConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Member/MemberConfigurationResponseModel.cs
@@ -2,6 +2,6 @@
 
 public class MemberConfigurationResponseModel
 {
-    [Obsolete("Use MemberTypeConfigurationResponseModel.ReservedFieldNames from the MemberTypeConfiguration endpoint instead.")]
+    [Obsolete("Use MemberTypeConfigurationResponseModel.ReservedFieldNames from the ConfigurationMemberTypeController endpoint instead.")]
     public required ISet<string> ReservedFieldNames { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Member/MemberConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Member/MemberConfigurationResponseModel.cs
@@ -2,5 +2,6 @@
 
 public class MemberConfigurationResponseModel
 {
+    [Obsolete("Use MemberTypeConfigurationResponseModel.ReservedFieldNames from the MemberTypeConfiguration endpoint instead.")]
     public required ISet<string> ReservedFieldNames { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/MemberType/MemberTypeConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/MemberType/MemberTypeConfigurationResponseModel.cs
@@ -1,0 +1,6 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.MemberType;
+
+public class MemberTypeConfigurationResponseModel
+{
+    public required ISet<string> ReservedFieldNames { get; set; }
+}


### PR DESCRIPTION
Moves the `ReservedFIeldNames` property into configuration endpoints for Document, Media, and Member, since these are required when creating the type, not the entity. 

# Testing

Request the endpoints and ensure they work

