### PR TITLE
V13: Ensure `TransformingIndexValues` event is also raised from the `DeliveryApiContentIndex`

### DIFF
--- a/src/Umbraco.Examine.Lucene/DeliveryApiContentIndex.cs
+++ b/src/Umbraco.Examine.Lucene/DeliveryApiContentIndex.cs
@@ -134,10 +134,4 @@ public class DeliveryApiContentIndex : UmbracoExamineIndex
 
         return (compositeIdModel.Id?.ToString(CultureInfo.InvariantCulture), compositeIdModel.Culture);
     }
-
-    protected override void OnTransformingIndexValues(IndexingItemEventArgs e)
-    {
-        // UmbracoExamineIndex (base class down the hierarchy) performs some magic transformations here for paths and icons;
-        // we don't want that for the Delivery API, so we'll have to override this method and simply do nothing.
-    }
 }

--- a/src/Umbraco.Examine.Lucene/DeliveryApiContentIndex.cs
+++ b/src/Umbraco.Examine.Lucene/DeliveryApiContentIndex.cs
@@ -17,6 +17,9 @@ public class DeliveryApiContentIndex : UmbracoExamineIndex
     private readonly IDeliveryApiCompositeIdHandler _deliveryApiCompositeIdHandler;
     private readonly ILogger<DeliveryApiContentIndex> _logger;
 
+    // The special path and icon value transformations are not needed in this case
+    protected override bool ApplySpecialValueTransformations => false;
+
     [Obsolete("Use the constructor that takes an IDeliveryApiCompositeIdHandler instead, scheduled for removal in v15")]
     public DeliveryApiContentIndex(
         ILoggerFactory loggerFactory,

--- a/src/Umbraco.Examine.Lucene/UmbracoExamineIndex.cs
+++ b/src/Umbraco.Examine.Lucene/UmbracoExamineIndex.cs
@@ -38,7 +38,13 @@ public abstract class UmbracoExamineIndex : LuceneIndex, IUmbracoIndex, IIndexDi
     }
 
     public Attempt<string?> IsHealthy() => _diagnostics.IsHealthy();
+
     public virtual IReadOnlyDictionary<string, object?> Metadata => _diagnostics.Metadata;
+
+    /// <summary>
+    ///     Performs special __Path and __Icon value transformations to all deriving indexes when set to true.
+    /// </summary>
+    protected virtual bool ApplySpecialValueTransformations => true;
 
     /// <summary>
     ///     When set to true Umbraco will keep the index in sync with Umbraco data automatically
@@ -115,12 +121,7 @@ public abstract class UmbracoExamineIndex : LuceneIndex, IUmbracoIndex, IIndexDi
     {
         base.OnTransformingIndexValues(e);
 
-        // Performs special value transformations to all deriving indexes of this base class
-        // but the DeliveryApiContentIndex (they are not needed in this case).
-        // The alternative is to move the call to ApplySpecialIndexValueTransformations into a new base class
-        // that all implementors but the DeliveryApiContentIndex would inherit from but that would be breaking
-        // for any custom indexes deriving from UmbracoExamineIndex.
-        if (e.Index.Name != Constants.UmbracoIndexes.DeliveryApiContentIndexName)
+        if (ApplySpecialValueTransformations)
         {
             ApplySpecialIndexValueTransformations(e);
         }


### PR DESCRIPTION
## Details
- Fixes #16589;
- We chose to add an overridable property for the special index value transformations that we check for, so we don't break any custom indexes deriving from `UmbracoExamineIndex`;
- The`DeliveryApiContentIndex` overrides it to `false` and that way we ensure the `TransformingIndexValues` event is also raised for the `DeliveryApiContentIndex` - "_You can use this event to add additional field values or modify existing field values._" ([Examine docs](https://shazwazza.github.io/Examine/articles/indexing.html#iindextransformingindexvalues)).

## Test
> On `v13/dev`
1. Enable the Delivery API is **appsettings.json**:
```json
{
  . . .
  "Umbraco": {
    "CMS": {
      "DeliveryApi": {
        "Enabled": true
      },
      . . .
}
```
2. Create some content;
3. In the Settings section > Examine Management > `DeliveryApiContentIndex` and `ExternalIndex` - remember the **FieldCount** from the **Index info**;
4. Add the following controller with 2 actions - we are adding a `"customField"` to the `DeliveryApiContentIndex` and `ExternalIndex`:
```c#
using Examine;
using Microsoft.AspNetCore.Mvc;
using Umbraco.Cms.Core;
using Umbraco.Cms.Web.Common.Controllers;

namespace Umbraco.Cms.Web.UI;

public class TestApiController : UmbracoApiController
{
    private readonly IExamineManager _examineManager;

    public TestApiController(IExamineManager examineManager)
    {
        _examineManager = examineManager;
    }

    // /umbraco/api/testapi/deliveryApi
    public IActionResult DeliveryApi()
    {
        if (!_examineManager.TryGetIndex(Constants.UmbracoIndexes.DeliveryApiContentIndexName, out IIndex? index))
        {
            throw new ArgumentException($"Index '{Constants.UmbracoIndexes.DeliveryApiContentIndexName}' not found");
        }

        index.TransformingIndexValues += TransformingIndexValues;
        return Ok("Done with DeliveryAPI index. Remember to rebuild");
    }

    // /umbraco/api/testapi/examine
    public IActionResult Examine()
    {
        if (!_examineManager.TryGetIndex(Constants.UmbracoIndexes.ExternalIndexName, out IIndex? index))
        {
            throw new ArgumentException($"Index '{Constants.UmbracoIndexes.ExternalIndexName}' not found");
        }

        index.TransformingIndexValues += TransformingIndexValues;
        return Ok("Done with External index. Remember to rebuild");
    }

    private void TransformingIndexValues(object? sender, IndexingItemEventArgs e)
    {
        // Add a custom field to the ValueSet
        var updatedValues = e.ValueSet.Values.ToDictionary(x => x.Key, x => x.Value.ToList());
        updatedValues.Add("customField", ["Hello from TransformingIndexValues!"]);
        e.SetValues(updatedValues.ToDictionary(x => x.Key, x => (IEnumerable<object>)x.Value));
    }
}
```
5. Visit `https://localhost:44331/umbraco/api/testapi/deliveryApi` and `https://localhost:44331/umbraco/api/testapi/examine`;
6. Rebuild both `DeliveryApiContentIndex` and `ExternalIndex`;
7. Search for the name of any of your content nodes in both indexes (through the Examine Management dashboard) and verify that `customField | Hello from TransformingIndexValues!` was only added to `ExternalIndex`;

</br>

> On this branch
8. Rebuild `ExternalIndex` - to remove the `customField` so we can verify that the functionality still works;
9. Visit again `https://localhost:44331/umbraco/api/testapi/deliveryApi` and `https://localhost:44331/umbraco/api/testapi/examine`;
10. Rebuild both `DeliveryApiContentIndex` and `ExternalIndex`;
11. Renew the search for the name of any of your content nodes and verify that `customField | Hello from TransformingIndexValues!` is added to both indexes this time.
