### PR TITLE
V14: Launch browser settings to true

### DIFF
--- a/src/Umbraco.Web.UI/Properties/launchSettings.json
+++ b/src/Umbraco.Web.UI/Properties/launchSettings.json
@@ -11,14 +11,14 @@
   "profiles": {
     "IIS Express": {
       "commandName": "IISExpress",
-      "launchBrowser": false,
+      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
     "Umbraco.Web.UI": {
       "commandName": "Project",
-      "launchBrowser": false,
+      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },


### PR DESCRIPTION
## Details
- Keeping `"launchBrowser"` setting consistent with v13 -> `true`.

## Test
- Verify that when running the **Umbraco.Web.UI** project, the browser is launched automatically.