### PR TITLE
Configure ImageSharp WebP encoder to use Lossy by default

### DIFF
--- a/src/Umbraco.Cms.Imaging.ImageSharp/ConfigureImageSharpMiddlewareOptions.cs
+++ b/src/Umbraco.Cms.Imaging.ImageSharp/ConfigureImageSharpMiddlewareOptions.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Headers;
 using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
+using SixLabors.ImageSharp.Formats.Webp;
 using SixLabors.ImageSharp.Web.Commands;
 using SixLabors.ImageSharp.Web.Middleware;
 using SixLabors.ImageSharp.Web.Processors;
@@ -85,5 +86,12 @@ public sealed class ConfigureImageSharpMiddlewareOptions : IConfigureOptions<Ima
 
             return Task.CompletedTask;
         };
+
+        options.Configuration.ImageFormatsManager.SetEncoder(WebpFormat.Instance, new WebpEncoder
+        {
+            // Default to Lossy encoding like in ImageSharp 2.x.
+            // ImageSharp 3.x seems to use Lossless for PNGs which creates files 10x larger than Lossy.
+            FileFormat = WebpFileFormatType.Lossy,
+        });
     }
 }


### PR DESCRIPTION
### Description

Fixes #16768, please see the issue for all details.