### PR TITLE
V13: Tours prevent you from interacting with the Backoffice on first log in

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbtour/umbtourstep.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umbtour/umbtourstep.directive.js
@@ -14,18 +14,15 @@
 (function () {
     'use strict';
 
-    function TourStepDirective(focusLockService) {
+    function TourStepDirective() {
 
         function link(scope, element, attrs, ctrl) {
 
             scope.close = function () {
                 if (scope.onClose) {
                   scope.onClose();
-                  focusLockService.removeInertAttribute();
                 }
             }
-
-            focusLockService.addInertAttribute();
         }
 
         var directive = {


### PR DESCRIPTION
### Description

Fixes #16742

This reverts one of the changes made in #15133, where the `inert` attribute was added when a Tour is active. This caused a few issues where:

- The `close` code was never called for the "email marketing" tour causing Cloud sites to be unresponsive until you refresh
- The "getting started" tour did not work on the steps, where you are supposed to click a button in the Backoffice UI

I think the `inert` attribute is useful in some cases where there is no "click-through" in a tour step, but we will have to be more clever about when to place it and when to remove it again.