### PR TITLE
Improve migration performance

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_12_0_0/UseNvarcharInsteadOfNText.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_12_0_0/UseNvarcharInsteadOfNText.cs
@@ -34,7 +34,6 @@ public class UseNvarcharInsteadOfNText : MigrationBase
 
     private void RawMigrateNtextColumn(string columnName, string tableName)
     {
-        var test = "sdfsf";
         var updateTypeSql = @$"
 ALTER TABLE {tableName}
 ALTER COLUMN {columnName} nvarchar(max)";
@@ -51,7 +50,7 @@ ALTER COLUMN {columnName} nvarchar(max)";
         }
 
         // since it's ntext to nvarchar(max) we should be able to just raw query this without having issues with fallback values on sql server
-        if (Database.DatabaseType != DatabaseType.SQLite && Database.DatabaseType != DatabaseType.SQLCe)
+        if (Database.DatabaseType != DatabaseType.SQLite)
         {
             RawMigrateNtextColumn(columnName, tableName);
             return;


### PR DESCRIPTION
This PR updates 2 existing migrations to be more performant. Both Cloud and heartcore have had issues with timeout regarding these performances.

The Heartcore team made a workaround (pre migration) on which these changes are based.

**v12 migration**
A result differential has been performed between the old and new migration with a large production copy database. No differences were found in the result.

**v10 migration**
A large amount of nodes with tags were generated, the differential again showed no differences in the result.

**note**
Testing should be done against a Sql-Server DB.

