### PR TITLE
V14: Remove user-defined.css

### DIFF
--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoBackOffice/Index.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoBackOffice/Index.cshtml
@@ -33,7 +33,6 @@
     <meta name="pinterest" content="nopin"/>
     <title>Umbraco</title>
 
-    <link rel="stylesheet" href="@backOfficeAssetsPath/css/user-defined.css" />
     <link rel="stylesheet" href="@backOfficeAssetsPath/css/umb-css.css" />
     <link rel="stylesheet" href="@backOfficeAssetsPath/css/uui-css.css" />
     @await Html.BackOfficeImportMapScriptAsync(JsonSerializer, BackOfficePathGenerator, PackageManifestService)

--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoLogin/Index.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoLogin/Index.cshtml
@@ -45,7 +45,6 @@
     <meta name="pinterest" content="nopin"/>
     <title>Umbraco</title>
 
-    <link rel="stylesheet" href="~/umbraco/login/user-defined.css" asp-append-version="true"/>
     <link rel="stylesheet" href="~/umbraco/backoffice/css/uui-css.css" asp-append-version="true" />
     <style>
       body {

--- a/src/Umbraco.Web.UI.Login/index.html
+++ b/src/Umbraco.Web.UI.Login/index.html
@@ -15,7 +15,6 @@
     await startMockServiceWorker();
     await import('./src/index.ts');
   </script>
-  <link rel="stylesheet" href="/user-defined.css" />
   <style>
     body {
       margin: 0;

--- a/src/Umbraco.Web.UI.Login/public/user-defined.css
+++ b/src/Umbraco.Web.UI.Login/public/user-defined.css
@@ -1,1 +1,0 @@
-/* This file can be overridden by placing a file with the same name in the /wwwroot/umbraco/login folder of the website */


### PR DESCRIPTION
### Description

These files intended that we would place them in the StaticAssets RCL and developers could overwrite them in their projects.

We need to devise a different way to do this as you cannot just overwrite assets in an RCL.