### PR TITLE
API access with client credentials (core functionality)

### DIFF
--- a/src/Umbraco.Cms.Api.Common/DependencyInjection/UmbracoBuilderAuthExtensions.cs
+++ b/src/Umbraco.Cms.Api.Common/DependencyInjection/UmbracoBuilderAuthExtensions.cs
@@ -54,10 +54,14 @@ public static class UmbracoBuilderAuthExtensions
                     .RequireProofKeyForCodeExchange()
                     .AllowRefreshTokenFlow();
 
+                // Enable the client credentials flow.
+                options.AllowClientCredentialsFlow();
+
                 // Register the ASP.NET Core host and configure for custom authentication endpoint.
                 options
                     .UseAspNetCore()
                     .EnableAuthorizationEndpointPassthrough()
+                    .EnableTokenEndpointPassthrough()
                     .EnableLogoutEndpointPassthrough();
 
                 // Enable reference tokens

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/Security/MemberController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/Security/MemberController.cs
@@ -109,6 +109,7 @@ public class MemberController : DeliveryApiControllerBase
             return BadRequest("Unable to obtain OpenID data from the current request.");
         }
 
+        // authorization code flow or refresh token flow?
         if ((request.IsAuthorizationCodeGrantType() || request.IsRefreshTokenGrantType()) && _deliveryApiSettings.MemberAuthorization?.AuthorizationCodeFlow?.Enabled is true)
         {
             // attempt to authorize against the supplied the authorization code
@@ -119,8 +120,11 @@ public class MemberController : DeliveryApiControllerBase
                 : BadRequest("The supplied authorization was not be verified.");
         }
 
+        // client credentials flow?
         if (request.IsClientCredentialsGrantType() && _deliveryApiSettings.MemberAuthorization?.ClientCredentialsFlow?.Enabled is true)
         {
+            // if we get here, the client ID and secret are valid (verified by OpenIddict)
+
             MemberIdentityUser? member = await _memberClientCredentialsManager.FindMemberAsync(request.ClientId!);
             return member is not null
                 ? await SignInMember(member, request)

--- a/src/Umbraco.Cms.Api.Delivery/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Delivery/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -21,6 +21,7 @@ using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Infrastructure.Security;
 using Umbraco.Cms.Web.Common.ApplicationBuilder;
 
@@ -60,6 +61,7 @@ public static class UmbracoBuilderExtensions
         builder.Services.AddSingleton<IApiMediaQueryService, ApiMediaQueryService>();
         builder.Services.AddTransient<IMemberApplicationManager, MemberApplicationManager>();
         builder.Services.AddTransient<IRequestMemberAccessService, RequestMemberAccessService>();
+        builder.Services.AddScoped<IMemberClientCredentialsManager, MemberClientCredentialsManager>();
 
         builder.Services.ConfigureOptions<ConfigureUmbracoDeliveryApiSwaggerGenOptions>();
         builder.AddUmbracoApiOpenApiUI();

--- a/src/Umbraco.Cms.Api.Delivery/Handlers/InitializeMemberApplicationNotificationHandler.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Handlers/InitializeMemberApplicationNotificationHandler.cs
@@ -5,6 +5,7 @@ using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Security;
 
@@ -16,16 +17,19 @@ internal sealed class InitializeMemberApplicationNotificationHandler : INotifica
     private readonly ILogger<InitializeMemberApplicationNotificationHandler> _logger;
     private readonly DeliveryApiSettings _deliveryApiSettings;
     private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly IMemberClientCredentialsManager _memberClientCredentialsManager;
 
     public InitializeMemberApplicationNotificationHandler(
         IRuntimeState runtimeState,
         IOptions<DeliveryApiSettings> deliveryApiSettings,
         ILogger<InitializeMemberApplicationNotificationHandler> logger,
-        IServiceScopeFactory serviceScopeFactory)
+        IServiceScopeFactory serviceScopeFactory,
+        IMemberClientCredentialsManager memberClientCredentialsManager)
     {
         _runtimeState = runtimeState;
         _logger = logger;
         _serviceScopeFactory = serviceScopeFactory;
+        _memberClientCredentialsManager = memberClientCredentialsManager;
         _deliveryApiSettings = deliveryApiSettings.Value;
     }
 
@@ -41,6 +45,12 @@ internal sealed class InitializeMemberApplicationNotificationHandler : INotifica
         using IServiceScope scope = _serviceScopeFactory.CreateScope();
         IMemberApplicationManager memberApplicationManager = scope.ServiceProvider.GetRequiredService<IMemberApplicationManager>();
 
+        await HandleMemberApplication(memberApplicationManager, cancellationToken);
+        await HandleMemberClientCredentialsApplication(memberApplicationManager, cancellationToken);
+    }
+
+    private async Task HandleMemberApplication(IMemberApplicationManager memberApplicationManager, CancellationToken cancellationToken)
+    {
         if (_deliveryApiSettings.MemberAuthorization?.AuthorizationCodeFlow?.Enabled is not true)
         {
             await memberApplicationManager.DeleteMemberApplicationAsync(cancellationToken);
@@ -64,6 +74,21 @@ internal sealed class InitializeMemberApplicationNotificationHandler : INotifica
             _deliveryApiSettings.MemberAuthorization.AuthorizationCodeFlow.LoginRedirectUrls,
             _deliveryApiSettings.MemberAuthorization.AuthorizationCodeFlow.LogoutRedirectUrls,
             cancellationToken);
+    }
+
+    private async Task HandleMemberClientCredentialsApplication(IMemberApplicationManager memberApplicationManager, CancellationToken cancellationToken)
+    {
+        if (_deliveryApiSettings.MemberAuthorization?.ClientCredentialsFlow?.Enabled is not true)
+        {
+            // disabled
+            return;
+        }
+
+        IEnumerable<MemberClientCredentials> memberClientCredentials = await _memberClientCredentialsManager.GetAllAsync();
+        foreach (MemberClientCredentials memberClientCredential in memberClientCredentials)
+        {
+            await memberApplicationManager.EnsureMemberClientCredentialsApplicationAsync(memberClientCredential.ClientId, memberClientCredential.ClientSecret, cancellationToken);
+        }
     }
 
     private bool ValidateRedirectUrls(Uri[] redirectUrls)

--- a/src/Umbraco.Cms.Api.Delivery/Security/MemberApplicationManager.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Security/MemberApplicationManager.cs
@@ -64,4 +64,26 @@ public class MemberApplicationManager : OpenIdDictApplicationManagerBase, IMembe
 
     public async Task DeleteMemberApplicationAsync(CancellationToken cancellationToken = default)
         => await Delete(Constants.OAuthClientIds.Member, cancellationToken);
+
+    public async Task EnsureMemberClientCredentialsApplicationAsync(string clientId, string clientSecret, CancellationToken cancellationToken = default)
+    {
+        var applicationDescriptor = new OpenIddictApplicationDescriptor
+        {
+            DisplayName = $"Umbraco client credentials member access: {clientId}",
+            ClientId = clientId,
+            ClientSecret = clientSecret,
+            ClientType = OpenIddictConstants.ClientTypes.Confidential,
+            Permissions =
+            {
+                OpenIddictConstants.Permissions.Endpoints.Token,
+                OpenIddictConstants.Permissions.Endpoints.Revocation,
+                OpenIddictConstants.Permissions.GrantTypes.ClientCredentials
+            }
+        };
+
+        await CreateOrUpdate(applicationDescriptor, cancellationToken);
+    }
+
+    public async Task DeleteMemberClientCredentialsApplicationAsync(string clientId, CancellationToken cancellationToken = default)
+        => await Delete(clientId, cancellationToken);
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeController.cs
@@ -42,6 +42,7 @@ public class BackOfficeController : SecurityControllerBase
     private readonly IBackOfficeTwoFactorOptions _backOfficeTwoFactorOptions;
     private readonly IUserTwoFactorLoginService _userTwoFactorLoginService;
     private readonly IBackOfficeExternalLoginService _externalLoginService;
+    private readonly IBackOfficeUserClientCredentialsManager _backOfficeUserClientCredentialsManager;
 
     private const string RedirectFlowParameter = "flow";
     private const string RedirectStatusParameter = "status";
@@ -55,7 +56,8 @@ public class BackOfficeController : SecurityControllerBase
         ILogger<BackOfficeController> logger,
         IBackOfficeTwoFactorOptions backOfficeTwoFactorOptions,
         IUserTwoFactorLoginService userTwoFactorLoginService,
-        IBackOfficeExternalLoginService externalLoginService)
+        IBackOfficeExternalLoginService externalLoginService,
+        IBackOfficeUserClientCredentialsManager backOfficeUserClientCredentialsManager)
     {
         _httpContextAccessor = httpContextAccessor;
         _backOfficeSignInManager = backOfficeSignInManager;
@@ -65,6 +67,7 @@ public class BackOfficeController : SecurityControllerBase
         _backOfficeTwoFactorOptions = backOfficeTwoFactorOptions;
         _userTwoFactorLoginService = userTwoFactorLoginService;
         _externalLoginService = externalLoginService;
+        _backOfficeUserClientCredentialsManager = backOfficeUserClientCredentialsManager;
     }
 
     [HttpPost("login")]
@@ -178,6 +181,48 @@ public class BackOfficeController : SecurityControllerBase
         return request.IdentityProvider.IsNullOrWhiteSpace()
             ? await AuthorizeInternal(request)
             : await AuthorizeExternal(request);
+    }
+
+    [AllowAnonymous]
+    [HttpPost("token")]
+    [MapToApiVersion("1.0")]
+    public async Task<IActionResult> Token()
+    {
+        HttpContext context = _httpContextAccessor.GetRequiredHttpContext();
+        OpenIddictRequest? request = context.GetOpenIddictServerRequest();
+        if (request == null)
+        {
+            return BadRequest("Unable to obtain OpenID data from the current request");
+        }
+
+        if (request.IsAuthorizationCodeGrantType() || request.IsRefreshTokenGrantType())
+        {
+            // attempt to authorize against the supplied the authorization code
+            AuthenticateResult authenticateResult = await context.AuthenticateAsync(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+
+            return authenticateResult is { Succeeded: true, Principal: not null }
+                ? new SignInResult(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme, authenticateResult.Principal)
+                : BadRequest("The supplied authorization could not be verified.");
+        }
+
+        if (request.IsClientCredentialsGrantType())
+        {
+            // if we get here, the client ID and secret are valid (verified by OpenIddict)
+
+            // grab the user associated with the client ID
+            BackOfficeIdentityUser? associatedUser = await _backOfficeUserClientCredentialsManager.FindUserAsync(request.ClientId!);
+
+            if (associatedUser is not null)
+            {
+                return await SignInBackOfficeUser(associatedUser, request);
+            }
+
+            // if this happens, the OpenIddict applications have somehow gone out of sync with the Umbraco users
+            _logger.LogError("The user associated with the client ID ({clientId}) could not be found", request.ClientId);
+            return BadRequest("The user associated with the client ID could not be found");
+        }
+
+        throw new InvalidOperationException("The requested grant type is not supported.");
     }
 
     [AllowAnonymous]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeController.cs
@@ -214,6 +214,10 @@ public class BackOfficeController : SecurityControllerBase
 
             if (associatedUser is not null)
             {
+                // log current datetime as last login (this also ensures that the user is not flagged as inactive)
+                associatedUser.LastLoginDateUtc = DateTime.UtcNow;
+                await _backOfficeUserManager.UpdateAsync(associatedUser);
+
                 return await SignInBackOfficeUser(associatedUser, request);
             }
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/ClientCredentials/ClientCredentialsUserControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/ClientCredentials/ClientCredentialsUserControllerBase.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Security.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User.ClientCredentials;
@@ -18,10 +17,6 @@ public class ClientCredentialsUserControllerBase : UserControllerBase
             BackOfficeUserClientCredentialsOperationStatus.DuplicateClientId => BadRequest(problemDetailsBuilder
                 .WithTitle("Duplicate client ID")
                 .WithDetail("The specified client ID is already in use. Choose another client ID.")
-                .Build()),
-            BackOfficeUserClientCredentialsOperationStatus.ReservedClientId => BadRequest(problemDetailsBuilder
-                .WithTitle("Reserved client ID")
-                .WithDetail("The specified client ID is reserved by the core. Choose another client ID.")
                 .Build()),
             _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown client credentials operation status.")

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/ClientCredentials/ClientCredentialsUserControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/ClientCredentials/ClientCredentialsUserControllerBase.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Security.OperationStatus;
+
+namespace Umbraco.Cms.Api.Management.Controllers.User.ClientCredentials;
+
+[ApiExplorerSettings(GroupName = "User")]
+public class ClientCredentialsUserControllerBase : UserControllerBase
+{
+    protected IActionResult BackOfficeUserClientCredentialsOperationStatusResult(BackOfficeUserClientCredentialsOperationStatus status) =>
+        OperationStatusResult(status, problemDetailsBuilder => status switch
+        {
+            BackOfficeUserClientCredentialsOperationStatus.InvalidUser => BadRequest(problemDetailsBuilder
+                .WithTitle("Invalid user")
+                .WithDetail("The specified user does not belong to the specified client ID.")
+                .Build()),
+            BackOfficeUserClientCredentialsOperationStatus.DuplicateClientId => BadRequest(problemDetailsBuilder
+                .WithTitle("Duplicate client ID")
+                .WithDetail("The specified client ID is already in use. Choose another client ID.")
+                .Build()),
+            BackOfficeUserClientCredentialsOperationStatus.ReservedClientId => BadRequest(problemDetailsBuilder
+                .WithTitle("Reserved client ID")
+                .WithDetail("The specified client ID is reserved by the core. Choose another client ID.")
+                .Build()),
+            _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
+                .WithTitle("Unknown client credentials operation status.")
+                .Build()),
+        });
+
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/ClientCredentials/ClientCredentialsUserControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/ClientCredentials/ClientCredentialsUserControllerBase.cs
@@ -12,7 +12,7 @@ public class ClientCredentialsUserControllerBase : UserControllerBase
         {
             BackOfficeUserClientCredentialsOperationStatus.InvalidUser => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid user")
-                .WithDetail("The specified user does not belong to the specified client ID.")
+                .WithDetail("The specified user does not support this operation. Possibly caused by a mismatched client ID or an inapplicable user type.")
                 .Build()),
             BackOfficeUserClientCredentialsOperationStatus.DuplicateClientId => BadRequest(problemDetailsBuilder
                 .WithTitle("Duplicate client ID")

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/ClientCredentials/ClientCredentialsUserControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/ClientCredentials/ClientCredentialsUserControllerBase.cs
@@ -5,7 +5,7 @@ using Umbraco.Cms.Core.Security.OperationStatus;
 namespace Umbraco.Cms.Api.Management.Controllers.User.ClientCredentials;
 
 [ApiExplorerSettings(GroupName = "User")]
-public class ClientCredentialsUserControllerBase : UserControllerBase
+public abstract class ClientCredentialsUserControllerBase : UserControllerBase
 {
     protected IActionResult BackOfficeUserClientCredentialsOperationStatusResult(BackOfficeUserClientCredentialsOperationStatus status) =>
         OperationStatusResult(status, problemDetailsBuilder => status switch
@@ -22,5 +22,4 @@ public class ClientCredentialsUserControllerBase : UserControllerBase
                 .WithTitle("Unknown client credentials operation status.")
                 .Build()),
         });
-
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/ClientCredentials/CreateClientCredentialsUserController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/ClientCredentials/CreateClientCredentialsUserController.cs
@@ -1,5 +1,6 @@
 ﻿using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.User.ClientCredentials;
 using Umbraco.Cms.Core;
@@ -26,6 +27,8 @@ public class CreateClientCredentialsUserController : ClientCredentialsUserContro
     }
 
     [HttpPost("{id:guid}/client-credentials")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Create(CancellationToken cancellationToken, Guid id, CreateUserClientCredentialsRequestModel model)
     {
         AuthorizationResult authorizationResult = await _authorizationService.AuthorizeResourceAsync(

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/ClientCredentials/CreateClientCredentialsUserController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/ClientCredentials/CreateClientCredentialsUserController.cs
@@ -1,0 +1,46 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.User.ClientCredentials;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Security.Authorization;
+using Umbraco.Cms.Core.Security.OperationStatus;
+using Umbraco.Cms.Web.Common.Authorization;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.Controllers.User.ClientCredentials;
+
+[ApiVersion("1.0")]
+public class CreateClientCredentialsUserController : ClientCredentialsUserControllerBase
+{
+    private readonly IBackOfficeUserClientCredentialsManager _backOfficeUserClientCredentialsManager;
+    private readonly IAuthorizationService _authorizationService;
+
+    public CreateClientCredentialsUserController(
+        IBackOfficeUserClientCredentialsManager backOfficeUserClientCredentialsManager,
+        IAuthorizationService authorizationService)
+    {
+        _backOfficeUserClientCredentialsManager = backOfficeUserClientCredentialsManager;
+        _authorizationService = authorizationService;
+    }
+
+    [HttpPost("{id:guid}/client-credentials")]
+    public async Task<IActionResult> Create(CancellationToken cancellationToken, Guid id, CreateUserClientCredentialsRequestModel model)
+    {
+        AuthorizationResult authorizationResult = await _authorizationService.AuthorizeResourceAsync(
+            User,
+            UserPermissionResource.WithKeys(id),
+            AuthorizationPolicies.UserPermissionByResource);
+
+        if (!authorizationResult.Succeeded)
+        {
+            return Forbidden();
+        }
+
+        Attempt<BackOfficeUserClientCredentialsOperationStatus> result = await _backOfficeUserClientCredentialsManager.SaveAsync(id, model.ClientId, model.ClientSecret);
+        return result.Success
+            ? Ok()
+            : BackOfficeUserClientCredentialsOperationStatusResult(result.Result);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/ClientCredentials/DeleteClientCredentialsUserController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/ClientCredentials/DeleteClientCredentialsUserController.cs
@@ -1,0 +1,45 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Security.Authorization;
+using Umbraco.Cms.Core.Security.OperationStatus;
+using Umbraco.Cms.Web.Common.Authorization;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.Controllers.User.ClientCredentials;
+
+[ApiVersion("1.0")]
+public class DeleteClientCredentialsUserController : ClientCredentialsUserControllerBase
+{
+    private readonly IBackOfficeUserClientCredentialsManager _backOfficeUserClientCredentialsManager;
+    private readonly IAuthorizationService _authorizationService;
+
+    public DeleteClientCredentialsUserController(
+        IBackOfficeUserClientCredentialsManager backOfficeUserClientCredentialsManager,
+        IAuthorizationService authorizationService)
+    {
+        _backOfficeUserClientCredentialsManager = backOfficeUserClientCredentialsManager;
+        _authorizationService = authorizationService;
+    }
+
+    [HttpDelete("{id:guid}/client-credentials/{clientId}")]
+    public async Task<IActionResult> Create(CancellationToken cancellationToken, Guid id, string clientId)
+    {
+        AuthorizationResult authorizationResult = await _authorizationService.AuthorizeResourceAsync(
+            User,
+            UserPermissionResource.WithKeys(id),
+            AuthorizationPolicies.UserPermissionByResource);
+
+        if (!authorizationResult.Succeeded)
+        {
+            return Forbidden();
+        }
+
+        Attempt<BackOfficeUserClientCredentialsOperationStatus> result = await _backOfficeUserClientCredentialsManager.DeleteAsync(id, clientId);
+        return result.Success
+            ? Ok()
+            : BackOfficeUserClientCredentialsOperationStatusResult(result.Result);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/ClientCredentials/DeleteClientCredentialsUserController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/ClientCredentials/DeleteClientCredentialsUserController.cs
@@ -1,5 +1,6 @@
 ﻿using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Security;
@@ -25,7 +26,9 @@ public class DeleteClientCredentialsUserController : ClientCredentialsUserContro
     }
 
     [HttpDelete("{id:guid}/client-credentials/{clientId}")]
-    public async Task<IActionResult> Create(CancellationToken cancellationToken, Guid id, string clientId)
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Delete(CancellationToken cancellationToken, Guid id, string clientId)
     {
         AuthorizationResult authorizationResult = await _authorizationService.AuthorizeResourceAsync(
             User,

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/ClientCredentials/GetAllClientCredentialsUserController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/ClientCredentials/GetAllClientCredentialsUserController.cs
@@ -1,0 +1,43 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Security.Authorization;
+using Umbraco.Cms.Web.Common.Authorization;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.Controllers.User.ClientCredentials;
+
+[ApiVersion("1.0")]
+public class GetAllClientCredentialsUserController : ClientCredentialsUserControllerBase
+{
+    private readonly IBackOfficeUserClientCredentialsManager _backOfficeUserClientCredentialsManager;
+    private readonly IAuthorizationService _authorizationService;
+
+    public GetAllClientCredentialsUserController(
+        IBackOfficeUserClientCredentialsManager backOfficeUserClientCredentialsManager,
+        IAuthorizationService authorizationService)
+    {
+        _backOfficeUserClientCredentialsManager = backOfficeUserClientCredentialsManager;
+        _authorizationService = authorizationService;
+    }
+
+    [HttpGet("{id:guid}/client-credentials")]
+    [ProducesResponseType(typeof(IEnumerable<string>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetAll(CancellationToken cancellationToken, Guid id)
+    {
+        AuthorizationResult authorizationResult = await _authorizationService.AuthorizeResourceAsync(
+            User,
+            UserPermissionResource.WithKeys(id),
+            AuthorizationPolicies.UserPermissionByResource);
+
+        if (!authorizationResult.Succeeded)
+        {
+            return Forbidden();
+        }
+
+        IEnumerable<string> clientIds = await _backOfficeUserClientCredentialsManager.GetClientIdsAsync(id);
+        return Ok(clientIds);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/UserOrCurrentUserControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/UserOrCurrentUserControllerBase.cs
@@ -128,6 +128,10 @@ public abstract class UserOrCurrentUserControllerBase : ManagementApiControllerB
                 .WithTitle("Self password reset not allowed")
                 .WithDetail("It is not allowed to reset the password for the account you are logged in to.")
                 .Build()),
+            UserOperationStatus.InvalidUserType => BadRequest(problemDetailsBuilder
+                .WithTitle("Invalid user type")
+                .WithDetail("The target user type does not support this operation.")
+                .Build()),
             UserOperationStatus.Forbidden => Forbidden(),
             _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown user operation status.")

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/UmbracoBuilder.BackOfficeIdentity.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/UmbracoBuilder.BackOfficeIdentity.cs
@@ -66,6 +66,7 @@ public static partial class UmbracoBuilderExtensions
         services.AddScoped<IInviteUriProvider, InviteUriProvider>();
         services.AddScoped<IForgotPasswordUriProvider, ForgotPasswordUriProvider>();
         services.AddScoped<IBackOfficePasswordChanger, BackOfficePasswordChanger>();
+        services.AddScoped<IBackOfficeUserClientCredentialsManager, BackOfficeUserClientCredentialsManager>();
 
         services.AddSingleton<IBackOfficeUserPasswordChecker, NoopBackOfficeUserPasswordChecker>();
 

--- a/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
@@ -80,6 +80,7 @@ public class UserPresentationFactory : IUserPresentationFactory
             LastLockoutDate = user.LastLockoutDate,
             LastPasswordChangeDate = user.LastPasswordChangeDate,
             IsAdmin = user.IsAdmin(),
+            Type = user.Type
         };
 
         return responseModel;
@@ -92,6 +93,7 @@ public class UserPresentationFactory : IUserPresentationFactory
             Name = user.Name ?? user.Username,
             AvatarUrls = user.GetUserAvatarUrls(_appCaches.RuntimeCache, _mediaFileManager, _imageUrlGenerator)
                 .Select(url => _absoluteUrlBuilder.ToAbsoluteUrl(url).ToString()),
+            Type = user.Type
         };
 
     public async Task<UserCreateModel> CreateCreationModelAsync(CreateUserRequestModel requestModel)
@@ -103,6 +105,7 @@ public class UserPresentationFactory : IUserPresentationFactory
             Name = requestModel.Name,
             UserName = requestModel.UserName,
             UserGroupKeys = requestModel.UserGroupIds.Select(x => x.Id).ToHashSet(),
+            Type = requestModel.Type
         };
 
         return await Task.FromResult(createModel);

--- a/src/Umbraco.Cms.Api.Management/Middleware/BackOfficeAuthorizationInitializationMiddleware.cs
+++ b/src/Umbraco.Cms.Api.Management/Middleware/BackOfficeAuthorizationInitializationMiddleware.cs
@@ -13,7 +13,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Middleware;
 
-public sealed class BackOfficeAuthorizationInitializationMiddleware : IMiddleware
+public class BackOfficeAuthorizationInitializationMiddleware : IMiddleware
 {
     private bool _firstBackOfficeRequest; // this only works because this is a singleton
     private SemaphoreSlim _firstBackOfficeRequestLocker = new(1); // this only works because this is a singleton

--- a/src/Umbraco.Cms.Api.Management/Middleware/BackOfficeAuthorizationInitializationMiddleware.cs
+++ b/src/Umbraco.Cms.Api.Management/Middleware/BackOfficeAuthorizationInitializationMiddleware.cs
@@ -13,7 +13,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Middleware;
 
-public class BackOfficeAuthorizationInitializationMiddleware : IMiddleware
+public sealed class BackOfficeAuthorizationInitializationMiddleware : IMiddleware
 {
     private bool _firstBackOfficeRequest; // this only works because this is a singleton
     private SemaphoreSlim _firstBackOfficeRequestLocker = new(1); // this only works because this is a singleton

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -30634,6 +30634,32 @@
               }
             }
           },
+          "400": {
+            "description": "Bad Request",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ProblemDetails"
+                    }
+                  ]
+                }
+              }
+            }
+          },
           "401": {
             "description": "The resource is protected and requires an authentication token"
           },
@@ -30651,6 +30677,49 @@
                 }
               }
             }
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      },
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "operationId": "GetUserByIdClientCredentials",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          },
+          "403": {
+            "description": "The authenticated user do not have access to this resource"
           }
         },
         "security": [
@@ -30697,6 +30766,32 @@
                     "$ref": "#/components/schemas/NotificationHeaderModel"
                   },
                   "nullable": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ProblemDetails"
+                    }
+                  ]
                 }
               }
             }

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -30570,6 +30570,163 @@
         ]
       }
     },
+    "/umbraco/management/api/v1/user/{id}/client-credentials": {
+      "post": {
+        "tags": [
+          "User"
+        ],
+        "operationId": "PostUserByIdClientCredentials",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateUserClientCredentialsRequestModel"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateUserClientCredentialsRequestModel"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateUserClientCredentialsRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          },
+          "403": {
+            "description": "The authenticated user do not have access to this resource",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/user/{id}/client-credentials/{clientId}": {
+      "delete": {
+        "tags": [
+          "User"
+        ],
+        "operationId": "DeleteUserByIdClientCredentialsByClientId",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "clientId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          },
+          "403": {
+            "description": "The authenticated user do not have access to this resource",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
     "/umbraco/management/api/v1/user/{id}/reset-password": {
       "post": {
         "tags": [
@@ -35107,6 +35264,22 @@
         },
         "additionalProperties": false
       },
+      "CreateUserClientCredentialsRequestModel": {
+        "required": [
+          "clientId",
+          "clientSecret"
+        ],
+        "type": "object",
+        "properties": {
+          "clientId": {
+            "type": "string"
+          },
+          "clientSecret": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
       "CreateUserDataRequestModel": {
         "required": [
           "group",
@@ -35226,6 +35399,7 @@
         "required": [
           "email",
           "name",
+          "type",
           "userGroupIds",
           "userName"
         ],
@@ -35255,6 +35429,9 @@
             "type": "string",
             "format": "uuid",
             "nullable": true
+          },
+          "type": {
+            "$ref": "#/components/schemas/UserTypeModel"
           }
         },
         "additionalProperties": false
@@ -37972,6 +38149,7 @@
         "required": [
           "email",
           "name",
+          "type",
           "userGroupIds",
           "userName"
         ],
@@ -38001,6 +38179,9 @@
             "type": "string",
             "format": "uuid",
             "nullable": true
+          },
+          "type": {
+            "$ref": "#/components/schemas/UserTypeModel"
           },
           "message": {
             "type": "string",
@@ -44806,7 +44987,8 @@
         "required": [
           "avatarUrls",
           "id",
-          "name"
+          "name",
+          "type"
         ],
         "type": "object",
         "properties": {
@@ -44822,6 +45004,9 @@
             "items": {
               "type": "string"
             }
+          },
+          "type": {
+            "$ref": "#/components/schemas/UserTypeModel"
           }
         },
         "additionalProperties": false
@@ -44895,6 +45080,7 @@
           "mediaStartNodeIds",
           "name",
           "state",
+          "type",
           "updateDate",
           "userGroupIds",
           "userName"
@@ -44995,6 +45181,9 @@
           },
           "isAdmin": {
             "type": "boolean"
+          },
+          "type": {
+            "$ref": "#/components/schemas/UserTypeModel"
           }
         },
         "additionalProperties": false
@@ -45054,6 +45243,13 @@
           }
         },
         "additionalProperties": false
+      },
+      "UserTypeModel": {
+        "enum": [
+          "Default",
+          "Api"
+        ],
+        "type": "string"
       },
       "VariantItemResponseModel": {
         "required": [

--- a/src/Umbraco.Cms.Api.Management/Security/BackOfficeApplicationManager.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/BackOfficeApplicationManager.cs
@@ -141,5 +141,27 @@ public class BackOfficeApplicationManager : OpenIdDictApplicationManagerBase, IB
         };
     }
 
+    public async Task EnsureBackOfficeClientCredentialsApplicationAsync(string clientId, string clientSecret, CancellationToken cancellationToken = default)
+    {
+        var applicationDescriptor = new OpenIddictApplicationDescriptor
+        {
+            DisplayName = $"Umbraco client credentials back-office access: {clientId}",
+            ClientId = clientId,
+            ClientSecret = clientSecret,
+            ClientType = OpenIddictConstants.ClientTypes.Confidential,
+            Permissions =
+            {
+                OpenIddictConstants.Permissions.Endpoints.Token,
+                OpenIddictConstants.Permissions.Endpoints.Revocation,
+                OpenIddictConstants.Permissions.GrantTypes.ClientCredentials
+            }
+        };
+
+        await CreateOrUpdate(applicationDescriptor, cancellationToken);
+    }
+
+    public async Task DeleteBackOfficeClientCredentialsApplicationAsync(string clientId, CancellationToken cancellationToken = default)
+        => await Delete(clientId, cancellationToken);
+
     private static Uri CallbackUrlFor(Uri url, string relativePath) => new Uri($"{url.GetLeftPart(UriPartial.Authority)}/{relativePath.TrimStart(Constants.CharArrays.ForwardSlash)}");
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/ClientCredentials/CreateUserClientCredentialsRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/ClientCredentials/CreateUserClientCredentialsRequestModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace Umbraco.Cms.Api.Management.ViewModels.User.ClientCredentials;
 
-public class CreateUserClientCredentialsRequestModel
+public sealed class CreateUserClientCredentialsRequestModel
 {
     public required string ClientId { get; set; }
 

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/ClientCredentials/CreateUserClientCredentialsRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/ClientCredentials/CreateUserClientCredentialsRequestModel.cs
@@ -1,0 +1,8 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.User.ClientCredentials;
+
+public class CreateUserClientCredentialsRequestModel
+{
+    public required string ClientId { get; set; }
+
+    public required string ClientSecret { get; set; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/CreateUserRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/CreateUserRequestModel.cs
@@ -1,6 +1,10 @@
-﻿namespace Umbraco.Cms.Api.Management.ViewModels.User;
+﻿using Umbraco.Cms.Core.Models.Membership;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.User;
 
 public class CreateUserRequestModel : UserPresentationBase
 {
     public Guid? Id { get; set; }
+
+    public UserType Type { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/Item/UserItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/Item/UserItemResponseModel.cs
@@ -1,8 +1,11 @@
 ﻿using Umbraco.Cms.Api.Management.ViewModels.Item;
+using Umbraco.Cms.Core.Models.Membership;
 
 namespace Umbraco.Cms.Api.Management.ViewModels.User.Item;
 
 public class UserItemResponseModel : NamedItemResponseModelBase
 {
     public IEnumerable<string> AvatarUrls { get; set; } = Enumerable.Empty<string>();
+
+    public UserType Type { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/User/UserResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/User/UserResponseModel.cs
@@ -31,5 +31,8 @@ public class UserResponseModel : UserPresentationBase
     public DateTimeOffset? LastLockoutDate { get; set; }
 
     public DateTimeOffset? LastPasswordChangeDate { get; set; }
+
     public bool IsAdmin { get; set; }
+
+    public UserType Type { get; set; }
 }

--- a/src/Umbraco.Core/Configuration/Models/DeliveryApiSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/DeliveryApiSettings.cs
@@ -70,7 +70,8 @@ public class DeliveryApiSettings
     /// <remarks>
     ///     This method is intended for future extension - see remark in <see cref="MemberAuthorizationSettings"/>.
     /// </remarks>
-    public bool MemberAuthorizationIsEnabled() => MemberAuthorization?.AuthorizationCodeFlow?.Enabled is true;
+    public bool MemberAuthorizationIsEnabled() => MemberAuthorization?.AuthorizationCodeFlow?.Enabled is true
+                                                  || MemberAuthorization?.ClientCredentialsFlow?.Enabled is true;
 
     /// <summary>
     ///     Typed configuration options for the Media APIs of the Delivery API.
@@ -116,6 +117,11 @@ public class DeliveryApiSettings
         ///     Gets or sets the Authorization Code Flow configuration for the Delivery API.
         /// </summary>
         public AuthorizationCodeFlowSettings? AuthorizationCodeFlow { get; set; } = null;
+
+        /// <summary>
+        ///     Gets or sets the Client Credentials Flow configuration for the Delivery API.
+        /// </summary>
+        public ClientCredentialsFlowSettings? ClientCredentialsFlow { get; set; } = null;
     }
 
     /// <summary>
@@ -180,5 +186,41 @@ public class DeliveryApiSettings
         /// </remarks>
         [DefaultValue(StaticDuration)]
         public TimeSpan MediaDuration { get; set; } = TimeSpan.Parse(StaticDuration);
+    }
+
+    /// <summary>
+    ///     Typed configuration options for the Client Credentials Flow settings for the Delivery API.
+    /// </summary>
+    public class ClientCredentialsFlowSettings
+    {
+        /// <summary>
+        ///     Gets or sets a value indicating whether Client Credentials Flow should be enabled for the Delivery API.
+        /// </summary>
+        /// <value><c>true</c> if Client Credentials Flow should be enabled; otherwise, <c>false</c>.</value>
+        [DefaultValue(StaticEnabled)]
+        public bool Enabled { get; set; } = StaticEnabled;
+
+        public IEnumerable<ClientCredentialsFlowMemberSettings> AssociatedMembers { get; set; } = [];
+    }
+
+    public class ClientCredentialsFlowMemberSettings
+    {
+        /// <summary>
+        ///     Gets or sets the user name of the member to associate with the session after a successful login.
+        /// </summary>
+        /// <value>The user name of the member.</value>
+        public string UserName { get; set; } = string.Empty;
+
+        /// <summary>
+        ///     Gets or sets the client ID that allows for a successful login.
+        /// </summary>
+        /// <value>The client ID.</value>
+        public string ClientId { get; set; } = string.Empty;
+
+        /// <summary>
+        ///     Gets or sets the client secret that allows for a successful login.
+        /// </summary>
+        /// <value>The client secret.</value>
+        public string ClientSecret { get; set; } = string.Empty;
     }
 }

--- a/src/Umbraco.Core/Models/Membership/IUser.cs
+++ b/src/Umbraco.Core/Models/Membership/IUser.cs
@@ -39,6 +39,14 @@ public interface IUser : IMembershipUser, IRememberBeingDirty
     /// </summary>
     string? Avatar { get; set; }
 
+    /// <summary>
+    ///     The type of user.
+    /// </summary>
+    /// <remarks>
+    ///     Cannot be changed after the user has been created.
+    /// </remarks>
+    UserType Type { get; set; }
+
     void RemoveGroup(string group);
 
     void ClearGroups();

--- a/src/Umbraco.Core/Models/Membership/IUser.cs
+++ b/src/Umbraco.Core/Models/Membership/IUser.cs
@@ -42,9 +42,6 @@ public interface IUser : IMembershipUser, IRememberBeingDirty
     /// <summary>
     ///     The type of user.
     /// </summary>
-    /// <remarks>
-    ///     Cannot be changed after the user has been created.
-    /// </remarks>
     UserType Type { get; set; }
 
     void RemoveGroup(string group);

--- a/src/Umbraco.Core/Models/Membership/User.cs
+++ b/src/Umbraco.Core/Models/Membership/User.cs
@@ -41,6 +41,7 @@ public class User : EntityBase, IUser, IProfile
     private HashSet<IReadOnlyUserGroup> _userGroups;
 
     private string _username;
+    private UserType _type;
 
     /// <summary>
     ///     Constructor for creating a new/empty user
@@ -355,6 +356,13 @@ public class User : EntityBase, IUser, IProfile
     {
         get => _language;
         set => SetPropertyValueAndDetectChanges(value, ref _language, nameof(Language));
+    }
+
+    [DataMember]
+    public UserType Type
+    {
+        get => _type;
+        set => SetPropertyValueAndDetectChanges(value, ref _type, nameof(Type));
     }
 
     /// <summary>

--- a/src/Umbraco.Core/Models/Membership/UserType.cs
+++ b/src/Umbraco.Core/Models/Membership/UserType.cs
@@ -1,0 +1,7 @@
+﻿namespace Umbraco.Cms.Core.Models.Membership;
+
+public enum UserType
+{
+    Default = 0,
+    Api
+}

--- a/src/Umbraco.Core/Models/UserCreateModel.cs
+++ b/src/Umbraco.Core/Models/UserCreateModel.cs
@@ -12,5 +12,7 @@ public class UserCreateModel
 
     public string Name { get; set; } = string.Empty;
 
+    public UserType Type { get; set; }
+
     public ISet<Guid> UserGroupKeys { get; set; } = new HashSet<Guid>();
 }

--- a/src/Umbraco.Core/Persistence/Constants-DatabaseSchema.cs
+++ b/src/Umbraco.Core/Persistence/Constants-DatabaseSchema.cs
@@ -52,6 +52,7 @@ public static partial class Constants
             public const string UserStartNode = TableNamePrefix + "UserStartNode";
             public const string User2UserGroup = TableNamePrefix + "User2UserGroup";
             public const string User2NodeNotify = TableNamePrefix + "User2NodeNotify";
+            public const string User2ClientId = TableNamePrefix + "User2ClientId";
             public const string UserGroup2App = TableNamePrefix + "UserGroup2App";
             public const string UserData = TableNamePrefix + "UserData";
 

--- a/src/Umbraco.Core/Persistence/Repositories/IUserRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IUserRepository.cs
@@ -150,4 +150,14 @@ public interface IUserRepository : IReadWriteQueryRepository<Guid, IUser>
     int ClearLoginSessions(TimeSpan timespan);
 
     void ClearLoginSession(Guid sessionId);
+
+    IEnumerable<string> GetAllClientIds();
+
+    IEnumerable<string> GetClientIds(int id);
+
+    void AddClientId(int id, string clientId);
+
+    bool RemoveClientId(int id, string clientId);
+
+    IUser? GetByClientId(string clientId);
 }

--- a/src/Umbraco.Core/Services/IUserService.cs
+++ b/src/Umbraco.Core/Services/IUserService.cs
@@ -406,4 +406,10 @@ public interface IUserService : IMembershipUserService
     Task<Attempt<UserInvitationResult, UserOperationStatus>> ResendInvitationAsync(Guid performingUserKey, UserResendInviteModel model);
 
     Task<Attempt<PasswordChangedModel, UserOperationStatus>> ResetPasswordAsync(Guid performingUserKey, Guid userKey);
+
+    Task<bool> AddClientIdAsync(Guid userKey, string clientId);
+
+    Task<bool> RemoveClientIdAsync(Guid userKey, string clientId);
+
+    Task<IUser?> FindByClientIdAsync(string clientId);
 }

--- a/src/Umbraco.Core/Services/IUserService.cs
+++ b/src/Umbraco.Core/Services/IUserService.cs
@@ -407,7 +407,7 @@ public interface IUserService : IMembershipUserService
 
     Task<Attempt<PasswordChangedModel, UserOperationStatus>> ResetPasswordAsync(Guid performingUserKey, Guid userKey);
 
-    Task<bool> AddClientIdAsync(Guid userKey, string clientId);
+    Task<UserClientCredentialsOperationStatus> AddClientIdAsync(Guid userKey, string clientId);
 
     Task<bool> RemoveClientIdAsync(Guid userKey, string clientId);
 

--- a/src/Umbraco.Core/Services/IUserService.cs
+++ b/src/Umbraco.Core/Services/IUserService.cs
@@ -412,4 +412,6 @@ public interface IUserService : IMembershipUserService
     Task<bool> RemoveClientIdAsync(Guid userKey, string clientId);
 
     Task<IUser?> FindByClientIdAsync(string clientId);
+
+    Task<IEnumerable<string>> GetClientIdsAsync(Guid userKey);
 }

--- a/src/Umbraco.Core/Services/OperationStatus/UserClientCredentialsOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/UserClientCredentialsOperationStatus.cs
@@ -1,0 +1,8 @@
+﻿namespace Umbraco.Cms.Core.Services.OperationStatus;
+
+public enum UserClientCredentialsOperationStatus
+{
+    Success,
+    DuplicateClientId,
+    InvalidUser
+}

--- a/src/Umbraco.Core/Services/OperationStatus/UserOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/UserOperationStatus.cs
@@ -40,4 +40,5 @@ public enum UserOperationStatus
     NotInInviteState,
     SelfPasswordResetNotAllowed,
     DuplicateId,
+    InvalidUserType,
 }

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -1189,6 +1189,11 @@ internal class UserService : RepositoryService, IUserService
             return Attempt.FailWithStatus(UserOperationStatus.UserNotFound, new PasswordChangedModel());
         }
 
+        if (user.Type != UserType.Default)
+        {
+            return Attempt.FailWithStatus(UserOperationStatus.InvalidUserType, new PasswordChangedModel());
+        }
+
         IUser? performingUser = await userStore.GetAsync(performingUserKey);
         if (performingUser is null)
         {

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -2478,25 +2478,25 @@ internal class UserService : RepositoryService, IUserService
         return CalculatePermissionsForPathForUser(groupPermissions, nodeIds);
     }
 
-    public async Task<bool> AddClientIdAsync(Guid userKey, string clientId)
+    public async Task<UserClientCredentialsOperationStatus> AddClientIdAsync(Guid userKey, string clientId)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
 
         IEnumerable<string> currentClientIds = _userRepository.GetAllClientIds();
         if (currentClientIds.Contains(clientId))
         {
-            return false;
+            return UserClientCredentialsOperationStatus.DuplicateClientId;
         }
 
         IUser? user = await GetAsync(userKey);
         if (user is null || user.Type != UserType.Api)
         {
-            return false;
+            return UserClientCredentialsOperationStatus.InvalidUser;
         }
 
         _userRepository.AddClientId(user.Id, clientId);
 
-        return true;
+        return UserClientCredentialsOperationStatus.Success;
     }
 
     public async Task<bool> RemoveClientIdAsync(Guid userKey, string clientId)

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -2488,7 +2488,7 @@ internal class UserService : RepositoryService, IUserService
         using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
 
         IEnumerable<string> currentClientIds = _userRepository.GetAllClientIds();
-        if (currentClientIds.Contains(clientId))
+        if (currentClientIds.InvariantContains(clientId))
         {
             return UserClientCredentialsOperationStatus.DuplicateClientId;
         }

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -2488,9 +2488,8 @@ internal class UserService : RepositoryService, IUserService
             return false;
         }
 
-        // TODO KJA: ensure that this is an "API" user
         IUser? user = await GetAsync(userKey);
-        if (user is null)
+        if (user is null || user.Type != UserType.Api)
         {
             return false;
         }
@@ -2513,9 +2512,7 @@ internal class UserService : RepositoryService, IUserService
         using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
 
         IUser? user = _userRepository.GetByClientId(clientId);
-
-        // TODO KJA: return null if this is not an "API" user
-        return Task.FromResult(user);
+        return Task.FromResult(user?.Type == UserType.Api ? user : null);
     }
 
     /// <summary>

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -2520,6 +2520,14 @@ internal class UserService : RepositoryService, IUserService
         return Task.FromResult(user?.Type == UserType.Api ? user : null);
     }
 
+    public async Task<IEnumerable<string>> GetClientIdsAsync(Guid userKey)
+    {
+        using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
+
+        var userId = await _userIdKeyResolver.GetAsync(userKey);
+        return _userRepository.GetClientIds(userId);
+    }
+
     /// <summary>
     ///     This performs the calculations for inherited nodes based on this
     ///     http://issues.umbraco.org/issue/U4-10075#comment=67-40085

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseSchemaCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseSchemaCreator.cs
@@ -53,6 +53,7 @@ public class DatabaseSchemaCreator
         typeof(ContentType2ContentTypeDto),
         typeof(ContentTypeAllowedContentTypeDto),
         typeof(User2NodeNotifyDto),
+        typeof(User2ClientIdDto),
         typeof(ServerRegistrationDto),
         typeof(AccessDto),
         typeof(AccessRuleDto),

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -91,5 +91,6 @@ public class UmbracoPlan : MigrationPlan
 
         // To 15.0.0
         To<V_15_0_0.AddUserClientId>("{7F4F31D8-DD71-4F0D-93FC-2690A924D84B}");
+        To<V_15_0_0.AddTypeToUser>("{1A8835EF-F8AB-4472-B4D8-D75B7C164022}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -88,5 +88,8 @@ public class UmbracoPlan : MigrationPlan
         // To 14.1.0
         To<V_14_1_0.MigrateRichTextConfiguration>("{FEF2DAF4-5408-4636-BB0E-B8798DF8F095}");
         To<V_14_1_0.MigrateOldRichTextSeedConfiguration>("{A385C5DF-48DC-46B4-A742-D5BB846483BC}");
+
+        // To 15.0.0
+        To<V_15_0_0.AddUserClientId>("{7F4F31D8-DD71-4F0D-93FC-2690A924D84B}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/AddTypeToUser.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/AddTypeToUser.cs
@@ -40,11 +40,9 @@ public class AddTypeToUser : UnscopedMigrationBase
         scope.Complete();
     }
 
-    // TODO KJA: TEST THIS!
     private void MigrateSqlServer()
     {
         var columns = SqlSyntax.GetColumnsInSchema(Context.Database).ToList();
-        // TODO KJA: do we need to explicitly set the default value or is the DB updated for us here?
         AddColumnIfNotExists<UserDto>(columns, NewColumnName);
     }
 
@@ -92,7 +90,6 @@ public class AddTypeToUser : UnscopedMigrationBase
             CreateDate = x.CreateDate,
             UpdateDate = x.UpdateDate,
             Avatar = x.Avatar,
-            // TODO KJA: use enum integer value here!
             Type = 0
         });
 

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/AddTypeToUser.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/AddTypeToUser.cs
@@ -1,0 +1,222 @@
+﻿using NPoco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Persistence.DatabaseAnnotations;
+using Umbraco.Cms.Infrastructure.Persistence.DatabaseModelDefinitions;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+using Umbraco.Cms.Infrastructure.Scoping;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_15_0_0;
+
+[Obsolete("Remove in Umbraco 18.")]
+public class AddTypeToUser : UnscopedMigrationBase
+{
+    private const string NewColumnName = "type";
+    private readonly IScopeProvider _scopeProvider;
+
+    public AddTypeToUser(IMigrationContext context, IScopeProvider scopeProvider)
+        : base(context)
+        => _scopeProvider = scopeProvider;
+
+    protected override void Migrate()
+    {
+        InvalidateBackofficeUserAccess = true;
+
+        using IScope scope = _scopeProvider.CreateScope();
+        using IDisposable notificationSuppression = scope.Notifications.Suppress();
+        ScopeDatabase(scope);
+
+        // SQL server can simply add the column, but for SQLite this won't work,
+        // so we'll have to create a new table and copy over data.
+        if (DatabaseType != DatabaseType.SQLite)
+        {
+            MigrateSqlServer();
+        }
+        else
+        {
+            MigrateSqlite();
+        }
+
+        Context.Complete();
+        scope.Complete();
+    }
+
+    // TODO KJA: TEST THIS!
+    private void MigrateSqlServer()
+    {
+        var columns = SqlSyntax.GetColumnsInSchema(Context.Database).ToList();
+        // TODO KJA: do we need to explicitly set the default value or is the DB updated for us here?
+        AddColumnIfNotExists<UserDto>(columns, NewColumnName);
+    }
+
+    private void MigrateSqlite()
+    {
+        // If the new column already exists we'll do nothing.
+        if (ColumnExists(Constants.DatabaseSchema.Tables.User, NewColumnName))
+        {
+            return;
+        }
+
+        /*
+         * We commit the initial transaction started by the scope. This is required in order to disable the foreign keys.
+         * We then begin a new transaction, this transaction will be committed or rolled back by the scope, like normal.
+         * We don't have to worry about re-enabling the foreign keys, since these are enabled by default every time a connection is established.
+         *
+         * Ideally we'd want to do this with the unscoped database we get, however, this cannot be done,
+         * since our scoped database cannot share a connection with the unscoped database, so a new one will be created, which enables the foreign keys.
+         * Similarly we cannot use Database.CompleteTransaction(); since this also closes the connection,
+         * so starting a new transaction would re-enable foreign keys.
+         */
+        Database.Execute("COMMIT;");
+        Database.Execute("PRAGMA foreign_keys=off;");
+        Database.Execute("BEGIN TRANSACTION;");
+
+        IEnumerable<UserDto> users = Database.Fetch<OldUserDto>().Select(x => new UserDto
+        {
+            Id = x.Id,
+            Key = x.Key,
+            Disabled = x.Disabled,
+            NoConsole = x.NoConsole,
+            UserName = x.UserName,
+            Login = x.Login,
+            Password = x.Password,
+            PasswordConfig = x.PasswordConfig,
+            Email = x.Email,
+            UserLanguage = x.UserLanguage,
+            SecurityStampToken = x.SecurityStampToken,
+            FailedLoginAttempts = x.FailedLoginAttempts,
+            LastLockoutDate = x.LastLockoutDate,
+            LastPasswordChangeDate = x.LastPasswordChangeDate,
+            LastLoginDate = x.LastLoginDate,
+            EmailConfirmedDate = x.EmailConfirmedDate,
+            InvitedDate = x.InvitedDate,
+            CreateDate = x.CreateDate,
+            UpdateDate = x.UpdateDate,
+            Avatar = x.Avatar,
+            // TODO KJA: use enum integer value here!
+            Type = 0
+        });
+
+        Delete.Table(Constants.DatabaseSchema.Tables.User).Do();
+        Create.Table<UserDto>().Do();
+
+        foreach (UserDto user in users)
+        {
+            Database.Insert(Constants.DatabaseSchema.Tables.User, "id", false, user);
+        }
+    }
+
+    [TableName(TableName)]
+    [PrimaryKey("id", AutoIncrement = true)]
+    [ExplicitColumns]
+    public class OldUserDto
+    {
+        public const string TableName = Constants.DatabaseSchema.Tables.User;
+
+        public OldUserDto()
+        {
+            UserGroupDtos = new List<UserGroupDto>();
+            UserStartNodeDtos = new HashSet<UserStartNodeDto>();
+        }
+
+        [Column("id")]
+        [PrimaryKeyColumn(Name = "PK_user")]
+        public int Id { get; set; }
+
+        [Column("userDisabled")]
+        [Constraint(Default = "0")]
+        public bool Disabled { get; set; }
+
+        [Column("key")]
+        [NullSetting(NullSetting = NullSettings.NotNull)]
+        [Constraint(Default = SystemMethods.NewGuid)]
+        [Index(IndexTypes.UniqueNonClustered, Name = "IX_umbracoUser_userKey")]
+        public Guid Key { get; set; }
+
+        [Column("userNoConsole")]
+        [Constraint(Default = "0")]
+        public bool NoConsole { get; set; }
+
+        [Column("userName")]
+        public string UserName { get; set; } = null!;
+
+        [Column("userLogin")]
+        [Length(125)]
+        [Index(IndexTypes.NonClustered)]
+        public string? Login { get; set; }
+
+        [Column("userPassword")]
+        [Length(500)]
+        public string? Password { get; set; }
+
+        /// <summary>
+        ///     This will represent a JSON structure of how the password has been created (i.e hash algorithm, iterations)
+        /// </summary>
+        [Column("passwordConfig")]
+        [NullSetting(NullSetting = NullSettings.Null)]
+        [Length(500)]
+        public string? PasswordConfig { get; set; }
+
+        [Column("userEmail")]
+        public string Email { get; set; } = null!;
+
+        [Column("userLanguage")]
+        [NullSetting(NullSetting = NullSettings.Null)]
+        [Length(10)]
+        public string? UserLanguage { get; set; }
+
+        [Column("securityStampToken")]
+        [NullSetting(NullSetting = NullSettings.Null)]
+        [Length(255)]
+        public string? SecurityStampToken { get; set; }
+
+        [Column("failedLoginAttempts")]
+        [NullSetting(NullSetting = NullSettings.Null)]
+        public int? FailedLoginAttempts { get; set; }
+
+        [Column("lastLockoutDate")]
+        [NullSetting(NullSetting = NullSettings.Null)]
+        public DateTime? LastLockoutDate { get; set; }
+
+        [Column("lastPasswordChangeDate")]
+        [NullSetting(NullSetting = NullSettings.Null)]
+        public DateTime? LastPasswordChangeDate { get; set; }
+
+        [Column("lastLoginDate")]
+        [NullSetting(NullSetting = NullSettings.Null)]
+        public DateTime? LastLoginDate { get; set; }
+
+        [Column("emailConfirmedDate")]
+        [NullSetting(NullSetting = NullSettings.Null)]
+        public DateTime? EmailConfirmedDate { get; set; }
+
+        [Column("invitedDate")]
+        [NullSetting(NullSetting = NullSettings.Null)]
+        public DateTime? InvitedDate { get; set; }
+
+        [Column("createDate")]
+        [NullSetting(NullSetting = NullSettings.NotNull)]
+        [Constraint(Default = SystemMethods.CurrentDateTime)]
+        public DateTime CreateDate { get; set; } = DateTime.Now;
+
+        [Column("updateDate")]
+        [NullSetting(NullSetting = NullSettings.NotNull)]
+        [Constraint(Default = SystemMethods.CurrentDateTime)]
+        public DateTime UpdateDate { get; set; } = DateTime.Now;
+
+        /// <summary>
+        ///     Will hold the media file system relative path of the users custom avatar if they uploaded one
+        /// </summary>
+        [Column("avatar")]
+        [NullSetting(NullSetting = NullSettings.Null)]
+        [Length(500)]
+        public string? Avatar { get; set; }
+
+        [ResultColumn]
+        [Reference(ReferenceType.Many, ReferenceMemberName = "UserId")]
+        public List<UserGroupDto> UserGroupDtos { get; set; }
+
+        [ResultColumn]
+        [Reference(ReferenceType.Many, ReferenceMemberName = "UserId")]
+        public HashSet<UserStartNodeDto> UserStartNodeDtos { get; set; }
+    }
+}

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/AddUserClientId.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/AddUserClientId.cs
@@ -1,0 +1,15 @@
+﻿using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_15_0_0;
+
+[Obsolete("Remove in Umbraco 18.")]
+public class AddUserClientId : MigrationBase
+{
+    public AddUserClientId(IMigrationContext context)
+        : base(context)
+    {
+    }
+
+    protected override void Migrate()
+        => Create.Table<User2ClientIdDto>().Do();
+}

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/User2ClientIdDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/User2ClientIdDto.cs
@@ -1,0 +1,20 @@
+﻿using NPoco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Persistence.DatabaseAnnotations;
+
+namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
+
+[TableName(Constants.DatabaseSchema.Tables.User2ClientId)]
+[PrimaryKey("userId", AutoIncrement = false)]
+[ExplicitColumns]
+public class User2ClientIdDto
+{
+    [Column("userId")]
+    [PrimaryKeyColumn(AutoIncrement = false, Name = "PK_umbracoUser2ClientId", OnColumns = "userId, clientId")]
+    [ForeignKey(typeof(UserDto))]
+    public int UserId { get; set; }
+
+    [Column("clientId")]
+    [Length(255)]
+    public string? ClientId { get; set; }
+}

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/UserDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/UserDto.cs
@@ -103,6 +103,11 @@ public class UserDto
     [Constraint(Default = SystemMethods.CurrentDateTime)]
     public DateTime UpdateDate { get; set; } = DateTime.Now;
 
+    [Column("type")]
+    [NullSetting(NullSetting = NullSettings.NotNull)]
+    [Constraint(Default = 0)]
+    public short Type { get; set; }
+
     /// <summary>
     ///     Will hold the media file system relative path of the users custom avatar if they uploaded one
     /// </summary>

--- a/src/Umbraco.Infrastructure/Persistence/Factories/UserFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Factories/UserFactory.cs
@@ -47,6 +47,7 @@ internal static class UserFactory
             user.Avatar = dto.Avatar;
             user.EmailConfirmedDate = dto.EmailConfirmedDate;
             user.InvitedDate = dto.InvitedDate;
+            user.Type = (UserType)dto.Type;
 
             // reset dirty initial properties (U4-1946)
             user.ResetDirtyProperties(false);
@@ -82,6 +83,7 @@ internal static class UserFactory
             Avatar = entity.Avatar,
             EmailConfirmedDate = entity.EmailConfirmedDate,
             InvitedDate = entity.InvitedDate,
+            Type = (short)entity.Type
         };
 
         if (entity.StartContentIds is not null)

--- a/src/Umbraco.Infrastructure/Security/BackOfficeIdentityUser.cs
+++ b/src/Umbraco.Infrastructure/Security/BackOfficeIdentityUser.cs
@@ -21,6 +21,7 @@ public class BackOfficeIdentityUser : UmbracoIdentityUser
     private DateTime? _inviteDateUtc;
     private int[] _startContentIds;
     private int[] _startMediaIds;
+    private UserType _type;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="BackOfficeIdentityUser" /> class.
@@ -115,6 +116,12 @@ public class BackOfficeIdentityUser : UmbracoIdentityUser
         }
     }
 
+    public UserType Type
+    {
+        get => _type;
+        set => BeingDirty.SetPropertyValueAndDetectChanges(value, ref _type, nameof(Type));
+    }
+
     /// <summary>
     ///     Used to construct a new instance without an identity
     /// </summary>
@@ -123,7 +130,7 @@ public class BackOfficeIdentityUser : UmbracoIdentityUser
     /// <param name="email">This is allowed to be null (but would need to be filled in if trying to persist this instance)</param>
     /// <param name="culture"></param>
     /// <param name="name"></param>
-    public static BackOfficeIdentityUser CreateNew(GlobalSettings globalSettings, string? username, string email, string culture, string? name = null, Guid? id = null)
+    public static BackOfficeIdentityUser CreateNew(GlobalSettings globalSettings, string? username, string email, string culture, string? name = null, Guid? id = null, UserType type = UserType.Default)
     {
         if (string.IsNullOrWhiteSpace(username))
         {
@@ -149,6 +156,7 @@ public class BackOfficeIdentityUser : UmbracoIdentityUser
         user.HasIdentity = false;
         user._culture = culture;
         user.Name = name;
+        user.Type = type;
         user.EnableChangeTracking();
         return user;
     }

--- a/src/Umbraco.Infrastructure/Security/BackOfficeUserClientCredentialsManager.cs
+++ b/src/Umbraco.Infrastructure/Security/BackOfficeUserClientCredentialsManager.cs
@@ -64,4 +64,7 @@ public sealed class BackOfficeUserClientCredentialsManager : ClientCredentialsMa
 
         return await _backOfficeUserManager.FindByNameAsync(user.Username);
     }
+
+    public async Task<IEnumerable<string>> GetClientIdsAsync(Guid userKey)
+        => await _userService.GetClientIdsAsync(userKey);
 }

--- a/src/Umbraco.Infrastructure/Security/BackOfficeUserClientCredentialsManager.cs
+++ b/src/Umbraco.Infrastructure/Security/BackOfficeUserClientCredentialsManager.cs
@@ -1,0 +1,70 @@
+﻿using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Security.OperationStatus;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Security;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Core.Security;
+
+public class BackOfficeUserClientCredentialsManager : IBackOfficeUserClientCredentialsManager
+{
+    private readonly IBackOfficeUserManager _backOfficeUserManager;
+    private readonly IBackOfficeApplicationManager _backOfficeApplicationManager;
+    private readonly IUserService _userService;
+
+    public BackOfficeUserClientCredentialsManager(
+        IBackOfficeUserManager backOfficeUserManager,
+        IBackOfficeApplicationManager backOfficeApplicationManager,
+        IUserService userService)
+    {
+        _backOfficeUserManager = backOfficeUserManager;
+        _userService = userService;
+        _backOfficeApplicationManager = backOfficeApplicationManager;
+    }
+
+    public async Task<Attempt<BackOfficeUserClientCredentialsOperationStatus>> SaveAsync(Guid userKey, string clientId, string clientSecret)
+    {
+        if (IsReservedClientId(clientId))
+        {
+            return Attempt.Fail(BackOfficeUserClientCredentialsOperationStatus.ReservedClientId);
+        }
+
+        if (await _userService.AddClientIdAsync(userKey, clientId) is false)
+        {
+            return Attempt.Fail(BackOfficeUserClientCredentialsOperationStatus.DuplicateClientId);
+        }
+
+        await _backOfficeApplicationManager.EnsureBackOfficeClientCredentialsApplicationAsync(clientId, clientSecret);
+
+        return Attempt.Succeed(BackOfficeUserClientCredentialsOperationStatus.Success);
+    }
+
+    public async Task<Attempt<BackOfficeUserClientCredentialsOperationStatus>> DeleteAsync(Guid userKey, string clientId)
+    {
+        if (IsReservedClientId(clientId))
+        {
+            return Attempt.Fail(BackOfficeUserClientCredentialsOperationStatus.ReservedClientId);
+        }
+
+        await _backOfficeApplicationManager.DeleteBackOfficeClientCredentialsApplicationAsync(clientId);
+        await _userService.RemoveClientIdAsync(userKey, clientId);
+
+        return Attempt.Succeed(BackOfficeUserClientCredentialsOperationStatus.Success);
+    }
+
+    public async Task<BackOfficeIdentityUser?> FindUserAsync(string clientId)
+    {
+        IUser? user = await _userService.FindByClientIdAsync(clientId);
+        if (user is null || user.IsApproved is false)
+        {
+            return null;
+        }
+
+        return await _backOfficeUserManager.FindByNameAsync(user.Username);
+    }
+
+    private static bool IsReservedClientId(string clientId)
+        => clientId.InvariantEquals(Constants.OAuthClientIds.BackOffice)
+           || clientId.InvariantEquals(Constants.OAuthClientIds.Postman)
+           || clientId.InvariantEquals(Constants.OAuthClientIds.Swagger);
+}

--- a/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
@@ -141,6 +141,7 @@ public class BackOfficeUserStore :
             StartMediaIds = user.StartMediaIds ?? new int[] { },
             IsLockedOut = user.IsLockedOut,
             Key = user.Key,
+            Type = user.Type
         };
 
 

--- a/src/Umbraco.Infrastructure/Security/ClientCredentialsManagerBase.cs
+++ b/src/Umbraco.Infrastructure/Security/ClientCredentialsManagerBase.cs
@@ -1,0 +1,10 @@
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Core.Security;
+
+public abstract class ClientCredentialsManagerBase
+{
+    protected abstract string ClientIdPrefix { get; }
+
+    protected string SafeClientId(string clientId) => clientId.EnsureStartsWith($"{ClientIdPrefix}-");
+}

--- a/src/Umbraco.Infrastructure/Security/IBackOfficeApplicationManager.cs
+++ b/src/Umbraco.Infrastructure/Security/IBackOfficeApplicationManager.cs
@@ -4,9 +4,7 @@ public interface IBackOfficeApplicationManager
 {
     Task EnsureBackOfficeApplicationAsync(Uri backOfficeUrl, CancellationToken cancellationToken = default);
 
-    Task EnsureBackOfficeClientCredentialsApplicationAsync(string clientId, string clientSecret, CancellationToken cancellationToken = default)
-        => Task.CompletedTask;
+    Task EnsureBackOfficeClientCredentialsApplicationAsync(string clientId, string clientSecret, CancellationToken cancellationToken = default);
 
-    Task DeleteBackOfficeClientCredentialsApplicationAsync(string clientId, CancellationToken cancellationToken = default)
-        => Task.CompletedTask;
+    Task DeleteBackOfficeClientCredentialsApplicationAsync(string clientId, CancellationToken cancellationToken = default);
 }

--- a/src/Umbraco.Infrastructure/Security/IBackOfficeApplicationManager.cs
+++ b/src/Umbraco.Infrastructure/Security/IBackOfficeApplicationManager.cs
@@ -3,4 +3,10 @@
 public interface IBackOfficeApplicationManager
 {
     Task EnsureBackOfficeApplicationAsync(Uri backOfficeUrl, CancellationToken cancellationToken = default);
+
+    Task EnsureBackOfficeClientCredentialsApplicationAsync(string clientId, string clientSecret, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    Task DeleteBackOfficeClientCredentialsApplicationAsync(string clientId, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
 }

--- a/src/Umbraco.Infrastructure/Security/IBackOfficeUserClientCredentialsManager.cs
+++ b/src/Umbraco.Infrastructure/Security/IBackOfficeUserClientCredentialsManager.cs
@@ -1,0 +1,12 @@
+﻿using Umbraco.Cms.Core.Security.OperationStatus;
+
+namespace Umbraco.Cms.Core.Security;
+
+public interface IBackOfficeUserClientCredentialsManager
+{
+    Task<BackOfficeIdentityUser?> FindUserAsync(string clientId);
+
+    Task<Attempt<BackOfficeUserClientCredentialsOperationStatus>> SaveAsync(Guid userKey, string clientId, string clientSecret);
+
+    Task<Attempt<BackOfficeUserClientCredentialsOperationStatus>> DeleteAsync(Guid userKey, string clientId);
+}

--- a/src/Umbraco.Infrastructure/Security/IBackOfficeUserClientCredentialsManager.cs
+++ b/src/Umbraco.Infrastructure/Security/IBackOfficeUserClientCredentialsManager.cs
@@ -6,6 +6,8 @@ public interface IBackOfficeUserClientCredentialsManager
 {
     Task<BackOfficeIdentityUser?> FindUserAsync(string clientId);
 
+    Task<IEnumerable<string>> GetClientIdsAsync(Guid userKey);
+
     Task<Attempt<BackOfficeUserClientCredentialsOperationStatus>> SaveAsync(Guid userKey, string clientId, string clientSecret);
 
     Task<Attempt<BackOfficeUserClientCredentialsOperationStatus>> DeleteAsync(Guid userKey, string clientId);

--- a/src/Umbraco.Infrastructure/Security/IMemberApplicationManager.cs
+++ b/src/Umbraco.Infrastructure/Security/IMemberApplicationManager.cs
@@ -5,4 +5,10 @@ public interface IMemberApplicationManager
     Task EnsureMemberApplicationAsync(IEnumerable<Uri> loginRedirectUrls, IEnumerable<Uri> logoutRedirectUrls, CancellationToken cancellationToken = default);
 
     Task DeleteMemberApplicationAsync(CancellationToken cancellationToken = default);
+
+    Task EnsureMemberClientCredentialsApplicationAsync(string clientId, string clientSecret, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    Task DeleteMemberClientCredentialsApplicationAsync(string clientId, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
 }

--- a/src/Umbraco.Infrastructure/Security/IMemberClientCredentialsManager.cs
+++ b/src/Umbraco.Infrastructure/Security/IMemberClientCredentialsManager.cs
@@ -1,0 +1,8 @@
+namespace Umbraco.Cms.Core.Security;
+
+public interface IMemberClientCredentialsManager
+{
+    Task<IEnumerable<MemberClientCredentials>> GetAllAsync();
+
+    Task<MemberIdentityUser?> FindMemberAsync(string clientId);
+}

--- a/src/Umbraco.Infrastructure/Security/IdentityMapDefinition.cs
+++ b/src/Umbraco.Infrastructure/Security/IdentityMapDefinition.cs
@@ -96,6 +96,7 @@ public class IdentityMapDefinition : IMapDefinition
         target.SecurityStamp = source.SecurityStamp;
         DateTime? lockedOutUntil = source.LastLockoutDate?.AddMinutes(_securitySettings.UserDefaultLockoutTimeInMinutes);
         target.LockoutEnd = source.IsLockedOut ? (lockedOutUntil ?? DateTime.MaxValue).ToUniversalTime() : null;
+        target.Type = source.Type;
     }
 
     // Umbraco.Code.MapAll -Id -LockoutEnabled -PhoneNumber -PhoneNumberConfirmed -ConcurrencyStamp -NormalizedEmail -NormalizedUserName -Roles

--- a/src/Umbraco.Infrastructure/Security/MemberClientCredentials.cs
+++ b/src/Umbraco.Infrastructure/Security/MemberClientCredentials.cs
@@ -1,0 +1,22 @@
+namespace Umbraco.Cms.Core.Security;
+
+public class MemberClientCredentials
+{
+    /// <summary>
+    ///     Gets or sets the user name of the member to associate with the session after a successful login.
+    /// </summary>
+    /// <value>The user name of the member.</value>
+    public required string UserName { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the client ID that allows for a successful login.
+    /// </summary>
+    /// <value>The client ID.</value>
+    public required string ClientId { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the client secret that allows for a successful login.
+    /// </summary>
+    /// <value>The client secret.</value>
+    public required string ClientSecret { get; set; }
+}

--- a/src/Umbraco.Infrastructure/Security/MemberClientCredentialsManager.cs
+++ b/src/Umbraco.Infrastructure/Security/MemberClientCredentialsManager.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
+
+namespace Umbraco.Cms.Core.Security;
+
+public sealed class MemberClientCredentialsManager : ClientCredentialsManagerBase, IMemberClientCredentialsManager
+{
+    private readonly DeliveryApiSettings _deliveryApiSettings;
+    private readonly IMemberManager _memberManager;
+    private readonly ILogger<MemberClientCredentialsManager> _logger;
+
+    public MemberClientCredentialsManager(
+        IOptions<DeliveryApiSettings> deliveryApiSettings,
+        IMemberManager memberManager,
+        ILogger<MemberClientCredentialsManager> logger)
+    {
+        _deliveryApiSettings = deliveryApiSettings.Value;
+        _memberManager = memberManager;
+        _logger = logger;
+    }
+
+    protected override string ClientIdPrefix => Constants.OAuthClientIds.Member;
+
+    public Task<IEnumerable<MemberClientCredentials>> GetAllAsync()
+    {
+        IEnumerable<MemberClientCredentials> result = IsDisabled()
+            ? Enumerable.Empty<MemberClientCredentials>()
+            : _deliveryApiSettings
+                .MemberAuthorization!
+                .ClientCredentialsFlow!
+                .AssociatedMembers
+                .Select(m => new MemberClientCredentials
+                {
+                    ClientId = SafeClientId(m.ClientId),
+                    ClientSecret = m.ClientSecret,
+                    UserName = m.UserName
+                })
+                .ToArray();
+
+        return Task.FromResult(result);
+    }
+
+    public async Task<MemberIdentityUser?> FindMemberAsync(string clientId)
+    {
+        clientId = SafeClientId(clientId);
+        var userName = IsDisabled()
+            ? null
+            : _deliveryApiSettings
+                .MemberAuthorization?
+                .ClientCredentialsFlow?
+                .AssociatedMembers
+                .FirstOrDefault(m => SafeClientId(m.ClientId) == clientId)?
+                .UserName;
+
+        if (userName is null)
+        {
+            return null;
+        }
+
+        MemberIdentityUser? user = await _memberManager.FindByNameAsync(userName);
+        if (user is null)
+        {
+            _logger.LogWarning("The member with username {userName} could not be retrieved by the member manager", userName);
+        }
+
+        return user;
+    }
+
+    private bool IsDisabled() => _deliveryApiSettings.MemberAuthorization?.ClientCredentialsFlow?.Enabled is not true
+                                 || _deliveryApiSettings.MemberAuthorization.ClientCredentialsFlow.AssociatedMembers.Any() is false;
+}

--- a/src/Umbraco.Infrastructure/Security/OperationStatus/BackOfficeUserClientCredentialsOperationStatus.cs
+++ b/src/Umbraco.Infrastructure/Security/OperationStatus/BackOfficeUserClientCredentialsOperationStatus.cs
@@ -4,6 +4,5 @@ public enum BackOfficeUserClientCredentialsOperationStatus
 {
     Success,
     DuplicateClientId,
-    ReservedClientId,
     InvalidUser
 }

--- a/src/Umbraco.Infrastructure/Security/OperationStatus/BackOfficeUserClientCredentialsOperationStatus.cs
+++ b/src/Umbraco.Infrastructure/Security/OperationStatus/BackOfficeUserClientCredentialsOperationStatus.cs
@@ -1,0 +1,9 @@
+﻿namespace Umbraco.Cms.Core.Security.OperationStatus;
+
+public enum BackOfficeUserClientCredentialsOperationStatus
+{
+    Success,
+    DuplicateClientId,
+    ReservedClientId,
+    InvalidUser
+}

--- a/src/Umbraco.Web.Common/Security/BackOfficeUserManager.cs
+++ b/src/Umbraco.Web.Common/Security/BackOfficeUserManager.cs
@@ -298,7 +298,8 @@ public class BackOfficeUserManager : UmbracoUserManager<BackOfficeIdentityUser, 
             createModel.Email,
             _globalSettings.DefaultUILanguage,
             createModel.Name,
-            createModel.Id);
+            createModel.Id,
+            createModel.Type);
 
         IdentityResult created = await CreateAsync(identityUser);
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserServiceCrudTests.ChangePassword.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserServiceCrudTests.ChangePassword.cs
@@ -1,0 +1,66 @@
+﻿using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Services;
+
+public partial class UserServiceCrudTests
+{
+    [Test]
+    public async Task Can_Reset_Password()
+    {
+        var securitySettings = new SecuritySettings();
+        var userService = CreateUserService(securitySettings);
+
+        var userGroup = await UserGroupService.GetAsync(Constants.Security.AdminGroupAlias);
+        var creationModel = new UserCreateModel
+        {
+            UserName = "some@one",
+            Email = "some@one",
+            Name = "Some One",
+            UserGroupKeys = new HashSet<Guid> { userGroup.Key }
+        };
+
+        var userKey = (await userService.CreateAsync(Constants.Security.SuperUserKey, creationModel, true)).Result.CreatedUser!.Key;
+
+        var result = await userService.ResetPasswordAsync(Constants.Security.SuperUserKey, userKey);
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(UserOperationStatus.Success, result.Status);
+            Assert.IsNotNull(result.Result.ResetPassword);
+        });
+    }
+
+    [Test]
+    public async Task Cannot_Reset_Password_For_Api_User()
+    {
+        var securitySettings = new SecuritySettings();
+        var userService = CreateUserService(securitySettings);
+
+        var userGroup = await UserGroupService.GetAsync(Constants.Security.AdminGroupAlias);
+        var creationModel = new UserCreateModel
+        {
+            UserName = "some@one",
+            Email = "some@one",
+            Name = "Some One",
+            UserGroupKeys = new HashSet<Guid> { userGroup.Key },
+            Type = UserType.Api
+        };
+
+        var userKey = (await userService.CreateAsync(Constants.Security.SuperUserKey, creationModel, true)).Result.CreatedUser!.Key;
+
+        var result = await userService.ResetPasswordAsync(Constants.Security.SuperUserKey, userKey);
+        Assert.Multiple(() =>
+        {
+            Assert.IsFalse(result.Success);
+            Assert.AreEqual(UserOperationStatus.InvalidUserType, result.Status);
+            Assert.IsNull(result.Result.ResetPassword);
+            Assert.IsNull(result.Exception);
+        });
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR introduces API access via client credentials (client ID + secret) to both the Management and the Delivery API. Client credentials is a necessary access mechanism for machine-to-machine integrations with these APIs.

The feature works by impersonating a concrete User (Management API) or Member (Delivery API). Thus we can reuse the entire permissions setup for both APIs.

Please note that this PR actively ensures a prefix for all created client IDs. This is to avoid collisions with the core client IDs:

- Management API client IDs are prefixed `umbraco-back-office-`.
- Delivery API client IDs are prefixed `umbraco-member-`.

Also note that this PR does _not_ include any UI support for managing client secrets. Only the core functionality (including Management APIs for client secrets) is included here.

### The Management API

With this PR it becomes possible to define pairs of client IDs and secrets for a specific User. In other words, one User can be associated with multiple client credentials. There are multiple applications for this, including rotation of client credentials.

Managing access to the Management API is quite critical, so we want to ensure that it's possible to distinguish between regular Users and integration Users in the UI. To that end, a new concept of "User type" is introduced:

- `Default`: A regular back-office User.
- `Api`: A back-office User meant to be used with client credentials for API access.

Client credentials can only be defined for `Api` Users. Likewise, `Api` Users are not allowed to define passwords, making it impossible to sign into the back-office with an `Api` User.

We only ever store the client IDs in the Umbraco database (the `umbracoUser2ClientId` table). We use them figure out which User to impersonate for a given client ID, and to avoid collisions between client IDs. The client secrets however are stored and handled exclusively by OpenIddict. This means that:

1. Once a set of client credentials have been created, we cannot retrieve the client secret again. Thus, the UI must encourage admins to copy the client secret before saving a set of client credentials.
2. A client secret can only be changed by deleting and re-creating the set of client credentials.

At this point there are no complexity requirements for client secrets. We might consider enforcing a certain level of client secret complexity in the future.

### The Delivery API

Member authorization is defined by configuration (see [the docs](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api#enabling-member-authorization) for details).

When introducing Member authorization (with _Authorization Code Flow + PKCE_) in the Delivery API, we prepared the `MemberAuthorization` configuration for an eventual future with more authorization flows. That future is now :smile: and the configuration has been extended with a `ClientCredentialsFlow` option:

```json
"MemberAuthorization": {
  "ClientCredentialsFlow": {
	"Enabled": true,
	"AssociatedMembers": [
	  {
		"ClientId": "client-2",
		"ClientSecret": "really-really-secret",
		"UserName": "test@test"
	  }
	]
  }
}
```

- As with all things Delivery API, the client credentials auth flow must be explicitly enabled (`"Enabled": true`).
- The impersonation is defined in `AssociatedMembers`, which is an array that maps client credentials and Members. This makes it possible to have multiple client credentials mapped to different (or the same) Member access setups.

### Testing this PR

#### Management API, Client Credentials Flow

Using Swagger:

1. Create an `Api` User (use `"type": "Api"` in the payload).
2. Add client credentials to the newly created User.
3. Verify that it is not possible to add client credentials to any other (regular) user.
4. Verify that it is not possible to add duplicate client IDs.

Download [this Node app](https://github.com/user-attachments/files/16377807/backoffice-client-credentials-node.zip) and tweak the `.env` variables to match your setup:

- `UMBRACO_CLIENT_ID` and `UMBRACO_CLIENT_SECRET` must match the your client credentials (client ID and secret, respectively).
- `UMBRACO_DOCUMENT_ID` must be an ID (key) of an existing document in your site.

Run the Node app from a terminal with `npm run start`. The app should print out the resulting JSON from the `/umbraco/management/api/v1/document/{id}` Management API endpoint:

![image](https://github.com/user-attachments/assets/f54fbbc0-a2b1-4c87-ae56-f74349dd5ed9)

Using Swagger, delete the client credentials from the `Api` User. Re-run the Node app and verify that it is no longer allowed to access the Management API.

#### Management API, Authorization Code Flow + PKCE

Verify that you can still log into the back-office :laughing:

#### Delivery Api, Client Credentials Flow

In Umbraco:

1. Create a document type with alias `article` (it doesn't need to have any properties).
2. Publish some documents of this type.
3. Restrict public access to one or more (but not all) of these documents to a specific Member or Member Group.
   - If you use a Member Group for your public access configuration, you'll still need a Member to be part of this group in order to perform impersonation later.

By configuration:

1. [Enable the Delivery API](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#enable-the-content-delivery-api) if you haven't already (remember to rebuild the Delivery API index if applicable).
2. Configure `ClientCredentialsFlow` as described above.

Download [this Node app](https://github.com/user-attachments/files/16377813/member-client-credentials-node.zip) and tweak the `.env` variables, so `UMBRACO_CLIENT_ID` and `UMBRACO_CLIENT_SECRET` match the your client credentials (client ID and secret, respectively).

Run the Node app from a terminal with `npm run start`. The app should print out all the `article` documents available to the configured client credentials.

For good measure, verify that `/umbraco/delivery/api/v2/content/?fetch=children:/&filter=contentType:article` only outputs the publicly available `article` documents when requested in a browser (i.e. anonymous access).

#### Delivery API, Authorization Code Flow + PKCE

_These tests are quite cumbersome. It might be easier to get in touch with @kjac who's got a test setup ready to go._

Create an application as described in [this docs artice](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api) and verify that _Authorization Code Flow + PKCE_ is not broken by this PR.

Also, ensure that refresh tokens still work (it might be simplest to do with Postman, once the application above has obtained a valid token).

#### Upgrading Umbraco

The new "User type" means that the `User` class is expanded with a new `Type` property. Historically this has sometimes been a challenge when performing upgrades.

Test that it's possible to perform an upgrade to this PR:

1. Both unattended and attended.
2. Both using SQLite and SQL Server.


### Breaking changes

The changes in this PR are binary breaking, due to the new methods in `IBackOfficeApplicationManager`, `IUserService` and `IUserRepository`. However, the PR targets a new major (V15.0), so binary breakage is probably OK 😄 