### PR TITLE
Don't shrink crops container on right side

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediaentryeditor/mediaentryeditor.less
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediaentryeditor/mediaentryeditor.less
@@ -37,6 +37,7 @@
 .umb-media-entry-editor__crops {
     background-color: white;
     overflow: auto;
+    flex-shrink: 0;
 
     > button {
         display: flex;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below


### Description
I noticed on a few on our projects the image (mainly at "root" Media item in crops sidebar) in flexbox container can grow and thus shrink crops on right side.

In v14 this looks correct.

**Before**

![image](https://github.com/user-attachments/assets/b9bd82f2-ea32-49d5-9367-0403f63e027d)

![image](https://github.com/user-attachments/assets/49cffc2f-b051-4d7a-927b-f64bf16d4d6c)

**After**

![image](https://github.com/user-attachments/assets/f0326432-09a4-426f-bbcc-d2dccee38795)
