### PR TITLE
Add Content-Security-Policy (CSP) health check

### DIFF
--- a/src/Umbraco.Core/Constants-HealthChecks.cs
+++ b/src/Umbraco.Core/Constants-HealthChecks.cs
@@ -52,6 +52,7 @@ public static partial class Constants
                 [Obsolete("This link is not used anymore in the XSS protected check.")]
                 public const string XssProtectionCheck = "https://umbra.co/healthchecks-xss-protection";
                 public const string ExcessiveHeadersCheck = "https://umbra.co/healthchecks-excessive-headers";
+                public const string CspHeaderCheck = "https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP";
 
                 public static class HttpsCheck
                 {

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -471,7 +471,7 @@
       <![CDATA[The header <strong>Content-Security-Policy (CSP)</strong> was found. ]]>
     </key>
     <key alias="contentSecurityPolicyCheckHeaderNotFound">
-      <![CDATA[The <strong>Content-Security-Policy (CSP)</strong> header was not found. This header is important because it helps prevent cross-site scripting (XSS) attacks and other code injection vulnerabilities by specifying which content sources are trusted and allowed to be loaded by the browser. ]]>
+      <![CDATA[The header <strong>Content-Security-Policy</strong> (CSP) used to prevent cross-site scripting (XSS) attacks and other code injection vulnerabilities was not found.]]>
     </key>
     <key alias="excessiveHeadersFound"><![CDATA[The following headers revealing information about the website technology were found: <strong>%0%</strong>.]]></key>
     <key alias="excessiveHeadersNotFound">No headers revealing information about the website technology were found.

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -467,6 +467,12 @@
     You can read about this on the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection" target="_blank" rel="noopener" class="btn-link -underline">Mozilla</a> website ]]></key>
     <key alias="xssProtectionCheckHeaderNotFound">
       <![CDATA[The header <strong>X-XSS-Protection</strong> was not found.]]></key>
+    <key alias="contentSecurityPolicyCheckHeaderFound">
+      <![CDATA[The header <strong>Content-Security-Policy (CSP)</strong> was found. ]]>
+    </key>
+    <key alias="contentSecurityPolicyCheckHeaderNotFound">
+      <![CDATA[The <strong>Content-Security-Policy (CSP)</strong> header was not found. This header is important because it helps prevent cross-site scripting (XSS) attacks and other code injection vulnerabilities by specifying which content sources are trusted and allowed to be loaded by the browser. ]]>
+    </key>
     <key alias="excessiveHeadersFound"><![CDATA[The following headers revealing information about the website technology were found: <strong>%0%</strong>.]]></key>
     <key alias="excessiveHeadersNotFound">No headers revealing information about the website technology were found.
     </key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -455,6 +455,12 @@
     You can read about this on the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection" target="_blank" rel="noopener" class="btn-link -underline">Mozilla</a> website ]]></key>
     <key alias="xssProtectionCheckHeaderNotFound">
       <![CDATA[The header <strong>X-XSS-Protection</strong> was not found.]]></key>
+    <key alias="contentSecurityPolicyCheckHeaderFound">
+      <![CDATA[The header <strong>Content-Security-Policy (CSP)</strong> was found. ]]>
+    </key>
+    <key alias="contentSecurityPolicyCheckHeaderNotFound">
+      <![CDATA[The <strong>Content-Security-Policy (CSP)</strong> header was not found. This header is important because it helps prevent cross-site scripting (XSS) attacks and other code injection vulnerabilities by specifying which content sources are trusted and allowed to be loaded by the browser. ]]>
+    </key>
     <key alias="excessiveHeadersFound">
       <![CDATA[The following headers revealing information about the website technology were found: <strong>%0%</strong>.]]></key>
     <key alias="excessiveHeadersNotFound">No headers revealing information about the website technology were found.

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -459,7 +459,7 @@
       <![CDATA[The header <strong>Content-Security-Policy (CSP)</strong> was found. ]]>
     </key>
     <key alias="contentSecurityPolicyCheckHeaderNotFound">
-      <![CDATA[The <strong>Content-Security-Policy (CSP)</strong> header was not found. This header is important because it helps prevent cross-site scripting (XSS) attacks and other code injection vulnerabilities by specifying which content sources are trusted and allowed to be loaded by the browser. ]]>
+      <![CDATA[The header <strong>Content-Security-Policy</strong> (CSP) used to prevent cross-site scripting (XSS) attacks and other code injection vulnerabilities was not found.]]>
     </key>
     <key alias="excessiveHeadersFound">
       <![CDATA[The following headers revealing information about the website technology were found: <strong>%0%</strong>.]]></key>

--- a/src/Umbraco.Core/HealthChecks/Checks/Security/CspCheck.cs
+++ b/src/Umbraco.Core/HealthChecks/Checks/Security/CspCheck.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Core.HealthChecks.Checks.Security;
+
+/// <summary>
+///     Health check for the recommended production setup regarding the content-security-policy header.
+/// </summary>
+[HealthCheck(
+    "10BEBF47-C128-4C5E-9680-5059BEAFBBDF",
+    "Content Security Policy (CSP)",
+    Description = "Checks whether the site contains a Content-Security-Policy (CSP) header.",
+    Group = "Security")]
+public class CspCheck : BaseHttpHeaderCheck
+{
+    private const string LocalizationPrefix = "contentSecurityPolicy";
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="CspCheck" /> class.
+    /// </summary>
+    public CspCheck(IHostingEnvironment hostingEnvironment, ILocalizedTextService textService)
+        : base(hostingEnvironment, textService, "Content-Security-Policy", LocalizationPrefix, false, false)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override string ReadMoreLink => Constants.HealthChecks.DocumentationLinks.Security.CspHeaderCheck;
+}


### PR DESCRIPTION
Added a health check to see if a CSP header is present.

When present:
![image](https://github.com/user-attachments/assets/ddafa3f7-9ffd-4641-95da-c017487ecff2)

If not:
![image](https://github.com/user-attachments/assets/70cfc411-399d-432c-ade2-e2268d46cc50)

This can be tested by adding a CSP header and running the health checks:

```csharp
app.Use(async (context, next) =>
{
    context.Response.Headers.Append("Content-Security-Policy", "default-src 'self' www.gravatar.com; script-src 'self' 'unsafe-eval' code.jquery.com ajax.aspnetcdn.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: i.ytimg.com dashboard.umbraco.com; font-src 'self' data:; connect-src 'self'; media-src 'self'; frame-src 'self';");
    await next();
});
```
