### PR TITLE
Graceful handling of unauthorized requests to the Management API

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Security/Authorization/User/AllowedApplicationHandler.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/Authorization/User/AllowedApplicationHandler.cs
@@ -17,8 +17,8 @@ internal sealed class AllowedApplicationHandler : MustSatisfyRequirementAuthoriz
 
     protected override Task<bool> IsAuthorized(AuthorizationHandlerContext context, AllowedApplicationRequirement requirement)
     {
-        IUser user = _authorizationHelper.GetUmbracoUser(context.User);
-        var allowed = user.AllowedSections.ContainsAny(requirement.Applications);
+        var allowed = _authorizationHelper.TryGetUmbracoUser(context.User, out IUser? user)
+                      && user.AllowedSections.ContainsAny(requirement.Applications);
         return Task.FromResult(allowed);
     }
 }

--- a/src/Umbraco.Core/Security/Authorization/IAuthorizationHelper.cs
+++ b/src/Umbraco.Core/Security/Authorization/IAuthorizationHelper.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Principal;
 using Umbraco.Cms.Core.Models.Membership;
 
@@ -9,11 +10,19 @@ namespace Umbraco.Cms.Core.Security.Authorization;
 public interface IAuthorizationHelper
 {
     /// <summary>
-    ///     Converts an <see cref="IUser" /> into <see cref="IPrincipal" />.
+    ///     Converts an <see cref="IPrincipal" /> into an <see cref="IUser" />.
     /// </summary>
     /// <param name="currentUser">The current user's principal.</param>
     /// <returns>
     ///     <see cref="IUser" />.
     /// </returns>
     IUser GetUmbracoUser(IPrincipal currentUser);
+
+    /// <summary>
+    ///     Attempts to convert an <see cref="IPrincipal" /> into an <see cref="IUser" />.
+    /// </summary>
+    /// <param name="currentUser">The current user's principal.</param>
+    /// <param name="user">The resulting <see cref="IUser" />, if the conversion is successful.</param>
+    /// <returns>True if the conversion is successful, false otherwise</returns>
+    bool TryGetUmbracoUser(IPrincipal currentUser, [NotNullWhen(true)] out IUser? user);
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

#16552 has had the unfortunate side-effect that exceptions are being thrown by the `AllowedApplicationHandler`, whenever a request is made to an endpoint that is guarded by this handler ("section" based access), resulting in a 500 error instead of the expected 401:

![image](https://github.com/user-attachments/assets/cfc40b21-ed43-49a7-b19f-49d0852efd2e)

This PR changes `AllowedApplicationHandler` so it doesn't assume a logged-in user by default.

### Testing this PR

1. Make an _unauthorized_ request to any endpoint that requires "section" access (e.g. to `/umbraco/management/api/v1/tree/data-type/root?skip=0&take=100`) and verify that the response is a 401.
2. Log into the backoffice and make sure things still work 😄 