### PR TITLE
Remove favicon from dotnet templates

### DIFF
--- a/templates/Umbraco.Templates.csproj
+++ b/templates/Umbraco.Templates.csproj
@@ -11,7 +11,6 @@
     <ContentTargetFolders>.</ContentTargetFolders>
     <NoWarn>NU5128</NoWarn>
   </PropertyGroup>
-
   <ItemGroup>
     <Content Include="..\src\Umbraco.Web.UI\Program.cs">
       <Link>UmbracoProject\Program.cs</Link>
@@ -32,13 +31,7 @@
       <Link>UmbracoProject\Views\_ViewImports.cshtml</Link>
       <PackagePath>UmbracoProject\Views</PackagePath>
     </Content>
-    <Content Include="..\src\Umbraco.Web.UI\wwwroot\favicon.ico">
-      <Link>UmbracoProject\wwwroot\favicon.ico</Link>
-      <PackagePath>UmbracoProject\wwwroot</PackagePath>
-    </Content>
   </ItemGroup>
-
-
   <!-- Update template.json files with the default UmbracoVersion value set to the current build version -->
   <ItemGroup>
     <PackageReference Include="Umbraco.JsonSchema.Extensions" PrivateAssets="all" />


### PR DESCRIPTION
Following a discussion about websites accidentally appearing in Google with an Umbraco favicon, I noted that Umbraco's dotnet templates automatically include this.

It's something I see time and again on our own + inherited projects, that people don't realise there is a default favicon.ico file shipped within the template. This makes it very easy to overlook and deploy a new Umbraco site with the Umbraco logo as a favicon.

I can't really see any good reason for this, other than for the wwwroot folder to appear in the project... which there must surely be better ways of doing!

This change seems like it could be backported to v13 also without any issues 🤞