### PR TITLE
Fix date conversion on the server-side

### DIFF
--- a/src/Umbraco.Core/Extensions/ObjectExtensions.cs
+++ b/src/Umbraco.Core/Extensions/ObjectExtensions.cs
@@ -219,6 +219,24 @@ public static class ObjectExtensions
                 }
             }
 
+            if (target == typeof(DateTime) && input is DateTimeOffset dateTimeOffset)
+            {
+                // IMPORTANT: for compatability with various editors, we must discard any Offset information and assume UTC time here
+                return Attempt.Succeed((object?)new DateTime(
+                    new DateOnly(dateTimeOffset.Year, dateTimeOffset.Month, dateTimeOffset.Day),
+                    new TimeOnly(dateTimeOffset.Hour, dateTimeOffset.Minute, dateTimeOffset.Second, dateTimeOffset.Millisecond, dateTimeOffset.Microsecond),
+                    DateTimeKind.Utc));
+            }
+
+            if (target == typeof(DateTimeOffset) && input is DateTime dateTime)
+            {
+                // IMPORTANT: for compatability with various editors, we must discard any DateTimeKind information and assume UTC time here
+                return Attempt.Succeed((object?)new DateTimeOffset(
+                    new DateOnly(dateTime.Year, dateTime.Month, dateTime.Day),
+                    new TimeOnly(dateTime.Hour, dateTime.Minute, dateTime.Second, dateTime.Millisecond, dateTime.Microsecond),
+                    TimeSpan.Zero));
+            }
+
             TypeConverter? inputConverter = GetCachedSourceTypeConverter(inputType, target);
             if (inputConverter != null)
             {

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/DatePickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/DatePickerValueConverter.cs
@@ -20,23 +20,19 @@ public class DatePickerValueConverter : PropertyValueConverterBase
 
     internal static DateTime ParseDateTimeValue(object? source)
     {
-        if (source == null)
+        if (source is null)
         {
             return DateTime.MinValue;
         }
 
-        // in XML a DateTime is: string - format "yyyy-MM-ddTHH:mm:ss"
-        // Actually, not always sometimes it is formatted in UTC style with 'Z' suffixed on the end but that is due to this bug:
-        // http://issues.umbraco.org/issue/U4-4145, http://issues.umbraco.org/issue/U4-3894
-        // We should just be using TryConvertTo instead.
-        if (source is string sourceString)
+        if (source is DateTime dateTimeValue)
         {
-            Attempt<DateTime> attempt = sourceString.TryConvertTo<DateTime>();
-            return attempt.Success == false ? DateTime.MinValue : attempt.Result;
+            return dateTimeValue;
         }
 
-        // in the database a DateTime is: DateTime
-        // default value is: DateTime.MinValue
-        return source is DateTime dateTimeValue ? dateTimeValue : DateTime.MinValue;
+        Attempt<DateTime> attempt = source.TryConvertTo<DateTime>();
+        return attempt.Success
+            ? attempt.Result
+            : DateTime.MinValue;
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #16795 (and #16779)

### Description

The `DateTimeOffset` parsing added in #16732 is the root cause of both #16795 and #16779. #16779 was fixed by a client-side change in the 14.1.1 patch, but #16795 still happens in that patch.

By the looks of it, any "date without time" property value saved before 14.1 will not work in 14.1 and 14.1.1 😱 

This PR fixes the problem at server level by:

1. Handling `DateTimeOffset` > `DateTime` conversion and vice versa for `object` types.
2. Making the value converter for the Date property editor more resilient.

Unit tests have been added to guard against this issue later on.

### Testing this

1. Create a V13 site.
2. Create some content with:
   - A "date without time" and a "date with time" property at content root level.
   - A block list with elements containing both "date without time" and a "date with time" properties.
3. Create a frontend rendering that outputs the content values.
4. Upgrade the site to V14.1.1
5. Verify that the frontend rendering still works.
6. Verify that the back-office editing still works.


