### PR TITLE
Fix: .well-known/openid-configuration doesn't work anymore

### DIFF
--- a/src/Umbraco.Cms.Api.Common/DependencyInjection/ProcessRequestContextHandler.cs
+++ b/src/Umbraco.Cms.Api.Common/DependencyInjection/ProcessRequestContextHandler.cs
@@ -10,14 +10,15 @@ public class ProcessRequestContextHandler
     : IOpenIddictServerHandler<OpenIddictServerEvents.ProcessRequestContext>, IOpenIddictValidationHandler<OpenIddictValidationEvents.ProcessRequestContext>
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
-    private readonly string _backOfficePathSegment;
+    private readonly string[] _pathsToHandle;
 
     public ProcessRequestContextHandler(IHttpContextAccessor httpContextAccessor)
     {
         _httpContextAccessor = httpContextAccessor;
-        _backOfficePathSegment = Constants.System.DefaultUmbracoPath.TrimStart(Constants.CharArrays.Tilde)
+        var backOfficePathSegment = Constants.System.DefaultUmbracoPath.TrimStart(Constants.CharArrays.Tilde)
             .EnsureStartsWith('/')
             .EnsureEndsWith('/');
+        _pathsToHandle = [backOfficePathSegment, "/.well-known/openid-configuration"];
     }
 
     public ValueTask HandleAsync(OpenIddictServerEvents.ProcessRequestContext context)
@@ -48,6 +49,14 @@ public class ProcessRequestContextHandler
             return false;
         }
 
-        return requestPath.StartsWith(_backOfficePathSegment) is false;
+        foreach (var path in _pathsToHandle)
+        {
+            if (requestPath.StartsWith(path))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Somewhere between 14.0 and 14.1, our .well-known endpoint for OpenID (/.well-known/openid-configuration) has gone missing. We need it back.

### testing
- Request https://localhost:[port]/.well-known/openid-configuration
  It should return something like ![image](https://github.com/user-attachments/assets/57b1edf9-75f6-4627-a530-d2667b70afe0)
- Make sure the backoffice requests are still working and openiddict is processing them (see console output)
- Make sure frontoffice requests are still working and openIddict skips them (see console output)