### PR TITLE
FIX: Deleting language can make the backoffice client unusable

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Factories/UserGroupPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/UserGroupPresentationFactory.cs
@@ -23,7 +23,7 @@ public class UserGroupPresentationFactory : IUserGroupPresentationFactory
     private readonly IPermissionPresentationFactory _permissionPresentationFactory;
     private readonly ILogger<UserGroupPresentationFactory> _logger;
 
-    [Obsolete("Use the constructor with ILogger<UserGroupPresentationFactory> instead.")]
+    [Obsolete("Use the new constructor instead, will be removed in v16.")]
     public UserGroupPresentationFactory(
         IEntityService entityService,
         IShortStringHelper shortStringHelper,

--- a/src/Umbraco.Cms.Api.Management/Factories/UserGroupPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/UserGroupPresentationFactory.cs
@@ -1,11 +1,12 @@
-﻿using Umbraco.Cms.Api.Management.Mapping;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Api.Management.Mapping;
 using Umbraco.Cms.Api.Management.ViewModels;
 using Umbraco.Cms.Api.Management.ViewModels.UserGroup;
-using Umbraco.Cms.Api.Management.ViewModels.UserGroup.Permissions;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Membership;
-using Umbraco.Cms.Core.Models.Membership.Permissions;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Cms.Core.Strings;
@@ -20,17 +21,30 @@ public class UserGroupPresentationFactory : IUserGroupPresentationFactory
     private readonly IShortStringHelper _shortStringHelper;
     private readonly ILanguageService _languageService;
     private readonly IPermissionPresentationFactory _permissionPresentationFactory;
+    private readonly ILogger<UserGroupPresentationFactory> _logger;
 
+    [Obsolete("Use the constructor with ILogger<UserGroupPresentationFactory> instead.")]
     public UserGroupPresentationFactory(
         IEntityService entityService,
         IShortStringHelper shortStringHelper,
         ILanguageService languageService,
         IPermissionPresentationFactory permissionPresentationFactory)
+    : this(entityService, shortStringHelper, languageService, permissionPresentationFactory, StaticServiceProvider.Instance.GetRequiredService<ILogger<UserGroupPresentationFactory>>())
+    {
+    }
+
+    public UserGroupPresentationFactory(
+        IEntityService entityService,
+        IShortStringHelper shortStringHelper,
+        ILanguageService languageService,
+        IPermissionPresentationFactory permissionPresentationFactory,
+        ILogger<UserGroupPresentationFactory> logger)
     {
         _entityService = entityService;
         _shortStringHelper = shortStringHelper;
         _languageService = languageService;
         _permissionPresentationFactory = permissionPresentationFactory;
+        _logger = logger;
     }
 
     /// <inheritdoc />
@@ -42,6 +56,11 @@ public class UserGroupPresentationFactory : IUserGroupPresentationFactory
         var mediaRootAccess = mediaStartNodeKey is null && userGroup.StartMediaId == Constants.System.Root;
 
         Attempt<IEnumerable<string>, UserGroupOperationStatus> languageIsoCodesMappingAttempt = await MapLanguageIdsToIsoCodeAsync(userGroup.AllowedLanguages);
+
+        if (languageIsoCodesMappingAttempt.Success is false)
+        {
+            _logger.LogDebug("Unknown language ID in User Group: {0}", userGroup.Name);
+        }
 
         return new UserGroupResponseModel
         {
@@ -70,6 +89,11 @@ public class UserGroupPresentationFactory : IUserGroupPresentationFactory
         Guid? contentStartNodeKey = GetKeyFromId(userGroup.StartContentId, UmbracoObjectTypes.Document);
         Guid? mediaStartNodeKey = GetKeyFromId(userGroup.StartMediaId, UmbracoObjectTypes.Media);
         Attempt<IEnumerable<string>, UserGroupOperationStatus> languageIsoCodesMappingAttempt = await MapLanguageIdsToIsoCodeAsync(userGroup.AllowedLanguages);
+
+        if (languageIsoCodesMappingAttempt.Success is false)
+        {
+            _logger.LogDebug("Unknown language ID in User Group: {0}", userGroup.Name);
+        }
 
         return new UserGroupResponseModel
         {


### PR DESCRIPTION
### Description
When a language is deleted and that language was set as allowed languages on one of the user groups of the current user, then the Backoffice client can no longer load due to /user/current throwing an error.

### Testing
- Perform a default (unattended) install
- Login with the admin
- Add a language
- Set this language as the allowed language of the admin user group
- Delete said language
- Refresh the client => All should be fine