### PR TITLE
Support transparant svg's in full window preview

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/media/umbmedianodeinfo.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/media/umbmedianodeinfo.directive.js
@@ -138,9 +138,10 @@
 
             scope.openSVG = () => {
                 var popup = window.open('', '_blank');
-                var html = '<!DOCTYPE html><body><img src="' + scope.nodeUrl + '"/>' +
-                    '<script>history.pushState(null, null,"' + $location.$$absUrl + '");</script></body>';
-                
+                var html = '<!DOCTYPE html><body style="background-image: linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(135deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(135deg, transparent 75%, #ccc 75%); background-size:30px 30px; background-position:0 0, 15px 0, 15px -15px, 0px 15px;">'
+                  +'<img src="' + scope.nodeUrl + '"/>'
+                  +'<script>history.pushState(null, null,"' + $location.$$absUrl + '");</script></body>';
+
                 popup.document.open();
                 popup.document.write(html);
                 popup.document.close();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #16749

### Description
This PR adds a css checkered background, as is quite standard for indicating full transparency, to the full window SVG rendering that replaced the direct linking to SVG's because of the security issue described in https://github.com/umbraco/Umbraco-CMS/pull/6182

### Testing
- Create a new media item of type SVG
- Upload an SVG with transparent elements or background to said item and save it.
- go to the info app/tab and click on the link
- [ ] the transparent parts of the SVG should be rendered as a checkered pattern
