### PR TITLE
Do not allow save of invalid domains

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/UpdateDomainsController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/UpdateDomainsController.cs
@@ -66,6 +66,10 @@ public class UpdateDomainsController : DocumentControllerBase
                     .WithDetail("One or more of the specified domain names were conflicting with domain assignments to other content items.")
                     .WithExtension("conflictingDomainNames", _domainPresentationFactory.CreateDomainAssignmentModels(result.Result.ConflictingDomains.EmptyNull()))
                     .Build()),
+                DomainOperationStatus.InvalidDomainName => BadRequest(problemDetailsBuilder
+                    .WithTitle("Invalid domain name detected")
+                    .WithDetail("One or more of the specified domain names were invalid.")
+                    .Build()),
                 _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                     .WithTitle("Unknown domain update operation status.")
                     .Build()),

--- a/src/Umbraco.Core/Services/DomainService.cs
+++ b/src/Umbraco.Core/Services/DomainService.cs
@@ -6,6 +6,7 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Extensions;
@@ -201,6 +202,11 @@ public class DomainService : RepositoryService, IDomainService
         foreach (DomainModel domainModel in updateModel.Domains)
         {
             domainModel.DomainName = domainModel.DomainName.ToLowerInvariant();
+
+            if(Uri.IsWellFormedUriString(domainModel.DomainName, UriKind.RelativeOrAbsolute) is false)
+            {
+                return Attempt.FailWithStatus(DomainOperationStatus.InvalidDomainName, new DomainUpdateResult());
+            }
         }
 
         // make sure we're not attempting to assign duplicate domains

--- a/src/Umbraco.Core/Services/OperationStatus/DomainOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/DomainOperationStatus.cs
@@ -7,5 +7,6 @@ public enum DomainOperationStatus
     ContentNotFound,
     LanguageNotFound,
     DuplicateDomainName,
-    ConflictingDomainName
+    ConflictingDomainName,
+    InvalidDomainName
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/UrlAndDomains/DomainAndUrlsTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/UrlAndDomains/DomainAndUrlsTests.cs
@@ -332,6 +332,22 @@ public class DomainAndUrlsTests : UmbracoIntegrationTest
         Assert.AreEqual(DomainOperationStatus.DuplicateDomainName, result.Status);
     }
 
+    [TestCase("https://*.umbraco.com")]
+    [TestCase("&#€%#€")]
+    [TestCase("¢”$¢”¢$≈{")]
+    public async Task Cannot_Assign_Invalid_Domains(string domainName)
+    {
+        var domainService = GetRequiredService<IDomainService>();
+        var updateModel = new DomainsUpdateModel
+        {
+            Domains = new DomainModel { DomainName = domainName, IsoCode = Cultures.First() }.Yield()
+        };
+
+        var result = await domainService.UpdateDomainsAsync(Root.Key, updateModel);
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(DomainOperationStatus.InvalidDomainName, result.Status);
+    }
+
     [Test]
     public async Task Cannot_Assign_Already_Used_Domains()
     {


### PR DESCRIPTION
### Description
Do not allow creation of invalid domains when assigning hostnames to documents. They will fail hard later anyway.

### Test
- Ensure you can create valid domains, both absolute and relative
- Ensure you cannot create invalid domains