### PR TITLE
Upgrade imagesharp2 dependency

### DIFF
--- a/src/Umbraco.Cms.Imaging.ImageSharp2/Umbraco.Cms.Imaging.ImageSharp2.csproj
+++ b/src/Umbraco.Cms.Imaging.ImageSharp2/Umbraco.Cms.Imaging.ImageSharp2.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" VersionOverride="[2.1.8, 3)" />
+    <PackageReference Include="SixLabors.ImageSharp" VersionOverride="[2.1.9, 3)" />
     <PackageReference Include="SixLabors.ImageSharp.Web" VersionOverride="[2.0.2, 3)" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes vulnerability in Nuget dependency by upgrading to a newer version
