### PR TITLE
Fix Mismatching constraint names in old migration

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_3_0/AlignUpgradedDatabase.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_3_0/AlignUpgradedDatabase.cs
@@ -1,5 +1,4 @@
 ﻿using NPoco;
-using StackExchange.Profiling.Internal;
 using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Infrastructure.Persistence.Dtos;
 using ColumnInfo = Umbraco.Cms.Infrastructure.Persistence.SqlSyntax.ColumnInfo;

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_3_0/AlignUpgradedDatabase.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_3_0/AlignUpgradedDatabase.cs
@@ -120,22 +120,24 @@ public class AlignUpgradedDatabase : MigrationBase
         // We need to do this to ensure we don't try to rename the constraint if it doesn't exist.
         const string tableName = "umbracoContentVersion";
         const string columnName = "VersionDate";
+        const string newColumnName = "versionDate";
+        const string expectedConstraintName = "DF_umbracoContentVersion_versionDate";
+
         ColumnInfo? versionDateColumn = columns
             .FirstOrDefault(x => x is { TableName: tableName, ColumnName: columnName });
 
-        if (versionDateColumn is null)
+        // we only want to rename the column if necessary
+        if (versionDateColumn is not null)
         {
             // The column was not found I.E. the column is correctly named
-            return;
+            RenameColumn(tableName, columnName, newColumnName, columns);
         }
-
-        RenameColumn(tableName, columnName, "versionDate", columns);
 
         // Renames the default constraint for the column,
         // apparently the content version table used to be prefixed with cms and not umbraco
         // We don't have a fluid way to rename the default constraint so we have to use raw SQL
         // This should be okay though since we are only running this migration on SQL Server
-        Sql<ISqlContext> constraintNameQuery = Database.SqlContext.Sql(@"
+        Sql<ISqlContext> constraintNameQuery = Database.SqlContext.Sql(@$"
 SELECT obj_Constraint.NAME AS 'constraintName'
     FROM   sys.objects obj_table
         JOIN sys.objects obj_Constraint
@@ -145,13 +147,21 @@ SELECT obj_Constraint.NAME AS 'constraintName'
         JOIN sys.columns columns
              ON columns.object_id = obj_table.object_id
             AND columns.column_id = constraints.colid
-    WHERE obj_table.NAME = 'umbracoContentVersion'
-	AND columns.NAME = 'VersionDate'
+    WHERE obj_table.NAME = '{tableName}'
+	AND columns.NAME = '{newColumnName}'
 	AND obj_Constraint.type = 'D'
 ");
         var currentConstraintName = Database.ExecuteScalar<string>(constraintNameQuery);
+
+
+        // only rename the constraint if necessary
+        if (currentConstraintName == expectedConstraintName)
+        {
+            return;
+        }
+
         Sql<ISqlContext> renameConstraintQuery = Database.SqlContext.Sql(
-            $"EXEC sp_rename N'{currentConstraintName}', N'DF_umbracoContentVersion_versionDate', N'OBJECT'");
+            $"EXEC sp_rename N'{currentConstraintName}', N'{expectedConstraintName}', N'OBJECT'");
         Database.Execute(renameConstraintQuery);
     }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #16267

### Description
Due to older versions of Umbraco not always having had explicit constraint names, some older databases have "system-named constraints" resulting in constraint names not matching up what what we expect in later versions.

This PR takes that behavior into account to change a [prior migration](https://github.com/umbraco/Umbraco-CMS/pull/15934) that relied on the constraint name being a fixed value. By utilizing the know table name, column name and constraint type (default, which only exists ones per column) we can identify the constraint without relying on it's name.

### Testing
Since it is not straight forward to get a DB in a state where it used system-named constraints, I have asked the community to test out this PR on their DB's

I have also tested on the following scenarios to cover as many meaningful permutations as possible.
SQL used to rename the constraint to a bogus one
`EXEC sp_rename N'DF_umbracoContentVersion_versionDate', N'DF_umbra#125498', N'OBJECT';`
- [x] test on db mentioned in issue (by the community)
- [x] test on a v10 db where the constraint in question was manually renamed
- [x] test on brand new db
- [x] test on v12.latest db
- [x] test on v10.tatest db
- [x] test on v13.0 base db
