### PR TITLE
Add the default date-with-time configuration if missing

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -88,5 +88,8 @@ public class UmbracoPlan : MigrationPlan
         // To 14.1.0
         To<V_14_1_0.MigrateRichTextConfiguration>("{FEF2DAF4-5408-4636-BB0E-B8798DF8F095}");
         To<V_14_1_0.MigrateOldRichTextSeedConfiguration>("{A385C5DF-48DC-46B4-A742-D5BB846483BC}");
+
+        // To 14.2.0
+        To<V_14_2_0.AddMissingDateTimeConfiguration>("{20ED404C-6FF9-4F91-8AC9-2B298E0002EB}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_2_0/AddMissingDateTimeConfiguration.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_2_0/AddMissingDateTimeConfiguration.cs
@@ -1,0 +1,50 @@
+﻿using NPoco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_14_2_0;
+
+public class AddMissingDateTimeConfiguration : MigrationBase
+{
+    private readonly IConfigurationEditorJsonSerializer _configurationEditorJsonSerializer;
+
+    public AddMissingDateTimeConfiguration(IMigrationContext context, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
+        : base(context)
+        => _configurationEditorJsonSerializer = configurationEditorJsonSerializer;
+
+    protected override void Migrate()
+    {
+        Sql<ISqlContext> sql = Sql()
+            .Select<DataTypeDto>()
+            .From<DataTypeDto>()
+            .Where<DataTypeDto>(dto =>
+                dto.NodeId == Constants.DataTypes.DateTime
+                && dto.EditorAlias.Equals(Constants.PropertyEditors.Aliases.DateTime));
+
+        DataTypeDto? dataTypeDto = Database.FirstOrDefault<DataTypeDto>(sql);
+        if (dataTypeDto is null)
+        {
+            return;
+        }
+
+        Dictionary<string, object> configurationData = dataTypeDto.Configuration.IsNullOrWhiteSpace()
+            ? new Dictionary<string, object>()
+            : _configurationEditorJsonSerializer
+                  .Deserialize<Dictionary<string, object?>>(dataTypeDto.Configuration)?
+                  .Where(item => item.Value is not null)
+                  .ToDictionary(item => item.Key, item => item.Value!)
+              ?? new Dictionary<string, object>();
+
+        // only proceed with the migration if the data-type has no format assigned
+        if (configurationData.TryAdd("format", "YYYY-MM-DD HH:mm:ss") is false)
+        {
+            return;
+        }
+
+        dataTypeDto.Configuration = _configurationEditorJsonSerializer.Serialize(configurationData);
+        Database.Update(dataTypeDto);
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

In V13 (and below), the default "Date Picker with time" data-type _seems_ to have a stored configuration:

![image](https://github.com/user-attachments/assets/3b153f11-6d4d-49f2-b7ad-876ee0c6a582)

But in fact, this is just a default value on the server-side implementation of `DateTimeConfiguration`:

![image](https://github.com/user-attachments/assets/43fa157b-3f6a-493c-a8c6-d63a4c1f3e01)

The database contains no configuration data for ID -36 (`Constants.DataTypes.DateTime`):

![image](https://github.com/user-attachments/assets/213bd250-cfaa-43d9-adad-b96592c6f4fa)

This works in V13, but not in V14, because the V14 UI honours the fallback/default behavior mentioned on the data-type configuration:

![image](https://github.com/user-attachments/assets/971c0709-9022-41d5-b5db-d7a5de540341)

In effect, this means that unless the default "Date Picker with time" has been explicitly saved in V13 (and thus the configuration has been persisted in the database), any upgraded "Date Picker with time" property will no longer have the time UI in V14 - they will appear and function as plan date editors.

The content property data, however, still contains the time component, so... we only need to ensure the correct configuration of the default data-type. And that's what this PR does😄 

### Testing this PR

Upgrade a default V13 database and verify that the data-type with ID -36 has the correct configuration:

![image](https://github.com/user-attachments/assets/c7ca9664-4a0b-42d8-93cf-f8a16837a31d)
