### PR TITLE
V14: Align permissions for audit log

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/GetAuditLogDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/GetAuditLogDocumentController.cs
@@ -39,7 +39,7 @@ public class GetAuditLogDocumentController : DocumentControllerBase
     {
         AuthorizationResult authorizationResult = await _authorizationService.AuthorizeResourceAsync(
             User,
-            ContentPermissionResource.WithKeys(ActionProtect.ActionLetter, id),
+            ContentPermissionResource.WithKeys(ActionBrowse.ActionLetter, id),
             AuthorizationPolicies.ContentPermissionByResource);
 
         if (!authorizationResult.Succeeded)


### PR DESCRIPTION
# Notes 
- Fixes an issue, where if a user only had access to content section and browse node permission, it would still throw an error, as audit log would fail to authenticate
- This PR fixes that issue, by using the `Browse` action letter instead of the `Protect`


# How to test
- Create some content in the content section (Use a doc type with allow as root, with no properties)
- Create a user group with access to only the content section and only browse permission
- ( I did this by changing the editor user group, disabling all permissions except for browse)
- Create a user, that is part of the user group.
- Login to the user
- Navigate to the content you created in step 1, this should no longer throw errors