### PR TITLE
Member type container in management API

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Folder/ByKeyMemberTypeFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Folder/ByKeyMemberTypeFolderController.cs
@@ -1,0 +1,25 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Folder;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.MemberType.Folder;
+
+[ApiVersion("1.0")]
+public class ByKeyDocumentTypeFolderController : MemberTypeFolderControllerBase
+{
+    public ByKeyDocumentTypeFolderController(
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
+        IContentTypeContainerService contentTypeContainerService)
+        : base(backOfficeSecurityAccessor, contentTypeContainerService)
+    {
+    }
+
+    [HttpGet("{id:guid}")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(FolderResponseModel), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> ByKey(CancellationToken cancellationToken, Guid id) => await GetFolderAsync(id);
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Folder/CreateMemberTypeFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Folder/CreateMemberTypeFolderController.cs
@@ -1,0 +1,31 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Folder;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.MemberType.Folder;
+
+[ApiVersion("1.0")]
+public class CreateMemberTypeFolderController : MemberTypeFolderControllerBase
+{
+    public CreateMemberTypeFolderController(
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
+        IContentTypeContainerService contentTypeContainerService)
+        : base(backOfficeSecurityAccessor, contentTypeContainerService)
+    {
+    }
+
+    [HttpPost]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Create(
+        CancellationToken cancellationToken,
+        CreateFolderRequestModel createFolderRequestModel)
+        => await CreateFolderAsync<ByKeyDocumentTypeFolderController>(
+            createFolderRequestModel,
+            controller => nameof(controller.ByKey)).ConfigureAwait(false);
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Folder/DeleteMemberTypeFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Folder/DeleteMemberTypeFolderController.cs
@@ -1,0 +1,25 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.MemberType.Folder;
+
+[ApiVersion("1.0")]
+public class DeleteMemberTypeFolderController : MemberTypeFolderControllerBase
+{
+    public DeleteMemberTypeFolderController(
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
+        IContentTypeContainerService contentTypeContainerService)
+        : base(backOfficeSecurityAccessor, contentTypeContainerService)
+    {
+    }
+
+    [HttpDelete("{id:guid}")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Delete(CancellationToken cancellationToken, Guid id) => await DeleteFolderAsync(id);
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Folder/MemberTypeFolderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Folder/MemberTypeFolderControllerBase.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Web.Common.Authorization;
+
+namespace Umbraco.Cms.Api.Management.Controllers.MemberType.Folder;
+
+[VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.MemberType}/folder")]
+[ApiExplorerSettings(GroupName = "Member Type")]
+[Authorize(Policy = AuthorizationPolicies.TreeAccessMemberTypes)]
+public abstract class MemberTypeFolderControllerBase : FolderManagementControllerBase<IMemberType>
+{
+    protected MemberTypeFolderControllerBase(
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
+        IMemberTypeContainerService memberTypeContainerService)
+        : base(backOfficeSecurityAccessor, memberTypeContainerService)
+    {
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Folder/UpdateMemberTypeFolderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Folder/UpdateMemberTypeFolderController.cs
@@ -1,0 +1,30 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Folder;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.MemberType.Folder;
+
+[ApiVersion("1.0")]
+public class UpdateMemberTypeFolderController : MemberTypeFolderControllerBase
+{
+    public UpdateMemberTypeFolderController(
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
+        IContentTypeContainerService contentTypeContainerService)
+        : base(backOfficeSecurityAccessor, contentTypeContainerService)
+    {
+    }
+
+    [HttpPut("{id:guid}")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Update(
+        CancellationToken cancellationToken,
+        Guid id,
+        UpdateFolderResponseModel updateFolderResponseModel)
+        => await UpdateFolderAsync(id, updateFolderResponseModel);
+}

--- a/src/Umbraco.Core/Constants-ObjectTypes.cs
+++ b/src/Umbraco.Core/Constants-ObjectTypes.cs
@@ -19,6 +19,8 @@ public static partial class Constants
 
         public static readonly Guid MediaTypeContainer = new(Strings.MediaTypeContainer);
 
+        public static readonly Guid MemberTypeContainer = new(Strings.MemberTypeContainer);
+
         public static readonly Guid DocumentBlueprintContainer = new(Strings.DocumentBlueprintContainer);
 
         public static readonly Guid DataType = new(Strings.DataType);
@@ -74,6 +76,8 @@ public static partial class Constants
             public const string DocumentTypeContainer = "2F7A2769-6B0B-4468-90DD-AF42D64F7F16";
 
             public const string MediaTypeContainer = "42AEF799-B288-4744-9B10-BE144B73CDC4";
+
+            public const string MemberTypeContainer = "59EF5767-7223-4ABC-B229-72821DC711B9";
 
             public const string DocumentBlueprintContainer = "A7EFF71B-FA69-4552-93FC-038F7DEEE453";
 

--- a/src/Umbraco.Core/Constants-UdiEntityType.cs
+++ b/src/Umbraco.Core/Constants-UdiEntityType.cs
@@ -33,14 +33,17 @@ public static partial class Constants
 
         public const string DocumentType = "document-type";
         public const string DocumentTypeContainer = "document-type-container";
-
         public const string DocumentBlueprintContainer = "document-blueprint-container";
+
         public const string MediaType = "media-type";
         public const string MediaTypeContainer = "media-type-container";
+
+        public const string MemberType = "member-type";
+        public const string MemberTypeContainer = "member-type-container";
+        public const string MemberGroup = "member-group";
+
         public const string DataType = "data-type";
         public const string DataTypeContainer = "data-type-container";
-        public const string MemberType = "member-type";
-        public const string MemberGroup = "member-group";
 
         public const string RelationType = "relation-type";
 

--- a/src/Umbraco.Core/Models/UmbracoObjectTypes.cs
+++ b/src/Umbraco.Core/Models/UmbracoObjectTypes.cs
@@ -36,14 +36,6 @@ public enum UmbracoObjectTypes
     Media,
 
     /// <summary>
-    ///     Member Type
-    /// </summary>
-    [UmbracoObjectType(Constants.ObjectTypes.Strings.MemberType, typeof(IMemberType))]
-    [FriendlyName("Member Type")]
-    [UmbracoUdiType(Constants.UdiEntityType.MemberType)]
-    MemberType,
-
-    /// <summary>
     ///     Template
     /// </summary>
     [UmbracoObjectType(Constants.ObjectTypes.Strings.Template, typeof(ITemplate))]
@@ -52,12 +44,12 @@ public enum UmbracoObjectTypes
     Template,
 
     /// <summary>
-    ///     Member Group
+    ///     Document Type
     /// </summary>
-    [UmbracoObjectType(Constants.ObjectTypes.Strings.MemberGroup, typeof(IMemberGroup))]
-    [FriendlyName("Member Group")]
-    [UmbracoUdiType(Constants.UdiEntityType.MemberGroup)]
-    MemberGroup,
+    [UmbracoObjectType(Constants.ObjectTypes.Strings.DocumentType, typeof(IContentType))]
+    [FriendlyName("Document Type")]
+    [UmbracoUdiType(Constants.UdiEntityType.DocumentType)]
+    DocumentType,
 
     /// <summary>
     ///     "Media Type
@@ -68,12 +60,20 @@ public enum UmbracoObjectTypes
     MediaType,
 
     /// <summary>
-    ///     Document Type
+    ///     Member Type
     /// </summary>
-    [UmbracoObjectType(Constants.ObjectTypes.Strings.DocumentType, typeof(IContentType))]
-    [FriendlyName("Document Type")]
-    [UmbracoUdiType(Constants.UdiEntityType.DocumentType)]
-    DocumentType,
+    [UmbracoObjectType(Constants.ObjectTypes.Strings.MemberType, typeof(IMemberType))]
+    [FriendlyName("Member Type")]
+    [UmbracoUdiType(Constants.UdiEntityType.MemberType)]
+    MemberType,
+
+    /// <summary>
+    ///     Member Group
+    /// </summary>
+    [UmbracoObjectType(Constants.ObjectTypes.Strings.MemberGroup, typeof(IMemberGroup))]
+    [FriendlyName("Member Group")]
+    [UmbracoUdiType(Constants.UdiEntityType.MemberGroup)]
+    MemberGroup,
 
     /// <summary>
     ///     Recycle Bin
@@ -113,6 +113,14 @@ public enum UmbracoObjectTypes
     [FriendlyName("Media Type Container")]
     [UmbracoUdiType(Constants.UdiEntityType.MediaTypeContainer)]
     MediaTypeContainer,
+
+    /// <summary>
+    ///     Member type container
+    /// </summary>
+    [UmbracoObjectType(Constants.ObjectTypes.Strings.MemberTypeContainer)]
+    [FriendlyName("Member Type Container")]
+    [UmbracoUdiType(Constants.UdiEntityType.MemberTypeContainer)]
+    MemberTypeContainer,
 
     /// <summary>
     ///     Media type container

--- a/src/Umbraco.Core/Services/IMemberTypeContainerService.cs
+++ b/src/Umbraco.Core/Services/IMemberTypeContainerService.cs
@@ -1,0 +1,7 @@
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Core.Services;
+
+public interface IMemberTypeContainerService : IEntityTypeContainerService<IMemberType>
+{
+}

--- a/src/Umbraco.Core/Services/Locking/MemberTypeLocks.cs
+++ b/src/Umbraco.Core/Services/Locking/MemberTypeLocks.cs
@@ -1,0 +1,9 @@
+namespace Umbraco.Cms.Core.Services.Locking;
+
+internal static class MemberTypeLocks
+{
+    // beware! order is important to avoid deadlocks
+    internal static int[] ReadLockIds { get; } = { Constants.Locks.MemberTypes };
+
+    internal static int[] WriteLockIds { get; } = { Constants.Locks.MemberTree, Constants.Locks.MemberTypes };
+}

--- a/src/Umbraco.Core/Services/MemberTypeContainerService.cs
+++ b/src/Umbraco.Core/Services/MemberTypeContainerService.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services.Locking;
+
+namespace Umbraco.Cms.Core.Services;
+
+internal sealed class MemberTypeContainerService : EntityTypeContainerService<IMemberType, IMemberTypeContainerRepository>, IMemberTypeContainerService
+{
+    public MemberTypeContainerService(
+        ICoreScopeProvider provider,
+        ILoggerFactory loggerFactory,
+        IEventMessagesFactory eventMessagesFactory,
+        IMemberTypeContainerRepository entityContainerRepository,
+        IAuditRepository auditRepository,
+        IEntityRepository entityRepository,
+        IUserIdKeyResolver userIdKeyResolver)
+        : base(provider, loggerFactory, eventMessagesFactory, entityContainerRepository, auditRepository, entityRepository, userIdKeyResolver)
+    {
+    }
+
+    protected override Guid ContainedObjectType => Constants.ObjectTypes.MemberType;
+
+    protected override UmbracoObjectTypes ContainerObjectType => UmbracoObjectTypes.MemberTypeContainer;
+
+    protected override int[] ReadLockIds => MemberTypeLocks.ReadLockIds;
+
+    protected override int[] WriteLockIds => MemberTypeLocks.WriteLockIds;
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This PR is a follow-up on https://github.com/umbraco/Umbraco-CMS/pull/14833 which wasn't merged in old backoffice.

However I think it is still relevant to support folders (containers) for member type to streamline it with document type and media type. Furthermore member type also have some recently added features like copy of member type and composition.

I found a few inconsistent in naming, e.g. `IContentTypeContainerService`, `ContentTypeContainerService` and `ContentTypeLocks`.
I think these should have been named `DocumentType` unless it was shared between multiple types.

Content type is in my opinion shared for document, media and member types.

We also use `document`, `media` and `member` naming, but it can be confusing as we also have content, media and media concept.

Perhaps there's chance to adjust to naming in future. On the other hand I am not sure if "Content Type" is the best term for the base class as it is related to content, but we also have media and member (one could argument this is content as well). Maybe Node Type" as these are possible to create in tree unlike "Element Type", which I also considered is should be separated from document types tree https://github.com/umbraco/Umbraco-CMS/discussions/15082 if element types can be shared between document, media and member types, e.g. a simple SoMe block.

It was a bit off topic. I think it would be great to have folders/containers for member types as well and I guess some logic later could be moved to some base classes and document, media and member type implements much of the same logic.