### PR TITLE
Support parentId in document/media item search endpoints

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/SearchDocumentItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/SearchDocumentItemController.cs
@@ -10,6 +10,7 @@ using Umbraco.Cms.Core.Services;
 namespace Umbraco.Cms.Api.Management.Controllers.Document.Item;
 
 [ApiVersion("1.0")]
+[ApiVersion("1.1")]
 public class SearchDocumentItemController : DocumentItemControllerBase
 {
     private readonly IIndexedEntitySearchService _indexedEntitySearchService;
@@ -25,23 +26,14 @@ public class SearchDocumentItemController : DocumentItemControllerBase
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedModel<DocumentItemResponseModel>), StatusCodes.Status200OK)]
     public async Task<IActionResult> Search(CancellationToken cancellationToken, string query, int skip = 0, int take = 100)
-    {
-        PagedModel<IEntitySlim> searchResult = _indexedEntitySearchService.Search(UmbracoObjectTypes.Document, query, skip, take);
-        var result = new PagedModel<DocumentItemResponseModel>
-        {
-            Items = searchResult.Items.OfType<IDocumentEntitySlim>().Select(_documentPresentationFactory.CreateItemResponseModel),
-            Total = searchResult.Total,
-        };
+        => await Search1_1(cancellationToken, query, skip, take);
 
-        return await Task.FromResult(Ok(result));
-    }
-
-    [HttpGet("{id:guid}/search")]
-    [MapToApiVersion("1.0")]
+    [HttpGet("search")]
+    [MapToApiVersion("1.1")]
     [ProducesResponseType(typeof(PagedModel<DocumentItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Search(CancellationToken cancellationToken, string query, Guid id, int skip = 0, int take = 100)
+    public async Task<IActionResult> Search1_1(CancellationToken cancellationToken, string query, int skip = 0, int take = 100, Guid? parentId = null)
     {
-        PagedModel<IEntitySlim> searchResult = _indexedEntitySearchService.Search(UmbracoObjectTypes.Document, query, id, skip, take);
+        PagedModel<IEntitySlim> searchResult = _indexedEntitySearchService.Search(UmbracoObjectTypes.Document, query, parentId, skip, take);
         var result = new PagedModel<DocumentItemResponseModel>
         {
             Items = searchResult.Items.OfType<IDocumentEntitySlim>().Select(_documentPresentationFactory.CreateItemResponseModel),

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/SearchDocumentItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/SearchDocumentItemController.cs
@@ -22,14 +22,13 @@ public class SearchDocumentItemController : DocumentItemControllerBase
         _documentPresentationFactory = documentPresentationFactory;
     }
 
-    [HttpGet("search")]
-    [MapToApiVersion("1.0")]
-    [ProducesResponseType(typeof(PagedModel<DocumentItemResponseModel>), StatusCodes.Status200OK)]
+    [NonAction]
+    [Obsolete("Scheduled to be removed in v16, use the non obsoleted method instead")]
     public async Task<IActionResult> Search(CancellationToken cancellationToken, string query, int skip = 0, int take = 100)
         => await Search1_1(cancellationToken, query, skip, take);
 
     [HttpGet("search")]
-    [MapToApiVersion("1.1")]
+    [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedModel<DocumentItemResponseModel>), StatusCodes.Status200OK)]
     public async Task<IActionResult> Search1_1(CancellationToken cancellationToken, string query, int skip = 0, int take = 100, Guid? parentId = null)
     {

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/SearchDocumentItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/SearchDocumentItemController.cs
@@ -10,7 +10,6 @@ using Umbraco.Cms.Core.Services;
 namespace Umbraco.Cms.Api.Management.Controllers.Document.Item;
 
 [ApiVersion("1.0")]
-[ApiVersion("1.1")]
 public class SearchDocumentItemController : DocumentItemControllerBase
 {
     private readonly IIndexedEntitySearchService _indexedEntitySearchService;
@@ -25,12 +24,12 @@ public class SearchDocumentItemController : DocumentItemControllerBase
     [NonAction]
     [Obsolete("Scheduled to be removed in v16, use the non obsoleted method instead")]
     public async Task<IActionResult> Search(CancellationToken cancellationToken, string query, int skip = 0, int take = 100)
-        => await Search1_1(cancellationToken, query, skip, take);
+        => await SearchFromParent(cancellationToken, query, skip, take);
 
     [HttpGet("search")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedModel<DocumentItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Search1_1(CancellationToken cancellationToken, string query, int skip = 0, int take = 100, Guid? parentId = null)
+    public async Task<IActionResult> SearchFromParent(CancellationToken cancellationToken, string query, int skip = 0, int take = 100, Guid? parentId = null)
     {
         PagedModel<IEntitySlim> searchResult = _indexedEntitySearchService.Search(UmbracoObjectTypes.Document, query, parentId, skip, take);
         var result = new PagedModel<DocumentItemResponseModel>

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/SearchDocumentItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/SearchDocumentItemController.cs
@@ -30,7 +30,22 @@ public class SearchDocumentItemController : DocumentItemControllerBase
         var result = new PagedModel<DocumentItemResponseModel>
         {
             Items = searchResult.Items.OfType<IDocumentEntitySlim>().Select(_documentPresentationFactory.CreateItemResponseModel),
-            Total = searchResult.Total
+            Total = searchResult.Total,
+        };
+
+        return await Task.FromResult(Ok(result));
+    }
+
+    [HttpGet("{id:guid}/search")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(PagedModel<DocumentItemResponseModel>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> Search(CancellationToken cancellationToken, string query, Guid id, int skip = 0, int take = 100)
+    {
+        PagedModel<IEntitySlim> searchResult = _indexedEntitySearchService.Search(UmbracoObjectTypes.Document, query, id, skip, take);
+        var result = new PagedModel<DocumentItemResponseModel>
+        {
+            Items = searchResult.Items.OfType<IDocumentEntitySlim>().Select(_documentPresentationFactory.CreateItemResponseModel),
+            Total = searchResult.Total,
         };
 
         return await Task.FromResult(Ok(result));

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/SearchMediaItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/SearchMediaItemController.cs
@@ -10,7 +10,6 @@ using Umbraco.Cms.Core.Services;
 namespace Umbraco.Cms.Api.Management.Controllers.Media.Item;
 
 [ApiVersion("1.0")]
-[ApiVersion("1.1")]
 public class SearchMediaItemController : MediaItemControllerBase
 {
     private readonly IIndexedEntitySearchService _indexedEntitySearchService;
@@ -25,12 +24,12 @@ public class SearchMediaItemController : MediaItemControllerBase
     [NonAction]
     [Obsolete("Scheduled to be removed in v16, use the non obsoleted method instead")]
     public async Task<IActionResult> Search(CancellationToken cancellationToken, string query, int skip = 0, int take = 100)
-        => await Search1_1(cancellationToken, query, skip, take, null);
+        => await SearchFromParent(cancellationToken, query, skip, take, null);
 
     [HttpGet("search")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedModel<MediaItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Search1_1(CancellationToken cancellationToken, string query, int skip = 0, int take = 100, Guid? parentId = null)
+    public async Task<IActionResult> SearchFromParent(CancellationToken cancellationToken, string query, int skip = 0, int take = 100, Guid? parentId = null)
     {
         PagedModel<IEntitySlim> searchResult = _indexedEntitySearchService.Search(UmbracoObjectTypes.Media, query, parentId, skip, take);
         var result = new PagedModel<MediaItemResponseModel>

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/SearchMediaItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/SearchMediaItemController.cs
@@ -24,15 +24,18 @@ public class SearchMediaItemController : MediaItemControllerBase
     [HttpGet("search")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedModel<MediaItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Search(CancellationToken cancellationToken, string query, int skip = 0, int take = 100)
+    public async Task<IActionResult> Search2(CancellationToken cancellationToken, string query, int skip = 0, int take = 100, Guid? parentId = null)
     {
-        PagedModel<IEntitySlim> searchResult = _indexedEntitySearchService.Search(UmbracoObjectTypes.Media, query, skip, take);
+        PagedModel<IEntitySlim> searchResult = _indexedEntitySearchService.Search(UmbracoObjectTypes.Media, query, parentId, skip, take);
         var result = new PagedModel<MediaItemResponseModel>
         {
             Items = searchResult.Items.OfType<IMediaEntitySlim>().Select(_mediaPresentationFactory.CreateItemResponseModel),
-            Total = searchResult.Total
+            Total = searchResult.Total,
         };
 
         return await Task.FromResult(Ok(result));
     }
+
+    public async Task<IActionResult> Search(CancellationToken cancellationToken, string query, int skip = 0, int take = 100)
+        => await Search2(cancellationToken, query, skip, take, null);
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/SearchMediaItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/SearchMediaItemController.cs
@@ -10,6 +10,7 @@ using Umbraco.Cms.Core.Services;
 namespace Umbraco.Cms.Api.Management.Controllers.Media.Item;
 
 [ApiVersion("1.0")]
+[ApiVersion("1.1")]
 public class SearchMediaItemController : MediaItemControllerBase
 {
     private readonly IIndexedEntitySearchService _indexedEntitySearchService;
@@ -24,7 +25,13 @@ public class SearchMediaItemController : MediaItemControllerBase
     [HttpGet("search")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedModel<MediaItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Search2(CancellationToken cancellationToken, string query, int skip = 0, int take = 100, Guid? parentId = null)
+    public async Task<IActionResult> Search(CancellationToken cancellationToken, string query, int skip = 0, int take = 100)
+        => await Search1_1(cancellationToken, query, skip, take, null);
+
+    [HttpGet("search")]
+    [MapToApiVersion("1.1")]
+    [ProducesResponseType(typeof(PagedModel<MediaItemResponseModel>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> Search1_1(CancellationToken cancellationToken, string query, int skip = 0, int take = 100, Guid? parentId = null)
     {
         PagedModel<IEntitySlim> searchResult = _indexedEntitySearchService.Search(UmbracoObjectTypes.Media, query, parentId, skip, take);
         var result = new PagedModel<MediaItemResponseModel>
@@ -35,7 +42,4 @@ public class SearchMediaItemController : MediaItemControllerBase
 
         return await Task.FromResult(Ok(result));
     }
-
-    public async Task<IActionResult> Search(CancellationToken cancellationToken, string query, int skip = 0, int take = 100)
-        => await Search2(cancellationToken, query, skip, take, null);
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/SearchMediaItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/SearchMediaItemController.cs
@@ -22,14 +22,13 @@ public class SearchMediaItemController : MediaItemControllerBase
         _mediaPresentationFactory = mediaPresentationFactory;
     }
 
-    [HttpGet("search")]
-    [MapToApiVersion("1.0")]
-    [ProducesResponseType(typeof(PagedModel<MediaItemResponseModel>), StatusCodes.Status200OK)]
+    [NonAction]
+    [Obsolete("Scheduled to be removed in v16, use the non obsoleted method instead")]
     public async Task<IActionResult> Search(CancellationToken cancellationToken, string query, int skip = 0, int take = 100)
         => await Search1_1(cancellationToken, query, skip, take, null);
 
     [HttpGet("search")]
-    [MapToApiVersion("1.1")]
+    [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedModel<MediaItemResponseModel>), StatusCodes.Status200OK)]
     public async Task<IActionResult> Search1_1(CancellationToken cancellationToken, string query, int skip = 0, int take = 100, Guid? parentId = null)
     {

--- a/src/Umbraco.Core/Services/IIndexedEntitySearchService.cs
+++ b/src/Umbraco.Core/Services/IIndexedEntitySearchService.cs
@@ -12,5 +12,8 @@ namespace Umbraco.Cms.Core.Services;
 /// </remarks>
 public interface IIndexedEntitySearchService
 {
-    PagedModel<IEntitySlim> Search(UmbracoObjectTypes objectType, string query, int skip = 0, int take = 100, bool ignoreUserStartNodes = false);
+    PagedModel<IEntitySlim> Search(UmbracoObjectTypes objectType, string query, Guid? startFrom, int skip = 0, int take = 100, bool ignoreUserStartNodes = false );
+
+    PagedModel<IEntitySlim> Search(UmbracoObjectTypes objectType, string query, int skip = 0, int take = 100, bool ignoreUserStartNodes = false)
+        => Search(objectType, query, null, skip, take, ignoreUserStartNodes);
 }

--- a/src/Umbraco.Core/Services/IIndexedEntitySearchService.cs
+++ b/src/Umbraco.Core/Services/IIndexedEntitySearchService.cs
@@ -12,8 +12,9 @@ namespace Umbraco.Cms.Core.Services;
 /// </remarks>
 public interface IIndexedEntitySearchService
 {
-    PagedModel<IEntitySlim> Search(UmbracoObjectTypes objectType, string query, int skip = 0, int take = 100, bool ignoreUserStartNodes = false)
-        => Search(objectType, query, null, skip, take, ignoreUserStartNodes);
+    PagedModel<IEntitySlim> Search(UmbracoObjectTypes objectType, string query, int skip = 0, int take = 100, bool ignoreUserStartNodes = false);
 
-    PagedModel<IEntitySlim> Search(UmbracoObjectTypes objectType, string query, Guid? startFrom, int skip = 0, int take = 100, bool ignoreUserStartNodes = false);
+    // default implementation to avoid breaking changes falls back to old behaviour
+    PagedModel<IEntitySlim> Search(UmbracoObjectTypes objectType, string query, Guid? parentId, int skip = 0, int take = 100, bool ignoreUserStartNodes = false)
+        => Search(objectType,query, skip, take, ignoreUserStartNodes);
 }

--- a/src/Umbraco.Core/Services/IIndexedEntitySearchService.cs
+++ b/src/Umbraco.Core/Services/IIndexedEntitySearchService.cs
@@ -12,8 +12,8 @@ namespace Umbraco.Cms.Core.Services;
 /// </remarks>
 public interface IIndexedEntitySearchService
 {
-    PagedModel<IEntitySlim> Search(UmbracoObjectTypes objectType, string query, Guid? startFrom, int skip = 0, int take = 100, bool ignoreUserStartNodes = false );
-
     PagedModel<IEntitySlim> Search(UmbracoObjectTypes objectType, string query, int skip = 0, int take = 100, bool ignoreUserStartNodes = false)
         => Search(objectType, query, null, skip, take, ignoreUserStartNodes);
+
+    PagedModel<IEntitySlim> Search(UmbracoObjectTypes objectType, string query, Guid? startFrom, int skip = 0, int take = 100, bool ignoreUserStartNodes = false);
 }

--- a/src/Umbraco.Examine.Lucene/BackOfficeExamineSearcher.cs
+++ b/src/Umbraco.Examine.Lucene/BackOfficeExamineSearcher.cs
@@ -356,8 +356,16 @@ public class BackOfficeExamineSearcher : IBackOfficeExamineSearcher
             throw new ArgumentNullException(nameof(entityService));
         }
 
-        UdiParser.TryParse(searchFrom, true, out Udi? udi);
-        searchFrom = udi == null ? searchFrom : entityService.GetId(udi).Result.ToString();
+        if (Guid.TryParse(searchFrom, out Guid guid))
+        {
+            searchFrom = entityService.GetId(guid, objectType).Result.ToString();
+        }
+        else
+        {
+            // fallback to Udi for legacy reasons as the calling methods take string?
+            UdiParser.TryParse(searchFrom, true, out Udi? udi);
+            searchFrom = udi == null ? searchFrom : entityService.GetId(udi).Result.ToString();
+        }
 
         TreeEntityPath? entityPath =
             int.TryParse(searchFrom, NumberStyles.Integer, CultureInfo.InvariantCulture, out var searchFromId) &&

--- a/src/Umbraco.Infrastructure/Services/Implement/IndexedEntitySearchService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/IndexedEntitySearchService.cs
@@ -19,7 +19,13 @@ internal sealed class IndexedEntitySearchService : IIndexedEntitySearchService
         _entityService = entityService;
     }
 
-    public PagedModel<IEntitySlim> Search(UmbracoObjectTypes objectType, string query, int skip = 0, int take = 100, bool ignoreUserStartNodes = false)
+    public PagedModel<IEntitySlim> Search(
+        UmbracoObjectTypes objectType,
+        string query,
+        Guid? startFrom,
+        int skip = 0,
+        int take = 100,
+        bool ignoreUserStartNodes = false)
     {
         UmbracoEntityTypes entityType = objectType switch
         {
@@ -37,7 +43,8 @@ internal sealed class IndexedEntitySearchService : IIndexedEntitySearchService
             pageSize,
             pageNumber,
             out var totalFound,
-            ignoreUserStartNodes: ignoreUserStartNodes);
+            ignoreUserStartNodes: ignoreUserStartNodes,
+            searchFrom: startFrom?.ToString());
 
         Guid[] keys = searchResults.Select(
                 result =>
@@ -56,4 +63,7 @@ internal sealed class IndexedEntitySearchService : IIndexedEntitySearchService
             Total = totalFound
         };
     }
+
+    public PagedModel<IEntitySlim> Search(UmbracoObjectTypes objectType, string query, int skip = 0, int take = 100, bool ignoreUserStartNodes = false)
+        => Search(objectType, query, null, skip, take, ignoreUserStartNodes);
 }

--- a/src/Umbraco.Infrastructure/Services/Implement/IndexedEntitySearchService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/IndexedEntitySearchService.cs
@@ -25,7 +25,7 @@ internal sealed class IndexedEntitySearchService : IIndexedEntitySearchService
     public PagedModel<IEntitySlim> Search(
         UmbracoObjectTypes objectType,
         string query,
-        Guid? startFrom,
+        Guid? parentId,
         int skip = 0,
         int take = 100,
         bool ignoreUserStartNodes = false)
@@ -47,7 +47,7 @@ internal sealed class IndexedEntitySearchService : IIndexedEntitySearchService
             pageNumber,
             out var totalFound,
             ignoreUserStartNodes: ignoreUserStartNodes,
-            searchFrom: startFrom?.ToString());
+            searchFrom: parentId?.ToString());
 
         Guid[] keys = searchResults.Select(
                 result =>

--- a/src/Umbraco.Infrastructure/Services/Implement/IndexedEntitySearchService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/IndexedEntitySearchService.cs
@@ -19,6 +19,9 @@ internal sealed class IndexedEntitySearchService : IIndexedEntitySearchService
         _entityService = entityService;
     }
 
+    public PagedModel<IEntitySlim> Search(UmbracoObjectTypes objectType, string query, int skip = 0, int take = 100, bool ignoreUserStartNodes = false)
+        => Search(objectType, query, null, skip, take, ignoreUserStartNodes);
+
     public PagedModel<IEntitySlim> Search(
         UmbracoObjectTypes objectType,
         string query,
@@ -63,7 +66,4 @@ internal sealed class IndexedEntitySearchService : IIndexedEntitySearchService
             Total = totalFound
         };
     }
-
-    public PagedModel<IEntitySlim> Search(UmbracoObjectTypes objectType, string query, int skip = 0, int take = 100, bool ignoreUserStartNodes = false)
-        => Search(objectType, query, null, skip, take, ignoreUserStartNodes);
 }


### PR DESCRIPTION
### Description
The document/media item search endpoints need to be enhanced with the ability to limit the search results based on the parentId for certain pickers to work better.

### Testing
Setting up a multi layer content structure (root-parents-children) and querying the updated endpoint with one of the parent ids should only return (some) of that parent's children.
Leaving out the parentId should work just like the old endpoint.
