### PR TITLE
Fix `IContentBase.GetUdi()` extension method to support document-blueprint entity type

### DIFF
--- a/src/Umbraco.Core/Extensions/UdiGetterExtensions.cs
+++ b/src/Umbraco.Core/Extensions/UdiGetterExtensions.cs
@@ -8,7 +8,7 @@ using Umbraco.Cms.Core.Models.Entities;
 namespace Umbraco.Extensions;
 
 /// <summary>
-/// Provides extension methods that return udis for Umbraco entities.
+/// Provides extension methods that return UDIs for Umbraco entities.
 /// </summary>
 public static class UdiGetterExtensions
 {
@@ -19,11 +19,177 @@ public static class UdiGetterExtensions
     /// <returns>
     /// The entity identifier of the entity.
     /// </returns>
-    public static GuidUdi GetUdi(this ITemplate entity)
+    public static Udi GetUdi(this IEntity entity)
     {
         ArgumentNullException.ThrowIfNull(entity);
 
-        return new GuidUdi(Constants.UdiEntityType.Template, entity.Key).EnsureClosed();
+        return entity switch
+        {
+            // Concrete types
+            EntityContainer container => container.GetUdi(),
+            Script script => script.GetUdi(),
+            Stylesheet stylesheet => stylesheet.GetUdi(),
+            // Interfaces
+            IContentBase contentBase => contentBase.GetUdi(),
+            IContentTypeComposition contentTypeComposition => contentTypeComposition.GetUdi(),
+            IDataType dataType => dataType.GetUdi(),
+            IDictionaryItem dictionaryItem => dictionaryItem.GetUdi(),
+            ILanguage language => language.GetUdi(),
+            IMemberGroup memberGroup => memberGroup.GetUdi(),
+            IPartialView partialView => partialView.GetUdi(),
+            IRelationType relationType => relationType.GetUdi(),
+            ITemplate template => template.GetUdi(),
+            IWebhook webhook => webhook.GetUdi(),
+            _ => throw new NotSupportedException($"Entity type {entity.GetType().FullName} is not supported."),
+        };
+    }
+
+    /// <summary>
+    /// Gets the entity identifier of the entity.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
+    public static GuidUdi GetUdi(this EntityContainer entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        string entityType;
+        if (entity.ContainedObjectType == Constants.ObjectTypes.DataType)
+        {
+            entityType = Constants.UdiEntityType.DataTypeContainer;
+        }
+        else if (entity.ContainedObjectType == Constants.ObjectTypes.DocumentType)
+        {
+            entityType = Constants.UdiEntityType.DocumentTypeContainer;
+        }
+        else if (entity.ContainedObjectType == Constants.ObjectTypes.MediaType)
+        {
+            entityType = Constants.UdiEntityType.MediaTypeContainer;
+        }
+        else if (entity.ContainedObjectType == Constants.ObjectTypes.DocumentBlueprint)
+        {
+            entityType = Constants.UdiEntityType.DocumentBlueprintContainer;
+        }
+        else
+        {
+            throw new NotSupportedException($"Contained object type {entity.ContainedObjectType} is not supported.");
+        }
+
+        return new GuidUdi(entityType, entity.Key).EnsureClosed();
+    }
+
+    /// <summary>
+    /// Gets the entity identifier of the entity.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
+    public static StringUdi GetUdi(this Script entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        return GetUdiFromPath(Constants.UdiEntityType.Script, entity.Path);
+    }
+
+    /// <summary>
+    /// Gets the entity identifier of the entity.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
+    public static StringUdi GetUdi(this Stylesheet entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        return GetUdiFromPath(Constants.UdiEntityType.Stylesheet, entity.Path);
+    }
+
+    /// <summary>
+    /// Gets the entity identifier of the entity.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
+    public static GuidUdi GetUdi(this IContentBase entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        return entity switch
+        {
+            IContent content => content.GetUdi(),
+            IMedia media => media.GetUdi(),
+            IMember member => member.GetUdi(),
+            _ => throw new NotSupportedException($"Content base type {entity.GetType().FullName} is not supported."),
+        };
+    }
+
+    /// <summary>
+    /// Gets the entity identifier of the entity.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
+    public static GuidUdi GetUdi(this IContent entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        string entityType = entity.Blueprint ? Constants.UdiEntityType.DocumentBlueprint : Constants.UdiEntityType.Document;
+
+        return new GuidUdi(entityType, entity.Key).EnsureClosed();
+    }
+
+    /// <summary>
+    /// Gets the entity identifier of the entity.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
+    public static GuidUdi GetUdi(this IMedia entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        return new GuidUdi(Constants.UdiEntityType.Media, entity.Key).EnsureClosed();
+    }
+
+    /// <summary>
+    /// Gets the entity identifier of the entity.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
+    public static GuidUdi GetUdi(this IMember entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        return new GuidUdi(Constants.UdiEntityType.Member, entity.Key).EnsureClosed();
+    }
+
+    /// <summary>
+    /// Gets the entity identifier of the entity.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
+    public static GuidUdi GetUdi(this IContentTypeComposition entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        return entity switch
+        {
+            IContentType contentType => contentType.GetUdi(),
+            IMediaType mediaType => mediaType.GetUdi(),
+            IMemberType memberType => memberType.GetUdi(),
+            _ => throw new NotSupportedException($"Composition type {entity.GetType().FullName} is not supported."),
+        };
     }
 
     /// <summary>
@@ -75,170 +241,11 @@ public static class UdiGetterExtensions
     /// <returns>
     /// The entity identifier of the entity.
     /// </returns>
-    public static GuidUdi GetUdi(this IMemberGroup entity)
-    {
-        ArgumentNullException.ThrowIfNull(entity);
-
-        return new GuidUdi(Constants.UdiEntityType.MemberGroup, entity.Key).EnsureClosed();
-    }
-
-    /// <summary>
-    /// Gets the entity identifier of the entity.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <returns>
-    /// The entity identifier of the entity.
-    /// </returns>
-    public static GuidUdi GetUdi(this IContentTypeComposition entity)
-    {
-        ArgumentNullException.ThrowIfNull(entity);
-
-        string entityType = entity switch
-        {
-            IContentType => Constants.UdiEntityType.DocumentType,
-            IMediaType => Constants.UdiEntityType.MediaType,
-            IMemberType => Constants.UdiEntityType.MemberType,
-            _ => throw new NotSupportedException(string.Format("Composition type {0} is not supported.", entity.GetType().FullName)),
-        };
-
-        return new GuidUdi(entityType, entity.Key).EnsureClosed();
-    }
-
-    /// <summary>
-    /// Gets the entity identifier of the entity.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <returns>
-    /// The entity identifier of the entity.
-    /// </returns>
     public static GuidUdi GetUdi(this IDataType entity)
     {
         ArgumentNullException.ThrowIfNull(entity);
 
         return new GuidUdi(Constants.UdiEntityType.DataType, entity.Key).EnsureClosed();
-    }
-
-    /// <summary>
-    /// Gets the entity identifier of the entity.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <returns>
-    /// The entity identifier of the entity.
-    /// </returns>
-    public static GuidUdi GetUdi(this EntityContainer entity)
-    {
-        ArgumentNullException.ThrowIfNull(entity);
-
-        string entityType;
-        if (entity.ContainedObjectType == Constants.ObjectTypes.DataType)
-        {
-            entityType = Constants.UdiEntityType.DataTypeContainer;
-        }
-        else if (entity.ContainedObjectType == Constants.ObjectTypes.DocumentType)
-        {
-            entityType = Constants.UdiEntityType.DocumentTypeContainer;
-        }
-        else if (entity.ContainedObjectType == Constants.ObjectTypes.MediaType)
-        {
-            entityType = Constants.UdiEntityType.MediaTypeContainer;
-        }
-        else if (entity.ContainedObjectType == Constants.ObjectTypes.DocumentBlueprint)
-        {
-            entityType = Constants.UdiEntityType.DocumentBlueprintContainer;
-        }
-        else
-        {
-            throw new NotSupportedException(string.Format("Contained object type {0} is not supported.", entity.ContainedObjectType));
-        }
-
-        return new GuidUdi(entityType, entity.Key).EnsureClosed();
-    }
-
-    /// <summary>
-    /// Gets the entity identifier of the entity.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <returns>
-    /// The entity identifier of the entity.
-    /// </returns>
-    public static GuidUdi GetUdi(this IMedia entity)
-    {
-        ArgumentNullException.ThrowIfNull(entity);
-
-        return new GuidUdi(Constants.UdiEntityType.Media, entity.Key).EnsureClosed();
-    }
-
-    /// <summary>
-    /// Gets the entity identifier of the entity.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <returns>
-    /// The entity identifier of the entity.
-    /// </returns>
-    public static GuidUdi GetUdi(this IContent entity)
-    {
-        ArgumentNullException.ThrowIfNull(entity);
-
-        string entityType = entity.Blueprint ? Constants.UdiEntityType.DocumentBlueprint : Constants.UdiEntityType.Document;
-
-        return new GuidUdi(entityType, entity.Key).EnsureClosed();
-    }
-
-    /// <summary>
-    /// Gets the entity identifier of the entity.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <returns>
-    /// The entity identifier of the entity.
-    /// </returns>
-    public static GuidUdi GetUdi(this IMember entity)
-    {
-        ArgumentNullException.ThrowIfNull(entity);
-
-        return new GuidUdi(Constants.UdiEntityType.Member, entity.Key).EnsureClosed();
-    }
-
-    /// <summary>
-    /// Gets the entity identifier of the entity.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <returns>
-    /// The entity identifier of the entity.
-    /// </returns>
-    public static StringUdi GetUdi(this Stylesheet entity)
-    {
-        ArgumentNullException.ThrowIfNull(entity);
-
-        return GetUdiFromPath(Constants.UdiEntityType.Stylesheet, entity.Path);
-    }
-
-    /// <summary>
-    /// Gets the entity identifier of the entity.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <returns>
-    /// The entity identifier of the entity.
-    /// </returns>
-    public static StringUdi GetUdi(this Script entity)
-    {
-        ArgumentNullException.ThrowIfNull(entity);
-
-        return GetUdiFromPath(Constants.UdiEntityType.Script, entity.Path);
-    }
-
-    /// <summary>
-    /// Gets the UDI from a path.
-    /// </summary>
-    /// <param name="entityType">The type of the entity.</param>
-    /// <param name="path">The path.</param>
-    /// <returns>
-    /// The entity identifier of the entity.
-    /// </returns>
-    private static StringUdi GetUdiFromPath(string entityType, string path)
-    {
-        string id = path.TrimStart(Constants.CharArrays.ForwardSlash).Replace("\\", "/");
-
-        return new StringUdi(entityType, id).EnsureClosed();
     }
 
     /// <summary>
@@ -262,11 +269,11 @@ public static class UdiGetterExtensions
     /// <returns>
     /// The entity identifier of the entity.
     /// </returns>
-    public static StringUdi GetUdi(this IPartialView entity)
+    public static StringUdi GetUdi(this ILanguage entity)
     {
         ArgumentNullException.ThrowIfNull(entity);
 
-        return GetUdiFromPath(Constants.UdiEntityType.PartialView, entity.Path);
+        return new StringUdi(Constants.UdiEntityType.Language, entity.IsoCode).EnsureClosed();
     }
 
     /// <summary>
@@ -276,17 +283,25 @@ public static class UdiGetterExtensions
     /// <returns>
     /// The entity identifier of the entity.
     /// </returns>
-    public static GuidUdi GetUdi(this IContentBase entity)
+    public static GuidUdi GetUdi(this IMemberGroup entity)
     {
         ArgumentNullException.ThrowIfNull(entity);
 
-        return entity switch
-        {
-            IContent content => content.GetUdi(),
-            IMedia media => media.GetUdi(),
-            IMember member => member.GetUdi(),
-            _ => throw new NotSupportedException($"Content base type {entity.GetType().FullName} is not supported."),
-        };
+        return new GuidUdi(Constants.UdiEntityType.MemberGroup, entity.Key).EnsureClosed();
+    }
+
+    /// <summary>
+    /// Gets the entity identifier of the entity.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
+    public static StringUdi GetUdi(this IPartialView entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        return GetUdiFromPath(Constants.UdiEntityType.PartialView, entity.Path);
     }
 
     /// <summary>
@@ -310,6 +325,20 @@ public static class UdiGetterExtensions
     /// <returns>
     /// The entity identifier of the entity.
     /// </returns>
+    public static GuidUdi GetUdi(this ITemplate entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        return new GuidUdi(Constants.UdiEntityType.Template, entity.Key).EnsureClosed();
+    }
+
+    /// <summary>
+    /// Gets the entity identifier of the entity.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
     public static GuidUdi GetUdi(this IWebhook entity)
     {
         ArgumentNullException.ThrowIfNull(entity);
@@ -318,56 +347,17 @@ public static class UdiGetterExtensions
     }
 
     /// <summary>
-    /// Gets the entity identifier of the entity.
+    /// Gets the UDI from a path.
     /// </summary>
-    /// <param name="entity">The entity.</param>
+    /// <param name="entityType">The type of the entity.</param>
+    /// <param name="path">The path.</param>
     /// <returns>
     /// The entity identifier of the entity.
     /// </returns>
-    public static StringUdi GetUdi(this ILanguage entity)
+    private static StringUdi GetUdiFromPath(string entityType, string path)
     {
-        ArgumentNullException.ThrowIfNull(entity);
+        string id = path.TrimStart(Constants.CharArrays.ForwardSlash).Replace("\\", "/");
 
-        return new StringUdi(Constants.UdiEntityType.Language, entity.IsoCode).EnsureClosed();
-    }
-
-    /// <summary>
-    /// Gets the entity identifier of the entity.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <returns>
-    /// The entity identifier of the entity.
-    /// </returns>
-    public static Udi GetUdi(this IEntity entity)
-    {
-        ArgumentNullException.ThrowIfNull(entity);
-
-        return entity switch
-        {
-            // Concrete types
-            EntityContainer container => container.GetUdi(),
-            Stylesheet stylesheet => stylesheet.GetUdi(),
-            Script script => script.GetUdi(),
-            // Content types
-            IContentType contentType => contentType.GetUdi(),
-            IMediaType mediaType => mediaType.GetUdi(),
-            IMemberType memberType => memberType.GetUdi(),
-            IContentTypeComposition contentTypeComposition => contentTypeComposition.GetUdi(),
-            // Content
-            IContent content => content.GetUdi(),
-            IMedia media => media.GetUdi(),
-            IMember member => member.GetUdi(),
-            IContentBase contentBase => contentBase.GetUdi(),
-            // Other
-            IDataType dataTypeComposition => dataTypeComposition.GetUdi(),
-            IDictionaryItem dictionaryItem => dictionaryItem.GetUdi(),
-            ILanguage language => language.GetUdi(),
-            IMemberGroup memberGroup => memberGroup.GetUdi(),
-            IPartialView partialView => partialView.GetUdi(),
-            IRelationType relationType => relationType.GetUdi(),
-            ITemplate template => template.GetUdi(),
-            IWebhook webhook => webhook.GetUdi(),
-            _ => throw new NotSupportedException(string.Format("Entity type {0} is not supported.", entity.GetType().FullName)),
-        };
+        return new StringUdi(entityType, id).EnsureClosed();
     }
 }

--- a/src/Umbraco.Core/Extensions/UdiGetterExtensions.cs
+++ b/src/Umbraco.Core/Extensions/UdiGetterExtensions.cs
@@ -280,15 +280,13 @@ public static class UdiGetterExtensions
     {
         ArgumentNullException.ThrowIfNull(entity);
 
-        string type = entity switch
+        return entity switch
         {
-            IContent => Constants.UdiEntityType.Document,
-            IMedia => Constants.UdiEntityType.Media,
-            IMember => Constants.UdiEntityType.Member,
-            _ => throw new NotSupportedException(string.Format("Content base type {0} is not supported.", entity.GetType().FullName)),
+            IContent content => content.GetUdi(),
+            IMedia media => media.GetUdi(),
+            IMember member => member.GetUdi(),
+            _ => throw new NotSupportedException($"Content base type {entity.GetType().FullName} is not supported."),
         };
-
-        return new GuidUdi(type, entity.Key).EnsureClosed();
     }
 
     /// <summary>

--- a/tests/Umbraco.Tests.Common/Builders/ContentBuilder.cs
+++ b/tests/Umbraco.Tests.Common/Builders/ContentBuilder.cs
@@ -53,6 +53,7 @@ public class ContentBuilder
     private int? _sortOrder;
     private bool? _trashed;
     private DateTime? _updateDate;
+    private bool? _blueprint;
     private int? _versionId;
 
     DateTime? IWithCreateDateBuilder.CreateDate
@@ -145,6 +146,13 @@ public class ContentBuilder
         set => _updateDate = value;
     }
 
+    public ContentBuilder WithBlueprint(bool blueprint)
+    {
+        _blueprint = blueprint;
+
+        return this;
+    }
+
     public ContentBuilder WithVersionId(int versionId)
     {
         _versionId = versionId;
@@ -217,6 +225,7 @@ public class ContentBuilder
     {
         var id = _id ?? 0;
         var versionId = _versionId ?? 0;
+        var blueprint = _blueprint ?? false;
         var key = _key ?? Guid.NewGuid();
         var parentId = _parentId ?? -1;
         var parent = _parent;
@@ -253,6 +262,7 @@ public class ContentBuilder
 
         content.Id = id;
         content.VersionId = versionId;
+        content.Blueprint = blueprint;
         content.Key = key;
         content.CreateDate = createDate;
         content.UpdateDate = updateDate;

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/UdiGetterExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/UdiGetterExtensionsTests.cs
@@ -3,6 +3,7 @@
 
 using NUnit.Framework;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
@@ -13,15 +14,22 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Extensions;
 [TestFixture]
 public class UdiGetterExtensionsTests
 {
-    [TestCase("style.css", "umb://stylesheet/style.css")]
-    [TestCase("editor\\style.css", "umb://stylesheet/editor/style.css")]
-    [TestCase("editor/style.css", "umb://stylesheet/editor/style.css")]
-    public void GetUdiForStylesheet(string path, string expected)
+    [TestCase(Constants.ObjectTypes.Strings.DataType, "6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://data-type-container/6ad82c70685c4e049b36d81bd779d16f")]
+    [TestCase(Constants.ObjectTypes.Strings.DocumentType, "6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://document-type-container/6ad82c70685c4e049b36d81bd779d16f")]
+    [TestCase(Constants.ObjectTypes.Strings.MediaType, "6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://media-type-container/6ad82c70685c4e049b36d81bd779d16f")]
+    [TestCase(Constants.ObjectTypes.Strings.DocumentBlueprint, "6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://document-blueprint-container/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForEntityContainer(Guid containedObjectType, Guid key, string expected)
     {
-        var builder = new StylesheetBuilder();
-        var stylesheet = builder.WithPath(path).Build();
-        var result = stylesheet.GetUdi();
-        Assert.AreEqual(expected, result.ToString());
+        EntityContainer entity = new EntityContainer(containedObjectType)
+        {
+            Key = key
+        };
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
     }
 
     [TestCase("script.js", "umb://script/script.js")]
@@ -29,10 +37,195 @@ public class UdiGetterExtensionsTests
     [TestCase("editor/script.js", "umb://script/editor/script.js")]
     public void GetUdiForScript(string path, string expected)
     {
-        var builder = new ScriptBuilder();
-        var script = builder.WithPath(path).Build();
-        var result = script.GetUdi();
-        Assert.AreEqual(expected, result.ToString());
+        Script entity = new ScriptBuilder()
+            .WithPath(path)
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("style.css", "umb://stylesheet/style.css")]
+    [TestCase("editor\\style.css", "umb://stylesheet/editor/style.css")]
+    [TestCase("editor/style.css", "umb://stylesheet/editor/style.css")]
+    public void GetUdiForStylesheet(string path, string expected)
+    {
+        Stylesheet entity = new StylesheetBuilder()
+            .WithPath(path)
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", false, "umb://document/6ad82c70685c4e049b36d81bd779d16f")]
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", true, "umb://document-blueprint/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForContent(Guid key, bool blueprint, string expected)
+    {
+        Content entity = new ContentBuilder()
+            .WithKey(key)
+            .WithBlueprint(blueprint)
+            .WithContentType(ContentTypeBuilder.CreateBasicContentType())
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IContentBase)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://media/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForMedia(Guid key, string expected)
+    {
+        Media entity = new MediaBuilder()
+            .WithKey(key)
+            .WithMediaType(MediaTypeBuilder.CreateImageMediaType())
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IContentBase)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://member/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForMember(Guid key, string expected)
+    {
+        Member entity = new MemberBuilder()
+            .WithKey(key)
+            .WithMemberType(MemberTypeBuilder.CreateSimpleMemberType())
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IContentBase)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://document-type/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForContentType(Guid key, string expected)
+    {
+        IContentType entity = new ContentTypeBuilder()
+            .WithKey(key)
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IContentTypeComposition)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://media-type/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForMediaType(Guid key, string expected)
+    {
+        IMediaType entity = new MediaTypeBuilder()
+            .WithKey(key)
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IContentTypeComposition)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://member-type/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForMemberType(Guid key, string expected)
+    {
+        IMemberType entity = new MemberTypeBuilder()
+            .WithKey(key)
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IContentTypeComposition)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://data-type/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForDataType(Guid key, string expected)
+    {
+        DataType entity = new DataTypeBuilder()
+            .WithKey(key)
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://dictionary-item/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForDictionaryItem(Guid key, string expected)
+    {
+        DictionaryItem entity = new DictionaryItemBuilder()
+            .WithKey(key)
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("en-US", "umb://language/en-US")]
+    [TestCase("en", "umb://language/en")]
+    public void GetUdiForLanguage(string isoCode, string expected)
+    {
+        ILanguage entity = new LanguageBuilder()
+            .WithCultureInfo(isoCode)
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://member-group/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForMemberGroup(Guid key, string expected)
+    {
+        MemberGroup entity = new MemberGroupBuilder()
+            .WithKey(key)
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
     }
 
     [TestCase("test.cshtml", "umb://partial-view/test.cshtml")]
@@ -40,26 +233,53 @@ public class UdiGetterExtensionsTests
     [TestCase("editor/test.cshtml", "umb://partial-view/editor/test.cshtml")]
     public void GetUdiForPartialView(string path, string expected)
     {
-        var builder = new PartialViewBuilder();
-        var partialView = builder
+        IPartialView entity = new PartialViewBuilder()
             .WithPath(path)
             .Build();
-        var result = partialView.GetUdi();
-        Assert.AreEqual(expected, result.ToString());
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://relation-type/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForRelationType(Guid key, string expected)
+    {
+        IRelationTypeWithIsDependency entity = new RelationTypeBuilder()
+            .WithKey(key)
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://template/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForTemplate(Guid key, string expected)
+    {
+        ITemplate entity = new TemplateBuilder()
+            .WithKey(key)
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
     }
 
     [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://webhook/6ad82c70685c4e049b36d81bd779d16f")]
-    public void GetUdiForWebhook(string key, string expected)
+    public void GetUdiForWebhook(Guid key, string expected)
     {
-        var builder = new WebhookBuilder();
-        var webhook = builder
-            .WithKey(Guid.Parse(key))
+        Webhook entity = new WebhookBuilder()
+            .WithKey(key)
             .Build();
 
-        Udi result = webhook.GetUdi();
-        Assert.AreEqual(expected, result.ToString());
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
 
-        result = ((IEntity)webhook).GetUdi();
-        Assert.AreEqual(expected, result.ToString());
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
While implementing document blueprint container support in Deploy 14, I noticed document blueprints (`IContent` with `Blueprint = true`) were returning UDIs using the document entity type (e.g. `umb://document/{GUID}`, instead of `umb://document-blueprint/{GUID}`).

This PR adds tests for all supported entity types, fixes the issue and cleans up the `UdiGetterExtensions` class to remove redundant code. The added tests should be sufficient to verify the issue, but reverting to the first commit will show the failing test:

```
Expected string length 57 but was 47. Strings differ at index 14.
Expected: "umb://document-blueprint/6ad82c70685c4e049b36d81bd779d16f"
But was:  "umb://document/6ad82c70685c4e049b36d81bd779d16f"
-------------------------^
```