### PR TITLE
Fix unresponsive block grid editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbBlockGridPropertyEditor.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/blockgrid/umbBlockGridPropertyEditor.component.js
@@ -369,7 +369,7 @@
                 let i = layoutEntry.areas.length;
                 while(i--) {
                     const layoutEntryArea = layoutEntry.areas[i];
-                    const areaConfigIndex = block.config.areas.findIndex(x => x.key === layoutEntryArea.key);
+                    const areaConfigIndex = block.config.unsupported ? -1 : block.config.areas.findIndex(x => x.key === layoutEntryArea.key);
                     if(areaConfigIndex === -1) {
                         layoutEntry.areas.splice(i, 1);
                     }


### PR DESCRIPTION
### Prerequisites
Fixes https://github.com/umbraco/Umbraco-CMS/issues/16046

### Description
See linked issue

### Testing
See updated reproduction steps in the linked issue.
Instead of an unresponsive editor, a message is displayed.