### PR TITLE
Ignore Visual Studio's generated launchSettings file.

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest.UmbracoProject/.gitignore
+++ b/tests/Umbraco.Tests.AcceptanceTest.UmbracoProject/.gitignore
@@ -1,0 +1,2 @@
+# Ignore Visual Studio's generated launchSettings file.
+Properties/launchSettings.json


### PR DESCRIPTION
The Umbraco.Tests.AcceptanceTest.UmbracoProject project is not a _real_ web application and can't be run, but when Visual Studio sees the SDK it adds a launchSettings file.

This PR just ignores the file to prevent contributors that are using Visual Studio from accidentally adding it in their PRs.