### PR TITLE
V13: Read only mode while saving

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbtabbedcontent.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbtabbedcontent.directive.js
@@ -15,7 +15,8 @@
 
             $scope.activeTabAlias = null;
             $scope.tabs = [];
-            $scope.allowUpdate = $scope.content.allowedActions.includes('A');
+            //$scope.allowUpdate = $scope.content.allowedActions.includes('A');
+            setAllowUpdate()
             $scope.allowEditInvariantFromNonDefault = Umbraco.Sys.ServerVariables.umbracoSettings.allowEditInvariantFromNonDefault;
 
             $scope.$watchCollection('content.tabs', (newValue) => {
@@ -43,6 +44,10 @@
                     scrollableNode.addEventListener("mousewheel", cancelScrollTween);
                 }
             });
+
+            function setAllowUpdate() {
+              $scope.allowUpdate = $scope.content.allowedActions.includes('A');
+            }
 
             function onScroll(event) {
 
@@ -149,6 +154,17 @@
                     setActiveAnchor($args.anchor);
                     scrollTo($args.anchor.id);
                 }
+            });
+
+            $scope.$on("formSubmitting", function() {
+              $scope.allowUpdate = false;
+            });
+
+            $scope.$on("formSubmitted", function() {
+                setAllowUpdate();
+            });
+            $scope.$on("formSubmittedValidationFailed", function() {
+                setAllowUpdate();
             });
 
             //ensure to unregister from all dom-events

--- a/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/blockeditormodelobject.service.js
@@ -637,21 +637,26 @@
                 }
 
                 blockObject.retrieveValuesFrom = function (content, settings) {
-                    if (this.content !== null) {
+                    if (this.content) {
                         mapElementValues(content, this.content);
+                        if (this.config.settingsElementTypeKey !== null) {
+                          mapElementValues(settings, this.settings);
+                      }
+                    } else {
+                      console.error("This data cannot be edited at the given movement. Maybe due to publishing while editing.");
                     }
-                    if (this.config.settingsElementTypeKey !== null) {
-                        mapElementValues(settings, this.settings);
-                    }
+
 
                 };
 
                 blockObject.sync = function () {
-                    if (this.content !== null) {
+                    if (this.content) {
                         mapToPropertyModel(this.content, this.data);
-                    }
-                    if (this.config.settingsElementTypeKey !== null) {
-                        mapToPropertyModel(this.settings, this.settingsData);
+                        if (this.config.settingsElementTypeKey !== null) {
+                            mapToPropertyModel(this.settings, this.settingsData);
+                        }
+                    } else {
+                      console.error("This data cannot be edited at the given movement. Maybe due to publishing while editing.");
                     }
                 };
                 // first time instant update of label.


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/15996

This PR. turns a document/node into read only mode while saving.
This prevent making changes while saving, because when done saving we reset everything till the state of the latest saved data.

This gives a better solution in general, try testing this with a normal text box.

The issue mentioned above, is not necessary fixed by this, cause that case is just opening a Block while saving(Not necessary editing it while its still saving). This PR will then leave the user with a Block Modal opened as in read only mode, where we have removed the Submit button. Potentially leaving the user a little confused, but having hidden away the problem. Let me describe furhter:

The main problem is that Blocks are edited via Modals, and the Modal is based on data given when it was opened, and that data is changed/re-instantiated when new data gets back. Meaning the connection between the two is broken. This is complex to fix. As well this would work with this PR. updating the Modal so the Submit button appears once readonly mode is disabled again.

This would be what we should have fixed, but that is a big task, and is not a problem in v.14 therefore I decided to down prioritize such. To accept that the user opens a block for editing while saving, will be left without the option to edit it. — Which at least makes the issue visible to the user.

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
