### PR TITLE
FIX sdk version mismatch

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "8.0.300",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
### Description
There is an SDK requirement mismatch between the the CMS repo and the Umbraco.code which currently shows up as a warning.

This mismatch showed itself during the pipeline run of [the warnings as errors PR](https://github.com/umbraco/Umbraco-CMS/pull/15019) as it will become a warning at that point. We chose to fix it as it is something we should keep in sync anyway

### Testing
Test whether you can still build the solution locally, you might have to install a newer sdk version.