### PR TITLE
V14: Extensions of type `AppEntryPoint` are not being executed on the login screen

### DIFF
--- a/src/Umbraco.Web.UI.Login/src/controllers/slim-backoffice-initializer.ts
+++ b/src/Umbraco.Web.UI.Login/src/controllers/slim-backoffice-initializer.ts
@@ -2,7 +2,10 @@ import {
   UmbBundleExtensionInitializer,
   UmbServerExtensionRegistrator
 } from "@umbraco-cms/backoffice/extension-api";
-import { umbExtensionsRegistry } from "@umbraco-cms/backoffice/extension-registry";
+import {
+  UmbAppEntryPointExtensionInitializer,
+  umbExtensionsRegistry
+} from "@umbraco-cms/backoffice/extension-registry";
 import type { UmbElement } from "@umbraco-cms/backoffice/element-api";
 import { UmbControllerBase } from "@umbraco-cms/backoffice/class-api";
 import { UUIIconRegistryEssential } from "@umbraco-cms/backoffice/external/uui";
@@ -21,6 +24,7 @@ export class UmbSlimBackofficeController extends UmbControllerBase {
   constructor(host: UmbElement) {
     super(host);
     new UmbBundleExtensionInitializer(host, umbExtensionsRegistry);
+    new UmbAppEntryPointExtensionInitializer(host, umbExtensionsRegistry);
     new UmbServerExtensionRegistrator(host, umbExtensionsRegistry).registerPublicExtensions();
 
     this.#uuiIconRegistry.attach(host);


### PR DESCRIPTION
### Description

AppEntryPoints should be executed on the login screen.

### How to test

1. Add an `umbraco-package.json` file containing an extension with type `appEntryPoint`
2. Make sure `allowPublicAccess` is set to `true` in the manifest file itself
3. Ensure the code is being run inside the entrypoint