### PR TITLE
Ensured data consistency across operations performed in any custom notification handlers in case of cancellation 

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -133,7 +133,6 @@ public class ContentService : RepositoryService, IContentService
             var rollingBackNotification = new ContentRollingBackNotification(content, evtMsgs);
             if (scope.Notifications.PublishCancelable(rollingBackNotification))
             {
-                scope.Complete();
                 return OperationResult.Cancel(evtMsgs);
             }
 
@@ -1009,7 +1008,6 @@ public class ContentService : RepositoryService, IContentService
             var savingNotification = new ContentSavingNotification(content, eventMessages);
             if (scope.Notifications.PublishCancelable(savingNotification))
             {
-                scope.Complete();
                 return OperationResult.Cancel(eventMessages);
             }
 
@@ -1082,7 +1080,6 @@ public class ContentService : RepositoryService, IContentService
             var savingNotification = new ContentSavingNotification(contentsA, eventMessages);
             if (scope.Notifications.PublishCancelable(savingNotification))
             {
-                scope.Complete();
                 return OperationResult.Cancel(eventMessages);
             }
 
@@ -2239,7 +2236,6 @@ public class ContentService : RepositoryService, IContentService
         {
             if (scope.Notifications.PublishCancelable(new ContentDeletingNotification(content, eventMessages)))
             {
-                scope.Complete();
                 return OperationResult.Cancel(eventMessages);
             }
 
@@ -2312,7 +2308,6 @@ public class ContentService : RepositoryService, IContentService
                 new ContentDeletingVersionsNotification(id, evtMsgs, dateToRetain: versionDate);
             if (scope.Notifications.PublishCancelable(deletingVersionsNotification))
             {
-                scope.Complete();
                 return;
             }
 
@@ -2345,7 +2340,6 @@ public class ContentService : RepositoryService, IContentService
             var deletingVersionsNotification = new ContentDeletingVersionsNotification(id, evtMsgs, versionId);
             if (scope.Notifications.PublishCancelable(deletingVersionsNotification))
             {
-                scope.Complete();
                 return;
             }
 
@@ -2396,7 +2390,6 @@ public class ContentService : RepositoryService, IContentService
                 new ContentMovingToRecycleBinNotification(moveEventInfo, eventMessages);
             if (scope.Notifications.PublishCancelable(movingToRecycleBinNotification))
             {
-                scope.Complete();
                 return OperationResult.Cancel(eventMessages); // causes rollback
             }
 
@@ -2468,7 +2461,6 @@ public class ContentService : RepositoryService, IContentService
             var movingNotification = new ContentMovingNotification(moveEventInfo, eventMessages);
             if (scope.Notifications.PublishCancelable(movingNotification))
             {
-                scope.Complete();
                 return OperationResult.Cancel(eventMessages); // causes rollback
             }
 
@@ -2596,7 +2588,6 @@ public class ContentService : RepositoryService, IContentService
             var deletingContentNotification = new ContentDeletingNotification(contents, eventMessages);
             if (scope.Notifications.PublishCancelable(emptyingRecycleBinNotification) || scope.Notifications.PublishCancelable(deletingContentNotification))
             {
-                scope.Complete();
                 return OperationResult.Cancel(eventMessages);
             }
 
@@ -2671,7 +2662,6 @@ public class ContentService : RepositoryService, IContentService
             // FIXME: Pass parent key in constructor too when proper Copy method is implemented
             if (scope.Notifications.PublishCancelable(new ContentCopyingNotification(content, copy, parentId, eventMessages)))
             {
-                scope.Complete();
                 return null;
             }
 
@@ -2796,7 +2786,6 @@ public class ContentService : RepositoryService, IContentService
             var sendingToPublishNotification = new ContentSendingToPublishNotification(content, evtMsgs);
             if (scope.Notifications.PublishCancelable(sendingToPublishNotification))
             {
-                scope.Complete();
                 return false;
             }
 
@@ -3413,7 +3402,6 @@ public class ContentService : RepositoryService, IContentService
 
             if (scope.Notifications.PublishCancelable(new ContentDeletingNotification(contents, eventMessages)))
             {
-                scope.Complete();
                 return;
             }
 

--- a/src/Umbraco.Core/Services/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
+++ b/src/Umbraco.Core/Services/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
@@ -511,7 +511,6 @@ public abstract class ContentTypeServiceBase<TRepository, TItem> : ContentTypeSe
         SavingNotification<TItem> savingNotification = GetSavingNotification(item, eventMessages);
         if (scope.Notifications.PublishCancelable(savingNotification))
         {
-            scope.Complete();
             return;
         }
 
@@ -564,7 +563,6 @@ public abstract class ContentTypeServiceBase<TRepository, TItem> : ContentTypeSe
             SavingNotification<TItem> savingNotification = GetSavingNotification(itemsA, eventMessages);
             if (scope.Notifications.PublishCancelable(savingNotification))
             {
-                scope.Complete();
                 return;
             }
 
@@ -621,7 +619,6 @@ public abstract class ContentTypeServiceBase<TRepository, TItem> : ContentTypeSe
         SavingNotification<TItem> savingNotification = GetSavingNotification(item, eventMessages);
         if (await scope.Notifications.PublishCancelableAsync(savingNotification))
         {
-            scope.Complete();
             return Attempt.Fail(ContentTypeOperationStatus.CancelledByNotification);
         }
 
@@ -713,7 +710,6 @@ public abstract class ContentTypeServiceBase<TRepository, TItem> : ContentTypeSe
             DeletingNotification<TItem> deletingNotification = GetDeletingNotification(item, eventMessages);
             if (scope.Notifications.PublishCancelable(deletingNotification))
             {
-                scope.Complete();
                 return;
             }
 
@@ -785,7 +781,6 @@ public abstract class ContentTypeServiceBase<TRepository, TItem> : ContentTypeSe
             DeletingNotification<TItem> deletingNotification = GetDeletingNotification(itemsA, eventMessages);
             if (scope.Notifications.PublishCancelable(deletingNotification))
             {
-                scope.Complete();
                 return;
             }
 
@@ -956,7 +951,6 @@ public abstract class ContentTypeServiceBase<TRepository, TItem> : ContentTypeSe
                 SavingNotification<TItem> savingNotification = GetSavingNotification(copy, eventMessages);
                 if (scope.Notifications.PublishCancelable(savingNotification))
                 {
-                    scope.Complete();
                     return OperationResult.Attempt.Fail(MoveOperationStatusType.FailedCancelledByEvent, eventMessages, copy);
                 }
 
@@ -1044,7 +1038,6 @@ public abstract class ContentTypeServiceBase<TRepository, TItem> : ContentTypeSe
             MovingNotification<TItem> movingNotification = GetMovingNotification(moveEventInfo, eventMessages);
             if (scope.Notifications.PublishCancelable(movingNotification))
             {
-                scope.Complete();
                 return OperationResult.Attempt.Fail(MoveOperationStatusType.FailedCancelledByEvent, eventMessages);
             }
 
@@ -1188,7 +1181,6 @@ public abstract class ContentTypeServiceBase<TRepository, TItem> : ContentTypeSe
             var savingNotification = new EntityContainerSavingNotification(container, eventMessages);
             if (scope.Notifications.PublishCancelable(savingNotification))
             {
-                scope.Complete();
                 return OperationResult.Attempt.Cancel(eventMessages, container);
             }
 
@@ -1232,7 +1224,6 @@ public abstract class ContentTypeServiceBase<TRepository, TItem> : ContentTypeSe
             var savingNotification = new EntityContainerSavingNotification(container, eventMessages);
             if (scope.Notifications.PublishCancelable(savingNotification))
             {
-                scope.Complete();
                 return OperationResult.Attempt.Cancel(eventMessages);
             }
 
@@ -1323,7 +1314,6 @@ public abstract class ContentTypeServiceBase<TRepository, TItem> : ContentTypeSe
         var deletingNotification = new EntityContainerDeletingNotification(container, eventMessages);
         if (scope.Notifications.PublishCancelable(deletingNotification))
         {
-            scope.Complete();
             return Attempt.Fail(new OperationResult(OperationResultType.FailedCancelledByEvent, eventMessages));
         }
 
@@ -1361,7 +1351,6 @@ public abstract class ContentTypeServiceBase<TRepository, TItem> : ContentTypeSe
                 var renamingNotification = new EntityContainerRenamingNotification(container, eventMessages);
                 if (scope.Notifications.PublishCancelable(renamingNotification))
                 {
-                    scope.Complete();
                     return OperationResult.Attempt.Cancel<EntityContainer>(eventMessages);
                 }
 

--- a/src/Umbraco.Core/Services/DataTypeService.cs
+++ b/src/Umbraco.Core/Services/DataTypeService.cs
@@ -443,7 +443,6 @@ namespace Umbraco.Cms.Core.Services.Implement
                 var movingDataTypeNotification = new DataTypeMovingNotification(moveEventInfo, eventMessages);
                 if (scope.Notifications.PublishCancelable(movingDataTypeNotification))
                 {
-                    scope.Complete();
                     return Attempt.FailWithStatus(DataTypeOperationStatus.CancelledByNotification, toMove);
                 }
 
@@ -591,7 +590,6 @@ namespace Umbraco.Cms.Core.Services.Implement
             var savingDataTypeNotification = new DataTypeSavingNotification(dataTypeDefinitions, evtMsgs);
             if (scope.Notifications.PublishCancelable(savingDataTypeNotification))
             {
-                scope.Complete();
                 return;
             }
 
@@ -644,7 +642,6 @@ namespace Umbraco.Cms.Core.Services.Implement
             var deletingDataTypeNotification = new DataTypeDeletingNotification(dataType, eventMessages);
             if (await scope.Notifications.PublishCancelableAsync(deletingDataTypeNotification))
             {
-                scope.Complete();
                 return Attempt.FailWithStatus<IDataType?, DataTypeOperationStatus>(DataTypeOperationStatus.CancelledByNotification, dataType);
             }
 
@@ -761,7 +758,6 @@ namespace Umbraco.Cms.Core.Services.Implement
             var savingDataTypeNotification = new DataTypeSavingNotification(dataType, eventMessages);
             if (await scope.Notifications.PublishCancelableAsync(savingDataTypeNotification))
             {
-                scope.Complete();
                 return Attempt.FailWithStatus(DataTypeOperationStatus.CancelledByNotification, dataType);
             }
 

--- a/src/Umbraco.Core/Services/DictionaryItemService.cs
+++ b/src/Umbraco.Core/Services/DictionaryItemService.cs
@@ -190,7 +190,6 @@ internal sealed class DictionaryItemService : RepositoryService, IDictionaryItem
             var deletingNotification = new DictionaryItemDeletingNotification(dictionaryItem, eventMessages);
             if (await scope.Notifications.PublishCancelableAsync(deletingNotification))
             {
-                scope.Complete();
                 return Attempt.FailWithStatus<IDictionaryItem?, DictionaryItemOperationStatus>(DictionaryItemOperationStatus.CancelledByNotification, dictionaryItem);
             }
 
@@ -252,7 +251,6 @@ internal sealed class DictionaryItemService : RepositoryService, IDictionaryItem
             var movingNotification = new DictionaryItemMovingNotification(moveEventInfo, eventMessages);
             if (await scope.Notifications.PublishCancelableAsync(movingNotification))
             {
-                scope.Complete();
                 return Attempt.FailWithStatus(DictionaryItemOperationStatus.CancelledByNotification, dictionaryItem);
             }
 
@@ -313,7 +311,6 @@ internal sealed class DictionaryItemService : RepositoryService, IDictionaryItem
             var savingNotification = new DictionaryItemSavingNotification(dictionaryItem, eventMessages);
             if (await scope.Notifications.PublishCancelableAsync(savingNotification))
             {
-                scope.Complete();
                 return Attempt.FailWithStatus(DictionaryItemOperationStatus.CancelledByNotification, dictionaryItem);
             }
 

--- a/src/Umbraco.Core/Services/DomainService.cs
+++ b/src/Umbraco.Core/Services/DomainService.cs
@@ -131,7 +131,6 @@ public class DomainService : RepositoryService, IDomainService
             var savingNotification = new DomainSavingNotification(domains, eventMessages);
             if (scope.Notifications.PublishCancelable(savingNotification))
             {
-                scope.Complete();
                 return OperationResult.Attempt.Cancel(eventMessages);
             }
 

--- a/src/Umbraco.Core/Services/EntityTypeContainerService.cs
+++ b/src/Umbraco.Core/Services/EntityTypeContainerService.cs
@@ -161,7 +161,6 @@ internal abstract class EntityTypeContainerService<TTreeEntity, TEntityContainer
         var deletingEntityContainerNotification = new EntityContainerDeletingNotification(container, eventMessages);
         if (await scope.Notifications.PublishCancelableAsync(deletingEntityContainerNotification))
         {
-            scope.Complete();
             return Attempt.FailWithStatus<EntityContainer?, EntityContainerOperationStatus>(EntityContainerOperationStatus.CancelledByNotification, container);
         }
 
@@ -196,7 +195,6 @@ internal abstract class EntityTypeContainerService<TTreeEntity, TEntityContainer
         var savingEntityContainerNotification = new EntityContainerSavingNotification(container, eventMessages);
         if (await scope.Notifications.PublishCancelableAsync(savingEntityContainerNotification))
         {
-            scope.Complete();
             return Attempt.FailWithStatus<EntityContainer?, EntityContainerOperationStatus>(EntityContainerOperationStatus.CancelledByNotification, container);
         }
 

--- a/src/Umbraco.Core/Services/FileService.cs
+++ b/src/Umbraco.Core/Services/FileService.cs
@@ -132,7 +132,6 @@ public class FileService : RepositoryService, IFileService
             var savingNotification = new StylesheetSavingNotification(stylesheet, eventMessages);
             if (scope.Notifications.PublishCancelable(savingNotification))
             {
-                scope.Complete();
                 return;
             }
 
@@ -163,7 +162,6 @@ public class FileService : RepositoryService, IFileService
             var deletingNotification = new StylesheetDeletingNotification(stylesheet, eventMessages);
             if (scope.Notifications.PublishCancelable(deletingNotification))
             {
-                scope.Complete();
                 return; // causes rollback
             }
 
@@ -275,7 +273,6 @@ public class FileService : RepositoryService, IFileService
             var savingNotification = new ScriptSavingNotification(script, eventMessages);
             if (scope.Notifications.PublishCancelable(savingNotification))
             {
-                scope.Complete();
                 return;
             }
 
@@ -305,7 +302,6 @@ public class FileService : RepositoryService, IFileService
             var deletingNotification = new ScriptDeletingNotification(script, eventMessages);
             if (scope.Notifications.PublishCancelable(deletingNotification))
             {
-                scope.Complete();
                 return;
             }
 
@@ -535,7 +531,6 @@ public class FileService : RepositoryService, IFileService
             var savingNotification = new TemplateSavingNotification(templatesA, eventMessages);
             if (scope.Notifications.PublishCancelable(savingNotification))
             {
-                scope.Complete();
                 return;
             }
 
@@ -644,7 +639,6 @@ public class FileService : RepositoryService, IFileService
             var creatingNotification = new PartialViewCreatingNotification(partialView, eventMessages);
             if (scope.Notifications.PublishCancelable(creatingNotification))
             {
-                scope.Complete();
                 return Attempt<IPartialView?>.Fail();
             }
 
@@ -675,7 +669,6 @@ public class FileService : RepositoryService, IFileService
             var savingNotification = new PartialViewSavingNotification(partialView, eventMessages);
             if (scope.Notifications.PublishCancelable(savingNotification))
             {
-                scope.Complete();
                 return Attempt<IPartialView?>.Fail();
             }
 
@@ -708,7 +701,6 @@ public class FileService : RepositoryService, IFileService
             var deletingNotification = new PartialViewDeletingNotification(partialView, eventMessages);
             if (scope.Notifications.PublishCancelable(deletingNotification))
             {
-                scope.Complete();
                 return false;
             }
 

--- a/src/Umbraco.Core/Services/LanguageService.cs
+++ b/src/Umbraco.Core/Services/LanguageService.cs
@@ -150,7 +150,6 @@ internal sealed class LanguageService : RepositoryService, ILanguageService
             var deletingLanguageNotification = new LanguageDeletingNotification(language, eventMessages);
             if (await scope.Notifications.PublishCancelableAsync(deletingLanguageNotification))
             {
-                scope.Complete();
                 return Attempt.FailWithStatus<ILanguage?, LanguageOperationStatus>(LanguageOperationStatus.CancelledByNotification, language);
             }
 
@@ -205,7 +204,6 @@ internal sealed class LanguageService : RepositoryService, ILanguageService
             var savingNotification = new LanguageSavingNotification(language, eventMessages);
             if (await scope.Notifications.PublishCancelableAsync(savingNotification))
             {
-                scope.Complete();
                 return Attempt.FailWithStatus(LanguageOperationStatus.CancelledByNotification, language);
             }
 

--- a/src/Umbraco.Core/Services/MediaService.cs
+++ b/src/Umbraco.Core/Services/MediaService.cs
@@ -738,7 +738,6 @@ namespace Umbraco.Cms.Core.Services
                 var savingNotification = new MediaSavingNotification(media, eventMessages);
                 if (scope.Notifications.PublishCancelable(savingNotification))
                 {
-                    scope.Complete();
                     return OperationResult.Attempt.Cancel(eventMessages);
                 }
 
@@ -795,7 +794,6 @@ namespace Umbraco.Cms.Core.Services
                 var savingNotification = new MediaSavingNotification(mediasA, messages);
                 if (scope.Notifications.PublishCancelable(savingNotification))
                 {
-                    scope.Complete();
                     return OperationResult.Attempt.Cancel(messages);
                 }
 
@@ -840,7 +838,6 @@ namespace Umbraco.Cms.Core.Services
             {
                 if (scope.Notifications.PublishCancelable(new MediaDeletingNotification(media, messages)))
                 {
-                    scope.Complete();
                     return OperationResult.Attempt.Cancel(messages);
                 }
 
@@ -939,7 +936,6 @@ namespace Umbraco.Cms.Core.Services
             var deletingVersionsNotification = new MediaDeletingVersionsNotification(id, evtMsgs, specificVersion: versionId);
             if (scope.Notifications.PublishCancelable(deletingVersionsNotification))
             {
-                scope.Complete();
                 return;
             }
 
@@ -992,7 +988,6 @@ namespace Umbraco.Cms.Core.Services
                 var movingToRecycleBinNotification = new MediaMovingToRecycleBinNotification(moveEventInfo, messages);
                 if (scope.Notifications.PublishCancelable(movingToRecycleBinNotification))
                 {
-                    scope.Complete();
                     return OperationResult.Attempt.Cancel(messages);
                 }
 
@@ -1042,7 +1037,6 @@ namespace Umbraco.Cms.Core.Services
                 var movingNotification = new MediaMovingNotification(moveEventInfo, messages);
                 if (scope.Notifications.PublishCancelable(movingNotification))
                 {
-                    scope.Complete();
                     return OperationResult.Attempt.Cancel(messages);
                 }
 
@@ -1149,7 +1143,6 @@ namespace Umbraco.Cms.Core.Services
                 var emptyingRecycleBinNotification = new MediaEmptyingRecycleBinNotification(medias, messages);
                 if (scope.Notifications.PublishCancelable(emptyingRecycleBinNotification))
                 {
-                    scope.Complete();
                     return OperationResult.Cancel(messages);
                 }
 
@@ -1200,7 +1193,6 @@ namespace Umbraco.Cms.Core.Services
                 var savingNotification = new MediaSavingNotification(itemsA, messages);
                 if (scope.Notifications.PublishCancelable(savingNotification))
                 {
-                    scope.Complete();
                     return false;
                 }
 
@@ -1339,7 +1331,6 @@ namespace Umbraco.Cms.Core.Services
 
                 if (scope.Notifications.PublishCancelable(new MediaDeletingNotification(medias, messages)))
                 {
-                    scope.Complete();
                     return;
                 }
 

--- a/src/Umbraco.Core/Services/MemberGroupService.cs
+++ b/src/Umbraco.Core/Services/MemberGroupService.cs
@@ -46,7 +46,6 @@ internal class MemberGroupService : RepositoryService, IMemberGroupService
             var savingNotification = new MemberGroupSavingNotification(memberGroup, evtMsgs);
             if (scope.Notifications.PublishCancelable(savingNotification))
             {
-                scope.Complete();
                 return;
             }
 
@@ -117,7 +116,6 @@ internal class MemberGroupService : RepositoryService, IMemberGroupService
         var savingNotification = new MemberGroupSavingNotification(memberGroup, eventMessages);
         if (await scope.Notifications.PublishCancelableAsync(savingNotification))
         {
-            scope.Complete();
             return Attempt.FailWithStatus<IMemberGroup?, MemberGroupOperationStatus>(MemberGroupOperationStatus.CancelledByNotification, null);
         }
 
@@ -144,7 +142,6 @@ internal class MemberGroupService : RepositoryService, IMemberGroupService
         var deletingNotification = new MemberGroupDeletingNotification(memberGroup, eventMessages);
         if (await scope.Notifications.PublishCancelableAsync(deletingNotification))
         {
-            scope.Complete();
             return Attempt.FailWithStatus<IMemberGroup?, MemberGroupOperationStatus>(MemberGroupOperationStatus.CancelledByNotification, null);
         }
 
@@ -177,7 +174,6 @@ internal class MemberGroupService : RepositoryService, IMemberGroupService
         var savingNotification = new MemberGroupSavingNotification(memberGroup, eventMessages);
         if (await scope.Notifications.PublishCancelableAsync(savingNotification))
         {
-            scope.Complete();
             return Attempt.FailWithStatus<IMemberGroup?, MemberGroupOperationStatus>(MemberGroupOperationStatus.CancelledByNotification, null);
         }
 

--- a/src/Umbraco.Core/Services/MemberService.cs
+++ b/src/Umbraco.Core/Services/MemberService.cs
@@ -776,7 +776,6 @@ namespace Umbraco.Cms.Core.Services
             var savingNotification = new MemberSavingNotification(member, evtMsgs);
             if (scope.Notifications.PublishCancelable(savingNotification))
             {
-                scope.Complete();
                 return OperationResult.Attempt.Cancel(evtMsgs);
             }
 
@@ -811,7 +810,6 @@ namespace Umbraco.Cms.Core.Services
             var savingNotification = new MemberSavingNotification(membersA, evtMsgs);
             if (scope.Notifications.PublishCancelable(savingNotification))
             {
-                scope.Complete();
                 return OperationResult.Attempt.Cancel(evtMsgs);
             }
 
@@ -851,7 +849,6 @@ namespace Umbraco.Cms.Core.Services
             var deletingNotification = new MemberDeletingNotification(member, evtMsgs);
             if (scope.Notifications.PublishCancelable(deletingNotification))
             {
-                scope.Complete();
                 return OperationResult.Attempt.Cancel(evtMsgs);
             }
 
@@ -1172,7 +1169,6 @@ namespace Umbraco.Cms.Core.Services
 
             if (scope.Notifications.PublishCancelable(new MemberDeletingNotification(members, evtMsgs)))
             {
-                scope.Complete();
                 return;
             }
 

--- a/src/Umbraco.Core/Services/PublicAccessService.cs
+++ b/src/Umbraco.Core/Services/PublicAccessService.cs
@@ -144,7 +144,6 @@ internal class PublicAccessService : RepositoryService, IPublicAccessService
             var savingNotifiation = new PublicAccessEntrySavingNotification(entry, evtMsgs);
             if (scope.Notifications.PublishCancelable(savingNotifiation))
             {
-                scope.Complete();
                 return OperationResult.Attempt.Cancel(evtMsgs, entry);
             }
 
@@ -189,7 +188,6 @@ internal class PublicAccessService : RepositoryService, IPublicAccessService
             var savingNotifiation = new PublicAccessEntrySavingNotification(entry, evtMsgs);
             if (scope.Notifications.PublishCancelable(savingNotifiation))
             {
-                scope.Complete();
                 return OperationResult.Attempt.Cancel(evtMsgs);
             }
 
@@ -216,7 +214,6 @@ internal class PublicAccessService : RepositoryService, IPublicAccessService
             var savingNotifiation = new PublicAccessEntrySavingNotification(entry, evtMsgs);
             if (scope.Notifications.PublishCancelable(savingNotifiation))
             {
-                scope.Complete();
                 return OperationResult.Attempt.Cancel(evtMsgs);
             }
 
@@ -259,7 +256,6 @@ internal class PublicAccessService : RepositoryService, IPublicAccessService
             var savingNotification = new PublicAccessEntrySavingNotification(entry, eventMessages);
             if (await scope.Notifications.PublishCancelableAsync(savingNotification))
             {
-                scope.Complete();
                 return Attempt.FailWithStatus<PublicAccessEntry?, PublicAccessOperationStatus>(PublicAccessOperationStatus.CancelledByNotification, null);
             }
 
@@ -349,7 +345,6 @@ internal class PublicAccessService : RepositoryService, IPublicAccessService
             var deletingNotification = new PublicAccessEntryDeletingNotification(entry, evtMsgs);
             if (scope.Notifications.PublishCancelable(deletingNotification))
             {
-                scope.Complete();
                 return OperationResult.Attempt.Cancel(evtMsgs);
             }
 
@@ -403,7 +398,6 @@ internal class PublicAccessService : RepositoryService, IPublicAccessService
             var deletingNotification = new PublicAccessEntryDeletingNotification(attempt.Result!, evtMsgs);
             if (scope.Notifications.PublishCancelable(deletingNotification))
             {
-                scope.Complete();
                 return Attempt.Fail(PublicAccessOperationStatus.CancelledByNotification);
             }
 

--- a/src/Umbraco.Core/Services/RelationService.cs
+++ b/src/Umbraco.Core/Services/RelationService.cs
@@ -446,7 +446,6 @@ public class RelationService : RepositoryService, IRelationService
             var savingNotification = new RelationSavingNotification(relation, eventMessages);
             if (scope.Notifications.PublishCancelable(savingNotification))
             {
-                scope.Complete();
                 return relation; // TODO: returning sth that does not exist here?!
             }
 
@@ -546,7 +545,6 @@ public class RelationService : RepositoryService, IRelationService
             var savingNotification = new RelationSavingNotification(relation, eventMessages);
             if (scope.Notifications.PublishCancelable(savingNotification))
             {
-                scope.Complete();
                 return;
             }
 
@@ -567,7 +565,6 @@ public class RelationService : RepositoryService, IRelationService
             var savingNotification = new RelationSavingNotification(relationsA, messages);
             if (scope.Notifications.PublishCancelable(savingNotification))
             {
-                scope.Complete();
                 return;
             }
 
@@ -587,7 +584,6 @@ public class RelationService : RepositoryService, IRelationService
             var savingNotification = new RelationTypeSavingNotification(relationType, eventMessages);
             if (scope.Notifications.PublishCancelable(savingNotification))
             {
-                scope.Complete();
                 return;
             }
 
@@ -651,7 +647,6 @@ public class RelationService : RepositoryService, IRelationService
             var savingNotification = new RelationTypeSavingNotification(relationType, eventMessages);
             if (scope.Notifications.PublishCancelable(savingNotification))
             {
-                scope.Complete();
                 return Attempt.FailWithStatus(RelationTypeOperationStatus.CancelledByNotification, relationType);
             }
 
@@ -675,7 +670,6 @@ public class RelationService : RepositoryService, IRelationService
             var deletingNotification = new RelationDeletingNotification(relation, eventMessages);
             if (scope.Notifications.PublishCancelable(deletingNotification))
             {
-                scope.Complete();
                 return;
             }
 
@@ -695,7 +689,6 @@ public class RelationService : RepositoryService, IRelationService
             var deletingNotification = new RelationTypeDeletingNotification(relationType, eventMessages);
             if (scope.Notifications.PublishCancelable(deletingNotification))
             {
-                scope.Complete();
                 return;
             }
 
@@ -720,7 +713,6 @@ public class RelationService : RepositoryService, IRelationService
             var deletingNotification = new RelationTypeDeletingNotification(relationType, eventMessages);
             if (scope.Notifications.PublishCancelable(deletingNotification))
             {
-                scope.Complete();
                 return Attempt.FailWithStatus<IRelationType?, RelationTypeOperationStatus>(RelationTypeOperationStatus.CancelledByNotification, null);
             }
 

--- a/src/Umbraco.Core/Services/TemplateService.cs
+++ b/src/Umbraco.Core/Services/TemplateService.cs
@@ -73,7 +73,6 @@ public class TemplateService : RepositoryService, ITemplateService
             var savingEvent = new TemplateSavingNotification(template, eventMessages, true, contentTypeAlias!);
             if (scope.Notifications.PublishCancelable(savingEvent))
             {
-                scope.Complete();
                 return Attempt.FailWithStatus(TemplateOperationStatus.CancelledByNotification, template);
             }
 
@@ -261,7 +260,6 @@ public class TemplateService : RepositoryService, ITemplateService
             var savingNotification = new TemplateSavingNotification(template, eventMessages);
             if (scope.Notifications.PublishCancelable(savingNotification))
             {
-                scope.Complete();
                 return Attempt.FailWithStatus(TemplateOperationStatus.CancelledByNotification, template);
             }
 
@@ -408,7 +406,6 @@ public class TemplateService : RepositoryService, ITemplateService
             var deletingNotification = new TemplateDeletingNotification(template, eventMessages);
             if (scope.Notifications.PublishCancelable(deletingNotification))
             {
-                scope.Complete();
                 return Attempt.FailWithStatus<ITemplate?, TemplateOperationStatus>(TemplateOperationStatus.CancelledByNotification, template);
             }
 

--- a/src/Umbraco.Core/Services/UserGroupService.cs
+++ b/src/Umbraco.Core/Services/UserGroupService.cs
@@ -193,7 +193,6 @@ internal sealed class UserGroupService : RepositoryService, IUserGroupService
 
         if (await scope.Notifications.PublishCancelableAsync(deletingNotification))
         {
-            scope.Complete();
             return Attempt.Fail(UserGroupOperationStatus.CancelledByNotification);
         }
 
@@ -302,7 +301,6 @@ internal sealed class UserGroupService : RepositoryService, IUserGroupService
         var savingNotification = new UserGroupSavingNotification(userGroup, eventMessages);
         if (await scope.Notifications.PublishCancelableAsync(savingNotification))
         {
-            scope.Complete();
             return Attempt.FailWithStatus(UserGroupOperationStatus.CancelledByNotification, userGroup);
         }
 
@@ -317,7 +315,6 @@ internal sealed class UserGroupService : RepositoryService, IUserGroupService
         var savingUserGroupWithUsersNotification = new UserGroupWithUsersSavingNotification(userGroupWithUsers, eventMessages);
         if (await scope.Notifications.PublishCancelableAsync(savingUserGroupWithUsersNotification))
         {
-            scope.Complete();
             return Attempt.FailWithStatus(UserGroupOperationStatus.CancelledByNotification, userGroup);
         }
 
@@ -385,7 +382,6 @@ internal sealed class UserGroupService : RepositoryService, IUserGroupService
         var savingNotification = new UserGroupSavingNotification(userGroup, eventMessages);
         if (await scope.Notifications.PublishCancelableAsync(savingNotification))
         {
-            scope.Complete();
             return Attempt.FailWithStatus(UserGroupOperationStatus.CancelledByNotification, userGroup);
         }
 
@@ -396,7 +392,6 @@ internal sealed class UserGroupService : RepositoryService, IUserGroupService
         var savingUserGroupWithUsersNotification = new UserGroupWithUsersSavingNotification(userGroupWithUsers, eventMessages);
         if (await scope.Notifications.PublishCancelableAsync(savingUserGroupWithUsersNotification))
         {
-            scope.Complete();
             return Attempt.FailWithStatus(UserGroupOperationStatus.CancelledByNotification, userGroup);
         }
 

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -305,7 +305,6 @@ internal class UserService : RepositoryService, IUserService
             var savingNotification = new UserSavingNotification(user, evtMsgs);
             if (scope.Notifications.PublishCancelable(savingNotification))
             {
-                scope.Complete();
                 return user;
             }
 
@@ -396,7 +395,6 @@ internal class UserService : RepositoryService, IUserService
                 var deletingNotification = new UserDeletingNotification(user, evtMsgs);
                 if (scope.Notifications.PublishCancelable(deletingNotification))
                 {
-                    scope.Complete();
                     return;
                 }
 
@@ -448,7 +446,6 @@ internal class UserService : RepositoryService, IUserService
             var savingNotification = new UserSavingNotification(entitiesA, evtMsgs);
             if (scope.Notifications.PublishCancelable(savingNotification))
             {
-                scope.Complete();
                 return;
             }
 
@@ -2045,7 +2042,6 @@ internal class UserService : RepositoryService, IUserService
             var savingNotification = new UserGroupSavingNotification(userGroup, evtMsgs);
             if (scope.Notifications.PublishCancelable(savingNotification))
             {
-                scope.Complete();
                 return;
             }
 
@@ -2054,7 +2050,6 @@ internal class UserService : RepositoryService, IUserService
                 new UserGroupWithUsersSavingNotification(userGroupWithUsers, evtMsgs);
             if (scope.Notifications.PublishCancelable(savingUserGroupWithUsersNotification))
             {
-                scope.Complete();
                 return;
             }
 
@@ -2084,7 +2079,6 @@ internal class UserService : RepositoryService, IUserService
             var deletingNotification = new UserGroupDeletingNotification(userGroup, evtMsgs);
             if (scope.Notifications.PublishCancelable(deletingNotification))
             {
-                scope.Complete();
                 return;
             }
 

--- a/src/Umbraco.Core/Services/WebhookService.cs
+++ b/src/Umbraco.Core/Services/WebhookService.cs
@@ -45,7 +45,6 @@ public class WebhookService : IWebhookService
         var savingNotification = new WebhookSavingNotification(webhook, eventMessages);
         if (await scope.Notifications.PublishCancelableAsync(savingNotification))
         {
-            scope.Complete();
             return Attempt.FailWithStatus(WebhookOperationStatus.CancelledByNotification, webhook);
         }
 
@@ -81,7 +80,6 @@ public class WebhookService : IWebhookService
         var savingNotification = new WebhookSavingNotification(webhook, eventMessages);
         if (await scope.Notifications.PublishCancelableAsync(savingNotification))
         {
-            scope.Complete();
             return Attempt.FailWithStatus(WebhookOperationStatus.CancelledByNotification, webhook);
         }
 
@@ -114,7 +112,6 @@ public class WebhookService : IWebhookService
         var deletingNotification = new WebhookDeletingNotification(webhook, eventMessages);
         if (await scope.Notifications.PublishCancelableAsync(deletingNotification))
         {
-            scope.Complete();
             return Attempt.FailWithStatus<IWebhook?, WebhookOperationStatus>(WebhookOperationStatus.CancelledByNotification, webhook);
         }
 

--- a/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
@@ -194,7 +194,6 @@ public class BackOfficeUserStore :
         var savingNotification = new UserSavingNotification(user, eventMessages);
         if (scope.Notifications.PublishCancelable(savingNotification))
         {
-            scope.Complete();
             return Task.FromResult(UserOperationStatus.CancelledByNotification);
         }
 


### PR DESCRIPTION
Hi Guys,

Here is a new PR regarding issue reported in: #13957.

I removed each occurrence of `scope.Complete()` in case the operation is canceled.

This way each cancellation will be consistent with the cancellation manner of the publishing as you can see here: 

https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Core/Services/ContentService.cs#L1207

In my opinion, completing a scope when any operation is cancelled doesn't make any sense from the data consistency perspective, but please correct me if I'm wrong and it's done intentionally for some reason.

This PR will allow us to ensure data consistency across any operations which could be performed in the custom notification handlers.

It would be perfect if you could include this update in the upcoming release for v13.

cc: @Zeegaan, @piotrbach, @10gler