### PR TITLE
V15 Bugfix: Temp remove tag helpers on login screen

### DIFF
--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoLogin/Index.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoLogin/Index.cshtml
@@ -31,7 +31,6 @@
     var allowPasswordReset = SecuritySettings.Value.AllowPasswordReset && EmailSender.CanSendRequiredEmail();
     var disableLocalLogin = ExternalLogins.HasDenyLocalLogin();
 }
-@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 
 <!DOCTYPE html>
 <html lang="@GlobalSettings.Value.DefaultUILanguage">
@@ -45,7 +44,7 @@
     <meta name="pinterest" content="nopin"/>
     <title>Umbraco</title>
 
-    <link rel="stylesheet" href="~/umbraco/backoffice/css/uui-css.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/umbraco/backoffice/css/uui-css.css" />
     <style>
       body {
         margin: 0;
@@ -55,7 +54,7 @@
     </style>
 
     @await Html.BackOfficeImportMapScriptAsync(JsonSerializer, BackOfficePathGenerator, PackageManifestService)
-    <script type="module" src="~/umbraco/login/login.js" asp-append-version="true"></script>
+    <script type="module" src="~/umbraco/login/login.js"></script>
 </head>
 
 <body class="uui-font uui-text" style="margin: 0; padding: 0; overflow: hidden">


### PR DESCRIPTION
Tag helpers are currently broken in .NET 9 preview which results in the `type="module"` attribute being removed from our login screen script tag.

This PR is a temporary fix to make the login screen work again for everybody. The issue is targeted to be fixed in .NET 9 rc where we will have to revert these changes again.

https://github.com/dotnet/aspnetcore/pull/57170