### PR TITLE
Ensure correct OpenID Connect error responses

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeController.cs
@@ -169,13 +169,19 @@ public class BackOfficeController : SecurityControllerBase
         OpenIddictRequest? request = context.GetOpenIddictServerRequest();
         if (request == null)
         {
-            return BadRequest("Unable to obtain OpenID data from the current request");
+            return BadRequest(new OpenIddictResponse
+            {
+                Error = "No context found", ErrorDescription = "Unable to obtain context from the current request."
+            });
         }
 
         // make sure we keep member authentication away from this endpoint
         if (request.ClientId is Constants.OAuthClientIds.Member)
         {
-            return BadRequest("The specified client ID cannot be used here.");
+            return BadRequest(new OpenIddictResponse
+            {
+                Error = "Invalid 'client ID'", ErrorDescription = "The specified 'client_id' is not valid."
+            });
         }
 
         return request.IdentityProvider.IsNullOrWhiteSpace()
@@ -192,7 +198,10 @@ public class BackOfficeController : SecurityControllerBase
         OpenIddictRequest? request = context.GetOpenIddictServerRequest();
         if (request == null)
         {
-            return BadRequest("Unable to obtain OpenID data from the current request");
+            return BadRequest(new OpenIddictResponse
+            {
+                Error = "No context found", ErrorDescription = "Unable to obtain context from the current request."
+            });
         }
 
         if (request.IsAuthorizationCodeGrantType() || request.IsRefreshTokenGrantType())
@@ -202,7 +211,10 @@ public class BackOfficeController : SecurityControllerBase
 
             return authenticateResult is { Succeeded: true, Principal: not null }
                 ? new SignInResult(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme, authenticateResult.Principal)
-                : BadRequest("The supplied authorization could not be verified.");
+                : BadRequest(new OpenIddictResponse
+                {
+                    Error = "Authorization failed", ErrorDescription = "The supplied authorization could not be verified."
+                });
         }
 
         if (request.IsClientCredentialsGrantType())
@@ -223,7 +235,10 @@ public class BackOfficeController : SecurityControllerBase
 
             // if this happens, the OpenIddict applications have somehow gone out of sync with the Umbraco users
             _logger.LogError("The user associated with the client ID ({clientId}) could not be found", request.ClientId);
-            return BadRequest("The user associated with the client ID could not be found");
+            return BadRequest(new OpenIddictResponse
+            {
+                Error = "Authorization failed", ErrorDescription = "The user associated with the supplied 'client_id' could not be found."
+            });
         }
 
         throw new InvalidOperationException("The requested grant type is not supported.");


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR aligns the custom error responses from the auth parts of the Management and Delivery APIs with those of OpenIddict, which in turn are aligned with the [OpenID Connect standard](https://openid.net/specs/openid-connect-core-1_0.html).

### Testing this PR

Invalid auth requests should have responses that conform to the standard.

For example attempting to use an invalid `client_id` (this is a custom error response in `MemberController`):

![image](https://github.com/user-attachments/assets/23d5ec97-735c-4262-857e-6301e1ca9251)

....compared to using an invalid `redirect_uri` (this is a response from OpenIddict):

![image](https://github.com/user-attachments/assets/2af1dffd-5f2c-46fc-b1c5-42134dd8b718)
