### PR TITLE
V14/fix/cookie breaking installer

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeDefaultController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeDefaultController.cs
@@ -1,19 +1,32 @@
 ﻿using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Security;
 
 public class BackOfficeDefaultController : Controller
 {
+    private readonly IRuntime _umbracoRunTime;
+
+    public BackOfficeDefaultController(IRuntime umbracoRunTime)
+    {
+        _umbracoRunTime = umbracoRunTime;
+    }
+
     [HttpGet]
     [AllowAnonymous]
     public async Task<IActionResult> Index(CancellationToken cancellationToken)
     {
         // force authentication to occur since this is not an authorized endpoint
-        AuthenticateResult result = await this.AuthenticateBackOfficeAsync();
+        // a user can not be authenticated if no users have been created yet, or the user repository is unavailable
+        AuthenticateResult result = _umbracoRunTime.State.Level < RuntimeLevel.Upgrade
+            ? AuthenticateResult.Fail("RuntimeLevel " + _umbracoRunTime.State.Level + " does not support authentication")
+            : await this.AuthenticateBackOfficeAsync();
 
         // if we are not authenticated then we need to redirect to the login page
         if (!result.Succeeded)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeDefaultController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeDefaultController.cs
@@ -13,9 +13,16 @@ public class BackOfficeDefaultController : Controller
 {
     private readonly IRuntime _umbracoRunTime;
 
+    [ActivatorUtilitiesConstructor]
     public BackOfficeDefaultController(IRuntime umbracoRunTime)
     {
         _umbracoRunTime = umbracoRunTime;
+    }
+
+    [Obsolete("Use the non obsoleted constructor instead. Scheduled to be removed in v17")]
+    public BackOfficeDefaultController()
+    {
+        _umbracoRunTime = StaticServiceProvider.Instance.GetRequiredService<IRuntime>();
     }
 
     [HttpGet]

--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeDefaultController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeDefaultController.cs
@@ -11,18 +11,16 @@ namespace Umbraco.Cms.Api.Management.Controllers.Security;
 
 public class BackOfficeDefaultController : Controller
 {
-    private readonly IRuntime _umbracoRunTime;
+    private readonly IRuntime _umbracoRuntime;
 
     [ActivatorUtilitiesConstructor]
-    public BackOfficeDefaultController(IRuntime umbracoRunTime)
-    {
-        _umbracoRunTime = umbracoRunTime;
-    }
+    public BackOfficeDefaultController(IRuntime umbracoRuntime)
+        => _umbracoRuntime = umbracoRuntime;
 
     [Obsolete("Use the non obsoleted constructor instead. Scheduled to be removed in v17")]
     public BackOfficeDefaultController()
+        : this(StaticServiceProvider.Instance.GetRequiredService<IRuntime>())
     {
-        _umbracoRunTime = StaticServiceProvider.Instance.GetRequiredService<IRuntime>();
     }
 
     [HttpGet]
@@ -31,8 +29,8 @@ public class BackOfficeDefaultController : Controller
     {
         // force authentication to occur since this is not an authorized endpoint
         // a user can not be authenticated if no users have been created yet, or the user repository is unavailable
-        AuthenticateResult result = _umbracoRunTime.State.Level < RuntimeLevel.Upgrade
-            ? AuthenticateResult.Fail("RuntimeLevel " + _umbracoRunTime.State.Level + " does not support authentication")
+        AuthenticateResult result = _umbracoRuntime.State.Level < RuntimeLevel.Upgrade
+            ? AuthenticateResult.Fail("RuntimeLevel " + _umbracoRuntime.State.Level + " does not support authentication")
             : await this.AuthenticateBackOfficeAsync();
 
         // if we are not authenticated then we need to redirect to the login page


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
During the boot process of a fresh install. The BackofficeDefaultController is hit and if a (timewise) valid cookie is found, the system will try to find the user bound to that cookie, but it can't since there are no users configured yet. So it errors out and breaks the install process

This PR uses the runtime state to figure out whether authentication is even possible in the current state. If not it fails the authentication without blowing up which results in the installer popping up as required.

### Testing
To force the bug. 
- Start a new project
- Run the installer.
- Stop the server.
- Clean the connectionstring and /umbraco folder
- Try to run the installer again, it should not work. On this branch it should.

All other calls to the BackofficeDefaultController should be have as before.