### PR TITLE
Updated the assembly names to avoid a debug-warning in the log

### DIFF
--- a/src/Umbraco.Core/Constants-Composing.cs
+++ b/src/Umbraco.Core/Constants-Composing.cs
@@ -13,7 +13,7 @@ public static partial class Constants
         public static readonly string[] UmbracoCoreAssemblyNames =
         {
             "Umbraco.Core", "Umbraco.Infrastructure", "Umbraco.PublishedCache.NuCache", "Umbraco.Examine.Lucene",
-            "Umbraco.Web.Common", "Umbraco.Web.BackOffice", "Umbraco.Web.Website",
+            "Umbraco.Web.Common", "Umbraco.Cms.Api.Common","Umbraco.Cms.Api.Delivery","Umbraco.Cms.Api.Management", "Umbraco.Web.Website",
         };
     }
 }


### PR DESCRIPTION
### Description
Updated the assembly names to avoid an debug-error message in the log, about the missing backoffice assembly

### Tests
- Verify Umbraco runs
- Set verbose debugging, and ensure there is not message in the beginning about assemblies that cannot be found.