### PR TITLE
Do not convert calculated lockedOutUntil time to UTC

### DIFF
--- a/src/Umbraco.Infrastructure/Security/IdentityMapDefinition.cs
+++ b/src/Umbraco.Infrastructure/Security/IdentityMapDefinition.cs
@@ -129,7 +129,7 @@ public class IdentityMapDefinition : IMapDefinition
         target.IsApproved = source.IsApproved;
         target.SecurityStamp = source.SecurityStamp;
         DateTime? lockedOutUntil = source.LastLockoutDate?.AddMinutes(_securitySettings.UserDefaultLockoutTimeInMinutes);
-        target.LockoutEnd = source.IsLockedOut ? (lockedOutUntil ?? DateTime.MaxValue).ToUniversalTime() : null;
+        target.LockoutEnd = source.IsLockedOut ? lockedOutUntil ?? DateTime.MaxValue : null;
     }
 
     // Umbraco.Code.MapAll -Id -LockoutEnabled -PhoneNumber -PhoneNumberConfirmed -ConcurrencyStamp -NormalizedEmail -NormalizedUserName -Roles
@@ -147,7 +147,7 @@ public class IdentityMapDefinition : IMapDefinition
         target.IsApproved = source.IsApproved;
         target.SecurityStamp = source.SecurityStamp;
         DateTime? lockedOutUntil = source.LastLockoutDate?.AddMinutes(_securitySettings.MemberDefaultLockoutTimeInMinutes);
-        target.LockoutEnd = source.IsLockedOut ? (lockedOutUntil ?? DateTime.MaxValue).ToUniversalTime() : null;
+        target.LockoutEnd = source.IsLockedOut ? lockedOutUntil ?? DateTime.MaxValue : null;
         target.Comments = source.Comments;
         target.LastLockoutDateUtc = source.LastLockoutDate == DateTime.MinValue
             ? null

--- a/src/Umbraco.Infrastructure/Security/IdentityMapDefinition.cs
+++ b/src/Umbraco.Infrastructure/Security/IdentityMapDefinition.cs
@@ -146,17 +146,46 @@ public class IdentityMapDefinition : IMapDefinition
         target.PasswordConfig = source.PasswordConfiguration;
         target.IsApproved = source.IsApproved;
         target.SecurityStamp = source.SecurityStamp;
-        DateTime? lockedOutUntil = source.LastLockoutDate?.AddMinutes(_securitySettings.MemberDefaultLockoutTimeInMinutes);
-        target.LockoutEnd = source.IsLockedOut ? lockedOutUntil ?? DateTime.MaxValue : null;
+        target.LockoutEnd = GetLockoutEnd(source);
+        target.LastLockoutDateUtc = GetLastLockoutDateUtc(source);
         target.Comments = source.Comments;
-        target.LastLockoutDateUtc = source.LastLockoutDate == DateTime.MinValue
-            ? null
-            : source.LastLockoutDate?.ToUniversalTime();
-        target.CreatedDateUtc = source.CreateDate.ToUniversalTime();
+        target.CreatedDateUtc = EnsureUtcWithServerTime(source.CreateDate);
         target.Key = source.Key;
         target.MemberTypeAlias = source.ContentTypeAlias;
         target.TwoFactorEnabled = _twoFactorLoginService.IsTwoFactorEnabledAsync(source.Key).GetAwaiter().GetResult();
 
         // NB: same comments re AutoMapper as per BackOfficeUser
     }
+
+    private DateTimeOffset? GetLockoutEnd(IMember source)
+    {
+        if (source.IsLockedOut is false)
+        {
+            return null;
+        }
+
+        DateTime? lockedOutUntil = source.LastLockoutDate?.AddMinutes(_securitySettings.MemberDefaultLockoutTimeInMinutes);
+        if (lockedOutUntil.HasValue is false)
+        {
+            return DateTime.MaxValue;
+        }
+
+        return EnsureUtcWithServerTime(lockedOutUntil.Value);
+    }
+
+    private static DateTime? GetLastLockoutDateUtc(IMember source)
+    {
+        if (source.LastLockoutDate is null || source.LastLockoutDate == DateTime.MinValue)
+        {
+            return null;
+        }
+
+        return EnsureUtcWithServerTime(source.LastLockoutDate.Value);
+    }
+
+    private static DateTime EnsureUtcWithServerTime(DateTime date) =>
+
+        // We have a server time value here, but the the Kind is UTC, so we can't use .ToUniversalTime() to convert to the UTC
+        // value that the LockoutEnd property expects. We need to create a DateTimeOffset with the correct offset.
+        DateTime.SpecifyKind(date, DateTimeKind.Local).ToUniversalTime();
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #16988

### Description
Back when Identity was upgraded to identity core, an oversight was made in the code conversion that ended up in a UTC time being stored inside a dateTimeOffset which results in Identity `LockoutEnd` value being set to values that do not correspond to the intend with the following timezone ranges
- For timezones in the +X range this results in lockouts taking longer than intended.
- For timezones in the -X range this results in a lockout never happening if the offset was bigger than the configured `DefaultLockoutTimeInMinutes`.

### Testing
- Set the `Umbraco::CMS::Security::MemberDefaultLockoutTimeInMinutes` setting to a managable time (like 1 minute)
- Implement a member login/logout flow, member group, member and protected content
- Lock the member out by trying to login with an incorrect password equal to `Umbraco::CMS::Security::MemberPassword::MaxFailedAccessAttemptsBeforeLockout` setting
- Check that the behavior in the description no longer happens and the lockout is lifted correctly on the next correct login attempt after the LockoutTimeInMinutes has passed. (and not before)

