### PR TITLE
Fix issue media search does not search child items

### DIFF
--- a/src/Umbraco.Infrastructure/Services/Implement/ContentListViewService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/ContentListViewService.cs
@@ -75,6 +75,32 @@ internal sealed class ContentListViewService : ContentListViewServiceBase<IConte
         return pagedResult;
     }
 
+    protected override async Task<PagedModel<IContent>> GetPagedDescendantsAsync(
+        int id,
+        IQuery<IContent>? filter,
+        Ordering? ordering,
+        int skip,
+        int take)
+    {
+        PaginationHelper.ConvertSkipTakeToPaging(skip, take, out var pageNumber, out var pageSize);
+
+        IEnumerable<IContent> items = await Task.FromResult(_contentService.GetPagedDescendants(
+            id,
+            pageNumber,
+            pageSize,
+            out var total,
+            filter,
+            ordering));
+
+        var pagedResult = new PagedModel<IContent>
+        {
+            Items = items,
+            Total = total,
+        };
+
+        return pagedResult;
+    }
+
     // We can use an authorizer here, as it already handles all the necessary checks for this filtering.
     // However, we cannot pass in all the items; we want only the ones that comply, as opposed to
     // a general response whether the user has access to all nodes.

--- a/src/Umbraco.Infrastructure/Services/Implement/MediaListViewService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/MediaListViewService.cs
@@ -47,7 +47,14 @@ internal sealed class MediaListViewService : ContentListViewServiceBase<IMedia, 
             return Attempt.FailWithStatus<ListViewPagedModel<IMedia>?, ContentCollectionOperationStatus>(ContentCollectionOperationStatus.ContentNotFound, null);
         }
 
-        return await GetListViewResultAsync(user, media, dataTypeKey, orderBy, null, orderDirection, filter, skip, take);
+        if (string.IsNullOrEmpty(filter))
+        {
+            return await GetListViewResultAsync(user, media, dataTypeKey, orderBy, null, orderDirection, filter, skip, take);
+        }
+        else
+        {
+            return await GetListViewDescendantsResultAsync(user, media, dataTypeKey, orderBy, null, orderDirection, filter, skip, take);
+        }
     }
 
     protected override async Task<PagedModel<IMedia>> GetPagedChildrenAsync(int id, IQuery<IMedia>? filter, Ordering? ordering, int skip, int take)
@@ -68,6 +75,26 @@ internal sealed class MediaListViewService : ContentListViewServiceBase<IMedia, 
             Total = total,
         };
 
+        return pagedResult;
+    }
+
+    protected override async Task<PagedModel<IMedia>> GetPagedDescendantsAsync(int id, IQuery<IMedia>? filter, Ordering? ordering, int skip, int take)
+    {
+        PaginationHelper.ConvertSkipTakeToPaging(skip, take, out var pageNumber, out var pageSize);
+
+        IEnumerable<IMedia> items = await Task.FromResult(_mediaService.GetPagedDescendants(
+            id,
+            pageNumber,
+            pageSize,
+            out var total,
+            filter,
+            ordering));
+
+        var pagedResult = new PagedModel<IMedia>
+        {
+            Items = items,
+            Total = total,
+        };
         return pagedResult;
     }
 


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

This PR is related to issue #16968
I fixed this issue by calling GetPagedDescendantsAsync function if search filter has data, otherwise if search filter has no data, it will be filtered as before.

How can test these changes:
1. Go to the Media section, create a folder named "**Product**", create a new image named "**tablet**", inside the folder "**Product**", create a new image named "**table**"
2. On the Media section, search for "**tab**" => results will show both images of "**table**" and "**tablet**"
3. Go to the "**Product**" folder and search for "**tab**" => results will show an image of "**table**".


<!-- Thanks for contributing to Umbraco CMS! -->
