### PR TITLE
Content.EditorDirectiveController: added formSubmittedValidationFailed broadcast to prevent fields to stay disabled

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -757,8 +757,8 @@
                                 formHelper.showNotifications(err.data);
                                 clearNotifications($scope.content);
                                 
-                                handleHttpException(err);
-                                deferred.reject(err);
+                              handleHttpException(err);
+                              deferred.reject(err);
                             });
                         },
                         close: function () {
@@ -787,6 +787,7 @@
                 }, function (err) {
                     $scope.page.buttonGroupState = "error";
                     handleHttpException(err);
+                    $scope.$broadcast("formSubmittedValidationFailed")
                     deferred.reject(err);
                 });
             }


### PR DESCRIPTION
Content.EditorDirectiveController: added formSubmittedValidationFailed broadcast to prevent fields to stay disabled

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #17019

### Version
v13.5.0 RC

### Description
#16961 resolved an issue with content saving.

We discovered that when attempting to save and publish with invalid fields, those fields remained disabled. After some investigation, we found that triggering the formSubmittedValidationFailed broadcast resolved the problem.

### Steps to reproduce
1. Add a mandatory text field to a doctype
2. Add a non mandatory text field to that doctype
3. Create an instance of that doctype
4. Save and publish without value
=> After validation text fields (and blocklist, mediapicker, ...) will stay disabled

In collab with @NielsAudoor ;) 
