### PR TITLE
Fix null reference exception in CacheValues.For when building the CompositeStringStringKey

### DIFF
--- a/src/Umbraco.PublishedCache.NuCache/Property.cs
+++ b/src/Umbraco.PublishedCache.NuCache/Property.cs
@@ -371,7 +371,9 @@ internal class Property : PublishedPropertyBase
 
         public CacheValue For(string? culture, string? segment)
         {
-            // since this allows null and empty string values, we need to assume null and empty string is the same
+            // As noted on IPropertyValue, null value means invariant
+            // But as we need an actual string value to build a CompositeStringStringKey
+            // We need to convert null to empty
             culture ??= string.Empty;
             segment ??= string.Empty;
 

--- a/src/Umbraco.PublishedCache.NuCache/Property.cs
+++ b/src/Umbraco.PublishedCache.NuCache/Property.cs
@@ -371,6 +371,10 @@ internal class Property : PublishedPropertyBase
 
         public CacheValue For(string? culture, string? segment)
         {
+            // since this allows null and empty string values, we need to assume null and empty string is the same
+            culture ??= string.Empty;
+            segment ??= string.Empty;
+
             if (culture == string.Empty && segment == string.Empty)
             {
                 return this;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #16753

### Bug summary
`CacheValues.For` accepts nullable string culture and segment parameters but only performs an empty string check on them, not a null or empty check. This results in an exception because it then attempts to create a `CompositeStringStringKey` with the culture and segment but this object doesn't accept null arguments.

### Description
As noted on IPropertyValue, null value means invariant.
But as we need an actual string value to build a CompositeStringStringKey, we need to convert null to empty

### Testing
Make sure (invariant) (published) content still behaves correctly in multi culture/segment scenarios.