### PR TITLE
Add endpoint for upgrade checks

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Server/ConfigurationServerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Server/ConfigurationServerController.cs
@@ -1,9 +1,11 @@
 ﻿using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Api.Management.ViewModels.Server;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Server;
 
@@ -11,8 +13,20 @@ namespace Umbraco.Cms.Api.Management.Controllers.Server;
 public class ConfigurationServerController : ServerControllerBase
 {
     private readonly SecuritySettings _securitySettings;
+    private readonly GlobalSettings _globalSettings;
 
-    public ConfigurationServerController(IOptions<SecuritySettings> securitySettings) => _securitySettings = securitySettings.Value;
+    [Obsolete("Use the constructor that accepts all arguments. Will be removed in V16.")]
+    public ConfigurationServerController(IOptions<SecuritySettings> securitySettings)
+        : this(securitySettings, StaticServiceProvider.Instance.GetRequiredService<IOptions<GlobalSettings>>())
+    {
+    }
+
+    [ActivatorUtilitiesConstructor]
+    public ConfigurationServerController(IOptions<SecuritySettings> securitySettings, IOptions<GlobalSettings> globalSettings)
+    {
+        _securitySettings = securitySettings.Value;
+        _globalSettings = globalSettings.Value;
+    }
 
     [HttpGet("configuration")]
     [MapToApiVersion("1.0")]
@@ -22,6 +36,7 @@ public class ConfigurationServerController : ServerControllerBase
         var responseModel = new ServerConfigurationResponseModel
         {
             AllowPasswordReset = _securitySettings.AllowPasswordReset,
+            VersionCheckPeriod = _globalSettings.VersionCheckPeriod
         };
 
         return Task.FromResult<IActionResult>(Ok(responseModel));

--- a/src/Umbraco.Cms.Api.Management/Controllers/Server/UpgradeCheckServerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Server/UpgradeCheckServerController.cs
@@ -1,0 +1,45 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Server;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Web.Common.Authorization;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Server;
+
+[ApiVersion("1.0")]
+[Authorize(Policy = AuthorizationPolicies.RequireAdminAccess)]
+public class UpgradeCheckServerController : ServerControllerBase
+{
+    private readonly IUpgradeService _upgradeService;
+    private readonly IUmbracoVersion _umbracoVersion;
+
+    public UpgradeCheckServerController(IUpgradeService upgradeService, IUmbracoVersion umbracoVersion)
+    {
+        _upgradeService = upgradeService;
+        _umbracoVersion = umbracoVersion;
+    }
+
+    [HttpGet("upgrade-check")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(UpgradeCheckResponseModel), StatusCodes.Status200OK)]
+    public async Task<IActionResult> UpgradeCheck(CancellationToken cancellationToken)
+    {
+        UpgradeResult upgradeResult = await _upgradeService.CheckUpgrade(_umbracoVersion.SemanticVersion);
+
+        var responseModel = new UpgradeCheckResponseModel
+        {
+            Type = upgradeResult.UpgradeType,
+            Comment = upgradeResult.Comment,
+            Url = upgradeResult.UpgradeUrl.IsNullOrWhiteSpace()
+                ? string.Empty
+                : $"{upgradeResult.UpgradeUrl}?version={_umbracoVersion.Version.ToString(3)}"
+        };
+
+        return Ok(responseModel);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -25176,6 +25176,41 @@
         ]
       }
     },
+    "/umbraco/management/api/v1/server/upgrade-check": {
+      "get": {
+        "tags": [
+          "Server"
+        ],
+        "operationId": "GetServerUpgradeCheck",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/UpgradeCheckResponseModel"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          },
+          "403": {
+            "description": "The authenticated user do not have access to this resource"
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
     "/umbraco/management/api/v1/item/static-file": {
       "get": {
         "tags": [
@@ -42446,12 +42481,17 @@
       },
       "ServerConfigurationResponseModel": {
         "required": [
-          "allowPasswordReset"
+          "allowPasswordReset",
+          "versionCheckPeriod"
         ],
         "type": "object",
         "properties": {
           "allowPasswordReset": {
             "type": "boolean"
+          },
+          "versionCheckPeriod": {
+            "type": "integer",
+            "format": "int32"
           }
         },
         "additionalProperties": false
@@ -44510,6 +44550,26 @@
             "items": {
               "type": "string"
             }
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpgradeCheckResponseModel": {
+        "required": [
+          "comment",
+          "type",
+          "url"
+        ],
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
           }
         },
         "additionalProperties": false

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Server/ServerConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Server/ServerConfigurationResponseModel.cs
@@ -3,4 +3,6 @@
 public class ServerConfigurationResponseModel
 {
     public bool AllowPasswordReset { get; set; }
+
+    public int VersionCheckPeriod { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Server/UpgradeCheckResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Server/UpgradeCheckResponseModel.cs
@@ -1,0 +1,10 @@
+﻿namespace Umbraco.Cms.Api.Management.ViewModels.Server;
+
+public class UpgradeCheckResponseModel
+{
+    public required string Type { get; init; }
+
+    public required string Comment { get; init; }
+
+    public required string Url { get; init; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Server/VersionResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Server/VersionResponseModel.cs
@@ -2,6 +2,7 @@
 
 namespace Umbraco.Cms.Api.Management.ViewModels.Server;
 
+[Obsolete("Not used. Will be removed in V15.")]
 public class VersionResponseModel
 {
     [Required]

--- a/src/Umbraco.Core/Persistence/Repositories/UpgradeCheckRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/UpgradeCheckRepository.cs
@@ -16,14 +16,10 @@ public class UpgradeCheckRepository : IUpgradeCheckRepository
     {
         try
         {
-            if (_httpClient == null)
-            {
-                _httpClient = new HttpClient();
-            }
+            _httpClient ??= new HttpClient { Timeout = TimeSpan.FromSeconds(1) };
 
             using var content = new StringContent(_jsonSerializer.Serialize(new CheckUpgradeDto(version)), Encoding.UTF8, "application/json");
 
-            _httpClient.Timeout = TimeSpan.FromSeconds(1);
             using HttpResponseMessage task = await _httpClient.PostAsync(RestApiUpgradeChecklUrl, content);
             var json = await task.Content.ReadAsStringAsync();
             UpgradeResult? result = _jsonSerializer.Deserialize<UpgradeResult>(json);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

We need this new endpoint to support upgrade checks.

Moving forward, it will be a client responsibility to only check within the defined intervals (default every 7 days). To support this, `VersionCheckPeriod` has been exposed in the server configuration endpoint.

### Testing this PR

1. As an admin, verify that the new endpoint yields an appropriate response.
   - To test this properly, it will be necessary to force a previous version into the check in `UpgradeCheckServerController.UpgradeCheck`. Either hardcode a different version, or attach a debugger and change the passed-in version in `IUpgradeService.CheckUpgrade`.
2. As a non-admin, verify that the new endpoint does not allow access.

Also verify that the `VersionCheckPeriod` configuration value is correctly exposed in the server configuration endpoint.