### PR TITLE
Add notification alias to document notifications endpoint output

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Factories/DocumentNotificationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DocumentNotificationPresentationFactory.cs
@@ -27,13 +27,14 @@ internal sealed class DocumentNotificationPresentationFactory : IDocumentNotific
                                           .ToArray()
                                       ?? Array.Empty<string>();
 
-        var availableActionIds = _actionCollection.Where(a => a.ShowInNotifier).Select(a => a.Letter.ToString()).ToArray();
-
-        return await Task.FromResult(
-            availableActionIds.Select(actionId => new DocumentNotificationResponseModel
+        return await Task.FromResult(_actionCollection
+            .Where(action => action.ShowInNotifier)
+            .Select(action => new DocumentNotificationResponseModel
             {
-                ActionId = actionId,
-                Subscribed = subscribedActionIds.Contains(actionId)
-            }).ToArray());
+                ActionId = action.Letter,
+                Alias = action.Alias,
+                Subscribed = subscribedActionIds.Contains(action.Letter)
+            })
+            .ToArray());
     }
 }

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -36516,11 +36516,15 @@
       "DocumentNotificationResponseModel": {
         "required": [
           "actionId",
+          "alias",
           "subscribed"
         ],
         "type": "object",
         "properties": {
           "actionId": {
+            "type": "string"
+          },
+          "alias": {
             "type": "string"
           },
           "subscribed": {

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentNotificationsResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentNotificationsResponseModel.cs
@@ -4,5 +4,7 @@ public class DocumentNotificationResponseModel
 {
     public required string ActionId { get; set; }
 
+    public required string Alias { get; set; }
+
     public required bool Subscribed { get; set; }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

To ease localization of the "Document notifications" dialog, the document notification aliases have been added to the output of the supporting endpoint.

### Testing this PR

Verify that the output from the document notifications endpoint contains an `alias` for each notification type.