### PR TITLE
Update obsolete message for get markup and rename method

### DIFF
--- a/src/Umbraco.Core/Media/EmbedProviders/DailyMotion.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/DailyMotion.cs
@@ -23,7 +23,7 @@ public class DailyMotion : OEmbedProviderBase
         { "format", "xml" },
     };
 
-    public override async Task<string?> GeOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
+    public override async Task<string?> GetOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
     {
         var requestUrl = base.GetEmbedProviderUrl(url, maxWidth, maxHeight);
         XmlDocument xmlDocument = await base.GetXmlResponseAsync(requestUrl, cancellationToken);
@@ -34,6 +34,6 @@ public class DailyMotion : OEmbedProviderBase
     [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
-        return GeOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
+        return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
     }
 }

--- a/src/Umbraco.Core/Media/EmbedProviders/DailyMotion.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/DailyMotion.cs
@@ -31,7 +31,7 @@ public class DailyMotion : OEmbedProviderBase
         return GetXmlProperty(xmlDocument, "/oembed/html");
     }
 
-    [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
+    [Obsolete("Use GetOEmbedDataAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
         return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();

--- a/src/Umbraco.Core/Media/EmbedProviders/Flickr.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Flickr.cs
@@ -20,7 +20,7 @@ public class Flickr : OEmbedProviderBase
 
     public override Dictionary<string, string> RequestParams => new();
 
-    [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
+    [Obsolete("Use GetOEmbedDataAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
         return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();

--- a/src/Umbraco.Core/Media/EmbedProviders/Flickr.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Flickr.cs
@@ -23,10 +23,10 @@ public class Flickr : OEmbedProviderBase
     [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
-        return GeOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
+        return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
     }
 
-    public override async Task<string?> GeOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
+    public override async Task<string?> GetOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
     {
         var requestUrl = base.GetEmbedProviderUrl(url, maxWidth, maxHeight);
         XmlDocument xmlDocument = await base.GetXmlResponseAsync(requestUrl, cancellationToken);

--- a/src/Umbraco.Core/Media/EmbedProviders/GettyImages.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/GettyImages.cs
@@ -23,10 +23,10 @@ public class GettyImages : OEmbedProviderBase
     [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
-        return GeOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
+        return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
     }
 
-    public override async Task<string?> GeOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
+    public override async Task<string?> GetOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
     {
         var requestUrl = base.GetEmbedProviderUrl(url, maxWidth, maxHeight);
         OEmbedResponse? oembed = await base.GetJsonResponseAsync<OEmbedResponse>(requestUrl, cancellationToken);

--- a/src/Umbraco.Core/Media/EmbedProviders/GettyImages.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/GettyImages.cs
@@ -20,7 +20,7 @@ public class GettyImages : OEmbedProviderBase
 
     public override Dictionary<string, string> RequestParams => new();
 
-    [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
+    [Obsolete("Use GetOEmbedDataAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
         return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();

--- a/src/Umbraco.Core/Media/EmbedProviders/Giphy.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Giphy.cs
@@ -18,7 +18,7 @@ public class Giphy : OEmbedProviderBase
 
     public override Dictionary<string, string> RequestParams => new();
 
-    [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
+    [Obsolete("Use GetOEmbedDataAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
         return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();

--- a/src/Umbraco.Core/Media/EmbedProviders/Giphy.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Giphy.cs
@@ -21,10 +21,10 @@ public class Giphy : OEmbedProviderBase
     [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
-        return GeOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
+        return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
     }
 
-    public override async Task<string?> GeOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
+    public override async Task<string?> GetOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
     {
         var requestUrl = base.GetEmbedProviderUrl(url, maxWidth, maxHeight);
         OEmbedResponse? oembed = await base.GetJsonResponseAsync<OEmbedResponse>(requestUrl, cancellationToken);

--- a/src/Umbraco.Core/Media/EmbedProviders/Hulu.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Hulu.cs
@@ -21,10 +21,10 @@ public class Hulu : OEmbedProviderBase
     [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
-        return GeOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
+        return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
     }
 
-    public override async Task<string?> GeOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
+    public override async Task<string?> GetOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
     {
         var requestUrl = base.GetEmbedProviderUrl(url, maxWidth, maxHeight);
         OEmbedResponse? oembed = await base.GetJsonResponseAsync<OEmbedResponse>(requestUrl, cancellationToken);

--- a/src/Umbraco.Core/Media/EmbedProviders/Hulu.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Hulu.cs
@@ -18,7 +18,7 @@ public class Hulu : OEmbedProviderBase
 
     public override Dictionary<string, string> RequestParams => new();
 
-    [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
+    [Obsolete("Use GetOEmbedDataAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
         return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();

--- a/src/Umbraco.Core/Media/EmbedProviders/Issuu.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Issuu.cs
@@ -26,7 +26,7 @@ public class Issuu : OEmbedProviderBase
         { "format", "xml" },
     };
 
-    [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
+    [Obsolete("Use GetOEmbedDataAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
         return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();

--- a/src/Umbraco.Core/Media/EmbedProviders/Issuu.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Issuu.cs
@@ -29,10 +29,10 @@ public class Issuu : OEmbedProviderBase
     [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
-        return GeOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
+        return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
     }
 
-    public override async Task<string?> GeOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
+    public override async Task<string?> GetOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
     {
         var requestUrl = base.GetEmbedProviderUrl(url, maxWidth, maxHeight);
         XmlDocument xmlDocument = await base.GetXmlResponseAsync(requestUrl, cancellationToken);

--- a/src/Umbraco.Core/Media/EmbedProviders/Kickstarter.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Kickstarter.cs
@@ -18,7 +18,7 @@ public class Kickstarter : OEmbedProviderBase
 
     public override Dictionary<string, string> RequestParams => new();
 
-    [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
+    [Obsolete("Use GetOEmbedDataAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
         return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();

--- a/src/Umbraco.Core/Media/EmbedProviders/Kickstarter.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Kickstarter.cs
@@ -21,10 +21,10 @@ public class Kickstarter : OEmbedProviderBase
     [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
-        return GeOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
+        return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
     }
 
-    public override async Task<string?> GeOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
+    public override async Task<string?> GetOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
     {
         var requestUrl = base.GetEmbedProviderUrl(url, maxWidth, maxHeight);
         OEmbedResponse? oembed = await base.GetJsonResponseAsync<OEmbedResponse>(requestUrl, cancellationToken);

--- a/src/Umbraco.Core/Media/EmbedProviders/LottieFiles.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/LottieFiles.cs
@@ -22,10 +22,10 @@ public class LottieFiles : OEmbedProviderBase
     [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
-        return GeOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
+        return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
     }
 
-    public override async Task<string?> GeOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
+    public override async Task<string?> GetOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
     {
         var requestUrl = this.GetEmbedProviderUrl(url, maxWidth, maxHeight);
         OEmbedResponse? oembed = await this.GetJsonResponseAsync<OEmbedResponse>(requestUrl, cancellationToken);

--- a/src/Umbraco.Core/Media/EmbedProviders/LottieFiles.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/LottieFiles.cs
@@ -19,7 +19,7 @@ public class LottieFiles : OEmbedProviderBase
 
     public override Dictionary<string, string> RequestParams => new();
 
-    [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
+    [Obsolete("Use GetOEmbedDataAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
         return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();

--- a/src/Umbraco.Core/Media/EmbedProviders/OEmbedProviderBase.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/OEmbedProviderBase.cs
@@ -21,7 +21,7 @@ public abstract class OEmbedProviderBase : IEmbedProvider
     [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
     public abstract string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0);
 
-    public virtual Task<string?> GeOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken) => Task.FromResult(GetMarkup(url, maxWidth ?? 0, maxHeight ?? 0));
+    public virtual Task<string?> GetOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken) => Task.FromResult(GetMarkup(url, maxWidth ?? 0, maxHeight ?? 0));
 
     public virtual string GetEmbedProviderUrl(string url, int? maxWidth, int? maxHeight) => GetEmbedProviderUrl(url, maxWidth ?? 0, maxHeight ?? 0);
     public virtual string GetEmbedProviderUrl(string url, int maxWidth, int maxHeight)

--- a/src/Umbraco.Core/Media/EmbedProviders/OEmbedProviderBase.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/OEmbedProviderBase.cs
@@ -18,7 +18,7 @@ public abstract class OEmbedProviderBase : IEmbedProvider
 
     public abstract Dictionary<string, string> RequestParams { get; }
 
-    [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
+    [Obsolete("Use GetOEmbedDataAsync instead. This will be removed in Umbraco 15.")]
     public abstract string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0);
 
     public virtual Task<string?> GetOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken) => Task.FromResult(GetMarkup(url, maxWidth ?? 0, maxHeight ?? 0));

--- a/src/Umbraco.Core/Media/EmbedProviders/Slideshare.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Slideshare.cs
@@ -22,10 +22,10 @@ public class Slideshare : OEmbedProviderBase
     [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
-        return GeOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
+        return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
     }
 
-    public override async Task<string?> GeOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
+    public override async Task<string?> GetOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
     {
         var requestUrl = base.GetEmbedProviderUrl(url, maxWidth, maxHeight);
         XmlDocument xmlDocument = await base.GetXmlResponseAsync(requestUrl, cancellationToken);

--- a/src/Umbraco.Core/Media/EmbedProviders/Slideshare.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Slideshare.cs
@@ -19,7 +19,7 @@ public class Slideshare : OEmbedProviderBase
 
     public override Dictionary<string, string> RequestParams => new();
 
-    [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
+    [Obsolete("Use GetOEmbedDataAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
         return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();

--- a/src/Umbraco.Core/Media/EmbedProviders/SoundCloud.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/SoundCloud.cs
@@ -23,10 +23,10 @@ public class Soundcloud : OEmbedProviderBase
     [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
-        return GeOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
+        return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
     }
 
-    public override async Task<string?> GeOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
+    public override async Task<string?> GetOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
     {
         var requestUrl = base.GetEmbedProviderUrl(url, maxWidth, maxHeight);
         XmlDocument xmlDocument = await base.GetXmlResponseAsync(requestUrl, cancellationToken);

--- a/src/Umbraco.Core/Media/EmbedProviders/SoundCloud.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/SoundCloud.cs
@@ -20,7 +20,7 @@ public class Soundcloud : OEmbedProviderBase
     public override Dictionary<string, string> RequestParams => new();
 
 
-    [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
+    [Obsolete("Use GetOEmbedDataAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
         return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();

--- a/src/Umbraco.Core/Media/EmbedProviders/Ted.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Ted.cs
@@ -19,7 +19,7 @@ public class Ted : OEmbedProviderBase
 
     public override Dictionary<string, string> RequestParams => new();
 
-    [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
+    [Obsolete("Use GetOEmbedDataAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
         return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();

--- a/src/Umbraco.Core/Media/EmbedProviders/Ted.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Ted.cs
@@ -22,10 +22,10 @@ public class Ted : OEmbedProviderBase
     [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
-        return GeOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
+        return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
     }
 
-    public override async Task<string?> GeOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
+    public override async Task<string?> GetOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
     {
         var requestUrl = base.GetEmbedProviderUrl(url, maxWidth, maxHeight);
         XmlDocument xmlDocument = await base.GetXmlResponseAsync(requestUrl, cancellationToken);

--- a/src/Umbraco.Core/Media/EmbedProviders/Twitter.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Twitter.cs
@@ -22,10 +22,10 @@ public class Twitter : OEmbedProviderBase
     [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
-        return GeOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
+        return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
     }
 
-    public override async Task<string?> GeOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
+    public override async Task<string?> GetOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
     {
         var requestUrl = base.GetEmbedProviderUrl(url, maxWidth, maxHeight);
         OEmbedResponse? oembed = await base.GetJsonResponseAsync<OEmbedResponse>(requestUrl, cancellationToken);

--- a/src/Umbraco.Core/Media/EmbedProviders/Twitter.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Twitter.cs
@@ -19,7 +19,7 @@ public class Twitter : OEmbedProviderBase
 
     public override Dictionary<string, string> RequestParams => new();
 
-    [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
+    [Obsolete("Use GetOEmbedDataAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
         return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();

--- a/src/Umbraco.Core/Media/EmbedProviders/Vimeo.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Vimeo.cs
@@ -19,7 +19,7 @@ public class Vimeo : OEmbedProviderBase
 
     public override Dictionary<string, string> RequestParams => new();
 
-    [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
+    [Obsolete("Use GetOEmbedDataAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
         return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();

--- a/src/Umbraco.Core/Media/EmbedProviders/Vimeo.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Vimeo.cs
@@ -22,10 +22,10 @@ public class Vimeo : OEmbedProviderBase
     [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
-        return GeOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
+        return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
     }
 
-    public override async Task<string?> GeOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
+    public override async Task<string?> GetOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
     {
         var requestUrl = base.GetEmbedProviderUrl(url, maxWidth, maxHeight);
         XmlDocument xmlDocument = await base.GetXmlResponseAsync(requestUrl, cancellationToken);

--- a/src/Umbraco.Core/Media/EmbedProviders/Youtube.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Youtube.cs
@@ -22,7 +22,7 @@ public class YouTube : OEmbedProviderBase
         { "format", "json" },
     };
 
-    [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
+    [Obsolete("Use GetOEmbedDataAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
         return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();

--- a/src/Umbraco.Core/Media/EmbedProviders/Youtube.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Youtube.cs
@@ -25,10 +25,10 @@ public class YouTube : OEmbedProviderBase
     [Obsolete("Use GetMarkupAsync instead. This will be removed in Umbraco 15.")]
     public override string? GetMarkup(string url, int maxWidth = 0, int maxHeight = 0)
     {
-        return GeOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
+        return GetOEmbedDataAsync(url, maxWidth, maxHeight, CancellationToken.None).GetAwaiter().GetResult();
     }
 
-    public override async Task<string?> GeOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
+    public override async Task<string?> GetOEmbedDataAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
     {
         var requestUrl = base.GetEmbedProviderUrl(url, maxWidth, maxHeight);
         OEmbedResponse? oembed = await base.GetJsonResponseAsync<OEmbedResponse>(requestUrl, cancellationToken);


### PR DESCRIPTION
### Description
I'm not sure if this can go to the contrib branch or if it should go to the v15 branch because this changes a method name which is actually a breaking change. 

* [x] Update obsolete messages for the `GetMarkup` method in `OEmbedProviders` 
* [x] Rename method (fix typo) `GeOEmbedDataAsync(...)` to `GetOEmbedDataAsync(...)`