### PR TITLE
Add EditorAlias to content value outputs

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Content/ContentCollectionControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Content/ContentCollectionControllerBase.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Cms.Api.Management.Controllers.Content;
 public abstract class ContentCollectionControllerBase<TContent, TCollectionResponseModel, TValueResponseModelBase, TVariantResponseModel> : ManagementApiControllerBase
     where TContent : class, IContentBase
     where TCollectionResponseModel : ContentResponseModelBase<TValueResponseModelBase, TVariantResponseModel>
-    where TValueResponseModelBase : ValueModelBase
+    where TValueResponseModelBase : ValueResponseModelBase
     where TVariantResponseModel : VariantResponseModelBase
 {
     private readonly IUmbracoMapper _mapper;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Collection/DocumentCollectionControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Collection/DocumentCollectionControllerBase.cs
@@ -15,7 +15,7 @@ namespace Umbraco.Cms.Api.Management.Controllers.Document.Collection;
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Collection}/{Constants.UdiEntityType.Document}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Document))]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessDocuments)]
-public abstract class DocumentCollectionControllerBase : ContentCollectionControllerBase<IContent, DocumentCollectionResponseModel, DocumentValueModel, DocumentVariantResponseModel>
+public abstract class DocumentCollectionControllerBase : ContentCollectionControllerBase<IContent, DocumentCollectionResponseModel, DocumentValueResponseModel, DocumentVariantResponseModel>
 {
     protected DocumentCollectionControllerBase(IUmbracoMapper mapper)
         : base(mapper)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Collection/MediaCollectionControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Collection/MediaCollectionControllerBase.cs
@@ -15,7 +15,7 @@ namespace Umbraco.Cms.Api.Management.Controllers.Media.Collection;
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Collection}/{Constants.UdiEntityType.Media}")]
 [ApiExplorerSettings(GroupName = nameof(Constants.UdiEntityType.Media))]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessMedia)]
-public abstract class MediaCollectionControllerBase : ContentCollectionControllerBase<IMedia, MediaCollectionResponseModel, MediaValueModel, MediaVariantResponseModel>
+public abstract class MediaCollectionControllerBase : ContentCollectionControllerBase<IMedia, MediaCollectionResponseModel, MediaValueResponseModel, MediaVariantResponseModel>
 {
     protected MediaCollectionControllerBase(IUmbracoMapper mapper)
         : base(mapper)

--- a/src/Umbraco.Cms.Api.Management/Mapping/Content/ContentMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Content/ContentMapDefinition.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Api.Management.Mapping.Content;
 
 public abstract class ContentMapDefinition<TContent, TValueViewModel, TVariantViewModel>
     where TContent : IContentBase
-    where TValueViewModel : ValueModelBase, new()
+    where TValueViewModel : ValueResponseModelBase, new()
     where TVariantViewModel : VariantResponseModelBase, new()
 {
     private readonly PropertyEditorCollection _propertyEditorCollection;
@@ -36,7 +36,8 @@ public abstract class ContentMapDefinition<TContent, TValueViewModel, TVariantVi
                         Culture = propertyValue.Culture,
                         Segment = propertyValue.Segment,
                         Alias = property.Alias,
-                        Value = propertyEditor.GetValueEditor().ToEditor(property, propertyValue.Culture, propertyValue.Segment)
+                        Value = propertyEditor.GetValueEditor().ToEditor(property, propertyValue.Culture, propertyValue.Segment),
+                        EditorAlias = propertyEditor.Alias
                     };
                     additionalPropertyMapping?.Invoke(propertyEditor, variantViewModel);
                     return variantViewModel;

--- a/src/Umbraco.Cms.Api.Management/Mapping/Document/DocumentMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Document/DocumentMapDefinition.cs
@@ -11,7 +11,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Mapping.Document;
 
-public class DocumentMapDefinition : ContentMapDefinition<IContent, DocumentValueModel, DocumentVariantResponseModel>, IMapDefinition
+public class DocumentMapDefinition : ContentMapDefinition<IContent, DocumentValueResponseModel, DocumentVariantResponseModel>, IMapDefinition
 {
     private readonly CommonMapper _commonMapper;
 

--- a/src/Umbraco.Cms.Api.Management/Mapping/Document/DocumentVersionMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Document/DocumentVersionMapDefinition.cs
@@ -9,7 +9,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Mapping.Document;
 
-public class DocumentVersionMapDefinition : ContentMapDefinition<IContent, DocumentValueModel, DocumentVariantResponseModel>, IMapDefinition
+public class DocumentVersionMapDefinition : ContentMapDefinition<IContent, DocumentValueResponseModel, DocumentVariantResponseModel>, IMapDefinition
 {
     public DocumentVersionMapDefinition(PropertyEditorCollection propertyEditorCollection)
         : base(propertyEditorCollection)

--- a/src/Umbraco.Cms.Api.Management/Mapping/Media/MediaMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Media/MediaMapDefinition.cs
@@ -10,7 +10,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Mapping.Media;
 
-public class MediaMapDefinition : ContentMapDefinition<IMedia, MediaValueModel, MediaVariantResponseModel>, IMapDefinition
+public class MediaMapDefinition : ContentMapDefinition<IMedia, MediaValueResponseModel, MediaVariantResponseModel>, IMapDefinition
 {
     private readonly CommonMapper _commonMapper;
 

--- a/src/Umbraco.Cms.Api.Management/Mapping/Member/MemberMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Member/MemberMapDefinition.cs
@@ -7,7 +7,7 @@ using Umbraco.Cms.Core.PropertyEditors;
 
 namespace Umbraco.Cms.Api.Management.Mapping.Member;
 
-public class MemberMapDefinition : ContentMapDefinition<IMember, MemberValueModel, MemberVariantResponseModel>, IMapDefinition
+public class MemberMapDefinition : ContentMapDefinition<IMember, MemberValueResponseModel, MemberVariantResponseModel>, IMapDefinition
 {
     public MemberMapDefinition(PropertyEditorCollection propertyEditorCollection)
         : base(propertyEditorCollection)

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -36314,7 +36314,7 @@
             "items": {
               "oneOf": [
                 {
-                  "$ref": "#/components/schemas/DocumentValueModel"
+                  "$ref": "#/components/schemas/DocumentValueResponseModel"
                 }
               ]
             }
@@ -36399,7 +36399,7 @@
             "items": {
               "oneOf": [
                 {
-                  "$ref": "#/components/schemas/DocumentValueModel"
+                  "$ref": "#/components/schemas/DocumentValueResponseModel"
                 }
               ]
             }
@@ -36652,7 +36652,7 @@
             "items": {
               "oneOf": [
                 {
-                  "$ref": "#/components/schemas/DocumentValueModel"
+                  "$ref": "#/components/schemas/DocumentValueResponseModel"
                 }
               ]
             }
@@ -37334,6 +37334,35 @@
         },
         "additionalProperties": false
       },
+      "DocumentValueResponseModel": {
+        "required": [
+          "alias",
+          "editorAlias"
+        ],
+        "type": "object",
+        "properties": {
+          "culture": {
+            "type": "string",
+            "nullable": true
+          },
+          "segment": {
+            "type": "string",
+            "nullable": true
+          },
+          "alias": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "value": {
+            "nullable": true
+          },
+          "editorAlias": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
       "DocumentVariantItemResponseModel": {
         "required": [
           "name",
@@ -37492,7 +37521,7 @@
             "items": {
               "oneOf": [
                 {
-                  "$ref": "#/components/schemas/DocumentValueModel"
+                  "$ref": "#/components/schemas/DocumentValueResponseModel"
                 }
               ]
             }
@@ -38534,7 +38563,7 @@
             "items": {
               "oneOf": [
                 {
-                  "$ref": "#/components/schemas/MediaValueModel"
+                  "$ref": "#/components/schemas/MediaValueResponseModel"
                 }
               ]
             }
@@ -38717,7 +38746,7 @@
             "items": {
               "oneOf": [
                 {
-                  "$ref": "#/components/schemas/MediaValueModel"
+                  "$ref": "#/components/schemas/MediaValueResponseModel"
                 }
               ]
             }
@@ -39305,6 +39334,35 @@
         },
         "additionalProperties": false
       },
+      "MediaValueResponseModel": {
+        "required": [
+          "alias",
+          "editorAlias"
+        ],
+        "type": "object",
+        "properties": {
+          "culture": {
+            "type": "string",
+            "nullable": true
+          },
+          "segment": {
+            "type": "string",
+            "nullable": true
+          },
+          "alias": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "value": {
+            "nullable": true
+          },
+          "editorAlias": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
       "MediaVariantRequestModel": {
         "required": [
           "name"
@@ -39473,7 +39531,7 @@
             "items": {
               "oneOf": [
                 {
-                  "$ref": "#/components/schemas/MemberValueModel"
+                  "$ref": "#/components/schemas/MemberValueResponseModel"
                 }
               ]
             }
@@ -39954,6 +40012,35 @@
           },
           "value": {
             "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "MemberValueResponseModel": {
+        "required": [
+          "alias",
+          "editorAlias"
+        ],
+        "type": "object",
+        "properties": {
+          "culture": {
+            "type": "string",
+            "nullable": true
+          },
+          "segment": {
+            "type": "string",
+            "nullable": true
+          },
+          "alias": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "value": {
+            "nullable": true
+          },
+          "editorAlias": {
+            "minLength": 1,
+            "type": "string"
           }
         },
         "additionalProperties": false

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Content/ContentCollectionResponseModelBase.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Content/ContentCollectionResponseModelBase.cs
@@ -4,7 +4,7 @@ namespace Umbraco.Cms.Api.Management.ViewModels.Content;
 
 public abstract class ContentCollectionResponseModelBase<TValueResponseModelBase, TVariantResponseModel>
     : ContentResponseModelBase<TValueResponseModelBase, TVariantResponseModel>
-    where TValueResponseModelBase : ValueModelBase
+    where TValueResponseModelBase : ValueResponseModelBase
     where TVariantResponseModel : VariantResponseModelBase
 {
     public string? Creator { get; set; }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/Collection/DocumentCollectionResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/Collection/DocumentCollectionResponseModel.cs
@@ -3,7 +3,7 @@ using Umbraco.Cms.Api.Management.ViewModels.DocumentType;
 
 namespace Umbraco.Cms.Api.Management.ViewModels.Document.Collection;
 
-public class DocumentCollectionResponseModel : ContentCollectionResponseModelBase<DocumentValueModel, DocumentVariantResponseModel>
+public class DocumentCollectionResponseModel : ContentCollectionResponseModelBase<DocumentValueResponseModel, DocumentVariantResponseModel>
 {
     public DocumentTypeCollectionReferenceResponseModel DocumentType { get; set; } = new();
 

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentResponseModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace Umbraco.Cms.Api.Management.ViewModels.Document;
 
-public class DocumentResponseModel : DocumentResponseModelBase<DocumentValueModel, DocumentVariantResponseModel>
+public class DocumentResponseModel : DocumentResponseModelBase<DocumentValueResponseModel, DocumentVariantResponseModel>
 {
     public IEnumerable<DocumentUrlInfo> Urls { get; set; } = Enumerable.Empty<DocumentUrlInfo>();
 

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentValueResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentValueResponseModel.cs
@@ -1,0 +1,7 @@
+﻿using Umbraco.Cms.Core.Models.ContentEditing;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.Document;
+
+public class DocumentValueResponseModel : ValueResponseModelBase
+{
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentVersionResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentVersionResponseModel.cs
@@ -1,6 +1,6 @@
 namespace Umbraco.Cms.Api.Management.ViewModels.Document;
 
-public class DocumentVersionResponseModel : DocumentResponseModelBase<DocumentValueModel, DocumentVariantResponseModel>
+public class DocumentVersionResponseModel : DocumentResponseModelBase<DocumentValueResponseModel, DocumentVariantResponseModel>
 {
     public ReferenceByIdModel? Document { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DocumentBlueprint/DocumentBlueprintResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DocumentBlueprint/DocumentBlueprintResponseModel.cs
@@ -2,6 +2,6 @@ using Umbraco.Cms.Api.Management.ViewModels.Document;
 
 namespace Umbraco.Cms.Api.Management.ViewModels.DocumentBlueprint;
 
-public class DocumentBlueprintResponseModel : DocumentResponseModelBase<DocumentValueModel, DocumentVariantResponseModel>
+public class DocumentBlueprintResponseModel : DocumentResponseModelBase<DocumentValueResponseModel, DocumentVariantResponseModel>
 {
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Media/Collection/MediaCollectionResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Media/Collection/MediaCollectionResponseModel.cs
@@ -3,7 +3,7 @@ using Umbraco.Cms.Api.Management.ViewModels.MediaType;
 
 namespace Umbraco.Cms.Api.Management.ViewModels.Media.Collection;
 
-public class MediaCollectionResponseModel : ContentCollectionResponseModelBase<MediaValueModel, MediaVariantResponseModel>
+public class MediaCollectionResponseModel : ContentCollectionResponseModelBase<MediaValueResponseModel, MediaVariantResponseModel>
 {
     public MediaTypeCollectionReferenceResponseModel MediaType { get; set; } = new();
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Media/MediaResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Media/MediaResponseModel.cs
@@ -3,7 +3,7 @@ using Umbraco.Cms.Api.Management.ViewModels.MediaType;
 
 namespace Umbraco.Cms.Api.Management.ViewModels.Media;
 
-public class MediaResponseModel : ContentResponseModelBase<MediaValueModel, MediaVariantResponseModel>
+public class MediaResponseModel : ContentResponseModelBase<MediaValueResponseModel, MediaVariantResponseModel>
 {
     public IEnumerable<MediaUrlInfo> Urls { get; set; } = Enumerable.Empty<MediaUrlInfo>();
 

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Media/MediaValueResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Media/MediaValueResponseModel.cs
@@ -1,0 +1,7 @@
+﻿using Umbraco.Cms.Core.Models.ContentEditing;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.Media;
+
+public class MediaValueResponseModel : ValueResponseModelBase
+{
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Member/MemberResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Member/MemberResponseModel.cs
@@ -4,7 +4,7 @@ using Umbraco.Cms.Core.Models.Membership;
 
 namespace Umbraco.Cms.Api.Management.ViewModels.Member;
 
-public class MemberResponseModel : ContentResponseModelBase<MemberValueModel, MemberVariantResponseModel>
+public class MemberResponseModel : ContentResponseModelBase<MemberValueResponseModel, MemberVariantResponseModel>
 {
     public string Email { get; set; } = string.Empty;
 

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Member/MemberValueResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Member/MemberValueResponseModel.cs
@@ -1,0 +1,7 @@
+﻿using Umbraco.Cms.Core.Models.ContentEditing;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.Member;
+
+public class MemberValueResponseModel : ValueResponseModelBase
+{
+}

--- a/src/Umbraco.Core/Models/ContentEditing/ValueResponseModelBase.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/ValueResponseModelBase.cs
@@ -1,0 +1,9 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Umbraco.Cms.Core.Models.ContentEditing;
+
+public abstract class ValueResponseModelBase : ValueModelBase
+{
+    [Required]
+    public string EditorAlias { get; set; } = string.Empty;
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The pending clipboard feature (and in part also block level variance) would benefit greatly from knowing up-front what kind of value editor is backing a content property value. To achieve this, we need an "editorAlias" property to each value in the content endpoint outputs (documents, media, member).

There will be a follow-up to this at block level for block level variance.

### Testing this PR

1. It should be possible to edit and save existing documents, media and members. Make sure you test this on items _with_ properties 😄 
2. Also verify that collection views still work as per usual (try a media folder).
3. Lastly, the output from a content endpoint (i.e. GET document) should contain `editorAlias` for each property value:
![image](https://github.com/user-attachments/assets/191bf6c6-e2fc-4822-9a70-312917114ce7)
