### PR TITLE
Expand RedirectUrl.Url storage type to avoid truncation

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -106,5 +106,6 @@ public class UmbracoPlan : MigrationPlan
         To<V_13_0_0.ChangeWebhookUrlColumnsToNvarcharMax>("{21C42760-5109-4C03-AB4F-7EA53577D1F5}");
         To<V_13_0_0.AddExceptionOccured>("{6158F3A3-4902-4201-835E-1ED7F810B2D8}");
         To<V_13_3_0.AlignUpgradedDatabase>("{985AF2BA-69D3-4DBA-95E0-AD3FA7459FA7}");
+        To<V_13_5_0.ChangeRedirectUrlToNvarcharMax>("{CC47C751-A81B-489A-A2BC-0240245DB687}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_5_0/ChangeRedirectUrlToNvarcharMax.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_5_0/ChangeRedirectUrlToNvarcharMax.cs
@@ -22,71 +22,20 @@ public class ChangeRedirectUrlToNvarcharMax : MigrationBase
             return;
         }
 
-        // There is an index with a dependency on the column, so we will have to remove it and recreate it after
-        // because we are deleting the column it is based on
-        Execute.Sql($"Drop Index IX_umbracoRedirectUrl_culture_hash on {Constants.DatabaseSchema.Tables.RedirectUrl}").Do();
-        MigrateNtextColumn<RedirectUrlDto>("url", Constants.DatabaseSchema.Tables.RedirectUrl, x => x.Url, false);
-        Execute.Sql($"CREATE INDEX IX_umbracoRedirectUrl_culture_hash ON {Constants.DatabaseSchema.Tables.RedirectUrl} (urlHash, contentKey, culture, createDateUtc)").Do();
-    }
+        string tableName = RedirectUrlDto.TableName;
+        string colName = "url";
 
-    private void MigrateNtextColumn<TDto>(string columnName, string tableName, Expression<Func<TDto, object?>> fieldSelector, bool nullable = true)
-    {
-        var columnType = ColumnType(tableName, columnName);
-        if (columnType is null || columnType.Equals("nvarchar", StringComparison.InvariantCultureIgnoreCase) is false)
+        // Determine the current datatype of the column within the database
+        string colDataType = Database.ExecuteScalar<string>($"SELECT TOP(1) CHARACTER_MAXIMUM_LENGTH FROM INFORMATION_SCHEMA.COLUMNS" +
+                                                            $" WHERE TABLE_NAME = '{tableName}' AND COLUMN_NAME = '{colName}'");
+
+        // 255 is the old length, -1 indicate MAX length
+        if (colDataType == "255")
         {
-            return;
+            // Upgrade to MAX length
+            Database.Execute($"Drop Index IX_umbracoRedirectUrl_culture_hash on {Constants.DatabaseSchema.Tables.RedirectUrl}");
+            Database.Execute($"ALTER TABLE {tableName} ALTER COLUMN {colName} nvarchar(MAX) NOT NULL");
+            Database.Execute($"CREATE INDEX IX_umbracoRedirectUrl_culture_hash ON {Constants.DatabaseSchema.Tables.RedirectUrl} (urlHash, contentKey, culture, createDateUtc)");
         }
-
-        var oldColumnName = $"Old{columnName}";
-
-        // Rename the column so we can create the new one and copy over the data.
-        Rename
-            .Column(columnName)
-            .OnTable(tableName)
-            .To(oldColumnName)
-            .Do();
-
-        // Create new column with the correct type
-        // This is pretty ugly, but we have to do it this way because the CacheInstruction.Instruction column doesn't support nullable.
-        // So we have to populate with some temporary placeholder value before we copy over the actual data.
-        ICreateColumnOptionBuilder builder = Create
-            .Column(columnName)
-            .OnTable(tableName)
-            .AsCustom("nvarchar(max)");
-
-        if (nullable is false)
-        {
-            builder
-                .NotNullable()
-                .WithDefaultValue("Placeholder");
-        }
-        else
-        {
-            builder.Nullable();
-        }
-
-        builder.Do();
-
-        // Copy over data NPOCO doesn't support this for some reason, so we'll have to do it like so
-        // While we're add it we'll also set all the old values to be NULL since it's recommended here:
-        // https://learn.microsoft.com/en-us/sql/t-sql/data-types/ntext-text-and-image-transact-sql?view=sql-server-ver16#remarks
-        StringBuilder queryBuilder = new StringBuilder()
-            .AppendLine($"UPDATE {tableName}")
-            .AppendLine("SET")
-            .Append($"\t{SqlSyntax.GetFieldNameForUpdate(fieldSelector)} = {SqlSyntax.GetQuotedTableName(tableName)}.{SqlSyntax.GetQuotedColumnName(oldColumnName)}");
-
-        if (nullable)
-        {
-            queryBuilder.AppendLine($"\n,\t{SqlSyntax.GetQuotedColumnName(oldColumnName)} = NULL");
-        }
-
-        Sql<ISqlContext> copyDataQuery = Database.SqlContext.Sql(queryBuilder.ToString());
-        Database.Execute(copyDataQuery);
-
-        // Delete old column
-        Delete
-            .Column(oldColumnName)
-            .FromTable(tableName)
-            .Do();
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_5_0/ChangeRedirectUrlToNvarcharMax.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_5_0/ChangeRedirectUrlToNvarcharMax.cs
@@ -1,0 +1,92 @@
+﻿using System.Linq.Expressions;
+using System.Text;
+using NPoco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Migrations.Expressions.Create.Column;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_13_5_0;
+
+public class ChangeRedirectUrlToNvarcharMax : MigrationBase
+{
+    public ChangeRedirectUrlToNvarcharMax(IMigrationContext context) : base(context)
+    {
+    }
+
+    protected override void Migrate()
+    {
+        // We don't need to run this migration for SQLite, since ntext is not a thing there, text is just text.
+        if (DatabaseType == DatabaseType.SQLite)
+        {
+            return;
+        }
+
+        // There is an index with a dependency on the column, so we will have to remove it and recreate it after
+        // because we are deleting the column it is based on
+        Execute.Sql($"Drop Index IX_umbracoRedirectUrl_culture_hash on {Constants.DatabaseSchema.Tables.RedirectUrl}").Do();
+        MigrateNtextColumn<RedirectUrlDto>("url", Constants.DatabaseSchema.Tables.RedirectUrl, x => x.Url, false);
+        Execute.Sql($"CREATE INDEX IX_umbracoRedirectUrl_culture_hash ON {Constants.DatabaseSchema.Tables.RedirectUrl} (urlHash, contentKey, culture, createDateUtc)").Do();
+    }
+
+    private void MigrateNtextColumn<TDto>(string columnName, string tableName, Expression<Func<TDto, object?>> fieldSelector, bool nullable = true)
+    {
+        var columnType = ColumnType(tableName, columnName);
+        if (columnType is null || columnType.Equals("nvarchar", StringComparison.InvariantCultureIgnoreCase) is false)
+        {
+            return;
+        }
+
+        var oldColumnName = $"Old{columnName}";
+
+        // Rename the column so we can create the new one and copy over the data.
+        Rename
+            .Column(columnName)
+            .OnTable(tableName)
+            .To(oldColumnName)
+            .Do();
+
+        // Create new column with the correct type
+        // This is pretty ugly, but we have to do it this way because the CacheInstruction.Instruction column doesn't support nullable.
+        // So we have to populate with some temporary placeholder value before we copy over the actual data.
+        ICreateColumnOptionBuilder builder = Create
+            .Column(columnName)
+            .OnTable(tableName)
+            .AsCustom("nvarchar(max)");
+
+        if (nullable is false)
+        {
+            builder
+                .NotNullable()
+                .WithDefaultValue("Placeholder");
+        }
+        else
+        {
+            builder.Nullable();
+        }
+
+        builder.Do();
+
+        // Copy over data NPOCO doesn't support this for some reason, so we'll have to do it like so
+        // While we're add it we'll also set all the old values to be NULL since it's recommended here:
+        // https://learn.microsoft.com/en-us/sql/t-sql/data-types/ntext-text-and-image-transact-sql?view=sql-server-ver16#remarks
+        StringBuilder queryBuilder = new StringBuilder()
+            .AppendLine($"UPDATE {tableName}")
+            .AppendLine("SET")
+            .Append($"\t{SqlSyntax.GetFieldNameForUpdate(fieldSelector)} = {SqlSyntax.GetQuotedTableName(tableName)}.{SqlSyntax.GetQuotedColumnName(oldColumnName)}");
+
+        if (nullable)
+        {
+            queryBuilder.AppendLine($"\n,\t{SqlSyntax.GetQuotedColumnName(oldColumnName)} = NULL");
+        }
+
+        Sql<ISqlContext> copyDataQuery = Database.SqlContext.Sql(queryBuilder.ToString());
+        Database.Execute(copyDataQuery);
+
+        // Delete old column
+        Delete
+            .Column(oldColumnName)
+            .FromTable(tableName)
+            .Do();
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/RedirectUrlDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/RedirectUrlDto.cs
@@ -37,7 +37,7 @@ internal class RedirectUrlDto
     public DateTime CreateDateUtc { get; set; }
 
     [Column("url")]
-    [NullSetting(NullSetting = NullSettings.NotNull)]
+    [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
     public string Url { get; set; } = null!;
 
     [Column("culture")]

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/RedirectUrlDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/RedirectUrlDto.cs
@@ -37,6 +37,7 @@ internal class RedirectUrlDto
     public DateTime CreateDateUtc { get; set; }
 
     [Column("url")]
+    [NullSetting(NullSetting = NullSettings.NotNull)]
     [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
     public string Url { get; set; } = null!;
 


### PR DESCRIPTION
HotFixes #16974

Will have to be rerun in v14 that were upgraded to v14 prior to this PR. The migration has a check to see if the column was migrated before.

Proof it creates the redirects in the database now and length is larger than what it could handle
![image](https://github.com/user-attachments/assets/5688e036-7378-47f4-a9b8-92531e6ab3cb)
