### PR TITLE
AlwaysExpandMediaProperties option in the Content Delivery Api

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Rendering/RequestContextOutputExpansionStrategyV2.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Rendering/RequestContextOutputExpansionStrategyV2.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
@@ -15,17 +17,16 @@ internal sealed class RequestContextOutputExpansionStrategyV2 : IOutputExpansion
 
     private readonly IApiPropertyRenderer _propertyRenderer;
     private readonly ILogger<RequestContextOutputExpansionStrategyV2> _logger;
+    private readonly DeliveryApiSettings _deliveryApiSettings;
 
     private readonly Stack<Node?> _expandProperties;
     private readonly Stack<Node?> _includeProperties;
 
-    public RequestContextOutputExpansionStrategyV2(
-        IHttpContextAccessor httpContextAccessor,
-        IApiPropertyRenderer propertyRenderer,
-        ILogger<RequestContextOutputExpansionStrategyV2> logger)
+    public RequestContextOutputExpansionStrategyV2(IHttpContextAccessor httpContextAccessor, IApiPropertyRenderer propertyRenderer, ILogger<RequestContextOutputExpansionStrategyV2> logger, IOptions<DeliveryApiSettings> deliveryApiSettings)
     {
         _propertyRenderer = propertyRenderer;
         _logger = logger;
+        _deliveryApiSettings = deliveryApiSettings.Value;
         _expandProperties = new Stack<Node?>();
         _includeProperties = new Stack<Node?>();
 
@@ -50,7 +51,7 @@ internal sealed class RequestContextOutputExpansionStrategyV2 : IOutputExpansion
             .ToArray();
 
         return properties.Any()
-            ? MapProperties(properties)
+            ? MapProperties(properties, _deliveryApiSettings.AlwaysExpandMediaProperties)
             : new Dictionary<string, object?>();
     }
 

--- a/src/Umbraco.Core/Configuration/Models/DeliveryApiSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/DeliveryApiSettings.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 
 namespace Umbraco.Cms.Core.Configuration.Models;
 
@@ -13,6 +13,8 @@ public class DeliveryApiSettings
     private const bool StaticPublicAccess = true;
 
     private const bool StaticRichTextOutputAsJson = false;
+
+    private const bool StaticAlwaysExpandMediaProperties = false;
 
     /// <summary>
     ///     Gets or sets a value indicating whether the Delivery API should be enabled.
@@ -48,6 +50,13 @@ public class DeliveryApiSettings
     /// <value><c>true</c> if the Delivery API should output rich text values as JSON; <c>false</c> they should be output as HTML (default).</value>
     [DefaultValue(StaticRichTextOutputAsJson)]
     public bool RichTextOutputAsJson { get; set; } = StaticRichTextOutputAsJson;
+
+    /// <summary>
+    ///     Gets or sets a value indicating whether the Delivery API should extend the values of MediaProperties by default.
+    /// </summary>
+    /// <value><c>true</c> if the Delivery API should extend the values of MediaProperties by default; <c>false</c> they should be extended manually (default).</value>
+    [DefaultValue(StaticAlwaysExpandMediaProperties)]
+    public bool AlwaysExpandMediaProperties { get; set; } = StaticAlwaysExpandMediaProperties;
 
     /// <summary>
     ///     Gets or sets the settings for the Media APIs of the Delivery API.

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/OutputExpansionStrategyV2Tests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/OutputExpansionStrategyV2Tests.cs
@@ -1,9 +1,11 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Api.Delivery.Rendering;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Models.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
@@ -343,7 +345,8 @@ public class OutputExpansionStrategyV2Tests : OutputExpansionStrategyTestBase
         IOutputExpansionStrategy outputExpansionStrategy = new RequestContextOutputExpansionStrategyV2(
             httpContextAccessorMock.Object,
             new ApiPropertyRenderer(new NoopPublishedValueFallback()),
-            Mock.Of<ILogger<RequestContextOutputExpansionStrategyV2>>());
+            Mock.Of<ILogger<RequestContextOutputExpansionStrategyV2>>(),
+            CreateDeliveryApiSettings());
         var outputExpansionStrategyAccessorMock = new Mock<IOutputExpansionStrategyAccessor>();
         outputExpansionStrategyAccessorMock.Setup(s => s.TryGetValue(out outputExpansionStrategy)).Returns(true);
 
@@ -352,4 +355,12 @@ public class OutputExpansionStrategyV2Tests : OutputExpansionStrategyTestBase
 
     protected override string? FormatExpandSyntax(bool expandAll = false, string[]? expandPropertyAliases = null)
         => expandAll ? "$all" : expandPropertyAliases?.Any() is true ? $"properties[{string.Join(",", expandPropertyAliases)}]" : null;
+
+    private IOptions<DeliveryApiSettings> CreateDeliveryApiSettings()
+    {
+        var deliveryApiSettings = new DeliveryApiSettings();
+        var deliveryApiOptionsMonitorMock = new Mock<IOptions<DeliveryApiSettings>>();
+        deliveryApiOptionsMonitorMock.Setup(s => s.Value).Returns(deliveryApiSettings);
+        return deliveryApiOptionsMonitorMock.Object;
+    }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: 
https://github.com/umbraco/Umbraco-CMS/issues/16804 

### Description
When implementing a headless website, we frequently encounter a situation where we need to retrieve media from the Media Delivery API to access properties such as AltTexts or SVG code. Although we can add the image fields to the expand query, we work with the Content Delivery API dynamically and often don’t know in advance which properties are MediaPickers.

To address this, it would be beneficial to have an option to always expand media options in the Content Delivery API.

I’ve added a new configuration option for this purpose and implemented it in the RequestContextOutputExpansionStrategyV2. By default, this option is set to false, but it can be enabled in the appsettings.json file. When set to true in appsettings.json, the media properties will always be expanded.

#### Test
To test this code do the following: 
##### Setup
- [ ] Enable ContentDeliveryApi in appsettings.json.
- [ ] Add custom property to one of your media types.
- [ ] Create a home node with some simple properties and one (or more) mediaPicker.
##### Test default values
- [ ] Fetch the node using the Content Delivery API.
- [ ] First, try with expand => none. The mediaPicker value should be displayed without any properties.
- [ ] Next, try expanding your mediaPicker property. The mediaPicker value should now display with custom properties.
##### Test AlwaysExpandMediaProperties
- [ ] In appsettings.json, add "AlwaysExpandMediaProperties": true to your DeliveryApi settings.
- [ ] Retrieve the same node from the Content Delivery API. The media properties should be expanded regardless of whether you have expanded the field in the query.
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
