### PR TITLE
Fix: V13.5 Bug #17054

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -652,6 +652,7 @@
                     },
                     close: function () {
                         overlayService.close();
+                        formHelper.resetForm({ scope: $scope });
                     }
                 };
 
@@ -697,6 +698,7 @@
                         },
                         close: function () {
                             overlayService.close();
+                            formHelper.resetForm({ scope: $scope });
                         }
                     };
 
@@ -758,14 +760,12 @@
                                 clearNotifications($scope.content);
 
                               handleHttpException(err);
-                              $scope.$broadcast("formSubmittedValidationFailed");
                               deferred.reject(err);
                             });
                         },
                         close: function () {
                             overlayService.close();
-                            // Well, it did not actually submit, but we did not have validation failed. And we need to fire an event to re-enable properties.
-                            $scope.$broadcast("formSubmitted");
+                            formHelper.resetForm({ scope: $scope });
                             deferred.reject();
                         }
                     };
@@ -774,7 +774,7 @@
                 else {
                     $scope.page.buttonGroupState = "error";
                     showValidationNotification();
-                    $scope.$broadcast("formSubmittedValidationFailed");
+                    formHelper.resetForm({ scope: $scope, errors: true });
                     deferred.reject();
                 }
             }
@@ -792,7 +792,6 @@
                 }, function (err) {
                     $scope.page.buttonGroupState = "error";
                     handleHttpException(err);
-                    $scope.$broadcast("formSubmittedValidationFailed")
                     deferred.reject(err);
                 });
             }
@@ -874,6 +873,7 @@
                         $scope.page.saveButtonState = "error";
                     }
                     handleHttpException(err);
+                    $scope.$broadcast("formSubmittedValidationFailed")
                     deferred.reject();
                 });
             }
@@ -918,6 +918,7 @@
                             formHelper.showNotifications(data);
                             clearNotifications($scope.content);
                             overlayService.close();
+                            formHelper.resetForm({ scope: $scope });
                             return $q.when(data);
                         }, function (err) {
                             clearDirtyState($scope.content.variants);
@@ -933,6 +934,7 @@
 
                     },
                     close: function () {
+                      formHelper.resetForm({ scope: $scope });
                         overlayService.close();
                     }
                 };
@@ -992,6 +994,7 @@
 
                     },
                     close: function () {
+                        formHelper.resetForm({ scope: $scope });
                         overlayService.close();
                     }
                 };
@@ -1007,7 +1010,7 @@
             const openPreviewWindow = (url, target) => {
                 // Chromes popup blocker will kick in if a window is opened
                 // without the initial scoped request. This trick will fix that.
-              
+
               const previewWindow = $window.open(url, target);
 
               previewWindow.addEventListener('load', () => {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -5,7 +5,7 @@
         appState, contentResource, entityResource, navigationService, notificationsService, contentAppHelper,
         serverValidationManager, contentEditingHelper, localizationService, formHelper, umbRequestHelper,
         editorState, $http, eventsService, overlayService, $location, localStorageService, treeService,
-        $exceptionHandler, uploadTracker) {        
+        $exceptionHandler, uploadTracker) {
 
         var evts = [];
         var infiniteMode = $scope.infiniteModel && $scope.infiniteModel.infiniteMode;
@@ -756,20 +756,25 @@
                                 //ensure error messages are displayed
                                 formHelper.showNotifications(err.data);
                                 clearNotifications($scope.content);
-                                
+
                               handleHttpException(err);
+                              $scope.$broadcast("formSubmittedValidationFailed");
                               deferred.reject(err);
                             });
                         },
                         close: function () {
                             overlayService.close();
+                            // Well, it did not actually submit, but we did not have validation failed. And we need to fire an event to re-enable properties.
+                            $scope.$broadcast("formSubmitted");
                             deferred.reject();
                         }
                     };
                     overlayService.open(dialog);
                 }
                 else {
+                    $scope.page.buttonGroupState = "error";
                     showValidationNotification();
+                    $scope.$broadcast("formSubmittedValidationFailed");
                     deferred.reject();
                 }
             }

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -774,7 +774,7 @@
                 else {
                     $scope.page.buttonGroupState = "error";
                     showValidationNotification();
-                    formHelper.resetForm({ scope: $scope, errors: true });
+                    formHelper.resetForm({ scope: $scope, hasErrors: true });
                     deferred.reject();
                 }
             }
@@ -873,7 +873,6 @@
                         $scope.page.saveButtonState = "error";
                     }
                     handleHttpException(err);
-                    $scope.$broadcast("formSubmittedValidationFailed")
                     deferred.reject();
                 });
             }


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/17054

Also other issues that was not reported. As there was a problem with a few of the dialogs if they where just closed. 

### Description

Notice this issue happened because the code has several flows.
So please test:

Publish:
Front-end validation failed.
Backend-validation failed.
Publish dialog closed.

And other dialogs.

Notice, code is horrible. because the `performeSave` method does handle formSubmittion/resetForm. But some dialog calls a `formHelper.submitForm` before and this needs to be handled by calling `resetForm` when closing or completing outside the performeSave method.

<!-- Thanks for contributing to Umbraco CMS! -->
