### PR TITLE
Fix: V13.5 RTE block paste resolver issue

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/rte-blockeditor-clipboard.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/rte-blockeditor-clipboard.service.js
@@ -50,13 +50,13 @@
 
 
         function rawRteBlockResolver(propertyValue, propPasteResolverMethod) {
-          if (propertyValue != null && typeof propertyValue === "object") {
+          if (propertyValue && typeof propertyValue === "object" && propertyValue.markup) {
 
               // object property of 'blocks' holds the data for the Block Editor.
               var value = propertyValue.blocks;
 
               // we got an object, and it has these three props then we are most likely dealing with a Block Editor.
-              if ((value.layout !== undefined && value.contentData !== undefined && value.settingsData !== undefined)) {
+              if ((value && value.layout !== undefined && value.contentData !== undefined && value.settingsData !== undefined)) {
 
                   // replaceUdisOfObject replaces udis of the value object(by instance reference), but also returns the updated markup (as we cant update the reference of a string).
                   propertyValue.markup = replaceUdisOfObject(value.layout, value, propertyValue.markup);


### PR DESCRIPTION
Clipboard pasting Blocks, which has a property which value is a object but not a Block fails.

![image](https://github.com/user-attachments/assets/998cc9f8-66b7-4f82-9288-242aa3e265c4)
![image](https://github.com/user-attachments/assets/2fc139d9-899e-42e6-b27c-a318cccb0676)

This PR fixes that.

A test case is making a block list editor with a Block that has a Media Picker, check that you can copy and paste that block.
