### PR TITLE
Bug: v13.5 17054 (take 2)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -5,7 +5,7 @@
         appState, contentResource, entityResource, navigationService, notificationsService, contentAppHelper,
         serverValidationManager, contentEditingHelper, localizationService, formHelper, umbRequestHelper,
         editorState, $http, eventsService, overlayService, $location, localStorageService, treeService,
-        $exceptionHandler, uploadTracker) {        
+        $exceptionHandler, uploadTracker) {
 
         var evts = [];
         var infiniteMode = $scope.infiniteModel && $scope.infiniteModel.infiniteMode;
@@ -497,6 +497,7 @@
             //Set them all to be invalid
             var fieldsToRollback = checkValidility();
             eventsService.emit("content.saving", { content: $scope.content, action: args.action });
+            eventsService.emit("form.lock");
 
             return contentEditingHelper.contentEditorPerformSave({
                 saveMethod: args.saveMethod,
@@ -517,6 +518,7 @@
                 syncTreeNode($scope.content, data.path, false, args.reloadChildren);
 
                 eventsService.emit("content.saved", { content: $scope.content, action: args.action, valid: true });
+                eventsService.emit("form.unlock");
 
                 if($scope.contentForm.$invalid !== true) {
                     resetNestedFieldValiation(fieldsToRollback);
@@ -534,6 +536,7 @@
                     if (err && err.status === 400 && err.data) {
                         // content was saved but is invalid.
                         eventsService.emit("content.saved", { content: $scope.content, action: args.action, valid: false });
+                        eventsService.emit("form.unlock");
                     }
 
                     return $q.reject(err);
@@ -1002,7 +1005,7 @@
             const openPreviewWindow = (url, target) => {
                 // Chromes popup blocker will kick in if a window is opened
                 // without the initial scoped request. This trick will fix that.
-              
+
               const previewWindow = $window.open(url, target);
 
               previewWindow.addEventListener('load', () => {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbtabbedcontent.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbtabbedcontent.directive.js
@@ -2,7 +2,7 @@
     'use strict';
 
     /** This directive is used to render out the current variant tabs and properties and exposes an API for other directives to consume  */
-    function tabbedContentDirective($timeout, $filter, contentEditingHelper, contentTypeHelper) {
+    function tabbedContentDirective($timeout, $filter, contentEditingHelper, contentTypeHelper, eventsService) {
 
         function link($scope, $element) {
 
@@ -156,14 +156,13 @@
                 }
             });
 
-            $scope.$on("formSubmitting", function() {
-              $scope.allowUpdate = false;
+            eventsService.on("form.lock", function() {
+              $scope.$evalAsync(() => {
+                $scope.allowUpdate = false;
+              });
             });
 
-            $scope.$on("formSubmitted", function() {
-                setAllowUpdate();
-            });
-            $scope.$on("formSubmittedValidationFailed", function() {
+            eventsService.on("form.unlock", function() {
                 setAllowUpdate();
             });
 


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/17054

Instead of using existing events, this PR created a new set of events that can be trusted.

The problem with the other events was that they where fired by many different cases and not necessary firing the ending event 'formSubmitted'.