### PR TITLE
Enable validation of specific cultures only for document updates

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Factories/DocumentEditingPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DocumentEditingPresentationFactory.cs
@@ -17,8 +17,20 @@ internal sealed class DocumentEditingPresentationFactory : ContentEditingPresent
     }
 
     public ContentUpdateModel MapUpdateModel(UpdateDocumentRequestModel requestModel)
+        => MapUpdateContentModel<ContentUpdateModel>(requestModel);
+
+    public ValidateContentUpdateModel MapValidateUpdateModel(ValidateUpdateDocumentRequestModel requestModel)
     {
-        ContentUpdateModel model = MapContentEditingModel<ContentUpdateModel>(requestModel);
+        ValidateContentUpdateModel model = MapUpdateContentModel<ValidateContentUpdateModel>(requestModel);
+        model.Cultures = requestModel.Cultures;
+
+        return model;
+    }
+
+    private TUpdateModel MapUpdateContentModel<TUpdateModel>(UpdateDocumentRequestModel requestModel)
+        where TUpdateModel : ContentUpdateModel, new()
+    {
+        TUpdateModel model = MapContentEditingModel<TUpdateModel>(requestModel);
         model.TemplateKey = requestModel.Template?.Id;
 
         return model;

--- a/src/Umbraco.Cms.Api.Management/Factories/IDocumentEditingPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IDocumentEditingPresentationFactory.cs
@@ -8,4 +8,6 @@ public interface IDocumentEditingPresentationFactory
     ContentCreateModel MapCreateModel(CreateDocumentRequestModel requestModel);
 
     ContentUpdateModel MapUpdateModel(UpdateDocumentRequestModel requestModel);
+
+    ValidateContentUpdateModel MapValidateUpdateModel(ValidateUpdateDocumentRequestModel requestModel);
 }

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -9372,6 +9372,149 @@
             }
           }
         },
+        "deprecated": true,
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1.1/document/{id}/validate": {
+      "put": {
+        "tags": [
+          "Document"
+        ],
+        "operationId": "PutUmbracoManagementApiV1.1DocumentByIdValidate1.1",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ValidateUpdateDocumentRequestModel"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ValidateUpdateDocumentRequestModel"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ValidateUpdateDocumentRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ProblemDetails"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ProblemDetails"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          },
+          "403": {
+            "description": "The authenticated user do not have access to this resource",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          }
+        },
         "security": [
           {
             "Backoffice User": [ ]
@@ -45522,6 +45665,52 @@
           },
           "isEnabledOnUser": {
             "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ValidateUpdateDocumentRequestModel": {
+        "required": [
+          "values",
+          "variants"
+        ],
+        "type": "object",
+        "properties": {
+          "values": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DocumentValueModel"
+                }
+              ]
+            }
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DocumentVariantRequestModel"
+                }
+              ]
+            }
+          },
+          "template": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ReferenceByIdModel"
+              }
+            ],
+            "nullable": true
+          },
+          "cultures": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
           }
         },
         "additionalProperties": false

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/ValidateUpdateDocumentRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/ValidateUpdateDocumentRequestModel.cs
@@ -1,0 +1,6 @@
+namespace Umbraco.Cms.Api.Management.ViewModels.Document;
+
+public class ValidateUpdateDocumentRequestModel : UpdateDocumentRequestModel
+{
+    public ISet<string>? Cultures { get; set; }
+}

--- a/src/Umbraco.Core/Models/ContentEditing/ValidateContentUpdateModel.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/ValidateContentUpdateModel.cs
@@ -1,0 +1,6 @@
+namespace Umbraco.Cms.Core.Models.ContentEditing;
+
+public class ValidateContentUpdateModel : ContentUpdateModel
+{
+    public ISet<string>? Cultures { get; set; }
+}

--- a/src/Umbraco.Core/Services/ContentEditingService.cs
+++ b/src/Umbraco.Core/Services/ContentEditingService.cs
@@ -36,11 +36,11 @@ internal sealed class ContentEditingService
         return await Task.FromResult(content);
     }
 
-    public async Task<Attempt<ContentValidationResult, ContentEditingOperationStatus>> ValidateUpdateAsync(Guid key, ContentUpdateModel updateModel)
+    public async Task<Attempt<ContentValidationResult, ContentEditingOperationStatus>> ValidateUpdateAsync(Guid key, ValidateContentUpdateModel updateModel)
     {
         IContent? content = ContentService.GetById(key);
         return content is not null
-            ? await ValidateCulturesAndPropertiesAsync(updateModel, content.ContentType.Key)
+            ? await ValidateCulturesAndPropertiesAsync(updateModel, content.ContentType.Key, updateModel.Cultures)
             : Attempt.FailWithStatus(ContentEditingOperationStatus.NotFound, new ContentValidationResult());
     }
 
@@ -137,10 +137,11 @@ internal sealed class ContentEditingService
 
     private async Task<Attempt<ContentValidationResult, ContentEditingOperationStatus>> ValidateCulturesAndPropertiesAsync(
         ContentEditingModelBase contentEditingModelBase,
-        Guid contentTypeKey)
+        Guid contentTypeKey,
+        IEnumerable<string>? culturesToValidate = null)
         => await ValidateCulturesAsync(contentEditingModelBase) is false
             ? Attempt.FailWithStatus(ContentEditingOperationStatus.InvalidCulture, new ContentValidationResult())
-            : await ValidatePropertiesAsync(contentEditingModelBase, contentTypeKey);
+            : await ValidatePropertiesAsync(contentEditingModelBase, contentTypeKey, culturesToValidate);
 
     private async Task<ContentEditingOperationStatus> UpdateTemplateAsync(IContent content, Guid? templateKey)
     {

--- a/src/Umbraco.Core/Services/ContentEditingServiceBase.cs
+++ b/src/Umbraco.Core/Services/ContentEditingServiceBase.cs
@@ -113,7 +113,8 @@ internal abstract class ContentEditingServiceBase<TContent, TContentType, TConte
 
     protected async Task<Attempt<ContentValidationResult, ContentEditingOperationStatus>> ValidatePropertiesAsync(
         ContentEditingModelBase contentEditingModelBase,
-        Guid contentTypeKey)
+        Guid contentTypeKey,
+        IEnumerable<string>? culturesToValidate = null)
     {
         TContentType? contentType = await ContentTypeService.GetAsync(contentTypeKey);
         if (contentType is null)
@@ -121,14 +122,15 @@ internal abstract class ContentEditingServiceBase<TContent, TContentType, TConte
             return Attempt.FailWithStatus(ContentEditingOperationStatus.ContentTypeNotFound, new ContentValidationResult());
         }
 
-        return await ValidatePropertiesAsync(contentEditingModelBase, contentType);
+        return await ValidatePropertiesAsync(contentEditingModelBase, contentType, culturesToValidate);
     }
 
     private async Task<Attempt<ContentValidationResult, ContentEditingOperationStatus>> ValidatePropertiesAsync(
         ContentEditingModelBase contentEditingModelBase,
-        TContentType contentType)
+        TContentType contentType,
+        IEnumerable<string>? culturesToValidate = null)
     {
-        ContentValidationResult result = await _validationService.ValidatePropertiesAsync(contentEditingModelBase, contentType);
+        ContentValidationResult result = await _validationService.ValidatePropertiesAsync(contentEditingModelBase, contentType, culturesToValidate);
         return result.ValidationErrors.Any() is false
             ? Attempt.SucceedWithStatus(ContentEditingOperationStatus.Success, result)
             : Attempt.FailWithStatus(ContentEditingOperationStatus.PropertyValidationError, result);

--- a/src/Umbraco.Core/Services/ContentValidationService.cs
+++ b/src/Umbraco.Core/Services/ContentValidationService.cs
@@ -12,6 +12,7 @@ internal sealed class ContentValidationService : ContentValidationServiceBase<IC
 
     public async Task<ContentValidationResult> ValidatePropertiesAsync(
         ContentEditingModelBase contentEditingModelBase,
-        IContentType contentType)
-        => await HandlePropertiesValidationAsync(contentEditingModelBase, contentType);
+        IContentType contentType,
+        IEnumerable<string>? culturesToValidate = null)
+        => await HandlePropertiesValidationAsync(contentEditingModelBase, contentType, culturesToValidate);
 }

--- a/src/Umbraco.Core/Services/ContentValidationServiceBase.cs
+++ b/src/Umbraco.Core/Services/ContentValidationServiceBase.cs
@@ -23,7 +23,8 @@ internal abstract class ContentValidationServiceBase<TContentType>
 
     protected async Task<ContentValidationResult> HandlePropertiesValidationAsync(
         ContentEditingModelBase contentEditingModelBase,
-        TContentType contentType)
+        TContentType contentType,
+        IEnumerable<string>? culturesToValidate = null)
     {
         var validationErrors = new List<PropertyValidationError>();
 
@@ -43,7 +44,7 @@ internal abstract class ContentValidationServiceBase<TContentType>
             return new ContentValidationResult { ValidationErrors = validationErrors };
         }
 
-        var cultures = await GetCultureCodes();
+        var cultures = culturesToValidate?.ToArray() ?? await GetCultureCodes();
         // we don't have any managed segments, so we have to make do with the ones passed in the model
         var segments = contentEditingModelBase.Variants.DistinctBy(variant => variant.Segment).Select(variant => variant.Segment).ToArray();
 

--- a/src/Umbraco.Core/Services/IContentEditingService.cs
+++ b/src/Umbraco.Core/Services/IContentEditingService.cs
@@ -10,7 +10,7 @@ public interface IContentEditingService
 
     Task<Attempt<ContentValidationResult, ContentEditingOperationStatus>> ValidateCreateAsync(ContentCreateModel createModel);
 
-    Task<Attempt<ContentValidationResult, ContentEditingOperationStatus>> ValidateUpdateAsync(Guid key, ContentUpdateModel updateModel);
+    Task<Attempt<ContentValidationResult, ContentEditingOperationStatus>> ValidateUpdateAsync(Guid key, ValidateContentUpdateModel updateModel);
 
     Task<Attempt<ContentCreateResult, ContentEditingOperationStatus>> CreateAsync(ContentCreateModel createModel, Guid userKey);
 

--- a/src/Umbraco.Core/Services/IContentValidationServiceBase.cs
+++ b/src/Umbraco.Core/Services/IContentValidationServiceBase.cs
@@ -6,7 +6,7 @@ namespace Umbraco.Cms.Core.Services;
 internal interface IContentValidationServiceBase<in TContentType>
     where TContentType : IContentTypeComposition
 {
-    Task<ContentValidationResult> ValidatePropertiesAsync(ContentEditingModelBase contentEditingModelBase, TContentType contentType);
+    Task<ContentValidationResult> ValidatePropertiesAsync(ContentEditingModelBase contentEditingModelBase, TContentType contentType, IEnumerable<string>? culturesToValidate = null);
 
     Task<bool> ValidateCulturesAsync(ContentEditingModelBase contentEditingModelBase);
 }

--- a/src/Umbraco.Core/Services/MediaValidationService.cs
+++ b/src/Umbraco.Core/Services/MediaValidationService.cs
@@ -12,6 +12,7 @@ internal sealed class MediaValidationService : ContentValidationServiceBase<IMed
 
     public async Task<ContentValidationResult> ValidatePropertiesAsync(
         ContentEditingModelBase contentEditingModelBase,
-        IMediaType mediaType)
-        => await HandlePropertiesValidationAsync(contentEditingModelBase, mediaType);
+        IMediaType mediaType,
+        IEnumerable<string>? culturesToValidate = null)
+        => await HandlePropertiesValidationAsync(contentEditingModelBase, mediaType, culturesToValidate);
 }

--- a/src/Umbraco.Core/Services/MemberValidationService.cs
+++ b/src/Umbraco.Core/Services/MemberValidationService.cs
@@ -12,6 +12,7 @@ internal sealed class MemberValidationService : ContentValidationServiceBase<IMe
 
     public async Task<ContentValidationResult> ValidatePropertiesAsync(
         ContentEditingModelBase contentEditingModelBase,
-        IMemberType memberType)
-        => await HandlePropertiesValidationAsync(contentEditingModelBase, memberType);
+        IMemberType memberType,
+        IEnumerable<string>? culturesToValidate = null)
+        => await HandlePropertiesValidationAsync(contentEditingModelBase, memberType, culturesToValidate);
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentValidationServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentValidationServiceTests.cs
@@ -317,6 +317,93 @@ public class ContentValidationServiceTests : UmbracoIntegrationTestWithContent
         Assert.AreEqual(expectedResult, result);
     }
 
+    [Test]
+    public async Task Can_Validate_For_All_Languages()
+    {
+        var contentType = await SetupLanguageTest();
+
+        var validationResult = await ContentValidationService.ValidatePropertiesAsync(
+            new ContentCreateModel
+            {
+                ContentTypeKey = contentType.Key,
+                Variants = [
+                    new()
+                    {
+                        Name = "Test Document (EN)",
+                        Culture = "en-US",
+                        Properties = [
+                            new()
+                            {
+                                Alias = "title",
+                                Value = "Invalid value in English",
+                            }
+                        ]
+                    },
+                    new()
+                    {
+                        Name = "Test Document (DA)",
+                        Culture = "da-DK",
+                        Properties = [
+                            new()
+                            {
+                                Alias = "title",
+                                Value = "Invalid value in Danish",
+                            }
+                        ]
+                    }
+                ]
+            },
+            contentType);
+
+        Assert.AreEqual(2, validationResult.ValidationErrors.Count());
+        Assert.IsNotNull(validationResult.ValidationErrors.SingleOrDefault(r => r.Alias == "title" && r.Culture == "en-US" && r.JsonPath == string.Empty));
+        Assert.IsNotNull(validationResult.ValidationErrors.SingleOrDefault(r => r.Alias == "title" && r.Culture == "da-DK" && r.JsonPath == string.Empty));
+    }
+
+    [TestCase("da-DK")]
+    [TestCase("en-US")]
+    public async Task Can_Validate_For_Specific_Language(string culture)
+    {
+        var contentType = await SetupLanguageTest();
+
+        var validationResult = await ContentValidationService.ValidatePropertiesAsync(
+            new ContentCreateModel
+            {
+                ContentTypeKey = contentType.Key,
+                Variants = [
+                    new()
+                    {
+                        Name = "Test Document (EN)",
+                        Culture = "en-US",
+                        Properties = [
+                            new()
+                            {
+                                Alias = "title",
+                                Value = "Invalid value in English",
+                            }
+                        ]
+                    },
+                    new()
+                    {
+                        Name = "Test Document (DA)",
+                        Culture = "da-DK",
+                        Properties = [
+                            new()
+                            {
+                                Alias = "title",
+                                Value = "Invalid value in Danish",
+                            }
+                        ]
+                    }
+                ]
+            },
+            contentType,
+            [culture]);
+
+        Assert.AreEqual(1, validationResult.ValidationErrors.Count());
+        Assert.IsNotNull(validationResult.ValidationErrors.SingleOrDefault(r => r.Alias == "title" && r.Culture == culture && r.JsonPath == string.Empty));
+    }
+
     private async Task<(IContentType DocumentType, IContentType ElementType)> SetupBlockListTest()
     {
         var propertyEditorCollection = GetRequiredService<PropertyEditorCollection>();
@@ -395,6 +482,24 @@ public class ContentValidationServiceTests : UmbracoIntegrationTestWithContent
         contentType.PropertyTypes.First(pt => pt.Alias == "author").ValidationRegExp = "^Valid.*$";
         contentType.AllowedAsRoot = true;
         ContentTypeService.Save(contentType);
+
+        return contentType;
+    }
+
+    private async Task<IContentType> SetupLanguageTest()
+    {
+        var language = new LanguageBuilder()
+            .WithCultureInfo("da-DK")
+            .Build();
+        await LanguageService.CreateAsync(language, Constants.Security.SuperUserKey);
+
+        var contentType = ContentTypeBuilder.CreateSimpleContentType("umbMandatory", "Mandatory Doc Type");
+        contentType.Variations = ContentVariation.Culture;
+        var titlePropertyType = contentType.PropertyTypes.First(pt => pt.Alias == "title");
+        titlePropertyType.Variations = ContentVariation.Culture;
+        titlePropertyType.ValidationRegExp = "^Valid.*$";
+        contentType.AllowedAsRoot = true;
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
 
         return contentType;
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This adds a version 1.1 of the document update validation endpoint, with the added ability to validate specific cultures only (instead of all cultures as it is today).