### PR TITLE
V15: Allows blocks in rich text editor to leave out the "Umbraco-Block" HTML comment

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RichTextParsingRegexes.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RichTextParsingRegexes.cs
@@ -4,6 +4,6 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 
 internal static partial class RichTextParsingRegexes
 {
-    [GeneratedRegex("<umb-rte-block(?:-inline)?(?: class=\"(.[^\"]*)\")? data-content-udi=\"(?<udi>.[^\"]*)\"><!--Umbraco-Block--><\\/umb-rte-block(?:-inline)?>")]
+    [GeneratedRegex("<umb-rte-block(?:-inline)?(?: class=\"(.[^\"]*)\")? data-content-udi=\"(?<udi>.[^\"]*)\">(?:<!--Umbraco-Block-->)?<\\/umb-rte-block(?:-inline)?>")]
     public static partial Regex BlockRegex();
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/RichTextPropertyEditorHelperTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/RichTextPropertyEditorHelperTests.cs
@@ -135,7 +135,7 @@ public class RichTextPropertyEditorHelperTests
     {
         const string input = """
                              {
-                              "markup": "<p>this is some markup</p><umb-rte-block data-content-udi=\"umb://element/36cc710ad8a645d0a07f7bbd8742cf02\"><!--Umbraco-Block--></umb-rte-block>",
+                              "markup": "<p>this is some markup</p><umb-rte-block data-content-udi=\"umb://element/36cc710ad8a645d0a07f7bbd8742cf02\"></umb-rte-block>",
                               "blocks": {
                                   "layout": {
                                       "Umbraco.TinyMCE": [{
@@ -157,7 +157,7 @@ public class RichTextPropertyEditorHelperTests
         var result = RichTextPropertyEditorHelper.TryParseRichTextEditorValue(input, JsonSerializer(), Logger(), out RichTextEditorValue? value);
         Assert.IsTrue(result);
         Assert.IsNotNull(value);
-        Assert.AreEqual("<p>this is some markup</p><umb-rte-block data-content-udi=\"umb://element/36cc710ad8a645d0a07f7bbd8742cf02\"><!--Umbraco-Block--></umb-rte-block>", value.Markup);
+        Assert.AreEqual("<p>this is some markup</p><umb-rte-block data-content-udi=\"umb://element/36cc710ad8a645d0a07f7bbd8742cf02\"></umb-rte-block>", value.Markup);
 
         Assert.IsNotNull(value.Blocks);
 
@@ -168,6 +168,57 @@ public class RichTextPropertyEditorHelperTests
         Assert.AreEqual(contentTypeGuid, item.ContentTypeKey);
         Assert.AreEqual(new GuidUdi(Constants.UdiEntityType.Element, itemGuid), item.Udi);
         Assert.AreEqual(itemGuid, item.Key);
+
+        Assert.AreEqual(0, value.Blocks.SettingsData.Count);
+    }
+
+    [Test]
+    public void Can_Parse_Mixed_Blocks_And_Inline_Blocks()
+    {
+        const string input = """
+                             {
+                              "markup": "<p>this is <umb-rte-block-inline data-content-udi=\"umb://element/36cc710ad8a645d0a07f7bbd8742cf03\"></umb-rte-block-inline> some markup</p><umb-rte-block data-content-udi=\"umb://element/36cc710ad8a645d0a07f7bbd8742cf02\"></umb-rte-block>",
+                              "blocks": {
+                                  "layout": {
+                                      "Umbraco.TinyMCE": [{
+                                              "contentUdi": "umb://element/36cc710ad8a645d0a07f7bbd8742cf02"
+                                          }, {
+                                              "contentUdi": "umb://element/36cc710ad8a645d0a07f7bbd8742cf03"
+                                          }
+                                      ]
+                                  },
+                                  "contentData": [{
+                                          "contentTypeKey": "b2f0806c-d231-4c78-88b2-3c97d26e1123",
+                                          "udi": "umb://element/36cc710ad8a645d0a07f7bbd8742cf02",
+                                          "contentPropertyAlias": "A content property value"
+                                        }, {
+                                          "contentTypeKey": "b2f0806c-d231-4c78-88b2-3c97d26e1124",
+                                          "udi": "umb://element/36cc710ad8a645d0a07f7bbd8742cf03",
+                                          "contentPropertyAlias": "A content property value"
+                                        }
+                                    ],
+                                    "settingsData": []
+                                }
+                             }
+                             """;
+
+        var result = RichTextPropertyEditorHelper.TryParseRichTextEditorValue(input, JsonSerializer(), Logger(), out RichTextEditorValue? value);
+        Assert.IsTrue(result);
+        Assert.IsNotNull(value);
+        Assert.AreEqual("<p>this is <umb-rte-block-inline data-content-udi=\"umb://element/36cc710ad8a645d0a07f7bbd8742cf03\"></umb-rte-block-inline> some markup</p><umb-rte-block data-content-udi=\"umb://element/36cc710ad8a645d0a07f7bbd8742cf02\"></umb-rte-block>", value.Markup);
+
+        Assert.IsNotNull(value.Blocks);
+
+        Guid[] contentTypeGuids = [Guid.Parse("b2f0806c-d231-4c78-88b2-3c97d26e1123"), Guid.Parse("b2f0806c-d231-4c78-88b2-3c97d26e1124")];
+        Guid[] itemGuids = [Guid.Parse("36cc710a-d8a6-45d0-a07f-7bbd8742cf02"), Guid.Parse("36cc710a-d8a6-45d0-a07f-7bbd8742cf03")];
+
+        Assert.AreEqual(2, value.Blocks.ContentData.Count);
+        for (var i = 0; i < value.Blocks.ContentData.Count; i++) {
+            var item = value.Blocks.ContentData[i];
+            Assert.AreEqual(contentTypeGuids[i], item.ContentTypeKey);
+            Assert.AreEqual(new GuidUdi(Constants.UdiEntityType.Element, itemGuids[i]), item.Udi);
+            Assert.AreEqual(itemGuids[i], item.Key);
+        }
 
         Assert.AreEqual(0, value.Blocks.SettingsData.Count);
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
Allows blocks in rte to leave out the "Umbraco-Block" comment from their bodies
