### PR TITLE
Make AddUserClientId able to run twice if needed

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/AddUserClientId.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/AddUserClientId.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+﻿using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
 
 namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_15_0_0;
 
@@ -11,5 +12,12 @@ public class AddUserClientId : MigrationBase
     }
 
     protected override void Migrate()
-        => Create.Table<User2ClientIdDto>().Do();
+    {
+        if (TableExists(Constants.DatabaseSchema.Tables.User2ClientId))
+        {
+            return;
+        }
+
+        Create.Table<User2ClientIdDto>().Do();
+    }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The `AddUserClientId` migration should be able to run twice, in the odd case that migrations need to be re-run.