### PR TITLE
Update ImageSharpMiddlewareOption for fixing invalid width and height

### DIFF
--- a/src/Umbraco.Cms.Imaging.ImageSharp/ConfigureImageSharpMiddlewareOptions.cs
+++ b/src/Umbraco.Cms.Imaging.ImageSharp/ConfigureImageSharpMiddlewareOptions.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Headers;
 using Microsoft.Extensions.Options;
@@ -48,16 +49,26 @@ public sealed class ConfigureImageSharpMiddlewareOptions : IConfigureOptions<Ima
                 return Task.CompletedTask;
             }
 
-            int width = context.Parser.ParseValue<int>(context.Commands.GetValueOrDefault(ResizeWebProcessor.Width), context.Culture);
-            if (width <= 0 || width > _imagingSettings.Resize.MaxWidth)
+            if (context.Commands.Contains(ResizeWebProcessor.Width))
             {
-                context.Commands.Remove(ResizeWebProcessor.Width);
+                if (!int.TryParse(context.Commands.GetValueOrDefault(ResizeWebProcessor.Width), NumberStyles.Integer,
+                    CultureInfo.InvariantCulture, out var width)
+                || width < 0
+                || width >= _imagingSettings.Resize.MaxWidth)
+                {
+                    context.Commands.Remove(ResizeWebProcessor.Width);
+                }
             }
 
-            int height = context.Parser.ParseValue<int>(context.Commands.GetValueOrDefault(ResizeWebProcessor.Height), context.Culture);
-            if (height <= 0 || height > _imagingSettings.Resize.MaxHeight)
+            if (context.Commands.Contains(ResizeWebProcessor.Height))
             {
-                context.Commands.Remove(ResizeWebProcessor.Height);
+                if (!int.TryParse(context.Commands.GetValueOrDefault(ResizeWebProcessor.Height), NumberStyles.Integer,
+                    CultureInfo.InvariantCulture, out var height)
+                || height < 0
+                || height >= _imagingSettings.Resize.MaxHeight)
+                {
+                    context.Commands.Remove(ResizeWebProcessor.Height);
+                }
             }
 
             return Task.CompletedTask;


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

There is an issue when passing an invalid value in the width or height parameter, it could get a FormatException thrown.
Example: domain.com/media/jk4feiat/image.png?width=foo&height=150
OR
domain.com/media/jk4feiat/image.png?width=200&height=bar
OR
domain.com/media/jk4feiat/image.png?width=foo&height=bar

Solution: Check width and height in ConfigureImageSharpMiddlewareOptions and parse it with invariant culture into an integer.

<!-- Thanks for contributing to Umbraco CMS! -->
