### PR TITLE
Move all V14 User and User Group migration to pre-migrations

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -67,15 +67,15 @@ public class UmbracoPlan : MigrationPlan
 
         // To 14.0.0
         To<V_14_0_0.AddPropertyEditorUiAliasColumn>("{419827A0-4FCE-464B-A8F3-247C6092AF55}");
-        To<V_14_0_0.AddGuidsToUserGroups>("{69E12556-D9B3-493A-8E8A-65EC89FB658D}");
-        To<V_14_0_0.AddUserGroup2PermisionTable>("{F2B16CD4-F181-4BEE-81C9-11CF384E6025}");
-        To<V_14_0_0.AddGuidsToUsers>("{A8E01644-9F2E-4988-8341-587EF5B7EA69}");
+        To<NoopMigration>("{69E12556-D9B3-493A-8E8A-65EC89FB658D}");
+        To<NoopMigration>("{F2B16CD4-F181-4BEE-81C9-11CF384E6025}");
+        To<NoopMigration>("{A8E01644-9F2E-4988-8341-587EF5B7EA69}");
         To<V_14_0_0.UpdateDefaultGuidsOfCreatedPackages>("{E073DBC0-9E8E-4C92-8210-9CB18364F46E}");
         To<V_14_0_0.RenameTechnologyLeakingPropertyEditorAliases>("{80D282A4-5497-47FF-991F-BC0BCE603121}");
         To<V_14_0_0.MigrateSchduledPublishesToUtc>("{96525697-E9DC-4198-B136-25AD033442B8}");
         To<V_14_0_0.AddListViewKeysToDocumentTypes>("{7FC5AC9B-6F56-415B-913E-4A900629B853}");
         To<V_14_0_0.MigrateDataTypeConfigurations>("{1539A010-2EB5-4163-8518-4AE2AA98AFC6}");
-        To<V_14_0_0.MigrateCharPermissionsToStrings>("{C567DE81-DF92-4B99-BEA8-CD34EF99DA5D}");
+        To<NoopMigration>("{C567DE81-DF92-4B99-BEA8-CD34EF99DA5D}");
         To<V_14_0_0.DeleteMacroTables>("{0D82C836-96DD-480D-A924-7964E458BD34}");
         To<V_14_0_0.MoveDocumentBlueprintsToFolders>("{1A0FBC8A-6FC6-456C-805C-B94816B2E570}");
         To<V_14_0_0.MigrateTours>("{302DE171-6D83-4B6B-B3C0-AC8808A16CA1}");

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPremigrationPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPremigrationPlan.cs
@@ -53,5 +53,9 @@ public class UmbracoPremigrationPlan : MigrationPlan
 
         // To 14.0.0
         To<V_14_0_0.UpdateToOpenIddictV5>("{76FBF80E-37E6-462E-ADC1-25668F56151D}");
+        To<V_14_0_0.AddGuidsToUserGroups>("{37CF4AC3-8489-44BC-A7E8-64908FEEC656}");
+        To<V_14_0_0.AddUserGroup2PermisionTable>("{7BCB5352-B2ED-4D4B-B27D-ECDED930B50A}");
+        To<V_14_0_0.AddGuidsToUsers>("{3E69BF9B-BEAB-41B1-BB11-15383CCA1C7F}");
+        To<V_14_0_0.MigrateCharPermissionsToStrings>("{F12C609B-86B9-4386-AFA4-78E02857247C}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddGuidsToUserGroups.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddGuidsToUserGroups.cs
@@ -20,6 +20,12 @@ public class AddGuidsToUserGroups : UnscopedMigrationBase
 
     protected override void Migrate()
     {
+        // If the new column already exists we'll do nothing.
+        if (ColumnExists(Constants.DatabaseSchema.Tables.UserGroup, NewColumnName))
+        {
+            return;
+        }
+
         // SQL server can simply add the column, but for SQLite this won't work,
         // so we'll have to create a new table and copy over data.
         if (DatabaseType != DatabaseType.SQLite)
@@ -36,11 +42,6 @@ public class AddGuidsToUserGroups : UnscopedMigrationBase
         using IScope scope = _scopeProvider.CreateScope();
         using IDisposable notificationSuppression = scope.Notifications.Suppress();
         ScopeDatabase(scope);
-
-        if (ColumnExists(Constants.DatabaseSchema.Tables.UserGroup, NewColumnName))
-        {
-            return;
-        }
 
         var columns = SqlSyntax.GetColumnsInSchema(Context.Database).ToList();
         AddColumnIfNotExists<UserGroupDto>(columns, NewColumnName);
@@ -67,12 +68,6 @@ public class AddGuidsToUserGroups : UnscopedMigrationBase
         using IScope scope = _scopeProvider.CreateScope();
         using IDisposable notificationSuppression = scope.Notifications.Suppress();
         ScopeDatabase(scope);
-
-        // If the new column already exists we'll do nothing.
-        if (ColumnExists(Constants.DatabaseSchema.Tables.UserGroup, NewColumnName))
-        {
-            return;
-        }
 
         // This isn't pretty,
         // But since you cannot alter columns, we have to copy the data over and delete the old table.

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddGuidsToUsers.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddGuidsToUsers.cs
@@ -26,6 +26,12 @@ internal class AddGuidsToUsers : UnscopedMigrationBase
 
     protected override void Migrate()
     {
+        if (ColumnExists(Constants.DatabaseSchema.Tables.User, NewColumnName))
+        {
+            Context.Complete();
+            return;
+        }
+
         InvalidateBackofficeUserAccess = true;
         using IScope scope = _scopeProvider.CreateScope();
         using IDisposable notificationSuppression = scope.Notifications.Suppress();
@@ -75,11 +81,6 @@ internal class AddGuidsToUsers : UnscopedMigrationBase
 
     private void MigrateSqlite()
     {
-        if (ColumnExists(Constants.DatabaseSchema.Tables.User, NewColumnName))
-        {
-            return;
-        }
-
         /*
          * We commit the initial transaction started by the scope. This is required in order to disable the foreign keys.
          * We then begin a new transaction, this transaction will be committed or rolled back by the scope, like normal.


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Attended upgrades have started failing for V14. These failures happen because the User and User Group DB schemas are not up to date when attempting to log in to initiate the upgrade (because the upgrade has not yet run).

This PR moves all User and User Group migrations for V14 into the pre-migrations plan, so attended upgrade only starts _after_ ensuring an up-to-date schema for Users and User Groups.

### Testing this PR

Verify that both attended and unattended upgrades work from V13 to V14.latest.

Run these tests for both SQLite and SQL Server.