### PR TITLE
Swagger sub types selectors (take 2)

### DIFF
--- a/src/Umbraco.Cms.Api.Common/Configuration/ConfigureUmbracoSwaggerGenOptions.cs
+++ b/src/Umbraco.Cms.Api.Common/Configuration/ConfigureUmbracoSwaggerGenOptions.cs
@@ -17,15 +17,6 @@ public class ConfigureUmbracoSwaggerGenOptions : IConfigureOptions<SwaggerGenOpt
     private readonly ISchemaIdSelector _schemaIdSelector;
     private readonly ISubTypesSelector _subTypesSelector;
 
-    [Obsolete("Use non-obsolete constructor. This will be removed in Umbraco 15.")]
-    public ConfigureUmbracoSwaggerGenOptions(
-        IOptions<ApiVersioningOptions> apiVersioningOptions,
-        IOperationIdSelector operationIdSelector,
-        ISchemaIdSelector schemaIdSelector)
-        : this(operationIdSelector, schemaIdSelector)
-    {
-    }
-
     [Obsolete("Use non-obsolete constructor. This will be removed in Umbraco 16.")]
     public ConfigureUmbracoSwaggerGenOptions(
         IOperationIdSelector operationIdSelector,

--- a/src/Umbraco.Cms.Api.Common/Configuration/ConfigureUmbracoSwaggerGenOptions.cs
+++ b/src/Umbraco.Cms.Api.Common/Configuration/ConfigureUmbracoSwaggerGenOptions.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Umbraco.Cms.Api.Common.OpenApi;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Common.Configuration;
@@ -14,6 +15,7 @@ public class ConfigureUmbracoSwaggerGenOptions : IConfigureOptions<SwaggerGenOpt
 {
     private readonly IOperationIdSelector _operationIdSelector;
     private readonly ISchemaIdSelector _schemaIdSelector;
+    private readonly ISubTypesSelector _subTypesSelector;
 
     [Obsolete("Use non-obsolete constructor. This will be removed in Umbraco 15.")]
     public ConfigureUmbracoSwaggerGenOptions(
@@ -24,12 +26,21 @@ public class ConfigureUmbracoSwaggerGenOptions : IConfigureOptions<SwaggerGenOpt
     {
     }
 
+    [Obsolete("Use non-obsolete constructor. This will be removed in Umbraco 16.")]
     public ConfigureUmbracoSwaggerGenOptions(
         IOperationIdSelector operationIdSelector,
         ISchemaIdSelector schemaIdSelector)
+        : this(operationIdSelector, schemaIdSelector, StaticServiceProvider.Instance.GetRequiredService<ISubTypesSelector>())
+    { }
+
+    public ConfigureUmbracoSwaggerGenOptions(
+        IOperationIdSelector operationIdSelector,
+        ISchemaIdSelector schemaIdSelector,
+        ISubTypesSelector subTypesSelector)
     {
         _operationIdSelector = operationIdSelector;
         _schemaIdSelector = schemaIdSelector;
+        _subTypesSelector = subTypesSelector;
     }
 
     public void Configure(SwaggerGenOptions swaggerGenOptions)
@@ -62,6 +73,7 @@ public class ConfigureUmbracoSwaggerGenOptions : IConfigureOptions<SwaggerGenOpt
         swaggerGenOptions.OrderActionsBy(ActionOrderBy);
         swaggerGenOptions.SchemaFilter<EnumSchemaFilter>();
         swaggerGenOptions.CustomSchemaIds(_schemaIdSelector.SchemaId);
+        swaggerGenOptions.SelectSubTypesUsing(_subTypesSelector.SubTypes);
         swaggerGenOptions.SupportNonNullableReferenceTypes();
     }
 

--- a/src/Umbraco.Cms.Api.Common/DependencyInjection/UmbracoBuilderApiExtensions.cs
+++ b/src/Umbraco.Cms.Api.Common/DependencyInjection/UmbracoBuilderApiExtensions.cs
@@ -23,6 +23,8 @@ public static class UmbracoBuilderApiExtensions
         builder.Services.AddSingleton<IOperationIdHandler, OperationIdHandler>();
         builder.Services.AddSingleton<ISchemaIdSelector, SchemaIdSelector>();
         builder.Services.AddSingleton<ISchemaIdHandler, SchemaIdHandler>();
+        builder.Services.AddSingleton<ISubTypesSelector, SubTypesSelector>();
+        builder.Services.AddSingleton<ISubTypesHandler, SubTypesHandler>();
         builder.Services.Configure<UmbracoPipelineOptions>(options => options.AddFilter(new SwaggerRouteTemplatePipelineFilter("UmbracoApiCommon")));
 
         return builder;

--- a/src/Umbraco.Cms.Api.Common/OpenApi/ISubTypesHandler.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/ISubTypesHandler.cs
@@ -1,0 +1,8 @@
+namespace Umbraco.Cms.Api.Common.OpenApi;
+
+public interface ISubTypesHandler
+{
+    bool CanHandle(Type type, string documentName);
+
+    IEnumerable<Type> Handle(Type type);
+}

--- a/src/Umbraco.Cms.Api.Common/OpenApi/ISubTypesSelector.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/ISubTypesSelector.cs
@@ -1,0 +1,6 @@
+namespace Umbraco.Cms.Api.Common.OpenApi;
+
+public interface ISubTypesSelector
+{
+    IEnumerable<Type> SubTypes(Type type);
+}

--- a/src/Umbraco.Cms.Api.Common/OpenApi/SubTypesHandler.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/SubTypesHandler.cs
@@ -2,8 +2,13 @@ using Umbraco.Cms.Api.Common.Serialization;
 
 namespace Umbraco.Cms.Api.Common.OpenApi;
 
-public class SubTypesHandler(IUmbracoJsonTypeInfoResolver umbracoJsonTypeInfoResolver) : ISubTypesHandler
+public class SubTypesHandler : ISubTypesHandler
 {
+    private readonly IUmbracoJsonTypeInfoResolver _umbracoJsonTypeInfoResolver;
+
+    public SubTypesHandler(IUmbracoJsonTypeInfoResolver umbracoJsonTypeInfoResolver)
+        => _umbracoJsonTypeInfoResolver = umbracoJsonTypeInfoResolver;
+
     public virtual bool CanHandle(Type type)
         => type.Namespace?.StartsWith("Umbraco.Cms") is true;
 
@@ -11,5 +16,5 @@ public class SubTypesHandler(IUmbracoJsonTypeInfoResolver umbracoJsonTypeInfoRes
         => CanHandle(type);
 
     public virtual IEnumerable<Type> Handle(Type type)
-        => umbracoJsonTypeInfoResolver.FindSubTypes(type);
+        => _umbracoJsonTypeInfoResolver.FindSubTypes(type);
 }

--- a/src/Umbraco.Cms.Api.Common/OpenApi/SubTypesHandler.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/SubTypesHandler.cs
@@ -1,0 +1,15 @@
+using Umbraco.Cms.Api.Common.Serialization;
+
+namespace Umbraco.Cms.Api.Common.OpenApi;
+
+public class SubTypesHandler(IUmbracoJsonTypeInfoResolver umbracoJsonTypeInfoResolver) : ISubTypesHandler
+{
+    public virtual bool CanHandle(Type type)
+        => type.Namespace?.StartsWith("Umbraco.Cms") is true;
+
+    public virtual bool CanHandle(Type type, string documentName)
+        => CanHandle(type);
+
+    public virtual IEnumerable<Type> Handle(Type type)
+        => umbracoJsonTypeInfoResolver.FindSubTypes(type);
+}

--- a/src/Umbraco.Cms.Api.Common/OpenApi/SubTypesHandler.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/SubTypesHandler.cs
@@ -9,7 +9,7 @@ public class SubTypesHandler : ISubTypesHandler
     public SubTypesHandler(IUmbracoJsonTypeInfoResolver umbracoJsonTypeInfoResolver)
         => _umbracoJsonTypeInfoResolver = umbracoJsonTypeInfoResolver;
 
-    public virtual bool CanHandle(Type type)
+    protected virtual bool CanHandle(Type type)
         => type.Namespace?.StartsWith("Umbraco.Cms") is true;
 
     public virtual bool CanHandle(Type type, string documentName)

--- a/src/Umbraco.Cms.Api.Common/OpenApi/SubTypesSelector.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/SubTypesSelector.cs
@@ -7,25 +7,41 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Common.OpenApi;
 
-public class SubTypesSelector(IOptions<GlobalSettings> settings,
-    IHostingEnvironment hostingEnvironment,
-    IHttpContextAccessor httpContextAccessor,
-    IEnumerable<ISubTypesHandler> subTypeHandlers,
-    IUmbracoJsonTypeInfoResolver umbracoJsonTypeInfoResolver) : ISubTypesSelector
+public class SubTypesSelector : ISubTypesSelector
 {
+    private readonly IOptions<GlobalSettings> _settings;
+    private readonly IHostingEnvironment _hostingEnvironment;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IEnumerable<ISubTypesHandler> _subTypeHandlers;
+    private readonly IUmbracoJsonTypeInfoResolver _umbracoJsonTypeInfoResolver;
+
+    public SubTypesSelector(
+        IOptions<GlobalSettings> settings,
+        IHostingEnvironment hostingEnvironment,
+        IHttpContextAccessor httpContextAccessor,
+        IEnumerable<ISubTypesHandler> subTypeHandlers,
+        IUmbracoJsonTypeInfoResolver umbracoJsonTypeInfoResolver)
+    {
+        _settings = settings;
+        _hostingEnvironment = hostingEnvironment;
+        _httpContextAccessor = httpContextAccessor;
+        _subTypeHandlers = subTypeHandlers;
+        _umbracoJsonTypeInfoResolver = umbracoJsonTypeInfoResolver;
+    }
+
     public IEnumerable<Type> SubTypes(Type type)
     {
-        var backOfficePath =  settings.Value.GetBackOfficePath(hostingEnvironment);
-        if (httpContextAccessor.HttpContext?.Request.Path.StartsWithSegments($"{backOfficePath}/swagger/") ?? false)
+        var backOfficePath =  _settings.Value.GetBackOfficePath(_hostingEnvironment);
+        if (_httpContextAccessor.HttpContext?.Request.Path.StartsWithSegments($"{backOfficePath}/swagger/") ?? false)
         {
             // Split the path into segments
-            var segments = httpContextAccessor.HttpContext.Request.Path.Value!.TrimStart($"{backOfficePath}/swagger/").Split('/');
+            var segments = _httpContextAccessor.HttpContext.Request.Path.Value!.TrimStart($"{backOfficePath}/swagger/").Split('/');
 
             // Extract the document name from the path
             var documentName = segments[0];
 
             // Find the first handler that can handle the type / document name combination
-            ISubTypesHandler? handler = subTypeHandlers.FirstOrDefault(h => h.CanHandle(type, documentName));
+            ISubTypesHandler? handler = _subTypeHandlers.FirstOrDefault(h => h.CanHandle(type, documentName));
             if (handler != null)
             {
                 return handler.Handle(type);
@@ -33,6 +49,6 @@ public class SubTypesSelector(IOptions<GlobalSettings> settings,
         }
 
         // Default implementation to maintain backwards compatibility
-        return umbracoJsonTypeInfoResolver.FindSubTypes(type);
+        return _umbracoJsonTypeInfoResolver.FindSubTypes(type);
     }
 }

--- a/src/Umbraco.Cms.Api.Common/OpenApi/SubTypesSelector.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/SubTypesSelector.cs
@@ -33,10 +33,15 @@ public class SubTypesSelector : ISubTypesSelector
     public IEnumerable<Type> SubTypes(Type type)
     {
         var backOfficePath =  _settings.Value.GetBackOfficePath(_hostingEnvironment);
-        if (_httpContextAccessor.HttpContext?.Request.Path.StartsWithSegments($"{backOfficePath}/swagger") ?? false)
+        var swaggerPath = $"{backOfficePath}/swagger";
+
+        if (_httpContextAccessor.HttpContext?.Request.Path.StartsWithSegments(swaggerPath) ?? false)
         {
             // Split the path into segments
-            var segments = _httpContextAccessor.HttpContext.Request.Path.Value!.TrimStart($"{backOfficePath}/swagger/").Split(Constants.CharArrays.ForwardSlash);
+            var segments = _httpContextAccessor.HttpContext.Request.Path.Value!
+                .Substring(swaggerPath.Length)
+                .TrimStart(Constants.CharArrays.ForwardSlash)
+                .Split(Constants.CharArrays.ForwardSlash);
 
             // Extract the document name from the path
             var documentName = segments[0];

--- a/src/Umbraco.Cms.Api.Common/OpenApi/SubTypesSelector.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/SubTypesSelector.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Api.Common.Serialization;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Common.OpenApi;
+
+public class SubTypesSelector(IOptions<GlobalSettings> settings,
+    IHostingEnvironment hostingEnvironment,
+    IHttpContextAccessor httpContextAccessor,
+    IEnumerable<ISubTypesHandler> subTypeHandlers,
+    IUmbracoJsonTypeInfoResolver umbracoJsonTypeInfoResolver) : ISubTypesSelector
+{
+    public IEnumerable<Type> SubTypes(Type type)
+    {
+        var backOfficePath =  settings.Value.GetBackOfficePath(hostingEnvironment);
+        if (httpContextAccessor.HttpContext?.Request.Path.StartsWithSegments($"{backOfficePath}/swagger/") ?? false)
+        {
+            // Split the path into segments
+            var segments = httpContextAccessor.HttpContext.Request.Path.Value!.TrimStart($"{backOfficePath}/swagger/").Split('/');
+
+            // Extract the document name from the path
+            var documentName = segments[0];
+
+            // Find the first handler that can handle the type / document name combination
+            ISubTypesHandler? handler = subTypeHandlers.FirstOrDefault(h => h.CanHandle(type, documentName));
+            if (handler != null)
+            {
+                return handler.Handle(type);
+            }
+        }
+
+        // Default implementation to maintain backwards compatibility
+        return umbracoJsonTypeInfoResolver.FindSubTypes(type);
+    }
+}

--- a/src/Umbraco.Cms.Api.Common/OpenApi/SubTypesSelector.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/SubTypesSelector.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Api.Common.Serialization;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Extensions;
@@ -35,7 +36,7 @@ public class SubTypesSelector : ISubTypesSelector
         if (_httpContextAccessor.HttpContext?.Request.Path.StartsWithSegments($"{backOfficePath}/swagger") ?? false)
         {
             // Split the path into segments
-            var segments = _httpContextAccessor.HttpContext.Request.Path.Value!.TrimStart($"{backOfficePath}/swagger/").Split('/');
+            var segments = _httpContextAccessor.HttpContext.Request.Path.Value!.TrimStart($"{backOfficePath}/swagger/").Split(Constants.CharArrays.ForwardSlash);
 
             // Extract the document name from the path
             var documentName = segments[0];

--- a/src/Umbraco.Cms.Api.Common/OpenApi/SubTypesSelector.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/SubTypesSelector.cs
@@ -32,7 +32,7 @@ public class SubTypesSelector : ISubTypesSelector
     public IEnumerable<Type> SubTypes(Type type)
     {
         var backOfficePath =  _settings.Value.GetBackOfficePath(_hostingEnvironment);
-        if (_httpContextAccessor.HttpContext?.Request.Path.StartsWithSegments($"{backOfficePath}/swagger/") ?? false)
+        if (_httpContextAccessor.HttpContext?.Request.Path.StartsWithSegments($"{backOfficePath}/swagger") ?? false)
         {
             // Split the path into segments
             var segments = _httpContextAccessor.HttpContext.Request.Path.Value!.TrimStart($"{backOfficePath}/swagger/").Split('/');

--- a/src/Umbraco.Cms.Api.Management/Configuration/ConfigureUmbracoManagementApiSwaggerGenOptions.cs
+++ b/src/Umbraco.Cms.Api.Management/Configuration/ConfigureUmbracoManagementApiSwaggerGenOptions.cs
@@ -31,7 +31,6 @@ public class ConfigureUmbracoManagementApiSwaggerGenOptions : IConfigureOptions<
             });
 
         swaggerGenOptions.OperationFilter<ResponseHeaderOperationFilter>();
-        swaggerGenOptions.SelectSubTypesUsing(_umbracoJsonTypeInfoResolver.FindSubTypes);
         swaggerGenOptions.UseOneOfForPolymorphism();
 
         // Ensure all types that implements the IOpenApiDiscriminator have a $type property in the OpenApi schema with the default value (The class name) that is expected by the server


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

_This is a replacement PR for #17072 ... description is still valid, and originates from the original PR._ 


This PR introduces a new `ISubTypesSelector` and `ISubTypesHandler` implementation to allow overriding how Swagger resolves subtypes of a type based on both the base type and the API document name.

This is required as the current default behaviour is to resolve all type implementations of the base type across all app domain assemblies. This poses a problem if you have (like we do in Umbraco Commerce) a shared base class used by multiple Swagger documents. In this scenario Swagger will throw an exception as it attempts to load the types from all endpoint definitions, not just the for the given API, casing duplicate schema to be generated.

With this PR in the same way `ISchemaIdSelector` and `IOperationIdSelector` allow developers to customise the default behaviour of Umbraco whilst generating Swagger Schemas, this new `ISubTypesSelector` lets you override the sub type resolution process.

In order to maintain backwards compatibility I have set the default `ISchemaIdSelector` to use the previous functionality if no explicit `ISubTypesSelector` is defined that can handle the supplied type.
