### PR TITLE
Execute V15 User data migrations as pre-migrations

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -78,7 +78,7 @@ public class UmbracoPlan : MigrationPlan
         To<NoopMigration>("{C567DE81-DF92-4B99-BEA8-CD34EF99DA5D}");
         To<V_14_0_0.DeleteMacroTables>("{0D82C836-96DD-480D-A924-7964E458BD34}");
         To<V_14_0_0.MoveDocumentBlueprintsToFolders>("{1A0FBC8A-6FC6-456C-805C-B94816B2E570}");
-        To<V_14_0_0.MigrateTours>("{302DE171-6D83-4B6B-B3C0-AC8808A16CA1}");
+        To<NoopMigration>("{302DE171-6D83-4B6B-B3C0-AC8808A16CA1}");
         To<V_14_0_0.MigrateUserGroup2PermissionPermissionColumnType>("{8184E61D-ECBA-4AAA-B61B-D7A82EB82EB7}");
         To<V_14_0_0.MigrateNotificationCharsToStrings>("{E261BF01-2C7F-4544-BAE7-49D545B21D68}");
         To<V_14_0_0.AddEditorUiToDataType>("{5A2EF07D-37B4-49D5-8E9B-3ED01877263B}");
@@ -98,6 +98,6 @@ public class UmbracoPlan : MigrationPlan
 
         // To 15.0.0
         To<V_15_0_0.AddUserClientId>("{7F4F31D8-DD71-4F0D-93FC-2690A924D84B}");
-        To<V_15_0_0.AddKindToUser>("{1A8835EF-F8AB-4472-B4D8-D75B7C164022}");
+        To<NoopMigration>("{1A8835EF-F8AB-4472-B4D8-D75B7C164022}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPremigrationPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPremigrationPlan.cs
@@ -57,5 +57,12 @@ public class UmbracoPremigrationPlan : MigrationPlan
         To<V_14_0_0.AddUserGroup2PermisionTable>("{7BCB5352-B2ED-4D4B-B27D-ECDED930B50A}");
         To<V_14_0_0.AddGuidsToUsers>("{3E69BF9B-BEAB-41B1-BB11-15383CCA1C7F}");
         To<V_14_0_0.MigrateCharPermissionsToStrings>("{F12C609B-86B9-4386-AFA4-78E02857247C}");
+
+        // To 15.0.0
+        // - The tours data migration was run as part of the regular upgrade plan for V14, but as it affects User data,
+        //   we need it to be run before the V15 User data migrations run. In the regular upgrade plan it has now been
+        //   replaced with a noop migration for the corresponding migration state.
+        To<V_14_0_0.MigrateTours>("{A08254B6-D9E7-4207-A496-2ED0A87FB4FD}");
+        To<V_15_0_0.AddKindToUser>("{69AA6889-8B67-42B4-AA4F-114704487A45}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateTours.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateTours.cs
@@ -26,16 +26,18 @@ internal class MigrateTours : UnscopedMigrationBase
 
     protected override void Migrate()
     {
+        // if the table already exists, do nothing
+        if (TableExists(Constants.DatabaseSchema.Tables.UserData))
+        {
+            Context.Complete();
+            return;
+        }
+
         using IScope scope = _scopeProvider.CreateScope();
         using IDisposable notificationSuppression = scope.Notifications.Suppress();
         ScopeDatabase(scope);
 
         // create table
-        if (TableExists(Constants.DatabaseSchema.Tables.UserData))
-        {
-            return;
-        }
-
         Create.Table<UserDataDto>().Do();
 
         // transform all existing UserTour fields in to userdata

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/AddKindToUser.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/AddKindToUser.cs
@@ -19,6 +19,13 @@ public class AddKindToUser : UnscopedMigrationBase
 
     protected override void Migrate()
     {
+        // If the new column already exists we'll do nothing.
+        if (ColumnExists(Constants.DatabaseSchema.Tables.User, NewColumnName))
+        {
+            Context.Complete();
+            return;
+        }
+
         InvalidateBackofficeUserAccess = true;
 
         using IScope scope = _scopeProvider.CreateScope();
@@ -48,12 +55,6 @@ public class AddKindToUser : UnscopedMigrationBase
 
     private void MigrateSqlite()
     {
-        // If the new column already exists we'll do nothing.
-        if (ColumnExists(Constants.DatabaseSchema.Tables.User, NewColumnName))
-        {
-            return;
-        }
-
         /*
          * We commit the initial transaction started by the scope. This is required in order to disable the foreign keys.
          * We then begin a new transaction, this transaction will be committed or rolled back by the scope, like normal.


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Similarly to #17130, we also need execute the V15 migrations affecting User data as pre-migrations.

As it happens, one of the V14 migrations (`MigrateTours`) must run before the V15 ones can run, so that one has been moved to pre-migrations as well. To achieve a smooth transition to V15 from both V14 _and_ V13:

1. `MigrateTours` has been replaced with a no-op migration in the regular upgrade plan.
2. `MigrateTours` has slightly altered to exit fast, in case it has already run (which will be the case in a V14 to V15 upgrade).

### Testing this PR

Verify that both attended and unattended upgrades work from V14 to V15 _and_ from V13 to V15.

Run these tests for both SQLite and SQL Server.
