### PR TITLE
Temporarily disable of windows integration tests

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -287,8 +287,8 @@ stages:
         displayName: Integration Tests (SQLite)
         strategy:
           matrix:
-            Windows:
-              vmImage: 'windows-latest'
+#            Windows:
+#              vmImage: 'windows-latest'
             Linux:
               vmImage: 'ubuntu-latest'
             macOS:


### PR DESCRIPTION
# Description

Due to the current situation with both NuCache and HybridCache we randomly hit out-of-memory exceptions that we cannot reproduce locally.

