### PR TITLE
V15: Replacing the usages of `Children` (navigation data) from `IPublishedContent`

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Services/ApiMediaQueryService.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/ApiMediaQueryService.cs
@@ -4,6 +4,7 @@ using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Services.Navigation;
 using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Extensions;
 
@@ -14,11 +15,13 @@ internal sealed class ApiMediaQueryService : IApiMediaQueryService
 {
     private readonly IPublishedMediaCache _publishedMediaCache;
     private readonly ILogger<ApiMediaQueryService> _logger;
+    private readonly IMediaNavigationQueryService _mediaNavigationQueryService;
 
-    public ApiMediaQueryService(IPublishedMediaCache publishedMediaCache, ILogger<ApiMediaQueryService> logger)
+    public ApiMediaQueryService(IPublishedMediaCache publishedMediaCache, ILogger<ApiMediaQueryService> logger, IMediaNavigationQueryService mediaNavigationQueryService)
     {
         _publishedMediaCache = publishedMediaCache;
         _logger = logger;
+        _mediaNavigationQueryService = mediaNavigationQueryService;
     }
 
     /// <inheritdoc/>
@@ -68,7 +71,7 @@ internal sealed class ApiMediaQueryService : IApiMediaQueryService
                 break;
             }
 
-            currentChildren = resolvedMedia.Children;
+            currentChildren = resolvedMedia.Children(null, _publishedMediaCache, _mediaNavigationQueryService);
         }
 
         return resolvedMedia;
@@ -101,7 +104,7 @@ internal sealed class ApiMediaQueryService : IApiMediaQueryService
             ? mediaCache.GetById(parentKey)
             : TryGetByPath(childrenOf, mediaCache);
 
-        return parent?.Children ?? Array.Empty<IPublishedContent>();
+        return parent?.Children(null, _publishedMediaCache, _mediaNavigationQueryService) ?? Array.Empty<IPublishedContent>();
     }
 
     private IEnumerable<IPublishedContent>? ApplyFilters(IEnumerable<IPublishedContent> source, IEnumerable<string> filters)

--- a/src/Umbraco.Core/EmbeddedResources/Snippets/ListDescendantsFromCurrentPage.cshtml
+++ b/src/Umbraco.Core/EmbeddedResources/Snippets/ListDescendantsFromCurrentPage.cshtml
@@ -1,16 +1,21 @@
 @using Umbraco.Cms.Core
 @using Umbraco.Cms.Core.Models.PublishedContent
+@using Umbraco.Cms.Core.PublishedCache
 @using Umbraco.Cms.Core.Routing
+@using Umbraco.Cms.Core.Services.Navigation
 @using Umbraco.Extensions
 @inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
 @inject IPublishedValueFallback PublishedValueFallback
 @inject IPublishedUrlProvider PublishedUrlProvider
+@inject IVariationContextAccessor VariationContextAccessor
+@inject IPublishedContentCache PublishedContentCache
+@inject IDocumentNavigationQueryService DocumentNavigationQueryService
 @*
     This snippet creates links for every single page (no matter how deep) below
     the page currently being viewed by the website visitor, displayed as nested unordered HTML lists.
 *@
 
-@{ var selection = Model?.Content.Children.Where(x => x.IsVisible(PublishedValueFallback)).ToArray(); }
+@{ var selection = Model?.Content.Children(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService).Where(x => x.IsVisible(PublishedValueFallback)).ToArray(); }
 
 @* Ensure that the Current Page has children *@
 @if (selection?.Length > 0)
@@ -28,7 +33,11 @@
 
                 @* if this child page has any children, where the property umbracoNaviHide is not True *@
                 @{
-                    var children = item.Children.Where(x => x.IsVisible(PublishedValueFallback)).ToArray();
+                    var children = item
+                        .Children(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService)
+                        .Where(x => x.IsVisible(PublishedValueFallback))
+                        .ToArray();
+
                     if (children.Length > 0)
                     {
                         @* Call a local method to display the children *@
@@ -58,7 +67,11 @@
 
                         @* if the page has any children, where the property umbracoNaviHide is not True *@
                         @{
-                            var children = item.Children.Where(x => x.IsVisible(PublishedValueFallback)).ToArray();
+                            var children = item
+                                .Children(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService)
+                                .Where(x => x.IsVisible(PublishedValueFallback))
+                                .ToArray();
+
                             if (children.Length > 0)
                             {
                                 @* Recurse and call the ChildPages method to display the children *@

--- a/src/Umbraco.Core/EmbeddedResources/Snippets/SiteMap.cshtml
+++ b/src/Umbraco.Core/EmbeddedResources/Snippets/SiteMap.cshtml
@@ -1,10 +1,15 @@
 @using Umbraco.Cms.Core
 @using Umbraco.Cms.Core.Models.PublishedContent
+@using Umbraco.Cms.Core.PublishedCache
 @using Umbraco.Cms.Core.Routing
+@using Umbraco.Cms.Core.Services.Navigation
 @using Umbraco.Extensions
 @inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
 @inject IPublishedValueFallback PublishedValueFallback
 @inject IPublishedUrlProvider PublishedUrlProvider
+@inject IVariationContextAccessor VariationContextAccessor
+@inject IPublishedContentCache PublishedContentCache
+@inject IDocumentNavigationQueryService DocumentNavigationQueryService
 @*
     This snippet makes a list of links of all visible pages of the site, as nested unordered HTML lists.
 
@@ -27,7 +32,10 @@
         const int maxLevelForSitemap = 4;
 
         @* Select visible children *@
-        var selection = node?.Children.Where(x => x.IsVisible(PublishedValueFallback) && x.Level <= maxLevelForSitemap).ToArray();
+        var selection = node?
+            .Children(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService)
+            .Where(x => x.IsVisible(PublishedValueFallback) && x.Level <= maxLevelForSitemap)
+            .ToArray();
 
         @* If any items are returned, render a list *@
         if (selection?.Length > 0)

--- a/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
@@ -120,29 +120,29 @@ public static class PublishedContentExtensions
     /// </summary>
     /// <typeparam name="T">The content type.</typeparam>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <returns>The parent of content, of the given content type, else null.</returns>
     public static T? Parent<T>(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService)
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService)
         where T : class, IPublishedContent
     {
         ArgumentNullException.ThrowIfNull(content);
 
-        return content.GetParent(contentCache, navigationQueryService) as T;
+        return content.GetParent(publishedCache, navigationQueryService) as T;
     }
 
     private static IPublishedContent? GetParent(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService)
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService)
     {
         IPublishedContent? parent;
         if (navigationQueryService.TryGetParentKey(content.Key, out Guid? parentKey))
         {
-            parent = parentKey.HasValue ? contentCache.GetById(parentKey.Value) : null;
+            parent = parentKey.HasValue ? publishedCache.GetById(parentKey.Value) : null;
         }
         else
         {
@@ -518,63 +518,63 @@ public static class PublishedContentExtensions
     ///     Gets the ancestors of the content.
     /// </summary>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <returns>The ancestors of the content, in down-top order.</returns>
     /// <remarks>Does not consider the content itself.</remarks>
     public static IEnumerable<IPublishedContent> Ancestors(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService) =>
-        content.AncestorsOrSelf(contentCache, navigationQueryService, false, null);
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService) =>
+        content.AncestorsOrSelf(publishedCache, navigationQueryService, false, null);
 
     /// <summary>
     ///     Gets the ancestors of the content, at a level lesser or equal to a specified level.
     /// </summary>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <param name="maxLevel">The level.</param>
     /// <returns>The ancestors of the content, at a level lesser or equal to the specified level, in down-top order.</returns>
     /// <remarks>Does not consider the content itself. Only content that are "high enough" in the tree are returned.</remarks>
     public static IEnumerable<IPublishedContent> Ancestors(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         int maxLevel) =>
-        content.AncestorsOrSelf(contentCache, navigationQueryService, false, n => n.Level <= maxLevel);
+        content.AncestorsOrSelf(publishedCache, navigationQueryService, false, n => n.Level <= maxLevel);
 
     /// <summary>
     ///     Gets the ancestors of the content, of a specified content type.
     /// </summary>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <param name="contentTypeAlias">The content type.</param>
     /// <returns>The ancestors of the content, of the specified content type, in down-top order.</returns>
     /// <remarks>Does not consider the content itself. Returns all ancestors, of the specified content type.</remarks>
     public static IEnumerable<IPublishedContent> Ancestors(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string contentTypeAlias) =>
-        content.AncestorsOrSelf(contentCache, navigationQueryService, false, n => n.ContentType.Alias.InvariantEquals(contentTypeAlias));
+        content.AncestorsOrSelf(publishedCache, navigationQueryService, false, n => n.ContentType.Alias.InvariantEquals(contentTypeAlias));
 
     /// <summary>
     ///     Gets the ancestors of the content, of a specified content type.
     /// </summary>
     /// <typeparam name="T">The content type.</typeparam>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <returns>The ancestors of the content, of the specified content type, in down-top order.</returns>
     /// <remarks>Does not consider the content itself. Returns all ancestors, of the specified content type.</remarks>
     public static IEnumerable<T> Ancestors<T>(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService)
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService)
         where T : class, IPublishedContent =>
-        content.Ancestors(contentCache, navigationQueryService).OfType<T>();
+        content.Ancestors(publishedCache, navigationQueryService).OfType<T>();
 
     /// <summary>
     ///     Gets the ancestors of the content, at a level lesser or equal to a specified level, and of a specified content
@@ -582,7 +582,7 @@ public static class PublishedContentExtensions
     /// </summary>
     /// <typeparam name="T">The content type.</typeparam>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <param name="maxLevel">The level.</param>
     /// <returns>
@@ -595,30 +595,30 @@ public static class PublishedContentExtensions
     /// </remarks>
     public static IEnumerable<T> Ancestors<T>(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         int maxLevel)
         where T : class, IPublishedContent =>
-        content.Ancestors(contentCache, navigationQueryService, maxLevel).OfType<T>();
+        content.Ancestors(publishedCache, navigationQueryService, maxLevel).OfType<T>();
 
     /// <summary>
     ///     Gets the content and its ancestors.
     /// </summary>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <returns>The content and its ancestors, in down-top order.</returns>
     public static IEnumerable<IPublishedContent> AncestorsOrSelf(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService) =>
-        content.AncestorsOrSelf(contentCache, navigationQueryService, true, null);
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService) =>
+        content.AncestorsOrSelf(publishedCache, navigationQueryService, true, null);
 
     /// <summary>
     ///     Gets the content and its ancestors, at a level lesser or equal to a specified level.
     /// </summary>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <param name="maxLevel">The level.</param>
     /// <returns>
@@ -631,42 +631,42 @@ public static class PublishedContentExtensions
     /// </remarks>
     public static IEnumerable<IPublishedContent> AncestorsOrSelf(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         int maxLevel) =>
-        content.AncestorsOrSelf(contentCache, navigationQueryService, true, n => n.Level <= maxLevel);
+        content.AncestorsOrSelf(publishedCache, navigationQueryService, true, n => n.Level <= maxLevel);
 
     /// <summary>
     ///     Gets the content and its ancestors, of a specified content type.
     /// </summary>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <param name="contentTypeAlias">The content type.</param>
     /// <returns>The content and its ancestors, of the specified content type, in down-top order.</returns>
     /// <remarks>May or may not begin with the content itself, depending on its content type.</remarks>
     public static IEnumerable<IPublishedContent> AncestorsOrSelf(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string contentTypeAlias) =>
-        content.AncestorsOrSelf(contentCache, navigationQueryService, true, n => n.ContentType.Alias.InvariantEquals(contentTypeAlias));
+        content.AncestorsOrSelf(publishedCache, navigationQueryService, true, n => n.ContentType.Alias.InvariantEquals(contentTypeAlias));
 
     /// <summary>
     ///     Gets the content and its ancestors, of a specified content type.
     /// </summary>
     /// <typeparam name="T">The content type.</typeparam>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <returns>The content and its ancestors, of the specified content type, in down-top order.</returns>
     /// <remarks>May or may not begin with the content itself, depending on its content type.</remarks>
     public static IEnumerable<T> AncestorsOrSelf<T>(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService)
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService)
         where T : class, IPublishedContent =>
-        content.AncestorsOrSelf(contentCache, navigationQueryService).OfType<T>();
+        content.AncestorsOrSelf(publishedCache, navigationQueryService).OfType<T>();
 
     /// <summary>
     ///     Gets the content and its ancestor, at a lever lesser or equal to a specified level, and of a specified content
@@ -674,7 +674,7 @@ public static class PublishedContentExtensions
     /// </summary>
     /// <typeparam name="T">The content type.</typeparam>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <param name="maxLevel">The level.</param>
     /// <returns>
@@ -684,80 +684,80 @@ public static class PublishedContentExtensions
     /// <remarks>May or may not begin with the content itself, depending on its level and content type.</remarks>
     public static IEnumerable<T> AncestorsOrSelf<T>(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         int maxLevel)
         where T : class, IPublishedContent =>
-        content.AncestorsOrSelf(contentCache, navigationQueryService, maxLevel).OfType<T>();
+        content.AncestorsOrSelf(publishedCache, navigationQueryService, maxLevel).OfType<T>();
 
     /// <summary>
     ///     Gets the ancestor of the content, ie its parent.
     /// </summary>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <returns>The ancestor of the content.</returns>
     /// <remarks>This method is here for consistency purposes but does not make much sense.</remarks>
     public static IPublishedContent? Ancestor(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService)
-        => content.GetParent(contentCache, navigationQueryService);
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService)
+        => content.GetParent(publishedCache, navigationQueryService);
 
     /// <summary>
     ///     Gets the nearest ancestor of the content, at a lever lesser or equal to a specified level.
     /// </summary>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <param name="maxLevel">The level.</param>
     /// <returns>The nearest (in down-top order) ancestor of the content, at a level lesser or equal to the specified level.</returns>
     /// <remarks>Does not consider the content itself. May return <c>null</c>.</remarks>
     public static IPublishedContent? Ancestor(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         int maxLevel) =>
-        content.EnumerateAncestors(contentCache, navigationQueryService, false).FirstOrDefault(x => x.Level <= maxLevel);
+        content.EnumerateAncestors(publishedCache, navigationQueryService, false).FirstOrDefault(x => x.Level <= maxLevel);
 
     /// <summary>
     ///     Gets the nearest ancestor of the content, of a specified content type.
     /// </summary>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <param name="contentTypeAlias">The content type alias.</param>
     /// <returns>The nearest (in down-top order) ancestor of the content, of the specified content type.</returns>
     /// <remarks>Does not consider the content itself. May return <c>null</c>.</remarks>
     public static IPublishedContent? Ancestor(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string contentTypeAlias) =>
-        content.EnumerateAncestors(contentCache, navigationQueryService, false).FirstOrDefault(x => x.ContentType.Alias.InvariantEquals(contentTypeAlias));
+        content.EnumerateAncestors(publishedCache, navigationQueryService, false).FirstOrDefault(x => x.ContentType.Alias.InvariantEquals(contentTypeAlias));
 
     /// <summary>
     ///     Gets the nearest ancestor of the content, of a specified content type.
     /// </summary>
     /// <typeparam name="T">The content type.</typeparam>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <returns>The nearest (in down-top order) ancestor of the content, of the specified content type.</returns>
     /// <remarks>Does not consider the content itself. May return <c>null</c>.</remarks>
     public static T? Ancestor<T>(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService)
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService)
         where T : class, IPublishedContent =>
-        content.Ancestors<T>(contentCache, navigationQueryService).FirstOrDefault();
+        content.Ancestors<T>(publishedCache, navigationQueryService).FirstOrDefault();
 
     /// <summary>
     ///     Gets the nearest ancestor of the content, at the specified level and of the specified content type.
     /// </summary>
     /// <typeparam name="T">The content type.</typeparam>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <param name="maxLevel">The level.</param>
     /// <returns>The ancestor of the content, at the specified level and of the specified content type.</returns>
@@ -767,11 +767,11 @@ public static class PublishedContentExtensions
     /// </remarks>
     public static T? Ancestor<T>(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         int maxLevel)
         where T : class, IPublishedContent =>
-        content.Ancestors<T>(contentCache, navigationQueryService, maxLevel).FirstOrDefault();
+        content.Ancestors<T>(publishedCache, navigationQueryService, maxLevel).FirstOrDefault();
 
     /// <summary>
     ///     Gets the content or its nearest ancestor.
@@ -785,49 +785,49 @@ public static class PublishedContentExtensions
     ///     Gets the content or its nearest ancestor, at a lever lesser or equal to a specified level.
     /// </summary>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <param name="maxLevel">The level.</param>
     /// <returns>The content or its nearest (in down-top order) ancestor, at a level lesser or equal to the specified level.</returns>
     /// <remarks>May or may not return the content itself depending on its level. May return <c>null</c>.</remarks>
     public static IPublishedContent AncestorOrSelf(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         int maxLevel) =>
-        content.EnumerateAncestors(contentCache, navigationQueryService, true).FirstOrDefault(x => x.Level <= maxLevel) ?? content;
+        content.EnumerateAncestors(publishedCache, navigationQueryService, true).FirstOrDefault(x => x.Level <= maxLevel) ?? content;
 
     /// <summary>
     ///     Gets the content or its nearest ancestor, of a specified content type.
     /// </summary>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <param name="contentTypeAlias">The content type.</param>
     /// <returns>The content or its nearest (in down-top order) ancestor, of the specified content type.</returns>
     /// <remarks>May or may not return the content itself depending on its content type. May return <c>null</c>.</remarks>
     public static IPublishedContent AncestorOrSelf(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string contentTypeAlias) => content
-        .EnumerateAncestors(contentCache, navigationQueryService, true).FirstOrDefault(x => x.ContentType.Alias.InvariantEquals(contentTypeAlias)) ?? content;
+        .EnumerateAncestors(publishedCache, navigationQueryService, true).FirstOrDefault(x => x.ContentType.Alias.InvariantEquals(contentTypeAlias)) ?? content;
 
     /// <summary>
     ///     Gets the content or its nearest ancestor, of a specified content type.
     /// </summary>
     /// <typeparam name="T">The content type.</typeparam>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <returns>The content or its nearest (in down-top order) ancestor, of the specified content type.</returns>
     /// <remarks>May or may not return the content itself depending on its content type. May return <c>null</c>.</remarks>
     public static T? AncestorOrSelf<T>(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService)
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService)
         where T : class, IPublishedContent =>
-        content.AncestorsOrSelf<T>(contentCache, navigationQueryService).FirstOrDefault();
+        content.AncestorsOrSelf<T>(publishedCache, navigationQueryService).FirstOrDefault();
 
     /// <summary>
     ///     Gets the content or its nearest ancestor, at a lever lesser or equal to a specified level, and of a specified
@@ -835,26 +835,26 @@ public static class PublishedContentExtensions
     /// </summary>
     /// <typeparam name="T">The content type.</typeparam>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <param name="maxLevel">The level.</param>
     /// <returns></returns>
     public static T? AncestorOrSelf<T>(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         int maxLevel)
         where T : class, IPublishedContent =>
-        content.AncestorsOrSelf<T>(contentCache, navigationQueryService, maxLevel).FirstOrDefault();
+        content.AncestorsOrSelf<T>(publishedCache, navigationQueryService, maxLevel).FirstOrDefault();
 
     public static IEnumerable<IPublishedContent> AncestorsOrSelf(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         bool orSelf,
         Func<IPublishedContent, bool>? func)
     {
-        IEnumerable<IPublishedContent> ancestorsOrSelf = content.EnumerateAncestors(contentCache, navigationQueryService, orSelf);
+        IEnumerable<IPublishedContent> ancestorsOrSelf = content.EnumerateAncestors(publishedCache, navigationQueryService, orSelf);
         return func == null ? ancestorsOrSelf : ancestorsOrSelf.Where(func);
     }
 
@@ -862,14 +862,14 @@ public static class PublishedContentExtensions
     ///     Enumerates ancestors of the content, bottom-up.
     /// </summary>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <param name="orSelf">Indicates whether the content should be included.</param>
     /// <returns>Enumerates bottom-up ie walking up the tree (parent, grand-parent, etc).</returns>
     internal static IEnumerable<IPublishedContent> EnumerateAncestors(
         this IPublishedContent? content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         bool orSelf)
     {
         if (content == null)
@@ -882,7 +882,7 @@ public static class PublishedContentExtensions
             yield return content;
         }
 
-        while ((content = content.GetParent(contentCache, navigationQueryService)) != null)
+        while ((content = content.GetParent(publishedCache, navigationQueryService)) != null)
         {
             yield return content;
         }
@@ -896,7 +896,7 @@ public static class PublishedContentExtensions
     ///     Gets the breadcrumbs (ancestors and self, top to bottom) for the specified <paramref name="content" />.
     /// </summary>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <param name="andSelf">Indicates whether the specified content should be included.</param>
     /// <returns>
@@ -904,17 +904,17 @@ public static class PublishedContentExtensions
     /// </returns>
     public static IEnumerable<IPublishedContent> Breadcrumbs(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         bool andSelf = true) =>
-        content.AncestorsOrSelf(contentCache, navigationQueryService, andSelf, null).Reverse();
+        content.AncestorsOrSelf(publishedCache, navigationQueryService, andSelf, null).Reverse();
 
     /// <summary>
     ///     Gets the breadcrumbs (ancestors and self, top to bottom) for the specified <paramref name="content" /> at a level
     ///     higher or equal to <paramref name="minLevel" />.
     /// </summary>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <param name="minLevel">The minimum level.</param>
     /// <param name="andSelf">Indicates whether the specified content should be included.</param>
@@ -924,11 +924,11 @@ public static class PublishedContentExtensions
     /// </returns>
     public static IEnumerable<IPublishedContent> Breadcrumbs(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         int minLevel,
         bool andSelf = true) =>
-        content.AncestorsOrSelf(contentCache, navigationQueryService, andSelf, n => n.Level >= minLevel).Reverse();
+        content.AncestorsOrSelf(publishedCache, navigationQueryService, andSelf, n => n.Level >= minLevel).Reverse();
 
     /// <summary>
     ///     Gets the breadcrumbs (ancestors and self, top to bottom) for the specified <paramref name="content" /> at a level
@@ -936,7 +936,7 @@ public static class PublishedContentExtensions
     /// </summary>
     /// <typeparam name="T">The root content type.</typeparam>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <param name="andSelf">Indicates whether the specified content should be included.</param>
     /// <returns>
@@ -945,8 +945,8 @@ public static class PublishedContentExtensions
     /// </returns>
     public static IEnumerable<IPublishedContent> Breadcrumbs<T>(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         bool andSelf = true)
         where T : class, IPublishedContent
     {
@@ -962,7 +962,7 @@ public static class PublishedContentExtensions
             }
         }
 
-        return TakeUntil(content.AncestorsOrSelf(contentCache, navigationQueryService, andSelf, null), n => n is T).Reverse();
+        return TakeUntil(content.AncestorsOrSelf(publishedCache, navigationQueryService, andSelf, null), n => n is T).Reverse();
     }
 
     #endregion
@@ -980,7 +980,7 @@ public static class PublishedContentExtensions
     ///     The specific culture to filter for. If null is used the current culture is used. (Default is
     ///     null)
     /// </param>
-    /// <param name="contentCache"></param>
+    /// <param name="publishedCache"></param>
     /// <returns></returns>
     /// <remarks>
     ///     This can be useful in order to return all nodes in an entire site by a type when combined with TypedContentAtRoot
@@ -988,11 +988,11 @@ public static class PublishedContentExtensions
     public static IEnumerable<IPublishedContent> DescendantsOrSelfOfType(
         this IEnumerable<IPublishedContent> parentNodes,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string docTypeAlias,
         string? culture = null) => parentNodes.SelectMany(x =>
-        x.DescendantsOrSelfOfType(variationContextAccessor, contentCache, navigationQueryService, docTypeAlias, culture));
+        x.DescendantsOrSelfOfType(variationContextAccessor, publishedCache, navigationQueryService, docTypeAlias, culture));
 
     /// <summary>
     ///     Returns all DescendantsOrSelf of all content referenced
@@ -1010,11 +1010,11 @@ public static class PublishedContentExtensions
     public static IEnumerable<T> DescendantsOrSelf<T>(
         this IEnumerable<IPublishedContent> parentNodes,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string? culture = null)
         where T : class, IPublishedContent =>
-        parentNodes.SelectMany(x => x.DescendantsOrSelf<T>(variationContextAccessor, contentCache, navigationQueryService, culture));
+        parentNodes.SelectMany(x => x.DescendantsOrSelf<T>(variationContextAccessor, publishedCache, navigationQueryService, culture));
 
     // as per XPath 1.0 specs �2.2,
     // - the descendant axis contains the descendants of the context node; a descendant is a child or a child of a child and so on; thus
@@ -1037,194 +1037,194 @@ public static class PublishedContentExtensions
     public static IEnumerable<IPublishedContent> Descendants(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string? culture = null) =>
-        content.DescendantsOrSelf(variationContextAccessor, contentCache, navigationQueryService, false, null, culture);
+        content.DescendantsOrSelf(variationContextAccessor, publishedCache, navigationQueryService, false, null, culture);
 
     public static IEnumerable<IPublishedContent> Descendants(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         int level,
         string? culture = null) =>
-        content.DescendantsOrSelf(variationContextAccessor, contentCache, navigationQueryService, false, p => p.Level >= level, culture);
+        content.DescendantsOrSelf(variationContextAccessor, publishedCache, navigationQueryService, false, p => p.Level >= level, culture);
 
     public static IEnumerable<IPublishedContent> DescendantsOfType(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string contentTypeAlias, string? culture = null) =>
-        content.DescendantsOrSelf(variationContextAccessor, contentCache, navigationQueryService, false, p => p.ContentType.Alias.InvariantEquals(contentTypeAlias), culture);
+        content.DescendantsOrSelf(variationContextAccessor, publishedCache, navigationQueryService, false, p => p.ContentType.Alias.InvariantEquals(contentTypeAlias), culture);
 
     public static IEnumerable<T> Descendants<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.Descendants(variationContextAccessor, contentCache, navigationQueryService, culture).OfType<T>();
+        content.Descendants(variationContextAccessor, publishedCache, navigationQueryService, culture).OfType<T>();
 
     public static IEnumerable<T> Descendants<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         int level,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.Descendants(variationContextAccessor, contentCache, navigationQueryService, level, culture).OfType<T>();
+        content.Descendants(variationContextAccessor, publishedCache, navigationQueryService, level, culture).OfType<T>();
 
     public static IEnumerable<IPublishedContent> DescendantsOrSelf(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string? culture = null) =>
-        content.DescendantsOrSelf(variationContextAccessor, contentCache, navigationQueryService, true, null, culture);
+        content.DescendantsOrSelf(variationContextAccessor, publishedCache, navigationQueryService, true, null, culture);
 
     public static IEnumerable<IPublishedContent> DescendantsOrSelf(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         int level,
         string? culture = null) =>
-        content.DescendantsOrSelf(variationContextAccessor, contentCache, navigationQueryService, true, p => p.Level >= level, culture);
+        content.DescendantsOrSelf(variationContextAccessor, publishedCache, navigationQueryService, true, p => p.Level >= level, culture);
 
     public static IEnumerable<IPublishedContent> DescendantsOrSelfOfType(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string contentTypeAlias,
         string? culture = null) =>
-        content.DescendantsOrSelf(variationContextAccessor, contentCache, navigationQueryService, true, p => p.ContentType.Alias.InvariantEquals(contentTypeAlias), culture);
+        content.DescendantsOrSelf(variationContextAccessor, publishedCache, navigationQueryService, true, p => p.ContentType.Alias.InvariantEquals(contentTypeAlias), culture);
 
     public static IEnumerable<T> DescendantsOrSelf<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.DescendantsOrSelf(variationContextAccessor, contentCache, navigationQueryService, culture).OfType<T>();
+        content.DescendantsOrSelf(variationContextAccessor, publishedCache, navigationQueryService, culture).OfType<T>();
 
     public static IEnumerable<T> DescendantsOrSelf<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         int level,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.DescendantsOrSelf(variationContextAccessor, contentCache, navigationQueryService, level, culture).OfType<T>();
+        content.DescendantsOrSelf(variationContextAccessor, publishedCache, navigationQueryService, level, culture).OfType<T>();
 
     public static IPublishedContent? Descendant(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string? culture = null) =>
-        content.Children(variationContextAccessor, contentCache, navigationQueryService, culture)?.FirstOrDefault();
+        content.Children(variationContextAccessor, publishedCache, navigationQueryService, culture)?.FirstOrDefault();
 
     public static IPublishedContent? Descendant(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         int level,
         string? culture = null) => content
-        .EnumerateDescendants(variationContextAccessor, contentCache, navigationQueryService, false, culture).FirstOrDefault(x => x.Level == level);
+        .EnumerateDescendants(variationContextAccessor, publishedCache, navigationQueryService, false, culture).FirstOrDefault(x => x.Level == level);
 
     public static IPublishedContent? DescendantOfType(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string contentTypeAlias,
         string? culture = null) => content
-        .EnumerateDescendants(variationContextAccessor, contentCache, navigationQueryService, false, culture)
+        .EnumerateDescendants(variationContextAccessor, publishedCache, navigationQueryService, false, culture)
         .FirstOrDefault(x => x.ContentType.Alias.InvariantEquals(contentTypeAlias));
 
     public static T? Descendant<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.EnumerateDescendants(variationContextAccessor, contentCache, navigationQueryService, false, culture).FirstOrDefault(x => x is T) as T;
+        content.EnumerateDescendants(variationContextAccessor, publishedCache, navigationQueryService, false, culture).FirstOrDefault(x => x is T) as T;
 
     public static T? Descendant<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         int level,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.Descendant(variationContextAccessor, contentCache, navigationQueryService, level, culture) as T;
+        content.Descendant(variationContextAccessor, publishedCache, navigationQueryService, level, culture) as T;
 
     public static IPublishedContent DescendantOrSelf(this IPublishedContent content, IVariationContextAccessor variationContextAccessor, string? culture = null) => content;
 
     public static IPublishedContent? DescendantOrSelf(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         int level,
         string? culture = null) => content
-        .EnumerateDescendants(variationContextAccessor, contentCache, navigationQueryService, true, culture).FirstOrDefault(x => x.Level == level);
+        .EnumerateDescendants(variationContextAccessor, publishedCache, navigationQueryService, true, culture).FirstOrDefault(x => x.Level == level);
 
     public static IPublishedContent? DescendantOrSelfOfType(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string contentTypeAlias,
         string? culture = null) => content
-        .EnumerateDescendants(variationContextAccessor, contentCache, navigationQueryService, true, culture)
+        .EnumerateDescendants(variationContextAccessor, publishedCache, navigationQueryService, true, culture)
         .FirstOrDefault(x => x.ContentType.Alias.InvariantEquals(contentTypeAlias));
 
     public static T? DescendantOrSelf<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.EnumerateDescendants(variationContextAccessor, contentCache, navigationQueryService, true, culture).FirstOrDefault(x => x is T) as T;
+        content.EnumerateDescendants(variationContextAccessor, publishedCache, navigationQueryService, true, culture).FirstOrDefault(x => x is T) as T;
 
     public static T? DescendantOrSelf<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         int level,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.DescendantOrSelf(variationContextAccessor, contentCache, navigationQueryService, level, culture) as T;
+        content.DescendantOrSelf(variationContextAccessor, publishedCache, navigationQueryService, level, culture) as T;
 
     internal static IEnumerable<IPublishedContent> DescendantsOrSelf(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         bool orSelf,
         Func<IPublishedContent, bool>? func,
         string? culture = null) =>
-        content.EnumerateDescendants(variationContextAccessor, contentCache, navigationQueryService, orSelf, culture)
+        content.EnumerateDescendants(variationContextAccessor, publishedCache, navigationQueryService, orSelf, culture)
         .Where(x => func == null || func(x));
 
     internal static IEnumerable<IPublishedContent> EnumerateDescendants(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         bool orSelf,
         string? culture = null)
     {
@@ -1238,11 +1238,11 @@ public static class PublishedContentExtensions
             yield return content;
         }
 
-        IEnumerable<IPublishedContent>? children = content.Children(variationContextAccessor, contentCache, navigationQueryService, culture);
+        IEnumerable<IPublishedContent>? children = content.Children(variationContextAccessor, publishedCache, navigationQueryService, culture);
         if (children is not null)
         {
             foreach (IPublishedContent desc in children.SelectMany(x =>
-                         x.EnumerateDescendants(variationContextAccessor, contentCache, navigationQueryService, culture)))
+                         x.EnumerateDescendants(variationContextAccessor, publishedCache, navigationQueryService, culture)))
             {
                 yield return desc;
             }
@@ -1252,16 +1252,16 @@ public static class PublishedContentExtensions
     internal static IEnumerable<IPublishedContent> EnumerateDescendants(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache publishedContentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string? culture = null)
     {
         yield return content;
-        IEnumerable<IPublishedContent>? children = content.Children(variationContextAccessor, publishedContentCache, navigationQueryService, culture);
+        IEnumerable<IPublishedContent>? children = content.Children(variationContextAccessor, publishedCache, navigationQueryService, culture);
         if (children is not null)
         {
             foreach (IPublishedContent desc in children.SelectMany(x =>
-                         x.EnumerateDescendants(variationContextAccessor, publishedContentCache, navigationQueryService, culture)))
+                         x.EnumerateDescendants(variationContextAccessor, publishedCache, navigationQueryService, culture)))
             {
                 yield return desc;
             }
@@ -1282,7 +1282,7 @@ public static class PublishedContentExtensions
     ///     The specific culture to get the URL children for. Default is null which will use the current culture in
     ///     <see cref="VariationContext" />
     /// </param>
-    /// <param name="contentCache"></param>
+    /// <param name="publishedCache"></param>
     /// <remarks>
     ///     <para>Gets children that are available for the specified culture.</para>
     ///     <para>Children are sorted by their sortOrder.</para>
@@ -1303,8 +1303,8 @@ public static class PublishedContentExtensions
     public static IEnumerable<IPublishedContent> Children(
         this IPublishedContent content,
         IVariationContextAccessor? variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string? culture = null)
     {
         // handle context culture for variant
@@ -1318,7 +1318,7 @@ public static class PublishedContentExtensions
             return [];
         }
 
-        IEnumerable<IPublishedContent> children = childrenKeys.Select(contentCache.GetById).WhereNotNull();
+        IEnumerable<IPublishedContent> children = childrenKeys.Select(publishedCache.GetById).WhereNotNull();
 
         if (culture == "*")
         {
@@ -1339,7 +1339,7 @@ public static class PublishedContentExtensions
     ///     The specific culture to filter for. If null is used the current culture is used. (Default is
     ///     null)
     /// </param>
-    /// <param name="contentCache"></param>
+    /// <param name="publishedCache"></param>
     /// <returns>The children of the content, filtered by the predicate.</returns>
     /// <remarks>
     ///     <para>Children are sorted by their sortOrder.</para>
@@ -1347,11 +1347,11 @@ public static class PublishedContentExtensions
     public static IEnumerable<IPublishedContent> Children(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         Func<IPublishedContent, bool> predicate,
         string? culture = null) =>
-        content.Children(variationContextAccessor, contentCache, navigationQueryService, culture).Where(predicate);
+        content.Children(variationContextAccessor, publishedCache, navigationQueryService, culture).Where(predicate);
 
     /// <summary>
     ///     Gets the children of the content, of any of the specified types.
@@ -1369,11 +1369,11 @@ public static class PublishedContentExtensions
     public static IEnumerable<IPublishedContent> ChildrenOfType(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache publishedContentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string? contentTypeAlias,
         string? culture = null) =>
-        content.Children(variationContextAccessor, publishedContentCache, navigationQueryService, x => x.ContentType.Alias.InvariantEquals(contentTypeAlias),
+        content.Children(variationContextAccessor, publishedCache, navigationQueryService, x => x.ContentType.Alias.InvariantEquals(contentTypeAlias),
             culture);
 
     /// <summary>
@@ -1393,19 +1393,19 @@ public static class PublishedContentExtensions
     public static IEnumerable<T> Children<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache publishedContentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.Children(variationContextAccessor, publishedContentCache, navigationQueryService, culture).OfType<T>();
+        content.Children(variationContextAccessor, publishedCache, navigationQueryService, culture).OfType<T>();
 
     public static IPublishedContent? FirstChild(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache publishedContentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string? culture = null) =>
-        content.Children(variationContextAccessor, publishedContentCache, navigationQueryService, culture)?.FirstOrDefault();
+        content.Children(variationContextAccessor, publishedCache, navigationQueryService, culture)?.FirstOrDefault();
 
     /// <summary>
     ///     Gets the first child of the content, of a given content type.
@@ -1413,48 +1413,48 @@ public static class PublishedContentExtensions
     public static IPublishedContent? FirstChildOfType(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache publishedContentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string contentTypeAlias,
         string? culture = null) =>
-        content.ChildrenOfType(variationContextAccessor, publishedContentCache, navigationQueryService, contentTypeAlias, culture)?.FirstOrDefault();
+        content.ChildrenOfType(variationContextAccessor, publishedCache, navigationQueryService, contentTypeAlias, culture)?.FirstOrDefault();
 
     public static IPublishedContent? FirstChild(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache publishedContentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         Func<IPublishedContent, bool> predicate,
         string? culture = null)
-        => content.Children(variationContextAccessor, publishedContentCache, navigationQueryService, predicate, culture)?.FirstOrDefault();
+        => content.Children(variationContextAccessor, publishedCache, navigationQueryService, predicate, culture)?.FirstOrDefault();
 
     public static IPublishedContent? FirstChild(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache publishedContentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         Guid uniqueId,
         string? culture = null) => content
-        .Children(variationContextAccessor, publishedContentCache, navigationQueryService, x => x.Key == uniqueId, culture)?.FirstOrDefault();
+        .Children(variationContextAccessor, publishedCache, navigationQueryService, x => x.Key == uniqueId, culture)?.FirstOrDefault();
 
     public static T? FirstChild<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache publishedContentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.Children<T>(variationContextAccessor, publishedContentCache, navigationQueryService, culture)?.FirstOrDefault();
+        content.Children<T>(variationContextAccessor, publishedCache, navigationQueryService, culture)?.FirstOrDefault();
 
     public static T? FirstChild<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache publishedContentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         Func<T, bool> predicate,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.Children<T>(variationContextAccessor, publishedContentCache, navigationQueryService, culture)?.FirstOrDefault(predicate);
+        content.Children<T>(variationContextAccessor, publishedCache, navigationQueryService, culture)?.FirstOrDefault(predicate);
 
     #endregion
 
@@ -1464,24 +1464,24 @@ public static class PublishedContentExtensions
     ///     Gets the siblings of the content.
     /// </summary>
     /// <param name="content">The content.</param>
-    /// <param name="documentNavigationQueryService">The navigation service</param>
+    /// <param name="navigationQueryService">The navigation service</param>
     /// <param name="variationContextAccessor">Variation context accessor.</param>
     /// <param name="culture">
     ///     The specific culture to filter for. If null is used the current culture is used. (Default is
     ///     null)
     /// </param>
-    /// <param name="contentCache">The content cache instance.</param>
+    /// <param name="publishedCache">The content cache instance.</param>
     /// <returns>The siblings of the content.</returns>
     /// <remarks>
     ///     <para>Note that in V7 this method also return the content node self.</para>
     /// </remarks>
     public static IEnumerable<IPublishedContent> Siblings(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService documentNavigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         IVariationContextAccessor variationContextAccessor,
         string? culture = null) =>
-        SiblingsAndSelf(content, contentCache, documentNavigationQueryService, variationContextAccessor, culture)
+        SiblingsAndSelf(content, publishedCache, navigationQueryService, variationContextAccessor, culture)
             ?.Where(x => x.Id != content.Id) ?? Enumerable.Empty<IPublishedContent>();
 
     /// <summary>
@@ -1502,11 +1502,11 @@ public static class PublishedContentExtensions
     public static IEnumerable<IPublishedContent> SiblingsOfType(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string contentTypeAlias,
         string? culture = null) =>
-        SiblingsAndSelfOfType(content, variationContextAccessor, contentCache, navigationQueryService, contentTypeAlias, culture)
+        SiblingsAndSelfOfType(content, variationContextAccessor, publishedCache, navigationQueryService, contentTypeAlias, culture)
             ?.Where(x => x.Id != content.Id) ?? Enumerable.Empty<IPublishedContent>();
 
     /// <summary>
@@ -1527,19 +1527,19 @@ public static class PublishedContentExtensions
     public static IEnumerable<T> Siblings<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService documentNavigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string? culture = null)
         where T : class, IPublishedContent =>
-        SiblingsAndSelf<T>(content, variationContextAccessor, contentCache, documentNavigationQueryService, culture)
+        SiblingsAndSelf<T>(content, variationContextAccessor, publishedCache, navigationQueryService, culture)
             ?.Where(x => x.Id != content.Id) ?? Enumerable.Empty<T>();
 
     /// <summary>
     ///     Gets the siblings of the content including the node itself to indicate the position.
     /// </summary>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">Cache instance.</param>
-    /// <param name="documentNavigationQueryService">The navigation service.</param>
+    /// <param name="publishedCache">Cache instance.</param>
+    /// <param name="navigationQueryService">The navigation service.</param>
     /// <param name="variationContextAccessor">Variation context accessor.</param>
     /// <param name="culture">
     ///     The specific culture to filter for. If null is used the current culture is used. (Default is
@@ -1548,29 +1548,29 @@ public static class PublishedContentExtensions
     /// <returns>The siblings of the content including the node itself.</returns>
     public static IEnumerable<IPublishedContent>? SiblingsAndSelf(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService documentNavigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         IVariationContextAccessor variationContextAccessor,
         string? culture = null)
     {
-        var success = documentNavigationQueryService.TryGetParentKey(content.Key, out Guid? parentKey);
+        var success = navigationQueryService.TryGetParentKey(content.Key, out Guid? parentKey);
 
         if (success is false || parentKey is null)
         {
-            if (documentNavigationQueryService.TryGetRootKeys(out IEnumerable<Guid> childrenKeys) is false)
+            if (navigationQueryService.TryGetRootKeys(out IEnumerable<Guid> childrenKeys) is false)
             {
                 return null;
             }
 
             return childrenKeys
-                .Select(contentCache.GetById)
+                .Select(publishedCache.GetById)
                 .WhereNotNull()
                 .WhereIsInvariantOrHasCulture(variationContextAccessor, culture);
         }
 
-        return documentNavigationQueryService.TryGetChildrenKeys(parentKey.Value, out IEnumerable<Guid> siblingKeys) is false
+        return navigationQueryService.TryGetChildrenKeys(parentKey.Value, out IEnumerable<Guid> siblingKeys) is false
             ? null
-            : siblingKeys.Select(contentCache.GetById).WhereNotNull();
+            : siblingKeys.Select(publishedCache.GetById).WhereNotNull();
     }
 
     /// <summary>
@@ -1588,15 +1588,15 @@ public static class PublishedContentExtensions
     public static IEnumerable<IPublishedContent> SiblingsAndSelfOfType(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache publishedContentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string contentTypeAlias,
         string? culture = null)
     {
 
         var parentSuccess = navigationQueryService.TryGetParentKey(content.Key, out Guid? parentKey);
 
-        IPublishedContent? parent = parentKey is null ? null : publishedContentCache.GetById(parentKey.Value);
+        IPublishedContent? parent = parentKey is null ? null : publishedCache.GetById(parentKey.Value);
 
         if (parentSuccess is false || parent is null)
         {
@@ -1606,13 +1606,13 @@ public static class PublishedContentExtensions
             }
 
             return childrenKeys
-                .Select(publishedContentCache.GetById)
+                .Select(publishedCache.GetById)
                 .WhereNotNull()
                 .OfTypes(contentTypeAlias)
                 .WhereIsInvariantOrHasCulture(variationContextAccessor, culture);
         }
 
-        return parent.ChildrenOfType(variationContextAccessor, publishedContentCache, navigationQueryService, contentTypeAlias, culture);
+        return parent.ChildrenOfType(variationContextAccessor, publishedCache, navigationQueryService, contentTypeAlias, culture);
     }
 
     /// <summary>
@@ -1630,13 +1630,13 @@ public static class PublishedContentExtensions
     public static IEnumerable<T> SiblingsAndSelf<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache publishedContentCache,
-        IDocumentNavigationQueryService navigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         string? culture = null)
         where T : class, IPublishedContent
     {
         var parentSuccess = navigationQueryService.TryGetParentKey(content.Key, out Guid? parentKey);
-        IPublishedContent? parent = parentKey is null ? null : publishedContentCache.GetById(parentKey.Value);
+        IPublishedContent? parent = parentKey is null ? null : publishedCache.GetById(parentKey.Value);
 
         if (parentSuccess is false || parent is null)
         {
@@ -1647,13 +1647,13 @@ public static class PublishedContentExtensions
             }
 
             return rootKeys
-                .Select(publishedContentCache.GetById)
+                .Select(publishedCache.GetById)
                 .WhereNotNull()
                 .WhereIsInvariantOrHasCulture(variationContextAccessor, culture)
                 .OfType<T>();
         }
 
-        return parent.Children<T>(variationContextAccessor, publishedContentCache, navigationQueryService, culture);
+        return parent.Children<T>(variationContextAccessor, publishedCache, navigationQueryService, culture);
     }
 
     #endregion
@@ -1664,7 +1664,7 @@ public static class PublishedContentExtensions
     ///     Gets the root content (ancestor or self at level 1) for the specified <paramref name="content" />.
     /// </summary>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <returns>
     ///     The root content (ancestor or self at level 1) for the specified <paramref name="content" />.
@@ -1676,8 +1676,8 @@ public static class PublishedContentExtensions
     /// </remarks>
     public static IPublishedContent Root(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService) => content.AncestorOrSelf(contentCache, navigationQueryService, 1);
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService) => content.AncestorOrSelf(publishedCache, navigationQueryService, 1);
 
     /// <summary>
     ///     Gets the root content (ancestor or self at level 1) for the specified <paramref name="content" /> if it's of the
@@ -1685,7 +1685,7 @@ public static class PublishedContentExtensions
     /// </summary>
     /// <typeparam name="T">The content type.</typeparam>
     /// <param name="content">The content.</param>
-    /// <param name="contentCache">The content cache.</param>
+    /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
     /// <returns>
     ///     The root content (ancestor or self at level 1) for the specified <paramref name="content" /> of content type
@@ -1698,10 +1698,10 @@ public static class PublishedContentExtensions
     /// </remarks>
     public static T? Root<T>(
         this IPublishedContent content,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService)
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService)
         where T : class, IPublishedContent =>
-        content.AncestorOrSelf<T>(contentCache, navigationQueryService, 1);
+        content.AncestorOrSelf<T>(publishedCache, navigationQueryService, 1);
 
     #endregion
 
@@ -1741,15 +1741,15 @@ public static class PublishedContentExtensions
     public static DataTable ChildrenAsTable(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService documentNavigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         IContentTypeService contentTypeService,
         IMediaTypeService mediaTypeService,
         IMemberTypeService memberTypeService,
         IPublishedUrlProvider publishedUrlProvider,
         string contentTypeAliasFilter = "",
         string? culture = null)
-        => GenerateDataTable(content, variationContextAccessor, contentCache, documentNavigationQueryService, contentTypeService, mediaTypeService, memberTypeService, publishedUrlProvider, contentTypeAliasFilter, culture);
+        => GenerateDataTable(content, variationContextAccessor, publishedCache, navigationQueryService, contentTypeService, mediaTypeService, memberTypeService, publishedUrlProvider, contentTypeAliasFilter, culture);
 
     /// <summary>
     ///     Gets the children of the content in a DataTable.
@@ -1769,8 +1769,8 @@ public static class PublishedContentExtensions
     private static DataTable GenerateDataTable(
         IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService documentNavigationQueryService,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         IContentTypeService contentTypeService,
         IMediaTypeService mediaTypeService,
         IMemberTypeService memberTypeService,
@@ -1779,10 +1779,10 @@ public static class PublishedContentExtensions
         string? culture = null)
     {
         IPublishedContent? firstNode = contentTypeAliasFilter.IsNullOrWhiteSpace()
-            ? content.Children(variationContextAccessor, contentCache, documentNavigationQueryService, culture)?.Any() ?? false
-                ? content.Children(variationContextAccessor, contentCache, documentNavigationQueryService, culture)?.ElementAt(0)
+            ? content.Children(variationContextAccessor, publishedCache, navigationQueryService, culture)?.Any() ?? false
+                ? content.Children(variationContextAccessor, publishedCache, navigationQueryService, culture)?.ElementAt(0)
                 : null
-            : content.Children(variationContextAccessor, contentCache, documentNavigationQueryService, culture)
+            : content.Children(variationContextAccessor, publishedCache, navigationQueryService, culture)
                 ?.FirstOrDefault(x => x.ContentType.Alias.InvariantEquals(contentTypeAliasFilter));
         if (firstNode == null)
         {
@@ -1805,7 +1805,7 @@ public static class PublishedContentExtensions
                 List<Tuple<IEnumerable<KeyValuePair<string, object?>>, IEnumerable<KeyValuePair<string, object?>>>>
                     tableData = DataTableExtensions.CreateTableData();
                 IOrderedEnumerable<IPublishedContent>? children =
-                    content.Children(variationContextAccessor, contentCache, documentNavigationQueryService)?.OrderBy(x => x.SortOrder);
+                    content.Children(variationContextAccessor, publishedCache, navigationQueryService)?.OrderBy(x => x.SortOrder);
                 if (children is not null)
                 {
                     // loop through each child and create row data for it

--- a/src/Umbraco.Core/Models/PublishedContent/IPublishedContent.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/IPublishedContent.cs
@@ -142,5 +142,6 @@ public interface IPublishedContent : IPublishedElement
     /// <summary>
     ///     Gets the children of the content item that are available for the current culture.
     /// </summary>
+    [Obsolete("Please use IDocumentNavigationQueryService.TryGetChildrenKeys() instead. Scheduled for removal in V16.")]
     IEnumerable<IPublishedContent> Children { get; }
 }

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentBase.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentBase.cs
@@ -77,7 +77,8 @@ namespace Umbraco.Cms.Core.Models.PublishedContent
 
         // FIXME
         /// <inheritdoc />
-        public virtual IEnumerable<IPublishedContent> Children => this.Children(_variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedContentCache>(), StaticServiceProvider.Instance.GetRequiredService<IDocumentNavigationQueryService>());
+        [Obsolete("Please use TryGetChildrenKeys() on IDocumentNavigationQueryService or IMediaNavigationQueryService instead. Scheduled for removal in V16.")]
+        public virtual IEnumerable<IPublishedContent> Children => GetChildren();
 
 
         /// <inheritdoc cref="IPublishedElement.Properties"/>
@@ -85,5 +86,27 @@ namespace Umbraco.Cms.Core.Models.PublishedContent
 
         /// <inheritdoc cref="IPublishedElement.GetProperty(string)"/>
         public abstract IPublishedProperty? GetProperty(string alias);
+
+        private IEnumerable<IPublishedContent> GetChildren()
+        {
+            INavigationQueryService? navigationQueryService;
+            IPublishedCache? publishedCache;
+
+            switch (ContentType.ItemType)
+            {
+                case PublishedItemType.Content:
+                    publishedCache = StaticServiceProvider.Instance.GetRequiredService<IPublishedContentCache>();
+                    navigationQueryService = StaticServiceProvider.Instance.GetRequiredService<IDocumentNavigationQueryService>();
+                    break;
+                case PublishedItemType.Media:
+                    publishedCache = StaticServiceProvider.Instance.GetRequiredService<IPublishedMediaCache>();
+                    navigationQueryService = StaticServiceProvider.Instance.GetRequiredService<IMediaNavigationQueryService>();
+                    break;
+                default:
+                    throw new NotImplementedException("Level is not implemented for " + ContentType.ItemType);
+            }
+
+            return this.Children(_variationContextAccessor, publishedCache, navigationQueryService);
+        }
     }
 }

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentBase.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentBase.cs
@@ -72,7 +72,7 @@ namespace Umbraco.Cms.Core.Models.PublishedContent
         public abstract bool IsPublished(string? culture = null);
 
         /// <inheritdoc />
-        [Obsolete("Please use IDocumentNavigationQueryService.TryGetParentKey() instead. Scheduled for removal in V16.")]
+        [Obsolete("Please use TryGetParentKey() on IDocumentNavigationQueryService or IMediaNavigationQueryService instead. Scheduled for removal in V16.")]
         public abstract IPublishedContent? Parent { get; }
 
         // FIXME

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentWrapped.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentWrapped.cs
@@ -105,6 +105,7 @@ public abstract class PublishedContentWrapped : IPublishedContent
     public virtual bool IsPublished(string? culture = null) => _content.IsPublished(culture);
 
     /// <inheritdoc />
+    [Obsolete("Please use TryGetChildrenKeys() on IDocumentNavigationQueryService or IMediaNavigationQueryService instead. Scheduled for removal in V16.")]
     public virtual IEnumerable<IPublishedContent> Children => _content.Children;
 
     /// <inheritdoc cref="IPublishedElement.Properties" />

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentWrapped.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentWrapped.cs
@@ -95,8 +95,8 @@ public abstract class PublishedContentWrapped : IPublishedContent
     public virtual PublishedItemType ItemType => _content.ItemType;
 
     /// <inheritdoc />
-    [Obsolete("Please use IDocumentNavigationQueryService.TryGetParentKey() instead. Scheduled for removal in V16.")]
-    public virtual IPublishedContent? Parent => _content.Parent<IPublishedContent>(StaticServiceProvider.Instance.GetRequiredService<IPublishedContentCache>(), StaticServiceProvider.Instance.GetRequiredService<IDocumentNavigationQueryService>());
+    [Obsolete("Please use TryGetParentKey() on IDocumentNavigationQueryService or IMediaNavigationQueryService instead. Scheduled for removal in V16.")]
+    public virtual IPublishedContent? Parent => _content.Parent;
 
     /// <inheritdoc />
     public virtual bool IsDraft(string? culture = null) => _content.IsDraft(culture);

--- a/src/Umbraco.Core/PublishedCache/Internal/InternalPublishedContent.cs
+++ b/src/Umbraco.Core/PublishedCache/Internal/InternalPublishedContent.cs
@@ -76,7 +76,12 @@ public sealed class InternalPublishedContent : IPublishedContent
 
     public bool IsPublished(string? culture = null) => true;
 
-    public IEnumerable<IPublishedContent> Children { get; set; } = Enumerable.Empty<IPublishedContent>();
+    [Obsolete(
+        "Please use TryGetChildrenKeys() on IDocumentNavigationQueryService or IMediaNavigationQueryService instead. Scheduled for removal in V16.")]
+    public IEnumerable<IPublishedContent> Children => this.Children(
+        StaticServiceProvider.Instance.GetRequiredService<IVariationContextAccessor>(),
+        StaticServiceProvider.Instance.GetRequiredService<IPublishedContentCache>(),
+        StaticServiceProvider.Instance.GetRequiredService<IDocumentNavigationQueryService>());
 
     public IEnumerable<IPublishedContent> ChildrenForAllCultures => Children;
 

--- a/src/Umbraco.Core/PublishedCache/Internal/InternalPublishedContent.cs
+++ b/src/Umbraco.Core/PublishedCache/Internal/InternalPublishedContent.cs
@@ -76,8 +76,7 @@ public sealed class InternalPublishedContent : IPublishedContent
 
     public bool IsPublished(string? culture = null) => true;
 
-    [Obsolete(
-        "Please use TryGetChildrenKeys() on IDocumentNavigationQueryService or IMediaNavigationQueryService instead. Scheduled for removal in V16.")]
+    [Obsolete("Please use TryGetChildrenKeys() on IDocumentNavigationQueryService or IMediaNavigationQueryService instead. Scheduled for removal in V16.")]
     public IEnumerable<IPublishedContent> Children => this.Children(
         StaticServiceProvider.Instance.GetRequiredService<IVariationContextAccessor>(),
         StaticServiceProvider.Instance.GetRequiredService<IPublishedContentCache>(),

--- a/src/Umbraco.Core/PublishedCache/Internal/InternalPublishedContent.cs
+++ b/src/Umbraco.Core/PublishedCache/Internal/InternalPublishedContent.cs
@@ -69,7 +69,7 @@ public sealed class InternalPublishedContent : IPublishedContent
 
     public PublishedItemType ItemType => PublishedItemType.Content;
 
-    [Obsolete("Please use IDocumentNavigationQueryService.TryGetParentKey() instead. Scheduled for removal in V16.")]
+    [Obsolete("Please use TryGetParentKey() on IDocumentNavigationQueryService or IMediaNavigationQueryService instead. Scheduled for removal in V16.")]
     public IPublishedContent? Parent => this.Parent<IPublishedContent>(StaticServiceProvider.Instance.GetRequiredService<IPublishedContentCache>(), StaticServiceProvider.Instance.GetRequiredService<IDocumentNavigationQueryService>());
 
     public bool IsDraft(string? culture = null) => false;

--- a/src/Umbraco.PublishedCache.HybridCache/PublishedContent.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/PublishedContent.cs
@@ -164,9 +164,8 @@ internal class PublishedContent : PublishedContentBase
         }
     }
 
-    [Obsolete("Please use IDocumentNavigationQueryService.TryGetParentKey() instead. Scheduled for removal in V16.")]
-    public override IPublishedContent? Parent
-        => this.Parent<IPublishedContent>(StaticServiceProvider.Instance.GetRequiredService<IPublishedContentCache>(), StaticServiceProvider.Instance.GetRequiredService<IDocumentNavigationQueryService>());
+    [Obsolete("Please use TryGetParentKey() on IDocumentNavigationQueryService or IMediaNavigationQueryService instead. Scheduled for removal in V16.")]
+    public override IPublishedContent? Parent => GetParent();
 
     /// <inheritdoc />
     public override IReadOnlyDictionary<string, PublishedCultureInfo> Cultures
@@ -268,5 +267,27 @@ internal class PublishedContent : PublishedContentBase
         // there is a 'published' published content, and varies
         // = depends on the culture
         return _contentNode.HasPublishedCulture(culture);
+    }
+
+    private IPublishedContent? GetParent()
+    {
+        INavigationQueryService? navigationQueryService;
+        IPublishedCache? publishedCache;
+
+        switch (ContentType.ItemType)
+        {
+            case PublishedItemType.Content:
+                publishedCache = StaticServiceProvider.Instance.GetRequiredService<IPublishedContentCache>();
+                navigationQueryService = StaticServiceProvider.Instance.GetRequiredService<IDocumentNavigationQueryService>();
+                break;
+            case PublishedItemType.Media:
+                publishedCache = StaticServiceProvider.Instance.GetRequiredService<IPublishedMediaCache>();
+                navigationQueryService = StaticServiceProvider.Instance.GetRequiredService<IMediaNavigationQueryService>();
+                break;
+            default:
+                throw new NotImplementedException("Level is not implemented for " + ContentType.ItemType);
+        }
+
+        return this.Parent<IPublishedContent>(publishedCache, navigationQueryService);
     }
 }


### PR DESCRIPTION
## Details
- Replacing the usages of the `Children` property from `IPublishedContent` since we now can retrieve the navigation data from a dedicated `IDocumentNavigationQueryService` or `IMediaNavigationQueryService`;
- Updating params in **PublishedContentExtensions.cs** to the general interfaces (`IPublishedCache` and `INavigationQueryService`), so that we can use the extension methods on both documents and media;
- Introducing `GetParent()` in **PublishedContent.cs** to inject the right services;
- Introducing `GetChildren()` in **PublishedContentBase.cs** to inject the right services;
- Fixing some obsolete messages.