### PR TITLE
V15: Use the `NuGetPackageVersion` rather than the `NpmPackageVersion` for MyGet

### DIFF
--- a/build/templates/backoffice-install.yml
+++ b/build/templates/backoffice-install.yml
@@ -6,11 +6,15 @@ steps:
       versionSource: 'fromFile'
       versionFilePath: src/Umbraco.Web.UI.Client/.nvmrc
 
+  # Install nbgv and set the NPM version to the same as the NuGet package version
+  # This is required to ensure that the NuGet package version and the NPM package version are in sync
+  # (nbgv can also calculate the "NpmPackageVersion" directly, but that does not contain the build number for preview builds
+  # so the retention rules on MyGet would not work as expected)
   - bash: |
       echo "##[command]Install nbgv"
       dotnet tool install --tool-path . nbgv
       echo "##[command]Running nbgv get-version"
-      PACKAGE_VERSION=$(nbgv get-version -v NpmPackageVersion)
+      PACKAGE_VERSION=$(nbgv get-version -v NuGetPackageVersion)
       echo "##[command]Running npm version"
       echo "##[debug]Version: $PACKAGE_VERSION"
       cd src/Umbraco.Web.UI.Client


### PR DESCRIPTION
### Description

This aligns the version numbers and ensures they are exactly the same across MyGet, whereas Nuget+npmjs.org were never really affected since the public release versions do not contain any build numbering.

Backoffice package before: 15.0.0-rc1.g7523e47

Backoffice package after: 15.0.0-rc1.preview.11.g7523e47