### PR TITLE
Make RTE work without blocks in a culture variant context

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
@@ -270,21 +270,20 @@ public class RichTextPropertyEditor : DataEditor
 
         internal override object? MergePartialPropertyValueForCulture(object? sourceValue, object? targetValue, string? culture)
         {
-            if (sourceValue is null)
+            if (sourceValue is null || TryParseEditorValue(sourceValue, out RichTextEditorValue? sourceRichTextEditorValue) is false)
             {
                 return null;
             }
 
-            if (TryParseEditorValue(sourceValue, out RichTextEditorValue? sourceRichTextEditorValue) is false
-                || sourceRichTextEditorValue.Blocks is null)
+            if (sourceRichTextEditorValue.Blocks is null)
             {
-                return null;
+                return sourceValue;
             }
 
             BlockEditorData<RichTextBlockValue, RichTextBlockLayoutItem>? sourceBlockEditorData = ConvertAndClean(sourceRichTextEditorValue.Blocks);
             if (sourceBlockEditorData?.Layout is null)
             {
-                return null;
+                return sourceValue;
             }
 
             TryParseEditorValue(targetValue, out RichTextEditorValue? targetRichTextEditorValue);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Block level variance (#17120) inadvertently broke RTEs _without_ blocks 🙈 

Specifically, RTE properties will not render any output if they're _invariant_ as part of a _variant_ document type, unless there are blocks added to the RTE.

This PR fixes it.