### PR TITLE
Bugfix: Media in new cache was created as published

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/DatabaseCacheRebuilder.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/DatabaseCacheRebuilder.cs
@@ -1,4 +1,5 @@
 ﻿using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Infrastructure.HybridCache.Persistence;
 
 namespace Umbraco.Cms.Infrastructure.HybridCache;
@@ -6,11 +7,18 @@ namespace Umbraco.Cms.Infrastructure.HybridCache;
 internal class DatabaseCacheRebuilder : IDatabaseCacheRebuilder
 {
     private readonly IDatabaseCacheRepository _databaseCacheRepository;
+    private readonly ICoreScopeProvider _coreScopeProvider;
 
-    public DatabaseCacheRebuilder(IDatabaseCacheRepository databaseCacheRepository)
+    public DatabaseCacheRebuilder(IDatabaseCacheRepository databaseCacheRepository, ICoreScopeProvider coreScopeProvider)
     {
         _databaseCacheRepository = databaseCacheRepository;
+        _coreScopeProvider = coreScopeProvider;
     }
 
-    public void Rebuild() => _databaseCacheRepository.Rebuild();
+    public void Rebuild()
+    {
+        using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
+        _databaseCacheRepository.Rebuild();
+        scope.Complete();
+    }
 }

--- a/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
@@ -87,7 +87,7 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
     public async Task RefreshMediaAsync(ContentCacheNode contentCacheNode)
     {
         IContentCacheDataSerializer serializer = _contentCacheDataSerializerFactory.Create(ContentCacheDataSerializerEntityType.Media);
-        await OnRepositoryRefreshed(serializer, contentCacheNode, false);
+        await OnRepositoryRefreshed(serializer, contentCacheNode, true);
     }
 
     /// <inheritdoc/>
@@ -117,20 +117,10 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
             }
         }
 
-        if (contentTypeIds != null)
-        {
-            RebuildContentDbCache(serializer, _nucacheSettings.Value.SqlPageSize, contentTypeIds);
-        }
+        RebuildContentDbCache(serializer, _nucacheSettings.Value.SqlPageSize, contentTypeIds);
+        RebuildMediaDbCache(serializer, _nucacheSettings.Value.SqlPageSize, mediaTypeIds);
+        RebuildMemberDbCache(serializer, _nucacheSettings.Value.SqlPageSize, memberTypeIds);
 
-        if (mediaTypeIds != null)
-        {
-            RebuildMediaDbCache(serializer, _nucacheSettings.Value.SqlPageSize, mediaTypeIds);
-        }
-
-        if (memberTypeIds != null)
-        {
-            RebuildMemberDbCache(serializer, _nucacheSettings.Value.SqlPageSize, memberTypeIds);
-        }
     }
 
     // assumes content tree lock


### PR DESCRIPTION
### Description
Fixes multiple issues with the cache:
- Media was created as published
- Rebuild did nothing in the repository
- Rebuild was not executed in an ambiant scope.

### Test
- Upload an image to the media section
- Restart - And verify the seeding to not fail anymore.
- change a value in the cmsContentNu table and use the rebuild functionality from backoffice, and verify it is back to the original value.