### PR TITLE
V15: Update dotnet version in template

### DIFF
--- a/templates/UmbracoProject/.template.config/template.json
+++ b/templates/UmbracoProject/.template.config/template.json
@@ -108,15 +108,19 @@
       "type": "generated",
       "generator": "switch",
       "datatype": "text",
-      "description": "Not relevant at the moment, but if we need to change the dotnet version based on the Umbraco version, we can do it here",
+      "description": "Used to calculate the dotnet version to use, for latest we want to use dotnet 9 and for LTS we want to use dotnet 8",
       "replaces": "DOTNET_VERSION_FROM_TEMPLATE",
       "parameters": {
         "evaluator": "C++",
         "datatype": "text",
         "cases": [
           {
-            "condition": "(true)",
+            "condition": "(UmbracoRelease == 'Latest')",
             "value": "net9.0"
+          },
+          {
+            "condition": "(UmbracoRelease == 'LTS')",
+            "value": "net8.0"
           }
         ]
       }

--- a/templates/UmbracoProject/UmbracoProject.csproj
+++ b/templates/UmbracoProject/UmbracoProject.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
     <TargetFramework>DOTNET_VERSION_FROM_TEMPLATE</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Updates the dotnet version in the template and removes the duplicate in the csproj file.

We now use the `UmbracoRelease` value to calculate the dotnet version, since we want to use dotnet 8 for v13 and dotnet 9 for V15 