### PR TITLE
Fix failing CodeQL due to needing .NET 9

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  dotnetVersion: 8.x
+  dotnetVersion: 9.x
   dotnetIncludePreviewVersions: true
   solution: umbraco.sln
   buildConfiguration: SkipTests


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Ensured compatibility with .NET 9 to fix failing CodeQL checks