### PR TITLE
Add swiss languages as backoffice languages

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/de_ch.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/de_ch.xml
@@ -1,0 +1,2455 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language alias="de_ch" intName="German Switzerland (DE-CH)" localName="Deutsch Schweiz (DE-CH)" lcid="7" culture="de-CH">
+	<creator>
+		<name>The Umbraco community</name>
+		<link>https://docs.umbraco.com/umbraco-cms/extending/language-files</link>
+	</creator>
+	<area alias="actions">
+		<key alias="assigndomain">Kulturen und Hostnamen</key>
+		<key alias="auditTrail">Protokoll</key>
+		<key alias="browse">Durchsuchen</key>
+		<key alias="changeDocType">Dokumenttyp ändern</key>
+		<key alias="changeDataType">Datentyp ändern</key>
+		<key alias="copy">Kopieren</key>
+		<key alias="create">Neu</key>
+		<key alias="export">Exportieren</key>
+		<key alias="createPackage">Neues Paket</key>
+		<key alias="createGroup">Neue Gruppe</key>
+		<key alias="delete">Entfernen</key>
+		<key alias="disable">Deaktivieren</key>
+		<key alias="editContent">Inhalt bearbeiten</key>
+		<key alias="editSettings">Einstellungen bearbeiten</key>
+		<key alias="emptyrecyclebin">Papierkorb leeren</key>
+		<key alias="enable">Aktivieren</key>
+		<key alias="exportDocumentType">Dokumenttyp exportieren</key>
+		<key alias="importdocumenttype">Dokumenttyp importieren</key>
+		<key alias="importPackage">Paket importieren</key>
+		<key alias="liveEdit">'Canvas'-Modus starten</key>
+		<key alias="logout">Abmelden</key>
+		<key alias="move">Verschieben</key>
+		<key alias="notify">Benachrichtigungen</key>
+		<key alias="protect">Öffentlicher Zugriff</key>
+		<key alias="publish">Veröffentlichen</key>
+		<key alias="unpublish">Veröffentlichung zurücknehmen</key>
+		<key alias="refreshNode">Aktualisieren</key>
+		<key alias="republish">Erneut veröffentlichen</key>
+		<key alias="remove">Entfernen</key>
+		<key alias="rename" version="7.3.0">Umbenennen</key>
+		<key alias="restore" version="7.3.0">Wiederherstellen</key>
+		<key alias="chooseWhereToCopy">Wähle worunter kopiert werden soll</key>
+		<key alias="chooseWhereToMove">Wähle worunter verschoben werden soll</key>
+		<key alias="chooseWhereToImport">Wähle wohin importiert werden soll</key>
+		<key alias="infiniteEditorChooseWhereToCopy">Wähle wohin die ausgewählten Elemente kopiert werden soll</key>
+		<key alias="infiniteEditorChooseWhereToMove">Wähle wohin die ausgewählten Elemente verschoben werden soll</key>
+		<key alias="toInTheTreeStructureBelow">in der Baumstrukture</key>
+		<key alias="wasMovedTo">wurde verschoben nach</key>
+		<key alias="wasCopiedTo">wurde kopiert nach</key>
+		<key alias="wasDeleted">wurde gelöscht</key>
+		<key alias="rights">Berechtigungen</key>
+		<key alias="rollback">Zurücksetzen</key>
+		<key alias="sendtopublish">Zur Veröffentlichung einreichen</key>
+		<key alias="sendToTranslate">Zur Übersetzung senden</key>
+		<key alias="setGroup">Gruppe festlegen</key>
+		<key alias="sort">Sortieren</key>
+		<key alias="translate">Übersetzen</key>
+		<key alias="update">Aktualisieren</key>
+		<key alias="setPermissions">Berechtigung festlegen</key>
+		<key alias="unlock">Freigeben</key>
+		<key alias="createblueprint">Inhaltsvorlage anlegen</key>
+		<key alias="resendInvite">Einladung erneut versenden</key>
+	</area>
+	<area alias="actionCategories">
+		<key alias="content">Inhalt</key>
+		<key alias="administration">Administration</key>
+		<key alias="structure">Struktur</key>
+		<key alias="other">Anderes</key>
+	</area>
+	<area alias="actionDescriptions">
+		<key alias="assignDomain">Erlaube Zugriff auf "Kultur und Hostname"-Einstellungen</key>
+		<key alias="auditTrail">Erlaube Zugriff auf Bearbeiten-Verlauf</key>
+		<key alias="browse">Erlaube das Anzeigen eines Knotens</key>
+		<key alias="changeDocType">Erlaube Ändern des Dokumenten-Typs</key>
+		<key alias="copy">Erlaube Kopieren</key>
+		<key alias="create">Erlaube Erzeugen</key>
+		<key alias="delete">Erlaube Entfernen</key>
+		<key alias="move">Erlaube Verschieben</key>
+		<key alias="protect">Erlaube Zugriff auf "Öffentlich zugänglich"-Einstellungen</key>
+		<key alias="publish">Erlaube Veröffentlichung</key>
+		<key alias="unpublish">Erlaube Rücknahme der Veröffentlichung</key>
+		<key alias="rights">Erlaube Zugriff auf die Berechtigungen</key>
+		<key alias="rollback">Erlaube Zurücksetzen auf eine vorherige Version</key>
+		<key alias="sendtopublish">Erlaube Anforderungen von Veröffentlichungen</key>
+		<key alias="sendToTranslate">Erlaube Anfordern von Übersetzungen</key>
+		<key alias="sort">Erlaube Sortieren</key>
+		<key alias="translate">Erlaube Übersetzung</key>
+		<key alias="update">Erlaube Sichern von Änderungen</key>
+		<key alias="createblueprint">Erlaube Anlegen von Inhaltsvorlagen</key>
+		<key alias="notify">Erlaube das Einrichten von Benachrichtungen für Inhalte</key>
+	</area>
+	<area alias="apps">
+		<key alias="umbContent">Inhalt</key>
+		<key alias="umbInfo">Info</key>
+	</area>
+	<area alias="assignDomain">
+		<key alias="permissionDenied">Erlaubnis verweigert.</key>
+		<key alias="addNew">Neue Domain hinzufügen</key>
+		<key alias="addCurrent">Aktuelle Domain hinzufügen</key>
+		<key alias="remove">entfernen</key>
+		<key alias="invalidNode">Ungültiges Element.</key>
+		<key alias="invalidDomain">Format der Domain ungültig.</key>
+		<key alias="duplicateDomain">Domain wurde bereits zugewiesen.</key>
+		<key alias="language">Sprache</key>
+		<key alias="domain">Domain</key>
+		<key alias="domainCreated">Domain '%0%' hinzugefügt</key>
+		<key alias="domainDeleted">Domain '%0%' entfernt</key>
+		<key alias="domainExists">Die Domain '%0%' ist bereits zugeordnet</key>
+		<key alias="domainUpdated">Domain '%0%' aktualisiert</key>
+		<key alias="orEdit">Domains bearbeiten</key>
+		<key alias="domainHelpWithVariants">
+			<![CDATA[Gültige Domain-Namen sind: "example.com", "www.example.com", "example.com:8080", oder "https://www.example.com/".
+     Außerdem werden Pfade mit erstem URL-Segment unterstützt z. B.: "example.com/en" or "/en".]]>
+		</key>
+		<key alias="inherit">Vererben</key>
+		<key alias="setLanguage">Kultur</key>
+		<key alias="setLanguageHelp">
+			Definiert die Kultureinstellung für untergeordnete Elemente dieses Elements oder vererbt vom übergeordneten Element.
+			Wird auch auf das aktuelle Element angewendet, sofern auf tieferer Ebene keine Domain zugeordnet ist.
+		</key>
+		<key alias="setDomains">Domainen</key>
+	</area>
+	<area alias="buttons">
+		<key alias="clearSelection">Auswahl aufheben</key>
+		<key alias="select">Auswählen</key>
+		<key alias="somethingElse">Etwas anderes machen</key>
+		<key alias="bold">Fett</key>
+		<key alias="deindent">Ausrücken</key>
+		<key alias="formFieldInsert">Formularelement einfügen</key>
+		<key alias="graphicHeadline">Graphische Überschrift einfügen</key>
+		<key alias="htmlEdit">HTML bearbeiten</key>
+		<key alias="indent">Einrücken</key>
+		<key alias="italic">Kursiv</key>
+		<key alias="justifyCenter">Zentriert</key>
+		<key alias="justifyLeft">Linksbündig</key>
+		<key alias="justifyRight">Rechtsbündig</key>
+		<key alias="linkInsert">Link einfügen</key>
+		<key alias="linkLocal">Anker einfügen</key>
+		<key alias="listBullet">Aufzählung</key>
+		<key alias="listNumeric">Nummerierung</key>
+		<key alias="macroInsert">Makro einfügen</key>
+		<key alias="pictureInsert">Abbildung einfügen</key>
+		<key alias="publishAndClose">Veröffentlichen und schliessen</key>
+		<key alias="publishDescendants">Veröffentlichen mit Unterknoten</key>
+		<key alias="relations">Datenbeziehungen bearbeiten</key>
+		<key alias="returnToList">Zurück zur Liste</key>
+		<key alias="save">Speichern</key>
+		<key alias="saveAndClose">Sichern und schliessen</key>
+		<key alias="saveAndPublish">Speichern und veröffentlichen</key>
+		<key alias="saveToPublish">Speichern und zur Abnahme übergeben</key>
+		<key alias="saveListView">Listenansicht sichern</key>
+		<key alias="schedulePublish">Veröffentlichung planen</key>
+		<key alias="saveAndPreview">Vorschau</key>
+		<key alias="showPageDisabled">Die Vorschaufunktion ist deaktiviert, da keine Vorlage zugewiesen ist</key>
+		<key alias="styleChoose">Stil auswählen</key>
+		<key alias="styleShow">Stil anzeigen</key>
+		<key alias="tableInsert">Tabelle einfügen</key>
+		<key alias="generateModelsAndClose">Erzeuge Daten-Model und schliesse</key>
+		<key alias="saveAndGenerateModels">Sichern und Daten-Model erzeugen</key>
+		<key alias="undo">Zurücknehmen</key>
+		<key alias="redo">Erneut anwenden</key>
+		<key alias="deleteTag">TAG entfernen</key>
+		<key alias="confirmActionCancel">Abbrechen</key>
+		<key alias="confirmActionConfirm">Bestätigen</key>
+		<key alias="morePublishingOptions">Mehr Veröffentlichungs Optionen</key>
+		<key alias="submitChanges">Senden</key>
+	</area>
+	<area alias="auditTrailsMedia">
+		<key alias="delete">Medie gelöscht</key>
+		<key alias="move">Medie verschoben</key>
+		<key alias="copy">Medie kopiert</key>
+		<key alias="save">Medie gesichert</key>
+	</area>
+	<area alias="auditTrails">
+		<key alias="atViewingFor">Anzeigen als</key>
+		<key alias="delete">Inhalt gelöscht</key>
+		<key alias="unpublish">Inhalt unveröffentlicht</key>
+		<key alias="unpublishvariant">Inhalt unveröffentlicht für Sprache: %0% </key>
+		<key alias="publish">Inhalt veröffentlicht</key>
+		<key alias="publishvariant">Inhalt veröffentlicht für Sprache: %0% </key>
+		<key alias="save">Inhalt gesichert</key>
+		<key alias="savevariant">Inhalt gesichert für Sprache: %0%</key>
+		<key alias="move">Inhalt verschoben</key>
+		<key alias="copy">Inhalt kopiert</key>
+		<key alias="rollback">Inhalt auf vorherige Version geändert</key>
+		<key alias="sendtopublish">Veröffentlichung für Inhalt angefordert</key>
+		<key alias="sendtopublishvariant">Veröffentlichung für Inhalt angefordert in Sprache: %0%</key>
+		<key alias="sort">Unterknoten wurden sortiert von Benutzer</key>
+		<key alias="custom">%0%</key>
+		<key alias="contentversionpreventcleanup">Versionsbereinigung deaktiviert für Version: %0%</key>
+		<key alias="contentversionenablecleanup">Versionsbereinigung aktiviert für Version: %0%</key>
+		<key alias="smallCopy">Kopieren</key>
+		<key alias="smallPublish">Veröffentlichen</key>
+		<key alias="smallPublishVariant">Veröffentlichen</key>
+		<key alias="smallMove">Verschieben</key>
+		<key alias="smallSave">Sichern</key>
+		<key alias="smallSaveVariant">Sichern</key>
+		<key alias="smallDelete">Entfernen</key>
+		<key alias="smallUnpublish">Veröffentlichung zurücknehmen</key>
+		<key alias="smallUnpublishVariant">Veröffentlichung zurücknehmen</key>
+		<key alias="smallRollBack">Vorgängerversion wieder herstellen</key>
+		<key alias="smallSendToPublish">Veröffentlichung anfordern</key>
+		<key alias="smallSendToPublishVariant">Veröffentlichung anfordern</key>
+		<key alias="smallSort">Sortieren</key>
+		<key alias="smallCustom">Benutzerdefiniert</key>
+		<key alias="smallContentVersionPreventCleanup">Speichern</key>
+		<key alias="smallContentVersionEnableCleanup">Speichern</key>
+		<key alias="historyIncludingVariants">Verlauf (alle Variationen)</key>
+	</area>
+	<area alias="codefile">
+		<key alias="createFolderIllegalChars">Der Verzeichnisname darf keine ungültigen Zeichen enthalten.</key>
+		<key alias="deleteItemFailed">Folgendes Element konnte nicht entfernt werden: %0%</key>
+	</area>
+	<area alias="content">
+		<key alias="isPublished" version="7.2">Ist veröffentlicht</key>
+		<key alias="about">Über dieses Dokument</key>
+		<key alias="alias">Alias</key>
+		<key alias="alternativeTextHelp">(Wie würden Sie das Bild über das Telefon beschreiben?)</key>
+		<key alias="alternativeUrls">Alternative Links</key>
+		<key alias="clickToEdit">Klicken, um das Dokument zu bearbeiten</key>
+		<key alias="createBy">Erstellt von</key>
+		<key alias="createByDesc" version="7.0">Ursprünglicher Autor</key>
+		<key alias="updatedBy" version="7.0">Aktualisiert von</key>
+		<key alias="createDate">Erstellt am</key>
+		<key alias="createDateDesc" version="7.0">Erstellungszeitpunkt des Dokuments</key>
+		<key alias="documentType">Dokumenttyp</key>
+		<key alias="editing">In Bearbeitung</key>
+		<key alias="expireDate">Veröffentlichung aufheben am</key>
+		<key alias="itemChanged">Dieses Dokument wurde nach dem Veröffentlichen bearbeitet.</key>
+		<key alias="itemNotPublished">Dieses Dokument ist nicht veröffentlicht.</key>
+		<key alias="lastPublished">Zuletzt veröffentlicht</key>
+		<key alias="noItemsToShow">Keine Elemente anzuzeigen</key>
+		<key alias="listViewNoItems" version="7.1.5">Diese Liste enthält keine Einträge.</key>
+		<key alias="listViewNoContent">Es wurden keine untergeordneten Elemente hinzugefügt</key>
+		<key alias="listViewNoMembers">Es wurden keine Mitglieder hinzugefügt</key>
+		<key alias="mediatype">Medientyp</key>
+		<key alias="mediaLinks">Verweis auf Medienobjekt(e)</key>
+		<key alias="membergroup">Mitgliedergruppe</key>
+		<key alias="memberrole">Mitgliederrolle</key>
+		<key alias="membertype">Mitglieder-Typ</key>
+		<key alias="noChanges">Es wurden keine Änderungen vorgenommen</key>
+		<key alias="noDate">Kein Datum gewählt</key>
+		<key alias="nodeName">Name des Dokument</key>
+		<key alias="noMediaLink">Dieses Media-Element hat keinen Link</key>
+		<key alias="noProperties">Diesem Element kann kein Inhalt zugewiesen werden</key>
+		<key alias="otherElements">Eigenschaften</key>
+		<key alias="parentNotPublished">
+			Dieses Dokument ist veröffentlicht aber nicht sichtbar,
+			da das übergeordnete Dokument '%0%' nicht publiziert ist
+		</key>
+		<key alias="parentCultureNotPublished">
+			Diese Kultur wurde veröffentlicht, aber wird nicht angezeigt,
+			weil sie auf dem Oberknoten '%0%' unveröffentlicht ist
+		</key>
+		<key alias="parentNotPublishedAnomaly">Ups! Dieses Dokument ist veröffentlicht aber nicht im internen Cache aufzufinden: Systemfehler.</key>
+		<key alias="getUrlException">Der URL wurde nicht gefunden</key>
+		<key alias="routeError">Dieses Dokument wurde veröffentlicht, aber sein URL würde mit Inhalt %0% kollidieren</key>
+		<key alias="routeErrorCannotRoute">Dieses Dokument wurde veröffentlicht, aber sein URL kann nicht aufgelöst (routed) werden</key>
+		<key alias="publish">Veröffentlichen</key>
+		<key alias="published">Veröffentlicht</key>
+		<key alias="publishedPendingChanges">Veröffentlicht (Änderungen bereit)</key>
+		<key alias="publishStatus">Publikationsstatus</key>
+		<key alias="publishDescendantsHelp">
+			<![CDATA[Wähle <em>Veröffentlichen mit Unterknoten</em> zum Veröffentlichen <strong>der gewählten Sprache</strong> samt aller Unterknoten der selben Sprache, um ihren Inhalt öffentlich verfügbar zu machen.]]>
+		</key>
+		<key alias="publishDescendantsWithVariantsHelp">
+			<![CDATA[Wähle <em>Veröffentlichen mit Unterknoten</em> zum Veröffentlichen <strong>der gewählten Sprache</strong> samt aller Unterknoten der selben Sprache, um ihren Inhalt öffentlich verfügbar zu machen.]]>
+		</key>
+		<key alias="releaseDate">Veröffentlichen am</key>
+		<key alias="unpublishDate">Veröffentlichung widerrufen am</key>
+		<key alias="removeDate">Datum entfernen</key>
+		<key alias="setDate">Datum wählen</key>
+		<key alias="sortDone">Sortierung abgeschlossen</key>
+		<key alias="sortHelp">
+			Um die Dokumente zu sortieren, ziehen Sie sie einfach an die gewünschte Position.
+			Sie können mehrere Zeilen markieren indem Sie die Umschalttaste ("Shift") oder die Steuerungstaste ("Strg") gedrückt halten
+		</key>
+		<key alias="statistics">Statistiken</key>
+		<key alias="titleOptional">Titel (optional)</key>
+		<key alias="altTextOptional">Alternativtext (optional)</key>
+		<key alias="captionTextOptional">Beschriftung (optional)</key>
+		<key alias="type">Typ</key>
+		<key alias="unpublish">Veröffentlichung widerrufen</key>
+		<key alias="unpublished">Entwurf</key>
+		<key alias="notCreated">Nicht angelegt</key>
+		<key alias="updateDate">Zuletzt bearbeitet am</key>
+		<key alias="updateDateDesc" version="7.0">Letzter Änderungszeitpunkt des Dokuments</key>
+		<key alias="uploadClear">Datei entfernen</key>
+		<key alias="uploadClearImageContext">Klicke hier um das das Bild vom Medienelement zu entfernen.</key>
+		<key alias="uploadClearFileContext">Klicke hier um das das Bild vom Medienelement zu entfernen.</key>
+		<key alias="urls">Link zum Dokument</key>
+		<key alias="memberof">Mitglied der Gruppe(n)</key>
+		<key alias="notmemberof">Kein Mitglied der Gruppe(n)</key>
+		<key alias="childItems" version="7.0">Untergeordnete Elemente</key>
+		<key alias="target" version="7.0">Ziel</key>
+		<key alias="scheduledPublishServerTime">Dies führt zur folgenden Zeit auf dem Server:</key>
+		<key alias="scheduledPublishDocumentation">
+			<![CDATA[<a href="https://docs.umbraco.com/umbraco-cms/fundamentals/data/scheduled-publishing#timezones" target="_blank" rel="noopener">Was bedeutet dies?</a>]]>
+		</key>
+		<key alias="nestedContentDeleteItem">Wollen Sie dieses Element wirklich entfernen?</key>
+		<key alias="nestedContentDeleteAllItems">Sicher das Sie alle Elemente entfernen wollen?</key>
+		<key alias="nestedContentEditorNotSupported">
+			Eigenschaft %0% verwendet Editor %1%,
+			welcher nicht von Nested Content unterstützt wird.
+		</key>
+		<key alias="nestedContentNoContentTypes">Keine Dokument-Typen für diese Eigenschaft konfiguriert.</key>
+		<key alias="nestedContentAddElementType">Elementtyp hinzufügen</key>
+		<key alias="nestedContentSelectElementTypeModalTitle">Elementtype auswählen</key>
+		<key alias="nestedContentGroupHelpText">
+			Wählen Sie die Gruppe aus von der die Eigenschaften angezeigt werden soll. Sollte der Wert leer sein
+			wird die erste Gruppe des Elementtypen verwendet.
+		</key>
+		<key alias="nestedContentTemplateHelpTextPart1">
+			Geben Sie eine Angular Anweisung an um den Namen für das jweilige Element
+			zu bestimmen. Verwende
+		</key>
+		<key alias="nestedContentTemplateHelpTextPart2">um den Index des Elements anzuzeigen.</key>
+		<key alias="nestedContentNoGroups">Das ausgewählte Element verfügt nicht über unterstützte Gruppen. (Tabs werden von diesem Editor nicht unterstützt, entweder Sie ändern diese zu Gruppen oder Sie verwenden den Block List Editor.</key>
+		<key alias="addTextBox">Füge ein weiteres Textfeld hinzu</key>
+		<key alias="removeTextBox">Entferne dieses Textfeld</key>
+		<key alias="contentRoot">Inhalt-Basis</key>
+		<key alias="includeUnpublished">Inklusive Entwürfen: veröffentliche auch unveröffentlichte Elemente.</key>
+		<key alias="isSensitiveValue">
+			Dieser Wert ist verborgen.
+			Wenn Sie diesen Wert einsehen müssen, wenden Sie sich bitte an einen Administrator.
+		</key>
+		<key alias="isSensitiveValue_short">Dieser Wert ist verborgen.</key>
+		<key alias="languagesToPublish">Welche Sprache möchten Sie veröffentlichen?</key>
+		<key alias="languagesToSendForApproval">Welche Sprachen möchten Sie zur Freigabe schicken?</key>
+		<key alias="languagesToSchedule">Welche Sprachen möchten Sie zu einer bestimmten Zeit veröffentlichen?</key>
+		<key alias="languagesToUnpublish">
+			Wählen Sie die Sprachen, deren Veröffentlichung zurück genommen werden soll.
+			Das Zurücknehmen der Veröffentlichung einer Pflichtsprache betrifft alle Sprachen.
+		</key>
+		<key alias="variantsWillBeSaved">Alle neuen Variationen werden gespeichert.</key>
+		<key alias="variantsToPublish">Welche Variationen wollen Sie veröffentlichen?</key>
+		<key alias="variantsToSave">Wählen Sie welche Variation gespeichert werden soll.</key>
+		<key alias="publishRequiresVariants">Folgende Variationen werden benötigt um das Element veröffentlichen zu können: </key>
+		<key alias="notReadyToPublish">Wir sind für Veröffentlichungen bereit</key>
+		<key alias="readyToPublish">Bereit zu Veröffentlichen?</key>
+		<key alias="readyToSave">Bereit zu Sichern?</key>
+		<key alias="resetFocalPoint">Fokus zurücksetzten.</key>
+		<key alias="sendForApproval">Freigabe anfordern</key>
+		<key alias="schedulePublishHelp">Wählen Sie Datum und Uhrzeit für die Veröffentlichung bzw. deren Rücknahme.</key>
+		<key alias="createEmpty">Neues Element anlegen</key>
+		<key alias="createFromClipboard">Aus der Zwischenablage einfügen</key>
+		<key alias="nodeIsInTrash">Dieses Element befindet sich im Papierkorb.</key>
+		<key alias="variantSaveNotAllowed">Speichern ist nicht erlaubt.</key>
+		<key alias="variantPublishNotAllowed">Veröffentlichen ist nicht erlaubt.</key>
+		<key alias="variantSendForApprovalNotAllowed">Zur Genehmigung senden ist nicht erlaubt.</key>
+		<key alias="variantScheduleNotAllowed">Plannung ist nicht erlaubt</key>
+		<key alias="variantUnpublishNotAllowed">Veröffentlichung zurücknehmen ist nicht erlaubt.</key>
+	</area>
+	<area alias="blueprints">
+		<key alias="createBlueprintFrom"><![CDATA[Erzeuge eine neue Inhaltsvorlage von <em>%0%</em>]]></key>
+		<key alias="blankBlueprint">Leer</key>
+		<key alias="selectBlueprint">Wählen Sie eine Inhaltsvorlage</key>
+		<key alias="createdBlueprintHeading">Inhaltsvorlage erzeugt</key>
+		<key alias="createdBlueprintMessage">Inhaltsvorlage von '%0%' wurde erzeugt</key>
+		<key alias="duplicateBlueprintMessage">Eine gleichnamige Inhaltsvorlage ist bereits vorhanden</key>
+		<key alias="blueprintDescription">
+			Eine Inhaltsvorlage ist vordefinierter Inhalt,
+			den ein Redakteur als Basis für neuen Inhalt verwenden kann
+		</key>
+	</area>
+	<area alias="media">
+		<key alias="clickToUpload">Für Upload klicken</key>
+		<key alias="orClickHereToUpload">oder klicken Sie hier um eine Datei zu wählen</key>
+		<key alias="disallowedFileType">Dieser Dateityp darf nicht hochgeladen werden</key>
+
+		<key alias="invalidFileName">Diese Datei kann nicht hochgeladen werden wil der Dateiname ungültig ist.</key>
+		<key alias="disallowedMediaType">Diese Datei kann nicht hochgeladen werden, der Medienttype mit dem Alias '%0%' ist hier nicht erlaubt.</key>
+		<key alias="maxFileSize">Max. Dateigröße ist</key>
+		<key alias="mediaRoot">Media-Basis</key>
+		<key alias="moveToSameFolderFailed">Eltern- und Ziel-Verzeichnis dürfen nicht übereinstimmen</key>
+		<key alias="createFolderFailed">Unter Element Id %0% konnte kein Verzeichnis angelegt werden</key>
+		<key alias="renameFolderFailed">Das Verzeichnis mit Id %0% konnte nicht umbenannt werden</key>
+		<key alias="dragAndDropYourFilesIntoTheArea">Wählen Sie Dateien aus und ziehen Sie diese in diesen Bereich</key>
+		<key alias="uploadNotAllowed">Hochladen ist in diesem Bereich nicht erlaubt.</key>
+	</area>
+	<area alias="member">
+		<key alias="createNewMember">Neues Mitglied anlegen</key>
+		<key alias="allMembers">Alle Mitglieder</key>
+		<key alias="duplicateMemberLogin">Ein Mitglied mit diesem Login existiert bereits.</key>
+		<key alias="memberGroupNoProperties">Mitgliedsgruppen haben keine weiteren editierbaren Eigenschaften.</key>
+		<key alias="memberHasGroup">Das Mitglied ist bereits in der Gruppe '%0%'</key>
+		<key alias="memberHasPassword">Das Mitglied hat bereits ein Passwort</key>
+		<key alias="memberLockoutNotEnabled">Sperren ist nicht aktiviert für dieses Mitglied.</key>
+		<key alias="memberNotInGroup">Das Mitglied ist nicht in der Gruppe '%0%'</key>
+		<key alias="2fa">Zwei-Faktor-Authentifizierung</key>
+	</area>
+	<area alias="contentType">
+		<key alias="copyFailed">Kopieren des Dokumenttyps fehlgeschlagen</key>
+		<key alias="moveFailed">Bewegen des Dokumenttyps fehlgeschlagen</key>
+	</area>
+	<area alias="mediaType">
+		<key alias="copyFailed">Kopieren des Medienttyps fehlgeschlagen</key>
+		<key alias="moveFailed">Bewegen des Medienttyps fehlgeschlagen</key>
+		<key alias="autoPickMediaType">Automatische auswahl.</key>
+	</area>
+	<area alias="memberType">
+		<key alias="copyFailed">Kopieren des Mitgliedtyps fehlgeschlagen</key>
+	</area>
+	<area alias="create">
+		<key alias="chooseNode">An welcher Stellen wollen Sie das Element erstellen</key>
+		<key alias="createUnder">Neues Element unterhalb von</key>
+		<key alias="createContentBlueprint">Wählen Sie einen Dokumenttyp für eine Inhaltsvorlage</key>
+		<key alias="enterFolderName">Geben Sie einen Verzeichnisnamen ein</key>
+		<key alias="updateData">Wählen Sie einen Namen und einen Typ</key>
+		<key alias="noDocumentTypes" version="7.0">
+			<![CDATA[Es stehen keine erlaubten Dokumenttypen zur Verfügung. Sie müssen diese in den Einstellungen (unter "Dokumenttypen") aktivieren.]]>
+		</key>
+		<key alias="noDocumentTypesAtRoot">
+			<![CDATA[Es stehen keine erlaubten Dokumenttypen zur Verfügung. Sie müssen diese in den Einstellungen (unter "Dokumenttypen") aktivieren.]]>
+		</key>
+		<key alias="noDocumentTypesWithNoSettingsAccess">
+			Die im Inhaltsbaum ausgewählte Seite
+			erlaubt keine Unterseiten.
+		</key>
+		<key alias="noDocumentTypesEditPermissions">Bearbeitungsrechte für diesen Dokumenttyp</key>
+		<key alias="noDocumentTypesCreateNew">Neuen Dokumenttypen erstellen</key>
+		<key alias="noDocumentTypesAllowedAtRoot">
+			<![CDATA[Keine Dokumenttypen vorhanden welche hier eingefügt werden dürfen. Sie müssen diese in den Einstellungen (unter "Dokumenttypen") aktivieren.]]>
+		</key>
+		<key alias="noMediaTypes" version="7.0">
+			<![CDATA[Es stehen keine erlaubten Medientypen zur Verfügung.
+      Sie müssen diese in den Einstellungen (unter "Medientypen") aktivieren.]]>
+		</key>
+		<key alias="noMediaTypesWithNoSettingsAccess">
+			Das im Strukturbaum ausgewählte Medienelement
+			erlaubt keine untergeordneten Elemente.
+		</key>
+		<key alias="noMediaTypesEditPermissions">Bearbeitungsrechte für diesen Medientyp</key>
+		<key alias="documentTypeWithoutTemplate">Dokumenttyp ohne Vorlage</key>
+		<key alias="documentTypeWithTemplate">Dokumenttyp mit Template</key>
+		<key alias="documentTypeWithTemplateDescription">
+			Die Definition für eine Inhaltsseite welche von einem
+			Redakteur im Inhaltsbaum angelgt werden können und direkt über die URL aufgerufen werden kann.
+		</key>
+		<key alias="documentType">Dokumenttype</key>
+		<key alias="documentTypeDescription">
+			Die Definition für eine Inhaltsseite welche von einem
+			Redakteur im Inhaltsbaum angelgt werden können und direkt über die URL aufgerufen werden kann.
+		</key>
+		<key alias="elementType">Elementtyp</key>
+		<key alias="elementTypeDescription">
+			Definiert die Vorlage für sich wiederholende Eigenschaften, zum Beispiel, in einer 'Block
+			List' oder im 'Nested Content' Editor.
+		</key>
+		<key alias="composition">Komposition</key>
+		<key alias="compositionDescription">
+			Definiert eine wiederverwendbare Komposition von Eigenschaften welche in anderen
+			Dokumenttypen wiederverwendet werden können.
+		</key>
+		<key alias="folder">Ordner</key>
+		<key alias="folderDescription">
+			Werden benützt um Dokumenttypen, Komposition und Elementtypen in diesem
+			Dokumenttypbaums zu organisieren.
+		</key>
+		<key alias="newFolder">Neues Verzeichnis</key>
+		<key alias="newDataType">Neuer Datentyp</key>
+		<key alias="newJavascriptFile">Neue JavaScript-Datei</key>
+		<key alias="newEmptyPartialView">Neue leere Partial-View</key>
+		<key alias="newPartialViewMacro">Neues Partial-View-Makro</key>
+		<key alias="newPartialViewFromSnippet">Neue Partial-View nach Vorlage</key>
+		<key alias="newPartialViewMacroFromSnippet">Neues Partial-View-Makro nach Vorlage</key>
+		<key alias="newPartialViewMacroNoMacro">Neues Partial-View-Makro (ohne Makro)</key>
+		<key alias="newStyleSheetFile">Neue Style-Sheet-Datei</key>
+		<key alias="newRteStyleSheetFile">Neue Rich-Text-Editor Style-Sheet-Datei</key>
+	</area>
+	<area alias="dashboard">
+		<key alias="browser">Website anzeigen</key>
+		<key alias="dontShowAgain">- Verstecken</key>
+		<key alias="nothinghappens">Wenn Umbraco nicht geöffnet wurde, wurde möglicherweise das Pop-Up unterdrückt.</key>
+		<key alias="openinnew">wurde in einem neuen Fenster geöffnet</key>
+		<key alias="restart">Neu öffnen</key>
+		<key alias="visit">Besuchen</key>
+		<key alias="welcome">Willkommen</key>
+	</area>
+	<area alias="prompt">
+		<key alias="stay">Bleiben</key>
+		<key alias="discardChanges">Änderungen verwerfen</key>
+		<key alias="unsavedChanges">Es gibt ungesicherte Änderungen</key>
+		<key alias="unsavedChangesWarning">
+			Wollen Sie diese Seite wirklich verlassen?
+			- es gibt ungesicherte Änderungen
+		</key>
+		<key alias="confirmListViewPublish">Veröffentlichen macht die ausgewählten Elemente auf der Website sichtbar.</key>
+		<key alias="confirmListViewUnpublish">
+			Aufheben der Veröffentlichung entfernt die ausgewählten Elemente
+			und ihre Unterknoten von der Website.
+		</key>
+		<key alias="confirmUnpublish">Aufheben der Veröffentlichung entfernt diese Seite und ihre Unterseiten von der Website.</key>
+		<key alias="doctypeChangeWarning">
+			Es gibt ungesicherte Änderungen.
+			Ändern des Dokumenttyps macht diese rückgängig.
+		</key>
+	</area>
+	<area alias="bulk">
+		<key alias="done">Fertig</key>
+		<key alias="deletedItem">%0% Element entfernt</key>
+		<key alias="deletedItems">%0% Elemente entfernt</key>
+		<key alias="deletedItemOfItem">%0% von %1% Element entfernt</key>
+		<key alias="deletedItemOfItems">%0% von %1% Elementen entfernt</key>
+		<key alias="publishedItem">%0% Element veröffentlicht</key>
+		<key alias="publishedItems">%0% Elemente veröffentlicht</key>
+		<key alias="publishedItemOfItem">%0% von %1% Element veröffentlicht</key>
+		<key alias="publishedItemOfItems">%0% von %1% Elementen veröffentlicht</key>
+		<key alias="unpublishedItem">%0% Veröffentlichung aufgehoben</key>
+		<key alias="unpublishedItems">%0% Veröffentlichungen aufgehoben</key>
+		<key alias="unpublishedItemOfItem">%0% von %1% Veröffentlichung aufgehoben</key>
+		<key alias="unpublishedItemOfItems">%0% von %1% Veröffentlichungen aufgehoben</key>
+		<key alias="movedItem">%0% Element verschoben</key>
+		<key alias="movedItems">%0% Elemente verschoben</key>
+		<key alias="movedItemOfItem">%0% von %1% Element verschoben</key>
+		<key alias="movedItemOfItems">%0% von %1% Elementen verschoben</key>
+		<key alias="copiedItem">%0% Element kopiert</key>
+		<key alias="copiedItems">%0% Elemente kopiert</key>
+		<key alias="copiedItemOfItem">%0% von %1% Element kopiert</key>
+		<key alias="copiedItemOfItems">%0% von %1% Elementen kopiert</key>
+	</area>
+	<area alias="defaultdialogs">
+		<key alias="nodeNameLinkPicker">Name des Link</key>
+		<key alias="urlLinkPicker">Link</key>
+		<key alias="anchorLinkPicker">Anker / querystring</key>
+		<key alias="anchorInsert">Name</key>
+		<key alias="closeThisWindow">Fenster schließen</key>
+		<key alias="confirmdelete">Wollen Sie dies wirklich entfernen</key>
+		<key alias="confirmdeleteNumberOfItems"><![CDATA[Sicher das Sie <strong>%0%</strong> von <strong>%1%</strong> Elementen löschen wollen?]]></key>
+		<key alias="confirmdisable">Wollen Sie folgendes wirklich deaktivieren</key>
+		<key alias="confirmremove">Sicher das Sie es entfernen wollen?</key>
+		<key alias="confirmremoveusageof"><![CDATA[Sicher das Sie die Verwendung von <strong>%0%</strong> entfernen wollen?]]></key>
+		<key alias="confirmlogout">Sind Sie sich wirklich abmelden?</key>
+		<key alias="confirmSure">Sind Sie sicher?</key>
+		<key alias="cut">Ausschneiden</key>
+		<key alias="editdictionary">Wörterbucheintrag bearbeiten</key>
+		<key alias="editlanguage">Sprache bearbeiten</key>
+		<key alias="editSelectedMedia">Ausgewähltes Medien</key>
+		<key alias="insertAnchor">Anker einfügen</key>
+		<key alias="insertCharacter">Zeichen einfügen</key>
+		<key alias="insertgraphicheadline">Grafische Überschrift einfügen</key>
+		<key alias="insertimage">Abbildung einfügen</key>
+		<key alias="insertlink">Link einfügen</key>
+		<key alias="insertMacro">klicken um Macro hinzuzufügen</key>
+		<key alias="inserttable">Tabelle einfügen</key>
+		<key alias="languagedeletewarning">Dies entfernt die Sprache</key>
+		<key alias="languageChangeWarning">
+			Die Kultur-Variante einer Sprache zu ändern ist möglicherweise eine aufwendige Operation und führt zum Erneuern von Inhalts-Zwischenspeicher und Such-Index.
+		</key>
+		<key alias="lastEdited">Zuletzt bearbeitet</key>
+		<key alias="link">Verknüpfung</key>
+		<key alias="linkinternal">Anker:</key>
+		<key alias="linklocaltip">Wenn lokale Links verwendet werden, füge ein "#" vor den Link ein</key>
+		<key alias="linknewwindow">In einem neuen Fenster öffnen?</key>
+		<key alias="macroDoesNotHaveProperties">Dieses Makro enthält keine einstellbaren Eigenschaften.</key>
+		<key alias="paste">Einfügen</key>
+		<key alias="permissionsEdit">Berechtigungen bearbeiten für</key>
+		<key alias="permissionsSet">Berechtigungen vergeben für</key>
+		<key alias="permissionsSetForGroup">Berechtigungen vergeben für %0% für Benutzer-Gruppe %1%</key>
+		<key alias="permissionsHelp">Wählen Sie die Benutzer-Gruppe, deren Berechtigungen Sie setzen möchten</key>
+		<key alias="recycleBinDeleting">
+			Der Papierkorb wird geleert.
+			Bitte warten Sie und schließen Sie das Fenster erst, wenn der Vorgang abgeschlossen ist.
+		</key>
+		<key alias="recycleBinIsEmpty">Der Papierkorb ist leer</key>
+		<key alias="recycleBinWarning">Wenn Sie den Papierkorb leeren, werden die enthaltenen Elemente endgültig gelöscht. Dieser Vorgang kann nicht rückgängig gemacht werden.</key>
+		<key alias="regexSearchError">
+			Der Webservice von &lt;a target='_blank' rel='noopener' href='http://regexlib.com'&gt;regexlib.com&lt;/a&gt; ist zur Zeit nicht erreichbar. Bitte versuchen Sie es später erneut.
+		</key>
+		<key alias="regexSearchHelp">
+			Finden Sie einen vorbereiteten regulären Ausdruck zur Validierung der Werte, die in dieses Feld eingegeben werden - zum Beispiel 'email, 'plz', 'URL' oder ähnlich.
+		</key>
+		<key alias="removeMacro">Macro entfernen</key>
+		<key alias="requiredField">Pflichtfeld</key>
+		<key alias="sitereindexed">Die Website-Index wurd neu erstellt</key>
+		<key alias="siterepublished">
+			Der Zwischenspeicher der Website wurde aktualisiert und alle veröffentlichten Inhalte sind jetzt auf dem neuesten Stand.
+			Bisher unveröffentliche Inhalte wurden dabei nicht veröffentlicht.
+		</key>
+		<key alias="siterepublishHelp">
+			Der Zwischenspeicher der Website wird aktualisiert und der veröffentlichte Inhalt auf den neuesten Stand gebracht.
+			Unveröffentlichte Inhalte bleiben dabei weiterhin unveröffentlicht.
+		</key>
+		<key alias="tableColumns">Anzahl der Spalten</key>
+		<key alias="tableRows">Anzahl der Zeilen</key>
+		<key alias="thumbnailimageclickfororiginal">Für Originalgröße auf die Abbildung klicken</key>
+		<key alias="treepicker">Element auswählen</key>
+		<key alias="viewCacheItem">Zwischenspeicher-Element anzeigen</key>
+		<key alias="relateToOriginalLabel">Verknüpfe mit Original</key>
+		<key alias="includeDescendants">Einschliesslich Unterknoten</key>
+		<key alias="theFriendliestCommunity">Die freundlichste Community</key>
+		<key alias="linkToPage">Seiten-Link</key>
+		<key alias="openInNewWindow">In neuem Fenster / Tab öffnen</key>
+		<key alias="linkToMedia">Medien-Link</key>
+		<key alias="selectContentStartNode">Inhalts-Startknoten wählen</key>
+		<key alias="selectMedia">Medienelement wählen</key>
+		<key alias="selectMediaType">Medientype wählen</key>
+		<key alias="selectIcon">Bildzeichen wählen</key>
+		<key alias="selectItem">Element wählen</key>
+		<key alias="selectLink">Link wählen</key>
+		<key alias="selectMacro">Makro wählen</key>
+		<key alias="selectContent">Inhalt wählen</key>
+		<key alias="selectContentType">Inhaltstyp wählen</key>
+		<key alias="selectMediaStartNode">Medien-Startknoten wählen</key>
+		<key alias="selectMember">Mitglied wählen</key>
+		<key alias="selectMemberGroup">Mitgliedergruppe wählen</key>
+		<key alias="selectMemberType">Membertype wählen</key>
+		<key alias="selectNode">Knoten wählen</key>
+		<key alias="selectSections">Bereich wählen</key>
+		<key alias="selectLanguages">Sprachen wählen</key>
+		<key alias="selectUser">Benutzer wählen</key>
+		<key alias="selectUsers">Benutzer wählen</key>
+		<key alias="noIconsFound">Keine Bildzeichen gefunden</key>
+		<key alias="noMacroParams">Für dieses Makro gibt es keine Parameter</key>
+		<key alias="noMacros">Es gibt keine Makros zum Einfügen</key>
+		<key alias="externalLoginProviders">Externe Login-Anbieter</key>
+		<key alias="exceptionDetail">Ausnahmedetails</key>
+		<key alias="stacktrace">Stacktrace</key>
+		<key alias="innerException">Inner Exception</key>
+		<key alias="linkYour">Verknüpfen Sie Ihr</key>
+		<key alias="unLinkYour">Trennen Sie Ihr</key>
+		<key alias="account">Konto</key>
+		<key alias="selectEditor">Editor wählen</key>
+		<key alias="selectEditorConfiguration">Konfiguration wählen</key>
+		<key alias="selectSnippet">Kode-Vorlage wählen</key>
+		<key alias="variantdeletewarning">
+			Dies wird den Knoten und all seine Sprachen entfernen.
+			Wenn Sie nur eine Sprache entfernen wollen, wählen Sie diese und setzen sie auf unveröffentlicht.
+		</key>
+		<key alias="propertyuserpickerremovewarning"><![CDATA[Dies entfernt den User <strong>%0%</strong>.]]></key>
+		<key alias="userremovewarning"><![CDATA[Dies entfernt den User <strong>%0%</strong> von der <strong>%1%</strong> Gruppe]]></key>
+		<key alias="yesRemove">Ja, entfernen</key>
+		<key alias="deleteLayout">Sie löschen das Layout</key>
+		<key alias="deletingALayout">Bearbeiten des layout resultiert im Verlust der aller Daten für bestehenden Inhalt basierend auf dieser Konfiruation.</key>
+	</area>
+	<area alias="dictionary">
+		<key alias="importDictionaryItemHelp">
+			Um einen Eintrag zu importieren, suchen sie die ".udt" Datei auf ihren Computer durch Klicken des
+			"Import" Knopfes. (Sie werden für Ihre Zustimmung im nächsten Schritt gefragt)
+		</key>
+		<key alias="itemDoesNotExists">Wörterbuch Eintrag existiert nicht.</key>
+		<key alias="parentDoesNotExists">Eltern Element existiert nicht.</key>
+		<key alias="noItems">Es gibt keine Einträge im Wörterbuch.</key>
+		<key alias="noItemsInFile">Keine Wörterbuch Einträge in dieser Datei gefunden.</key>
+		<key alias="noItemsFound">Keine Wörterbuch Einträge gefunden.</key>
+		<key alias="createNew">Eintrag erstellen</key>
+	</area>
+	<area alias="dictionaryItem">
+		<key alias="description">
+			<![CDATA[
+    Bearbeiten Sie nachfolgend die verschiedenen Sprachversionen für den Wörterbucheintrag '<em>%0%</em>'.
+    <br/>Unter dem links angezeigten Menüpunkt 'Sprachen' können Sie weitere hinzufügen.]]>
+		</key>
+		<key alias="displayName">Name der Kultur</key>
+		<key alias="changeKeyError">
+			<![CDATA[
+      Der Wert '%0%' ist bereits vorhanden.
+   ]]>
+		</key>
+		<key alias="overviewTitle">Wörterbuch Übersicht</key>
+	</area>
+	<area alias="examineManagement">
+		<key alias="configuredSearchers"><![CDATA[<em>Sucher</em> einrichten ]]></key>
+		<key alias="configuredSearchersDescription">
+			<![CDATA[
+    Zeigt die Eigenschaften und Werkzeuge für eingerichtete <em>Sucher</em> (z.B.: multi-index searcher)]]>
+		</key>
+		<key alias="fieldValues">Feldwerte</key>
+		<key alias="healthStatus">Gesundheitsstatus</key>
+		<key alias="healthStatusDescription">Der Gesundheitsstatus und Lesbarkeit des Indizes.</key>
+		<key alias="indexers">Indizierer</key>
+		<key alias="indexInfo">Indexinformationen</key>
+		<key alias="contentInIndex">Inhalt des Indexes</key>
+		<key alias="indexInfoDescription">Zeigt die Eigenschaften des Indizes</key>
+		<key alias="manageIndexes">Examine Index-Verwaltung</key>
+		<key alias="manageIndexesDescription">
+			Index Detailanzeige und Verwaltungswerkzeuge
+		</key>
+		<key alias="rebuildIndex">Index erneuern</key>
+		<key alias="rebuildIndexWarning">
+			<![CDATA[
+      Dies erzeugt den Index neu.<br />
+      Abhängig von der Inhaltsmenge Ihrer <em>Website</em> kann das eingie Zeit dauern.<br />
+      Es wird davon abgeraten, einen Index einer <em>Website</em> während hoher Auslastung- oder Inhaltbearbeitungszeiten zu erneuern.
+     ]]>
+		</key>
+		<key alias="searchers">Sucher</key>
+		<key alias="searchDescription">Durchsuche den Index und betrachte die Ergebnisse</key>
+		<key alias="tools">Werkzeuge</key>
+		<key alias="toolsDescription">Werkzeuge zur Indexverwaltung</key>
+		<key alias="fields">Felder</key>
+		<key alias="indexCannotRead">Der Index kann nicht gelesen werden und wird deshalb neu erstellt.</key>
+		<key alias="processIsTakingLonger">
+			Der Prozess dauert länger als erwartet, checken Sie die Umbraco Logs um zu sehen ob
+			Fehler passiert sind.
+		</key>
+		<key alias="indexCannotRebuild">Der Index kann nicht rebuilded werden weil er nicht zugewissen wurde.</key>
+		<key alias="iIndexPopulator">IIndexPopulator</key>
+	</area>
+	<area alias="placeholders">
+		<key alias="username">Benutzername eingeben</key>
+		<key alias="password">Kennwort eingeben</key>
+		<key alias="confirmPassword">Bestätige das Kennwort</key>
+		<key alias="nameentity">%0% benennen ...</key>
+		<key alias="entername">Bitte Name angeben ...</key>
+		<key alias="enteremail">Bitte E-Mail eingeben...</key>
+		<key alias="enterusername">Bitte Benutzernamen eingeben...</key>
+		<key alias="label">Label...</key>
+		<key alias="enterDescription">Bitte eine Beschreibung eingeben...</key>
+		<key alias="search">Durchsuchen ...</key>
+		<key alias="filter">Filtern ...</key>
+		<key alias="enterTags">Tippen, um Tags hinzuzufügen (nach jedem Tag die Eingabetaste drücken) ...</key>
+		<key alias="email">Bitte E-Mail eingeben</key>
+		<key alias="enterMessage">Bitte Nachricht eingeben...</key>
+		<key alias="usernameHint">Der Benutzername ist normalerweise Ihre E-Mail-Adresse</key>
+		<key alias="anchor">#value oder ?key=value</key>
+		<key alias="enterAlias">Bitte einen Alias eingeben...</key>
+		<key alias="generatingAlias">Alias erzeugen...</key>
+		<key alias="a11yCreateItem">Element erstellen</key>
+		<key alias="a11yEdit">Bearbeiten</key>
+		<key alias="a11yName">Benennen</key>
+	</area>
+	<area alias="editcontenttype">
+		<key alias="createListView" version="7.2">Angepasste Listenansicht erstellen</key>
+		<key alias="removeListView" version="7.2">Angepasste Listenansicht entfernen</key>
+		<key alias="aliasAlreadyExists">Ein Inhalts-, Medien oder Mitgliedstyp mit gleichem Alias ist bereits vorhanden.</key>
+	</area>
+	<area alias="renamecontainer">
+		<key alias="renamed">Umbenannt</key>
+		<key alias="enterNewFolderName">Tragen Sie hier einen neuen Verzeichnisnamen ein</key>
+		<key alias="folderWasRenamed">%0% wurde umbenannt in %1%</key>
+	</area>
+	<area alias="editdatatype">
+		<key alias="canChangePropertyEditorHelp">Ändern des Editors in einem Datatyps mit gespeicherten Werten ist nicht erlaubt. Um es zu erlauben müssen Sie die Umbraco:CMS:DataTypes:CanBeChanged Einstellung in der appsettings.json ändern.</key>
+		<key alias="addPrevalue">Neuer Vorgabewert</key>
+		<key alias="dataBaseDatatype">Feldtyp in der Datenbank</key>
+		<key alias="guid">Datentyp-GUID</key>
+		<key alias="renderControl">Steuerelement zur Darstellung</key>
+		<key alias="rteButtons">Schaltflächen</key>
+		<key alias="rteEnableAdvancedSettings">Erweiterte Einstellungen aktivieren für</key>
+		<key alias="rteEnableContextMenu">Kontextmenü aktivieren</key>
+		<key alias="rteMaximumDefaultImgSize">Maximale Standardgröße für eingefügte Bilder</key>
+		<key alias="rteRelatedStylesheets">Verknüpfte Stylesheets</key>
+		<key alias="rteShowLabel">Beschriftung anzeigen</key>
+		<key alias="rteWidthAndHeight">Breite und Höhe</key>
+		<key alias="selectFolder">Wählen Sie das Verzeichnis aus der untenstehenden Baumstruktur, in das</key>
+		<key alias="inTheTree">verschoben werden soll.</key>
+		<key alias="wasMoved">wurde verschoben in</key>
+		<key alias="hasReferencesDeleteConsequence">
+			<![CDATA[Löschen von <strong>%0%</strong> wird die Eigenschaften und Daten von folgenden Element löschen]]>
+		</key>
+		<key alias="acceptDeleteConsequence">
+			Ich verstehe das diese Aktion Eigenschaften und Daten basierend auf diesem
+			DataTyps löschen wird.
+		</key>
+	</area>
+	<area alias="errorHandling">
+		<key alias="errorButDataWasSaved">
+			Ihre Daten wurden gespeichert.
+			Bevor Sie diese Seite jedoch veröffentlichen können, müssen Sie die folgenden Korrekturen vornehmen:
+		</key>
+		<key alias="errorChangingProviderPassword">
+			Der aktuelle Mitgliedschaftsanbieter erlaubt keine Kennwortänderung
+			(EnablePasswordRetrieval muss auf "true" gesetzt sein)
+		</key>
+		<key alias="errorExistsWithoutTab">'%0%' ist bereits vorhanden</key>
+		<key alias="errorHeader">Bitte prüfen und korrigieren:</key>
+		<key alias="errorHeaderWithoutTab">Bitte prüfen und korrigieren:</key>
+		<key alias="errorInPasswordFormat">
+			Für das Kennwort ist eine Mindestlänge von %0% Zeichen vorgesehen,
+			wovon mindestens %1% Sonderzeichen (nicht alphanumerisch) sein müssen
+		</key>
+		<key alias="errorIntegerWithoutTab">'%0%' muss eine Zahl sein</key>
+		<key alias="errorMandatory">'%0%' (in Registerkarte '%1%') ist ein Pflichtfeld</key>
+		<key alias="errorMandatoryWithoutTab">'%0%' ist ein Pflichtfeld</key>
+		<key alias="errorRegExp">'%0%' (in Registerkarte '%1%') hat ein falsches Format</key>
+		<key alias="errorRegExpWithoutTab">'%0%' hat ein falsches Format</key>
+	</area>
+	<area alias="errors">
+		<key alias="defaultError">Ein unbekannter Fehler ist passiert.</key>
+		<key alias="concurrencyError">Optimistic concurrency Fehler, Objekte wurde geändert.</key>
+		<key alias="receivedErrorFromServer">Der Server hat einen Fehler gemeldet</key>
+		<key alias="dissallowedMediaType">Dieser Dateityp wird durch die Systemeinstellungen blockiert</key>
+		<key alias="codemirroriewarning">
+			ACHTUNG! Obwohl CodeMirror in den Einstellungen aktiviert ist,
+			bleibt das Modul wegen mangelnder Stabilität in Internet Explorer deaktiviert.
+		</key>
+		<key alias="contentTypeAliasAndNameNotNull">Bitte geben Sie die Bezeichnung und den Alias des neuen Dokumenttyps ein.</key>
+		<key alias="filePermissionsError">Es besteht ein Problem mit den Lese-/Schreibrechten auf eine Datei oder einen Ordner</key>
+		<key alias="macroErrorLoadingPartialView">Fehler beim Laden einer "Partial View Kodedatei" (Datei: %0%)</key>
+		<key alias="missingTitle">Bitte geben Sie einen Titel ein</key>
+		<key alias="missingType">Bitte wählen Sie einen Typ</key>
+		<key alias="pictureResizeBiggerThanOrg">
+			Soll die Abbildung wirklich über die
+			Originalgröße hinaus vergrößert werden?
+		</key>
+		<key alias="startNodeDoesNotExists">Startelement gelöscht, bitte kontaktieren Sie den System-Administrator.</key>
+		<key alias="stylesMustMarkBeforeSelect">Bitte markieren Sie den gewünschten Text, bevor Sie einen Stil auswählen</key>
+		<key alias="stylesNoStylesOnPage">Keine aktiven Stile vorhanden</key>
+		<key alias="tableColMergeLeft">Bitte platzieren Sie den Mauszeiger in die erste der zusammenzuführenden Zellen</key>
+		<key alias="tableSplitNotSplittable">Sie können keine Zelle trennen, die nicht zuvor aus mehreren zusammengeführt wurde.</key>
+		<key alias="propertyHasErrors">Die Eigenschaft ist nicht valide</key>
+	</area>
+	<area alias="general">
+		<key alias="options">Optionen</key>
+		<key alias="about">Info</key>
+		<key alias="action">Aktion</key>
+		<key alias="actions">Aktionen</key>
+		<key alias="add">Hinzufügen</key>
+		<key alias="alias">Alias</key>
+		<key alias="all">Alles</key>
+		<key alias="areyousure">Sind Sie sicher?</key>
+		<key alias="back">Zurück</key>
+		<key alias="backToOverview">Zurück zur Übersicht</key>
+		<key alias="border">Rahmen</key>
+		<key alias="by">von</key>
+		<key alias="cancel">Abbrechen</key>
+		<key alias="cellMargin">Zellabstand</key>
+		<key alias="choose">Auswählen</key>
+		<key alias="close">Schließen</key>
+		<key alias="clear">Leeren</key>
+		<key alias="closewindow">Fenster schließen</key>
+		<key alias="closepane">Fenster Pane</key>
+		<key alias="comment">Kommentar</key>
+		<key alias="confirm">bestätigen</key>
+		<key alias="constrain">Beschneiden</key>
+		<key alias="constrainProportions">Seitenverhältnis beibehalten</key>
+		<key alias="content">Inhalt</key>
+		<key alias="continue">Weiter</key>
+		<key alias="copy">Kopieren</key>
+		<key alias="create">Neu</key>
+		<key alias="cropSection">Ausschnitte Bereich</key>
+		<key alias="database">Datenbank</key>
+		<key alias="date">Datum</key>
+		<key alias="default">Standard</key>
+		<key alias="delete">Löschen</key>
+		<key alias="deleted">Gelöscht</key>
+		<key alias="deleting">Löschen ...</key>
+		<key alias="design">Design</key>
+		<key alias="dictionary">Wörterbuch</key>
+		<key alias="dimensions">Abmessungen</key>
+		<key alias="discard">Verwerfen</key>
+		<key alias="down">nach unten</key>
+		<key alias="download">Herunterladen</key>
+		<key alias="edit">Bearbeiten</key>
+		<key alias="edited">Bearbeitet</key>
+		<key alias="elements">Elemente</key>
+		<key alias="email">E-Mail</key>
+		<key alias="error">Fehler</key>
+		<key alias="field">Feld</key>
+		<key alias="findDocument">Suche</key>
+		<key alias="first">Erste(s)</key>
+		<key alias="general">Allgemein</key>
+		<key alias="groups">Gruppen</key>
+		<key alias="groups">Gruppe</key>
+		<key alias="generic">Generisch</key>
+		<key alias="group">Gruppe</key>
+		<key alias="height">Höhe</key>
+		<key alias="help">Hilfe</key>
+		<key alias="hide">Verbergen</key>
+		<key alias="history">Verlauf</key>
+		<key alias="icon">Bildzeichen</key>
+		<key alias="id">Id</key>
+		<key alias="import">Import</key>
+		<key alias="excludeFromSubFolders">Nur in diesem Ordner suchen</key>
+		<key alias="info">Info</key>
+		<key alias="innerMargin">Innerer Abstand</key>
+		<key alias="insert">Einfügen</key>
+		<key alias="install">Installieren</key>
+		<key alias="invalid">Ungültig</key>
+		<key alias="justify">Zentrieren</key>
+		<key alias="label">Bezeichnung</key>
+		<key alias="language">Sprache</key>
+		<key alias="last">Letzte(s)</key>
+		<key alias="layout">Layout</key>
+		<key alias="links">Links</key>
+		<key alias="loading">Laden</key>
+		<key alias="locked">Gesperrt</key>
+		<key alias="login">Anmelden</key>
+		<key alias="logoff">Abmelden</key>
+		<key alias="logout">Abmelden</key>
+		<key alias="macro">Makro</key>
+		<key alias="mandatory">Pflichtfeld</key>
+		<key alias="media">Medien</key>
+		<key alias="message">Nachricht</key>
+		<key alias="move">Verschieben</key>
+		<key alias="name">Name</key>
+		<key alias="new">Neu</key>
+		<key alias="next">Weiter</key>
+		<key alias="no">Nein</key>
+		<key alias="nodeName">Knoten Name</key>
+		<key alias="of">von</key>
+		<key alias="off">Aus</key>
+		<key alias="ok">Ok</key>
+		<key alias="open">Öffnen</key>
+		<key alias="on">An</key>
+		<key alias="or">oder</key>
+		<key alias="orderBy">Sortieren nach</key>
+		<key alias="password">Kennwort</key>
+		<key alias="path">Pfad</key>
+		<key alias="pleasewait">Einen Moment bitte...</key>
+		<key alias="previous">Zurück</key>
+		<key alias="properties">Eigenschaften</key>
+		<key alias="readMore">Mehr erfahren</key>
+		<key alias="rebuild">Erneuern</key>
+		<key alias="reciept">E-Mail-Empfänger für die Formulardaten</key>
+		<key alias="recycleBin">Papierkorb</key>
+		<key alias="recycleBinEmpty">Ihr Mülleimer ist leer</key>
+		<key alias="reload">Neu laden</key>
+		<key alias="remaining">Verbleibend</key>
+		<key alias="remove">Entfernen</key>
+		<key alias="revert">Rückgängig</key>
+		<key alias="rename">Umbenennen</key>
+		<key alias="renew">Erneuern</key>
+		<key alias="required" version="7.0">Pflichtangabe</key>
+		<key alias="retrieve">Wiederherstellen</key>
+		<key alias="retry">Wiederholen</key>
+		<key alias="rights">Berechtigungen</key>
+		<key alias="scheduledPublishing">Geplantes Veröffentlichen</key>
+		<key alias="umbracoInfo">Umbraco Information</key>
+		<key alias="search">Suchen</key>
+		<key alias="searchNoResult">Leider können wir nicht finden, wonach Sie suchen.</key>
+		<key alias="noItemsInList">Es wurden keine Elemente hinzugefügt</key>
+		<key alias="server">Server</key>
+		<key alias="settings">Einstellungen</key>
+		<key alias="shared">Geteilt</key>
+		<key alias="show">Anzeigen</key>
+		<key alias="showPageOnSend">Seite beim Senden anzeigen</key>
+		<key alias="size">Größe</key>
+		<key alias="sort">Sortieren</key>
+		<key alias="status">Status</key>
+		<key alias="submit">Senden</key>
+		<key alias="success">Erfolt</key>
+		<key alias="type">Typ</key>
+		<key alias="typeName">Typ Name</key>
+		<key alias="typeToSearch">Durchsuchen ...</key>
+		<key alias="under">unter</key>
+		<key alias="up">nach oben</key>
+		<key alias="update">Aktualisieren</key>
+		<key alias="upgrade">Update</key>
+		<key alias="upload">Hochladen</key>
+		<key alias="url">URL</key>
+		<key alias="user">Benutzer</key>
+		<key alias="username">Benutzername</key>
+		<key alias="validate">Validieren</key>
+		<key alias="value">Wert</key>
+		<key alias="view">Ansicht</key>
+		<key alias="welcome">Willkommen ...</key>
+		<key alias="width">Breite</key>
+		<key alias="yes">Ja</key>
+		<key alias="folder">Ordner</key>
+		<key alias="searchResults">Suchergebnisse</key>
+		<key alias="reorder">Sortieren</key>
+		<key alias="reorderDone">Sortierung abschließen</key>
+		<key alias="preview">Vorschau</key>
+		<key alias="changePassword">Kennwort ändern</key>
+		<key alias="to">nach</key>
+		<key alias="listView">Listenansicht</key>
+		<key alias="saving">Sichern läuft...</key>
+		<key alias="current">Aktuelle(s)</key>
+		<key alias="embed">Eingebettet</key>
+		<key alias="selected">ausgewählt</key>
+		<key alias="other">Anderes</key>
+		<key alias="articles">Artikel</key>
+		<key alias="videos">Videos</key>
+		<key alias="avatar">Avatar für</key>
+		<key alias="header">Kopf</key>
+		<key alias="systemField">System Feld</key>
+		<key alias="lastUpdated">Zuletzt geändert</key>
+	</area>
+	<area alias="colors">
+		<key alias="blue">Blau</key>
+	</area>
+	<area alias="shortcuts">
+		<key alias="addTab">Tab hinzufügen</key>
+		<key alias="addGroup">Neue Gruppe</key>
+		<key alias="addProperty">Neue Eigenschaft</key>
+		<key alias="addEditor">Editor hinzufügen</key>
+		<key alias="addTemplate">Vorlage hinzufügen</key>
+		<key alias="addChildNode">Knoten unterhalb hinzufügen</key>
+		<key alias="addChild">Element unterhalb hinzufügen</key>
+		<key alias="editDataType">Datentyp bearbeiten</key>
+		<key alias="navigateSections">Bereiche wechseln</key>
+		<key alias="shortcut">Abkürzungen</key>
+		<key alias="showShortcuts">Abkürzungen anzeigen</key>
+		<key alias="toggleListView">Listenansicht wechseln</key>
+		<key alias="toggleAllowAsRoot">Wurzelknotenberechtigung wechseln</key>
+		<key alias="commentLine">Zeile ein-/auskommentieren</key>
+		<key alias="removeLine">Zeile entfernen</key>
+		<key alias="copyLineUp">Zeilen oberhalb kopieren</key>
+		<key alias="copyLineDown">Zeilen unterhalb kopieren</key>
+		<key alias="moveLineUp">Zeilen nach oben schieben</key>
+		<key alias="moveLineDown">Zeilen nach unten schieben</key>
+		<key alias="generalHeader">Standard</key>
+		<key alias="editorHeader">Editor</key>
+		<key alias="toggleAllowCultureVariants">Kulturvariantenberechtigung wechseln</key>
+	</area>
+	<area alias="graphicheadline">
+		<key alias="backgroundcolor">Hintergrundfarbe</key>
+		<key alias="bold">Fett</key>
+		<key alias="color">Textfarbe</key>
+		<key alias="font">Schriftart</key>
+		<key alias="text">Text</key>
+	</area>
+	<area alias="headers">
+		<key alias="page">Dokument</key>
+	</area>
+	<area alias="installer">
+		<key alias="databaseErrorCannotConnect">Mit dieser Datenbank kann leider keine Verbindung hergestellt werden.</key>
+		<key alias="databaseErrorWebConfig">
+			Appsettings.json Datei konnte nicht gespeichert werden. Bitte ändern Sie die Datei
+			manuell.
+		</key>
+		<key alias="databaseFound">Die Datenbank ist erreichbar und wurde identifiziert als</key>
+		<key alias="databaseHeader">Datenbank</key>
+		<key alias="databaseInstall">
+			<![CDATA[
+    Klicken Sie auf <strong>Installieren</strong>, um die Datenbank für Umbraco %0% einzurichten.
+    ]]>
+		</key>
+		<key alias="databaseInstallDone">
+			Die Datenbank wurde für Umbraco %0% konfiguriert.
+			Klicken Sie auf &lt;strong&gt;weiter&lt;/strong&gt;, um fortzufahren.
+		</key>
+		<key alias="databaseText">Um diesen Schritt abzuschließen, müssen Sie die notwendigen Informationen zur Datenbankverbindung angeben.&lt;br /&gt;Bitte kontaktieren Sie Ihren Provider bzw. Server-Administrator für weitere Informationen.</key>
+		<key alias="databaseUpgrade">
+			<![CDATA[
+	  <p>
+	  Bitte bestätigen Sie mit einem Klick auf <strong>Update</strong>, dass die Datenbank auf Umbraco %0% aktualisiert werden soll.
+	  </p>
+	  <p>
+	  Keine Sorge - Dabei werden keine Inhalte gelöscht und alles wird weiterhin funktionieren!
+	  </p>
+    ]]>
+		</key>
+		<key alias="databaseUpgradeDone">Die Datenbank wurde auf die Version %0% aktualisiert. Klicken Sie auf &lt;strong&gt;weiter&lt;/strong&gt;, um fortzufahren.</key>
+		<key alias="databaseUpToDate">Die Datenbank ist fertig eingerichtet. Klicken Sie auf &lt;strong&gt;"weiter"&lt;/strong&gt;, um mit der Einrichtung fortzufahren.</key>
+		<key alias="defaultUserChangePass">&lt;strong&gt;Das Kennwort des Standard-Benutzers muss geändert werden!&lt;/strong&gt;</key>
+		<key alias="defaultUserDisabled">&lt;strong&gt;Der Standard-Benutzer wurde deaktiviert oder hat keinen Zugriff auf Umbraco.&lt;/strong&gt;&lt;/p&gt;&lt;p&gt;Es sind keine weiteren Aktionen notwendig. Klicken Sie auf &lt;b&gt;Weiter&lt;/b&gt; um fortzufahren.</key>
+		<key alias="defaultUserPassChanged">&lt;strong&gt;Das Kennwort des Standard-Benutzers wurde seit der Installation verändert.&lt;/strong&gt;&lt;/p&gt;&lt;p&gt;Es sind keine weiteren Aktionen notwendig. Klicken Sie auf &lt;b&gt;Weiter&lt;/b&gt; um fortzufahren.</key>
+		<key alias="defaultUserPasswordChanged">Das Kennwort wurde geändert!</key>
+		<key alias="greatStart">Schauen Sie sich die Einführungsvideos für einen schnellen und einfachen Start an.</key>
+		<key alias="None">Noch nicht installiert.</key>
+		<key alias="permissionsAffectedFolders">Betroffene Verzeichnisse und Dateien</key>
+		<key alias="permissionsAffectedFoldersMoreInfo">Weitere Informationen zum Thema "Dateiberechtigungen" für Umbraco</key>
+		<key alias="permissionsAffectedFoldersText">Für die folgenden Dateien und Verzeichnisse müssen ASP.NET-Schreibberechtigungen gesetzt werden</key>
+		<key alias="permissionsAlmostPerfect">&lt;strong&gt;Die Dateiberechtigungen sind fast perfekt eingestellt!&lt;/strong&gt;&lt;br /&gt;&lt;br /&gt;Damit können Sie Umbraco ohne Probleme verwenden, werden aber viele Erweiterungspakete können nicht installiert werden.</key>
+		<key alias="permissionsHowtoResolve">Problemlösung</key>
+		<key alias="permissionsHowtoResolveLink">Klicken Sie hier, um den technischen Artikel zu lesen</key>
+		<key alias="permissionsHowtoResolveText">Schauen Sie sich die &lt;strong&gt;Video-Lehrgänge&lt;/strong&gt; zum Thema Verzeichnisberechtigungen für Umbraco an oder lesen Sie den technischen Artikel.</key>
+		<key alias="permissionsMaybeAnIssue">&lt;strong&gt;Die Dateiberechtigungen sind möglicherweise fehlerhaft!&lt;/strong&gt;Sie können Umbraco vermutlich ohne Probleme verwenden, werden aber viele Erweiterungspakete können nicht installiert werden.</key>
+		<key alias="permissionsNotReady">
+			&lt;strong&gt;Die Dateiberechtigungen sind nicht geeignet!&lt;/strong&gt;&lt;br /&gt;&lt;br /&gt;
+			Die Dateiberechtigungen müssen angepasst werden.
+		</key>
+		<key alias="permissionsPerfect">&lt;strong&gt;Die Dateiberechtigungen sind perfekt eingestellt!&lt;/strong&gt;&lt;br /&gt;&lt;br /&gt; Damit ist Umbraco komplett eingerichtet und es können problemlos Erweiterungspakete installiert werden.</key>
+		<key alias="permissionsResolveFolderIssues">Verzeichnisprobleme lösen</key>
+		<key alias="permissionsResolveFolderIssuesLink">Folgen Sie diesem Link für weitere Informationen zum Thema ASP.NET und der Erstellung von Verzeichnissen.</key>
+		<key alias="permissionsSettingUpPermissions">Verzeichnisberechtigungen anpassen</key>
+		<key alias="permissionsText">Umbraco benötigt Schreibrechte auf verschiedene Verzeichnisse, um Dateien wie Bilder oder PDF-Dokumente speichern zu können. Außerdem werden temporäre Daten zur Leistungssteigerung der Website angelegt.</key>
+		<key alias="runwayFromScratch">Ich möchte mit einem leeren System ohne Inhalte und Vorgaben starten</key>
+		<key alias="runwayFromScratchText">
+			Die Website ist zur Zeit komplett leer und ohne Inhalte und Vorgaben zu Erstellung eigener Dokumenttypen und Vorlagen bereit.
+			(&lt;a href="https://umbraco.tv/documentation/videos/for-site-builders/foundation/document-types"&gt;So geht's&lt;/a&gt;)
+			Sie können "Runway" auch jederzeit später installieren. Verwenden Sie hierzu den Punkt "Pakete" im Entwickler-Bereich.
+		</key>
+		<key alias="runwayHeader">Die Einrichtung von Umbraco ist abgeschlossen und das Content-Management-System steht bereit. Wie soll es weitergehen?</key>
+		<key alias="runwayInstalled">'Runway' wurde installiert</key>
+		<key alias="runwayInstalledText">
+			Die Basis ist eingerichtet. Wählen Sie die Module aus, die Sie nun installieren möchten.&lt;br /&gt;
+			Dies sind unsere empfohlenen Module. Schauen Sie sich die an, die Sie installieren möchten oder Sie sich die &lt;a href="#" onclick="toggleModules(); return false;" id="toggleModuleList"&gt;komplette Liste der Module an.&lt;/a&gt;
+		</key>
+		<key alias="runwayOnlyProUsers">Nur für erfahrene Benutzer empfohlen</key>
+		<key alias="runwaySimpleSite">Ich möchte mit einer einfache Website starten</key>
+		<key alias="runwaySimpleSiteText">
+			&lt;p&gt;
+			"Runway" ist eine einfache Website mit einfachen Dokumententypen und Vorlagen. Der Installer kann Runway automatisch einrichten,
+			aber es kann einfach verändert, erweitert oder entfernt werden. Es ist nicht zwingend notwendig und Umbraco kann auch ohne Runway verwendet werden.
+			Runway bietet eine einfache Basis zum schnellen Start mit Umbraco.
+			Wenn Sie sich für Runway entscheiden, können Sie optional Blöcke nutzen, die "Runway Modules" und Ihre Runway-Seite erweitern.
+			&lt;/p&gt;
+			&lt;small&gt;
+			&lt;em&gt;Runway umfasst:&lt;/em&gt; Home page, Getting Started page, Installing Modules page.&lt;br /&gt;
+			&lt;em&gt;Optionale Module:&lt;/em&gt; Top Navigation, Sitemap, Contact, Gallery.
+			&lt;/small&gt;
+		</key>
+		<key alias="runwayWhatIsRunway">Was ist 'Runway'?</key>
+		<key alias="step1">Schritt 1/5 Lizenz</key>
+		<key alias="step2">Schritt 2/5: Datenbank</key>
+		<key alias="step3">Schritt 3/5: Dateiberechtigungen</key>
+		<key alias="step4">Schritt 4/5: Sicherheit</key>
+		<key alias="step5">Schritt 5/5: Umbraco ist startklar!</key>
+		<key alias="thankYou">Vielen Dank, dass Sie Umbraco installieren!</key>
+		<key alias="theEndBrowseSite">&lt;h3&gt;Zur neuen Seite&lt;/h3&gt;Sie haben Runway installiert, schauen Sie sich doch mal auf Ihrer Website um.</key>
+		<key alias="theEndFurtherHelp">&lt;h3&gt;Weitere Hilfe und Informationen&lt;/h3&gt;Hilfe von unserer preisgekrönten Community, Dokumentation und kostenfreie Videos, wie Sie eine einfache Website erstellen, ein Packages nutzen und eine schnelle Einführung in alle Umbraco-Begriffe</key>
+		<key alias="theEndHeader">Umbraco %0% wurde installiert und kann verwendet werden</key>
+		<key alias="theEndInstallSuccess">Sie können &lt;strong&gt;sofort starten&lt;/strong&gt;, in dem Sie auf "Umbraco starten" klicken.</key>
+		<key alias="theEndOpenUmbraco">&lt;h3&gt;Umbraco starten&lt;/h3&gt;Um Ihre Website zu verwalten, öffnen Sie einfach den Administrationsbereich und beginnen Sie damit, Inhalte hinzuzufügen sowie Vorlagen und Stylesheets zu bearbeiten oder neue Funktionen einzurichten</key>
+		<key alias="Unavailable">Verbindung zur Datenbank fehlgeschlagen.</key>
+		<key alias="Version3">Umbraco Version 3</key>
+		<key alias="Version4">Umbraco Version 4</key>
+		<key alias="watch">Anschauen</key>
+		<key alias="welcomeIntro">Dieser Assistent führt Sie durch die Einrichtung einer neuen Installation von &lt;strong&gt;Umbraco %0%&lt;/strong&gt; oder einem Upgrade von Version 3.0.&lt;br /&gt;&lt;br /&gt;Klicken Sie auf &lt;strong&gt;weiter&lt;/strong&gt;, um zu beginnen.</key>
+	</area>
+	<area alias="language">
+		<key alias="cultureCode">Kode der Kultur</key>
+		<key alias="displayName">Name der Kultur</key>
+	</area>
+	<area alias="lockout">
+		<key alias="lockoutWillOccur">Sie haben keine Tätigkeiten mehr durchgeführt und werden automatisch abgemeldet in</key>
+		<key alias="renewSession">Erneuern Sie, um Ihre Arbeit zu speichern ...</key>
+	</area>
+	<area alias="login">
+		<key alias="greeting0">Willkommen</key>
+		<key alias="greeting1">Willkommen</key>
+		<key alias="greeting2">Willkommen</key>
+		<key alias="greeting3">Willkommen</key>
+		<key alias="greeting4">Willkommen</key>
+		<key alias="greeting5">Willkommen</key>
+		<key alias="greeting6">Willkommen</key>
+		<key alias="instruction">Hier anmelden:</key>
+		<key alias="signInWith">Anmelden mit</key>
+		<key alias="timeout">Sitzung abgelaufen</key>
+		<key alias="bottomText">&lt;p style="text-align:right;"&gt;&amp;copy; 2001 - %0% &lt;br /&gt;&lt;a href="https://umbraco.com" style="text-decoration: none" target="_blank" rel="noopener"&gt;umbraco.org&lt;/a&gt;&lt;/p&gt; </key>
+		<key alias="forgottenPassword">Kennwort vergessen?</key>
+		<key alias="forgottenPasswordInstruction">Es wird eine E-Mail mit einem Kennwort-Zurücksetzen-Link an die angegebene Adresse geschickt.</key>
+		<key alias="requestPasswordResetConfirmation">Es wird eine E-Mail mit Anweisungen zum Zurücksetzen des Kennwortes an die angegebene Adresse geschickt sofern diese im Datenbestand gefunden wurde.</key>
+		<key alias="showPassword">Kennwort zeigen</key>
+		<key alias="hidePassword">Kennwort verbergen</key>
+		<key alias="returnToLogin">Zurück zur Anmeldung</key>
+		<key alias="setPasswordInstruction">Bitte wählen Sie ein neues Kennwort</key>
+		<key alias="setPasswordConfirmation">Ihr Kennwort wurde aktualisiert</key>
+		<key alias="resetCodeExpired">Der aufgerufene Link ist ungültig oder abgelaufen</key>
+		<key alias="resetPasswordEmailCopySubject">Umbraco: Kennwort zurücksetzen</key>
+		<key alias="resetPasswordEmailCopyFormat">
+			<![CDATA[
+<html>
+	<head>
+		<meta name='viewport' content='width=device-width'>
+		<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>
+	</head>
+	<body class='' style='font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; color: #392F54; line-height: 22px; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background: #1d1333; margin: 0; padding: 0;' bgcolor='#1d1333'>
+		<style type='text/css'> @media only screen and (max-width: 620px) {table[class=body] h1 {font-size: 28px !important; margin-bottom: 10px !important; } table[class=body] .wrapper {padding: 32px !important; } table[class=body] .article {padding: 32px !important; } table[class=body] .content {padding: 24px !important; } table[class=body] .container {padding: 0 !important; width: 100% !important; } table[class=body] .main {border-left-width: 0 !important; border-radius: 0 !important; border-right-width: 0 !important; } table[class=body] .btn table {width: 100% !important; } table[class=body] .btn a {width: 100% !important; } table[class=body] .img-responsive {height: auto !important; max-width: 100% !important; width: auto !important; } } .btn-primary table td:hover {background-color: #34495e !important; } .btn-primary a:hover {background-color: #34495e !important; border-color: #34495e !important; } .btn  a:visited {color:#FFFFFF;} </style>
+		<table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #1d1333;" bgcolor="#1d1333">
+			<tr>
+				<td style="font-family: sans-serif; font-size: 14px; vertical-align: top; padding: 24px;" valign="top">
+					<table style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+						<tr>
+							<td background="https://umbraco.com/umbraco/assets/img/application/logo.png" bgcolor="#1d1333" width="28" height="28" valign="top" style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
+								<!--[if gte mso 9]> <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:30px;height:30px;"> <v:fill type="tile" src="https://umbraco.com/umbraco/assets/img/application/logo.png" color="#1d1333" /> <v:textbox inset="0,0,0,0"> <![endif]-->
+								<div> </div>
+								<!--[if gte mso 9]> </v:textbox> </v:rect> <![endif]-->
+							</td>
+							<td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top"></td>
+						</tr>
+					</table>
+				</td>
+			</tr>
+		</table>
+		<table border='0' cellpadding='0' cellspacing='0' class='body' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #1d1333;' bgcolor='#1d1333'>
+			<tr>
+				<td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'> </td>
+				<td class='container' style='font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; max-width: 560px; width: 560px; margin: 0 auto; padding: 10px;' valign='top'>
+					<div class='content' style='box-sizing: border-box; display: block; max-width: 560px; margin: 0 auto; padding: 10px;'>
+						<br>
+						<table class='main' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; border-radius: 3px; background: #FFFFFF;' bgcolor='#FFFFFF'>
+							<tr>
+								<td class='wrapper' style='font-family: sans-serif; font-size: 14px; vertical-align: top; box-sizing: border-box; padding: 50px;' valign='top'>
+									<table border='0' cellpadding='0' cellspacing='0' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;'>
+										<tr>
+											<td style='line-height: 24px; font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'>
+												<h1 style='color: #392F54; font-family: sans-serif; font-weight: bold; line-height: 1.4; font-size: 24px; text-align: left; margin: 0 0 30px;' align='left'>
+													Das Zurücksetzen Ihres Kennwortes wurde angefordert
+												</h1>
+												<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+													Ihr Benutzername für das Umbraco-Administration lautet: <strong>%0%</strong>
+												</p>
+												<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+													<table border='0' cellpadding='0' cellspacing='0' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;'>
+														<tbody>
+															<tr>
+																<td style='font-family: sans-serif; font-size: 14px; vertical-align: top; border-radius: 5px; text-align: center; background: #35C786;' align='center' bgcolor='#35C786' valign='top'>
+																	<a href='%1%' target='_blank' rel='noopener' style='color: #FFFFFF; text-decoration: none; -ms-word-break: break-all; word-break: break-all; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; background: #35C786; margin: 0; padding: 12px 30px; border: 1px solid #35c786;'>
+																		Klicken Sie hier, um Ihr Kennwort zurück zu setzen
+																	</a>
+																</td>
+															</tr>
+														</tbody>
+													</table>
+												</p>
+												<p style='max-width: 400px; display: block; color: #392F54; font-family: sans-serif; font-size: 14px; line-height: 20px; font-weight: normal; margin: 15px 0;'>Wenn Sie den Link nicht klicken können, kopieren Sie den fogenden URL und fügen Sie ihn direkt im Browser-Fenster ein:</p>
+													<table border='0' cellpadding='0' cellspacing='0'>
+														<tr>
+															<td style='-ms-word-break: break-all; word-break: break-all; font-family: sans-serif; font-size: 11px; line-height:14px;'>
+																<font style="-ms-word-break: break-all; word-break: break-all; font-size: 11px; line-height:14px;">
+																	<a style='-ms-word-break: break-all; word-break: break-all; color: #392F54; text-decoration: underline; font-size: 11px; line-height:15px;' href='%1%'>%1%</a>
+																</font>
+															</td>
+														</tr>
+													</table>
+												</p>
+											</td>
+										</tr>
+									</table>
+								</td>
+							</tr>
+						</table>
+						<br><br><br>
+					</div>
+				</td>
+				<td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'> </td>
+			</tr>
+		</table>
+	</body>
+</html>
+	]]>
+		</key>
+	</area>
+	<area alias="main">
+		<key alias="dashboard">Dashboard</key>
+		<key alias="sections">Bereiche</key>
+		<key alias="tree">Inhalt</key>
+	</area>
+	<area alias="moveOrCopy">
+		<key alias="choose">Bitte Element auswählen ...</key>
+		<key alias="copyDone">%0% wurde nach %1% kopiert</key>
+		<key alias="copyTo">Bitte wählen Sie, wohin das Element %0% kopiert werden soll:</key>
+		<key alias="moveDone">%0% wurde nach %1% verschoben</key>
+		<key alias="moveTo">Bitte wählen Sie, wohin das Element %0% verschoben werden soll:</key>
+		<key alias="nodeSelected">wurde als das Ziel ausgewählt. Bestätigen mit 'Ok'.</key>
+		<key alias="noNodeSelected">Es ist noch kein Element ausgewählt. Bitte wählen Sie ein Element aus der Liste aus, bevor Sie fortfahren.</key>
+		<key alias="notAllowedByContentType">Das aktuelle Element kann aufgrund seines Dokumenttyps nicht an diese Stelle verschoben werden.</key>
+		<key alias="notAllowedByPath">Das ausgewählte Element kann nicht zu einem seiner eigenen Unterelemente verschoben werden.</key>
+		<key alias="notAllowedAtRoot">Dieses Element kann nicht auf der obersten Ebene platziert werden.</key>
+		<key alias="notValid">Diese Aktion ist nicht erlaubt, da Sie unzureichende Berechtigungen für mindestens ein untergeordnetes Element haben.</key>
+		<key alias="relateToOriginal">Kopierte Elemente mit dem Original verknüpfen</key>
+	</area>
+	<area alias="notifications">
+		<key alias="editNotifications">Bearbeiten Sie Ihre Benachrichtigungseinstellungen für '%0%'</key>
+		<key alias="notificationsSavedFor">Benachrichtigungseinstellungen wurden gesichert für</key>
+		<key alias="mailBody">
+			Hallo %0%,
+
+			die Aufgabe '%1%' (von Benutzer '%3%') an der Seite '%2%' wurde ausgeführt.
+
+			Zum Bearbeiten verwenden Sie bitte diesen Link: http://%4%/#/content/content/edit/%5%
+
+			Einen schönen Tag wünscht
+			Ihr freundlicher Umbraco-Robot
+		</key>
+		<key alias="mailBodyVariantSummary">Die folgenden Sprachen wurden geändert %0%</key>
+		<key alias="mailBodyHtml">
+			<![CDATA[
+    <html>
+	<head>
+		<meta name='viewport' content='width=device-width'>
+		<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>
+	</head>
+	<body class='' style='font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; color: #392F54; line-height: 22px; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background: #1d1333; margin: 0; padding: 0;' bgcolor='#1d1333'>
+		<style type='text/css'> @media only screen and (max-width: 620px) {table[class=body] h1 {font-size: 28px !important; margin-bottom: 10px !important; } table[class=body] .wrapper {padding: 32px !important; } table[class=body] .article {padding: 32px !important; } table[class=body] .content {padding: 24px !important; } table[class=body] .container {padding: 0 !important; width: 100% !important; } table[class=body] .main {border-left-width: 0 !important; border-radius: 0 !important; border-right-width: 0 !important; } table[class=body] .btn table {width: 100% !important; } table[class=body] .btn a {width: 100% !important; } table[class=body] .img-responsive {height: auto !important; max-width: 100% !important; width: auto !important; } } .btn-primary table td:hover {background-color: #34495e !important; } .btn-primary a:hover {background-color: #34495e !important; border-color: #34495e !important; } .btn  a:visited {color:#FFFFFF;} </style>
+		<table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #1d1333;" bgcolor="#1d1333">
+			<tr>
+				<td style="font-family: sans-serif; font-size: 14px; vertical-align: top; padding: 24px;" valign="top">
+					<table style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+						<tr>
+							<td background="https://umbraco.com/umbraco/assets/img/application/logo.png" bgcolor="#1d1333" width="28" height="28" valign="top" style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
+								<!--[if gte mso 9]> <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:30px;height:30px;"> <v:fill type="tile" src="https://umbraco.com/umbraco/assets/img/application/logo.png" color="#1d1333" /> <v:textbox inset="0,0,0,0"> <![endif]-->
+								<div> </div>
+								<!--[if gte mso 9]> </v:textbox> </v:rect> <![endif]-->
+							</td>
+							<td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top"></td>
+						</tr>
+					</table>
+				</td>
+			</tr>
+		</table>
+		<table border='0' cellpadding='0' cellspacing='0' class='body' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #1d1333;' bgcolor='#1d1333'>
+			<tr>
+				<td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'> </td>
+				<td class='container' style='font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; max-width: 560px; width: 560px; margin: 0 auto; padding: 10px;' valign='top'>
+					<div class='content' style='box-sizing: border-box; display: block; max-width: 560px; margin: 0 auto; padding: 10px;'>
+						<br>
+						<table class='main' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; border-radius: 3px; background: #FFFFFF;' bgcolor='#FFFFFF'>
+							<tr>
+								<td class='wrapper' style='font-family: sans-serif; font-size: 14px; vertical-align: top; box-sizing: border-box; padding: 50px;' valign='top'>
+									<table border='0' cellpadding='0' cellspacing='0' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;'>
+										<tr>
+											<td style='line-height: 24px; font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'>
+												<h1 style='color: #392F54; font-family: sans-serif; font-weight: bold; line-height: 1.4; font-size: 24px; text-align: left; text-transform: capitalize; margin: 0 0 30px;' align='left'>
+													Hallo %0%,
+												</h1>
+												<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+													Diese automatische E-Mail soll Sie informiern, dass die Aufgabe <strong>'%1%'</strong> auf Seite <a style="color: #392F54; text-decoration: none; -ms-word-break: break-all; word-break: break-all;" href="http://%4%/#/content/content/edit/%5%"><strong>'%2%'</strong></a> von Benutzer <strong>'%3%'</strong> ausgeführt wurde.
+												</p>
+												<table border='0' cellpadding='0' cellspacing='0' class='btn btn-primary' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; box-sizing: border-box;'>
+													<tbody>
+														<tr>
+															<td align='left' style='font-family: sans-serif; font-size: 14px; vertical-align: top; padding-bottom: 15px;' valign='top'>
+																<table border='0' cellpadding='0' cellspacing='0' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;'><tbody><tr>
+																	<td style='font-family: sans-serif; font-size: 14px; vertical-align: top; border-radius: 5px; text-align: center; background: #35C786;' align='center' bgcolor='#35C786' valign='top'>
+																		<a href='http://%4%/#/content/content/edit/%5%' target='_blank' rel='noopener' style='color: #FFFFFF; text-decoration: none; -ms-word-break: break-all; word-break: break-all; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; text-transform: capitalize; background: #35C786; margin: 0; padding: 12px 30px; border: 1px solid #35c786;'>Bearbeiten</a> </td> </tr></tbody></table>
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+													<h3>Zusammenfassung der Änderungen:</h3>
+													%6%
+												</p>
+												<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+													Einen schönen Tag wünscht<br />
+													<br />
+													Ihr freundlicher Umbraco-Robot
+												</p>
+											</td>
+										</tr>
+									</table>
+								</td>
+							</tr>
+						</table>
+						<br><br><br>
+					</div>
+				</td>
+				<td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'> </td>
+			</tr>
+		</table>
+	</body>
+</html>
+]]>
+		</key>
+		<key alias="mailBodyVariantHtmlSummary">
+			<![CDATA[<p>Folgende Sprachen wurden geändert:</p>
+        %0%
+    ]]>
+		</key>
+		<key alias="mailSubject">[%0%] Benachrichtigung: %1% ausgeführt an Seite '%2%' </key>
+		<key alias="notifications">Benachrichtigungen</key>
+	</area>
+	<area alias="packager">
+		<key alias="actions">Aktionen</key>
+		<key alias="created">Angelegt</key>
+		<key alias="createPackage">Neues Paket</key>
+		<key alias="chooseLocalPackageText">
+			<![CDATA[
+        Wählen Sie ein Paket auf Ihrem lokalen Computer über "Datei auswählen" aus. <br />
+    Umbraco-Pakete besitzen üblicherweise die Dateiendungen ".umb" oder ".zip".
+      ]]>
+		</key>
+		<key alias="deletewarning">Diese Aktion entfernt das Paket</key>
+		<key alias="includeAllChildNodes">Alle Unterknoten einschließen</key>
+		<key alias="installed">Installiert</key>
+		<key alias="installedPackages">Installierte Pakete</key>
+		<key alias="noConfigurationView">Diese Paket hat keine Einstellungen</key>
+		<key alias="noPackagesCreated">Es wurden noche keine Pakete angelegt</key>
+		<key alias="noPackages">Sie haben keine Pakete installiert</key>
+		<key alias="noPackagesDescription">
+			<![CDATA[
+    Sie haben keine Pakete installiert.
+    Sie können entweder ein Paket von Ihrem Computer wählen oder suchen in den vorhandenen Paketen (via Klick auf Bildsymbol
+    <strong>'Pakete'</strong> rechts, oben), um es zu installieren
+    ]]>
+		</key>
+		<key alias="packageContent">Paketinhalt</key>
+		<key alias="packageLicense">Lizenz</key>
+		<key alias="packageSearch">Paket suchen</key>
+		<key alias="packageSearchResults">Ergebnis(se) für</key>
+		<key alias="packageNoResults">Keine Ergebnisse für</key>
+		<key alias="packageNoResultsDescription">Bitte versuchen Sie einen anderen Begriff oder stöbern Sie in den Kategorien</key>
+		<key alias="packagesPopular">Beliebt</key>
+		<key alias="packagesNew">Neue Veröffentlichungen</key>
+		<key alias="packageHas">hat</key>
+		<key alias="packageKarmaPoints">Karma Punkte</key>
+		<key alias="packageInfo">Information</key>
+		<key alias="packageOwner">Besitzer</key>
+		<key alias="packageContrib">Beitragende</key>
+		<key alias="packageCreated">Angelegt</key>
+		<key alias="packageCurrentVersion">Aktuelle Version</key>
+		<key alias="packageNetVersion">.NET Version</key>
+		<key alias="packageDownloads">Heruntergeladenes</key>
+		<key alias="packageLikes">Likes</key>
+		<key alias="packageCompatibility">Kompatibilität</key>
+		<key alias="packageCompatibilityDescription">
+			Dieses Paket ist nach Berichten von Community-Mitgliedern mit folgenden Umbraco-Version kompatibel.
+			Es kann keine vollständige Kompatibilität garantiert werden für Versionen mit weniger als 100% Bewertungen.
+		</key>
+		<key alias="packageExternalSources">Externe Quellen</key>
+		<key alias="packageAuthor">Autor</key>
+		<key alias="packageDocumentation">Dokumentation</key>
+		<key alias="packageMetaData">Paket-Meta-Daten</key>
+		<key alias="packageName">Name des Pakets</key>
+		<key alias="packageNoItemsHeader">Paket enthält keine Elemente</key>
+		<key alias="packageNoItemsText">
+			<![CDATA[Die Paket-Datei enthält keine Elemente die deinstalliert werden können.<br/><br/>
+    Sie können das Paket ohne Gefahr deinstallieren indem Sie "Paket deinstallieren" anklicken.]]>
+		</key>
+		<key alias="packageOptions">Paket-Optionen</key>
+		<key alias="packageReadme">Informationen zum Paket</key>
+		<key alias="packageRepository">Paket-Repository</key>
+		<key alias="packageUninstallConfirm">Deinstallation bestätigen</key>
+		<key alias="packageUninstalledHeader">Paket wurde deinstalliert</key>
+		<key alias="packageUninstalledText">Das Paket wurde erfolgreich deinstalliert</key>
+		<key alias="packageUninstallHeader">Paket deinstallieren</key>
+		<key alias="packageUninstallText">
+			<![CDATA[Sie können einzelne Elemente, die Sie nicht deinstallieren möchten, unten abwählen.
+    Wenn Sie "Deinstallation bestätigen" klicken, werden alle markierten Elemente entfernt.<br />
+    <span style="color: Red; font-weight: bold;">Achtung:</span> alle Dokumente, Medien, etc, die von den zu entfernenden Elementen abhängen,
+    werden nicht mehr funktionieren und im Zweifelsfall kann dass gesamte CMS instabil werden.
+    Bitte deinstallieren Sie also mit Vorsicht. Falls Sie unsicher sind, kontaktieren Sie den Autor des Pakets.]]>
+		</key>
+		<key alias="packageVersion">Paketversion</key>
+		<key alias="verifiedToWorkOnUmbracoCloud">Bestätigt auf Umbraco Cloud zu funktioneren</key>
+	</area>
+	<area alias="paste">
+		<key alias="doNothing">Einfügen mit Formatierung (Nicht empfohlen)</key>
+		<key alias="errorMessage">Der Text, den Sie einfügen möchten, enthält Sonderzeichen oder spezielle Formatierungen. Dies kann zum Beispiel beim Kopieren aus Microsoft Word heraus passieren. Umbraco kann Sonderzeichen und spezielle Formatierungen automatisch entfernen, damit der eingefügte Inhalt besser für die Veröffentlichung im Web geeignet ist.</key>
+		<key alias="removeAll">Als reinen Text ohne jede Formatierung einfügen</key>
+		<key alias="removeSpecialFormattering">Einfügen, aber Formatierung bereinigen (Empfohlen)</key>
+	</area>
+	<area alias="publicAccess">
+		<key alias="paGroups">Rollenbasierter Zugriffschutz</key>
+		<key alias="paGroupsHelp">Wenn Sie rollenbasierte Authentifikation mit Umbraco-Mitgliedsgruppen verwenden wollen.</key>
+		<key alias="paGroupsNoGroups">Sie müssen zuerst eine Mitgliedsgruppe erstellen, bevor derrollenbasierte Zugriffschutz aktiviert werden kann.</key>
+		<key alias="paErrorPage">Fehlerseite</key>
+		<key alias="paErrorPageHelp">Seite mit Fehlermeldung (Benutzer-Login erfolgt, aber keinen Zugriff auf die aufgerufene Seite erlaubt)</key>
+		<key alias="paHowWould">Bitte wählen Sie, auf welche Art der Zugriff auf diese Seite geschützt werden soll</key>
+		<key alias="paIsProtected">%0% ist nun zugriffsgeschützt</key>
+		<key alias="paIsRemoved">Zugriffsschutz von %0% entfernt</key>
+		<key alias="paLoginPage">Login-Seite</key>
+		<key alias="paLoginPageHelp">Seite mit Login-Formular</key>
+		<key alias="paRemoveProtection">Zugriffsschutz entfernen</key>
+		<key alias="paRemoveProtectionConfirm">
+			<![CDATA[
+    Möchten Sie den Schutz der Seite <strong>%0%</strong> wirklich entfernen?
+    ]]>
+		</key>
+		<key alias="paSelectPages">Auswahl der Seiten, die das Login-Formular und die Fehlermeldung enthalten</key>
+		<key alias="paSelectGroups">
+			Auswahl der Benutzergruppen, die Zugriff auf Seite <strong>%0%</strong> haben sollen
+		</key>
+		<key alias="paSelectMembers"><![CDATA[Wählen Sie die Mitglieder, die Zugriff auf Seite <strong>%0%</strong> haben sollen.]]></key>
+		<key alias="paMembers">Mitglieder basierte Zugriffsberechtigung</key>
+		<key alias="paMembersHelp">Falls Sie Mitglieder basierte Zugriffsberechtigung gewähren wollen</key>
+	</area>
+	<area alias="publish">
+		<key alias="invalidPublishBranchPermissions">Die Zugriffsrechte des Benutzers sind ungenügend, um alle Unterknoten zu veröffentlichen</key>
+		<key alias="contentPublishedFailedIsTrashed">
+			<![CDATA[
+      %0% konnte nicht veröffentlicht werden, weil das Element im Papierkorb ist.
+    ]]>
+		</key>
+		<key alias="contentPublishedFailedAwaitingRelease">
+			%0% kann nicht veröffentlicht werden, da die Veröffentlichung zeitlich geplant ist.
+		</key>
+		<key alias="contentPublishedFailedExpired">
+			<![CDATA[
+    %0% konnte nicht veröffentlicht werden, weil das Element abgelaufen ist.
+    ]]>
+		</key>
+		<key alias="contentPublishedFailedInvalid">
+			<![CDATA[
+    %0% konnte nicht veröffentlicht werden, weil einige Eigenschaften ungültig sind.
+    ]]>
+		</key>
+		<key alias="contentPublishedFailedByEvent">
+			%0% konnte nicht veröffentlicht werden, da ein Plug-In die Aktion abgebrochen hat.
+		</key>
+		<key alias="contentPublishedFailedByParent">
+			%0% kann nicht veröffentlicht werden, da das übergeordnete Dokument nicht veröffentlicht ist.
+		</key>
+		<key alias="includeUnpublished">Unveröffentlichte Unterelemente einschließen</key>
+		<key alias="inProgress">Bitte warten, Veröffentlichung läuft...</key>
+		<key alias="inProgressCounter">%0% Elemente veröffentlicht, %1% Elemente ausstehend ...</key>
+		<key alias="nodePublish">%0% wurde veröffentlicht</key>
+		<key alias="nodePublishAll">%0% und die untergeordneten Elemente wurden veröffentlicht</key>
+		<key alias="publishAll">%0% und alle untergeordneten Elemente veröffentlichen</key>
+		<key alias="publishHelp">
+			<![CDATA[
+    Klicken Sie <em>Sichern und Veröffentlichen</em>, um <strong>%0%</strong> zu veröffentlicht und auf der Website sichtbar zu machen.<br><br>
+    Sie können dieses Element mitsamt seinen untergeordneten Elementen veröffentlichen, indem Sie <em>Unveröffentlichte Unterelemente einschließen</em> markieren.
+    ]]>
+		</key>
+	</area>
+	<area alias="colorpicker">
+		<key alias="noColors">Sie haben keine freigegeben Farben konfiguriert</key>
+	</area>
+	<area alias="contentPicker">
+		<key alias="allowedItemTypes">Sie können nur Elemente folgender Typen wählen: %0%</key>
+		<key alias="pickedTrashedItem">Sie haben ein entferntes oder im Papierkorb befindliches Inhaltselement ausgewählt</key>
+		<key alias="pickedTrashedItems">Sie haben entfernte oder im Papierkorb befindliche Inhaltselemente ausgewählt</key>
+	</area>
+	<area alias="mediaPicker">
+		<key alias="deletedItem">Element entfernen</key>
+		<key alias="pickedTrashedItem">Sie haben ein entferntes oder im Papierkorb befindliches Medienelement ausgewählt</key>
+		<key alias="pickedTrashedItems">Sie haben entfernte oder im Papierkorb befindliche medienelemente ausgewählt</key>
+		<key alias="trashed">Verworfen</key>
+		<key alias="openMedia">Medien öffnen</key>
+		<key alias="changeMedia">Medientyp ändern</key>
+		<key alias="editMediaEntryLabel">Ändere %0% auf %1%</key>
+		<key alias="confirmCancelMediaEntryCreationHeadline">Erstellen abbrechen?</key>
+		<key alias="confirmCancelMediaEntryCreationMessage"><![CDATA[Sind Sie sich sicher das Sie das Erstellen abbrechen wollen?]]></key>
+		<key alias="confirmCancelMediaEntryHasChanges">
+			Sie haben Änderungen an diesem Inhalt vorgenommen. Sind Sie sich sicher das Sie
+			diese verwerfen wollen?
+		</key>
+		<key alias="confirmRemoveAllMediaEntryMessage">Alle Medien löschen?</key>
+		<key alias="tabClipboard">Clipboard</key>
+		<key alias="notAllowed">Nicht erlaubt</key>
+		<key alias="openMediaPicker">Medienpicker öffnen</key>
+	</area>
+	<area alias="propertyEditorPicker">
+		<key alias="title">Wählen Sie einen Editor</key>
+		<key alias="openPropertyEditorPicker">Editor auswählen</key>
+	</area>
+	<area alias="relatedlinks">
+		<key alias="enterExternal">Externen Link eingeben</key>
+		<key alias="chooseInternal">Internen Link auswählen</key>
+		<key alias="caption">Beschriftung</key>
+		<key alias="link">Link</key>
+		<key alias="newWindow">In neuem Fenster öffnen</key>
+		<key alias="captionPlaceholder">Bezeichnung eingeben</key>
+		<key alias="externalLinkPlaceholder">Link eingeben</key>
+	</area>
+	<area alias="imagecropper">
+		<key alias="reset">Zurücksetzen</key>
+		<key alias="updateEditCrop">Fertig</key>
+		<key alias="undoEditCrop">Rückgängig machen</key>
+		<key alias="customCrop">Benutzer definiert</key>
+	</area>
+	<area alias="rollback">
+		<key alias="changes">Änderungen</key>
+		<key alias="created">Erstellt</key>
+		<key alias="headline">Wählen Sie eine Version, um diese mit der aktuellen zu vergleichen</key>
+		<key alias="currentVersion">Aktuelle Version</key>
+		<key alias="diffHelp">Zeigt die Unterschiede zwischen der aktuellen und der ausgewählten Version an.&lt;br /&gt;Text in &lt;del&gt;rot&lt;/del&gt; fehlen in der ausgewählten Version, &lt;ins&gt;grün&lt;/ins&gt; markierter Text wurde hinzugefügt.</key>
+		<key alias="noDiff">Keine Unterschiede zwischen den beiden Versionen gefunden.</key>
+		<key alias="documentRolledBack">Dokument wurde zurückgesetzt</key>
+		<key alias="htmlHelp">Zeigt die ausgewählte Version als HTML an. Wenn Sie sich die Unterschiede zwischen zwei Versionen anzeigen lassen wollen, benutzen Sie bitte die Vergleichsansicht.</key>
+		<key alias="rollbackTo">Zurücksetzen auf</key>
+		<key alias="selectVersion">Version auswählen</key>
+		<key alias="view">Ansicht</key>
+		<key alias="pagination"><![CDATA[Zeige Versionen von %0% zu %1% von %2% Versionen]]></key>
+		<key alias="versions">Versionen</key>
+		<key alias="currentDraftVersion">Aktulle Bearbeitungs Version</key>
+		<key alias="currentPublishedVersion">Aktulle veröffentlichte Version</key>
+	</area>
+	<area alias="scripts">
+		<key alias="editscript">Skript bearbeiten</key>
+	</area>
+	<area alias="sections">
+		<key alias="content">Inhalte</key>
+		<key alias="forms">Formulare</key>
+		<key alias="media">Medien</key>
+		<key alias="member">Mitglieder</key>
+		<key alias="packages">Pakete</key>
+		<key alias="settings">Einstellungen</key>
+		<key alias="translation">Übersetzung</key>
+		<key alias="users">Benutzer</key>
+	</area>
+	<area alias="help">
+		<key alias="tours">Touren</key>
+		<key alias="theBestUmbracoVideoTutorials">Die besten Umbraco-Video-Tutorials</key>
+		<key alias="umbracoForum">Besuche our.umbraco.com</key>
+		<key alias="umbracoTv">Besuche umbraco.tv</key>
+		<key alias="umbracoLearningBase">Schaue gratis Tutorials</key>
+		<key alias="umbracoLearningBaseDescription">von Umbraco Learning Base</key>
+	</area>
+	<area alias="settings">
+		<key alias="defaulttemplate">Standardvorlage</key>
+		<key alias="importDocumentTypeHelp">Wählen Sie die lokale .udt-Datei aus, die den zu importierenden Dokumenttyp enthält und fahren Sie mit dem Import fort. Die endgültige Übernahme erfolgt im Anschluss erst nach einer weiteren Bestätigung.</key>
+		<key alias="newtabname">Beschriftung der neuen Registerkarte</key>
+		<key alias="nodetype">Elementtyp</key>
+		<key alias="objecttype">Typ</key>
+		<key alias="stylesheet">Stylesheet</key>
+		<key alias="script">Skript</key>
+		<key alias="tab">Registerkarte</key>
+		<key alias="tabname">Registerkartenbeschriftung</key>
+		<key alias="tabs">Registerkarten</key>
+		<key alias="contentTypeEnabled">Masterdokumenttyp aktiviert</key>
+		<key alias="contentTypeUses">Dieser Dokumenttyp verwendet</key>
+		<key alias="noPropertiesDefinedOnTab">Für dieses Register sind keine Eigenschaften definiert. Klicken Sie oben auf "neue Eigenschaft hinzufügen", um eine neue Eigenschaft hinzuzufügen.</key>
+		<key alias="createMatchingTemplate">Zugehörige Vorlage anlegen</key>
+		<key alias="addIcon">Bildsymbol hinzufügen</key>
+	</area>
+	<area alias="sort">
+		<key alias="sortOrder">Sortierreihenfolge</key>
+		<key alias="sortCreationDate">Erstellungsdatum</key>
+		<key alias="sortDone">Sortierung abgeschlossen.</key>
+		<key alias="sortHelp">Ziehen Sie die Elemente an ihre gewünschte neue Position.</key>
+		<key alias="sortPleaseWait">Bitte warten, die Seiten werden sortiert. Das kann einen Moment dauern.</key>
+		<key alias="sortEmptyState">Dieser Knoten hat keine Unterknoten zum Sortieren</key>
+	</area>
+	<area alias="speechBubbles">
+		<key alias="validationFailedHeader">Validierung</key>
+		<key alias="validationFailedMessage">Validierungsfehler müssen behoben werden, bevor das Element gesichert werden kann</key>
+		<key alias="operationFailedHeader">Fehlgeschlagen</key>
+		<key alias="operationSavedHeader">Gesichert</key>
+		<key alias="invalidUserPermissionsText">Unzureichende Benutzerberechtigungen. Vorgang kann nicht abgeschlossen werden.</key>
+		<key alias="operationCancelledHeader">Abgebrochen</key>
+		<key alias="operationCancelledText">Vorgang wurde durch eine benutzerdefinierte Erweiterung abgebrochen</key>
+		<key alias="contentTypeDublicatePropertyType">Eigenschaft existiert bereits</key>
+		<key alias="contentTypePropertyTypeCreated">Eigenschaft erstellt</key>
+		<key alias="contentTypePropertyTypeCreatedText">Name: %0%  Datentyp: %1%</key>
+		<key alias="contentTypePropertyTypeDeleted">Eigenschaft gelöscht</key>
+		<key alias="contentTypeSavedHeader">Dokumenttyp gespeichert</key>
+		<key alias="contentTypeTabCreated">Registerkarte erstellt</key>
+		<key alias="contentTypeTabDeleted">Registerkarte gelöscht</key>
+		<key alias="contentTypeTabDeletedText">Registerkarte %0% gelöscht</key>
+		<key alias="cssErrorHeader">Stylesheet wurde nicht gespeichert</key>
+		<key alias="cssSavedHeader">Stylesheet gespeichert</key>
+		<key alias="cssSavedText">Stylesheet erfolgreich gespeichert</key>
+		<key alias="dataTypeSaved">Datentyp gespeichert</key>
+		<key alias="dictionaryItemSaved">Wörterbucheintrag gespeichert</key>
+		<key alias="editContentPublishedHeader">Inhalt veröffentlicht</key>
+		<key alias="editContentPublishedText">und ist auf der Website sichtbar</key>
+		<key alias="editMultiContentPublishedText">%0% Documente veröffentlicht und auf der Website sichtbar</key>
+		<key alias="editVariantPublishedText">%0% veröffentlicht und auf der Website sichtbar</key>
+		<key alias="editMultiVariantPublishedText">%0% Documente veröffentlicht in Sprache %1% und auf der Website sichtbar</key>
+		<key alias="editContentSavedHeader">Inhalte gespeichert</key>
+		<key alias="editContentSavedText">Denken Sie daran, die Inhalte zu veröffentlichen, um die Änderungen sichtbar zu machen</key>
+		<key alias="editContentScheduledSavedText">Der Termin für die Veröffentlichung wurde geändert</key>
+		<key alias="editVariantSavedText">%0% gesichert</key>
+		<key alias="editContentSendToPublish">Zur Abnahme eingereicht</key>
+		<key alias="editContentSendToPublishText">Die Änderungen wurden zur Abnahme eingereicht</key>
+		<key alias="editVariantSendToPublishText">%0% Änderungen wurden zur Abnahme eingereicht</key>
+		<key alias="editMediaSaved">Medium gespeichert</key>
+		<key alias="editMediaSavedText">Medium fehlerfrei gespeichert</key>
+		<key alias="editMemberSaved">Mitglied gespeichert</key>
+		<key alias="editStylesheetPropertySaved">Stylesheet-Regel gespeichert</key>
+		<key alias="editStylesheetSaved">Stylesheet gespeichert</key>
+		<key alias="editTemplateSaved">Vorlage gespeichert</key>
+		<key alias="editUserError">Fehler beim Speichern des Benutzers.</key>
+		<key alias="editUserSaved">Benutzer gespeichert</key>
+		<key alias="editUserTypeSaved">Benutzertyp gepsichert</key>
+		<key alias="editUserGroupSaved">Benutzergruppe gepsichert</key>
+		<key alias="fileErrorHeader">Datei wurde nicht gespeichert</key>
+		<key alias="fileErrorText">Datei konnte nicht gespeichert werden. Bitte überprüfen Sie die Schreibrechte auf Dateiebene.</key>
+		<key alias="fileSavedHeader">Datei gespeichert</key>
+		<key alias="fileSavedText">Datei erfolgreich gespeichert</key>
+		<key alias="languageSaved">Sprache gespeichert</key>
+		<key alias="mediaTypeSavedHeader">Medientyp gespeichert</key>
+		<key alias="memberTypeSavedHeader">Mitgliedertyp gespeichert</key>
+		<key alias="memberGroupSavedHeader">Mitgliedergruppe gespeichert</key>
+		<key alias="templateErrorHeader">Vorlage wurde nicht gespeichert</key>
+		<key alias="templateErrorText">Bitte prüfen Sie, ob möglicherweise zwei Vorlagen den gleichen Alias verwenden.</key>
+		<key alias="templateSavedHeader">Vorlage gespeichert</key>
+		<key alias="templateSavedText">Vorlage erfolgreich gespeichert!</key>
+		<key alias="contentUnpublished">Veröffentlichung des Inhalts aufgehoben</key>
+		<key alias="contentCultureUnpublished">Inhaltsvariante %0% unveröffentlicht</key>
+		<key alias="contentMandatoryCultureUnpublished">Die Veröffentlichung der Pflichtsprache '%0%' wurde zurück genommen. Das gleiche gilt für alle Sprachen dieses Inhalts.</key>
+		<key alias="partialViewSavedHeader">Partielle Ansicht gespeichert</key>
+		<key alias="partialViewSavedText">Partielle Ansicht ohne Fehler gespeichert.</key>
+		<key alias="partialViewErrorHeader">Partielle Ansicht nicht gespeichert</key>
+		<key alias="partialViewErrorText">Fehler beim Speichern der Datei.</key>
+		<key alias="permissionsSavedFor">Berechtigungen gesichert für</key>
+		<key alias="deleteUserGroupsSuccess">%0% Benutzergruppen entfernt</key>
+		<key alias="deleteUserGroupSuccess">%0% wurde entfernt</key>
+		<key alias="enableUsersSuccess">%0% Benutzer aktiviert</key>
+		<key alias="disableUsersSuccess">%0% Benutzer deaktiviert</key>
+		<key alias="enableUserSuccess">%0% ist jetzt aktiviert</key>
+		<key alias="disableUserSuccess">%0% ist jetzt deaktiviert</key>
+		<key alias="setUserGroupOnUsersSuccess">Benutzergruppen wurden gesetzt</key>
+		<key alias="unlockUsersSuccess">%0% Benutzer freigegeben</key>
+		<key alias="unlockUserSuccess">%0% ist jetzt freigegeben</key>
+		<key alias="memberExportedSuccess">Mitglied wurde in Datei exportiert</key>
+		<key alias="memberExportedError">Beim Exportieren des Mitglieds trat ein Fehler auf</key>
+		<key alias="deleteUserSuccess">Benutzer %0% wurde entfernt</key>
+		<key alias="resendInviteHeader">Benutzer einladen</key>
+		<key alias="resendInviteSuccess">Einladung wurde erneut an %0% geschickt</key>
+		<key alias="contentReqCulturePublishError">Das Dokument kann nicht veröffentlicht werden, solange '%0%' nicht veröffentlicht wurde</key>
+		<key alias="contentCultureValidationError">Validierung fehlgeschlagen für Sprache '%0%'</key>
+		<key alias="documentTypeExportedSuccess">Dokumenttyp wurde in eine Datei exportiert</key>
+		<key alias="documentTypeExportedError">Beim Exportieren des Dokumenttyps trat ein Fehler auf</key>
+		<key alias="scheduleErrReleaseDate1">Das Veröffentlichungsdatum kann nicht in der Vergangenheit liegen</key>
+		<key alias="scheduleErrReleaseDate2">Die Veröffentlichung kann nicht eingeplant werden, solange '%0%' (benötigt) nicht veröffentlicht wurde</key>
+		<key alias="scheduleErrReleaseDate3">Die Veröffentlichung kann nicht eingeplant werden, solange '%0%' (benötigt) ein späteres Veröffentlichungsdatum hat als eine optionale Sprache</key>
+		<key alias="scheduleErrExpireDate1">Das Ablaufdatum darf nicht in der Vergangenheit liegen</key>
+		<key alias="scheduleErrExpireDate2">Das Ablaufdatum darf nicht vor dem Veröffentlichungsdatum liegen</key>
+	</area>
+	<area alias="stylesheet">
+		<key alias="addRule">Neuer Stil</key>
+		<key alias="editRule">Stil bearbeiten</key>
+		<key alias="editorRules">Rich text editor Stile</key>
+		<key alias="editorRulesHelp">Definiere die Styles, die im Rich-Text-Editor dieses Stylesheets verfügbar sein sollen.</key>
+		<key alias="editstylesheet">Stylesheet bearbeiten</key>
+		<key alias="editstylesheetproperty">Stylesheet-Regel bearbeiten</key>
+		<key alias="nameHelp">Bezeichnung im Auswahlmenü des Rich-Text-Editors  </key>
+		<key alias="preview">Vorschau</key>
+		<key alias="previewHelp">So wird der Text im Rich-Text-Editor aussehen.</key>
+		<key alias="selector">Selector</key>
+		<key alias="selectorHelp">Benutze CSS Syntax, z. B.: "h1" oder ".redHeader"</key>
+		<key alias="styles">Stile</key>
+		<key alias="stylesHelp">Die CSS-Auszeichnungen, die im Rich-Text-Editor verwendet werden soll, z. B.: "color:red;"</key>
+		<key alias="tabCode">Kode</key>
+		<key alias="tabRules">Rich Text Editor</key>
+	</area>
+	<area alias="template">
+		<key alias="deleteByIdFailed">Beim Entfernen der Vorlage mit Id %0% trat ein Fehler auf</key>
+		<key alias="edittemplate">Vorlage bearbeiten</key>
+		<key alias="insertSections">Bereich</key>
+		<key alias="insertContentArea">Platzhalter-Bereich verwenden</key>
+		<key alias="insertContentAreaPlaceHolder">Platzhalter einfügen</key>
+		<key alias="insert">Einfügen</key>
+		<key alias="insertDesc">Wählen Sie, was in die Vorlage eingefügt werden soll</key>
+		<key alias="insertDictionaryItem">Wörterbucheintrag einfügen</key>
+		<key alias="insertDictionaryItemDesc">Ein Wörterbuchelement ist ein Platzhalter für lokalisierbaren Text. Das macht es einfach mehrsprachige Websites zu gestalten.</key>
+		<key alias="insertMacro">Makro</key>
+		<key alias="insertMacroDesc">
+			Ein Makro ist eine konfigurierbare Komponente, die großartig
+			für wiederverwendbare Teile Ihres Entwurfes sind,
+			für welche Sie optionale Parameter benötigen, wie z. B. Galerien, Formulare oder Listen.
+		</key>
+		<key alias="insertPageField">Umbraco-Feld</key>
+		<key alias="insertPageFieldDesc">
+			Zeigt den Wert eines benannten Feldes der aktuellen Seite an, mit der Möglichkeit den Wert zu verändern
+			oder einen alternativen Ersatzwert zu wählen.
+		</key>
+		<key alias="insertPartialView">Teilansicht (Partial View)</key>
+		<key alias="insertPartialViewDesc">
+			Eine Teilansicht ist eine eigenständige Vorlagen-Datei, die innerhalb einer anderen Vorlage verwendet werden kann.
+			Sie ist gut geeignet, um "Markup"-Kode wiederzuverwenden oder komplexe Vorlagen in mehrere Dateien aufzuteilen.
+		</key>
+		<key alias="mastertemplate">Basisvorlage</key>
+		<key alias="noMaster">Keine Basis</key>
+		<key alias="renderBody">Untergeordnete Vorlage einfügen</key>
+		<key alias="renderBodyDesc">
+			<![CDATA[
+      Verarbeitet den Inhalt einer untergeordneten Vorlage durch
+      Einfügen eines <code>@RenderBody()</code> Platzhalters.
+      ]]>
+		</key>
+		<key alias="defineSection">Definiert einen benannten Bereich</key>
+		<key alias="defineSectionDesc">
+			<![CDATA[
+      Definiert einen Teil Ihrer Vorlage als benannten Bereich durch Umschließen mit <code>@section { ... }</code>.
+      Dieser benannte Bereich kann in der übergeordneten Vorlage
+      durch Verwendung von <code>@RenderSection</code> eingefügt werden.
+      ]]>
+		</key>
+		<key alias="renderSection">Füge einen benannten Bereich ein</key>
+		<key alias="renderSectionDesc">
+			<![CDATA[
+      Fügt einen benannten Bereich einer untergeordneten Vorlage durch Verwendung des Platzhalters <code>@RenderSection(name)</code> ein.
+      Dies verarbeitet einen benannten Bereich einer untergeordneten Vorlage, der mit <code>@section [name]{ ... }</code> umschlossen, definiert wurde.
+      ]]>
+		</key>
+		<key alias="sectionName">Bereichsname</key>
+		<key alias="sectionMandatory">Bereich ist notwendig</key>
+		<key alias="sectionMandatoryDesc">
+			<![CDATA[
+      Wenn notwendig, dann muss die untergeordnete Vorlage eine <code>@section</code> Definition gleichen Namens enthalten,
+      anderfalls tritt ein Fehler auf.
+    ]]>
+		</key>
+		<key alias="queryBuilder">Abfrage-Generator</key>
+		<key alias="itemsReturned">zurückgegebene Elemente, in</key>
+		<key alias="iWant">Ich möchte</key>
+		<key alias="allContent">den ganzen Inhalt</key>
+		<key alias="contentOfType">Inhalt vom Typ "%0%"</key>
+		<key alias="from">von</key>
+		<key alias="websiteRoot">meiner website</key>
+		<key alias="where">wobei</key>
+		<key alias="and">und</key>
+		<key alias="is">ist</key>
+		<key alias="isNot">ist nicht</key>
+		<key alias="before">vor</key>
+		<key alias="beforeIncDate">vor (inkl. gewähltes Datum)</key>
+		<key alias="after">nach</key>
+		<key alias="afterIncDate">nach (inkl. gewähltes Datum)</key>
+		<key alias="equals">gleich</key>
+		<key alias="doesNotEqual">ungleich</key>
+		<key alias="contains">enthält</key>
+		<key alias="doesNotContain">ohne</key>
+		<key alias="greaterThan">größer als</key>
+		<key alias="greaterThanEqual">größer als oder gleich</key>
+		<key alias="lessThan">weniger als</key>
+		<key alias="lessThanEqual">weniger als oder gleich</key>
+		<key alias="id">Id</key>
+		<key alias="name">Name</key>
+		<key alias="createdDate">Datum der Erzeugung</key>
+		<key alias="lastUpdatedDate">Datum der letzten Aktualisierung</key>
+		<key alias="orderBy">sortiert nach</key>
+		<key alias="ascending">aufsteigend</key>
+		<key alias="descending">absteigend</key>
+		<key alias="template">Vorlage</key>
+	</area>
+	<area alias="grid">
+		<key alias="media">Image</key>
+		<key alias="macro">Macro</key>
+		<key alias="insertControl">Neues Element</key>
+		<key alias="chooseLayout">Layout auswählen</key>
+		<key alias="addRows">Neue Zeile</key>
+		<key alias="addElement">Neuer Inhalt</key>
+		<key alias="dropElement">Inhalt entfernen</key>
+		<key alias="settingsApplied">Einstellungen anwenden</key>
+		<key alias="contentNotAllowed"><![CDATA[Dieser Inhalt ist hier <strong>nicht</strong> zugelassen]]></key>
+		<key alias="contentAllowed">Dieser Inhalt ist hier zugelassen</key>
+		<key alias="clickToEmbed">Klicken, um Inhalt einzubetten</key>
+		<key alias="clickToInsertImage">Klicken, um Abbildung einzufügen</key>
+		<key alias="placeholderWriteHere">Hier schreiben ...</key>
+		<key alias="gridLayouts">Layouts</key>
+		<key alias="gridLayoutsDetail">Layouts sind die grundlegenden Arbeitsflächen für das Gestaltungsraster. Üblicherweise sind nicht mehr als ein oder zwei Layouts nötig.</key>
+		<key alias="addGridLayout">Layout hinzufügen</key>
+		<key alias="addGridLayoutDetail">Passen Sie das Layout an, indem Sie die Spaltenbreiten einstellen und Abschnitte hinzufügen.</key>
+		<key alias="rowConfigurations">Einstellungen für das Zeilenlayout</key>
+		<key alias="rowConfigurationsDetail">Zeilen sind vordefinierte horizontale Zellenanordnungen</key>
+		<key alias="addRowConfiguration">Zeilenlayout hinzufügen</key>
+		<key alias="addRowConfigurationDetail">Passen Sie das Zeilenlayout an, indem Sie die Zellenbreite einstellen und Zellen hinzufügen.</key>
+		<key alias="columns">Spalten</key>
+		<key alias="columnsDetails">Insgesamte Spaltenanzahl im Layout</key>
+		<key alias="settings">Einstellungen</key>
+		<key alias="settingsDetails">Legen Sie fest, welche Einstellungen die Autoren anpassen können.</key>
+		<key alias="styles">CSS-Stile</key>
+		<key alias="stylesDetails">Legen Sie fest, welche Stile die Autoren anpassen können.</key>
+		<key alias="allowAllEditors">Alle Elemente erlauben</key>
+		<key alias="allowAllRowConfigurations">Alle Zeilenlayouts erlauben</key>
+		<key alias="maxItems">Maximal erlaubte Elemente</key>
+		<key alias="maxItemsDescription">Leer lassen oder auf 0 setzen für unbegrenzt</key>
+		<key alias="setAsDefault">Als Standard setzen</key>
+		<key alias="chooseExtra">Extra wählen</key>
+		<key alias="chooseDefault">Standard wählen</key>
+		<key alias="areAdded">wurde hinzugefügt</key>
+	</area>
+	<area alias="contentTypeEditor">
+		<key alias="compositions">Mischungen</key>
+		<key alias="group">Gruppe</key>
+		<key alias="noGroups">Sie haben keine Gruppen hinzugefügt</key>
+		<key alias="addGroup">Gruppe hinzufügen</key>
+		<key alias="inheritedFrom">Übernimm von</key>
+		<key alias="addProperty">Eigenschaft hinzufügen</key>
+		<key alias="requiredLabel">Notwendige Bezeichnung</key>
+		<key alias="enableListViewHeading">Listenansicht aktivieren</key>
+		<key alias="enableListViewDescription">
+			Konfiguriert die Verwendung einer sortier- und filterbaren Listenansicht der Unterknoten für diesen Dokumenttyp.
+			Die Unterknoten werden nicht in Baumstruktur angezeigt.
+		</key>
+		<key alias="allowedTemplatesHeading">Erlaubte Vorlagen</key>
+		<key alias="allowedTemplatesDescription">
+			Wählen Sie die Vorlagen, die Editoren für diesen Dokumenttyp wählen dürfen
+		</key>
+		<key alias="allowAsRootHeading">Als Wurzelknoten zulassen</key>
+		<key alias="allowAsRootDescription">
+			Ermöglicht es Editoren diesen Dokumenttyp in der obersten Ebene der Inhalt-Baum-Strukur zu wählen
+		</key>
+		<key alias="childNodesHeading">Erlaubte Dokumenttypen für Unterknoten</key>
+		<key alias="childNodesDescription">
+			Erlaubt es Inhalt der angegebenen Typen unterhalb Inhalten dieses Typs anzulegen
+		</key>
+		<key alias="chooseChildNode">Wählen Sie einen Unterknoten</key>
+		<key alias="compositionsDescription">Übernimm Tabs und Eigenschaften vone einem vorhandenen Inhaltstyp. Neue Tabs werden zum vorliegenden Inhaltstyp hinzugefügt oder mit einem gleichnamigen Tab zusammengeführt.</key>
+		<key alias="compositionInUse">Dieser Inhaltstyp wird in einer Mischung verwendet und kann deshalb nicht selbst zusammengemischt werden.</key>
+		<key alias="noAvailableCompositions">Es sind keine Inhaltstypen für eine Mischung vorhanden.</key>
+		<key alias="availableEditors">Neu anlegen</key>
+		<key alias="reuse">Vorhandenen nutzen</key>
+		<key alias="editorSettings">Editor-Einstellungen</key>
+		<key alias="configuration">Konfiguration</key>
+		<key alias="yesDelete">Ja, entferne</key>
+		<key alias="movedUnderneath">wurde verschoben unter</key>
+		<key alias="copiedUnderneath">wurde kopiert unter</key>
+		<key alias="folderToMove">Wähle den Ordner in den verschoben wird</key>
+		<key alias="folderToCopy">Wähle den Ordner in den kopiert wird</key>
+		<key alias="structureBelow">in der untenstehenden Baumstruktur</key>
+		<key alias="allDocumentTypes">Alle Dokumenttypen</key>
+		<key alias="allDocuments">Alle Inhalte</key>
+		<key alias="allMediaItems">Alle Medien</key>
+		<key alias="usingThisDocument">welche auf diesem Dokumenttyp beruhen, werden unwiderruflich entfernt, bitte bestätigen Sie, dass diese ebenfalls entfernt werden sollen.</key>
+		<key alias="usingThisMedia">welche auf diesem Medientyp beruhen, werden unwiderruflich entfernt, bitte bestätigen Sie, dass diese ebenfalls entfernt werden sollen.</key>
+		<key alias="usingThisMember">welche auf diesem Mitgliedstyp beruhen, werden unwiderruflich entfernt, bitte bestätigen Sie, dass diese ebenfalls entfernt werden sollen.</key>
+		<key alias="andAllDocuments">und alle Inhalte, die auf diesem Typ basieren</key>
+		<key alias="andAllMediaItems">und alle Medienelemente, die auf diesem Typ basieren</key>
+		<key alias="andAllMembers">und alle Mitglieder, die auf diesem Typ basieren</key>
+		<key alias="memberCanEdit">Mitglied kann bearbeiten</key>
+		<key alias="memberCanEditDescription">
+			Diese Eigenschaft zur Bearbeitung des Mitglieds auf seiner Profileseite freigeben
+		</key>
+		<key alias="isSensitiveData">sensibelle Daten</key>
+		<key alias="isSensitiveDataDescription">
+			Diese Eigenschaft für Editoren, die keine Berechtigung für sensibelle Daten haben, verbergen
+		</key>
+		<key alias="showOnMemberProfile">Auf Mitgliedsprofil anzeigen</key>
+		<key alias="showOnMemberProfileDescription">Diesen Eigenschaftswert für die Anzeige auf der Profilseite des Mitglieds zulassen</key>
+		<key alias="tabHasNoSortOrder">Tab hat keine Sortierung</key>
+		<key alias="compositionUsageHeading">Wo wird diese Mischung verwendet?</key>
+		<key alias="compositionUsageSpecification">
+			Diese Mischung wird aktuell in den Mischungen folgender Dokumenttypen verwendet:
+		</key>
+		<key alias="variantsHeading">Kultur basierte Variationen zulassen</key>
+		<key alias="variantsDescription">Editoren erlauben, Inhalt dieses Typs in verschiedenen Sprachen anzulegen</key>
+		<key alias="allowVaryByCulture">Kultur basierte Variationen zulassen</key>
+		<key alias="elementHeading">Ist ein Elementtyp</key>
+		<key alias="elementDescription">
+			<![CDATA[
+    Ein Elementtyp ist z. B. für die Verwendung in <em>Nested Content</em> vorgesehen, nicht jedoch als Inhalt-Knoten in der Baumstruktur
+    ]]>
+		</key>
+		<key alias="elementDoesNotSupport">Dies kann nicht für Elementtypen verwendet werden</key>
+	</area>
+	<area alias="languages">
+		<key alias="addLanguage">Sparche hinzufügen</key>
+		<key alias="mandatoryLanguage">Notwendige Sprache</key>
+		<key alias="mandatoryLanguageHelp">Eigenschaften müssen für diese Sprache ausgefüllt sein bevor ein Knoten veröffentlicht werden kann.</key>
+		<key alias="defaultLanguage">Standardsprache</key>
+		<key alias="defaultLanguageHelp">Eine Umbraco site kann nur eine Standardsprache haben.</key>
+		<key alias="changingDefaultLanguageWarning">Ändern der Standardsprache kann zum Fehlen von Standard-Inhalt führen.</key>
+		<key alias="fallsbackToLabel">Wird ersetzt durch</key>
+		<key alias="noFallbackLanguageOption">Kein Ersatzsprache</key>
+		<key alias="fallbackLanguageDescription">
+			Um mehrsprachigem Inhalt zu ermöglichen durch eine andere Sprache ersetzt zu werden,
+			falls die angefragte Sprache nicht verfügbar ist, wählen Sie diese Option hier aus.
+		</key>
+		<key alias="fallbackLanguage">Ersatzsprache</key>
+		<key alias="none">Keine</key>
+		<key alias="invariantPropertyUnlockHelp"><![CDATA[<strong>%0%</strong> wird zwischen Sprachen und Segmenten geteilt.]]></key>
+		<key alias="invariantCulturePropertyUnlockHelp"><![CDATA[<strong>%0%</strong> wird zwischen allen Sprachen geteilt.]]></key>
+		<key alias="invariantSegmentPropertyUnlockHelp"><![CDATA[<strong>%0%</strong> wird zwischen allen Segmenten geteilt.]]></key>
+		<key alias="invariantLanguageProperty">Geteilt: Sprachen</key>
+		<key alias="invariantSegmentProperty">Geteilt: Segmente</key>
+	</area>
+	<area alias="macro">
+		<key alias="addParameter">Parameter hinzufügen</key>
+		<key alias="editParameter">Parameter bearbeiten</key>
+		<key alias="enterMacroName">Makroname vergeben</key>
+		<key alias="parameters">Parameter</key>
+		<key alias="parametersDescription">Definiere die Parameter, die verfügbar sein sollen, wenn dieses Makro verwendet wird.</key>
+	</area>
+	<area alias="modelsBuilder">
+		<key alias="buildingModels">Datenmodel erzeugen</key>
+		<key alias="waitingMessage">Keine Sorge, das kann eine Weile dauern</key>
+		<key alias="modelsGenerated">Datenmodel erzeugt</key>
+		<key alias="modelsGeneratedError">Datenmodel konnte nicht erzeugt werden</key>
+		<key alias="modelsExceptionInUlog">Erzeugung des Datenmodels fehlgeschlagen, siehe Ausnahmen in den Log-Daten</key>
+	</area>
+	<area alias="templateEditor">
+		<key alias="addDefaultValue">Standardwert hinzufügen</key>
+		<key alias="defaultValue">Standardwert</key>
+		<key alias="alternativeField">Alternatives Feld</key>
+		<key alias="alternativeText">Alternativer Text</key>
+		<key alias="casing">Groß- und Kleinschreibung</key>
+		<key alias="encoding">Kodierung</key>
+		<key alias="chooseField">Feld auswählen</key>
+		<key alias="convertLineBreaks">Zeilenumbrüche ersetzen</key>
+		<key alias="convertLineBreaksHelp">Ersetzt Zeilenumbrüche durch das HTML-Tag &lt;br /&gt;</key>
+		<key alias="customFields">Benutzerdefinierte Felder</key>
+		<key alias="dateOnly">nur Datum</key>
+		<key alias="formatAsDate">Als Datum formatieren</key>
+		<key alias="htmlEncode">HTML kodieren</key>
+		<key alias="htmlEncodeHelp">Wandelt Sonderzeichen in HTML-Zeichencodes um</key>
+		<key alias="insertedAfter">Wird nach dem Feldinhalt eingefügt</key>
+		<key alias="insertedBefore">Wird vor dem Feldinhalt eingefügt</key>
+		<key alias="lowercase">Kleinbuchstaben</key>
+		<key alias="none">Keine</key>
+		<key alias="outputSample">Beispiel-Ausgabe</key>
+		<key alias="postContent">An den Feldinhalt anhängen</key>
+		<key alias="preContent">Dem Feldinhalt voranstellen</key>
+		<key alias="recursive">Rekursiv</key>
+		<key alias="recursiveDescr">Ja, verwende es rekursiv</key>
+		<key alias="standardFields">Standardfelder</key>
+		<key alias="uppercase">Großbuchstaben</key>
+		<key alias="urlEncode">URL kodieren</key>
+		<key alias="urlEncodeHelp">Wandelt Sonderzeichen zur Verwendung in URLs um</key>
+		<key alias="usedIfAllEmpty">Wird nur verwendet, wenn beide vorgenannten Felder leer sind</key>
+		<key alias="usedIfEmpty">Dieses Feld wird nur verwendet, wenn das primäre Feld leer ist</key>
+		<key alias="withTime">Datum und Zeit</key>
+	</area>
+	<area alias="translation">
+		<key alias="details">Details zur Übersetzung</key>
+		<key alias="DownloadXmlDTD">Herunterladen der XML-Defintionen (XML-DTD)</key>
+		<key alias="fields">Felder</key>
+		<key alias="includeSubpages">Einschließlich der Unterseiten</key>
+		<key alias="mailBody">
+			<![CDATA[
+      Hallo %0%,
+
+      das Dokument '%1%' wurde von '%2%' zur Übersetzung in '%5%' freigegeben.
+
+      Zum Bearbeiten verwenden Sie bitte diesen Link: http://%3%/translation/details.aspx?id=%4%.
+
+      Sie können sich auch alle anstehenden Übersetzungen gesammelt im Umbraco-Verwaltungsbereich anzeigen lassen: http://%3%/umbraco
+
+      Einen schönen Tag wünscht
+      Ihr freundlicher Umbraco-Robot
+	]]>
+		</key>
+		<key alias="noTranslators">Bitte erstellen Sie zuerst mindestens einen Übersetzer.</key>
+		<key alias="pageHasBeenSendToTranslation">Die Seite '%0%' wurde zur Übersetzung gesendet</key>
+		<key alias="sendToTranslate">Sendet die Seite '%0%' zur Übersetzung</key>
+		<key alias="totalWords">Anzahl der Wörter</key>
+		<key alias="translateTo">Übersetzen in</key>
+		<key alias="translationDone">Übersetzung abgeschlossen.</key>
+		<key alias="translationDoneHelp">Sie können eine Vorschau der Seiten anzeigen, die Sie gerade übersetzt haben, indem Sie sie unten anklicken. Wenn die Originalseite zugeordnet werden kann, erhalten Sie einen Vergleich der beiden Seiten angezeigt.</key>
+		<key alias="translationFailed">Übersetzung fehlgeschlagen, die XML-Datei könnte beschädigt oder falsch formatiert sein</key>
+		<key alias="translationOptions">Übersetzungsoptionen</key>
+		<key alias="translator">Übersetzer</key>
+		<key alias="uploadTranslationXml">Hochladen der XML-Übersetzungsdatei</key>
+	</area>
+	<area alias="treeHeaders">
+		<key alias="content">Inhalt</key>
+		<key alias="contentBlueprints">Inhalt-Vorlage</key>
+		<key alias="media">Medien</key>
+		<key alias="cacheBrowser">Zwischenspeicher</key>
+		<key alias="contentRecycleBin">Papierkorb</key>
+		<key alias="createdPackages">Erstellte Pakete</key>
+		<key alias="dataTypes">Datentypen</key>
+		<key alias="dictionary">Wörterbuch</key>
+		<key alias="installedPackages">Installierte Pakete</key>
+		<key alias="installSkin">Design-Skin installieren</key>
+		<key alias="installStarterKit">Starter-Kit installieren</key>
+		<key alias="languages">Sprachen</key>
+		<key alias="localPackage">Lokales Paket hochladen und installieren</key>
+		<key alias="macros">Makros</key>
+		<key alias="mediaTypes">Medientypen</key>
+		<key alias="member">Mitglieder</key>
+		<key alias="memberGroups">Mitgliedergruppen</key>
+		<key alias="memberRoles">Mitgliederrollen</key>
+		<key alias="memberTypes">Mitglieder-Typen</key>
+		<key alias="documentTypes">Dokumententypen</key>
+		<key alias="relationTypes">Relationstypen</key>
+		<key alias="packager">Pakete</key>
+		<key alias="packages">Pakete</key>
+		<key alias="partialViews">Teilansicht (Partial View)</key>
+		<key alias="partialViewMacros">Makro-Teilansicht(Partial View Macro Files)</key>
+		<key alias="repositories">Paket-Repositories</key>
+		<key alias="runway">'Runway' installieren</key>
+		<key alias="runwayModules">Runway-Module</key>
+		<key alias="scripting">Server-Skripte</key>
+		<key alias="scripts">Client-Skripte</key>
+		<key alias="stylesheets">Stylesheets</key>
+		<key alias="templates">Vorlagen</key>
+		<key alias="logViewer">Log-Einträge anzeigen</key>
+		<key alias="users">Benutzer</key>
+		<key alias="settingsGroup">Einstellungen</key>
+		<key alias="templatingGroup">Vorlagen</key>
+		<key alias="thirdPartyGroup">Drittanbieter</key>
+	</area>
+	<area alias="update">
+		<key alias="updateAvailable">Neues Update verfügbar</key>
+		<key alias="updateDownloadText">%0% verfügbar, hier klicken zum Herunterladen</key>
+		<key alias="updateNoServer">Keine Verbindung zum Update-Server</key>
+		<key alias="updateNoServerError">Fehler beim Überprüfen der Updates. Weitere Informationen finden Sie im Stacktrace.</key>
+	</area>
+	<area alias="user">
+		<key alias="access">Zugang</key>
+		<key alias="accessHelp">Basierend auf den zugewiesenen Gruppen und Startknoten, hat der Benutzer Zugang zu folgenden Knoten</key>
+		<key alias="assignAccess">Zugang zuweisen</key>
+		<key alias="administrators">Administrator</key>
+		<key alias="categoryField">Feld für Kategorie</key>
+		<key alias="createDate">Benutzer angelegt</key>
+		<key alias="changePassword">Kennwort ändern</key>
+		<key alias="changePhoto">Foto ändern</key>
+		<key alias="emailRequired">Benötigt - geben Sie eine Email Adresse für diesen User an</key>
+		<key alias="newPassword">Neues Kennwort</key>
+		<key alias="newPasswordFormatLengthTip">Noch %0% Zeichen benötigt!</key>
+		<key alias="newPasswordFormatNonAlphaTip">Es sollten mindestens %0% Sonderzeichen verwendet werden.</key>
+		<key alias="noLockouts">wurde nicht ausgeschlossen</key>
+		<key alias="noPasswordChange">Das Kennwort wurde nicht geändert</key>
+		<key alias="confirmNewPassword">Neues Kennwort (Bestätigung)</key>
+		<key alias="changePasswordDescription">Sie können Ihr Kennwort für den Zugriff auf den Umbraco-Verwaltungsbereich ändern, indem Sie das nachfolgende Formular ausfüllen und auf 'Kennwort ändern' klicken</key>
+		<key alias="contentChannel">Schnittstelle für externe Editoren</key>
+		<key alias="createAnotherUser">Weiteren Benutzer anlegen</key>
+		<key alias="createUserHelp">
+			Lege neue Benutzer an, um ihnen Zugang zum Umbraco-Back-Office zu geben.
+			Während des Anlegens eines neuen Benutzer wird ein Kennwort erzeugt, das Sie dem Benutzer mitteilen können.
+		</key>
+		<key alias="descriptionField">Feld für Beschreibung</key>
+		<key alias="disabled">Benutzer endgültig deaktivieren</key>
+		<key alias="documentType">Dokumenttyp</key>
+		<key alias="editors">Editor</key>
+		<key alias="excerptField">Feld für Textausschnitt</key>
+		<key alias="failedPasswordAttempts">Fehlgeschlagene Anmeldeversuche</key>
+		<key alias="goToProfile">Benutzerprofil aufrufen</key>
+		<key alias="groupsHelp">Gruppen hinzufügen, um Zugang und Berechtigungen zuzuweisen</key>
+		<key alias="inviteAnotherUser">Weitere Benutzer einladen</key>
+		<key alias="inviteUserHelp">
+			Laden Sie neue Benutzer ein, um ihnen Zugang zum Umbraco-Back-Office zu geben.
+			Eine Einladungs-E-Mail wird an dem Benutzer geschickt. Diese enthält Informationen, wie sich der Benutzer im Umbraco-Back-Office anmelden kann.
+			Einladungen sind 72 Stunden lang gültig.
+		</key>
+		<key alias="language">Sprache</key>
+		<key alias="languageHelp">Bestimmen Sie die Sprache für Menüs und Dialoge</key>
+		<key alias="lastLockoutDate">Letztes Abmeldedatum</key>
+		<key alias="lastLogin">Letzte Anmeldung</key>
+		<key alias="lastPasswordChangeDate">letzte Änderung des Kennworts</key>
+		<key alias="loginname">Benutzername</key>
+		<key alias="mediastartnode">Startelement in der Medienbibliothek</key>
+		<key alias="mediastartnodehelp">Beschränke die Medien-Bibliothek auf einen bestimmen Startknoten</key>
+		<key alias="mediastartnodes">Medien-Startknoten</key>
+		<key alias="mediastartnodeshelp">Beschränke die Medien-Bibliothek auf bestimme Startknoten</key>
+		<key alias="modules">Bereiche</key>
+		<key alias="noConsole">Umbraco-Back-Office sperren</key>
+		<key alias="noLogin">hat sich noch nie angemeldet</key>
+		<key alias="oldPassword">Altes Kennwort</key>
+		<key alias="password">Kennwort</key>
+		<key alias="resetPassword">Kennwort zurücksetzen</key>
+		<key alias="passwordChanged">Ihr Kennwort wurde geändert!</key>
+		<key alias="passwordConfirm">Bitte bestätigen Sie das neue Kennwort</key>
+		<key alias="passwordEnterNew">Geben Sie Ihr neues Kennwort ein</key>
+		<key alias="passwordIsBlank">Ihr neues Kennwort darf nicht leer sein!</key>
+		<key alias="passwordCurrent">Aktuelles Kennwort</key>
+		<key alias="passwordInvalid">Aktuelles Kennwort falsch</key>
+		<key alias="passwordIsDifferent">Ihr neues Kennwort und die Wiederholung Ihres neuen Kennworts stimmen nicht überein. Bitte versuchen Sie es erneut!</key>
+		<key alias="passwordMismatch">Die Bestätigung Ihres Kennworts stimmt nicht mit dem angegebenen neuen Kennwort überein!</key>
+		<key alias="permissionReplaceChildren">Die Berechtigungen der untergeordneten Elemente ersetzen</key>
+		<key alias="permissionSelectedPages">Die Berechtigungen für folgende Seiten werden angepasst:</key>
+		<key alias="permissionSelectPages">Dokumente auswählen, um deren Berechtigungen zu ändern</key>
+		<key alias="removePhoto">Foto entfernen</key>
+		<key alias="permissionsDefault">Normale Berechtigungen</key>
+		<key alias="permissionsGranular">Detailierte Berechtigungen</key>
+		<key alias="permissionsGranularHelp">Knoten basierte Berechtigungen vergeben</key>
+		<key alias="profile">Profil</key>
+		<key alias="searchAllChildren">Untergeordnete Elemente durchsuchen</key>
+		<key alias="sectionsHelp">Bereiche hinzufügen, um Benutzern Zugang zu gewähren</key>
+		<key alias="selectUserGroups">Wählen Sie Benutzergruppen</key>
+		<key alias="noStartNode">Kein Startknoten ausgewählt</key>
+		<key alias="noStartNodes">Keine Startknoten ausgewählt</key>
+		<key alias="startnode">Startknoten in den Inhalten</key>
+		<key alias="startnodehelp">Inhalt auf bestimmt Startknoten beschränken</key>
+		<key alias="startnodes">Startknoten in den Inhalten</key>
+		<key alias="startnodeshelp">Inhalt auf bestimmte Startknoten beschränken</key>
+		<key alias="updateDate">Benutzer zuletzt aktualiert</key>
+		<key alias="userCreated">wurde angelegt</key>
+		<key alias="userCreatedSuccessHelp">Der Benutzer wurde erfolgreich angelegt. Zu Anmelden im Umbraco-Back-Office verwenden Sie bitte folgendes Kennwort:</key>
+		<key alias="userManagement">Benutzer Verwaltung</key>
+		<key alias="username">Benutzername</key>
+		<key alias="userPermissions">Berechtigungen</key>
+		<key alias="usergroup">Benutzergruppe</key>
+		<key alias="userInvited">wurde eingeladen</key>
+		<key alias="userInvitedSuccessHelp">Eine Einladung mit Anweisungen zur Anmeldung im Umbraco-Back-Office wurde dem neuen Benutzer zugeschickt.</key>
+		<key alias="userinviteWelcomeMessage">Hallo und Willkommen bei Umbraco! In nur einer Minute sind Sie bereit loszulegen, Sie müssen nur ein Kennwort festlegen.</key>
+		<key alias="userinviteExpiredMessage">Willkommen bei Umbraco! Bedauerlicherweise ist Ihre Einladung verfallen. Bitte kontaktieren Sie Ihren Administrator und bitten Sie ihn, diese erneut zu schicken.</key>
+		<key alias="writer">Autor</key>
+		<key alias="change">Änderung</key>
+		<!--???-->
+		<key alias="yourProfile" version="7.0">Ihr Profil</key>
+		<key alias="yourHistory" version="7.0">Ihr Verlauf</key>
+		<key alias="sessionExpires" version="7.0">Sitzung läuft ab in</key>
+		<key alias="inviteUser">Benutzer einladen</key>
+		<key alias="createUser">Benutzer anlegen</key>
+		<key alias="sendInvite">Einladung schicken</key>
+		<key alias="backToUsers">Zurück zu den Benutzern</key>
+		<key alias="inviteEmailCopySubject">Umbraco: Einladung</key>
+		<key alias="inviteEmailCopyFormat">
+			<![CDATA[
+ <html>
+	<head>
+		<meta name='viewport' content='width=device-width'>
+		<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>
+	</head>
+	<body class='' style='font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; color: #392F54; line-height: 22px; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background: #1d1333; margin: 0; padding: 0;' bgcolor='#1d1333'>
+		<style type='text/css'> @media only screen and (max-width: 620px) {table[class=body] h1 {font-size: 28px !important; margin-bottom: 10px !important; } table[class=body] .wrapper {padding: 32px !important; } table[class=body] .article {padding: 32px !important; } table[class=body] .content {padding: 24px !important; } table[class=body] .container {padding: 0 !important; width: 100% !important; } table[class=body] .main {border-left-width: 0 !important; border-radius: 0 !important; border-right-width: 0 !important; } table[class=body] .btn table {width: 100% !important; } table[class=body] .btn a {width: 100% !important; } table[class=body] .img-responsive {height: auto !important; max-width: 100% !important; width: auto !important; } } .btn-primary table td:hover {background-color: #34495e !important; } .btn-primary a:hover {background-color: #34495e !important; border-color: #34495e !important; } .btn  a:visited {color:#FFFFFF;} </style>
+		<table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #1d1333;" bgcolor="#1d1333">
+			<tr>
+				<td style="font-family: sans-serif; font-size: 14px; vertical-align: top; padding: 24px;" valign="top">
+					<table style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+						<tr>
+							<td background="https://umbraco.com/umbraco/assets/img/application/logo.png" bgcolor="#1d1333" width="28" height="28" valign="top" style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
+								<!--[if gte mso 9]> <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:30px;height:30px;"> <v:fill type="tile" src="https://umbraco.com/umbraco/assets/img/application/logo.png" color="#1d1333" /> <v:textbox inset="0,0,0,0"> <![endif]-->
+								<div> </div>
+								<!--[if gte mso 9]> </v:textbox> </v:rect> <![endif]-->
+							</td>
+							<td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top"></td>
+						</tr>
+					</table>
+				</td>
+			</tr>
+		</table>
+		<table border='0' cellpadding='0' cellspacing='0' class='body' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #1d1333;' bgcolor='#1d1333'>
+			<tr>
+				<td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'> </td>
+				<td class='container' style='font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; max-width: 560px; width: 560px; margin: 0 auto; padding: 10px;' valign='top'>
+					<div class='content' style='box-sizing: border-box; display: block; max-width: 560px; margin: 0 auto; padding: 10px;'>
+						<br>
+						<table class='main' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; border-radius: 3px; background: #FFFFFF;' bgcolor='#FFFFFF'>
+							<tr>
+								<td class='wrapper' style='font-family: sans-serif; font-size: 14px; vertical-align: top; box-sizing: border-box; padding: 50px;' valign='top'>
+									<table border='0' cellpadding='0' cellspacing='0' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;'>
+										<tr>
+											<td style='line-height: 24px; font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'>
+												<h1 style='color: #392F54; font-family: sans-serif; font-weight: bold; line-height: 1.4; font-size: 24px; text-align: left; text-transform: capitalize; margin: 0 0 30px;' align='left'>
+													Hallo %0%,
+												</h1>
+												<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+													Sie wurden von <a href="mailto:%4%" style="text-decoration: underline; color: #392F54; -ms-word-break: break-all; word-break: break-all;">%1%</a> ins Umbraco-Back-Office eingeladen.
+												</p>
+												<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+													Nachricht von <a href="mailto:%1%" style="text-decoration: none; color: #392F54; -ms-word-break: break-all; word-break: break-all;">%1%</a>:
+													<br/>
+													<em>%2%</em>
+												</p>
+												<table border='0' cellpadding='0' cellspacing='0' class='btn btn-primary' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; box-sizing: border-box;'>
+													<tbody>
+														<tr>
+															<td align='left' style='font-family: sans-serif; font-size: 14px; vertical-align: top; padding-bottom: 15px;' valign='top'>
+																<table border='0' cellpadding='0' cellspacing='0' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;'>
+																	<tbody>
+																		<tr>
+																			<td style='font-family: sans-serif; font-size: 14px; vertical-align: top; border-radius: 5px; text-align: center; background: #35C786;' align='center' bgcolor='#35C786' valign='top'>
+																				<a href='%3%' target='_blank' rel='noopener' style='color: #FFFFFF; text-decoration: none; -ms-word-break: break-all; word-break: break-all; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; background: #35C786; margin: 0; padding: 12px 30px; border: 1px solid #35c786;'>
+																				Um diese Einladung anzunehmen,<br>klicken Sie diese Schaltfläche
+																				</a>
+																			</td>
+																		</tr>
+																	</tbody>
+																</table>
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												<p style='max-width: 400px; display: block; color: #392F54; font-family: sans-serif; font-size: 14px; line-height: 20px; font-weight: normal; margin: 15px 0;'>
+												Falls die Schaltfläche nicht funktioniert, kopieren Sie folgenden URL und fügen ihn im Browser ein:</p>
+													<table border='0' cellpadding='0' cellspacing='0'>
+														<tr>
+															<td style='-ms-word-break: break-all; word-break: break-all; font-family: sans-serif; font-size: 11px; line-height:14px;'>
+																<font style="-ms-word-break: break-all; word-break: break-all; font-size: 11px; line-height:14px;">
+																	<a style='-ms-word-break: break-all; word-break: break-all; color: #392F54; text-decoration: underline; font-size: 11px; line-height:15px;' href='%3%'>%3%</a>
+																</font>
+															</td>
+														</tr>
+													</table>
+												</p>
+											</td>
+										</tr>
+									</table>
+								</td>
+							</tr>
+						</table>
+						<br><br><br>
+					</div>
+				</td>
+				<td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'> </td>
+			</tr>
+		</table>
+	</body>
+</html>
+]]>
+		</key>
+		<key alias="defaultInvitationMessage">Einladung erneut verschicken...</key>
+		<key alias="deleteUser">Benutzer entfernen</key>
+		<key alias="deleteUserConfirmation">Wollen Sie dieses Benutzerkonto wirklich entfernen?</key>
+		<key alias="stateAll">Alle</key>
+		<key alias="stateActive">Aktiv</key>
+		<key alias="stateDisabled">Gesperrt</key>
+		<key alias="stateLockedOut">Ausgeschlossen</key>
+		<key alias="stateInvited">Eingeladen</key>
+		<key alias="stateInactive">Nicht aktiv</key>
+		<key alias="sortNameAscending">Name (A-Z)</key>
+		<key alias="sortNameDescending">Name (Z-A)</key>
+		<key alias="sortCreateDateAscending">Oldest</key>
+		<key alias="sortCreateDateDescending">Newest</key>
+		<key alias="sortLastLoginDateDescending">Last login</key>
+	</area>
+	<area alias="validation">
+		<key alias="validation">Validierung</key>
+		<key alias="validateAsEmail">Prüfe auf gültiges E-Mail-Format</key>
+		<key alias="validateAsNumber">Prüfe auf gültiges Zahlen-Format</key>
+		<key alias="validateAsUrl">Prüfe auf gültiges URL-Format</key>
+		<key alias="enterCustomValidation">...oder verwende eigene Validierung</key>
+		<key alias="fieldIsMandatory">Pflichtfeld</key>
+		<key alias="validationRegExp">Regulären Ausdruck eingeben</key>
+		<key alias="minCount">Fügen Sie mindestens</key>
+		<key alias="maxCount">Fügen Sie maximal</key>
+		<key alias="items">Element(e) hinzu</key>
+		<key alias="itemsSelected">Element(e) ausgewählt</key>
+		<key alias="invalidDate">Ungültiges Datum</key>
+		<key alias="invalidNumber">Keine Zahl</key>
+		<key alias="invalidEmail">Ungültiges E-Mail-Format</key>
+		<key alias="invalidNull">Der Wert darf nicht ungesetzt bleiben</key>
+		<key alias="invalidEmpty">Der Wert darf nicht leer bleiben</key>
+		<key alias="invalidPattern">Der Wert ist ungültig</key>
+		<key alias="customValidation">Eigene Validierung</key>
+	</area>
+	<area alias="healthcheck">
+		<!--!!!-->
+		<key alias="checkSuccessMessage">Wert wurde auf den empfohlenen Wert gesetzt: '%0%'.</key>
+		<key alias="checkErrorMessageDifferentExpectedValue">Erwartete Wert '%1%' für '%2%' in der Konfigurationsdatei '%3%', '%0%' wurde jedoch gefunden.</key>
+		<key alias="checkErrorMessageUnexpectedValue">Unerwarteten Wert '%0%' für '%2%' in der Konfigurationsdatei '%3%' gefunden.</key>
+		<key alias="macroErrorModeCheckSuccessMessage">"MacroErrors" auf '%0%' gesetzt.</key>
+		<key alias="macroErrorModeCheckErrorMessage">
+			"MacroErrors" sind auf '%0%' gesetzt,
+			was verhindert, dass einige oder alle Seiten Ihrer Website vollständig geladen werden, falls Fehler in Makros auftreten. Schaltfläche "Beheben" setzt den Wert auf '%1%'.
+		</key>
+		<key alias="httpsCheckValidCertificate">Ihr Website-Zertifikat (SSL) ist gültig.</key>
+		<key alias="httpsCheckInvalidCertificate">(SSL-)Zertifikat-Validierungsfehler: '%0%'</key>
+		<key alias="httpsCheckExpiredCertificate">Ihr Website-Zertifikat (SSL) ist abgelaufen.</key>
+		<key alias="httpsCheckExpiringCertificate">Ihr Website-Zertifikat (SSL) wird in %0% Tagen ablaufen.</key>
+		<key alias="healthCheckInvalidUrl">Fehler beim PINGen der URL %0% - '%1%'</key>
+		<key alias="httpsCheckIsCurrentSchemeHttps">Sie betrachten diese Website %0% unter Verwendung des HTTPS-Schemas.</key>
+		<key alias="compilationDebugCheckSuccessMessage">'Debug' Kompilierungsmodus ist abgeschaltet.</key>
+		<key alias="compilationDebugCheckErrorMessage">'Debug' Kompilierungsmodus ist gegenwertig eingeschaltet. Es ist empfehlenswert diesen vor Live-Gang abzuschalten.</key>
+		<!-- The following keys get these tokens passed in:
+	    0: Path to the file not found
+  	-->
+		<key alias="clickJackingCheckHeaderFound"><![CDATA[Der Header oder das Meta-Tag <strong>X-Frame-Options</strong> ist vorhanden. Diese dienen zur Kontrolle, ob eine Site in IFRAMES anderer Sites angezeigt werden kann.]]></key>
+		<key alias="clickJackingCheckHeaderNotFound"><![CDATA[Der Header oder das Meta-Tag <strong>X-Frame-Options</strong> ist <strong>nicht</strong> vorhanden. Es dient zur Kontrolle, ob eine Site in IFRAMES anderer Sites angezeigt werden kann.]]></key>
+		<key alias="noSniffCheckHeaderFound"><![CDATA[Der Header oder das Meta-Tag <strong>X-Content-Type-Options</strong> ist vorhanden. Diese dienen zum Schutz gegen MIME-'Schnüffeln'-Schwachstellen. ]]></key>
+		<key alias="noSniffCheckHeaderNotFound"><![CDATA[Der Header oder das Meta-Tag <strong>X-Content-Type-Options</strong> ist <strong>nicht</strong> vorhanden. Diese dienen zum Schutz gegen MIME-'Schnüffeln'-Schwachstellen. ]]></key>
+		<key alias="hSTSCheckHeaderFound"><![CDATA[Der Header <strong>Strict-Transport-Security</strong>, auch bekannt als HSTS-Header, ist vorhanden.]]></key>
+		<key alias="hSTSCheckHeaderNotFound"><![CDATA[Der Header <strong>Strict-Transport-Security</strong>, auch bekannt als HSTS-Header, ist <strong>nicht</strong> vorhanden.]]></key>
+		<key alias="xssProtectionCheckHeaderFound"><![CDATA[Der Header <strong>X-XSS-Protection</strong> ist vorhanden.]]></key>
+		<key alias="xssProtectionCheckHeaderNotFound"><![CDATA[Der Header <strong>X-XSS-Protection</strong> ist <strong>nicht</strong> vorhanden]]></key>
+		<key alias="excessiveHeadersFound"><![CDATA[Folgende Header, die Informationen über die Website-Technologie preisgeben, sind vorhanden: <strong>%0%</strong>.]]></key>
+		<key alias="excessiveHeadersNotFound">Es sind keine Header, die Informationen über die Website-Technologie preisgeben, vorhanden.</key>
+		<key alias="smtpMailSettingsConnectionSuccess">Die SMTP-Einstellungen sind korrekt konfiguriert und der Dienst arbeitet wie erwartet.</key>
+		<key alias="notificationEmailsCheckSuccessMessage"><![CDATA[Die E-Mail-Adresse für Benachrichtigungen wurde auf <strong>%0%</strong> eingestellt.]]></key>
+		<key alias="notificationEmailsCheckErrorMessage"><![CDATA[Die E-Mail-Adresse für Benachrichtigungen ist noch auf den Standardwert <strong>%0%</strong> gestellt.]]></key>
+		<key alias="scheduledHealthCheckEmailBody">
+			<![CDATA[
+    <html><body><p>
+    Die Ergebnisse der geplanten Systemzustandsprüfung läuft am %0% um %1% lauten wie folgt:
+    </p>%2%</body></html>
+    ]]>
+		</key>
+		<key alias="scheduledHealthCheckEmailSubject">Status der Umbraco Systemzustand: %0%</key>
+	</area>
+	<area alias="redirectUrls">
+		<key alias="disableUrlTracker">URL-Änderungsaufzeichnung abschalten</key>
+		<key alias="enableUrlTracker">URL-Änderungsaufzeichnung einschalten</key>
+		<key alias="culture">Kultur</key>
+		<key alias="originalUrl">Original URL</key>
+		<key alias="redirectedTo">Weiterleiten zu</key>
+		<key alias="redirectUrlManagement">URL-Weiterleitungen verwalten</key>
+		<key alias="panelInformation">Die folgenden URLs leiten auf diesen Inhalt:</key>
+		<key alias="noRedirects">Es wurden keine Weiterleitungen angelegt</key>
+		<key alias="noRedirectsDescription">
+			Wenn eine veröffentlichte Seite umbenannt oder verschoben wird,
+			erzeugt dieses CMS automatisch eine entsprechende Weiterleitung.
+		</key>
+		<key alias="redirectRemoved">URL-Weiterleitung wurde entfernt.</key>
+		<key alias="redirectRemoveError">Beim Entfernen der URL-Weiterleitung ist ein Fehler aufgetreten.</key>
+		<key alias="redirectRemoveWarning">Dies entfernt die Weiterleitung</key>
+		<key alias="confirmDisable">Wollen Sie die URL-Änderungsaufzeichnung wirklich abschalten?</key>
+		<key alias="disabledConfirm">Die URL-Änderungsaufzeichnung wurde abgeschaltet.</key>
+		<key alias="disableError">Fehler während der Abschaltung der URL-Änderungsaufzeichnung, weitere Information finden Sie in den Log-Dateien.</key>
+		<key alias="enabledConfirm">Die URL-Änderungsaufzeichnung wurde eingeschaltet.</key>
+		<key alias="enableError">Fehler während der Aktivierung der URL-Änderungsaufzeichnung, weitere Information finden Sie in den Log-Dateien.</key>
+	</area>
+	<area alias="emptyStates">
+		<key alias="emptyDictionaryTree">Das Wörterbuch ist leer</key>
+	</area>
+	<area alias="textbox">
+		<key alias="characters_left">Buchstaben verbleiben</key>
+	</area>
+	<area alias="recycleBin">
+		<key alias="contentTrashed">Inhalt mit Id = {0} des Oberknotens mit Id = {1} wurde verworfen</key>
+		<key alias="mediaTrashed">Medienelement mit Id = {0} des Oberknotens mit Id = {1} wurde verworfen</key>
+		<key alias="itemCannotBeRestored">Dieses Element kann nicht automatisch wiederhergestellt werden</key>
+		<key alias="itemCannotBeRestoredHelpText">
+			Es gibt keine Position für das automatische Wiederherstellen dieses Elementes.
+			Sie können es manuell mit Hilfe der untenstehenden Baumstruktur verschieben.
+		</key>
+		<key alias="wasRestored">wurde wiederhergestellt unterhalb von</key>
+	</area>
+	<area alias="relationType">
+		<key alias="direction">Richtung</key>
+		<key alias="parentToChild">Ober- zu Unterknoten</key>
+		<key alias="bidirectional">Bidirektional</key>
+		<key alias="parent">Oberknoten</key>
+		<key alias="child">Unterknoten</key>
+		<key alias="count">Anzahl</key>
+		<!--???-->
+		<key alias="relations">Relationen</key>
+		<key alias="created">Angelegt</key>
+		<key alias="comment">Kommentar</key>
+		<key alias="name">Name</key>
+		<key alias="noRelations">Es gibt keine Relationen für diesen Typ.</key>
+		<key alias="tabRelationType">Relationentyp</key>
+		<key alias="tabRelations">Relationen</key>
+	</area>
+	<area alias="dashboardTabs">
+		<key alias="contentIntro">Lassen Sie uns beginnen</key>
+		<key alias="contentRedirectManager">URL-Weiterleitungen verwalten</key>
+		<key alias="mediaFolderBrowser">Inhalt</key>
+		<key alias="settingsWelcome">Begrüßung</key>
+		<key alias="settingsExamine">Examine Management</key>
+		<key alias="settingsPublishedStatus">Status der Veröffentlichungen</key>
+		<key alias="settingsModelsBuilder">Models Builder</key>
+		<key alias="settingsHealthCheck">Systemzustand prüfen</key>
+		<key alias="memberIntro">Lassen Sie uns beginnen</key>
+		<key alias="formsInstall">Umbraco Forms installieren</key>
+	</area>
+	<area alias="visuallyHiddenTexts">
+		<key alias="goBack">zurück gehen</key>
+		<key alias="activeListLayout">Aktives Layout:</key>
+		<key alias="jumpTo">Springe zu</key>
+		<key alias="group">Gruppe</key>
+		<key alias="passed">bestanden</key>
+		<key alias="warning">alarmierend</key>
+		<key alias="failed">fehlgeschlagen</key>
+		<key alias="suggestion">Vorschlag</key>
+		<key alias="checkPassed">Prüfung bestanden</key>
+		<key alias="checkFailed">Prüfung fehlgeschlagen</key>
+		<key alias="openBackofficeSearch">Back-Office Suche öffnen</key>
+		<key alias="openCloseBackofficeHelp">Back-Office Hilfe öffnen / schliessen</key>
+		<key alias="openCloseBackofficeProfileOptions">Ihre Profil-Einstellungen öffnen / schliessen</key>
+	</area>
+	<area alias="logViewer">
+		<key alias="selectAllLogLevelFilters">Wählen Sie Alle</key>
+		<key alias="deselectAllLogLevelFilters">Alle abwählen</key>
+	</area>
+	<area alias="formsDashboard">
+		<key alias="formsHeadline">Umbraco Forms</key>
+		<key alias="formsDescription">
+			Erstellen Sie Formulare mithilfe einer intuitiven Benutzeroberfläche. Von einfachen Kontaktformularen
+			die Email verschicken bis hin zu komplexen Fragebögen die mit einem CRM System verbunden sind. Ihre Kunden werden es lieben!
+		</key>
+	</area>
+	<area alias="contentTemplatesDashboard">
+		<key alias="whatHeadline">Was sind Inhaltsvorlagen?</key>
+		<key alias="whatDescription">
+			Inhaltsvorlagen sind vordefinierte Inhalte die ausgewählt werden können
+			wenn Sie einen neuen Inhaltsknoten anlegen wollen.
+		</key>
+		<key alias="createHeadline">Wie erstelle ich eine Inhaltsvorlage?</key>
+		<key alias="createDescription">
+			<![CDATA[
+            <p>Es gibt zwei Möglichkeiten eine Inhaltsvorlage zu erstellen:</p>
+            <ul>
+                <li>Rechtsklicken Sie einen Inhaltsknoten und wählen Sie "Inhaltsvorlage erstellen" aus.</li>
+                <li>Rechtsklicken Sie den Inhaltsvorlagen-Baum und wählen Sie den Dokumententypen aus für den Sie eine Vorlage erstellen wollen.</li>
+            </ul>
+            <p>Wenn Sie einen Namen vergen haben können Reakteure diese als Vorlage für neue Seiten benutzen.</p>
+        ]]>
+		</key>
+		<key alias="manageHeadline">Wie verwalte ich eine Inhaltsvorlage?</key>
+		<key alias="manageDescription">
+			Sie können Inhaltsvorlagen bearbeiten und löschen in dem Sie im Inhaltsvorlage-Baum die gewünschte
+			Vorlage auswählen. Außerdem können Sie auch direkt den Dokumenttypen bearbeiten oder löschen auf dem die Vorlage basiert
+		</key>
+	</area>
+	<area alias="preview">
+		<key alias="endLabel">Beenden</key>
+		<key alias="endTitle">Vorschau beenden</key>
+		<key alias="openWebsiteLabel">Website Vorschau</key>
+		<key alias="openWebsiteTitle">Website in Vorschaumodus öffnen</key>
+		<key alias="returnToPreviewHeadline">Websitevorschau anzeigen?</key>
+		<key alias="returnToPreviewDescription">
+			Sie haben den Vorschaumodus beendet, wollen Sie ihn erneut öffnen um
+			gespeicherte Version der Website anzusehen?
+		</key>
+		<key alias="returnToPreviewAcceptButton">Vorschau der letzten Version anzeigen</key>
+		<key alias="returnToPreviewDeclineButton">Veröffentlichte Version anzeigen</key>
+		<key alias="viewPublishedContentHeadline">Veröffentlichte Version anzeigen?</key>
+		<key alias="viewPublishedContentDescription">
+			Sie befinden sich im Vorschaumodus, wollen Sie ihn verlassen um die letzte
+			veröffentlichte Version ihrer Website zu sehen?
+		</key>
+		<key alias="viewPublishedContentAcceptButton">Veröffentlichte Version anzeigen</key>
+		<key alias="viewPublishedContentDeclineButton">Im Vorschaumodus bleiben</key>
+	</area>
+	<area alias="permissions">
+		<key alias="FolderCreation">Ornder erstellen</key>
+		<key alias="FileWritingForPackages">Dateien durch Packages erstellen lassen</key>
+		<key alias="FileWriting">Dateien schreiben</key>
+		<key alias="MediaFolderCreation">Medien Ordner stellen</key>
+	</area>
+	<area alias="treeSearch">
+		<key alias="searchResult">Element zurückgegeben</key>
+		<key alias="searchResults">Elemente zurückgegeben</key>
+	</area>
+</language>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/fr_ch.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/fr_ch.xml
@@ -1,0 +1,2357 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language alias="fr_ch" intName="French Switzerland (FR-CH)" localName="français Suisse (FR-CH)" lcid="12" culture="fr-CH">
+	<creator>
+		<name>The Umbraco community</name>
+		<link>https://docs.umbraco.com/umbraco-cms/extending/language-files</link>
+	</creator>
+	<area alias="actions">
+		<key alias="assigndomain">Culture et noms d'hôte</key>
+		<key alias="auditTrail">Informations d'audit</key>
+		<key alias="browse">Parcourir</key>
+		<key alias="changeDocType">Changer le type de document</key>
+		<key alias="copy">Copier</key>
+		<key alias="create">Créer</key>
+		<key alias="export">Exporter</key>
+		<key alias="createPackage">Créer un package</key>
+		<key alias="createGroup">Créer un groupe</key>
+		<key alias="delete">Supprimer</key>
+		<key alias="disable">Désactiver</key>
+		<key alias="emptyrecyclebin">Vider la corbeille</key>
+		<key alias="enable">Activer</key>
+		<key alias="exportDocumentType">Exporter le type de document</key>
+		<key alias="importdocumenttype">Importer un type de document</key>
+		<key alias="importPackage">Importer un package</key>
+		<key alias="liveEdit">Editer dans Canvas</key>
+		<key alias="logout">Déconnexion</key>
+		<key alias="move">Déplacer</key>
+		<key alias="notify">Notifications</key>
+		<key alias="protect">Accès public</key>
+		<key alias="publish">Publier</key>
+		<key alias="unpublish">Dépublier</key>
+		<key alias="refreshNode">Rafraîchir</key>
+		<key alias="republish">Republier le site tout entier</key>
+		<key alias="rename" version="7.3.0">Renommer</key>
+		<key alias="restore" version="7.3.0">Récupérer</key>
+		<key alias="chooseWhereToCopy">Choisissez où copier</key>
+		<key alias="chooseWhereToMove">Choisissez où déplacer</key>
+		<key alias="chooseWhereToImport">Choisissez où importer</key>
+		<key alias="toInTheTreeStructureBelow">dans l'arborescence ci-dessous</key>
+		<key alias="wasMovedTo">a été déplacé vers</key>
+		<key alias="wasCopiedTo">a été copié vers</key>
+		<key alias="wasDeleted">a été supprimé</key>
+		<key alias="rights">Permissions</key>
+		<key alias="rollback">Version antérieure</key>
+		<key alias="sendtopublish">Envoyer pour publication</key>
+		<key alias="sendToTranslate">Envoyer pour traduction</key>
+		<key alias="setGroup">Spécifier le groupe</key>
+		<key alias="sort">Trier</key>
+		<key alias="translate">Traduire</key>
+		<key alias="update">Mettre à jour</key>
+		<key alias="setPermissions">Spécifier les permissions</key>
+		<key alias="unlock">Débloquer</key>
+		<key alias="createblueprint">Créer un modèle de contenu</key>
+		<key alias="resendInvite">Envoyer à nouveau l'invitation</key>
+	</area>
+	<area alias="actionCategories">
+		<key alias="content">Contenu</key>
+		<key alias="administration">Administration</key>
+		<key alias="structure">Structure</key>
+		<key alias="other">Autre</key>
+	</area>
+	<area alias="actionDescriptions">
+		<key alias="assignDomain">Permettre d'attribuer la culture et des noms d'hôte</key>
+		<key alias="auditTrail">Permettre d'accéder au journal d'historique d'un noeud</key>
+		<key alias="browse">Permettre d'accéder à un noeud</key>
+		<key alias="changeDocType">Permettre de modifier le type de document d'un noeud</key>
+		<key alias="copy">Permettre de copier un noeud</key>
+		<key alias="create">Permettre de créer des noeuds</key>
+		<key alias="delete">Permettre de supprimer des noeuds</key>
+		<key alias="move">Permettre de déplacer un noeud</key>
+		<key alias="protect">Permettre de définir et modifier l'accès public à un noeud</key>
+		<key alias="publish">Permettre de publier un noeud</key>
+		<key alias="unpublish">Permettre d'annuler la publication d'un noeud</key>
+		<key alias="rights">Permettre de modifier les permissions pour un noeud</key>
+		<key alias="rollback">Permettre de revenir à une situation antérieure</key>
+		<key alias="sendtopublish">Permettre d'envoyer un noeud pour approbation avant publication</key>
+		<key alias="sendToTranslate">Permettre d'envoyer un noeud à la traduction</key>
+		<key alias="sort">Permettre de modifier l'ordonnancement des noeuds</key>
+		<key alias="translate">Permettre de traduire un noeud</key>
+		<key alias="update">Permettre de sauvegarder un noeud</key>
+		<key alias="createblueprint">Permettre la création d'un Modèle de Contenu</key>
+	</area>
+	<area alias="apps">
+		<key alias="umbContent">Contenu</key>
+		<key alias="umbInfo">Info</key>
+	</area>
+	<area alias="assignDomain">
+		<key alias="permissionDenied">Permission refusée.</key>
+		<key alias="addNew">Ajouter un nouveau domaine</key>
+		<key alias="remove">Supprimer</key>
+		<key alias="invalidNode">Noeud invalide.</key>
+		<key alias="invalidDomain">Domaine invalide.</key>
+		<key alias="duplicateDomain">Domaine déjà assigné.</key>
+		<key alias="language">Langue</key>
+		<key alias="domain">Domaine</key>
+		<key alias="domainCreated">Nouveau domaine '%0%' créé</key>
+		<key alias="domainDeleted">Domaine '%0%' supprimé</key>
+		<key alias="domainExists">Domaine '%0%' déjà assigné</key>
+		<key alias="domainUpdated">Domaine '%0%' mis à jour</key>
+		<key alias="orEdit">Editer les domaines actuels</key>
+		<key alias="domainHelpWithVariants">
+			<![CDATA[Noms de domaines valides: "example.com", "www.example.com", "example.com:8080", ou "https://www.example.com/".
+     De plus, les chemins d'un niveau sous le domaine sont également supportés, eg. "example.com/en" ou "/en".]]>
+		</key>
+		<key alias="inherit">Hériter</key>
+		<key alias="setLanguage">Culture</key>
+		<key alias="setLanguageHelp">
+			<![CDATA[Définir la culture pour les noeuds enfants du noeud courant,<br /> ou hériter de la culture des noeuds parents. S'appliquera aussi<br />
+      au noeud courant, à moins qu'un domaine ci-dessous soit aussi d'application.]]>
+		</key>
+		<key alias="setDomains">Domaines</key>
+	</area>
+	<area alias="buttons">
+		<key alias="clearSelection">Vider la sélection</key>
+		<key alias="select">Choisir</key>
+		<key alias="somethingElse">Faire autre chose</key>
+		<key alias="bold">Gras</key>
+		<key alias="deindent">Annuler l'indentation de paragraphe</key>
+		<key alias="formFieldInsert">Insérer un champ de formulaire</key>
+		<key alias="graphicHeadline">Insérer un entête graphique</key>
+		<key alias="htmlEdit">Editer le HTML</key>
+		<key alias="indent">Indenter le paragraphe</key>
+		<key alias="italic">Italique</key>
+		<key alias="justifyCenter">Centrer</key>
+		<key alias="justifyLeft">Justifier à gauche</key>
+		<key alias="justifyRight">Justifier à droite</key>
+		<key alias="linkInsert">Insérer un lien</key>
+		<key alias="linkLocal">Insérer un lien local (ancre)</key>
+		<key alias="listBullet">Liste à puces</key>
+		<key alias="listNumeric">Liste numérique</key>
+		<key alias="macroInsert">Insérer une macro</key>
+		<key alias="pictureInsert">Insérer une image</key>
+		<key alias="publishAndClose">Publier et fermer</key>
+		<key alias="publishDescendants">Publier avec les descendants</key>
+		<key alias="relations">Editer les relations</key>
+		<key alias="returnToList">Retourner à la liste</key>
+		<key alias="save">Sauver</key>
+		<key alias="saveAndClose">Sauver et fermer</key>
+		<key alias="saveAndPublish">Sauver et publier</key>
+		<key alias="saveToPublish">Sauver et envoyer pour approbation</key>
+		<key alias="saveListView">Sauver la mise en page de la liste</key>
+		<key alias="schedulePublish">Planifier</key>
+		<key alias="saveAndPreview">Prévisualiser</key>
+		<key alias="showPage">Prévisualiser</key>
+		<key alias="showPageDisabled">La prévisualisation est désactivée car aucun modèle n'a été assigné.</key>
+		<key alias="styleChoose">Choisir un style</key>
+		<key alias="styleShow">Afficher les styles</key>
+		<key alias="tableInsert">Insérer un tableau</key>
+		<key alias="generateModelsAndClose">Générer les modèles et fermer</key>
+		<key alias="saveAndGenerateModels">Sauver et générer les modèles</key>
+		<key alias="undo">Défaire</key>
+		<key alias="redo">Refaire</key>
+		<key alias="deleteTag">Supprimer un tag</key>
+		<key alias="confirmActionCancel">Annuler</key>
+		<key alias="confirmActionConfirm">Confirmer</key>
+		<key alias="morePublishingOptions">Options de publication supplémentaires</key>
+	</area>
+	<area alias="auditTrailsMedia">
+		<key alias="delete">Media supprimé</key>
+		<key alias="move">Media déplacé</key>
+		<key alias="copy">Media copié</key>
+		<key alias="save">Media sauvegardé</key>
+	</area>
+	<area alias="auditTrails">
+		<key alias="atViewingFor">Aperçu pour</key>
+		<key alias="delete">Contenu supprimé</key>
+		<key alias="unpublish">Contenu dé-publié</key>
+		<key alias="unpublishvariant">Contenu dé-publié pour les langues : %0% </key>
+		<key alias="publish">Contenu publié</key>
+		<key alias="publishvariant">Contenu publié pour les langues : %0% </key>
+		<key alias="save">Contenu sauvegardé</key>
+		<key alias="savevariant">Contenu sauvegardé pour les langues : %0%</key>
+		<key alias="move">Contenu déplacé</key>
+		<key alias="copy">Contenu copié</key>
+		<key alias="rollback">Contenu restauré</key>
+		<key alias="sendtopublish">Contenu envoyé pour publication</key>
+		<key alias="sendtopublishvariant">Contenu envoyé pour publication pour les langues : %0%</key>
+		<key alias="sort">Ordonnancement des sous-éléments réalisé par l'utilisateur</key>
+		<key alias="smallCopy">Copier</key>
+		<key alias="smallPublish">Publier</key>
+		<key alias="smallPublishVariant">Publier</key>
+		<key alias="smallMove">Déplacer</key>
+		<key alias="smallSave">Sauvegarder</key>
+		<key alias="smallSaveVariant">Sauvegarder</key>
+		<key alias="smallDelete">Supprimer</key>
+		<key alias="smallUnpublish">Annuler publication</key>
+		<key alias="smallUnpublishVariant">Annuler publication</key>
+		<key alias="smallRollBack">Restaurer</key>
+		<key alias="smallSendToPublish">Envoyer pour publication</key>
+		<key alias="smallSendToPublishVariant">Envoyer pour publication</key>
+		<key alias="smallSort">Ordonner</key>
+		<key alias="historyIncludingVariants">Historique (toutes variantes)</key>
+	</area>
+	<area alias="codefile">
+		<key alias="createFolderIllegalChars">Le nom du dossier ne peut pas contenir de caractères illégaux.</key>
+		<key alias="deleteItemFailed">Echec de la suppression de l'élément : %0%</key>
+	</area>
+	<area alias="content">
+		<key alias="isPublished" version="7.2">A été publié</key>
+		<key alias="about">A propos de cette page</key>
+		<key alias="alias">Alias</key>
+		<key alias="alternativeTextHelp">(comment décririez-vous l'image oralement)</key>
+		<key alias="alternativeUrls">Liens alternatifs</key>
+		<key alias="clickToEdit">Cliquez pour éditer cet élément</key>
+		<key alias="createBy">Créé par</key>
+		<key alias="createByDesc" version="7.0">Auteur original</key>
+		<key alias="updatedBy" version="7.0">Mis à jour par</key>
+		<key alias="createDate">Créé</key>
+		<key alias="createDateDesc" version="7.0">Date/heure à laquelle ce document a été créé</key>
+		<key alias="documentType">Type de Document</key>
+		<key alias="editing">Edition</key>
+		<key alias="expireDate">Expire le</key>
+		<key alias="itemChanged">Cet élément a été modifié après la publication</key>
+		<key alias="itemNotPublished">Cet élément n'est pas publié</key>
+		<key alias="lastPublished">Dernière publication</key>
+		<key alias="noItemsToShow">Il n'y a aucun élément à afficher</key>
+		<key alias="listViewNoItems" version="7.1.5">Il n'y a aucun élément à afficher dans cette liste.</key>
+		<key alias="listViewNoContent">Aucun contenu n'a encore été ajouté</key>
+		<key alias="listViewNoMembers">Aucun membre n'a encore été ajouté</key>
+		<key alias="mediatype">Type de Média</key>
+		<key alias="mediaLinks">Lien vers des média(s)</key>
+		<key alias="membergroup">Groupe de membres</key>
+		<key alias="memberrole">Rôle</key>
+		<key alias="membertype">Type de membre</key>
+		<key alias="noChanges">Aucune modification n'a été faite</key>
+		<key alias="noDate">Aucune date choisie</key>
+		<key alias="nodeName">Titre de la page</key>
+		<key alias="noMediaLink">Ce média n'a pas de lien</key>
+		<key alias="noProperties">Aucun contenu ne peut être ajouté pour cet élément</key>
+		<key alias="otherElements">Propriétés</key>
+		<key alias="parentNotPublished">Ce document est publié mais n'est pas visible car son parent '%0%' n'est pas publié</key>
+		<key alias="parentCultureNotPublished">Cette culture est publiée mais n'est pas visible car elle n'est pas publiée pour le parent '%0%'</key>
+		<key alias="parentNotPublishedAnomaly">Ce document est publié mais n'est pas présent dans le cache</key>
+		<key alias="getUrlException">Oups: impossible d'obtenir cet URL (erreur interne - voir fichier log)</key>
+		<key alias="routeError">Ce document est publié mais son URL entrerait en collision avec le contenu %0%</key>
+		<key alias="routeErrorCannotRoute">Ce document est publié mais son URL ne peut pas être routé</key>
+		<key alias="publish">Publier</key>
+		<key alias="published">Publié</key>
+		<key alias="publishedPendingChanges">Publié (changements en cours)</key>
+		<key alias="publishStatus">Statut de publication</key>
+		<key alias="publishDescendantsHelp"><![CDATA[Cliquez sur <em>Publier avec ses descendants</em> pour publier <strong>%0%</strong> et tous les éléments de contenu en-dessous, rendant de ce fait leur contenu accessible publiquement.]]></key>
+		<key alias="publishDescendantsWithVariantsHelp"><![CDATA[Cliquez sur <em>Publier avec ses descendants</em> pour publier <strong>les langues sélectionnées</strong> et les mêmes langues des éléments de contenu en-dessous, rendant de ce fait leur contenu accessible publiquement.]]></key>
+		<key alias="releaseDate">Publié le</key>
+		<key alias="unpublishDate">Dépublié le</key>
+		<key alias="removeDate">Supprimer la date</key>
+		<key alias="setDate">Défininir la date</key>
+		<key alias="sortDone">Ordre de tri mis à jour</key>
+		<key alias="sortHelp">Pour trier les noeuds, faites-les simplement glisser à l'aide de la souris ou cliquez sur les entêtes de colonne. Vous pouvez séléctionner plusieurs noeuds en gardant la touche "shift" ou "ctrl" enfoncée pendant votre séléction.</key>
+		<key alias="statistics">Statistiques</key>
+		<key alias="titleOptional">Titre (optionnel)</key>
+		<key alias="altTextOptional">Texte alternatif (optionnel)</key>
+		<key alias="captionTextOptional">Légende (optionnel)</key>
+		<key alias="type">Type</key>
+		<key alias="unpublish">Dépublier</key>
+		<key alias="unpublished">Dépublié</key>
+		<key alias="notCreated">Non créé</key>
+		<key alias="updateDate">Dernière édition</key>
+		<key alias="updateDateDesc" version="7.0">Date/heure à laquelle ce document a été édité</key>
+		<key alias="uploadClear">Supprimer le(s) fichier(s)</key>
+		<key alias="urls">Lien vers un document</key>
+		<key alias="memberof">Membre du/des groupe(s)</key>
+		<key alias="notmemberof">Pas membre du/des groupe(s)</key>
+		<key alias="childItems" version="7.0">Eléments enfants</key>
+		<key alias="target" version="7.0">Cible</key>
+		<key alias="scheduledPublishServerTime">Ceci se traduit par l'heure suivante sur le serveur :</key>
+		<key alias="scheduledPublishDocumentation"><![CDATA[<a href="https://docs.umbraco.com/umbraco-cms/fundamentals/data/scheduled-publishing#timezones" target="_blank" rel="noopener">Qu'est-ce que cela signifie?</a>]]></key>
+		<key alias="nestedContentDeleteItem">Etes-vous certain(e) de vouloir supprimer cet élément?</key>
+		<key alias="nestedContentDeleteAllItems">Etes-vous certain(e) de vouloir supprimer tous les éléments?</key>
+		<key alias="nestedContentEditorNotSupported">La propriété %0% utilise l'éditeur %1% qui n'est pas supporté par Nested Content.</key>
+		<key alias="nestedContentNoContentTypes">Aucun type de contenu n'est configuré pour cette propriété.</key>
+		<key alias="nestedContentAddElementType">Ajouter un type d'élément</key>
+		<key alias="nestedContentSelectElementTypeModalTitle">Sélectionner un type d'élément</key>
+		<key alias="nestedContentNoGroups">Le type d'élément sélectionné ne contient aucun groupe supporté (les onglets/tabs ne sont pas supportés par cet éditeur, changez-les en groupes ou utilisez l'éditeur Block List).</key>
+		<key alias="addTextBox">Ajouter un autre champ texte</key>
+		<key alias="removeTextBox">Enlever ce champ texte</key>
+		<key alias="contentRoot">Racine du contenu</key>
+		<key alias="includeUnpublished">Inclure les brouillons : publier également les éléments de contenu non publiés.</key>
+		<key alias="isSensitiveValue">Cette valeur est masquée. Si vous avez besoin de pouvoir accéder à cette valeur, veuillez prendre contact avec l'administrateur du site web.</key>
+		<key alias="isSensitiveValue_short">Cette valeur est masquée.</key>
+		<key alias="languagesToPublish">Quelles langues souhaitez-vous publier?</key>
+		<key alias="languagesToSendForApproval">Quells langues souhaitez-vous envoyer pour approbation?</key>
+		<key alias="languagesToSchedule">Quelles langues souhaitez-vous planifier?</key>
+		<key alias="languagesToUnpublish">Sélectionnez les langues à dépublier. La dépublication d'une langue obligatoire provoquera la dépublication de toutes les langues.</key>
+		<key alias="readyToPublish">Prêt.e à publier?</key>
+		<key alias="readyToSave">Prêt.e à sauvegarder?</key>
+		<key alias="sendForApproval">Envoyer pour approbation</key>
+		<key alias="schedulePublishHelp">Sélectionnez la date et l'heure de publication/dépublication de l'élément de contenu.</key>
+		<key alias="createEmpty">Créer nouveau</key>
+		<key alias="createFromClipboard">Copier du clipboard</key>
+	</area>
+	<area alias="blueprints">
+		<key alias="createBlueprintFrom"><![CDATA[Créer un nouveau Modèle de Contenu à partir de <em>%0%</em>]]></key>
+		<key alias="blankBlueprint">Vide</key>
+		<key alias="selectBlueprint">Sélectionner un Modèle de Contenu</key>
+		<key alias="createdBlueprintHeading">Modèle de Contenu créé</key>
+		<key alias="createdBlueprintMessage">Un modèle de Contenu a été créé à partir de '%0%'</key>
+		<key alias="duplicateBlueprintMessage">Un autre Modèle de Contenu existe déjà avec le même nom</key>
+		<key alias="blueprintDescription">Un Modèle de Contenu est du contenu pré-défini qu'un éditeur peut sélectionner et utiliser comme base pour la création de nouveau contenu</key>
+	</area>
+	<area alias="media">
+		<key alias="clickToUpload">Cliquez pour télécharger</key>
+		<key alias="orClickHereToUpload">ou cliquez ici pour choisir un fichier</key>
+		<key alias="disallowedFileType">Ce fichier ne peut pas ête chargé, il n'est pas d'un type de fichier autorisé.</key>
+		<key alias="invalidFileName">Ce fichier ne peut pas être chargé, le nom du fichier n'est pas valide</key>
+		<key alias="maxFileSize">La taille maximum de fichier est</key>
+		<key alias="mediaRoot">Racine du média</key>
+		<key alias="moveToSameFolderFailed">Les dossiers parent et destination ne peuvent pas être identiques</key>
+		<key alias="createFolderFailed">Echec de la création d'un dossier sous le parent avec l'id %0%</key>
+		<key alias="renameFolderFailed">Echec du changement de nom du dossier avec l'id %0%</key>
+		<key alias="dragAndDropYourFilesIntoTheArea">Glissez et déposez vos fichiers dans la zone</key>
+	</area>
+	<area alias="member">
+		<key alias="createNewMember">Créer un nouveau membre</key>
+		<key alias="allMembers">Tous les membres</key>
+		<key alias="memberGroupNoProperties">Les groupes de membres n'ont pas de propriétés supplémentaires modifiables.</key>
+	</area>
+	<area alias="contentType">
+		<key alias="copyFailed">Echec de la copie du type de contenu</key>
+		<key alias="moveFailed">Echec du déplacement du type de contenu</key>
+	</area>
+	<area alias="mediaType">
+		<key alias="copyFailed">Echec de la copie du type de media</key>
+		<key alias="moveFailed">Echec du déplacement du type de media</key>
+	</area>
+	<area alias="memberType">
+		<key alias="copyFailed">Echec de la copie du type de membre</key>
+	</area>
+	<area alias="create">
+		<key alias="chooseNode">Où voulez-vous créer le nouveau %0%</key>
+		<key alias="createUnder">Créer un élément sous</key>
+		<key alias="createContentBlueprint">Sélectionnez le type de document pour lequel vous souhaitez créer un modèle de contenu</key>
+		<key alias="enterFolderName">Introduisez un nom de dossier</key>
+		<key alias="updateData">Choisissez un type et un titre</key>
+		<key alias="noDocumentTypes" version="7.0"><![CDATA[Il n'y a aucun type de document disponible pour créer du contenu ici. Vous devez d'abord les activer dans <strong>Types de documents</strong> sous la section <strong>Paramètres</strong>, en modifiant les <strong>Types de noeuds enfants autorisés</strong> sous les <strong>Permissions</strong>.]]></key>
+		<key alias="noDocumentTypesAtRoot"><![CDATA[Il n'y a aucun type de document disponible pour créer du contenu ici. Vous devez d'abord les activer dans <strong>Types de documents</strong> sous la section <strong>Paramètres</strong>.]]></key>
+		<key alias="noDocumentTypesWithNoSettingsAccess">La page sélectionnée dans l'arborescence de contenu n'autorise pas la création de pages sous elle.</key>
+		<key alias="noDocumentTypesEditPermissions">Modifier les permissions pour ce type de document</key>
+		<key alias="noDocumentTypesCreateNew">Créer un nouveau type de document</key>
+		<key alias="noDocumentTypesAllowedAtRoot"><![CDATA[Il n'y a aucun type de document disponible pour créer du contenu ici. Vous devez d'abord les activer dans <strong>Types de documents</strong> sous la section <strong>Paramètres</strong>, en modifiant l'option <strong>Autoriser comme racine</strong> sous les <strong>Permissions</strong>.]]></key>
+		<key alias="noMediaTypes" version="7.0"><![CDATA[Il n'y a aucun type de média disponible pour créer un media ici. Vous devez d'abord les activer dans <strong>Types de médias</strong> dans la section <strong>Paramètres</strong>, en modifiant les <strong>Types de noeuds enfants autorisés</strong> sous les <strong>Permissions</strong>.]]></key>
+		<key alias="noMediaTypesWithNoSettingsAccess">Le media sélectionné dans l'arborescence n'autorise pas la création d'un autre media sous lui.</key>
+		<key alias="noMediaTypesEditPermissions">Modifier les permissions pour ce type de media</key>
+		<key alias="documentTypeWithoutTemplate">Type de document sans modèle</key>
+		<key alias="newFolder">Nouveau répertoire</key>
+		<key alias="newDataType">Nouveau type de données</key>
+		<key alias="newJavascriptFile">Nouveau fichier javascript</key>
+		<key alias="newEmptyPartialView">Nouvelle vue partielle vide</key>
+		<key alias="newPartialViewMacro">Nouvelle macro pour vue partielle</key>
+		<key alias="newPartialViewFromSnippet">Nouvelle vue partielle à partir d'un snippet</key>
+		<key alias="newPartialViewMacroFromSnippet">Nouvelle macro pour vue partielle à partir d'un snippet</key>
+		<key alias="newPartialViewMacroNoMacro">Nouvelle macro pour vue partielle (sans macro)</key>
+		<key alias="newStyleSheetFile">Nouveau fichier de feuille de style</key>
+		<key alias="newRteStyleSheetFile">Nouveau fichier de feuille de style pour l'éditeur de texte</key>
+	</area>
+	<area alias="dashboard">
+		<key alias="browser">Parcourir votre site</key>
+		<key alias="dontShowAgain">- Cacher</key>
+		<key alias="nothinghappens">Si Umbraco ne s'ouvre pas, peut-être devez-vous autoriser l'ouverture des popups pour ce site.</key>
+		<key alias="openinnew">s'est ouvert dans une nouvelle fenêtre</key>
+		<key alias="restart">Redémarrer</key>
+		<key alias="visit">Visiter</key>
+		<key alias="welcome">Bienvenue</key>
+	</area>
+	<area alias="prompt">
+		<key alias="stay">Rester</key>
+		<key alias="discardChanges">Invalider les changements</key>
+		<key alias="unsavedChanges">Vous avez des changements en cours</key>
+		<key alias="unsavedChangesWarning">Etes-vous certain(e) de vouloir quitter cette page? - vous avez des changements en cours</key>
+		<key alias="confirmListViewPublish">La publication rendra les éléments sélectionnés visibles sur le site.</key>
+		<key alias="confirmListViewUnpublish">La suppression de la publication supprimera du site les éléments sélectionnés et tous leurs descendants.</key>
+		<key alias="confirmUnpublish">La suppression de la publication supprimera du site cette page ainsi que tous ses descendants.</key>
+		<key alias="doctypeChangeWarning">Vous avez des modifications en cours. Modifier le Type de Document fera disparaître ces modifications.</key>
+	</area>
+	<area alias="bulk">
+		<key alias="done">Terminé</key>
+		<key alias="deletedItem">%0% élément supprimé</key>
+		<key alias="deletedItems">%0% éléments supprimés</key>
+		<key alias="deletedItemOfItem">%0% élément sur %1% supprimé</key>
+		<key alias="deletedItemOfItems">%0% éléments sur %1% supprimés</key>
+		<key alias="publishedItem">%0% élément publié</key>
+		<key alias="publishedItems">%0% éléments publiés</key>
+		<key alias="publishedItemOfItem">%0% élément sur %1% publié</key>
+		<key alias="publishedItemOfItems">%0% éléments sur %1% publiés</key>
+		<key alias="unpublishedItem">%0% élément dépublié</key>
+		<key alias="unpublishedItems">%0% éléments dépubliés</key>
+		<key alias="unpublishedItemOfItem">%0% élément sur %1% dépublié</key>
+		<key alias="unpublishedItemOfItems">%0% éléments sur %1% dépubliés</key>
+		<key alias="movedItem">%0% élément déplacé</key>
+		<key alias="movedItems">%0% éléments déplacés</key>
+		<key alias="movedItemOfItem">%0% élément sur %1% déplacé</key>
+		<key alias="movedItemOfItems">%0% éléments sur %1% déplacés</key>
+		<key alias="copiedItem">%0% élément copié</key>
+		<key alias="copiedItems">%0% éléments copiés</key>
+		<key alias="copiedItemOfItem">%0% élément sur %1% copié</key>
+		<key alias="copiedItemOfItems">%0% éléments sur %1% copiés</key>
+	</area>
+	<area alias="defaultdialogs">
+		<key alias="nodeNameLinkPicker">Titre du lien</key>
+		<key alias="urlLinkPicker">Lien</key>
+		<key alias="anchorLinkPicker">Ancrage / requête</key>
+		<key alias="anchorInsert">Nom</key>
+		<key alias="closeThisWindow">Fermer cette fenêtre</key>
+		<key alias="confirmdelete">Êtes-vous certain(e) de vouloir supprimer</key>
+		<key alias="confirmdeleteNumberOfItems"><![CDATA[Êtes-vous certain(e) de vouloir supprimer <strong>%0%</strong> des <strong>%1%</strong> éléments]]></key>
+		<key alias="confirmdisable">Êtes-vous certain(e) de vouloir désactiver</key>
+		<key alias="confirmlogout">Êtes-vous certain(e)?</key>
+		<key alias="confirmSure">Êtes-vous certain(e)?</key>
+		<key alias="cut">Couper</key>
+		<key alias="editdictionary">Editer une entrée du Dictionnaire</key>
+		<key alias="editlanguage">Modifier la langue</key>
+		<key alias="editSelectedMedia">Modifier le media sélectionné</key>
+		<key alias="insertAnchor">Insérer un lien local (ancre)</key>
+		<key alias="insertCharacter">Insérer un caractère</key>
+		<key alias="insertgraphicheadline">Insérer un entête graphique</key>
+		<key alias="insertimage">Insérer une image</key>
+		<key alias="insertlink">Insérer un lien</key>
+		<key alias="insertMacro">Insérer une macro</key>
+		<key alias="inserttable">Insérer un tableau</key>
+		<key alias="languagedeletewarning">Ceci supprimera la langue</key>
+		<key alias="languageChangeWarning">Modifier la culture d'une langue peut être une opération lourde qui aura pour conséquence la réinitialisation de la cache de contenu et des index</key>
+		<key alias="lastEdited">Dernière modification</key>
+		<key alias="link">Lien</key>
+		<key alias="linkinternal">Lien interne :</key>
+		<key alias="linklocaltip">Si vous utilisez des ancres, insérez # au début du lien</key>
+		<key alias="linknewwindow">Ouvrir dans une nouvelle fenêtre?</key>
+		<key alias="macroDoesNotHaveProperties">Cette macro ne contient aucune propriété éditable</key>
+		<key alias="paste">Coller</key>
+		<key alias="permissionsEdit">Editer les permissions pour</key>
+		<key alias="permissionsSet">Définir les permissions pour</key>
+		<key alias="permissionsSetForGroup">Définir les permissions pour %0% pour le groupe d'utilisateurs %1%</key>
+		<key alias="permissionsHelp">Sélectionnez les groupes d'utilisateurs pour lesquels vous souhaitez définir les permissions</key>
+		<key alias="recycleBinDeleting">Les éléments dans la corbeille sont en cours de suppression. Veuillez ne pas fermer cette fenêtre avant que cette opération ne soit terminée.</key>
+		<key alias="recycleBinIsEmpty">La corbeille est maintenant vide</key>
+		<key alias="recycleBinWarning">Les éléments supprimés de la corbeille seront supprimés définitivement</key>
+		<key alias="regexSearchError"><![CDATA[Le webservice <a target='_blank' rel='noopener' href='http://regexlib.com'>regexlib.com</a> rencontre actuellement des problèmes sur lesquels nous n'avons aucun contrôle. Nous sommes sincèrement désolés pour le désagrément.]]></key>
+		<key alias="regexSearchHelp">Rechercher une expression régulière à ajouter pour la validation d'un champ de formulaire. Exemple: 'email, 'zip-code', 'URL'.</key>
+		<key alias="removeMacro">Supprimer la macro</key>
+		<key alias="requiredField">Champ obligatoire</key>
+		<key alias="sitereindexed">Le site a été réindéxé</key>
+		<key alias="siterepublished">Le cache du site a été mis à jour. Tous les contenus publiés sont maintenant à jour. Et tous les contenus dépubliés sont restés invisibles.</key>
+		<key alias="siterepublishHelp">Le cache du site va être mis à jour. Tous les contenus publiés seront mis à jour. Et tous les contenus dépubliés resteront invisibles.</key>
+		<key alias="tableColumns">Nombre de colonnes</key>
+		<key alias="tableRows">Nombre de lignes</key>
+		<key alias="thumbnailimageclickfororiginal">Cliquez sur l'image pour la voir en taille réelle</key>
+		<key alias="treepicker">Sélectionner un élément</key>
+		<key alias="viewCacheItem">Voir l'élément de cache</key>
+		<key alias="relateToOriginalLabel">Lier à l'original</key>
+		<key alias="includeDescendants">Inclure les descendants</key>
+		<key alias="theFriendliestCommunity">La communauté la plus amicale</key>
+		<key alias="linkToPage">Lier à la page</key>
+		<key alias="openInNewWindow">Ouvre le document lié dans une nouvelle fenêtre ou un nouvel onglet</key>
+		<key alias="linkToMedia">Lier à un media</key>
+		<key alias="selectContentStartNode">Sélectionner le noeud de base du contenu</key>
+		<key alias="selectMedia">Sélectionner le media</key>
+		<key alias="selectMediaType">Sélectionner le type de media</key>
+		<key alias="selectIcon">Sélectionner l'icône</key>
+		<key alias="selectItem">Sélectionner l'élément</key>
+		<key alias="selectLink">Sélectionner le lien</key>
+		<key alias="selectMacro">Sélectionner la macro</key>
+		<key alias="selectContent">Sélectionner le contenu</key>
+		<key alias="selectContentType">Sélectionner le type de contenu</key>
+		<key alias="selectMediaStartNode">Sélectionner le noeud de base des media</key>
+		<key alias="selectMember">Sélectionner le membre</key>
+		<key alias="selectMemberGroup">Sélectionner le groupe de membres</key>
+		<key alias="selectMemberType">Sélectionner le type de membre</key>
+		<key alias="selectNode">Sélectionner le noeud</key>
+		<key alias="selectSections">Sélectionner les sections</key>
+		<key alias="selectUsers">Sélectionner les utilisateurs</key>
+		<key alias="noIconsFound">Aucune icone n'a été trouvée</key>
+		<key alias="noMacroParams">Il n'y a pas de paramètres pour cette macro</key>
+		<key alias="noMacros">Il n'y a pas de macro disponible à insérer</key>
+		<key alias="externalLoginProviders">Fournisseurs externes d'identification</key>
+		<key alias="exceptionDetail">Détails de l'exception</key>
+		<key alias="stacktrace">Trace d'exécution</key>
+		<key alias="innerException">Exception interne</key>
+		<key alias="linkYour">Liez votre</key>
+		<key alias="unLinkYour">Enlevez votre</key>
+		<key alias="account">compte</key>
+		<key alias="selectEditor">Sélectionner un éditeur</key>
+		<key alias="selectSnippet">Selectionner un snippet</key>
+		<key alias="variantdeletewarning">Ceci supprimera le noeud et toutes ses langues. Si vous souhaitez supprimer une langue spécifique, vous devriez plutôt supprimer la publication du noeud dans cette langue-là.</key>
+	</area>
+	<area alias="dictionary">
+		<key alias="importDictionaryItemHelp">
+			Pour importer un élément de dictionnaire, trouvez le fichier ".udt" sur votre ordinateur en cliquant sur le bouton "Importer" (une confirmation vous sera demandée dans l'écran suivant)
+		</key>
+		<key alias="itemDoesNotExists">L'élément de dictionnaire n'existe pas.</key>
+		<key alias="parentDoesNotExists">L'élément parent n'existe pas.</key>
+		<key alias="noItems">Il n'y a pas d'élément dans le dictionnaire.</key>
+		<key alias="noItemsInFile">Il n'y a pas d'élément de dictionnaire dans ce fichier.</key>
+		<key alias="createNew">Créer un élément de dictionnaire</key>
+	</area>
+	<area alias="dictionaryItem">
+		<key alias="description">
+			<![CDATA[
+      Editez les différentes versions de langues pour l'élément de dictionnaire '<em>%0%</em>' ci-dessous.
+   ]]>
+		</key>
+		<key alias="displayName">Nom de Culture</key>
+		<key alias="changeKeyError">
+			<![CDATA[
+      La clé '%0%' existe déjà.
+   ]]>
+		</key>
+		<key alias="overviewTitle">Aperçu du dictionaire</key>
+	</area>
+	<area alias="examineManagement">
+		<key alias="configuredSearchers">Recherches configurées</key>
+		<key alias="configuredSearchersDescription">Affiche les propriétés et les outils de chaque Recherche configurée (e.g. une recherche multi-index)</key>
+		<key alias="fieldValues">Valeurs du champ</key>
+		<key alias="healthStatus">Etat de santé</key>
+		<key alias="healthStatusDescription">L'état de santé de l'index et s'il peut être lu</key>
+		<key alias="indexers">Indexeurs</key>
+		<key alias="indexInfo">Info Index</key>
+		<key alias="indexInfoDescription">Liste les propriétés de l'index</key>
+		<key alias="manageIndexes">Gérer les index d'Examine</key>
+		<key alias="manageIndexesDescription">Vous permet de voir les détails de chaque index et fournit des outils pour gérer les index</key>
+		<key alias="rebuildIndex">Reconstruire l'index</key>
+		<key alias="rebuildIndexWarning">
+			<![CDATA[
+      Ceci provoquera la reconstruction de l'index.<br />
+      Cela pourrait prendre un certain temps en fonction de la quantité de contenu présente dans votre site.<br />
+      Il est déconseillé de reconstruire un index pendant les périodes de trafic intense sur le site web ou quand les éditeurs sont en train d'éditer du contenu.
+     ]]>
+		</key>
+		<key alias="searchers">Recherches</key>
+		<key alias="searchDescription">Rechercher dans l'index et afficher les résultats</key>
+		<key alias="tools">Outils</key>
+		<key alias="toolsDescription">Outils pour gérer l'index</key>
+		<key alias="fields">champs</key>
+		<key alias="indexCannotRead">L'index ne peut pas être lu et devra être reconstruit</key>
+		<key alias="processIsTakingLonger">Le processus dure plus de temps que prévu, vérifiez les logs Umbraco afin de voir s'il y a eu des erreurs pendant cette opératon</key>
+		<key alias="indexCannotRebuild">Cet index ne peut pas être reconstruit parce qu'on ne lui a pas assigné de</key>
+		<key alias="iIndexPopulator">IIndexPopulator</key>
+	</area>
+	<area alias="placeholders">
+		<key alias="username">Votre nom d'utilisateur</key>
+		<key alias="password">Votre mot de passe</key>
+		<key alias="confirmPassword">Confirmation de votre mot de passe</key>
+		<key alias="nameentity">Nommer %0%...</key>
+		<key alias="entername">Entrez un nom...</key>
+		<key alias="enteremail">Entrez un email...</key>
+		<key alias="enterusername">Entrez un nom d'utilisateur...</key>
+		<key alias="label">Libellé...</key>
+		<key alias="enterDescription">Entrez une description...</key>
+		<key alias="search">Rechercher...</key>
+		<key alias="filter">Filtrer...</key>
+		<key alias="enterTags">Ajouter des tags (appuyer sur enter entre chaque tag)...</key>
+		<key alias="email">Entrez votre email</key>
+		<key alias="enterMessage">Entrez un message...</key>
+		<key alias="usernameHint">Votre nom d'utilisateur est généralement votre adresse email</key>
+		<key alias="anchor">#value ou ?key=value</key>
+		<key alias="enterAlias">Introduisez l'alias...</key>
+		<key alias="generatingAlias">Génération de l'alias...</key>
+		<key alias="a11yCreateItem">Créer un élément</key>
+		<key alias="a11yEdit">Modifier</key>
+		<key alias="a11yName">Nom</key>
+	</area>
+	<area alias="editcontenttype">
+		<key alias="createListView" version="7.2">Créer une liste personnalisée</key>
+		<key alias="removeListView" version="7.2">Supprimer la liste personnalisée</key>
+		<key alias="aliasAlreadyExists">Il existe déjà un type de contenu, un tye de media ou un type de membre avec cet alias</key>
+	</area>
+	<area alias="renamecontainer">
+		<key alias="renamed">Renommé</key>
+		<key alias="enterNewFolderName">Entrez un nouveau nom de répertoire ici</key>
+		<key alias="folderWasRenamed">%0% a été renommé en %1%</key>
+	</area>
+	<area alias="editdatatype">
+		<key alias="addPrevalue">Ajouter une valeur de base</key>
+		<key alias="dataBaseDatatype">Type de donnée en base de donées</key>
+		<key alias="guid">GUID du Property Editor</key>
+		<key alias="renderControl">Property editor</key>
+		<key alias="rteButtons">Boutons</key>
+		<key alias="rteEnableAdvancedSettings">Activer les paramètres avancés pour</key>
+		<key alias="rteEnableContextMenu">Activer le menu contextuel</key>
+		<key alias="rteMaximumDefaultImgSize">Taille maximale par défaut des images insérées</key>
+		<key alias="rteRelatedStylesheets">CSS associées</key>
+		<key alias="rteShowLabel">Afficher le libellé</key>
+		<key alias="rteWidthAndHeight">Largeur et hauteur</key>
+		<key alias="selectFolder">Sélectionnez le répertoire où déplacer</key>
+		<key alias="inTheTree">dans l'arborescence ci-dessous</key>
+		<key alias="wasMoved">a été déplacé sous</key>
+		<key alias="hasReferencesDeleteConsequence"><![CDATA[La suppression de <strong>%0%</strong> supprimera les propriétés et leurs données des éléments suivants]]></key>
+		<key alias="acceptDeleteConsequence">Je comprends que cette action va supprimer les propriétés et les données basées sur ce Type de Données</key>
+	</area>
+	<area alias="errorHandling">
+		<key alias="errorButDataWasSaved">Vos données ont été sauvegardées, mais avant de pouvoir publier votre page, il y a des erreurs que vous devez d'abord corriger :</key>
+		<key alias="errorChangingProviderPassword">Le Membership Provider n'autorise pas le changement des mots de passe (EnablePasswordRetrieval doit être défini à true)</key>
+		<key alias="errorExistsWithoutTab">%0% existe déjà</key>
+		<key alias="errorHeader">Des erreurs sont survenues :</key>
+		<key alias="errorHeaderWithoutTab">Des erreurs sont survenues :</key>
+		<key alias="errorInPasswordFormat">Le mot de passe doit contenir un minimum de %0% caractères et contenir au moins %1% caractère(s) non-alphanumerique</key>
+		<key alias="errorIntegerWithoutTab">%0% doit être un entier</key>
+		<key alias="errorMandatory">Le champ %0% dans l'onglet %1% est obligatoire</key>
+		<key alias="errorMandatoryWithoutTab">%0% est un champ obligatoire</key>
+		<key alias="errorRegExp">%0% dans %1% n'est pas correctement formaté</key>
+		<key alias="errorRegExpWithoutTab">%0% n'est pas correctement formaté</key>
+	</area>
+	<area alias="errors">
+		<key alias="receivedErrorFromServer">Le serveur a retourné une erreur</key>
+		<key alias="dissallowedMediaType">Le type de fichier spécifié n'est pas autorisé par l'administrateur</key>
+		<key alias="codemirroriewarning">NOTE ! Même si CodeMirror est activé dans la configuration, il est désactivé dans Internet Explorer car il n'est pas suffisamment stable dans ce navigateur.</key>
+		<key alias="contentTypeAliasAndNameNotNull">Veuillez remplir l'alias et le nom de la nouvelle propriété!</key>
+		<key alias="filePermissionsError">Il y a un problème de droits en lecture/écriture sur un fichier ou dossier spécifique</key>
+		<key alias="macroErrorLoadingPartialView">Erreur de chargement du script d'une Partial View (fichier : %0%)</key>
+		<key alias="missingTitle">Veuillez entrer un titre</key>
+		<key alias="missingType">Veuillez choisir un type</key>
+		<key alias="pictureResizeBiggerThanOrg">Vous allez définir une taille d'image supérieure à sa taille d'origine. Êtes-vous certain(e) de vouloir continuer?</key>
+		<key alias="startNodeDoesNotExists">Noeud de départ supprimé, contactez votre administrateur</key>
+		<key alias="stylesMustMarkBeforeSelect">Veuillez sélectionner du contenu avant de changer le style</key>
+		<key alias="stylesNoStylesOnPage">Aucun style actif disponible</key>
+		<key alias="tableColMergeLeft">Veuillez placer le curseur à la gauche des deux cellules que vous voulez fusionner</key>
+		<key alias="tableSplitNotSplittable">Vous ne pouvez pas scinder une cellule qui n'a pas été fusionnée.</key>
+		<key alias="propertyHasErrors">Cette propriété n'est pas valide</key>
+	</area>
+	<area alias="general">
+		<key alias="options">Options</key>
+		<key alias="about">A propos</key>
+		<key alias="action">Action</key>
+		<key alias="actions">Actions</key>
+		<key alias="add">Ajouter</key>
+		<key alias="alias">Alias</key>
+		<key alias="all">Tout</key>
+		<key alias="areyousure">Êtes-vous certain(e)?</key>
+		<key alias="back">Retour</key>
+		<key alias="backToOverview">Retour à l'aperçu</key>
+		<key alias="border">Bord</key>
+		<key alias="by">par</key>
+		<key alias="cancel">Annuler</key>
+		<key alias="cellMargin">Marge de cellule</key>
+		<key alias="choose">Choisir</key>
+		<key alias="close">Fermer</key>
+		<key alias="closewindow">Fermer la fenêtre</key>
+		<key alias="closepane">Fermer le panel</key>
+		<key alias="comment">Commenter</key>
+		<key alias="confirm">Confirmer</key>
+		<key alias="constrain">Conserver</key>
+		<key alias="constrainProportions">Conserver les proportions</key>
+		<key alias="content">Contenu</key>
+		<key alias="continue">Continuer</key>
+		<key alias="copy">Copier</key>
+		<key alias="create">Créer</key>
+		<key alias="database">Base de données</key>
+		<key alias="date">Date</key>
+		<key alias="default">Défaut</key>
+		<key alias="delete">Supprimer</key>
+		<key alias="deleted">Supprimé</key>
+		<key alias="deleting">Suppression...</key>
+		<key alias="design">Design</key>
+		<key alias="dictionary">Dictionnaire</key>
+		<key alias="dimensions">Dimensions</key>
+		<key alias="down">Bas</key>
+		<key alias="download">Télécharger</key>
+		<key alias="edit">Editer</key>
+		<key alias="edited">Edité</key>
+		<key alias="elements">Eléments</key>
+		<key alias="email">Email</key>
+		<key alias="error">Erreur</key>
+		<key alias="field">Champ</key>
+		<key alias="findDocument">Trouver</key>
+		<key alias="first">Premier</key>
+		<key alias="focalPoint">Point focal</key>
+		<key alias="general">Général</key>
+		<key alias="groups">Groupes</key>
+		<key alias="group">Groupe</key>
+		<key alias="height">Hauteur</key>
+		<key alias="help">Aide</key>
+		<key alias="hide">Cacher</key>
+		<key alias="history">Historique</key>
+		<key alias="icon">Icône</key>
+		<key alias="id">Id</key>
+		<key alias="import">Importer</key>
+		<key alias="info">Info</key>
+		<key alias="innerMargin">Marge intérieure</key>
+		<key alias="insert">Insérer</key>
+		<key alias="install">Installer</key>
+		<key alias="invalid">Non valide</key>
+		<key alias="justify">Justifier</key>
+		<key alias="label">Libellé</key>
+		<key alias="language">Langue</key>
+		<key alias="last">Dernier</key>
+		<key alias="layout">Mise en page</key>
+		<key alias="links">Liens</key>
+		<key alias="loading">En cours de chargement</key>
+		<key alias="locked">Bloqué</key>
+		<key alias="login">Connexion</key>
+		<key alias="logoff">Déconnexion</key>
+		<key alias="logout">Déconnexion</key>
+		<key alias="macro">Macro</key>
+		<key alias="mandatory">Obligatoire</key>
+		<key alias="message">Message</key>
+		<key alias="move">Déplacer</key>
+		<key alias="name">Nom</key>
+		<key alias="new">Nouveau</key>
+		<key alias="next">Suivant</key>
+		<key alias="no">Non</key>
+		<key alias="of">de</key>
+		<key alias="off">Inactif</key>
+		<key alias="ok">OK</key>
+		<key alias="open">Ouvrir</key>
+		<key alias="on">Actif</key>
+		<key alias="or">ou</key>
+		<key alias="orderBy">Trier par</key>
+		<key alias="password">Mot de passe</key>
+		<key alias="path">Chemin</key>
+		<key alias="pleasewait">Un moment s'il vous plaît...</key>
+		<key alias="previous">Précédent</key>
+		<key alias="properties">Propriétés</key>
+		<key alias="readMore">En savoir plus</key>
+		<key alias="rebuild">Reconstruire</key>
+		<key alias="reciept">Email de réception des données de formulaire</key>
+		<key alias="recycleBin">Corbeille</key>
+		<key alias="recycleBinEmpty">Votre corbeille est vide</key>
+		<key alias="reload">Rafraîchir</key>
+		<key alias="remaining">Restant</key>
+		<key alias="remove">Enlever</key>
+		<key alias="rename">Renommer</key>
+		<key alias="renew">Renouveller</key>
+		<key alias="required" version="7.0">Requis</key>
+		<key alias="retrieve">Retrouver</key>
+		<key alias="retry">Réessayer</key>
+		<key alias="rights">Permissions</key>
+		<key alias="scheduledPublishing">Publication Programmée</key>
+		<key alias="search">Rechercher</key>
+		<key alias="searchNoResult">Désolé, nous ne pouvons pas trouver ce que vous recherchez</key>
+		<key alias="noItemsInList">Aucun élément n'a été ajouté</key>
+		<key alias="server">Serveur</key>
+		<key alias="settings">Paramètres</key>
+		<key alias="shared">Partagé</key>
+		<key alias="show">Montrer</key>
+		<key alias="showPageOnSend">Afficher la page à l'envoi</key>
+		<key alias="size">Taille</key>
+		<key alias="sort">Trier</key>
+		<key alias="status">Statut</key>
+		<key alias="submit">Envoyer</key>
+		<key alias="type">Type</key>
+		<key alias="typeToSearch">Rechercher...</key>
+		<key alias="under">sous</key>
+		<key alias="up">Haut</key>
+		<key alias="update">Mettre à jour</key>
+		<key alias="upgrade">Upgrader</key>
+		<key alias="upload">Télécharger</key>
+		<key alias="url">URL</key>
+		<key alias="user">Utilisateur</key>
+		<key alias="username">Nom d'utilisateur</key>
+		<key alias="value">Valeur</key>
+		<key alias="view">Voir</key>
+		<key alias="welcome">Bienvenue...</key>
+		<key alias="width">Largeur</key>
+		<key alias="yes">Oui</key>
+		<key alias="folder">Dossier</key>
+		<key alias="searchResults">Résultats de recherche</key>
+		<key alias="reorder">Réorganiser</key>
+		<key alias="reorderDone">J'ai fini de réorganiser</key>
+		<key alias="preview">Prévisualiser</key>
+		<key alias="changePassword">Modifier le mot de passe</key>
+		<key alias="to">vers</key>
+		<key alias="listView">Liste</key>
+		<key alias="saving">Sauvegarde...</key>
+		<key alias="current">actuel</key>
+		<key alias="embed">Intégrer</key>
+		<key alias="selected">sélectionné</key>
+		<key alias="avatar">Avatar de</key>
+		<key alias="header">Entête</key>
+		<key alias="systemField">champ système</key>
+		<key alias="lastUpdated">Dernière mise à jour</key>
+	</area>
+	<area alias="colors">
+		<key alias="blue">Bleu</key>
+	</area>
+	<area alias="shortcuts">
+		<key alias="addGroup">Ajouter un onglet</key>
+		<key alias="addProperty">Ajouter une propriété</key>
+		<key alias="addEditor">Ajouter un éditeur</key>
+		<key alias="addTemplate">Ajouter un modèle</key>
+		<key alias="addChildNode">Ajouter un noeud enfant</key>
+		<key alias="addChild">Ajouter un enfant</key>
+		<key alias="editDataType">Editer le type de données</key>
+		<key alias="navigateSections">Parcourir les sections</key>
+		<key alias="shortcut">Raccourcis</key>
+		<key alias="showShortcuts">afficher les raccourcis</key>
+		<key alias="toggleListView">Activer / Désactiver la vue en liste</key>
+		<key alias="toggleAllowAsRoot">Activer / Désactiver l'autorisation comme racine</key>
+		<key alias="commentLine">Commenter/Décommenter les lignes</key>
+		<key alias="removeLine">Supprimer la ligne</key>
+		<key alias="copyLineUp">Copier les lignes vers le haut</key>
+		<key alias="copyLineDown">Copier les lignes vers le bas</key>
+		<key alias="moveLineUp">Déplacer les lignes vers le haut</key>
+		<key alias="moveLineDown">Déplacer les lignes vers le bas</key>
+		<key alias="generalHeader">Général</key>
+		<key alias="editorHeader">Editeur</key>
+		<key alias="toggleAllowCultureVariants">Activer / Désactiver les variantes de culture</key>
+	</area>
+	<area alias="graphicheadline">
+		<key alias="backgroundcolor">Couleur de fond</key>
+		<key alias="bold">Gras</key>
+		<key alias="color">Couleur de texte</key>
+		<key alias="font">Police</key>
+		<key alias="text">Texte</key>
+	</area>
+	<area alias="headers">
+		<key alias="page">Page</key>
+	</area>
+	<area alias="installer">
+		<key alias="databaseErrorCannotConnect">Le programme d'installation ne parvient pas à se connecter à la base de données.</key>
+		<key alias="databaseFound">Votre base de données a été détectée et est identifiée comme étant</key>
+		<key alias="databaseHeader">Configuration de la base de données</key>
+		<key alias="databaseInstall">
+			<![CDATA[
+      Appuyez sur le bouton <strong>installer</strong> pour installer la base de données Umbraco %0%
+    ]]>
+		</key>
+		<key alias="databaseInstallDone"><![CDATA[Umbraco %0% a été copié dans votre base de données. Appuyez sur <strong>Suivant</strong> pour poursuivre.]]></key>
+		<key alias="databaseText">
+			<![CDATA[Pour réaliser cette étape, vous devez d'abord connaître des informations concernant votre serveur de base de données ("connection string").<br />
+        Veuillez contacter votre fournisseur de services internet si nécessaire.
+        Si vous installez Umbraco sur un ordinateur ou un serveur local, vous aurez peut-être besoin de consulter votre administrateur système.]]>
+		</key>
+		<key alias="databaseUpgrade">
+			<![CDATA[
+      <p>
+      Appuyez sur le bouton <strong>Upgrader</strong> pour mettre à jour votre base de données vers Umbraco %0%</p>
+      <p>
+      N'ayez pas d'inquiétude : aucun contenu ne sera supprimé et tout continuera à fonctionner parfaitement par après !
+      </p>
+      ]]>
+		</key>
+		<key alias="databaseUpgradeDone">
+			<![CDATA[Votre base de données a été mise à jour vers la version %0%.<br />Appuyez sur <strong>Suivant</strong> pour
+      poursuivre. ]]>
+		</key>
+		<key alias="databaseUpToDate"><![CDATA[Votre base de données est à jour ! Cliquez sur <strong>Suivant</strong> pour poursuivre la configuration]]></key>
+		<key alias="defaultUserChangePass"><![CDATA[<strong>Le mot de passe par défaut doit être modifié !</strong>]]></key>
+		<key alias="defaultUserDisabled"><![CDATA[<strong>L'utilisateur par défaut a été désactivé ou n'a pas accès à Umbraco!</strong></p><p>Aucune autre action n'est requise. Cliquez sur <strong>Suivant</strong> pour poursuivre.]]></key>
+		<key alias="defaultUserPassChanged"><![CDATA[<strong>Le mot de passe par défaut a été modifié avec succès depuis l'installation!</strong></p><p>Aucune autre action n'est requise. Cliquez sur <strong>Suivant</strong> pour poursuivre.]]></key>
+		<key alias="defaultUserPasswordChanged">Le mot de passe a été modifié !</key>
+		<key alias="greatStart">Pour bien commencer, regardez nos vidéos d'introduction</key>
+		<key alias="None">Pas encore installé.</key>
+		<key alias="permissionsAffectedFolders">Fichiers et dossiers concernés</key>
+		<key alias="permissionsAffectedFoldersMoreInfo">Plus d'informations sur la configuration des permissions</key>
+		<key alias="permissionsAffectedFoldersText">Vous devez donner à ASP.NET les droits de modification sur les fichiers/dossiers suivants</key>
+		<key alias="permissionsAlmostPerfect">
+			<![CDATA[<strong>Vos configurations de permissions sont presque parfaites !</strong><br /><br />
+        Vous pouvez faire fonctionner Umbraco sans problèmes, mais vous ne serez pas en mesure d'installer des packages, ce qui est hautement recommandé pour tirer pleinement profit d'Umbraco.]]>
+		</key>
+		<key alias="permissionsHowtoResolve">Comment résoudre</key>
+		<key alias="permissionsHowtoResolveLink">Cliquez ici pour lire la version texte</key>
+		<key alias="permissionsHowtoResolveText"><![CDATA[Regardez notre <strong>tutoriel vidéo</strong> sur la définition des permissions des répertoires pour Umbraco, ou lisez la version texte.]]></key>
+		<key alias="permissionsMaybeAnIssue">
+			<![CDATA[<strong>Vos configurations de permissions pourraient poser problème !</strong>
+      <br/><br />
+      Vous pouvez faire fonctionner Umbraco sans problèmes, mais vous ne serez pas en mesure d'installer des packages, ce qui est hautement recommandé pour tirer pleinement profit d'Umbraco.]]>
+		</key>
+		<key alias="permissionsNotReady">
+			<![CDATA[<strong>Vos configurations de permissions ne sont pas prêtes pour Umbraco !</strong>
+          <br /><br />
+          Pour faire fonctionner Umbraco, vous aurez besoin de mettre à jour les permissions sur les fichiers/dossiers.]]>
+		</key>
+		<key alias="permissionsPerfect">
+			<![CDATA[<strong>Vos configurations de permissions sont parfaites !</strong><br /><br />
+              Vous êtes prêt(e) à faire fonctionner Umbraco et à installer des packages !]]>
+		</key>
+		<key alias="permissionsResolveFolderIssues">Résoudre un problème sur un dossier</key>
+		<key alias="permissionsResolveFolderIssuesLink">Suivez ce lien pour plus d'informations sur les problèmes avec ASP.NET et la création de dossiers</key>
+		<key alias="permissionsSettingUpPermissions">Définir les permissions de dossier</key>
+		<key alias="permissionsText">
+			<![CDATA[
+      Umbraco nécessite des permissions d'écriture/modification sur certains dossiers pour pouvoir stocker des fichiers comme des images et des PDF.
+      Il stocke également des données temporaires (i.e : cache) pour améliorer les performances de votre site.
+    ]]>
+		</key>
+		<key alias="runwayFromScratch">Je veux démarrer "from scratch"</key>
+		<key alias="runwayFromScratchText">
+			<![CDATA[
+        Votre site est vide pour le moment, ce qui est parfait si vous voulez commencer "from scratch" et créer vos propres types de documents et modèles d'affichage.
+        (<a href="https://umbraco.tv/documentation/videos/for-site-builders/foundation/document-types">Apprenez comment</a>)
+        Vous pouvez toujours choisir d'installer Runway plus tard. Pour cela, allez dans la section "Développeur" et sélectionnez "Packages".
+      ]]>
+		</key>
+		<key alias="runwayHeader">Vous venez de mettre en place une plateforme Umbraco toute nette. Que voulez-vous faire ensuite ?</key>
+		<key alias="runwayInstalled">Runway est installé</key>
+		<key alias="runwayInstalledText">
+			<![CDATA[
+      Les fondations en place. Choisissez les modules que vous souhaitez installer par-dessus<br />
+      Voici la liste des modules recommandés, cochez ceux que vous souhaitez installer, ou regardez la <a href="#" onclick="toggleModules(); return false;" id="toggleModuleList">liste complète des modules</a>
+      ]]>
+		</key>
+		<key alias="runwayOnlyProUsers">Recommandé uniquement pour les utilisateurs expérimentés</key>
+		<key alias="runwaySimpleSite">Je veux commencer avec un site simple</key>
+		<key alias="runwaySimpleSiteText">
+			<![CDATA[
+      <p>
+      "Runway" est un site simple qui fournit des types de documents et des modèles de base. L'installateur peut mettre en place Runway automatiquement pour vous,
+        mais vous pouvez facilement l'éditer, l'enrichir, ou le supprimer par la suite. Il n'est pas nécessaire, et vous pouvez parfaitement vous en passer pour utiliser Umbraco. Cela étant dit,
+        Runway offre une base facile, fondée sur des bonnes pratiques, pour vous permettre de commencer plus rapidement que jamais.
+        Si vous choisissez d'installer Runway, vous pouvez sélectionner en option des blocs de base, appelés Runway Modules, pour enrichir les pages de votre site.
+        </p>
+        <small>
+        <em>Inclus avec Runway :</em> Home page, Getting Started page, Installing Modules page.<br />
+        <em>Modules optionnels :</em> Top Navigation, Sitemap, Contact, Gallery.
+        </small>
+      ]]>
+		</key>
+		<key alias="runwayWhatIsRunway">Qu'est-ce que Runway</key>
+		<key alias="step1">Etape 1/5 : Accepter la licence</key>
+		<key alias="step2">Etape 2/5 : Configuration de la base de données</key>
+		<key alias="step3">Etape 3/5 : Validation des permissions de fichiers</key>
+		<key alias="step4">Etape 4/5 : Sécurité Umbraco</key>
+		<key alias="step5">Etape 5/5 : Umbraco est prêt</key>
+		<key alias="thankYou">Merci d'avoir choisi Umbraco</key>
+		<key alias="theEndBrowseSite">
+			<![CDATA[<h3>Parcourir votre nouveau site</h3>
+Vous avez installé Runway, alors pourquoi ne pas jeter un oeil au look de votre nouveau site ?]]>
+		</key>
+		<key alias="theEndFurtherHelp">
+			<![CDATA[<h3>Aide et informations complémentaires</h3>
+Obtenez de l'aide de notre communauté "award winning", parcourez la documentation ou regardez quelques vidéos gratuites sur la manière de construire un site simple, d'utiliser les packages ainsi qu'un guide rapide sur la terminologie Umbraco]]>
+		</key>
+		<key alias="theEndHeader">Umbraco %0% est installé et prêt à être utilisé</key>
+		<key alias="theEndInstallSuccess">
+			<![CDATA[Vous pouvez <strong>démarrer instantanément</strong> en cliquant sur le bouton "Lancer Umbraco" ci-dessous.<br />
+Si vous <strong>débutez avec Umbraco</strong>, vous pouvez trouver une foule de ressources dans nos pages "Getting Started".]]>
+		</key>
+		<key alias="theEndOpenUmbraco">
+			<![CDATA[<h3>Lancer Umbraco</h3>
+Pour gérer votre site, ouvrez simplement le backoffice Umbraco et commencez à ajouter du contenu, à mettre à jour les modèles d'affichage et feuilles de styles ou à ajouter de nouvelles fonctionnalités]]>
+		</key>
+		<key alias="Unavailable">La connexion à la base de données a échoué.</key>
+		<key alias="Version3">Umbraco Version 3</key>
+		<key alias="Version4">Umbraco Version 4</key>
+		<key alias="watch">Regarder</key>
+		<key alias="welcomeIntro">
+			<![CDATA[Cet assistant vous guidera tout au long du processus de configuration d'<strong>Umbraco %0%</strong>, qu'il s'agisse d'une nouvelle installation ou d'une mise à jour à partir de la version 3.0
+      <br /><br />
+      Appuyez sur <strong>"suivant"</strong> pour commencer l'assistant.]]>
+		</key>
+	</area>
+	<area alias="language">
+		<key alias="cultureCode">Code de la Culture</key>
+		<key alias="displayName">Nom de la culture</key>
+	</area>
+	<area alias="lockout">
+		<key alias="lockoutWillOccur">Vous avez été inactif et la déconnexion aura lieu automatiquement dans</key>
+		<key alias="renewSession">Renouvellez votre session maintenant pour sauvegarder votre travail</key>
+	</area>
+	<area alias="login">
+		<key alias="greeting0">Bienvenue</key>
+		<key alias="greeting1">Bienvenue</key>
+		<key alias="greeting2">Bienvenue</key>
+		<key alias="greeting3">Bienvenue</key>
+		<key alias="greeting4">Bienvenue</key>
+		<key alias="greeting5">Bienvenue</key>
+		<key alias="greeting6">Bienvenue</key>
+		<key alias="instruction">Connectez-vous ci-dessous</key>
+		<key alias="signInWith">Identifiez-vous avec</key>
+		<key alias="timeout">La session a expiré</key>
+		<key alias="bottomText"><![CDATA[<p style="text-align:right;">&copy; 2001 - %0% <br /><a href="https://umbraco.com" style="text-decoration: none" target="_blank" rel="noopener">Umbraco.com</a></p> ]]></key>
+		<key alias="forgottenPassword">Mot de passe oublié?</key>
+		<key alias="forgottenPasswordInstruction">Un email contenant un lien pour ré-initialiser votre mot de passe sera envoyé à l'adresse spécifiée</key>
+		<key alias="requestPasswordResetConfirmation">Un email contenant les instructions de ré-initialisation de votre mot de passe sera envoyée à l'adresse spécifiée si elle correspond à nos informations.</key>
+		<key alias="showPassword">Montrer le mot de passe</key>
+		<key alias="hidePassword">Cacher le mot de passe</key>
+		<key alias="returnToLogin">Revenir au formulaire de connexion</key>
+		<key alias="setPasswordInstruction">Veuillez fournir un nouveau mot de passe</key>
+		<key alias="setPasswordConfirmation">Votre mot de passe a été mis à jour</key>
+		<key alias="resetCodeExpired">Le lien sur lequel vous avez cliqué est non valide ou a expiré.</key>
+		<key alias="resetPasswordEmailCopySubject">Umbraco: Ré-initialiser le mot de passe</key>
+		<key alias="resetPasswordEmailCopyFormat">
+			<![CDATA[
+        <html>
+			<head>
+				<meta name='viewport' content='width=device-width'>
+				<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>
+			</head>
+			<body class='' style='font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; color: #392F54; line-height: 22px; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background: #1d1333; margin: 0; padding: 0;' bgcolor='#1d1333'>
+				<style type='text/css'> @media only screen and (max-width: 620px) {table[class=body] h1 {font-size: 28px !important; margin-bottom: 10px !important; } table[class=body] .wrapper {padding: 32px !important; } table[class=body] .article {padding: 32px !important; } table[class=body] .content {padding: 24px !important; } table[class=body] .container {padding: 0 !important; width: 100% !important; } table[class=body] .main {border-left-width: 0 !important; border-radius: 0 !important; border-right-width: 0 !important; } table[class=body] .btn table {width: 100% !important; } table[class=body] .btn a {width: 100% !important; } table[class=body] .img-responsive {height: auto !important; max-width: 100% !important; width: auto !important; } } .btn-primary table td:hover {background-color: #34495e !important; } .btn-primary a:hover {background-color: #34495e !important; border-color: #34495e !important; } .btn  a:visited {color:#FFFFFF;} </style>
+				<table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #1d1333;" bgcolor="#1d1333">
+					<tr>
+						<td style="font-family: sans-serif; font-size: 14px; vertical-align: top; padding: 24px;" valign="top">
+							<table style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+								<tr>
+									<td background="https://umbraco.com/umbraco/assets/img/application/logo.png" bgcolor="#1d1333" width="28" height="28" valign="top" style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
+										<!--[if gte mso 9]> <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:30px;height:30px;"> <v:fill type="tile" src="https://umbraco.com/umbraco/assets/img/application/logo.png" color="#1d1333" /> <v:textbox inset="0,0,0,0"> <![endif]-->
+										<div> </div>
+										<!--[if gte mso 9]> </v:textbox> </v:rect> <![endif]-->
+									</td>
+									<td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top"></td>
+								</tr>
+							</table>
+						</td>
+					</tr>
+				</table>
+				<table border='0' cellpadding='0' cellspacing='0' class='body' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #1d1333;' bgcolor='#1d1333'>
+					<tr>
+						<td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'> </td>
+						<td class='container' style='font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; max-width: 560px; width: 560px; margin: 0 auto; padding: 10px;' valign='top'>
+							<div class='content' style='box-sizing: border-box; display: block; max-width: 560px; margin: 0 auto; padding: 10px;'>
+								<br>
+								<table class='main' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; border-radius: 3px; background: #FFFFFF;' bgcolor='#FFFFFF'>
+									<tr>
+										<td class='wrapper' style='font-family: sans-serif; font-size: 14px; vertical-align: top; box-sizing: border-box; padding: 50px;' valign='top'>
+											<table border='0' cellpadding='0' cellspacing='0' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;'>
+												<tr>
+													<td style='line-height: 24px; font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'>
+														<h1 style='color: #392F54; font-family: sans-serif; font-weight: bold; line-height: 1.4; font-size: 24px; text-align: left; text-transform: capitalize; margin: 0 0 30px;' align='left'>
+															Une réinitialisation de votre mot de passe a été demandée
+														</h1>
+														<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+															Votre nom d'utilisateur pour vous connecter au backoffice Umbraco est : <strong>%0%</strong>
+														</p>
+														<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+															<table border='0' cellpadding='0' cellspacing='0' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;'>
+																<tbody>
+																	<tr>
+																		<td style='font-family: sans-serif; font-size: 14px; vertical-align: top; border-radius: 5px; text-align: center; background: #35C786;' align='center' bgcolor='#35C786' valign='top'>
+																			<a href='%1%' target='_blank' rel='noopener' style='color: #FFFFFF; text-decoration: none; -ms-word-break: break-all; word-break: break-all; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; text-transform: capitalize; background: #35C786; margin: 0; padding: 12px 30px; border: 1px solid #35c786;'>
+																				Cliquez sur ce lien pour réinitialiser votre mot de passe
+																			</a>
+																		</td>
+																	</tr>
+																</tbody>
+															</table>
+														</p>
+														<p style='max-width: 400px; display: block; color: #392F54; font-family: sans-serif; font-size: 14px; line-height: 20px; font-weight: normal; margin: 15px 0;'>Si vous ne pouvez pas cliquer sur le lien, recopiez cet URL dans votre navigateur :</p>
+															<table border='0' cellpadding='0' cellspacing='0'>
+																<tr>
+																	<td style='-ms-word-break: break-all; word-break: break-all; font-family: sans-serif; font-size: 11px; line-height:14px;'>
+																		<font style="-ms-word-break: break-all; word-break: break-all; font-size: 11px; line-height:14px;">
+																			<a style='-ms-word-break: break-all; word-break: break-all; color: #392F54; text-decoration: underline; font-size: 11px; line-height:15px;' href='%1%'>%1%</a>
+																		</font>
+																	</td>
+																</tr>
+															</table>
+														</p>
+													</td>
+												</tr>
+											</table>
+										</td>
+									</tr>
+								</table>
+								<br><br><br>
+							</div>
+						</td>
+						<td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'> </td>
+					</tr>
+				</table>
+			</body>
+		</html>
+	]]>
+		</key>
+	</area>
+	<area alias="main">
+		<key alias="dashboard">Tableau de bord</key>
+		<key alias="sections">Sections</key>
+		<key alias="tree">Contenu</key>
+	</area>
+	<area alias="moveOrCopy">
+		<key alias="choose">Choisissez la page au-dessus...</key>
+		<key alias="copyDone">%0% a été copié dans %1%</key>
+		<key alias="copyTo">Choisissez ci-dessous l'endroit où le document %0% doit être copié</key>
+		<key alias="moveDone">%0% a été déplacé dans %1%</key>
+		<key alias="moveTo">Choisissez ci-dessous l'endroit où le document %0% doit être déplacé</key>
+		<key alias="nodeSelected">a été choisi comme racine de votre nouveau contenu, cliquez sur 'ok' ci-dessous.</key>
+		<key alias="noNodeSelected">Aucun noeud n'a encore été choisi, veuillez choisir un noeud dans la liste ci-dessus avant de cliquer sur 'ok'.</key>
+		<key alias="notAllowedByContentType">Le noeud actuel n'est pas autorisé sous le noeud choisi à cause de son type</key>
+		<key alias="notAllowedByPath">Le noeud actuel ne peut pas être déplacé dans une de ses propres sous-pages</key>
+		<key alias="notAllowedAtRoot">Le noeud actuel ne peut pas exister à la racine</key>
+		<key alias="notValid">L'action n'est pas autorisée car vous n'avez pas les droits suffisants sur un ou plusieurs noeuds enfants.</key>
+		<key alias="relateToOriginal">Relier les éléments copiés à l'original</key>
+	</area>
+	<area alias="notifications">
+		<key alias="editNotifications">Editez vos notifications pour %0%</key>
+		<key alias="notificationsSavedFor">Paramètres de notification enregistrés pour</key>
+		<key alias="mailBody">
+			<![CDATA[
+      Hello %0%
+
+      Ceci est un email automatique pour vous informer que la tâche '%1%'
+      a été executée sur la page '%2%'
+      par l'utilisateur '%3%'
+
+      Allez sur http://%4%/#/content/content/edit/%5% pour éditer cette page.
+
+      Bonne journée !
+
+      Avec les salutations du Robot Umbraco
+    ]]>
+		</key>
+		<key alias="mailBodyVariantSummary">Les langues suivantes ont été modifiées : %0%</key>
+		<key alias="mailBodyHtml">
+			<![CDATA[
+		<html>
+			<head>
+				<meta name='viewport' content='width=device-width'>
+				<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>
+			</head>
+			<body class='' style='font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; color: #392F54; line-height: 22px; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background: #1d1333; margin: 0; padding: 0;' bgcolor='#1d1333'>
+				<style type='text/css'> @media only screen and (max-width: 620px) {table[class=body] h1 {font-size: 28px !important; margin-bottom: 10px !important; } table[class=body] .wrapper {padding: 32px !important; } table[class=body] .article {padding: 32px !important; } table[class=body] .content {padding: 24px !important; } table[class=body] .container {padding: 0 !important; width: 100% !important; } table[class=body] .main {border-left-width: 0 !important; border-radius: 0 !important; border-right-width: 0 !important; } table[class=body] .btn table {width: 100% !important; } table[class=body] .btn a {width: 100% !important; } table[class=body] .img-responsive {height: auto !important; max-width: 100% !important; width: auto !important; } } .btn-primary table td:hover {background-color: #34495e !important; } .btn-primary a:hover {background-color: #34495e !important; border-color: #34495e !important; } .btn  a:visited {color:#FFFFFF;} </style>
+				<table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #1d1333;" bgcolor="#1d1333">
+					<tr>
+						<td style="font-family: sans-serif; font-size: 14px; vertical-align: top; padding: 24px;" valign="top">
+							<table style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+								<tr>
+									<td background="https://umbraco.com/umbraco/assets/img/application/logo.png" bgcolor="#1d1333" width="28" height="28" valign="top" style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
+										<!--[if gte mso 9]> <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:30px;height:30px;"> <v:fill type="tile" src="https://umbraco.com/umbraco/assets/img/application/logo.png" color="#1d1333" /> <v:textbox inset="0,0,0,0"> <![endif]-->
+										<div> </div>
+										<!--[if gte mso 9]> </v:textbox> </v:rect> <![endif]-->
+									</td>
+									<td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top"></td>
+								</tr>
+							</table>
+						</td>
+					</tr>
+				</table>
+				<table border='0' cellpadding='0' cellspacing='0' class='body' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #1d1333;' bgcolor='#1d1333'>
+					<tr>
+						<td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'> </td>
+						<td class='container' style='font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; max-width: 560px; width: 560px; margin: 0 auto; padding: 10px;' valign='top'>
+							<div class='content' style='box-sizing: border-box; display: block; max-width: 560px; margin: 0 auto; padding: 10px;'>
+								<br>
+								<table class='main' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; border-radius: 3px; background: #FFFFFF;' bgcolor='#FFFFFF'>
+									<tr>
+										<td class='wrapper' style='font-family: sans-serif; font-size: 14px; vertical-align: top; box-sizing: border-box; padding: 50px;' valign='top'>
+											<table border='0' cellpadding='0' cellspacing='0' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;'>
+												<tr>
+													<td style='line-height: 24px; font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'>
+														<h1 style='color: #392F54; font-family: sans-serif; font-weight: bold; line-height: 1.4; font-size: 24px; text-align: left; text-transform: capitalize; margin: 0 0 30px;' align='left'>
+															Salut %0%,
+														</h1>
+														<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+															Ceci est un email automatique pour vous informer que la tâche <strong>'%1%'</strong> a été exécutée sur la page <a style="color: #392F54; text-decoration: none; -ms-word-break: break-all; word-break: break-all;" href="http://%4%/#/content/content/edit/%5%"><strong>'%2%'</strong></a> par l'utilisateur <strong>'%3%'</strong>
+														</p>
+														<table border='0' cellpadding='0' cellspacing='0' class='btn btn-primary' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; box-sizing: border-box;'>
+															<tbody>
+																<tr>
+																	<td align='left' style='font-family: sans-serif; font-size: 14px; vertical-align: top; padding-bottom: 15px;' valign='top'>
+																		<table border='0' cellpadding='0' cellspacing='0' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;'><tbody><tr>
+																			<td style='font-family: sans-serif; font-size: 14px; vertical-align: top; border-radius: 5px; text-align: center; background: #35C786;' align='center' bgcolor='#35C786' valign='top'>
+																				<a href='http://%4%/#/content/content/edit/%5%' target='_blank' rel='noopener' style='color: #FFFFFF; text-decoration: none; -ms-word-break: break-all; word-break: break-all; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; text-transform: capitalize; background: #35C786; margin: 0; padding: 12px 30px; border: 1px solid #35c786;'>MODIFIER</a> </td> </tr></tbody></table>
+																	</td>
+																</tr>
+															</tbody>
+														</table>
+														<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+															<h3>Résumé de la mise à jour :</h3>
+															<table style="width: 100%;">
+																 %6%
+															</table>
+														</p>
+														<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+															Bonne journée !<br /><br />
+															Avec les salutations du Robot Umbraco
+														</p>
+													</td>
+												</tr>
+											</table>
+										</td>
+									</tr>
+								</table>
+								<br><br><br>
+							</div>
+						</td>
+						<td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'> </td>
+					</tr>
+				</table>
+			</body>
+		</html>
+		]]>
+		</key>
+		<key alias="mailBodyVariantHtmlSummary">
+			<![CDATA[<p>Les langues suivantes ont été modifiées :</p>
+        %0%
+    ]]>
+		</key>
+		<key alias="mailSubject">La notification [%0%] à propos de %1% a été executée sur %2%</key>
+		<key alias="notifications">Notifications</key>
+	</area>
+	<area alias="packager">
+		<key alias="actions">Actions</key>
+		<key alias="created">Créé</key>
+		<key alias="createPackage">Créer un package</key>
+		<key alias="chooseLocalPackageText">
+			<![CDATA[
+      Choisissez un package sur votre ordinateur en cliquant sur le bouton Parcourir <br />
+	et localisez le package. Les packages Umbraco ont généralement une extension ".umb" ou ".zip".
+      ]]>
+		</key>
+		<key alias="deletewarning">Ceci va supprimer le package</key>
+		<key alias="includeAllChildNodes">Inclure tous les noeuds enfant</key>
+		<key alias="installed">Installé</key>
+		<key alias="installedPackages">Packages installés</key>
+		<key alias="noConfigurationView">Ce package n'a pas de vue de configuration</key>
+		<key alias="noPackagesCreated">Aucun package n'a encore été créé</key>
+		<key alias="noPackages">Vous n'avez aucun package installé</key>
+		<key alias="noPackagesDescription"><![CDATA[Vous n'avez pas de package installé. Veuillez soit installer un package local en le sélectionnant sur votre ordinateur, soit naviguer dans la liste des packages disponibles en utilisant l'icone <strong>'Packages'</strong> en haut à droite de votre écran]]></key>
+		<key alias="packageContent">Contenu du package</key>
+		<key alias="packageLicense">Licence</key>
+		<key alias="packageSearch">Chercher des packages</key>
+		<key alias="packageSearchResults">Résultats pour</key>
+		<key alias="packageNoResults">Nous n'avons rien pu trouver pour</key>
+		<key alias="packageNoResultsDescription">Veuillez essayer de chercher un autre package ou naviguez à travers les catégories</key>
+		<key alias="packagesPopular">Populaires</key>
+		<key alias="packagesNew">Nouvelles releases</key>
+		<key alias="packageHas">a</key>
+		<key alias="packageKarmaPoints">points de karma</key>
+		<key alias="packageInfo">Information</key>
+		<key alias="packageOwner">Propriétaire</key>
+		<key alias="packageContrib">Contributeurs</key>
+		<key alias="packageCreated">Créé</key>
+		<key alias="packageCurrentVersion">Version actuelle</key>
+		<key alias="packageNetVersion">version .NET</key>
+		<key alias="packageDownloads">Téléchargements</key>
+		<key alias="packageLikes">Coups de coeur</key>
+		<key alias="packageCompatibility">Compatibilité</key>
+		<key alias="packageCompatibilityDescription">Ce package est compatible avec les versions suivantes de Umbraco, selon les rapports des membres de la communauté. Une compatibilité complète ne peut pas être garantie pour les versions rapportées sous 100%</key>
+		<key alias="packageExternalSources">Sources externes</key>
+		<key alias="packageAuthor">Auteur</key>
+		<key alias="packageDocumentation">Documentation</key>
+		<key alias="packageMetaData">Meta data du package</key>
+		<key alias="packageName">Nom du package</key>
+		<key alias="packageNoItemsHeader">Le package ne contient aucun élément</key>
+		<key alias="packageNoItemsText">
+			<![CDATA[Ce fichier de package ne contient aucun élément à désinstaller.<br/><br/>
+      Vous pouvez supprimer tranquillement ce package de votre installation en cliquant sur "Désinstaller le package" ci-dessous.]]>
+		</key>
+		<key alias="packageOptions">Options du package</key>
+		<key alias="packageReadme">Package readme</key>
+		<key alias="packageRepository">Repository des packages</key>
+		<key alias="packageUninstallConfirm">Confirmation de désinstallation</key>
+		<key alias="packageUninstalledHeader">Le package a été désinstallé</key>
+		<key alias="packageUninstalledText">Le package a été désinstallé avec succès</key>
+		<key alias="packageUninstallHeader">Désinstaller le package</key>
+		<key alias="packageUninstallText">
+			<![CDATA[Vous pouvez désélectionner ci-dessous les éléments que vous ne souhaitez pas supprimer pour le moment. Lorsque vous cliquerez sur "Confirmer la désinstallation", tous les éléments cochés seront supprimés.<br />
+      <span style="color: Red; font-weight: bold;">Remarque :</span> tous les documents, media etc. dépendant des éléments que vous supprimez vont cesser de fonctionner, ce qui peut provoquer une instabilité du système,
+      désinstallez donc avec prudence. En cas de doute, contactez l'auteur du package.]]>
+		</key>
+		<key alias="packageVersion">Version du package</key>
+	</area>
+	<area alias="paste">
+		<key alias="doNothing">Coller en conservant le formatage (non recommandé)</key>
+		<key alias="errorMessage">Le texte que vous tentez de coller contient des caractères spéciaux ou du formatage. Cela peut être dû à une copie d'un texte depuis Microsoft Word. Umbraco peut supprimer automatiquement les caractères spéciaux et le formatage, de manière à ce que le texte collé convienne mieux pour le Web.</key>
+		<key alias="removeAll">Coller en tant que texte brut sans aucun formatage</key>
+		<key alias="removeSpecialFormattering">Coller, mais supprimer le formatage (recommandé)</key>
+	</area>
+	<area alias="publicAccess">
+		<key alias="paGroups">Protection basée sur les groupes</key>
+		<key alias="paGroupsHelp">Si vous souhaitez donner accès à tous les utilisateurs de groupes de membres spécifiques</key>
+		<key alias="paGroupsNoGroups">Vous devez créer un groupe de membres avant de pouvoir utiliser la protection basée sur les groupes</key>
+		<key alias="paErrorPage">Page d'erreur</key>
+		<key alias="paErrorPageHelp">Utilisé pour les personnes connectées, mais qui n'ont pas accès</key>
+		<key alias="paHowWould"><![CDATA[Choisissez comment restreindre l'accès à la page <strong>%0%</strong>]]></key>
+		<key alias="paIsProtected"><![CDATA[<strong>%0%</strong> est maintenant protégée]]></key>
+		<key alias="paIsRemoved"><![CDATA[Protection de <strong>%0%</strong> supprimée]]></key>
+		<key alias="paLoginPage">Page de connexion</key>
+		<key alias="paLoginPageHelp">Choisissez la page qui contient le formulaire de connexion</key>
+		<key alias="paRemoveProtection">Supprimer la protection...</key>
+		<key alias="paRemoveProtectionConfirm"><![CDATA[Etes-vous certain.e de vouloir supprimer la protection de la page <strong>%0%</strong>?]]></key>
+		<key alias="paSelectPages">Choisissez les pages qui contiennent le formulaire de connexion et les messages d'erreur</key>
+		<key alias="paSelectGroups"><![CDATA[Sélectionnez les groupes qui ont accès à la page <strong>%0%</strong>]]></key>
+		<key alias="paSelectMembers"><![CDATA[Sélectionnez les membres qui ont accès à la page <strong>%0%</strong>]]></key>
+		<key alias="paMembers">Protection pour des membres spécifiques</key>
+		<key alias="paMembersHelp">Si vous souhaitez donner accès à des membres spécifiques</key>
+	</area>
+	<area alias="publish">
+		<key alias="invalidPublishBranchPermissions">Permissions utilisateur insuffisantes pour publier tous les documents enfants.</key>
+		<key alias="contentPublishedFailedIsTrashed">
+			<![CDATA[
+      %0% n'a pas pu être publié car cet élément est dans la corbeille.
+    ]]>
+		</key>
+		<key alias="contentPublishedFailedAwaitingRelease">
+			<![CDATA[
+      %0% n'a pas pu être publié car cet élément est programmé pour être publié bientôt.
+    ]]>
+		</key>
+		<key alias="contentPublishedFailedExpired">
+			<![CDATA[
+      %0% n'a pas pu être publié car cet élément a expiré.
+    ]]>
+		</key>
+		<key alias="contentPublishedFailedInvalid">
+			<![CDATA[
+      %0% n'a pas pu être publié à cause des propriétés suivantes qui n'ont pas passé les règles de validation :  %1%.
+    ]]>
+		</key>
+		<key alias="contentPublishedFailedByEvent">
+			<![CDATA[
+      %0% n'a pas pu être publié, l'action a été annulée par une extension tierce.
+    ]]>
+		</key>
+		<key alias="contentPublishedFailedByParent">
+			<![CDATA[
+      %0% ne peut pas être publié car une page parente n'est pas publiée.
+    ]]>
+		</key>
+		<key alias="contentPublishedFailedByMissingName"><![CDATA[%0% ne peut pas être publié, parce qu'il n'a pas de nom.]]></key>
+		<key alias="contentPublishedFailedReqCultureValidationError">La validation a échoué pour la langue obligatoire '%0%'. Cette langue a été sauvegardée mais pas publiée.</key>
+		<key alias="inProgress">Publication en cours - veuillez patienter...</key>
+		<key alias="inProgressCounter">%0% pages sur %1% ont été publiées...</key>
+		<key alias="nodePublish">%0% a été publié</key>
+		<key alias="nodePublishAll">%0% et ses pages enfants ont été publiées</key>
+		<key alias="publishAll">Publier %0% et toutes ses pages enfant</key>
+		<key alias="publishHelp">
+			<![CDATA[Cliquez sur <em>Publier</em> pour publier <strong>%0%</strong> et la rendre ainsi accessible publiquement.<br/><br />
+      Vous pouvez publier cette page et toutes ses sous-pages en cochant <em>Inclure les pages enfant non pubiées</em> ci-dessous.
+      ]]>
+		</key>
+	</area>
+	<area alias="colorpicker">
+		<key alias="noColors">Vous n'avez configuré aucune couleur approuvée</key>
+	</area>
+	<area alias="contentPicker">
+		<key alias="allowedItemTypes">Vous pouvez uniquement sélectionner des éléments du(des) type(s) : %0%</key>
+		<key alias="pickedTrashedItem">Vous avez choisi un élément de contenu actuellement supprimé ou dans la corbeille</key>
+		<key alias="pickedTrashedItems">Vous avez choisi des éléments de contenu actuellement supprimés ou dans la corbeille</key>
+	</area>
+	<area alias="mediaPicker">
+		<key alias="deletedItem">Elément supprimé</key>
+		<key alias="pickedTrashedItem">Vous avez choisi un élément media actuellement supprimé ou dans la corbeille</key>
+		<key alias="pickedTrashedItems">Vous avez choisi des éléments media actuellement supprimés ou dans la corbeille</key>
+		<key alias="trashed">Mis dans la corbeille</key>
+	</area>
+	<area alias="relatedlinks">
+		<key alias="enterExternal">introduire un lien externe</key>
+		<key alias="chooseInternal">choisir une page interne</key>
+		<key alias="caption">Légende</key>
+		<key alias="link">Lien</key>
+		<key alias="newWindow">Ouvrir dans une nouvelle fenêtre</key>
+		<key alias="captionPlaceholder">introduisez la légende à afficher</key>
+		<key alias="externalLinkPlaceholder">Introduiser le lien</key>
+	</area>
+	<area alias="imagecropper">
+		<key alias="reset">Réinitialiser</key>
+		<key alias="updateEditCrop">Terminé</key>
+		<key alias="undoEditCrop">Annuler les modifications</key>
+	</area>
+	<area alias="rollback">
+		<key alias="headline">Sélectionnez une version à comparer avec la version actuelle</key>
+		<key alias="diffHelp"><![CDATA[Ceci affiche les différences entre la version actuelle et la version choisie<br />Le texte en <del>Rouge</del> signifie qu'il a été supprimé de la version choisie, <ins>vert signifie ajouté</ins>]]></key>
+		<key alias="documentRolledBack">Le document a été restauré à une version antérieure</key>
+		<key alias="htmlHelp">Ceci affiche la version choisie en tant que HTML, si vous souhaitez voir les différences entre les deux versions en même temps, utilisez la vue différentielle</key>
+		<key alias="rollbackTo">Revenir à</key>
+		<key alias="selectVersion">Choisissez une version</key>
+		<key alias="view">Voir</key>
+		<key alias="pagination"><![CDATA[Afficher les versions %0% à %1% des %2% versions]]></key>
+		<key alias="versions">Versions</key>
+		<key alias="currentDraftVersion">Version de travail</key>
+		<key alias="currentPublishedVersion">Version publiée</key>
+	</area>
+	<area alias="scripts">
+		<key alias="editscript">Editer le fichier de script</key>
+	</area>
+	<area alias="sections">
+		<key alias="content">Contenu</key>
+		<key alias="forms">Formulaires</key>
+		<key alias="media">Medias</key>
+		<key alias="member">Membres</key>
+		<key alias="packages">Packages</key>
+		<key alias="settings">Configuration</key>
+		<key alias="translation">Traduction</key>
+		<key alias="users">Utilisateurs</key>
+	</area>
+	<area alias="help">
+		<key alias="theBestUmbracoVideoTutorials">Les meilleurs tutoriels vidéo Umbraco</key>
+	</area>
+	<area alias="settings">
+		<key alias="defaulttemplate">Modèle par défaut</key>
+		<key alias="importDocumentTypeHelp">Pour importer un type de document, trouvez le fichier ".udt" sur votre ordinateur en cliquant sur le bouton "Parcourir" et cliquez sur "Importer" (une confirmation vous sera demandée à l'écran suivant)</key>
+		<key alias="newtabname">Titre du nouvel onglet</key>
+		<key alias="nodetype">Type de noeud</key>
+		<key alias="objecttype">Type</key>
+		<key alias="stylesheet">Feuille de style</key>
+		<key alias="script">Script</key>
+		<key alias="tab">Onglet</key>
+		<key alias="tabname">Titre de l'onglet</key>
+		<key alias="tabs">Onglets</key>
+		<key alias="contentTypeEnabled">Type de contenu de base activé</key>
+		<key alias="contentTypeUses">Ce type de contenu utilise</key>
+		<key alias="noPropertiesDefinedOnTab">Aucune propriété définie dans cet onglet. Cliquez sur le lien "Ajouter une nouvelle propriété" en-haut pour créer une nouvelle propriété.</key>
+		<key alias="createMatchingTemplate">Créer le template correspondant</key>
+		<key alias="addIcon">Ajouter une icône</key>
+	</area>
+	<area alias="sort">
+		<key alias="sortOrder">Ordre de tri</key>
+		<key alias="sortCreationDate">Date de création</key>
+		<key alias="sortDone">Tri achevé.</key>
+		<key alias="sortHelp">Faites glisser les différents éléments vers le haut ou vers le bas pour définir la manière dont ils doivent être organisés. Ou cliquez sur les en-têtes de colonnes pour trier la collection complète d'éléments</key>
+		<key alias="sortPleaseWait"><![CDATA[Veuillez patienter. Les éléments sont en cours de tri, cela peut prendre un moment.]]></key>
+		<key alias="sortEmptyState">Ce noeud n'a aucun noeud enfant à trier</key>
+	</area>
+	<area alias="speechBubbles">
+		<key alias="validationFailedHeader">Validation</key>
+		<key alias="validationFailedMessage">Les erreurs de validation doivent être corrigées avant de pouvoir sauvegarder l'élément</key>
+		<key alias="operationFailedHeader">Echec</key>
+		<key alias="operationSavedHeader">Sauvegardé</key>
+		<key alias="operationSavedHeaderReloadUser">Sauvegardé. Veuillez rafraîchir votre navigateur pour voir les changements</key>
+		<key alias="invalidUserPermissionsText">Permissions utilisateur insuffisantes, l'opération n'a pas pu être complétée</key>
+		<key alias="operationCancelledHeader">Annulation</key>
+		<key alias="operationCancelledText">L'opération a été annulée par une extension tierce</key>
+		<key alias="contentTypeDublicatePropertyType">Le type de propriété existe déjà</key>
+		<key alias="contentTypePropertyTypeCreated">Type de propriété créé</key>
+		<key alias="contentTypePropertyTypeCreatedText"><![CDATA[Nom : %0% <br /> Type de données : %1%]]></key>
+		<key alias="contentTypePropertyTypeDeleted">Type de propriété supprimé</key>
+		<key alias="contentTypeSavedHeader">Type de document sauvegardé</key>
+		<key alias="contentTypeTabCreated">Onglet créé</key>
+		<key alias="contentTypeTabDeleted">Onglet supprimé</key>
+		<key alias="contentTypeTabDeletedText">Onglet avec l'ID : %0% supprimé</key>
+		<key alias="cssErrorHeader">Feuille de style non sauvegardée</key>
+		<key alias="cssSavedHeader">Feuille de style sauvegardée</key>
+		<key alias="cssSavedText">Feuille de style sauvegardée sans erreurs</key>
+		<key alias="dataTypeSaved">Type de données sauvegardé</key>
+		<key alias="dictionaryItemSaved">Elément de dictionnaire sauvegardé</key>
+		<key alias="editContentPublishedHeader">Contenu publié</key>
+		<key alias="editContentPublishedText">et visible sur le site</key>
+		<key alias="editMultiContentPublishedText">%0% documents publiés et visibles sur le site web</key>
+		<key alias="editVariantPublishedText">%0% publié et visible sur le site web</key>
+		<key alias="editMultiVariantPublishedText">%0% documents publiés pour la langue %1% et visibles sur le site web</key>
+		<key alias="editContentSavedHeader">Contenu sauvegardé</key>
+		<key alias="editContentSavedText">N'oubliez pas de publier pour rendre les modifications visibles</key>
+		<key alias="editContentScheduledSavedText">Un planning de publication a été mis à jour</key>
+		<key alias="editVariantSavedText">%0% sauvegardé</key>
+		<key alias="editContentSendToPublish">Envoyer pour approbation</key>
+		<key alias="editContentSendToPublishText">Les modifications ont été envoyées pour approbation</key>
+		<key alias="editVariantSendToPublishText">%0% modifications ont été envoyées pour approbation</key>
+		<key alias="editMediaSaved">Media sauvegardé</key>
+		<key alias="editMediaSavedText">Media sauvegardé sans erreurs</key>
+		<key alias="editMemberSaved">Membre sauvegardé</key>
+		<key alias="editStylesheetPropertySaved">Propriété de feuille de style sauvegardée</key>
+		<key alias="editStylesheetSaved">Feuille de style sauvegardée</key>
+		<key alias="editTemplateSaved">Modèle sauvegardé</key>
+		<key alias="editUserError">Erreur lors de la sauvegarde de l'utilisateur (consultez les logs)</key>
+		<key alias="editUserSaved">Utilisateur sauvegardé</key>
+		<key alias="editUserTypeSaved">Type d'utilisateur sauvegardé</key>
+		<key alias="editUserGroupSaved">Groupe d'utilisateurs sauvegardé</key>
+		<key alias="fileErrorHeader">Fichier non sauvegardé</key>
+		<key alias="fileErrorText">Le fichier n'a pas pu être sauvegardé. Vérifiez les permissions de fichier.</key>
+		<key alias="fileSavedHeader">Fichier sauvegardé</key>
+		<key alias="fileSavedText">Fichier sauvegardé sans erreurs</key>
+		<key alias="languageSaved">Langue sauvegardée</key>
+		<key alias="mediaTypeSavedHeader">Type de média sauvegardé</key>
+		<key alias="memberTypeSavedHeader">Type de membre sauvegardé</key>
+		<key alias="memberGroupSavedHeader">Groupe de membres sauvegardé</key>
+		<key alias="memberGroupNameDuplicate">Un autre groupe de membres existe déjà avec le même nom</key>
+		<key alias="templateErrorHeader">Modèle non sauvegardé</key>
+		<key alias="templateErrorText">Assurez-vous de ne pas avoir 2 modèles avec le même alias.</key>
+		<key alias="templateSavedHeader">Modèle sauvegardé</key>
+		<key alias="templateSavedText">Modèle sauvegardé sans aucune erreurs !</key>
+		<key alias="contentUnpublished">Contenu publié</key>
+		<key alias="contentCultureUnpublished">Variation de contenu %0% dépubliée</key>
+		<key alias="contentMandatoryCultureUnpublished">La langue obligatoire '%0%' a été dépubliée. Toutes les langues pour cet éléménent de contenu sont maintenant dépubliées.</key>
+		<key alias="partialViewSavedHeader">Vue partielle sauvegardée</key>
+		<key alias="partialViewSavedText">Vue partielle sauvegardée sans erreurs !</key>
+		<key alias="partialViewErrorHeader">Vue partielle non sauvegardée</key>
+		<key alias="partialViewErrorText">Une erreur est survenue lors de la sauvegarde du fichier.</key>
+		<key alias="permissionsSavedFor">Permissions sauvegardées pour</key>
+		<key alias="deleteUserGroupsSuccess">%0% groupes d'utilisateurs supprimés</key>
+		<key alias="deleteUserGroupSuccess">%0% a été supprimé</key>
+		<key alias="enableUsersSuccess">%0% utilisateurs activés</key>
+		<key alias="disableUsersSuccess">%0% utilisateurs désactivés</key>
+		<key alias="enableUserSuccess">%0% est à présent activé</key>
+		<key alias="disableUserSuccess">%0% est à présent désactivé</key>
+		<key alias="setUserGroupOnUsersSuccess">Les groupes d'utilisateurs ont été définis</key>
+		<key alias="unlockUsersSuccess">%0% utilisateurs débloqués</key>
+		<key alias="unlockUserSuccess">%0% est à présent débloqué</key>
+		<key alias="memberExportedSuccess">Le membre a été exporté vers le fichier</key>
+		<key alias="memberExportedError">Une erreur est survenue lors de l'export du membre</key>
+		<key alias="deleteUserSuccess">L'utilisateur %0% a été supprimé</key>
+		<key alias="resendInviteHeader">Inviter l'utilisateur</key>
+		<key alias="resendInviteSuccess">L'invitation a été envoyée à nouveau à %0%</key>
+		<key alias="contentReqCulturePublishError">Impossible de publier le document car la langue obligatoire '%0%' n'est pas publiée</key>
+		<key alias="contentCultureValidationError">La validation a échoué pour la langue '%0%'</key>
+		<key alias="documentTypeExportedSuccess">Le Type de Document a été exporté dans le fichier</key>
+		<key alias="documentTypeExportedError">Une erreur est survenue durant l'export du type de document</key>
+		<key alias="dictionaryItemExportedSuccess">Les éléments de dictionnaire ont été exportés vers le fichier</key>
+		<key alias="dictionaryItemExportedError">Une erreur est survenue lors de l'export des éléments de dictionnaire.</key>
+		<key alias="dictionaryItemImported">Les éléments de dictionnaire suivants ont été importés!</key>
+		<key alias="scheduleErrReleaseDate1">La date de publication ne peut pas être dans le passé</key>
+		<key alias="scheduleErrReleaseDate2">Impossible de planifier la publication du document car la langue obligatoire '%0%' n'est pas publiée</key>
+		<key alias="scheduleErrReleaseDate3">Impossible de planifier la publication du document car la langue obligatoire '%0%' a une date de publication postérieure à celle d'une langue non obligatoire</key>
+		<key alias="scheduleErrExpireDate1">La date d'expiration ne peut pas être dans le passé</key>
+		<key alias="scheduleErrExpireDate2">La date d'expiration ne peut pas être antérieure à la date de publication</key>
+	</area>
+	<area alias="stylesheet">
+		<key alias="addRule">Ajouter un style</key>
+		<key alias="editRule">Modifier un style</key>
+		<key alias="editorRules">Styles pour l'éditeur de texte</key>
+		<key alias="editorRulesHelp">Definir les styles qui doivent êtres disponibles dans l'éditeur de texte pour cette feuille de style</key>
+		<key alias="editstylesheet">Editer la feuille de style</key>
+		<key alias="editstylesheetproperty">Editer la propriété de feuille de style</key>
+		<key alias="nameHelp">Donner un nom pour identifier la propriété dans le Rich Text Editor</key>
+		<key alias="preview">Prévisualiser</key>
+		<key alias="previewHelp">L'apparence qu'aura le text dans l'éditeur de texte.</key>
+		<key alias="selector">Sélecteur</key>
+		<key alias="selectorHelp">Utilise la syntaxe CSS. Ex : "h1" ou ".redHeader"</key>
+		<key alias="styles">Styles</key>
+		<key alias="stylesHelp">Le CSS qui devrait être appliqué dans l'éditeur de texte, e.g. "color:red;"</key>
+		<key alias="tabCode">Code</key>
+		<key alias="tabRules">Editeur de Texte</key>
+	</area>
+	<area alias="template">
+		<key alias="deleteByIdFailed">Echec de la suppression du modèle avec l'ID %0%</key>
+		<key alias="edittemplate">Editer le modèle</key>
+		<key alias="insertSections">Sections</key>
+		<key alias="insertContentArea">Insérer une zone de contenu</key>
+		<key alias="insertContentAreaPlaceHolder">Insérer un placeholder de zone de contenu</key>
+		<key alias="insert">Insérer</key>
+		<key alias="insertDesc">Choisissez l'élément à insérer dans votre modèle</key>
+		<key alias="insertDictionaryItem">Elément de dictionnaire</key>
+		<key alias="insertDictionaryItemDesc">Un élément de dictionnaire est un espace pour un morceau de texte traduisible, ce qui facilite la création de designs pour des sites web multilangues.</key>
+		<key alias="insertMacro">Macro</key>
+		<key alias="insertMacroDesc">
+			Une Macro est un composant configurable, ce qui est génial pour les parties réutilisables de votre
+			design où vous devez pouvoir fournir des paramètres,
+			comme les galeries, les formulaires et les listes.
+		</key>
+		<key alias="insertPageField">Valeur</key>
+		<key alias="insertPageFieldDesc">Affiche la valeur d'un des champs de la page en cours, avec des options pour modifier la valeur ou spécifier des valeurs alternatives.</key>
+		<key alias="insertPartialView">Vue partielle</key>
+		<key alias="insertPartialViewDesc">
+			Une vue partielle est un fichier modèle séparé qui peut être  à l'intérieur d'un aute modèle,
+			c'est génial pour réutiliser du markup ou pour séparer des modèles complexes en plusieurs fichiers.
+		</key>
+		<key alias="mastertemplate">Modèle de base</key>
+		<key alias="noMaster">Pas de modèle</key>
+		<key alias="renderBody">Afficher un modèle enfant</key>
+		<key alias="renderBodyDesc">
+			<![CDATA[
+     Affiche le contenu d'un modèle enfant, en insérant un contenant
+     <code>@RenderBody()</code>.
+      ]]>
+		</key>
+		<key alias="defineSection">Définir une section nommée</key>
+		<key alias="defineSectionDesc">
+			<![CDATA[
+         Définit une partie de votre modèle en tant que section nommée en l'entourant
+         de <code>@section { ... }</code>. Celle-ci peut être affichée dans une région
+          spécifique du parent de ce modèle, en utilisant <code>@RenderSection</code>.
+      ]]>
+		</key>
+		<key alias="renderSection">Afficher une section nommée</key>
+		<key alias="renderSectionDesc">
+			<![CDATA[
+      Affiche une région nommée d'un modèle enfant, en insérant un contenant <code>@RenderSection(name)</code>.
+      Ceci affiche une région d'un modèle enfant qui est entourée d'une définition <code>@section [name]{ ... }</code> correspondante.
+      ]]>
+		</key>
+		<key alias="sectionName">Nom de la section</key>
+		<key alias="sectionMandatory">La section est obligatoire</key>
+		<key alias="sectionMandatoryDesc">
+			<![CDATA[
+      Si obligatoire, le modèle enfant doit contenir une définition <code>@section</code>, sinon une erreur est affichée.
+    ]]>
+		</key>
+		<key alias="queryBuilder">Générateur de requêtes</key>
+		<key alias="itemsReturned">éléments trouvés, en</key>
+		<key alias="iWant">Je veux</key>
+		<key alias="allContent">tout le contenu</key>
+		<key alias="contentOfType">le contenu du type "%0%"</key>
+		<key alias="from">à partir de</key>
+		<key alias="websiteRoot">mon site web</key>
+		<key alias="where">où</key>
+		<key alias="and">et</key>
+		<key alias="is">est</key>
+		<key alias="isNot">n'est pas</key>
+		<key alias="before">avant</key>
+		<key alias="beforeIncDate">avant (incluant la date sélectionnée)</key>
+		<key alias="after">après</key>
+		<key alias="afterIncDate">après (incluant la date sélectionnée)</key>
+		<key alias="equals">égal</key>
+		<key alias="doesNotEqual">n'est pas égal</key>
+		<key alias="contains">contient</key>
+		<key alias="doesNotContain">ne contient pas</key>
+		<key alias="greaterThan">supérieur à</key>
+		<key alias="greaterThanEqual">supérieur ou égal à</key>
+		<key alias="lessThan">inférieur à</key>
+		<key alias="lessThanEqual">inférieur ou égal à</key>
+		<key alias="id">Id</key>
+		<key alias="name">Nom</key>
+		<key alias="createdDate">Date de Création</key>
+		<key alias="lastUpdatedDate">Date de Dernière Modification</key>
+		<key alias="orderBy">trier par</key>
+		<key alias="ascending">ascendant</key>
+		<key alias="descending">descendant</key>
+		<key alias="template">Modèle</key>
+	</area>
+	<area alias="grid">
+		<key alias="media">Image</key>
+		<key alias="macro">Macro</key>
+		<key alias="insertControl">Choisissez le type de contenu</key>
+		<key alias="chooseLayout">Choisissez une mise en page</key>
+		<key alias="addRows">Ajouter une ligne</key>
+		<key alias="addElement">Ajouter du contenu</key>
+		<key alias="dropElement">Supprimer le contenu</key>
+		<key alias="settingsApplied">Paramètres appliqués</key>
+		<key alias="contentNotAllowed">Ce contenu n'est pas autorisé ici</key>
+		<key alias="contentAllowed">Ce contenu est autorisé ici</key>
+		<key alias="clickToEmbed">Cliquez pour intégrer</key>
+		<key alias="clickToInsertImage">Cliquez pour insérer une image</key>
+		<key alias="clickToInsertMacro">Cliquez pour insérer une macro</key>
+		<key alias="placeholderWriteHere">Ecrivez ici...</key>
+		<key alias="gridLayouts">Mises en pages de la Grid</key>
+		<key alias="gridLayoutsDetail">Les mises en pages représentent la surface de travail globale pour l'éditeur de grille, en général, vous n'avez seulement besoin que d'une ou deux mises en pages différentes</key>
+		<key alias="addGridLayout">Ajouter une mise en page de grille</key>
+		<key alias="addGridLayoutDetail">Ajustez la mise en page en définissant la largeur des colonnes et en ajoutant des sections supplémentaires</key>
+		<key alias="rowConfigurations">Configurations des rangées</key>
+		<key alias="rowConfigurationsDetail">Les rangées sont des cellules prédéfinies disposées horizontalement</key>
+		<key alias="addRowConfiguration">Ajouter une configuration de rangée</key>
+		<key alias="addRowConfigurationDetail">Ajustez la rangée en réglant la largeur des cellules et en ajoutant des cellules supplémentaires</key>
+		<key alias="columns">Colonnes</key>
+		<key alias="columnsDetails">Nombre total combiné de colonnes dans la configuration de la grille</key>
+		<key alias="settings">Paramètres</key>
+		<key alias="settingsDetails">Configurez les paramètres qui peuvent être modifiés par les éditeurs</key>
+		<key alias="styles">Styles</key>
+		<key alias="stylesDetails">Configurez les effets de style qui peuvent être modifiés par les éditeurs</key>
+		<key alias="allowAllEditors">Autoriser tous les éditeurs</key>
+		<key alias="allowAllRowConfigurations">Autoriser toutes les configurations de rangées</key>
+		<key alias="maxItems">Eléments maximum</key>
+		<key alias="maxItemsDescription">Laisser vide ou mettre à 0 pour un nombre illimté</key>
+		<key alias="setAsDefault">Configurer comme défaut</key>
+		<key alias="chooseExtra">Choisir en plus</key>
+		<key alias="chooseDefault">Choisir le défaut</key>
+		<key alias="areAdded">ont été ajoutés</key>
+	</area>
+	<area alias="contentTypeEditor">
+		<key alias="compositions">Compositions</key>
+		<key alias="group">Groupe</key>
+		<key alias="noGroups">Vous n'avez pas ajouté de groupe</key>
+		<key alias="addGroup">Ajouter un groupe</key>
+		<key alias="inheritedFrom">Hérité de</key>
+		<key alias="addProperty">Ajouter une propriété</key>
+		<key alias="requiredLabel">Label requis</key>
+		<key alias="enableListViewHeading">Activer la vue en liste</key>
+		<key alias="enableListViewDescription">Configure l'élément de contenu de manière à afficher ses éléments enfants sous forme d'une liste que l'on peut trier et filtrer, les enfants ne seront pas affichés dans l'arborescence</key>
+		<key alias="allowedTemplatesHeading">Modèles autorisés</key>
+		<key alias="allowedTemplatesDescription">Sélectionnez les modèles que les éditeurs sont autorisés à utiliser pour du contenu de ce type.</key>
+		<key alias="allowAsRootHeading">Autoriser comme racine</key>
+		<key alias="allowAsRootDescription">Autorisez les éditeurs à créer du contenu de ce type à la racine de l'arborescence de contenu.</key>
+		<key alias="childNodesHeading">Types de noeuds enfants autorisés</key>
+		<key alias="childNodesDescription">Autorisez la création de contenu des types spécifiés sous le contenu de ce type-ci</key>
+		<key alias="chooseChildNode">Choisissez les noeuds enfants</key>
+		<key alias="compositionsDescription">Hériter des onglets et propriétés d'un type de document existant. De nouveaux onglets seront ajoutés au type de document actuel, ou fusionnés s'il existe un onglet avec un nom sililaire.</key>
+		<key alias="compositionInUse">Ce type de contenu est utilisé dans une composition, et ne peut donc pas être lui-même un composé.</key>
+		<key alias="noAvailableCompositions">Il n'y a pas de type de contenu disponible à utiliser dans une composition.</key>
+		<key alias="compositionRemoveWarning">La suppression d'une composition supprimera les données de toutes les propriétés associées. Une fois que vous sauvegardez le type de document, il n'y a plus moyen de faire marche arrière.</key>
+		<key alias="availableEditors">Editeurs disponibles</key>
+		<key alias="reuse">Réutiliser</key>
+		<key alias="editorSettings">Configuration de l'éditeur</key>
+		<key alias="configuration">Configuration</key>
+		<key alias="yesDelete">Oui, supprimer</key>
+		<key alias="movedUnderneath">a été déplacé en-dessous</key>
+		<key alias="copiedUnderneath">a été copié en-dessous</key>
+		<key alias="folderToMove">Sélectionnez le répertoire à déplacer</key>
+		<key alias="folderToCopy">Sélectionnez le répertoire à copier</key>
+		<key alias="structureBelow">dans l'arborescence ci-dessous</key>
+		<key alias="allDocumentTypes">Tous les types de document</key>
+		<key alias="allDocuments">Tous les documents</key>
+		<key alias="allMediaItems">Tous les éléments media</key>
+		<key alias="usingThisDocument">utilisant ce type de document seront supprimés définitivement, veuillez confirmer que vous souhaitez les supprimer également.</key>
+		<key alias="usingThisMedia">utilisant ce type de media seront supprimés définitivement, veuillez confirmer que vous souhaitez les supprimer également.</key>
+		<key alias="usingThisMember">utilisant ce type de membre seront supprimés définitivement, veuillez confirmer que vous souhaitez les supprimer également</key>
+		<key alias="andAllDocuments">et tous les documents utilisant ce type</key>
+		<key alias="andAllMediaItems">et tous les éléments media utilisant ce type</key>
+		<key alias="andAllMembers">et tous les membres utilisant ce type</key>
+		<key alias="memberCanEdit">Le membre peut éditer</key>
+		<key alias="memberCanEditDescription">Autoriser la modification de la valeur de cette propriété par le membre à partir de sa page de profil</key>
+		<key alias="isSensitiveData">Est une donnée sensible</key>
+		<key alias="isSensitiveDataDescription">Cacher cette propriété aux éditeurs de contenu qui n'ont pas accès à la visualisation des données sensibles</key>
+		<key alias="showOnMemberProfile">Afficher dans le profil du membre</key>
+		<key alias="showOnMemberProfileDescription">Permettre d'afficher la valeur de cette propriété sur la page de profil du membre</key>
+		<key alias="tabHasNoSortOrder">l'onglet n'a pas d'ordre de tri</key>
+		<key alias="compositionUsageHeading">Où cette composition est-elle utilisée?</key>
+		<key alias="compositionUsageSpecification">Cette composition est actuellement utilisée dans la composition des types de contenu suivants :</key>
+		<key alias="variantsHeading">Permettre une variation par culture</key>
+		<key alias="variantsDescription">Permettre aux éditeurs de créer du contenu de ce type dans différentes langues.</key>
+		<key alias="allowVaryByCulture">Permettre une variation par culture</key>
+		<key alias="elementType">Type de l'Elément</key>
+		<key alias="elementHeading">Est un Type d'Elément</key>
+		<key alias="elementDescription">Un Type d'Elément est destiné à être utilisé par exemple dans Nested Content, et pas dans l'arborescence.</key>
+		<key alias="elementDoesNotSupport">Ceci n'est pas d'application pour un Type d'Elément</key>
+		<key alias="propertyHasChanges">Vous avez apporté des modifications à cette propriété. Etes-vous certain.e de vouloir les annuler?</key>
+		<key alias="historyCleanupHeading">Nettoyer l'historique</key>
+		<key alias="historyCleanupDescription">Autoriser le remplacement des paramètres globaux de nettoyage de l'historique.</key>
+		<key alias="historyCleanupKeepAllVersionsNewerThanDays">Garder toutes les versions plus récentes que jours</key>
+		<key alias="historyCleanupKeepLatestVersionPerDayForDays">Garder la dernière version quotidienne pendant jours</key>
+		<key alias="historyCleanupPreventCleanup">Empêcher le nettoyage</key>
+		<key alias="historyCleanupEnableCleanup">Activer le nettoyage</key>
+		<key alias="historyCleanupGloballyDisabled"><![CDATA[<strong>REMARQUE!</strong> Le nettoyage de l'historique des versions de contenu est désactvé globalement. Ces paramètres ne prendront pas effet avant qu'il ne soit activé.]]></key>
+	</area>
+	<area alias="webhooks">
+		<key alias="addWebhook">Créer un webhook</key>
+		<key alias="addWebhookHeader">Ajouter un header au webhook</key>
+		<key alias="logs">Logs</key>
+		<key alias="addDocumentType">Ajouter un Type de Document</key>
+		<key alias="addMediaType">Ajouter un Type de Media</key>
+	</area>
+	<area alias="languages">
+		<key alias="addLanguage">Ajouter une langue</key>
+		<key alias="mandatoryLanguage">Langue obligatoire</key>
+		<key alias="mandatoryLanguageHelp">Les propriétés doivent être remplies dans cette langue avant que le noeud ne puisse être publié.</key>
+		<key alias="defaultLanguage">Langue par défaut</key>
+		<key alias="defaultLanguageHelp">Un site Umbraco ne peut avoir qu'une seule langue par défaut définie.</key>
+		<key alias="changingDefaultLanguageWarning">Changer la langue par défaut peut amener à ce que du contenu par défaut soit manquant.</key>
+		<key alias="fallsbackToLabel">Retombe sur</key>
+		<key alias="noFallbackLanguageOption">Pas de langue alternative</key>
+		<key alias="fallbackLanguageDescription">Pour permettre à un site multi-langue de retomber sur une autre langue dans le cas où il n'existe pas dans la langue demandée, sélectionnez-là ici.</key>
+		<key alias="fallbackLanguage">Langue alternative</key>
+		<key alias="none">aucune</key>
+	</area>
+	<area alias="macro">
+		<key alias="addParameter">Ajouter un paramètre</key>
+		<key alias="editParameter">Modifier le paramètre</key>
+		<key alias="enterMacroName">Introduire le nom de la macro</key>
+		<key alias="parameters">Paramètres</key>
+		<key alias="parametersDescription">Définir les paramètres qui devraient être disponibles lorsque l'on utilise cette macro.</key>
+		<key alias="selectViewFile">Sélectionner le fichier de vue partielle de la macro</key>
+	</area>
+	<area alias="modelsBuilder">
+		<key alias="buildingModels">Fabrication des modèles</key>
+		<key alias="waitingMessage">ceci peut prendre un peu de temps, ne vous inquiétez pas</key>
+		<key alias="modelsGenerated">Modèles générés</key>
+		<key alias="modelsGeneratedError">Les modèles n'ont pas pu être générés</key>
+		<key alias="modelsExceptionInUlog">La génération des modèles a échoué, voyez les exceptions dans les U log</key>
+	</area>
+	<area alias="templateEditor">
+		<key alias="addDefaultValue">Ajouter une valeur par défaut</key>
+		<key alias="defaultValue">Valeur par défaut</key>
+		<key alias="alternativeField">Champ alternatif</key>
+		<key alias="alternativeText">Texte alternatif</key>
+		<key alias="casing">Casse</key>
+		<key alias="encoding">Encodage</key>
+		<key alias="chooseField">Choisir un champ</key>
+		<key alias="convertLineBreaks">Convertir les sauts de ligne</key>
+		<key alias="convertLineBreaksHelp">Remplace les sauts de ligne avec des balises 'br'</key>
+		<key alias="customFields">Champs particuliers</key>
+		<key alias="dateOnly">Oui, la date seulement</key>
+		<key alias="formatAsDate">Formater comme une date</key>
+		<key alias="htmlEncode">Encoder en HTML</key>
+		<key alias="htmlEncodeHelp">Remplacera les caractères spéciaux par leur équivalent HTML.</key>
+		<key alias="insertedAfter">Sera inséré après la valeur du champ</key>
+		<key alias="insertedBefore">Sera inséré avant la valeur du champ</key>
+		<key alias="lowercase">Minuscules</key>
+		<key alias="none">Aucun</key>
+		<key alias="outputSample">Example de résultat</key>
+		<key alias="postContent">Insérer après le champ</key>
+		<key alias="preContent">Insérer avant le champ</key>
+		<key alias="recursive">Récursif</key>
+		<key alias="recursiveDescr">Oui, rendre récursif</key>
+		<key alias="standardFields">Champs standards</key>
+		<key alias="uppercase">Majuscules</key>
+		<key alias="urlEncode">Encode pour URL</key>
+		<key alias="urlEncodeHelp">Formatera les caractères spéciaux dans les URL</key>
+		<key alias="usedIfAllEmpty">Sera seulement utilisé si toutes les valeurs des champs ci-dessus sont vides</key>
+		<key alias="usedIfEmpty">Ce champ sera utilisé seulement si le champ initial est vide</key>
+		<key alias="withTime">Oui, avec l'heure. Séparateur: </key>
+	</area>
+	<area alias="translation">
+		<key alias="details">Détails</key>
+		<key alias="DownloadXmlDTD">Télécharger la DTD XML</key>
+		<key alias="fields">Champs</key>
+		<key alias="includeSubpages">Inclure les pages enfants</key>
+		<key alias="mailBody">
+			<![CDATA[
+      Hello %0%
+
+      Ceci est un mail automatique pour vous informer que le document '%1%'
+      a été envoyé pour traduction en '%5%' par %2%.
+
+      Allez sur http://%3%/translation/details.aspx?id=%4% pour l'éditer.
+
+      Ou connectez-vous à Umbraco pour obtenir une vue d'ensemble des tâches de traduction qui vous sont assignées
+      http://%3%
+
+      Bonne journée !
+
+      Avec les salutations du Robot Umbraco
+    ]]>
+		</key>
+		<key alias="noTranslators">Aucun utilisateur traducteur trouvé. Veuillez créer un utilisateur traducteur avant d'envoyer du contenu pour traduction</key>
+		<key alias="pageHasBeenSendToTranslation">La page '%0%' a été envoyée pour traduction</key>
+		<key alias="sendToTranslate">Envoyer la page '%0%' pour traduction</key>
+		<key alias="totalWords">Nombre total de mots</key>
+		<key alias="translateTo">Traduire en</key>
+		<key alias="translationDone">Traduction complétée.</key>
+		<key alias="translationDoneHelp">Vous pouvez prévisualiser les pages que vous avez traduites en cliquant ci-dessous. Si la page originale est trouvée, vous verrez une comparaison entre les deux pages.</key>
+		<key alias="translationFailed">Traduction échouée, il se pourrait que fichier XML soit corrompu</key>
+		<key alias="translationOptions">Options de traduction</key>
+		<key alias="translator">Traducteur</key>
+		<key alias="uploadTranslationXml">Uploader le fichier de traduction XML</key>
+	</area>
+	<area alias="treeHeaders">
+		<key alias="content">Contenu</key>
+		<key alias="contentBlueprints">Types de contenu</key>
+		<key alias="media">Media</key>
+		<key alias="cacheBrowser">Navigateur de cache</key>
+		<key alias="contentRecycleBin">Corbeille</key>
+		<key alias="createdPackages">Packages créés</key>
+		<key alias="dataTypes">Types de données</key>
+		<key alias="dictionary">Dictionnaire</key>
+		<key alias="installedPackages">Packages installés</key>
+		<key alias="installSkin">Installer une skin</key>
+		<key alias="installStarterKit">Installer un starter kit</key>
+		<key alias="languages">Langues</key>
+		<key alias="localPackage">Installer un package local</key>
+		<key alias="macros">Macros</key>
+		<key alias="mediaTypes">Types de média</key>
+		<key alias="member">Membres</key>
+		<key alias="memberGroups">Groupes de membres</key>
+		<key alias="memberRoles">Rôles</key>
+		<key alias="memberTypes">Types de membres</key>
+		<key alias="documentTypes">Types de documents</key>
+		<key alias="relationTypes">Types de relations</key>
+		<key alias="packager">Packages</key>
+		<key alias="packages">Packages</key>
+		<key alias="partialViews">Vues Partielles</key>
+		<key alias="partialViewMacros">Vues Partielles pour les Fichiers Macro</key>
+		<key alias="repositories">Installer depuis le repository</key>
+		<key alias="runway">Installer Runway</key>
+		<key alias="runwayModules">Modules Runway</key>
+		<key alias="scripting">Fichiers de script</key>
+		<key alias="scripts">Scripts</key>
+		<key alias="stylesheets">Feuilles de style</key>
+		<key alias="templates">Modèles</key>
+		<key alias="logViewer">Visualisation des Log</key>
+		<key alias="users">Utilisateurs</key>
+		<key alias="settingsGroup">Configuration</key>
+		<key alias="templatingGroup">Modélisation</key>
+		<key alias="thirdPartyGroup">Parties Tierces</key>
+		<key alias="webhooks">Webhooks</key>
+	</area>
+	<area alias="update">
+		<key alias="updateAvailable">Nouvelle mise à jour disponible</key>
+		<key alias="updateDownloadText">%0% est disponible, cliquez ici pour télécharger</key>
+		<key alias="updateNoServer">Aucune connexion au serveur</key>
+		<key alias="updateNoServerError">Erreur lors de la recherche de mises à jour. Veuillez vérifier le stack trace pour obtenir plus d'informations.</key>
+	</area>
+	<area alias="user">
+		<key alias="access">Accès</key>
+		<key alias="accessHelp">Sur base des groupes et des noeuds de départ, l'utilisateur a accès aux noeuds suivants</key>
+		<key alias="assignAccess">Donner accès</key>
+		<key alias="administrators">Administrateur</key>
+		<key alias="categoryField">Champ catégorie</key>
+		<key alias="createDate">Utilisateur créé</key>
+		<key alias="changePassword">Changer le mot de passe</key>
+		<key alias="changePhoto">Changer la photo</key>
+		<key alias="newPassword">Nouveau mot de passe</key>
+		<key alias="newPasswordFormatLengthTip">Plus que %0% caractère(s) minimum!</key>
+		<key alias="newPasswordFormatNonAlphaTip">Il devrait y avoir au moins %0% caractère(s) spéciaux.</key>
+		<key alias="noLockouts">n'a pas été bloqué</key>
+		<key alias="noPasswordChange">Le mot de passe n'a pas été modifié</key>
+		<key alias="confirmNewPassword">Confirmez votre nouveau mot de passe</key>
+		<key alias="changePasswordDescription">Vous pouvez changer votre mot de passe d'accès au backoffice Umbraco en remplissant le formulaire ci-dessous puis en cliquant sur le bouton "Changer le mot de passe"</key>
+		<key alias="contentChannel">Canal de contenu</key>
+		<key alias="createAnotherUser">Créer un autre utilisateur</key>
+		<key alias="createUserHelp">Créer de nouveaux utilisateurs pour leur donner accès à Umbraco. Lors de la création d'un nouvel utilisateur, un mot de passe est généré que vous pouvez partager avec ce dernier.</key>
+		<key alias="descriptionField">Champ description</key>
+		<key alias="disabled">Désactiver l'utilisateur</key>
+		<key alias="documentType">Type de document</key>
+		<key alias="editors">Editeur</key>
+		<key alias="excerptField">Champ extrait</key>
+		<key alias="failedPasswordAttempts">Tentatives de connexion échouées</key>
+		<key alias="goToProfile">Voir le profil de l'utilisateur</key>
+		<key alias="groupsHelp">Ajouter des groupes pour donner les accès et permissions</key>
+		<key alias="inviteAnotherUser">Inviter un autre utilisateur</key>
+		<key alias="inviteUserHelp">Inviter de nouveaux utilisateurs pour leur donner accès à Umbraco. Un email d'invitation sera envoyé à chaque utilisateur avec des informations concernant la connexion à Umbraco. Les invitations sont valables pendant 72 heures.</key>
+		<key alias="language">Langue</key>
+		<key alias="languageHelp">Spécifiez la langue dans laquelle vous souhaitez voir les menus et dialogues</key>
+		<key alias="lastLockoutDate">Date du dernier bloquage</key>
+		<key alias="lastLogin">Dernière connexion</key>
+		<key alias="lastPasswordChangeDate">Dernière modification du mot de passe</key>
+		<key alias="loginname">Identifiant</key>
+		<key alias="mediastartnode">Noeud de départ dans la librarie de média</key>
+		<key alias="mediastartnodehelp">Limiter la librairie média à un noeud de départ spécifique</key>
+		<key alias="mediastartnodes">Noeuds de départ dans la librairie de média</key>
+		<key alias="mediastartnodeshelp">Limiter la librairie média à des noeuds de départ spécifique</key>
+		<key alias="modules">Sections</key>
+		<key alias="noConsole">Désactiver l'accès Umbraco</key>
+		<key alias="noLogin">ne s'est pas encore connecté</key>
+		<key alias="oldPassword">Ancien mot de passe</key>
+		<key alias="password">Mot de passe</key>
+		<key alias="resetPassword">Réinitialiser le mot de passe</key>
+		<key alias="passwordChanged">Votre mot de passe a été modifié!</key>
+		<key alias="passwordConfirm">Veuillez confirmer votre nouveau mot de passe</key>
+		<key alias="passwordEnterNew">Introduisez votre nouveau mot de passe</key>
+		<key alias="passwordIsBlank">Votre nouveau mot de passe ne peut être vide !</key>
+		<key alias="passwordCurrent">Mot de passe actuel</key>
+		<key alias="passwordInvalid">Mot de passe actuel invalide</key>
+		<key alias="passwordIsDifferent">Il y a une différence entre le nouveau mot de passe et le mot de passe confirmé. Veuillez réessayer.</key>
+		<key alias="passwordMismatch">Le mot de passe confirmé ne correspond pas au nouveau mot de passe saisi!</key>
+		<key alias="permissionReplaceChildren">Remplacer les permissions sur les noeuds enfants</key>
+		<key alias="permissionSelectedPages">Vous êtes en train de modifiez les permissions pour les pages :</key>
+		<key alias="permissionSelectPages">Choisissez les pages dont les permissions doivent être modifiées</key>
+		<key alias="removePhoto">Supprimer la photo</key>
+		<key alias="permissionsDefault">Permissions par défaut</key>
+		<key alias="permissionsGranular">Permissions granulaires</key>
+		<key alias="permissionsGranularHelp">Définir les permissions sur des noeuds spécifiques</key>
+		<key alias="profile">Profil</key>
+		<key alias="searchAllChildren">Rechercher tous les enfants</key>
+		<key alias="sectionsHelp">Ajouter les sections auxquelles les utilisateurs peuvent accéder</key>
+		<key alias="selectUserGroups">Sélectionner les groupes d'utilisateurs</key>
+		<key alias="noStartNode">Aucun noeud de départ sélectionné</key>
+		<key alias="noStartNodes">Aucun noeud de départ sélectionné</key>
+		<key alias="startnode">Noeud de départ du contenu</key>
+		<key alias="startnodehelp">Limiter l'arborescence de contenu à un noeud de départ spécifique</key>
+		<key alias="startnodes">Noeuds de départ du contenu</key>
+		<key alias="startnodeshelp">Limiter l'arborescence de contenu à des noeuds de départ spécifiques</key>
+		<key alias="updateDate">Dernière mise à jour de l'utilisateur</key>
+		<key alias="userCreated">a été créé</key>
+		<key alias="userCreatedSuccessHelp">Le nouvel utilisateur a été créé avec succès. Utilisez le mot de passe ci-dessous pour la connexion à Umbraco.</key>
+		<key alias="userManagement">Gestion des utilisateurs</key>
+		<key alias="username">Nom d'utilisateur</key>
+		<key alias="userPermissions">Permissions de l'utilisateur</key>
+		<key alias="usergroup">Groupe d'utilisateurs</key>
+		<key alias="userInvited">a été invité</key>
+		<key alias="userInvitedSuccessHelp">Une invitation a été envoyée au nouvel utilisateur avec les détails concernant la connexion à Umbraco.</key>
+		<key alias="userinviteWelcomeMessage">Bien le bonjour et bienvenue dans Umbraco! Vous serez prêt.e dans moins d'1 minute, vous devez encore simplement configurer votre mot de passe.</key>
+		<key alias="userinviteExpiredMessage">Bienvenue dans Umbraco! Malheureusement, votre invitation a expiré. Veuillez contacter votre administrateur et demandez-lui de vous l'envoyer à nouveau.</key>
+		<key alias="writer">Rédacteur</key>
+		<key alias="change">Modifier</key>
+		<key alias="yourProfile" version="7.0">Votre profil</key>
+		<key alias="yourHistory" version="7.0">Votre historique récent</key>
+		<key alias="sessionExpires" version="7.0">La session expire dans</key>
+		<key alias="inviteUser">Inviter un utilisateur</key>
+		<key alias="createUser">Créer un utilisateur</key>
+		<key alias="sendInvite">Envoyer l'invitation</key>
+		<key alias="backToUsers">Retour aux utilisateurs</key>
+		<key alias="inviteEmailCopySubject">Umbraco: Invitation</key>
+		<key alias="inviteEmailCopyFormat">
+			<![CDATA[
+        <html>
+			<head>
+				<meta name='viewport' content='width=device-width'>
+				<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>
+			</head>
+			<body class='' style='font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; color: #392F54; line-height: 22px; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background: #1d1333; margin: 0; padding: 0;' bgcolor='#1d1333'>
+				<style type='text/css'> @media only screen and (max-width: 620px) {table[class=body] h1 {font-size: 28px !important; margin-bottom: 10px !important; } table[class=body] .wrapper {padding: 32px !important; } table[class=body] .article {padding: 32px !important; } table[class=body] .content {padding: 24px !important; } table[class=body] .container {padding: 0 !important; width: 100% !important; } table[class=body] .main {border-left-width: 0 !important; border-radius: 0 !important; border-right-width: 0 !important; } table[class=body] .btn table {width: 100% !important; } table[class=body] .btn a {width: 100% !important; } table[class=body] .img-responsive {height: auto !important; max-width: 100% !important; width: auto !important; } } .btn-primary table td:hover {background-color: #34495e !important; } .btn-primary a:hover {background-color: #34495e !important; border-color: #34495e !important; } .btn  a:visited {color:#FFFFFF;} </style>
+				<table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #1d1333;" bgcolor="#1d1333">
+					<tr>
+						<td style="font-family: sans-serif; font-size: 14px; vertical-align: top; padding: 24px;" valign="top">
+							<table style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+								<tr>
+									<td background="https://umbraco.com/umbraco/assets/img/application/logo.png" bgcolor="#1d1333" width="28" height="28" valign="top" style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
+										<!--[if gte mso 9]> <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:30px;height:30px;"> <v:fill type="tile" src="https://umbraco.com/umbraco/assets/img/application/logo.png" color="#1d1333" /> <v:textbox inset="0,0,0,0"> <![endif]-->
+										<div> </div>
+										<!--[if gte mso 9]> </v:textbox> </v:rect> <![endif]-->
+									</td>
+									<td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top"></td>
+								</tr>
+							</table>
+						</td>
+					</tr>
+				</table>
+				<table border='0' cellpadding='0' cellspacing='0' class='body' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #1d1333;' bgcolor='#1d1333'>
+					<tr>
+						<td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'> </td>
+						<td class='container' style='font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; max-width: 560px; width: 560px; margin: 0 auto; padding: 10px;' valign='top'>
+							<div class='content' style='box-sizing: border-box; display: block; max-width: 560px; margin: 0 auto; padding: 10px;'>
+								<br>
+								<table class='main' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; border-radius: 3px; background: #FFFFFF;' bgcolor='#FFFFFF'>
+									<tr>
+										<td class='wrapper' style='font-family: sans-serif; font-size: 14px; vertical-align: top; box-sizing: border-box; padding: 50px;' valign='top'>
+											<table border='0' cellpadding='0' cellspacing='0' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;'>
+												<tr>
+													<td style='line-height: 24px; font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'>
+														<h1 style='color: #392F54; font-family: sans-serif; font-weight: bold; line-height: 1.4; font-size: 24px; text-align: left; text-transform: capitalize; margin: 0 0 30px;' align='left'>
+															Salut %0%,
+														</h1>
+														<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+															Vous avez été invité.e par <a href="mailto:%4%" style="text-decoration: underline; color: #392F54; -ms-word-break: break-all; word-break: break-all;">%1%</a> à accéder au Umbraco Back Office.
+														</p>
+														<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+															Message de <a href="mailto:%1%" style="text-decoration: none; color: #392F54; -ms-word-break: break-all; word-break: break-all;">%1%</a>:
+															<br/>
+															<em>%2%</em>
+														</p>
+														<table border='0' cellpadding='0' cellspacing='0' class='btn btn-primary' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; box-sizing: border-box;'>
+															<tbody>
+																<tr>
+																	<td align='left' style='font-family: sans-serif; font-size: 14px; vertical-align: top; padding-bottom: 15px;' valign='top'>
+																		<table border='0' cellpadding='0' cellspacing='0' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;'>
+																			<tbody>
+																				<tr>
+																					<td style='font-family: sans-serif; font-size: 14px; vertical-align: top; border-radius: 5px; text-align: center; background: #35C786;' align='center' bgcolor='#35C786' valign='top'>
+																						<a href='%3%' target='_blank' rel='noopener' style='color: #FFFFFF; text-decoration: none; -ms-word-break: break-all; word-break: break-all; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; text-transform: capitalize; background: #35C786; margin: 0; padding: 12px 30px; border: 1px solid #35c786;'>
+																							Cliquez sur ce lien pour accepter l'invitation
+																						</a>
+																					</td>
+																				</tr>
+																			</tbody>
+																		</table>
+																	</td>
+																</tr>
+															</tbody>
+														</table>
+														<p style='max-width: 400px; display: block; color: #392F54; font-family: sans-serif; font-size: 14px; line-height: 20px; font-weight: normal; margin: 15px 0;'>Si vous ne pouvez pas cliquer sur le lien, copiez cet URL dans votre navigateur :</p>
+															<table border='0' cellpadding='0' cellspacing='0'>
+																<tr>
+																	<td style='-ms-word-break: break-all; word-break: break-all; font-family: sans-serif; font-size: 11px; line-height:14px;'>
+																		<font style="-ms-word-break: break-all; word-break: break-all; font-size: 11px; line-height:14px;">
+																			<a style='-ms-word-break: break-all; word-break: break-all; color: #392F54; text-decoration: underline; font-size: 11px; line-height:15px;' href='%3%'>%3%</a>
+																		</font>
+																	</td>
+																</tr>
+															</table>
+														</p>
+													</td>
+												</tr>
+											</table>
+										</td>
+									</tr>
+								</table>
+								<br><br><br>
+							</div>
+						</td>
+						<td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'> </td>
+					</tr>
+				</table>
+			</body>
+    </html>]]>
+		</key>
+		<key alias="defaultInvitationMessage">Nouvel envoi de l'invitation en cours...</key>
+		<key alias="deleteUser">Supprimer l'Utilisateur</key>
+		<key alias="deleteUserConfirmation">Etes-vous certain(e) de vouloir supprimer le compte de cet utilisateur?</key>
+		<key alias="stateAll">Tous</key>
+		<key alias="stateActive">Actif</key>
+		<key alias="stateDisabled">Désactivé</key>
+		<key alias="stateLockedOut">Bloqué</key>
+		<key alias="stateInvited">Invité</key>
+		<key alias="stateInactive">Inactif</key>
+		<key alias="sortNameAscending">Nom (A-Z)</key>
+		<key alias="sortNameDescending">Nom (Z-A)</key>
+		<key alias="sortCreateDateAscending">Plus ancien</key>
+		<key alias="sortCreateDateDescending">Plus récent</key>
+		<key alias="sortLastLoginDateDescending">Dernière connexion</key>
+	</area>
+	<area alias="validation">
+		<key alias="validation">Validation</key>
+		<key alias="validateAsEmail">Valider comme email</key>
+		<key alias="validateAsNumber">Valider comme nombre</key>
+		<key alias="validateAsUrl">Valider comme URL</key>
+		<key alias="enterCustomValidation">...ou introduisez une validation spécifique</key>
+		<key alias="fieldIsMandatory">Champ obligatoire</key>
+		<key alias="mandatoryMessage">Introduisez un message d'erreur de validation personnalisé (optionnel)</key>
+		<key alias="validationRegExp">Introduisez une expression régulière</key>
+		<key alias="validationRegExpMessage">Introduisez un message d'erreur de validation personnalisé (optionnel)</key>
+		<key alias="minCount">Vous devez ajouter au moins</key>
+		<key alias="maxCount">Vous ne pouvez avoir que</key>
+		<key alias="items">éléments</key>
+		<key alias="itemsSelected">éléments sélectionnés</key>
+		<key alias="invalidDate">Date non valide</key>
+		<key alias="invalidNumber">Pas un nombre</key>
+		<key alias="invalidEmail">Email non valide</key>
+		<key alias="invalidNull">La valeur ne peut pas être null</key>
+		<key alias="invalidEmpty">La valeur ne peut pas être vide</key>
+		<key alias="invalidPattern">Valeur non valide, elle ne correspond pas au modèle correct</key>
+		<key alias="customValidation">Validation personnalisée</key>
+		<key alias="entriesShort"><![CDATA[Minimum %0% éléments, en nécessite <strong>%1%</strong> supplémentaires.]]></key>
+		<key alias="entriesExceed"><![CDATA[Maximum %0% éléments, <strong>%1%</strong> en trop.]]></key>
+	</area>
+	<area alias="healthcheck">
+		<!-- The following keys get these tokens passed in:
+	     0: Current value
+		   1: Recommended value
+		   2: XPath
+		   3: Configuration file path
+	  -->
+		<key alias="checkSuccessMessage">La valeur est égale à la valeur recommandée : '%0%'.</key>
+		<key alias="checkErrorMessageDifferentExpectedValue">La valeur attendue pour '%2%' dans le fichier de configuration '%3%' est '%1%', mais la valeur trouvée est '%0%'.</key>
+		<key alias="checkErrorMessageUnexpectedValue">La valeur inattendue '%0%' a été trouvée pour '%2%' dans le fichier de configuration '%3%'.</key>
+		<!-- The following keys get these tokens passed in:
+	     0: Current value
+		   1: Recommended value
+	  -->
+		<key alias="macroErrorModeCheckSuccessMessage">MacroErrors est fixé à la valeur '%0%'.</key>
+		<key alias="macroErrorModeCheckErrorMessage">MacroErrors est fixé à la valeur '%0%', ce qui empêchera certaines ou même toutes les pages de votre site de se charger complètement en cas d'erreur dans les macros. La rectification de ceci fixera la valeur à '%1%'.</key>
+		<!-- The following keys get these tokens passed in:
+	     0: Current value
+		   1: Recommended value
+		   2: Server version
+	  -->
+		<!-- The following keys get predefined tokens passed in that are not all the same, like above -->
+		<key alias="httpsCheckValidCertificate">Le certificat de votre site a été marqué comme valide.</key>
+		<key alias="httpsCheckInvalidCertificate">Erreur de validation du certificat : '%0%'</key>
+		<key alias="httpsCheckExpiredCertificate">Le certificat SSL de votre site web a expiré.</key>
+		<key alias="httpsCheckExpiringCertificate">Le certificat SSL de votre site web va expirer dans %0% jours.</key>
+		<key alias="healthCheckInvalidUrl">Erreur en essayant de contacter l'URL %0% - '%1%'</key>
+		<key alias="httpsCheckIsCurrentSchemeHttps">Vous êtes actuellement %0% à voir le site via le schéma HTTPS.</key>
+		<key alias="httpsCheckConfigurationRectifyNotPossible">
+			L'appSetting 'Umbraco:CMS:Global:UseHttps' se trouve à 'false' dans votre fichier appSettings.json.
+			Une fois que vous aurez accès à ce site via le schema HTTPS, il faudra la mettre à 'true'.
+		</key>
+		<key alias="httpsCheckConfigurationCheckResult">
+			L'appSetting 'Umbraco:CMS:Global:UseHttps' se trouve à '%0%' dans votre fichier
+			appSettings.json, vos cookies sont %1% marqués comme 'secured'.
+		</key>
+		<!-- The following keys don't get tokens passed in -->
+		<key alias="compilationDebugCheckSuccessMessage">Le mode de compilation Debug est désactivé.</key>
+		<key alias="compilationDebugCheckErrorMessage">Le mode de compilation Debug est actuellement activé. Il est recommandé de désactiver ce paramètre avant la mise en ligne.</key>
+		<!-- The following keys get these tokens passed in:
+	    0: Path to the file not found
+  	-->
+		<!-- The following keys get these tokens passed in:
+	    0: Comma delimitted list of failed folder paths
+  	-->
+		<!-- The following keys get these tokens passed in:
+	    0: Comma delimitted list of failed folder paths
+  	-->
+		<key alias="clickJackingCheckHeaderFound"><![CDATA[Le header ou meta-tag <strong>X-Frame-Options</strong>, utilisé pour contrôler si un site peut être intégré dans un autre via IFRAME, a été trouvé.]]></key>
+		<key alias="clickJackingCheckHeaderNotFound"><![CDATA[Le header ou meta-tag <strong>X-Frame-Options</strong> , utilisé pour contrôler si un site peut être intégré dans un autre via IFRAME, n'a pas été trouvé.]]></key>
+		<key alias="noSniffCheckHeaderFound"><![CDATA[L'en-tête ou le meta-tag <strong>X-Content-Type-Options</strong> utilisé pour la protection contre les vulnérabilités de MIME sniffing a été trouvé.]]></key>
+		<key alias="noSniffCheckHeaderNotFound"><![CDATA[L'en-tête ou le meta-tag <strong>X-Content-Type-Options</strong> utilisé pour la protection contre les vulnérabilités de MIME sniffing n'a pas été trouvé.]]></key>
+		<key alias="hSTSCheckHeaderFound"><![CDATA[L'en-tête <strong>Strict-Transport-Security</strong>, aussi connu sous le nom de HSTS-header, a été trouvé.]]></key>
+		<key alias="hSTSCheckHeaderNotFound"><![CDATA[L'en-tête <strong>Strict-Transport-Security</strong>, aussi connu sous le nom de HSTS-header, n'a pas été trouvé.]]></key>
+		<key alias="xssProtectionCheckHeaderFound"><![CDATA[L'en-tête <strong>X-XSS-Protection</strong> a été trouvé.]]></key>
+		<key alias="xssProtectionCheckHeaderNotFound"><![CDATA[L'en-tête <strong>X-XSS-Protection</strong> n'a pas été trouvé.]]></key>
+		<!-- The following key get these tokens passed in:
+	    0: Comma delimitted list of headers found
+  	-->
+		<key alias="excessiveHeadersFound"><![CDATA[Les headers suivants révélant des informations à propos de la technologie du site web ont été trouvés  : <strong>%0%</strong>.]]></key>
+		<key alias="excessiveHeadersNotFound">Aucun header révélant des informations à propos de la technologie du site web n'a été trouvé.</key>
+		<key alias="smtpMailSettingsConnectionSuccess">La configuration SMTP est correcte et le service fonctionne comme prévu.</key>
+		<key alias="notificationEmailsCheckSuccessMessage"><![CDATA[Un email de notification a été envoyé à <strong>%0%</strong>.]]></key>
+		<key alias="notificationEmailsCheckErrorMessage"><![CDATA[L'adresse email de notification est toujours à sa valeur par défaut : <strong>%0%</strong>.]]></key>
+		<key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Les résultats de l'exécution du Umbraco Health Checks planifiée le %0% à %1% sont les suivants :</p>%2%</body></html>]]></key>
+		<key alias="scheduledHealthCheckEmailSubject">Statut du Umbraco Health Check: %0%</key>
+	</area>
+	<area alias="redirectUrls">
+		<key alias="disableUrlTracker">Désactiver URL tracker</key>
+		<key alias="enableUrlTracker">Activer URL tracker</key>
+		<key alias="culture">Culture</key>
+		<key alias="originalUrl">URL original</key>
+		<key alias="redirectedTo">Redirigé Vers</key>
+		<key alias="redirectUrlManagement">Gestion des redirections d'URL</key>
+		<key alias="panelInformation">Les URLs suivants redirigent vers cet élément de contenu :</key>
+		<key alias="noRedirects">Aucune redirection n'a été créée</key>
+		<key alias="noRedirectsDescription">Lorsqu'une page publiée est renommée ou déplacée, une redirection sera automatiquement créée vers la nouvelle page.</key>
+		<key alias="redirectRemoved">Redirection d'URL supprimée.</key>
+		<key alias="redirectRemoveError">Erreur lors de la suppression de la redirection d'URL.</key>
+		<key alias="redirectRemoveWarning">Ceci supprimera la redirection</key>
+		<key alias="confirmDisable">Etes-vous certain(e) de vouloir désactiver le URL tracker?</key>
+		<key alias="disabledConfirm">URL tracker est maintenant désactivé.</key>
+		<key alias="disableError">Erreur lors de la désactivation de l'URL tracker, plus d'information disponible dans votre fichier log.</key>
+		<key alias="enabledConfirm">URL tracker est maintenant activé.</key>
+		<key alias="enableError">Erreur lors de l'activation de l'URL tracker, plus d'information disponible dans votre fichier log.</key>
+	</area>
+	<area alias="emptyStates">
+		<key alias="emptyDictionaryTree">Pas d'élément de dictionaire à choisir</key>
+	</area>
+	<area alias="textbox">
+		<key alias="characters_left"><![CDATA[<strong>%0%</strong> caractères restant.]]></key>
+		<key alias="characters_exceed"><![CDATA[Maximum %0% caractères, <strong>%1%</strong> en trop.]]></key>
+	</area>
+	<area alias="recycleBin">
+		<key alias="contentTrashed">Suppression du contenu avec l'Id : {0} lié au contenu parent original avec l'Id : {1}</key>
+		<key alias="mediaTrashed">Suppression du media avec l'Id : {0} lié à l'élément media parent original avec l'Id : {1}</key>
+		<key alias="itemCannotBeRestored">Cet élément ne peut pas être restauré automatiquement</key>
+		<key alias="itemCannotBeRestoredHelpText">Il n'y a aucun endroit où cet élément peut être restauré automatiquement. Vous pouvez déplacer l'élément manuellement en utilisant l'arborescence ci-dessous.</key>
+		<key alias="wasRestored">a été restauré sous</key>
+	</area>
+	<area alias="relationType">
+		<key alias="direction">Direction</key>
+		<key alias="parentToChild">Parent vers enfant</key>
+		<key alias="bidirectional">Bi-directionnel</key>
+		<key alias="parent">Parent</key>
+		<key alias="child">Enfant</key>
+		<key alias="count">Nombre</key>
+		<key alias="relations">Relations</key>
+		<key alias="created">Création</key>
+		<key alias="comment">Remarque</key>
+		<key alias="name">Nom</key>
+		<key alias="noRelations">Aucune relation pour ce type de relation.</key>
+		<key alias="tabRelationType">Type de Relation</key>
+		<key alias="tabRelations">Relations</key>
+	</area>
+	<area alias="dashboardTabs">
+		<key alias="contentIntro">Pour Commencer</key>
+		<key alias="contentRedirectManager">Gestion des redirections d'URL</key>
+		<key alias="mediaFolderBrowser">Contenu</key>
+		<key alias="settingsWelcome">Bienvenue</key>
+		<key alias="settingsExamine">Gestion d'Examine</key>
+		<key alias="settingsPublishedStatus">Statut Publié</key>
+		<key alias="settingsModelsBuilder">Models Builder</key>
+		<key alias="settingsHealthCheck">Health Check</key>
+		<key alias="settingsProfiler">Profilage</key>
+		<key alias="memberIntro">Pour Commencer</key>
+		<key alias="formsInstall">Installer Umbraco Forms</key>
+	</area>
+	<area alias="visuallyHiddenTexts">
+		<key alias="goBack">Retour</key>
+		<key alias="activeListLayout">Layouts actifs :</key>
+		<key alias="jumpTo">Aller à</key>
+		<key alias="group">groupe</key>
+		<key alias="passed">passé</key>
+		<key alias="warning">avertissement</key>
+		<key alias="failed">échoué</key>
+		<key alias="suggestion">suggestion</key>
+		<key alias="checkPassed">Vérifier les succès</key>
+		<key alias="checkFailed">Vérifier les échecs</key>
+		<key alias="openBackofficeSearch">Ouvrir la recherche backoffice</key>
+		<key alias="openCloseBackofficeHelp">Ouvrir/Fermer l'aide backoffice</key>
+		<key alias="openCloseBackofficeProfileOptions">Ouvrir/Fermer vos options de profil</key>
+		<key alias="openContextMenu">Ouvrir le menu de contexte pour</key>
+		<key alias="currentLanguage">Langue actuelle</key>
+		<key alias="switchLanguage">Changer la langue vers</key>
+		<key alias="createNewFolder">Créer un nouveau dossier</key>
+		<key alias="newPartialView">Partial View</key>
+		<key alias="newPartialViewMacro">Macro de Partial View</key>
+		<key alias="newMember">Membre</key>
+		<key alias="searchContentTree">Chercher dans l'arborescence de contenu</key>
+		<key alias="maxAmount">Quantité maximum</key>
+		<key alias="expandChildItems">Afficher les éléments enfant pour</key>
+		<key alias="openContextNode">Ouvrir le noeud de contexte pour</key>
+	</area>
+	<area alias="references">
+		<key alias="tabName">Références</key>
+		<key alias="DataTypeNoReferences">Ce Type de Données n'a pas de références.</key>
+		<key alias="labelUsedByDocumentTypes">Utilisé dans des Types de Document</key>
+		<key alias="labelUsedByMediaTypes">Utilisé dans les Types de Media</key>
+		<key alias="labelUsedByMemberTypes">Utilisé dans les Types de Membre</key>
+		<key alias="usedByProperties">Utilisé par</key>
+	</area>
+	<area alias="logViewer">
+		<key alias="logLevels">Niveaux de Log</key>
+		<key alias="selectAllLogLevelFilters">Tout sélectionner</key>
+		<key alias="deselectAllLogLevelFilters">Tout déselectionner</key>
+		<key alias="savedSearches">Recherches sauvegardées</key>
+		<key alias="totalItems">Nombre total d'éléments</key>
+		<key alias="timestamp">Date</key>
+		<key alias="level">Niveau</key>
+		<key alias="machine">Machine</key>
+		<key alias="message">Message</key>
+		<key alias="exception">Exception</key>
+		<key alias="properties">Propriétés</key>
+		<key alias="searchWithGoogle">Chercher avec Google</key>
+		<key alias="searchThisMessageWithGoogle">Chercher ce message avec Google</key>
+		<key alias="searchWithBing">Chercher avec Bing</key>
+		<key alias="searchThisMessageWithBing">Chercher ce message avec Bing</key>
+		<key alias="searchOurUmbraco">Chercher dans Our Umbraco</key>
+		<key alias="searchThisMessageOnOurUmbracoForumsAndDocs">Chercher ce message dans les forums et docs de Our Umbraco</key>
+		<key alias="searchOurUmbracoWithGoogle">Chercher dans Our Umbraco avec Google</key>
+		<key alias="searchOurUmbracoForumsUsingGoogle">Chercher dans les forums de Our Umbraco en utilisant Google</key>
+		<key alias="searchUmbracoSource">Chercher dans les Sources Umbraco</key>
+		<key alias="searchWithinUmbracoSourceCodeOnGithub">Chercher dans le code source d'Umbraco sur Github</key>
+		<key alias="searchUmbracoIssues">Chercher dans les Umbraco Issues</key>
+		<key alias="searchUmbracoIssuesOnGithub">Chercher dans les Umbraco Issues sur Github</key>
+		<key alias="deleteThisSearch">Supprimer cette recherche</key>
+		<key alias="findLogsWithRequestId">Trouver les Logs avec la Request ID</key>
+		<key alias="findLogsWithNamespace">Trouver les Logs avec le Namespace</key>
+		<key alias="findLogsWithMachineName">Trouver les logs avec le Nom de Machine</key>
+		<key alias="open">Ouvrir</key>
+	</area>
+	<area alias="clipboard">
+		<key alias="labelForCopyAllEntries">Copier %0%</key>
+		<key alias="labelForArrayOfItemsFrom">%0% de %1%</key>
+		<key alias="labelForRemoveAllEntries">Supprimer tous les éléments</key>
+	</area>
+	<area alias="propertyActions">
+		<key alias="tooltipForPropertyActionsMenu">Ouvrir les Property Actions</key>
+	</area>
+	<area alias="nuCache">
+		<key alias="refreshStatus">Rafraîchir le Statut</key>
+		<key alias="memoryCache">Cache Mémoire</key>
+		<key alias="memoryCacheDescription">
+			<![CDATA[
+			Ce bouton vous permet de recharger la cache en mémoire, en la rechargeant entièrement à partir de la cache
+	en base de données (mais sans reconstruire cette cache en base de données). C'est une opération relativement rapide.
+	Utilisez-le lorsque vous pensez que la cache en mémoire n'a pas été rafraîchie convenablement, après que certains
+	événements ont été déclenchés&mdash;ce qui indiquerait un problème mineur dans Umbraco.
+	(remarque: ceci déclenche le rechargement sur tous les serveurs dans un environnement LB).
+    ]]>
+		</key>
+		<key alias="reload">Recharger</key>
+		<key alias="databaseCache">Cache en Base de Données</key>
+		<key alias="databaseCacheDescription">
+			<![CDATA[
+	Ce bouton vous permet de reconstruire la cache en base de données, càd le contenu de la table cmsContentNu.
+    <strong>La reconstruction peut être une opération lourde.</strong>
+	Utilisez-le lorsque le rechargement ne suffit pas, et que vous pensez que la cache en base de données n'a pas été
+	générée convenablement&mdash;ce qui indiquerait des problèmes critiques dans Umbraco.
+    ]]>
+		</key>
+		<key alias="rebuild">Reconstruire</key>
+		<key alias="internals">Opérations Internes</key>
+		<key alias="internalsDescription">
+			<![CDATA[
+	Ce bouton vous permet de déclencher une collection de snapshots NuCache (après exécution d'un fullCLR GC).
+	A moins que vous sachiez ce que cela signifie, vous n'avez probablement <em>pas</em> besoin de l'utiliser.
+    ]]>
+		</key>
+		<key alias="collect">Collecter</key>
+		<key alias="publishedCacheStatus">Statut de la Cache Publiée</key>
+		<key alias="caches">Caches</key>
+	</area>
+	<area alias="profiling">
+		<key alias="performanceProfiling">Profilage de performances</key>
+		<key alias="performanceProfilingDescription">
+			<![CDATA[
+                <p>
+				   Umbraco est actuellement exécuté en mode debug. Cela signifie que vous pouvez utiliser le profileur de performances intégré pour évaluer les performance lors du rendu des pages.
+                </p>
+                <p>
+                    Si vous souhaitez activer le profileur pour le rendu d'une page spécifique, ajoutez simplement <strong>umbDebug=true</strong> au querystring lorsque vous demandez la page.
+                </p>
+                <p>
+                    Si vous souhaitez que le profileur soit activé par défaut pour tous les rendus de pages, vous pouvez utiliser le bouton bascule ci-dessous.
+					Cela créera un cookie dans votre browser, qui activera alors le profileur automatiquement.
+                    En d'autres termes, le profileur ne sera activé par défaut que dans <em>votre</em> browser - pas celui des autres.
+                </p>
+        ]]>
+		</key>
+		<key alias="activateByDefault">Activer le profileur par défaut</key>
+		<key alias="reminder">Rappel amical</key>
+	</area>
+	<area alias="settingsDashboardVideos">
+		<key alias="trainingHeadline">Des heures de vidéos de formation Umbraco ne sont qu'à un clic d'ici</key>
+		<key alias="trainingDescription">
+			<![CDATA[
+        <p>Vous voulez maîtriser Umbraco? Passez quelques minutes à apprendre certaines des meilleures pratiques en regardant une de ces vidéos à propos de l'utilisation d'Umbraco. Et visitez <a href="http://umbraco.tv" target="_blank" rel="noopener">umbraco.tv</a> pour encore plus de vidéos Umbraco</p>
+    ]]>
+		</key>
+		<key alias="getStarted">Pour démarrer</key>
+	</area>
+	<area alias="settingsDashboard">
+		<key alias="start">Commencer ici</key>
+		<key alias="startDescription">Cette section contient les blocs fondamentaux pour votre site Umbraco. Suivez les liens ci-dessous pour en apprendre d'avantage sur la façon de travailler avec les éléments de la section Settings</key>
+		<key alias="more">En savoir plus</key>
+		<key alias="bulletPointOne">
+			<![CDATA[
+            Lisez-en plus sur la façon de travailler avec les éléments dans la section Settings <a class="btn-link -underline" href="https://docs.umbraco.com/umbraco-cms/fundamentals/backoffice/sections/" target="_blank" rel="noopener">dans la section Documentation</a> de Our Umbraco
+        ]]>
+		</key>
+		<key alias="bulletPointTwo">
+			<![CDATA[
+            Posez une question dans le <a class="btn-link -underline" href="https://our.umbraco.com/forum" target="_blank" rel="noopener">Community Forum</a>
+        ]]>
+		</key>
+		<key alias="bulletPointThree">
+			<![CDATA[
+            Regardez nos <a class="btn-link -underline" href="https://umbraco.tv" target="_blank" rel="noopener">tutoriels vidéos</a> (certains sont gratuits, certains nécessitent un abonnement)
+        ]]>
+		</key>
+		<key alias="bulletPointFour">
+			<![CDATA[
+            Découvrez nos <a class="btn-link -underline" href="https://umbraco.com/products/" target="_blank" rel="noopener">outils d'amélioration de productivité et notre support commercial</a>
+        ]]>
+		</key>
+		<key alias="bulletPointFive">
+			<![CDATA[
+            Découvrez nos possibilités de <a class="btn-link -underline" href="https://umbraco.com/training/" target="_blank" rel="noopener">formations et certifications</a>
+        ]]>
+		</key>
+	</area>
+	<area alias="treeSearch">
+		<key alias="searchResult">élément retrouvé</key>
+		<key alias="searchResults">éléments retrouvés</key>
+	</area>
+</language>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/it_ch.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/it_ch.xml
@@ -1,0 +1,3170 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language alias="it_ch" intName="Italian Switzerland (IT-CH)" localName="italiano Svizerra (IT-CH)" lcid="16" culture="it-CH">
+	<creator>
+		<name>The Umbraco community</name>
+		<link>https://docs.umbraco.com/umbraco-cms/extending/language-files</link>
+	</creator>
+	<area alias="actions">
+		<key alias="assigndomain">Gestisci hostnames</key>
+		<key alias="auditTrail">Audit Trail</key>
+		<key alias="browse">Sfoglia</key>
+		<key alias="changeDocType">Cambia tipo di documento</key>
+		<key alias="changeDataType">Cambia tipo di dato</key>
+		<key alias="copy">Copia</key>
+		<key alias="create">Crea</key>
+		<key alias="export">Esporta</key>
+		<key alias="createPackage">Crea pacchetto</key>
+		<key alias="createGroup">Crea gruppo</key>
+		<key alias="delete">Cancella</key>
+		<key alias="disable">Disabilita</key>
+		<key alias="editSettings">Modifica impostazioni</key>
+		<key alias="emptyrecyclebin">Svuota il cestino</key>
+		<key alias="enable">Abilita</key>
+		<key alias="exportDocumentType">Esporta il tipo di documento</key>
+		<key alias="importdocumenttype">Importa il tipo di documento</key>
+		<key alias="importPackage">Importa il pacchetto</key>
+		<key alias="liveEdit">Modifica in Area di Lavoro</key>
+		<key alias="logout">Uscita</key>
+		<key alias="move">Sposta</key>
+		<key alias="notify">Notifiche</key>
+		<key alias="protect">Accesso pubblico</key>
+		<key alias="publish">Pubblica</key>
+		<key alias="unpublish">Non pubblicare</key>
+		<key alias="refreshNode">Aggiorna</key>
+		<key alias="republish">Ripubblica intero sito</key>
+		<key alias="remove">Rimuovi</key>
+		<key alias="rename" version="7.3.0">Rinomina</key>
+		<key alias="restore" version="7.3.0">Ripristina</key>
+		<key alias="SetPermissionsForThePage">Imposta i permessi per la pagina %0%</key>
+		<key alias="chooseWhereToCopy">Scegli dove copiare</key>
+		<key alias="chooseWhereToMove">Scegli dove muovere</key>
+		<key alias="toInTheTreeStructureBelow">nella struttura sottostante</key>
+		<key alias="infiniteEditorChooseWhereToCopy">Scegli dove copiare l'oggetto/gli oggetti selezionati</key>
+		<key alias="infiniteEditorChooseWhereToMove">Scegli dove spostare l'oggetto/gli oggetti selezionati</key>
+		<key alias="wasMovedTo"><![CDATA[è stato spostato in]]></key>
+		<key alias="wasCopiedTo"><![CDATA[è stato copiato in]]></key>
+		<key alias="wasDeleted"><![CDATA[è stato eliminato]]></key>
+		<key alias="rights">Permessi</key>
+		<key alias="rollback">Annulla ultima modifica</key>
+		<key alias="sendtopublish">Invia per la pubblicazione</key>
+		<key alias="sendToTranslate">Invia per la traduzione</key>
+		<key alias="setGroup">Crea gruppo</key>
+		<key alias="sort">Ordina</key>
+		<key alias="translate">Traduci</key>
+		<key alias="update">Aggiorna</key>
+		<key alias="setPermissions">Imposta permessi</key>
+		<key alias="unlock">Sblocca</key>
+		<key alias="createblueprint">Crea modello di contenuto</key>
+		<key alias="resendInvite">Invia nuovamente l'invito</key>
+	</area>
+	<area alias="actionCategories">
+		<key alias="content">Contenuto</key>
+		<key alias="administration">Amministrazione</key>
+		<key alias="structure">Struttura</key>
+		<key alias="other">Altro</key>
+	</area>
+	<area alias="actionDescriptions">
+		<key alias="assignDomain">Consenti l'accesso per assegnare gli hostnames</key>
+		<key alias="auditTrail">Consenti l'accesso per visualizzare la cronologia di un nodo</key>
+		<key alias="browse">Consenti l'accesso per visualizzare un nodo</key>
+		<key alias="changeDocType">Consenti l'accesso per cambiare tipo di documento a un nodo</key>
+		<key alias="copy">Consenti l'accesso per copiare un nodo</key>
+		<key alias="create">Consenti l'accesso per creare i nodi</key>
+		<key alias="delete">Consenti l'accesso per eliminare i nodi</key>
+		<key alias="move">Consenti l'accesso per spostare un nodo</key>
+		<key alias="protect">Consenti l'accesso per impostare e cambiare le restrizioni di accesso a un nodo</key>
+		<key alias="publish">Consenti l'accesso per pubblicare un nodo</key>
+		<key alias="unpublish">Consenti l'accesso per non pubblicare un nodo</key>
+		<key alias="rights">Consenti l'accesso per cambiare i permessi di un nodo</key>
+		<key alias="rollback">Consenti l'accesso per riportare un nodo a una versione precedente</key>
+		<key alias="sendtopublish">Consenti l'accesso per inviare un nodo in approvazione prima di pubblicare</key>
+		<key alias="sendToTranslate">Consenti l'accesso per inviare un nodo per la traduzione</key>
+		<key alias="sort">Consenti l'accesso per cambiare l'ordinamento dei nodi</key>
+		<key alias="translate">Consenti l'accesso per tradurre un nodo</key>
+		<key alias="update">Consenti l'accesso per salvare un nodo</key>
+		<key alias="createblueprint">Consenti l'accesso per creare un modello di contenuto</key>
+	</area>
+	<area alias="apps">
+		<key alias="umbContent">Contenuto</key>
+		<key alias="umbInfo">Info</key>
+	</area>
+	<area alias="assignDomain">
+		<key alias="permissionDenied">Permesso negato.</key>
+		<key alias="addNew">Aggiungi nuovo dominio</key>
+		<key alias="remove">rimuovi</key>
+		<key alias="invalidNode">Nodo non valido.</key>
+		<key alias="invalidDomain"><![CDATA[Uno o più domini hanno un formato non valido.]]></key>
+		<key alias="duplicateDomain"><![CDATA[Il dominio è già stato assegnato.]]></key>
+		<key alias="language">Lingua</key>
+		<key alias="domain">Dominio</key>
+		<key alias="domainCreated"><![CDATA[Il dominio '%0%' è stato creato]]></key>
+		<key alias="domainDeleted"><![CDATA[Il dominio '%0%' è stato cancellato]]></key>
+		<key alias="domainExists"><![CDATA[Il dominio '%0%' è già stato assegnato]]></key>
+		<key alias="domainUpdated"><![CDATA[Il dominio '%0%' è stato aggiornato]]></key>
+		<key alias="orEdit">Modifica il dominio corrente</key>
+		<key alias="domainHelpWithVariants">
+			<![CDATA[Nomi di dominio validi sono: "example.com", "www.example.com", "example.com:8080", oppure "https://www.example.com/".
+     Inoltre sono supportati anche i percorsi a un livello nei domini, ad esempio "example.com/it" oppure "/it".]]>
+		</key>
+		<key alias="inherit">Eredita</key>
+		<key alias="setLanguage">Lingua</key>
+		<key alias="setLanguageHelp">
+			<![CDATA[Imposta la lingua per i nodi sotto il nodo corrente,<br /> oppure eredita la lingua dai nodi padre. Si applicherà anche<br />
+      al nodo corrente, a meno che un dominio sotto non venga applicato.]]>
+		</key>
+		<key alias="setDomains">Domini</key>
+	</area>
+	<area alias="buttons">
+		<key alias="clearSelection">Cancella selezione</key>
+		<key alias="select">Seleziona</key>
+		<key alias="somethingElse">Fai qualcos'altro</key>
+		<key alias="bold">Grassetto</key>
+		<key alias="deindent">Cancella rientro paragrafo</key>
+		<key alias="formFieldInsert">Inserisci campo del form</key>
+		<key alias="graphicHeadline">Inserisci intestazione grafica</key>
+		<key alias="htmlEdit">Modifica Html</key>
+		<key alias="indent">Inserisci rientro paragrafo</key>
+		<key alias="italic">Corsivo</key>
+		<key alias="justifyCenter">Centra</key>
+		<key alias="justifyLeft">Allinea testo a sinistra</key>
+		<key alias="justifyRight">Allinea testo a destra</key>
+		<key alias="linkInsert">Inserisci Link</key>
+		<key alias="linkLocal">Inserisci local link (ancora)</key>
+		<key alias="listBullet">Elenco puntato</key>
+		<key alias="listNumeric">Elenco numerato</key>
+		<key alias="macroInsert">Inserisci macro</key>
+		<key alias="pictureInsert">Inserisci immagine</key>
+		<key alias="publishAndClose">Pubblica e chiudi</key>
+		<key alias="publishDescendants">Pubblica con discendenti</key>
+		<key alias="relations">Modifica relazioni</key>
+		<key alias="returnToList">Ritorna alla lista</key>
+		<key alias="save">Salva</key>
+		<key alias="saveAndClose">Salva e chiudi</key>
+		<key alias="saveAndPublish">Salva e pubblica</key>
+		<key alias="saveAndSchedule">Salva e pianifica</key>
+		<key alias="saveToPublish">Salva e invia per approvazione</key>
+		<key alias="saveListView">Salva list view</key>
+		<key alias="schedulePublish">Pianifica</key>
+		<key alias="showPage">Anteprima</key>
+		<key alias="saveAndPreview">Salva e visualizza anteprima</key>
+		<key alias="showPageDisabled"><![CDATA[L'anteprima è disabilitata perché non ci sono template assegnati]]></key>
+		<key alias="styleChoose">Scegli stile</key>
+		<key alias="styleShow">Vedi stili</key>
+		<key alias="tableInsert">Inserisci tabella</key>
+		<key alias="generateModelsAndClose">Genera modelli e chiudi</key>
+		<key alias="saveAndGenerateModels">Salva e genera modelli</key>
+		<key alias="undo">Indietro</key>
+		<key alias="redo">Avanti</key>
+		<key alias="rollback">Ripristina</key>
+		<key alias="deleteTag">Elimina tag</key>
+		<key alias="confirmActionCancel">Cancella</key>
+		<key alias="confirmActionConfirm">Conferma</key>
+		<key alias="morePublishingOptions"><![CDATA[Più opzioni di pubblicazione]]></key>
+		<key alias="submitChanges">Invia</key>
+		<key alias="submitChangesAndClose">Invia e chiudi</key>
+	</area>
+	<area alias="auditTrailsMedia">
+		<key alias="delete">Media eliminato</key>
+		<key alias="move">Media spostato</key>
+		<key alias="copy">Media copiato</key>
+		<key alias="save">Media salvato</key>
+	</area>
+	<area alias="auditTrails">
+		<key alias="atViewingFor">Visualizzazione per</key>
+		<key alias="delete">Contenuto eliminato</key>
+		<key alias="unpublish">Contenuto non pubblicato</key>
+		<key alias="unpublishvariant">Contenuto non pubblicato per le lingue: %0%</key>
+		<key alias="publish">Contenuto pubblicato</key>
+		<key alias="publishvariant">Contenuto pubblicato per le lingue: %0%</key>
+		<key alias="save">Contenuto salvato</key>
+		<key alias="savevariant">Contenuto salvato per le lingue: %0%</key>
+		<key alias="move">Contenuto spostato</key>
+		<key alias="copy">Contenuto copiato</key>
+		<key alias="rollback">Contenuto ripristinato</key>
+		<key alias="sendtopublish">Contenuto inviato per l'approvazione</key>
+		<key alias="sendtopublishvariant">Contenuto inviato per l'approvazione per le lingue: %0%</key>
+		<key alias="sort">Ordina gli elementi figlio eseguito dall'utente</key>
+		<key alias="custom">%0%</key>
+		<key alias="smallCopy">Copia</key>
+		<key alias="smallPublish">Pubblica</key>
+		<key alias="smallPublishVariant">Pubblica</key>
+		<key alias="smallMove">Sposta</key>
+		<key alias="smallSave">Salva</key>
+		<key alias="smallSaveVariant">Salva</key>
+		<key alias="smallDelete">Elimina</key>
+		<key alias="smallUnpublish">Non pubblicare</key>
+		<key alias="smallUnpublishVariant">Non pubblicare</key>
+		<key alias="smallRollBack">Ripristina</key>
+		<key alias="smallSendToPublish">Invia per l'approvazione</key>
+		<key alias="smallSendToPublishVariant">Invia per l'approvazione</key>
+		<key alias="smallSort">Ordina</key>
+		<key alias="smallCustom">Personalizzato</key>
+		<key alias="historyIncludingVariants">Cronologia (tutte le varianti)</key>
+	</area>
+	<area alias="codefile">
+		<key alias="createFolderFailedById">Impossibile creare una cartella sotto genitore con ID %0%</key>
+		<key alias="createFolderFailedByName">Impossibile creare una cartella sotto genitore con nome %0%</key>
+		<key alias="createFolderIllegalChars">
+			<![CDATA[Il nome della cartella non può contenere caratteri non validi.]]>
+		</key>
+		<key alias="deleteItemFailed">Impossibile eliminare l'elemento: %0%</key>
+	</area>
+	<area alias="content">
+		<key alias="isPublished" version="7.2">Pubblicato</key>
+		<key alias="about">Informazioni su questa pagina</key>
+		<key alias="alias">Alias</key>
+		<key alias="alternativeTextHelp">(come descriveresti l'immagine via telefono)</key>
+		<key alias="alternativeUrls">Links alternativi</key>
+		<key alias="clickToEdit">Clicca per modificare questo elemento</key>
+		<key alias="createBy">Creato da</key>
+		<key alias="createByDesc" version="7.0">Autore originale</key>
+		<key alias="updatedBy" version="7.0">Aggiornato da</key>
+		<key alias="createDate">Creato il</key>
+		<key alias="createDateDesc" version="7.0"><![CDATA[Data e ora in cui questo documento è stato creato]]></key>
+		<key alias="documentType">Tipo di documento</key>
+		<key alias="editing">Modifica</key>
+		<key alias="expireDate">Attivo fino al</key>
+		<key alias="itemChanged"><![CDATA[Questo elemento è stato modificato dopo la pubblicazione]]></key>
+		<key alias="itemNotPublished"><![CDATA[Questo elemento non è stato pubblicato]]></key>
+		<key alias="lastPublished">Ultima pubblicazione</key>
+		<key alias="noItemsToShow">Non ci sono elementi da visualizzare</key>
+		<key alias="listViewNoItems" version="7.1.5">Non ci sono elementi da visualizzare nella lista.</key>
+		<key alias="listViewNoContent"><![CDATA[Nessun elemento figlio è stato aggiunto]]></key>
+		<key alias="listViewNoMembers"><![CDATA[Nessun membro è stato aggiunto]]></key>
+		<key alias="mediatype">Tipo di media</key>
+		<key alias="mediaLinks">Link ai media</key>
+		<key alias="membergroup">Gruppo di membri</key>
+		<key alias="memberrole">Ruolo</key>
+		<key alias="membertype">Tipo di Membro</key>
+		<key alias="noChanges">Non sono state effettuate modifiche</key>
+		<key alias="noDate"><![CDATA[La data non è stata selezionata]]></key>
+		<key alias="nodeName">Titolo della Pagina</key>
+		<key alias="noMediaLink">Questo media non ha link</key>
+		<key alias="noProperties"><![CDATA[Nessun contenuto può essere aggiunto per questo elemento]]></key>
+		<key alias="otherElements"><![CDATA[Proprietà]]></key>
+		<key alias="parentNotPublished">
+			<![CDATA[Questo documento è pubblicato, ma non è visibile perché il padre '%0%' non è pubblicato]]>
+		</key>
+		<key alias="parentCultureNotPublished">
+			<![CDATA[Questa lingua è pubblicata, ma non è visibile perché non è pubblicata al padre '%0%']]>
+		</key>
+		<key alias="parentNotPublishedAnomaly"><![CDATA[Questo documento è pubblicato, ma non è nella cache]]></key>
+		<key alias="getUrlException">Impossibile ottenere l'URL</key>
+		<key alias="routeError">
+			<![CDATA[Questo documento è pubblicato ma il suo URL entrerebbe in conflitto con il contenuto %0%]]>
+		</key>
+		<key alias="routeErrorCannotRoute">
+			<![CDATA[Questo documento è pubblicato ma il suo URL non può essere instradato]]>
+		</key>
+		<key alias="publish">Pubblica</key>
+		<key alias="published">Pubblicato</key>
+		<key alias="publishedPendingChanges">Pubblicato (modifiche in sospeso)</key>
+		<key alias="publishStatus">Stato della pubblicazione</key>
+		<key alias="publishDescendantsHelp">
+			<![CDATA[Pubblica <strong>%0%</strong> e tutti gli elementi sottostanti, rendendo così il loro contenuto pubblicamente disponibile.]]>
+		</key>
+		<key alias="publishDescendantsWithVariantsHelp">
+			<![CDATA[Pubblica le varianti e le varianti dello stesso tipo sottostanti, rendendo così il loro contenuto pubblicamente disponibile.]]>
+		</key>
+		<key alias="releaseDate">Pubblicato il</key>
+		<key alias="unpublishDate">Non pubblicato il</key>
+		<key alias="removeDate">Rimuovi data</key>
+		<key alias="setDate">Imposta data</key>
+		<key alias="sortDone">Ordinamento dei nodi aggiornato</key>
+		<key alias="sortHelp">
+			<![CDATA[Per ordinare i nodi, è sufficiente trascinare i nodi o fare clic su una delle intestazioni di colonna. È possibile selezionare più nodi tenendo premuto il tasto "shift" o "control" durante la selezione]]>
+		</key>
+		<key alias="statistics">Statistiche</key>
+		<key alias="titleOptional">Titolo (opzionale)</key>
+		<key alias="altTextOptional">Testo alternativo (opzionale)</key>
+		<key alias="captionTextOptional">Didascalia (opzionale)</key>
+		<key alias="type">Tipo</key>
+		<key alias="unpublish">Non pubblicare</key>
+		<key alias="unpublished">Bozza</key>
+		<key alias="notCreated">Non creato</key>
+		<key alias="updateDate">Ultima modifica</key>
+		<key alias="updateDateDesc" version="7.0"><![CDATA[Data e ora in cui questo documento è stato modificato]]></key>
+		<key alias="uploadClear">Rimuovi file(s)</key>
+		<key alias="uploadClearImageContext">Clicca qui per rimuovere l'immagine dal media</key>
+		<key alias="uploadClearFileContext">Clicca qui per rimuovere il file dal media</key>
+		<key alias="urls">Link al documento</key>
+		<key alias="memberof">Membro del gruppo/i</key>
+		<key alias="notmemberof">Non un membro del gruppo/i</key>
+		<key alias="childItems" version="7.0">Elementi figli</key>
+		<key alias="target" version="7.0">Target</key>
+		<key alias="scheduledPublishServerTime">Questo si traduce nella seguente ora sul server:</key>
+		<key alias="scheduledPublishDocumentation">
+			<![CDATA[<a href="https://docs.umbraco.com/umbraco-cms/fundamentals/data/scheduled-publishing#timezones" target="_blank" rel="noopener">Cosa significa questo?</a>]]>
+		</key>
+		<key alias="nestedContentDeleteItem">Sei sicuro di voler eliminare questo oggetto?</key>
+		<key alias="nestedContentDeleteAllItems">Sei sicuro di voler eliminare tutti gli oggetti?</key>
+		<key alias="nestedContentEditorNotSupported">
+			<![CDATA[La proprietà %0% usa l'editor %1% che non è supportato dal Nested Content.]]>
+		</key>
+		<key alias="nestedContentNoContentTypes">
+			<![CDATA[Nessun tipo di contenuto configurato per questa proprietà.]]>
+		</key>
+		<key alias="nestedContentAddElementType">Aggiungi Element Type</key>
+		<key alias="nestedContentSelectElementTypeModalTitle">Seleziona Element Type</key>
+		<key alias="nestedContentGroupHelpText">
+			<![CDATA[Seleziona il gruppo di cui devono essere visualizzate le proprietà. Se lasciato vuoto, verrà utilizzato il primo gruppo sull'Element Type.]]>
+		</key>
+		<key alias="nestedContentTemplateHelpTextPart1">
+			Immettere un'espressione di angular da valutare rispetto a ciascun
+			elemento per il relativo nome. Utilizza
+		</key>
+		<key alias="nestedContentTemplateHelpTextPart2">per visualizzare l'index dell'oggetto</key>
+		<key alias="addTextBox">Aggiungi un altro box di testo</key>
+		<key alias="removeTextBox">Rimuovi questa text box</key>
+		<key alias="contentRoot">Root del contenuto</key>
+		<key alias="includeUnpublished">Includi elementi di contenuto non pubblicati.</key>
+		<key alias="isSensitiveValue">
+			<![CDATA[Questo valore è nascosto. Se hai bisogno dell'accesso per visualizzare questo valore contatta l'amministratore del sito.]]>
+		</key>
+		<key alias="isSensitiveValue_short"><![CDATA[Questo valore è nascosto.]]></key>
+		<key alias="languagesToPublishForFirstTime">
+			Quali lingue vorresti pubblicare? Tutte le lingue con contenuto vengono
+			salvate!
+		</key>
+		<key alias="languagesToPublish">Quali lingue vorresti pubblicare?</key>
+		<key alias="languagesToSave">Quali lingue vorresti salvare?</key>
+		<key alias="languagesToSaveForFirstTime">Tutte le lingue con contenuto vengono salvate alla creazione!</key>
+		<key alias="languagesToSendForApproval">Quali lingue vorresti inviare per l'approvazione?</key>
+		<key alias="languagesToSchedule">Quali lingue vorresti pianificare?</key>
+		<key alias="languagesToUnpublish">
+			Seleziona le lingue da non pubblicare. Non pubblicando una lingua obbligatoria
+			annullerai la pubblicazione di tutte le lingue.
+		</key>
+		<key alias="publishedLanguages">Lingue pubblicate</key>
+		<key alias="unpublishedLanguages">Lingue non pubblicate</key>
+		<key alias="unmodifiedLanguages">Lingue non modificate</key>
+		<key alias="untouchedLanguagesForFirstTime">Queste lingue non sono state create.</key>
+
+		<key alias="variantsWillBeSaved">Tutte le nuove varianti verranno salvate.</key>
+		<key alias="variantsToPublish">Quali varianti vorresti pubblicare?</key>
+		<key alias="variantsToSave">Scegli quali varianti verranno salvate.</key>
+		<key alias="variantsToSendForApproval">Scegli le varianti da inviare per l'approvazione.</key>
+		<key alias="variantsToSchedule">Imposta pubblicazione pianificata...</key>
+		<key alias="variantsToUnpublish">
+			Seleziona le varianti da non pubblicare. Non pubblicando una lingua obbligatoria
+			annullerai la pubblicazione di tutte le varianti.
+		</key>
+		<key alias="publishRequiresVariants">Per la pubblicazione sono necessarie le seguenti varianti:</key>
+
+		<key alias="notReadyToPublish">Non siamo pronti per la pubblicazione</key>
+		<key alias="readyToPublish">Pronto per la pubblicazione?</key>
+		<key alias="readyToSave">Pronto per il salvataggio?</key>
+		<key alias="sendForApproval">Invia per l'approvazione</key>
+		<key alias="schedulePublishHelp">Seleziona da data e l'ora in cui pubblicare/non pubblicare il contenuto.</key>
+		<key alias="createEmpty">Crea nuovo/a</key>
+		<key alias="createFromClipboard">Incolla dagli appunti</key>
+		<key alias="nodeIsInTrash"><![CDATA[Questo articolo è nel cestino]]></key>
+	</area>
+	<area alias="blueprints">
+		<key alias="createBlueprintFrom">Crea un nuovo modello di contenuto da '%0%'</key>
+		<key alias="blankBlueprint">Vuoto</key>
+		<key alias="selectBlueprint">Seleziona un modello di contenuto</key>
+		<key alias="createdBlueprintHeading">Modello di contenuto creato</key>
+		<key alias="createdBlueprintMessage"><![CDATA[Un modello di contenuto è stato creato da '%0%']]></key>
+		<key alias="duplicateBlueprintMessage"><![CDATA[Un altro modello di contenuto con lo stesso nome esiste già]]></key>
+		<key alias="blueprintDescription">
+			<![CDATA[Un modello di contenuto è del contenuto predefinito che un editor può utilizzare come base per creare un nuovo contenuto.]]>
+		</key>
+	</area>
+	<area alias="media">
+		<key alias="clickToUpload">Clicca per caricare</key>
+		<key alias="orClickHereToUpload">o clicca qui per scegliere i files</key>
+		<key alias="dragFilesHereToUpload">Puoi trascinare i file qui per caricarli.</key>
+		<key alias="disallowedFileType">Impossibile caricare questo file, non ha un tipo di file approvato</key>
+		<key alias="maxFileSize"><![CDATA[La dimensione massima del file è]]></key>
+		<key alias="mediaRoot">Media root</key>
+		<key alias="moveFailed">Impossibile spostare il media</key>
+		<key alias="moveToSameFolderFailed">La cartella padre e di destinazione non possono essere le stesse</key>
+		<key alias="copyFailed">Impossibile copiare il media</key>
+		<key alias="createFolderFailed">Impossibile creare una cartella sotto l'id padre %0%</key>
+		<key alias="renameFolderFailed">Impossibile rinominare la cartella con id %0%</key>
+		<key alias="dragAndDropYourFilesIntoTheArea">Trascina e rilascia i tuoi file nell'area</key>
+		<key alias="uploadNotAllowed"><![CDATA[Il caricamento non è consentito in questa posizione.]]></key>
+	</area>
+	<area alias="member">
+		<key alias="createNewMember">Crea un nuovo membro</key>
+		<key alias="allMembers">Tutti i membri</key>
+		<key alias="memberGroupNoProperties">
+			<![CDATA[I gruppi di membri non hanno proprietà aggiuntive per la modifica.]]>
+		</key>
+	</area>
+	<area alias="contentType">
+		<key alias="copyFailed">Impossibile copiare il content type</key>
+		<key alias="moveFailed">Impossibile spostare il content type</key>
+	</area>
+	<area alias="mediaType">
+		<key alias="copyFailed">Impossibile copiare il media type</key>
+		<key alias="moveFailed">Impossibile spostare il media type</key>
+		<key alias="autoPickMediaType">Selezione automatica</key>
+	</area>
+	<area alias="memberType">
+		<key alias="copyFailed">Impossibile copiare il member type</key>
+	</area>
+	<area alias="create">
+		<key alias="chooseNode"><![CDATA[Dove vuoi creare il nuovo %0%]]></key>
+		<key alias="createUnder">Crea un elemento sotto</key>
+		<key alias="createContentBlueprint">Seleziona il Document Type per cui vuoi creare un modello di contenuto</key>
+		<key alias="enterFolderName">Inserisci il nome della cartella</key>
+		<key alias="updateData">Scegli il tipo ed il titolo</key>
+		<key alias="noDocumentTypes" version="7.0">
+			<![CDATA[Non ci sono tipi di documento abilitati disponibili per creare un contenuto qui. Devi abilitarli in <strong>Tipi di documento</strong> dentro la sezione <strong>Impostazioni</strong>, modificando <strong>Tipi di nodi figlio consentiti</strong> sotto <strong>Permessi</strong>.]]>
+		</key>
+		<key alias="noDocumentTypesAtRoot">
+			<![CDATA[Non ci sono tipi di documento abilitati disponibili per creare un contenuto qui. Devi crearli in <strong>Tipi di documento</strong> dentro la sezione <strong>Impostazioni</strong>.]]>
+		</key>
+		<key alias="noDocumentTypesWithNoSettingsAccess">
+			La pagina selezionata nel content tree non permette a nessuna
+			pagina di essere creata sotto di essa.
+		</key>
+		<key alias="noDocumentTypesEditPermissions">Modifica permessi per questo tipo di documento</key>
+		<key alias="noDocumentTypesCreateNew">Crea un nuovo tipo di documento</key>
+		<key alias="noDocumentTypesAllowedAtRoot">
+			<![CDATA[Non ci sono tipi di documento abilitati disponibili per creare un contenuto qui. Devi abilitarli in <strong>Tipi di documento</strong> dentro la sezione <strong>Impostazioni</strong>, cambiando l'opzione <strong>Consenti come root</strong> sotto <strong>Permessi</strong>.]]>
+		</key>
+		<key alias="noMediaTypes" version="7.0">
+			<![CDATA[Non ci sono tipi di documento abilitati disponibili per creare un media qui. Devi abilitarli in <strong>Tipi di documento</strong> dentro la sezione <strong>Impostazioni</strong>, modificando <strong>Tipi di nodi figlio consentiti</strong> sotto <strong>Permessi</strong>.]]>
+		</key>
+		<key alias="noMediaTypesWithNoSettingsAccess">
+			Il media selezionato non consente la creazione di altri media al di
+			sotto di esso.
+		</key>
+		<key alias="noMediaTypesEditPermissions">Modifica permessi per questo tipo di media</key>
+		<key alias="documentTypeWithoutTemplate">Tipo di documento senza template</key>
+		<key alias="documentTypeWithTemplate">Tipo di documento con template</key>
+		<key alias="documentTypeWithTemplateDescription">
+			<![CDATA[La definizione dei dati per una pagina di contenuto che può essere creata dagli editor nella struttura dei contenuti ed è direttamente accessibile tramite un URL.]]>
+		</key>
+		<key alias="documentType">Tipo di documento</key>
+		<key alias="documentTypeDescription">
+			<![CDATA[La definizione dei dati per un componente del contenuto che può essere creato dagli editor nella struttura del contenuto e prelevato su altre pagine ma non ha un URL diretto.]]>
+		</key>
+		<key alias="elementType">Tipo di elemento</key>
+		<key alias="elementTypeDescription">
+			<![CDATA[Definisce lo schema per un insieme ripetuto di proprietà, ad esempio, in un editor di proprietà 'Block List' o 'Nested Content'.]]>
+		</key>
+		<key alias="composition">Composizione</key>
+		<key alias="compositionDescription">
+			<![CDATA[Definisce un insieme riutilizzabile di proprietà che possono essere incluse nella definizione di più altri tipi di documento. Ad esempio, un insieme di "Impostazioni pagina comuni".]]>
+		</key>
+		<key alias="folder">Cartella</key>
+		<key alias="folderDescription">
+			Utilizzato per organizzare i tipi di documento, le composizioni e i tipi di elementi
+			creati in questo albero dei tipi di documento.
+		</key>
+		<key alias="newFolder">Nuova cartella</key>
+		<key alias="newDataType">Nuovo tipo di dato</key>
+		<key alias="newJavascriptFile">Nuovo file JavaScript</key>
+		<key alias="newEmptyPartialView">Nuova partial view vuota</key>
+		<key alias="newPartialViewMacro">Nuova partial view macro</key>
+		<key alias="newPartialViewFromSnippet">Nuova partial view da snippet</key>
+		<key alias="newPartialViewMacroFromSnippet">Nuova partial view macro da snippet</key>
+		<key alias="newPartialViewMacroNoMacro">Nuova partial view macro (senza macro)</key>
+		<key alias="newStyleSheetFile">Nuovo foglio di stile</key>
+		<key alias="newRteStyleSheetFile">Nuovo foglio di stile per Rich Text Editor</key>
+	</area>
+	<area alias="dashboard">
+		<key alias="browser"><![CDATA[Naviga il tuo sito web]]></key>
+		<key alias="dontShowAgain"><![CDATA[Non mostrare più]]></key>
+		<key alias="nothinghappens">
+			<![CDATA[se Umbraco non si sta aprendo, potresti aver bisogno di rimuovere il blocco popup]]>
+		</key>
+		<key alias="openinnew">hai aperto una nuova finestra</key>
+		<key alias="restart">Riavvia</key>
+		<key alias="visit">Visita</key>
+		<key alias="welcome">Benvenuto</key>
+	</area>
+	<area alias="prompt">
+		<key alias="stay">Rimani</key>
+		<key alias="discardChanges">Scarta le modifiche</key>
+		<key alias="unsavedChanges">Hai delle modifiche non salvate</key>
+		<key alias="unsavedChangesWarning">
+			Sei sicuro di voler lasciare questa pagina? Hai delle modifiche non salvate!
+		</key>
+		<key alias="confirmListViewPublish">Pubblicando renderai visibli gli oggetti selezionati sul sito.</key>
+		<key alias="confirmListViewUnpublish">
+			Non pubblicando rimuoverai gli oggetti selezionati e i loro discendenti dal
+			sito.
+		</key>
+		<key alias="confirmUnpublish">Non pubblicando rimuoverai questa pagina e tutti i suoi discendenti dal sito.</key>
+		<key alias="doctypeChangeWarning">
+			<![CDATA[Hai modifiche non salvate. Apportare modifiche al tipo di documento annullerà le modifiche.]]>
+		</key>
+	</area>
+	<area alias="bulk">
+		<key alias="done">Fatto</key>
+		<key alias="deletedItem">Eliminato %0% elemento</key>
+		<key alias="deletedItems">Eliminati %0% elementi</key>
+		<key alias="deletedItemOfItem">Eliminato %0% su %1% elemento</key>
+		<key alias="deletedItemOfItems">Eliminati %0% su %1% elementi</key>
+		<key alias="publishedItem">Pubblicato %0% elemento</key>
+		<key alias="publishedItems">Pubblicati %0% elementi</key>
+		<key alias="publishedItemOfItem">Pubblicato %0% su %1% elemento</key>
+		<key alias="publishedItemOfItems">Pubblicati %0% su %1% elementi</key>
+		<key alias="unpublishedItem">%0% elemento non pubblicato</key>
+		<key alias="unpublishedItems">%0% elementi non pubblicati</key>
+		<key alias="unpublishedItemOfItem">Elementi non pubblicati: %0% su %1%</key>
+		<key alias="unpublishedItemOfItems">Elementi non pubblicati: %0% su %1%</key>
+		<key alias="movedItem">Spostato %0% elemento</key>
+		<key alias="movedItems">Spostati %0% elementi</key>
+		<key alias="movedItemOfItem">Spostato %0% su %1% elemento</key>
+		<key alias="movedItemOfItems">Spostati %0% su %1% elementi</key>
+		<key alias="copiedItem">Copiato %0% elemento</key>
+		<key alias="copiedItems">Copiati %0% elementi</key>
+		<key alias="copiedItemOfItem">Copiato %0% su %1% elemento</key>
+		<key alias="copiedItemOfItems">Copiati %0% su %1% elementi</key>
+	</area>
+	<area alias="defaultdialogs">
+		<key alias="nodeNameLinkPicker">Titolo del Link</key>
+		<key alias="urlLinkPicker">Link</key>
+		<key alias="anchorLinkPicker">Ancora / querystring</key>
+		<key alias="anchorInsert">Nome</key>
+		<key alias="closeThisWindow">Chiudi questa finestra</key>
+		<key alias="confirmdelete">Sei sicuro di voler eliminare</key>
+		<key alias="confirmdisable">Sei sicuro di voler disabilitare</key>
+		<key alias="confirmremove">Sei sicuro di voler rimuovere</key>
+		<key alias="confirmremoveusageof"><![CDATA[Sei sicuro di voler rimuovere l'utilizzo di <strong>%0%</strong>]]></key>
+		<key alias="confirmremovereferenceto"><![CDATA[Sei sicuro di voler rimuovere la referenza a <strong>%0%</strong>]]></key>
+		<key alias="confirmlogout"><![CDATA[Sei sicuro?]]></key>
+		<key alias="confirmSure"><![CDATA[Sei sicuro?]]></key>
+		<key alias="cut">Taglia</key>
+		<key alias="editdictionary">Modifica elemento del Dizionario</key>
+		<key alias="editlanguage">Modifica la lingua</key>
+		<key alias="editSelectedMedia">Modifica il media selezionato</key>
+		<key alias="insertAnchor">Inserisci il link locale</key>
+		<key alias="insertCharacter">Inserisci carattere</key>
+		<key alias="insertgraphicheadline">Inserisci intestazione grafica</key>
+		<key alias="insertimage">Inserisci immagine</key>
+		<key alias="insertlink">Inserisci link</key>
+		<key alias="insertMacro">Inserisci macro</key>
+		<key alias="inserttable">Inserisci tabella</key>
+		<key alias="languagedeletewarning"><![CDATA[Questo eliminerà la lingua]]></key>
+		<key alias="languageChangeWarning">
+			<![CDATA[La modifica della cultura di una lingua può essere un'operazione costosa e comporterà la ricostruzione della cache dei contenuti e degli indici]]>
+		</key>
+		<key alias="lastEdited">Ultima modifica</key>
+		<key alias="link">Link</key>
+		<key alias="linkinternal"><![CDATA[Link interno:]]></key>
+		<key alias="linklocaltip"><![CDATA[Quando usi il link locale, inserisci # prima del link]]></key>
+		<key alias="linknewwindow"><![CDATA[Apri in nuova finestra?]]></key>
+		<key alias="macroContainerSettings">Impostazioni della macro</key>
+		<key alias="macroDoesNotHaveProperties"><![CDATA[Questa macro non contiene proprietà editabili]]></key>
+		<key alias="paste">Incolla</key>
+		<key alias="permissionsEdit">Modifica i permessi per</key>
+		<key alias="permissionsSet">Imposta i permessi per</key>
+		<key alias="permissionsSetForGroup">Imposta i permessi per %0% per il gruppo di utenti %1%</key>
+		<key alias="permissionsHelp">Seleziona i gruppi di utenti per il quale vuoi impostare i permessi</key>
+		<key alias="recycleBinDeleting">
+			<![CDATA[Gli elementi presenti nel cestino verranno cancellati. Non chiudere questa finestra finchè l'operazione non è terminata.]]>
+		</key>
+		<key alias="recycleBinIsEmpty"><![CDATA[Il cestino è vuoto]]></key>
+		<key alias="recycleBinWarning"><![CDATA[Gli elementi cancellati dal cestino non potranno essere recuperati.]]></key>
+		<key alias="regexSearchError">
+			<![CDATA[Il webservice <a target='_blank' rel='noopener' href='http://regexlib.com'>regexlib.com</a> ha attualmente qualche problema, di cui non abbiamo il controllo. Siamo spiacevoli dell'inconveniente.]]>
+		</key>
+		<key alias="regexSearchHelp">
+			<![CDATA[Ricerca un'espressione regolare da aggiungere al campo della form per poter validare il contenuto. Esempio: 'email, 'zip-code', 'URL'.]]>
+		</key>
+		<key alias="removeMacro">Elimina Macro</key>
+		<key alias="requiredField">Campo obbligatorio</key>
+		<key alias="sitereindexed"><![CDATA[Il sito è stato reindicizzato]]></key>
+		<key alias="siterepublished"><![CDATA[Il sito è stato ripubblicato]]></key>
+		<key alias="siterepublishHelp">
+			<![CDATA[La cache del sito sarà ricreata. Tutti gli elementi pubblicati saranno aggiornati, tutti quelli non pubblicati rimarranno tali.]]>
+		</key>
+		<key alias="tableColumns">Numero di colonne</key>
+		<key alias="tableRows">Numero di righe</key>
+		<key alias="thumbnailimageclickfororiginal"><![CDATA[Clicca sull'immmagine per ingrandirla]]></key>
+		<key alias="treepicker">Seleziona elemento</key>
+		<key alias="viewCacheItem">Visualizza gli elementi in cache</key>
+		<key alias="relateToOriginalLabel">Relaziona con l'originale</key>
+		<key alias="includeDescendants">Includi discendenti</key>
+		<key alias="theFriendliestCommunity"><![CDATA[La comunità più amichevole]]></key>
+		<key alias="linkToPage">Link alla pagina</key>
+		<key alias="openInNewWindow">Apre il documento linkato in una nuova finestra o tab</key>
+		<key alias="linkToMedia">Link al media</key>
+		<key alias="selectContentStartNode">Seleziona il nodo di inizio per il contenuto</key>
+		<key alias="selectMedia">Seleziona media</key>
+		<key alias="selectMediaType">Seleziona tipo di media</key>
+		<key alias="selectIcon">Seleziona icona</key>
+		<key alias="selectItem">Seleziona oggetto</key>
+		<key alias="selectLink">Seleziona link</key>
+		<key alias="selectMacro">Seleziona macro</key>
+		<key alias="selectContent">Seleziona contenuto</key>
+		<key alias="selectContentType">Seleziona tipo di contenuto</key>
+		<key alias="selectMediaStartNode">Seleziona il nodo di inizio per i media</key>
+		<key alias="selectMember">Seleziona membro</key>
+		<key alias="selectMemberGroup">Seleziona gruppo di membri</key>
+		<key alias="selectMemberType">Seleziona tipo di membri</key>
+		<key alias="selectNode">Seleziona nodo</key>
+		<key alias="selectSections">Seleziona sezioni</key>
+		<key alias="selectUser">Seleziona utente</key>
+		<key alias="selectUsers">Seleziona utenti</key>
+		<key alias="noIconsFound">Non sono state trovate icone</key>
+		<key alias="noMacroParams">Non ci sono parametri per questa macro</key>
+		<key alias="noMacros">Non ci sono macro disponibili da inserire</key>
+		<key alias="externalLoginProviders">Provider di accesso esterni</key>
+		<key alias="exceptionDetail">Exception Details</key>
+		<key alias="stacktrace">Stacktrace</key>
+		<key alias="innerException">Inner Exception</key>
+		<key alias="linkYour">Linka il tuo</key>
+		<key alias="unLinkYour">Togli il link al tuo</key>
+		<key alias="account">account</key>
+		<key alias="selectEditor">Seleziona editor</key>
+		<key alias="selectEditorConfiguration">Seleziona configurazione</key>
+		<key alias="selectSnippet">Seleziona snippet</key>
+		<key alias="variantdeletewarning">
+			<![CDATA[Questo cancellerà il nodo e tutte le sue lingue. Se desideri eliminare solo una lingua, dovresti invece non pubblicare il nodo in quella lingua.]]>
+		</key>
+		<key alias="propertyuserpickerremovewarning"><![CDATA[Questo rimuoverà l'utente <strong>%0%</strong>.]]></key>
+		<key alias="userremovewarning"><![CDATA[Questo rimuoverà l'utente <strong>%0%</strong> dal gruppo <strong>%1%</strong>]]></key>
+		<key alias="yesRemove">Si, rimuovi</key>
+	</area>
+	<area alias="dictionary">
+		<key alias="noItems">Non ci sono oggetti nel Dizionario.</key>
+	</area>
+	<area alias="dictionaryItem">
+		<key alias="description"><![CDATA[Modifica le lingue per l'elemento '<em>%0%</em>' qui sotto.]]></key>
+		<key alias="displayName">Nome della cultura</key>
+		<key alias="changeKeyError"><![CDATA[La chiave '%0%' esiste già.]]></key>
+		<key alias="overviewTitle">Panoramica del Dizionario</key>
+	</area>
+	<area alias="examineManagement">
+		<key alias="configuredSearchers">Searchers configurati</key>
+		<key alias="configuredSearchersDescription">
+			<![CDATA[Visualizza le proprietà e gli strumenti per ogni Searcher configurato (per esempio un multi-index searcher)]]>
+		</key>
+		<key alias="fieldValues">Valori del campo</key>
+		<key alias="healthStatus">Stato di salute</key>
+		<key alias="healthStatusDescription"><![CDATA[Lo stato di salute dell'index e se può essere letto]]></key>
+		<key alias="indexers">Indexers</key>
+		<key alias="indexInfo">Index info</key>
+		<key alias="indexInfoDescription"><![CDATA[Elenca le proprietà dell'index]]></key>
+		<key alias="manageIndexes">Gestisci gli indexes di Examine</key>
+		<key alias="manageIndexesDescription">
+			Permette di visualizzare i dettagli di ogni index e fornisce alcuni strumenti
+			per gestire gli index
+		</key>
+		<key alias="rebuildIndex">Ricostruisci index</key>
+		<key alias="rebuildIndexWarning">
+			<![CDATA[
+      Questo causerà la ricostruzione dell'index.<br />
+      A seconda della quantità di contenuti presenti nel tuo sito, potrebbe volerci un po' di tempo.<br />
+      Non è consigliabile ricostruire un indice durante i periodi di elevato traffico del sito Web o quando gli editor modificano i contenuti.
+     ]]>
+		</key>
+		<key alias="searchers">Searchers</key>
+		<key alias="searchDescription">Cerca nell'index e visualizza i risultati</key>
+		<key alias="tools">Strumenti</key>
+		<key alias="toolsDescription">Strumenti per gestire l'index</key>
+		<key alias="fields">Campi</key>
+		<key alias="indexCannotRead"><![CDATA[L'indice non può essere letto e dovrà essere ricostruito]]></key>
+		<key alias="processIsTakingLonger">
+			<![CDATA[Il processo sta impiegando più tempo del previsto, controlla il log di Umbraco per vedere se ci sono stati errori durante questa operazione]]>
+		</key>
+		<key alias="indexCannotRebuild"><![CDATA[Questo indice non può essere ricostruito perché non ha assegnato]]></key>
+		<key alias="iIndexPopulator">IIndexPopulator</key>
+	</area>
+	<area alias="placeholders">
+		<key alias="username">Inserisci il tuo username</key>
+		<key alias="password">Inserisci la tua password</key>
+		<key alias="confirmPassword">Conferma la tua password</key>
+		<key alias="nameentity">Dai un nome a %0%...</key>
+		<key alias="entername">Inserisci un nome...</key>
+		<key alias="enteremail">Inserisci un email...</key>
+		<key alias="enterusername">Inserisci un username...</key>
+		<key alias="label">Etichetta...</key>
+		<key alias="enterDescription">Inserisci una descrizione...</key>
+		<key alias="search">Cerca...</key>
+		<key alias="filter">Filtra...</key>
+		<key alias="enterTags">Scrivi per aggiungere tags (premi invio dopo ogni tag)...</key>
+		<key alias="email">Inserisci la tua email</key>
+		<key alias="enterMessage">Inserisci un messaggio...</key>
+		<key alias="usernameHint"><![CDATA[Il tuo username di solito è la tua email]]></key>
+		<key alias="anchor">#value oppure ?key=value</key>
+		<key alias="enterAlias">Inserisci un alias...</key>
+		<key alias="generatingAlias">Sto generando l'alias...</key>
+		<key alias="a11yCreateItem">Crea oggetto</key>
+		<key alias="a11yEdit">Modifica</key>
+		<key alias="a11yName">Nome</key>
+	</area>
+	<area alias="editcontenttype">
+		<key alias="createListView" version="7.2">Crea una list view custom</key>
+		<key alias="removeListView" version="7.2">Rimuovi la list view custom</key>
+		<key alias="aliasAlreadyExists">
+			<![CDATA[Un tipo di contenuto, tipo di media o tipo di membro con questo alias esiste già]]>
+		</key>
+	</area>
+	<area alias="renamecontainer">
+		<key alias="renamed">Rinominato</key>
+		<key alias="enterNewFolderName">Inserisci qui il nuovo nome della cartella</key>
+		<key alias="folderWasRenamed"><![CDATA['%0%' è stato rinominato in '%1%']]></key>
+	</area>
+	<area alias="editdatatype">
+		<key alias="addPrevalue"><![CDATA[Aggiungi valore predefinito]]></key>
+		<key alias="dataBaseDatatype"><![CDATA[Tipo di Dato del database]]></key>
+		<key alias="guid"><![CDATA[Tipo di dati GUID]]></key>
+		<key alias="renderControl">Rendering controllo</key>
+		<key alias="rteButtons">Bottoni</key>
+		<key alias="rteEnableAdvancedSettings">Abilita impostazioni avanzate per</key>
+		<key alias="rteEnableContextMenu">Abilita menu contestuale</key>
+		<key alias="rteMaximumDefaultImgSize">Dimensione massima delle immagini inserite</key>
+		<key alias="rteRelatedStylesheets">Fogli di stile collegati</key>
+		<key alias="rteShowLabel">Visualizza etichetta</key>
+		<key alias="rteWidthAndHeight">Larghezza e altezza</key>
+		<key alias="allPropTypes"><![CDATA[Tutti i tipi di proprietà & dati delle proprietà]]></key>
+		<key alias="willBeDeleted">
+			<![CDATA[usando questo tipo di dato verrà eliminato permanentemente, per favore conferma che vuoi eliminare anche questo.]]>
+		</key>
+		<key alias="yesDelete">Si, elimina</key>
+		<key alias="andAllRelated">
+			<![CDATA[e tutti i tipi di proprietà &amp; dati delle proprietà che usano questo tipo di dato]]>
+		</key>
+		<key alias="selectFolder">Seleziona la cartella da spostare</key>
+		<key alias="inTheTree">nella struttura sottostante</key>
+		<key alias="wasMoved"><![CDATA[è stato spostato sotto]]></key>
+		<key alias="hasReferencesDeleteConsequence">
+			<![CDATA[Eliminando <strong>%0%</strong> eliminerà le proprietà e i dati dagli oggetti seguenti]]>
+		</key>
+		<key alias="acceptDeleteConsequence">
+			<![CDATA[Capisco che questa azione eliminerà le proprietà e i dati basati su questo tipo di dato]]>
+		</key>
+	</area>
+	<area alias="errorHandling">
+		<key alias="errorButDataWasSaved">
+			<![CDATA[I tuoi dati sono stati salvati, ma prima che tu possa pubblicare la tua pagina ci sono degli errori che devono essere corretti:]]>
+		</key>
+		<key alias="errorChangingProviderPassword">
+			<![CDATA[Il MemberShip provider corrente non supporta il cambio password (EnablePasswordRetrieval deve essere true)]]>
+		</key>
+		<key alias="errorExistsWithoutTab"><![CDATA[%0% esiste già]]></key>
+		<key alias="errorHeader"><![CDATA[Si sono verificati degli errori:]]></key>
+		<key alias="errorHeaderWithoutTab"><![CDATA[Si sono verificati degli errori:]]></key>
+		<key alias="errorInPasswordFormat">
+			<![CDATA[La password deve essere lunga almeno %0% caratteri e deve contenere almeno %1% carattere(i) non alfanumerico(i)]]>
+		</key>
+		<key alias="errorIntegerWithoutTab"><![CDATA[%0% deve essere un intero]]></key>
+		<key alias="errorMandatory"><![CDATA[%0% nella tab %1% è un campo obbligatorio]]></key>
+		<key alias="errorMandatoryWithoutTab"><![CDATA[%0% è un campo obbligatorio]]></key>
+		<key alias="errorRegExp"><![CDATA[%0% in %1% non è un formato corretto]]></key>
+		<key alias="errorRegExpWithoutTab"><![CDATA[%0% non è un formato corretto]]></key>
+	</area>
+	<area alias="errors">
+		<key alias="receivedErrorFromServer"><![CDATA[È stato ricevuto un errore dal server]]></key>
+		<key alias="dissallowedMediaType">
+			<![CDATA[Il tipo di file specificato è stato disabilitato dall'amministratore]]>
+		</key>
+		<key alias="codemirroriewarning">
+			<![CDATA[NOTA! Anche se CodeMirror è attivata per la configurazione, è disattivato in Internet Explorer perché non è abbastanza stabile.]]>
+		</key>
+		<key alias="contentTypeAliasAndNameNotNull">
+			<![CDATA[Per favore compila entrambi i campi alias e nome sul nuovo propertytype!]]>
+		</key>
+		<key alias="filePermissionsError">
+			<![CDATA[Si è verificato un problema nella lettura/scrittura di un file o di una cartella]]>
+		</key>
+		<key alias="macroErrorLoadingPartialView">Errore durante il caricamento di una Partial View script (file: %0%)</key>
+		<key alias="missingTitle"><![CDATA[Per favore inserisci un titolo]]></key>
+		<key alias="missingType"><![CDATA[Per favore scegli un tipo]]></key>
+		<key alias="pictureResizeBiggerThanOrg">
+			<![CDATA[Stai allargano l'immagine più dell'originale. Sei sicuro che vuoi procedere?]]>
+		</key>
+		<key alias="startNodeDoesNotExists">
+			<![CDATA[Nodo iniziale cancellato, per favore contatta il tuo amministratore]]>
+		</key>
+		<key alias="stylesMustMarkBeforeSelect">
+			<![CDATA[Per favore evidenzia il contenuto prima di cambiare lo stile]]>
+		</key>
+		<key alias="stylesNoStylesOnPage"><![CDATA[Nessuno stile attivo disponibile]]></key>
+		<key alias="tableColMergeLeft">
+			<![CDATA[Per favore posiziona il cursore a sinistra delle due celle che desideri unire ]]>
+		</key>
+		<key alias="tableSplitNotSplittable"><![CDATA[Non puoi dividere una cella che non è stata unita.]]></key>
+		<key alias="propertyHasErrors"><![CDATA[Questa proprietà non è valida]]></key>
+	</area>
+	<area alias="general">
+		<key alias="options">Opzioni</key>
+		<key alias="about">Info</key>
+		<key alias="action">Azione</key>
+		<key alias="actions">Azioni</key>
+		<key alias="add">Aggiungi</key>
+		<key alias="alias">Alias</key>
+		<key alias="all">Tutti</key>
+		<key alias="areyousure"><![CDATA[Sei sicuro?]]></key>
+		<key alias="back">Indietro</key>
+		<key alias="backToOverview">Torna alla panoramica</key>
+		<key alias="border">Bordo</key>
+		<key alias="by">o</key>
+		<key alias="cancel">Annulla</key>
+		<key alias="cellMargin"><![CDATA[Margine Cella (cell margin)]]></key>
+		<key alias="choose">Scegli</key>
+		<key alias="clear">Pulisci</key>
+		<key alias="close">Chiudi</key>
+		<key alias="closewindow">Chiudi la finestra</key>
+		<key alias="closepane">Chiudi il pannello</key>
+		<key alias="comment">Commento</key>
+		<key alias="confirm">Conferma</key>
+		<key alias="constrain">Vincola</key>
+		<key alias="constrainProportions">Vincola le proporzioni</key>
+		<key alias="content">Contenuto</key>
+		<key alias="continue">Continua</key>
+		<key alias="copy">Copia</key>
+		<key alias="create">Crea</key>
+		<key alias="cropSection">Selezione di ritaglio</key>
+		<key alias="database">Database</key>
+		<key alias="date">Data</key>
+		<key alias="default">Default</key>
+		<key alias="delete">Elimina</key>
+		<key alias="deleted">Eliminato</key>
+		<key alias="deleting">Eliminazione...</key>
+		<key alias="design">Design</key>
+		<key alias="dictionary">Dizionario</key>
+		<key alias="dimensions">Dimensioni</key>
+		<key alias="discard">Scarta</key>
+		<key alias="down"><![CDATA[Giù]]></key>
+		<key alias="download">Scarica</key>
+		<key alias="edit">Modifica</key>
+		<key alias="edited">Modificato</key>
+		<key alias="elements">Elementi</key>
+		<key alias="email">Email</key>
+		<key alias="error">Errore</key>
+		<key alias="field">Campo</key>
+		<key alias="findDocument">Trova</key>
+		<key alias="first">Primo</key>
+		<key alias="focalPoint">Punto focale</key>
+		<key alias="general">Generale</key>
+		<key alias="groups">Gruppi</key>
+		<key alias="group">Gruppo</key>
+		<key alias="height">Altezza</key>
+		<key alias="help">Guida</key>
+		<key alias="hide">Nascondi</key>
+		<key alias="history">Cronologia</key>
+		<key alias="icon">Icona</key>
+		<key alias="id">Id</key>
+		<key alias="import">Importa</key>
+		<key alias="includeFromsubFolders">Includi le sottocartelle nella ricerca</key>
+		<key alias="excludeFromSubFolders">Cerca solo in questa cartella</key>
+		<key alias="info">Info</key>
+		<key alias="innerMargin"><![CDATA[Margine interno (inner margin)]]></key>
+		<key alias="insert">Inserisci</key>
+		<key alias="install">Installa</key>
+		<key alias="invalid">Non valido</key>
+		<key alias="justify">Giustificato</key>
+		<key alias="label">Etichetta</key>
+		<key alias="language">Lingua</key>
+		<key alias="last">Ultimo</key>
+		<key alias="layout">Layout</key>
+		<key alias="links">Links</key>
+		<key alias="loading">Caricamento</key>
+		<key alias="locked">Bloccato</key>
+		<key alias="login">Login</key>
+		<key alias="logoff">Log off</key>
+		<key alias="logout">Logout</key>
+		<key alias="macro">Macro</key>
+		<key alias="mandatory">Obbligatorio</key>
+		<key alias="message">Messaggio</key>
+		<key alias="move">Sposta</key>
+		<key alias="name">Nome</key>
+		<key alias="new">Nuovo</key>
+		<key alias="next">Successivo</key>
+		<key alias="no">No</key>
+		<key alias="of">di</key>
+		<key alias="off">Off</key>
+		<key alias="ok">Ok</key>
+		<key alias="open">Apri</key>
+		<key alias="on">On</key>
+		<key alias="or">o</key>
+		<key alias="orderBy">Ordina per</key>
+		<key alias="password">Password</key>
+		<key alias="path">Percorso</key>
+		<key alias="pleasewait"><![CDATA[Attendere prego...]]></key>
+		<key alias="previous">Precedente</key>
+		<key alias="properties"><![CDATA[Proprietà]]></key>
+		<key alias="rebuild">Ricompila</key>
+		<key alias="reciept"><![CDATA[Email per ricevere i dati del modulo]]></key>
+		<key alias="recycleBin">Cestino</key>
+		<key alias="recycleBinEmpty"><![CDATA[Il cestino è vuoto]]></key>
+		<key alias="reload">Ricarica</key>
+		<key alias="remaining">Rimangono</key>
+		<key alias="remove">Rimuovi</key>
+		<key alias="rename">Rinomina</key>
+		<key alias="renew">Rinnova</key>
+		<key alias="required" version="7.0">Obbligatorio</key>
+		<key alias="retrieve">Recupera</key>
+		<key alias="retry">Riprova</key>
+		<key alias="rights">Permessi</key>
+		<key alias="scheduledPublishing">Pubblicazione programmata</key>
+		<key alias="search">Cerca</key>
+		<key alias="searchNoResult">Spiacenti, non riusciamo a trovare quello che stai cercando.</key>
+		<key alias="noItemsInList"><![CDATA[Non è stato aggiunto nessun elemento]]></key>
+		<key alias="server">Server</key>
+		<key alias="settings">Impostazioni</key>
+		<key alias="show">Mostra</key>
+		<key alias="showPageOnSend">Mostra la pagina inviata</key>
+		<key alias="size">Dimensione</key>
+		<key alias="sort">Ordina</key>
+		<key alias="status">Stato</key>
+		<key alias="submit">Conferma</key>
+		<key alias="success">Riuscito</key>
+		<key alias="type">Tipo</key>
+		<key alias="typeToSearch">Digita per cercare...</key>
+		<key alias="under">sotto</key>
+		<key alias="up">Su</key>
+		<key alias="update">Aggiorna</key>
+		<key alias="upgrade">Aggiornamento</key>
+		<key alias="upload">Carica</key>
+		<key alias="url">URL</key>
+		<key alias="user">Utente</key>
+		<key alias="username"><![CDATA[Username]]></key>
+		<key alias="value">Valore</key>
+		<key alias="view">Vedi</key>
+		<key alias="welcome">Benvenuto...</key>
+		<key alias="width">Larghezza</key>
+		<key alias="yes">Si</key>
+		<key alias="folder">Cartella</key>
+		<key alias="searchResults">Risultati di ricerca</key>
+		<key alias="reorder">Riordina</key>
+		<key alias="reorderDone">Ho finito di riordinare</key>
+		<key alias="preview">Anteprima</key>
+		<key alias="changePassword">Cambia password</key>
+		<key alias="to">a</key>
+		<key alias="listView">Vista lista</key>
+		<key alias="saving">Salvataggio...</key>
+		<key alias="current">corrente</key>
+		<key alias="embed">Incorpora</key>
+		<key alias="selected">selezionato</key>
+		<key alias="other">Altro</key>
+		<key alias="articles">Articoli</key>
+		<key alias="videos">Video</key>
+		<key alias="installing">Installazione</key>
+		<key alias="avatar">Avatar per</key>
+	</area>
+	<area alias="colors">
+		<key alias="blue">Blu</key>
+	</area>
+	<area alias="shortcuts">
+		<key alias="addGroup">Aggiungi gruppo</key>
+		<key alias="addProperty"><![CDATA[Aggiungi proprietà]]></key>
+		<key alias="addEditor">Aggiungi editor</key>
+		<key alias="addTemplate">Aggiungi template</key>
+		<key alias="addChildNode">Aggiungi nodo figlio</key>
+		<key alias="addChild">Aggiungi figlio</key>
+		<key alias="editDataType">Modifica tipo di dato</key>
+		<key alias="navigateSections">Naviga tra le sezioni</key>
+		<key alias="shortcut">Scorciatoie</key>
+		<key alias="showShortcuts">vedi scorciatoie</key>
+		<key alias="toggleListView">Attiva/disattiva vista lista</key>
+		<key alias="toggleAllowAsRoot">Attiva/disattiva consenti come root</key>
+		<key alias="commentLine">Commenta/Non commentare righe</key>
+		<key alias="removeLine">Rimuovi riga</key>
+		<key alias="copyLineUp">Copia linee sopra</key>
+		<key alias="copyLineDown">Copia linee sotto</key>
+		<key alias="moveLineUp">Sposta linee in su</key>
+		<key alias="moveLineDown"><![CDATA[Sposta linee in giù]]></key>
+		<key alias="generalHeader">Generale</key>
+		<key alias="editorHeader">Editor</key>
+		<key alias="toggleAllowCultureVariants">Attiva/disattiva consenti varianti lingua</key>
+		<key alias="toggleAllowSegmentVariants">Attiva/disattiva la segmentazione</key>
+	</area>
+	<area alias="graphicheadline">
+		<key alias="backgroundcolor">Colore di sfondo</key>
+		<key alias="bold">Grassetto</key>
+		<key alias="color">Colore del testo</key>
+		<key alias="font">Carattere</key>
+		<key alias="text">Testo</key>
+	</area>
+	<area alias="headers">
+		<key alias="page">Pagina</key>
+	</area>
+	<area alias="installer">
+		<key alias="databaseErrorCannotConnect"><![CDATA[L'installer non può connettersi al database.]]></key>
+		<key alias="databaseFound"><![CDATA[Database trovato ed identificato come]]></key>
+		<key alias="databaseHeader"><![CDATA[Configurazione database]]></key>
+		<key alias="databaseInstall">
+			<![CDATA[
+      Premi il tasto <strong>installa</strong> per installare il database Umbraco %0%
+    ]]>
+		</key>
+		<key alias="databaseInstallDone">
+			<![CDATA[Umbraco %0% è stato copiato nel tuo database. Premi <strong>Avanti</strong> per proseguire.]]>
+		</key>
+		<key alias="databaseText">
+			<![CDATA[Per completare questo passaggio, devi conoscere alcune informazioni riguardanti il tuo database server ("connection string").<br />
+        Se è necessario contatta il tuo ISP per reperire le informazioni necessarie.
+        Se stai effettuando l'installazione in locale o su un server, puoi richiederle al tuo amministratore di sistema.]]>
+		</key>
+		<key alias="databaseUpgrade">
+			<![CDATA[
+        		<p>
+        		Premi il tasto <strong>aggiorna</strong> per aggiornare il database ad Umbraco %0%</p>
+        		<p>
+        		Non preoccuparti, il contenuto non verrà perso e tutto continuerà a funzionare dopo l'aggiornamento!
+        		</p>
+        	]]>
+		</key>
+		<key alias="databaseUpgradeDone">
+			<![CDATA[Il tuo database è stato aggiornato all'ultima versione %0%.<br />Premi il tasto <strong>Avanti</strong> per
+        continuare. ]]>
+		</key>
+		<key alias="databaseUpToDate">
+			<![CDATA[Il tuo database è aggiornato!. Clicca il tasto <strong>Avanti</strong> per continuare la configurazione.]]>
+		</key>
+		<key alias="defaultUserChangePass">
+			<![CDATA[<strong>La password predefinita per l'utente di default deve essere cambiata!</strong>]]>
+		</key>
+		<key alias="defaultUserDisabled">
+			<![CDATA[<strong>L'utente di default è stato disabilitato o non ha accesso ad Umbraco!</strong></p><p>Non è necessario eseguire altre operazioni. Clicca il tasto <strong>Avanti</strong> per continuare.]]>
+		</key>
+		<key alias="defaultUserPassChanged">
+			<![CDATA[<strong>La password dell'utente di default è stata modificata con successo</strong></p><p>Non è necessario eseguire altre operazioni. Clicca il tasto <strong>Avanti</strong> per continuare.]]>
+		</key>
+		<key alias="defaultUserPasswordChanged"><![CDATA[La password è stata modificata!]]></key>
+		<key alias="greatStart"><![CDATA[Parti alla grande, guarda i nostri video introduttivi]]></key>
+		<key alias="None"><![CDATA[Ancora non installato.]]></key>
+		<key alias="permissionsAffectedFolders"><![CDATA[File e directory interessati]]></key>
+		<key alias="permissionsAffectedFoldersMoreInfo">
+			<![CDATA[Ulteriori informazioni sull'impostazione dei permessi per Umbraco qui]]>
+		</key>
+		<key alias="permissionsAffectedFoldersText">
+			<![CDATA[Devi autorizzare l'utente ASP.NET a modificare i seguenti files/cartelle]]>
+		</key>
+		<key alias="permissionsAlmostPerfect">
+			<![CDATA[<strong>La configurazione dei permessi è quasi perfetta!</strong><br /><br />
+        	Puoi eseguire Umbraco senza problemi, ma non sarai in grado di installare i pacchetti che sono consigliati per sfruttare a pieno le potenzialità di Umbraco.]]>
+		</key>
+		<key alias="permissionsHowtoResolve"><![CDATA[Risoluzione del problema]]></key>
+		<key alias="permissionsHowtoResolveLink"><![CDATA[Clicca qui per leggere la versione testuale]]></key>
+		<key alias="permissionsHowtoResolveText">
+			<![CDATA[Guarda il nostro <strong>video tutorial</strong> su come impostare i permessi delle cartelle per Umbraco o leggi la versione testuale.]]>
+		</key>
+		<key alias="permissionsMaybeAnIssue">
+			<![CDATA[<strong>Le impostazioni dei permessi potrebbero avere dei problemi!</strong>
+        	<br/><br />
+        	Puoi eseguire Umbraco senza problemi, ma non sarai in grado di creare cartelle o installare pacchetti che sono consigliati per sfruttare a pieno le potenzialità di Umbraco.]]>
+		</key>
+		<key alias="permissionsNotReady">
+			<![CDATA[<strong>Le impostazioni dei permessi non sono corrette per Umbraco!</strong>
+        	<br /><br />
+        	Per eseguire Umbraco, devi aggiornare le impostazioni dei permessi.]]>
+		</key>
+		<key alias="permissionsPerfect">
+			<![CDATA[<strong>La configurazione dei permessi è perfetta!</strong><br /><br />
+        	Sei pronto per avviare Umbraco e installare i pacchetti!]]>
+		</key>
+		<key alias="permissionsResolveFolderIssues"><![CDATA[Risolvere il problema sulle cartelle]]></key>
+		<key alias="permissionsResolveFolderIssuesLink">
+			<![CDATA[Clicca questo link per ulteriori informazioni sui problemi con ASP.NET e la creazione di cartelle.]]>
+		</key>
+		<key alias="permissionsSettingUpPermissions"><![CDATA[Impostazione dei permessi delle cartelle]]></key>
+		<key alias="permissionsText">
+			<![CDATA[
+        		Per poter archiviare file come immagini e PDF, Umbraco deve avere accesso in scrittura/modifica ad alcune directory.
+        		Inoltre per incrementare le prestazioni del tuo sito, deve essere possibile memorizzare informazioni temporanee (es: cache).
+        	]]>
+		</key>
+		<key alias="runwayFromScratch"><![CDATA[Voglio partire da zero]]></key>
+		<key alias="runwayFromScratchText">
+			<![CDATA[
+        		Il tuo sito al momento è completamente vuoto, e questo è il punto di partenza ideale per creare da zero i tuoi tipi documento e i tuoi templates.
+        		(<a href="https://umbraco.tv/documentation/videos/for-site-builders/foundation/document-types">Guarda come</a>)
+        		Puoi anche installare eventuali Runway in un secondo momento. Vai nella sezione Developer e scegli Pacchetti.
+        	]]>
+		</key>
+		<key alias="runwayHeader">
+			<![CDATA[Hai configurato una versione pulita della piattaforma Umbraco. Cosa vuoi fare adesso?]]>
+		</key>
+		<key alias="runwayInstalled"><![CDATA[Runway è installato]]></key>
+		<key alias="runwayInstalledText">
+			<![CDATA[
+      			Hai le basi. Seleziona quali moduli vorresti installare.<br />
+      			Questa è la lista dei nostri moduli raccomandati, seleziona quali vorresti installare, o vedi <a href="#" onclick="toggleModules(); return false;" id="toggleModuleList">l'intera lista di moduli</a>
+      		]]>
+		</key>
+		<key alias="runwayOnlyProUsers">Raccommandato solo per utenti esperti</key>
+		<key alias="runwaySimpleSite">Vorrei iniziare da un sito semplice</key>
+		<key alias="runwaySimpleSiteText">
+			<![CDATA[
+      <p>
+      "Runway" è un semplice sito web contenente alcuni tipi di documento e alcuni templates di base. L'installer configurerà Runway per te automaticamente,
+        ma tu potrai facilmente modificarlo, estenderlo o eliminarlo. Non è necessario installarlo e potrai usare Umbraco anche senza di esso, ma
+        Runway ti offre le basi e le best practices per cominciare velocemente.
+        Se sceglierai di installare Runway, volendo potrai anche selezionare i moduli di Runway per migliorare le pagine.
+        </p>
+        <small>
+        <em>Inclusi in Runway:</em> Home page, pagina Guida introduttiva, pagina Installazione moduli<br />
+        <em>Moduli opzionali:</em> Top Navigation, Sitemap, Contatti, Gallery.
+        </small>
+      ]]>
+		</key>
+		<key alias="runwayWhatIsRunway"><![CDATA[Cos'è Runway]]></key>
+		<key alias="step1">Passo 1/5 Accettazione licenza</key>
+		<key alias="step2">Passo 2/5: Configurazione database</key>
+		<key alias="step3">Passo 3/5: Controllo permessi dei file</key>
+		<key alias="step4">Passo 4/5: Controllo impostazioni sicurezza</key>
+		<key alias="step5"><![CDATA[Passo 5/5: Umbraco è pronto per iniziare]]></key>
+		<key alias="thankYou">Grazie per aver scelto Umbraco</key>
+		<key alias="theEndBrowseSite">
+			<![CDATA[<h3>Naviga per il tuo nuovo sito</h3>
+Hai installato Runway, quindi perché non dare uno sguardo al vostro nuovo sito web.]]>
+		</key>
+		<key alias="theEndFurtherHelp">
+			<![CDATA[<h3>Ulteriori informazioni e assistenza</h3>
+Fatti aiutare dalla nostra community, consulta la documentazione o guarda alcuni video gratuiti su come costruire un semplice sito web, come usare i pacchetti e una guida rapida alla terminologia Umbraco]]>
+		</key>
+		<key alias="theEndHeader"><![CDATA[Umbraco %0% è installato e pronto per l'uso]]></key>
+		<key alias="theEndInstallSuccess">
+			<![CDATA[Puoi <strong>iniziare immediatamente</strong> cliccando sul bottone "Avvia Umbraco". <br />Se sei <strong>nuovo su Umbraco</strong>,
+        	si possono trovare un sacco di risorse sulle nostre pagine Getting Started.]]>
+		</key>
+		<key alias="theEndOpenUmbraco">
+			<![CDATA[<h3>Avvia Umbraco</h3>
+Per gestire il tuo sito web, è sufficiente aprire il backoffice di Umbraco e iniziare ad aggiungere i contenuti, aggiornando i modelli e i fogli di stile o aggiungere nuove funzionalità]]>
+		</key>
+		<key alias="Unavailable">Connessione al database non riuscita.</key>
+		<key alias="Version3">Umbraco Versione 3</key>
+		<key alias="Version4">Umbraco Versione 4</key>
+		<key alias="watch">Guarda</key>
+		<key alias="welcomeIntro">
+			<![CDATA[Questa procedura guidata ti guiderà attraverso il processo di configurazione di <strong>Umbraco %0%</strong> per una nuova installazione o per l'aggiornamento dalla versione 3.0.
+                                <br /><br />
+                                Clicca <strong>"avanti"</strong> per avviare la procedura.]]>
+		</key>
+	</area>
+	<area alias="language">
+		<key alias="cultureCode">Codice cultura</key>
+		<key alias="displayName">Nome cultura</key>
+	</area>
+	<area alias="lockout">
+		<key alias="lockoutWillOccur"><![CDATA[Sei stato inattivo, si verificherà quindi un logout automatico tra]]></key>
+		<key alias="renewSession">Riconnetti adesso per salvare il tuo lavoro</key>
+	</area>
+	<area alias="login">
+		<key alias="greeting0">Benvenuto</key>
+		<key alias="greeting1">Benvenuto</key>
+		<key alias="greeting2">Benvenuto</key>
+		<key alias="greeting3">Benvenuto</key>
+		<key alias="greeting4">Benvenuto</key>
+		<key alias="greeting5">Benvenuto</key>
+		<key alias="greeting6">Benvenuto</key>
+		<key alias="instruction">Fai il login qui sotto</key>
+		<key alias="signInWith">Fai il login con</key>
+		<key alias="timeout">Sessione scaduta</key>
+		<key alias="bottomText">
+			<![CDATA[<p style="text-align:right;">&copy; 2001 - %0% <br /><a href="https://umbraco.com" style="text-decoration: none" target="_blank" rel="noopener">umbraco.com</a></p> ]]>
+		</key>
+		<key alias="forgottenPassword">Password dimenticata?</key>
+		<key alias="forgottenPasswordInstruction">
+			<![CDATA[Una email verrà inviata all'indirizzo specificato con un link per il reset della password]]>
+		</key>
+		<key alias="requestPasswordResetConfirmation">
+			<![CDATA[Un'e-mail con le istruzioni per il reset della password verrà inviata all'indirizzo specificato se registrato.]]>
+		</key>
+		<key alias="showPassword">Mostra password</key>
+		<key alias="hidePassword">Nascondi password</key>
+		<key alias="returnToLogin">Ritorna alla finestra di login</key>
+		<key alias="setPasswordInstruction">Inserisci una nuova password</key>
+		<key alias="setPasswordConfirmation"><![CDATA[La tua password è stata modificata]]></key>
+		<key alias="resetCodeExpired"><![CDATA[Il link su cui hai cliccato non è valido o è scaduto]]></key>
+		<key alias="resetPasswordEmailCopySubject">Umbraco: Reset Password</key>
+		<key alias="resetPasswordEmailCopyFormat">
+			<![CDATA[
+        <html>
+			<head>
+				<meta name='viewport' content='width=device-width'>
+				<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>
+			</head>
+			<body class='' style='font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; color: #392F54; line-height: 22px; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background: #1d1333; margin: 0; padding: 0;' bgcolor='#1d1333'>
+				<style type='text/css'> @media only screen and (max-width: 620px) {table[class=body] h1 {font-size: 28px !important; margin-bottom: 10px !important; } table[class=body] .wrapper {padding: 32px !important; } table[class=body] .article {padding: 32px !important; } table[class=body] .content {padding: 24px !important; } table[class=body] .container {padding: 0 !important; width: 100% !important; } table[class=body] .main {border-left-width: 0 !important; border-radius: 0 !important; border-right-width: 0 !important; } table[class=body] .btn table {width: 100% !important; } table[class=body] .btn a {width: 100% !important; } table[class=body] .img-responsive {height: auto !important; max-width: 100% !important; width: auto !important; } } .btn-primary table td:hover {background-color: #34495e !important; } .btn-primary a:hover {background-color: #34495e !important; border-color: #34495e !important; } .btn  a:visited {color:#FFFFFF;} </style>
+				<table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #1d1333;" bgcolor="#1d1333">
+					<tr>
+						<td style="font-family: sans-serif; font-size: 14px; vertical-align: top; padding: 24px;" valign="top">
+							<table style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+								<tr>
+									<td background="https://umbraco.com/umbraco/assets/img/application/logo.png" bgcolor="#1d1333" width="28" height="28" valign="top" style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
+										<!--[if gte mso 9]> <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:30px;height:30px;"> <v:fill type="tile" src="https://umbraco.com/umbraco/assets/img/application/logo.png" color="#1d1333" /> <v:textbox inset="0,0,0,0"> <![endif]-->
+										<div> </div>
+										<!--[if gte mso 9]> </v:textbox> </v:rect> <![endif]-->
+									</td>
+									<td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top"></td>
+								</tr>
+							</table>
+						</td>
+					</tr>
+				</table>
+				<table border='0' cellpadding='0' cellspacing='0' class='body' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #1d1333;' bgcolor='#1d1333'>
+					<tr>
+						<td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'> </td>
+						<td class='container' style='font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; max-width: 560px; width: 560px; margin: 0 auto; padding: 10px;' valign='top'>
+							<div class='content' style='box-sizing: border-box; display: block; max-width: 560px; margin: 0 auto; padding: 10px;'>
+								<br>
+								<table class='main' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; border-radius: 3px; background: #FFFFFF;' bgcolor='#FFFFFF'>
+									<tr>
+										<td class='wrapper' style='font-family: sans-serif; font-size: 14px; vertical-align: top; box-sizing: border-box; padding: 50px;' valign='top'>
+											<table border='0' cellpadding='0' cellspacing='0' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;'>
+												<tr>
+													<td style='line-height: 24px; font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'>
+														<h1 style='color: #392F54; font-family: sans-serif; font-weight: bold; line-height: 1.4; font-size: 24px; text-align: left; text-transform: capitalize; margin: 0 0 30px;' align='left'>
+															Reset della password richiesto
+														</h1>
+														<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+															Il tuo username per effettuare l'accesso al backoffice di Umbraco è: <strong>%0%</strong>
+														</p>
+														<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+															<table border='0' cellpadding='0' cellspacing='0' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;'>
+																<tbody>
+																	<tr>
+																		<td style='font-family: sans-serif; font-size: 14px; vertical-align: top; border-radius: 5px; text-align: center; background: #35C786;' align='center' bgcolor='#35C786' valign='top'>
+																			<a href='%1%' target='_blank' rel='noopener' style='color: #FFFFFF; text-decoration: none; -ms-word-break: break-all; word-break: break-all; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; text-transform: capitalize; background: #35C786; margin: 0; padding: 12px 30px; border: 1px solid #35c786;'>
+																				Clicca questo link per resettare la password
+																			</a>
+																		</td>
+																	</tr>
+																</tbody>
+															</table>
+														</p>
+														<p style='max-width: 400px; display: block; color: #392F54; font-family: sans-serif; font-size: 14px; line-height: 20px; font-weight: normal; margin: 15px 0;'>Se non riesci a cliccare sul link, copia e incolla questo URL nella finestra del browser:</p>
+															<table border='0' cellpadding='0' cellspacing='0'>
+																<tr>
+																	<td style='-ms-word-break: break-all; word-break: break-all; font-family: sans-serif; font-size: 11px; line-height:14px;'>
+																		<font style="-ms-word-break: break-all; word-break: break-all; font-size: 11px; line-height:14px;">
+																			<a style='-ms-word-break: break-all; word-break: break-all; color: #392F54; text-decoration: underline; font-size: 11px; line-height:15px;' href='%1%'>%1%</a>
+																		</font>
+																	</td>
+																</tr>
+															</table>
+														</p>
+													</td>
+												</tr>
+											</table>
+										</td>
+									</tr>
+								</table>
+								<br><br><br>
+							</div>
+						</td>
+						<td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'> </td>
+					</tr>
+				</table>
+			</body>
+		</html>
+	]]>
+		</key>
+	</area>
+	<area alias="main">
+		<key alias="dashboard">Dashboard</key>
+		<key alias="sections">Sezioni</key>
+		<key alias="tree">Contenuto</key>
+	</area>
+	<area alias="moveOrCopy">
+		<key alias="choose">Scegli la pagina sopra...</key>
+		<key alias="copyDone"><![CDATA[%0% è stato copiato in %1%]]></key>
+		<key alias="copyTo">Seleziona dove il documento %0% deve essere copiato</key>
+		<key alias="moveDone"><![CDATA[%0% è stato spostato in %1%]]></key>
+		<key alias="moveTo">Seleziona dove il documento %0% deve essere spostato</key>
+		<key alias="nodeSelected">
+			<![CDATA[è stato selezionato come radice del nuovo contenuto, clicca 'ok' per proseguire.]]>
+		</key>
+		<key alias="noNodeSelected">
+			<![CDATA[Nessun nodo selezionato, si prega di selezionare un nodo nella lista di cui sopra prima di fare click su 'ok']]>
+		</key>
+		<key alias="notAllowedByContentType">
+			<![CDATA[Non è possibile associare questo tipo di nodo sotto il nodo selezionato.]]>
+		</key>
+		<key alias="notAllowedByPath"><![CDATA[Il nodo corrente non può essere spostato in un'altra sua sottopagina]]></key>
+		<key alias="notAllowedAtRoot"><![CDATA[Il nodo corrente non può esistere nella root]]></key>
+		<key alias="notValid">
+			<![CDATA[Quest'azione non è consentita dato che non hai i permessi su uno o più documenti figlio.]]>
+		</key>
+		<key alias="relateToOriginal"><![CDATA[Collega gli elementi copiati all'originale]]></key>
+	</area>
+	<area alias="notifications">
+		<key alias="editNotifications"><![CDATA[Modifica le tue notifiche per <strong>%0%</strong>]]></key>
+		<key alias="notificationsSavedFor">Impostazioni di notifica salvate per</key>
+		<key alias="mailBody">
+			<![CDATA[
+      Ciao %0%
+
+      Questa è un'email automatica per informare che l'azione '%1%'
+      è stata eseguita sulla pagina '%2%'
+      dall'utente '%3%'
+
+      Vai al link http://%4%/#/content/content/edit/%5% per modificare.
+
+      %6%
+
+      Buona giornata!
+
+      Saluti dal robot di Umbraco
+    ]]>
+		</key>
+		<key alias="mailBodyVariantSummary">Sono state modificate le lingue seguenti %0%</key>
+		<key alias="mailBodyHtml">
+			<![CDATA[
+            	<html>
+			<head>
+				<meta name='viewport' content='width=device-width'>
+				<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>
+			</head>
+			<body class='' style='font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; color: #392F54; line-height: 22px; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background: #1d1333; margin: 0; padding: 0;' bgcolor='#1d1333'>
+				<style type='text/css'> @media only screen and (max-width: 620px) {table[class=body] h1 {font-size: 28px !important; margin-bottom: 10px !important; } table[class=body] .wrapper {padding: 32px !important; } table[class=body] .article {padding: 32px !important; } table[class=body] .content {padding: 24px !important; } table[class=body] .container {padding: 0 !important; width: 100% !important; } table[class=body] .main {border-left-width: 0 !important; border-radius: 0 !important; border-right-width: 0 !important; } table[class=body] .btn table {width: 100% !important; } table[class=body] .btn a {width: 100% !important; } table[class=body] .img-responsive {height: auto !important; max-width: 100% !important; width: auto !important; } } .btn-primary table td:hover {background-color: #34495e !important; } .btn-primary a:hover {background-color: #34495e !important; border-color: #34495e !important; } .btn  a:visited {color:#FFFFFF;} </style>
+				<table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #1d1333;" bgcolor="#1d1333">
+					<tr>
+						<td style="font-family: sans-serif; font-size: 14px; vertical-align: top; padding: 24px;" valign="top">
+							<table style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+								<tr>
+									<td background="https://umbraco.com/umbraco/assets/img/application/logo.png" bgcolor="#1d1333" width="28" height="28" valign="top" style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
+										<!--[if gte mso 9]> <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:30px;height:30px;"> <v:fill type="tile" src="https://umbraco.com/umbraco/assets/img/application/logo.png" color="#1d1333" /> <v:textbox inset="0,0,0,0"> <![endif]-->
+										<div> </div>
+										<!--[if gte mso 9]> </v:textbox> </v:rect> <![endif]-->
+									</td>
+									<td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top"></td>
+								</tr>
+							</table>
+						</td>
+					</tr>
+				</table>
+				<table border='0' cellpadding='0' cellspacing='0' class='body' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #1d1333;' bgcolor='#1d1333'>
+					<tr>
+						<td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'> </td>
+						<td class='container' style='font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; max-width: 560px; width: 560px; margin: 0 auto; padding: 10px;' valign='top'>
+							<div class='content' style='box-sizing: border-box; display: block; max-width: 560px; margin: 0 auto; padding: 10px;'>
+								<br>
+								<table class='main' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; border-radius: 3px; background: #FFFFFF;' bgcolor='#FFFFFF'>
+									<tr>
+										<td class='wrapper' style='font-family: sans-serif; font-size: 14px; vertical-align: top; box-sizing: border-box; padding: 50px;' valign='top'>
+											<table border='0' cellpadding='0' cellspacing='0' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;'>
+												<tr>
+													<td style='line-height: 24px; font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'>
+														<h1 style='color: #392F54; font-family: sans-serif; font-weight: bold; line-height: 1.4; font-size: 24px; text-align: left; text-transform: capitalize; margin: 0 0 30px;' align='left'>
+															Ciao %0%,
+														</h1>
+														<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+															Questa è un'email automatica per informare che l'azione <strong>'%1%'</strong> è stata eseguita sulla pagina <a style="color: #392F54; text-decoration: none; -ms-word-break: break-all; word-break: break-all;" href="http://%4%/#/content/content/edit/%5%"><strong>'%2%'</strong></a> dall'utente <strong>'%3%'</strong>
+														</p>
+														<table border='0' cellpadding='0' cellspacing='0' class='btn btn-primary' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; box-sizing: border-box;'>
+															<tbody>
+																<tr>
+																	<td align='left' style='font-family: sans-serif; font-size: 14px; vertical-align: top; padding-bottom: 15px;' valign='top'>
+																		<table border='0' cellpadding='0' cellspacing='0' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;'><tbody><tr>
+																			<td style='font-family: sans-serif; font-size: 14px; vertical-align: top; border-radius: 5px; text-align: center; background: #35C786;' align='center' bgcolor='#35C786' valign='top'>
+																				<a href='http://%4%/#/content/content/edit/%5%' target='_blank' rel='noopener' style='color: #FFFFFF; text-decoration: none; -ms-word-break: break-all; word-break: break-all; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; text-transform: capitalize; background: #35C786; margin: 0; padding: 12px 30px; border: 1px solid #35c786;'>MODIFICA</a> </td> </tr></tbody></table>
+																	</td>
+																</tr>
+															</tbody>
+														</table>
+														<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+															<h3>Riepilogo dell'aggiornamento:</h3>
+															%6%
+														</p>
+														<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+															Buona giornata!<br /><br />
+															Saluti dal robot di Umbraco
+														</p>
+													</td>
+												</tr>
+											</table>
+										</td>
+									</tr>
+								</table>
+								<br><br><br>
+							</div>
+						</td>
+						<td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'> </td>
+					</tr>
+				</table>
+			</body>
+		</html>
+	]]>
+		</key>
+		<key alias="mailBodyVariantHtmlSummary">
+			<![CDATA[<p>Sono state modificate le seguenti lingue:</p>
+        %0%
+    ]]>
+		</key>
+		<key alias="mailSubject">[%0%] Notifica per %1% eseguito su %2%</key>
+		<key alias="notifications">Notifiche</key>
+	</area>
+	<area alias="packager">
+		<key alias="actions">Azioni</key>
+		<key alias="created">Creati</key>
+		<key alias="createPackage">Crea pacchetto</key>
+		<key alias="chooseLocalPackageText">
+			<![CDATA[
+      Scegli un pacchetto dal tuo computer cliccando il pulsante Sfoglia<br />
+         e selezionando il pacchetto. I pacchetti Umbraco generalmente hanno l'estensione ".umb" o ".zip".
+      ]]>
+		</key>
+		<key alias="deletewarning"><![CDATA[Questo eliminerà il pacchetto]]></key>
+		<key alias="dropHere">Trascina qui caricare</key>
+		<key alias="includeAllChildNodes">Includi tutti i figli</key>
+		<key alias="orClickHereToUpload">o clicca qui per scegliere il file del pacchetto</key>
+		<key alias="uploadPackage">Carica pacchetto</key>
+		<key alias="localPackageDescription">
+			Installa un pacchetto locale dalla tua macchina. Installa solamente pacchetti
+			di cui ti fidi e ne conosci la provenienza
+		</key>
+		<key alias="uploadAnother">Carica un altro pacchetto</key>
+		<key alias="cancelAndUploadAnother">Cancella e carica un altro pacchetto</key>
+		<key alias="accept">Accetto</key>
+		<key alias="termsOfUse">termini di servizio</key>
+		<key alias="pathToFile">Percorso del file</key>
+		<key alias="pathToFileDescription">Percorso assoluto del file (es: /bin/umbraco.bin)</key>
+		<key alias="installed">Installati</key>
+		<key alias="installedPackages">Pacchetti installati</key>
+		<key alias="installLocal">Installa localmente</key>
+		<key alias="installFinish">Termina</key>
+		<key alias="noConfigurationView">Questo pacchetto non ha una vista di configurazione</key>
+		<key alias="noPackagesCreated">Non sono ancora stati creati pacchetti</key>
+		<key alias="noPackages">Non hai installato nessun pacchetto</key>
+		<key alias="noPackagesDescription">
+			<![CDATA[Non hai installato nessun pacchetto. Installa un pacchetto selezionandolo dalla tua macchina, oppure cerca tra i pacchetti disponibili usando l'icona <strong>'Pacchetti'</strong> in alto a destra del tuo schermo]]>
+		</key>
+		<key alias="packageActions">Azioni del pacchetto</key>
+		<key alias="packageAuthorUrl"><![CDATA[URL dell'autore]]></key>
+		<key alias="packageContent">Contenuto del pacchetto</key>
+		<key alias="packageFiles">Files del pacchetto</key>
+		<key alias="packageIconUrl"><![CDATA[URL dell'icona]]></key>
+		<key alias="packageInstall">Installa pacchetto</key>
+		<key alias="packageLicense">Licenza</key>
+		<key alias="packageLicenseUrl">URL della licenza</key>
+		<key alias="packageProperties"><![CDATA[Proprietà del pacchetto]]></key>
+		<key alias="packageSearch">Cerca un pacchetto...</key>
+		<key alias="packageSearchResults">Risultati per</key>
+		<key alias="packageNoResults">Non abbiamo trovato niente per</key>
+		<key alias="packageNoResultsDescription">
+			Per favore prova a cercare un altro pacchetto oppure cerca tra le
+			categorie
+		</key>
+		<key alias="packagesPopular">Popolari</key>
+		<key alias="packagesNew">Nuove uscite</key>
+		<key alias="packageHas">ha</key>
+		<key alias="packageKarmaPoints">punti karma</key>
+		<key alias="packageInfo">Informazioni</key>
+		<key alias="packageOwner">Proprietario</key>
+		<key alias="packageContrib">Contributori</key>
+		<key alias="packageCreated">Creato</key>
+		<key alias="packageCurrentVersion">Versione corrente</key>
+		<key alias="packageNetVersion">Versione .NET</key>
+		<key alias="packageDownloads">Downloads</key>
+		<key alias="packageLikes">Likes</key>
+		<key alias="packageCompatibility"><![CDATA[Compatibilità]]></key>
+		<key alias="packageCompatibilityDescription">
+			<![CDATA[Questo pacchetto è compatibile con le seguenti versioni di Umbraco, come riportato dai membri della community. La piena compatibilità non può essere garantita per le versioni con un giudizio inferiore al 100%]]>
+		</key>
+		<key alias="packageExternalSources">Sorgenti esterne</key>
+		<key alias="packageAuthor">Autore</key>
+		<key alias="packageDocumentation">Documentazione</key>
+		<key alias="packageMetaData">Meta dati del pacchetto</key>
+		<key alias="packageName">Nome del pacchetto</key>
+		<key alias="packageNoItemsHeader">Il pacchetto non contiene nessun elemento</key>
+		<key alias="packageNoItemsText">
+			<![CDATA[Questo pacchetto non contiene elementi da disinstallare.<br/><br/>
+      È possibile rimuovere questo pacchetto dal sistema cliccando "rimuovi pacchetto" in basso.]]>
+		</key>
+		<key alias="packageOptions">Opzioni del pacchetto</key>
+		<key alias="packageReadme">Pacchetto leggimi</key>
+		<key alias="packageRepository">Repository del pacchetto</key>
+		<key alias="packageUninstallConfirm">Conferma eliminazione</key>
+		<key alias="packageUninstalledHeader"><![CDATA[Il pacchetto è stato disinstallato]]></key>
+		<key alias="packageUninstalledText"><![CDATA[Il pacchetto è stato disinstallato con successo]]></key>
+		<key alias="packageUninstallHeader">Disinstalla pacchetto</key>
+		<key alias="packageUninstallText">
+			<![CDATA[È possibile deselezionare gli elementi che non si desidera rimuovere, in questo momento, in basso. Quando si fa click su "Conferma eliminazione" verranno rimossi tutti gli elementi selezionati.<br />
+      <span style="color: Red; font-weight: bold;">Avviso:</span> tutti i documenti, i media, etc a seconda degli elementi che rimuoverai, smetteranno di funzionare, e potrebbero portare a un'instabilità del sistema,
+      perciò disinstalla con cautela. In caso di dubbio contattare l'autore del pacchetto.]]>
+		</key>
+		<key alias="packageVersion">Versione del pacchetto</key>
+		<key alias="packageVersionUpgrade">Aggiornamento dalla versione</key>
+		<key alias="packageAlreadyInstalled"><![CDATA[Pacchetto già installato]]></key>
+		<key alias="targetVersionMismatch">
+			<![CDATA[Questo pacchetto non può essere installato poichè richiede almeno Umbraco]]>
+		</key>
+		<key alias="installStateUninstalling">Sto disinstallando...</key>
+		<key alias="installStateDownloading">Sto scaricando...</key>
+		<key alias="installStateImporting">Sto importando...</key>
+		<key alias="installStateInstalling">Sto installando...</key>
+		<key alias="installStateRestarting">Sto riavviando, per favore aspetta...</key>
+		<key alias="installStateComplete"><![CDATA[Completato, la tua pagina verrà ora ricaricata, aspetta...]]></key>
+		<key alias="installStateCompleted">
+			Per favore clicca 'Completa' per completare l'installazione e ricaricare la
+			pagina.
+		</key>
+		<key alias="installStateUploading">Sto effettuando l'upload del pacchetto...</key>
+		<key alias="verifiedToWorkOnUmbracoCloud">Verificato il funzionamento su Umbraco Cloud</key>
+	</area>
+	<area alias="paste">
+		<key alias="doNothing"><![CDATA[Incolla con tutte le formattazioni (Non consigliato)]]></key>
+		<key alias="errorMessage">
+			<![CDATA[Il testo che stai cercando di incollare contiene caratteri speciali o una formattazione. Questo potrebbe essere causato da Microsoft Word. Umbraco può rimuovere carattere speciali o formattazioni automaticamente, per rendere il contenuto da incollare più adatto per il web.]]>
+		</key>
+		<key alias="removeAll"><![CDATA[Incolla come testo semplice senza alcuna formattazione]]></key>
+		<key alias="removeSpecialFormattering"><![CDATA[Incolla, ma rimuove  la formattazione (Consigliato)]]></key>
+	</area>
+	<area alias="publicAccess">
+		<key alias="paGroups"><![CDATA[Protezione basata su gruppi]]></key>
+		<key alias="paGroupsHelp"><![CDATA[Se vuoi controllare gli accessi usando i gruppi di membri]]></key>
+		<key alias="paGroupsNoGroups">
+			Devi creare un gruppo di membri prima di utilizzare l'autenticazione basata sui
+			gruppi
+		</key>
+		<key alias="paErrorPage"><![CDATA[Pagina di Errore]]></key>
+		<key alias="paErrorPageHelp"><![CDATA[Usato quando qualcuno è connesso, ma non ha accesso]]></key>
+		<key alias="paHowWould"><![CDATA[Seleziona come restringere l'accesso alla pagina <strong>%0%</strong>]]></key>
+		<key alias="paIsProtected"><![CDATA[<strong>%0%</strong> è ora protetta]]></key>
+		<key alias="paIsRemoved"><![CDATA[Protezione rimossa da <strong>%0%</strong>]]></key>
+		<key alias="paLoginPage"><![CDATA[Pagina di Login]]></key>
+		<key alias="paLoginPageHelp"><![CDATA[Scegliere la pagina che contiene il form di login]]></key>
+		<key alias="paRemoveProtection"><![CDATA[Rimuovi la protezione...]]></key>
+		<key alias="paRemoveProtectionConfirm">
+			<![CDATA[Sei sicuro di voler rimuovere la protezione dalla pagina <strong>%0%</strong>?]]>
+		</key>
+		<key alias="paSelectPages">
+			<![CDATA[Seleziona le pagine che contengono il form di login e i messaggi di errore]]>
+		</key>
+		<key alias="paSelectGroups"><![CDATA[Seleziona i gruppi che hanno accesso alla pagina <strong>%0%</strong>]]></key>
+		<key alias="paSelectMembers"><![CDATA[Seleziona i membri che hanno accesso alla pagina <strong>%0%</strong>]]></key>
+		<key alias="paMembers">Protezione specifica per membri</key>
+		<key alias="paMembersHelp">Se vuoi controllare gli accessi per membri specifici</key>
+	</area>
+	<area alias="publish">
+		<key alias="invalidPublishBranchPermissions">Permessi insufficienti per pubblicare tutti i discendenti</key>
+		<key alias="contentPublishedFailedIsTrashed">
+			<![CDATA[
+      %0% non può essere pubblicato perché l'elemento è nel cestino.
+    ]]>
+		</key>
+		<key alias="contentPublishedFailedAwaitingRelease">
+			<![CDATA[
+      %0% non può essere pubblicato perché l'elemento ha in corso una pubblicazione programmata.
+    ]]>
+		</key>
+		<key alias="contentPublishedFailedExpired">
+			<![CDATA[
+      %0% non può essere pubblicato perché l'elemento è scaduto.
+    ]]>
+		</key>
+		<key alias="contentPublishedFailedInvalid">
+			<![CDATA[
+      %0% non può essere pubblicato perché alcune proprietà non hanno passato la validazione.
+    ]]>
+		</key>
+		<key alias="contentPublishedFailedByEvent">
+			<![CDATA[
+      %0% non può essere pubblicato, un add-on di terze parti ha cancellato l'azione.
+    ]]>
+		</key>
+		<key alias="contentPublishedFailedByParent">
+			<![CDATA[
+      %0% non può essere pubblicato perché la pagina padre non è pubblicata.
+    ]]>
+		</key>
+		<key alias="contentPublishedFailedByMissingName">
+			<![CDATA[%0% non può essere pubblicato perché manca un nome.]]>
+		</key>
+		<key alias="contentPublishedFailedReqCultureValidationError">
+			<![CDATA[Validazione fallita per la lingua obbligatoria '%0%'. Questa lingua è stata salvata ma non pubblicata.]]>
+		</key>
+		<key alias="inProgress">Pubblicazione in corso, aspetta...</key>
+		<key alias="inProgressCounter">%0% di %1% pagine sono state pubblicate...</key>
+		<key alias="nodePublish"><![CDATA[%0% è stato pubblicato]]></key>
+		<key alias="nodePublishAll">%0% e le relative sottopagine sono state pubblicate</key>
+		<key alias="publishAll">Pubblica %0% e tutte le sue sottopagine</key>
+		<key alias="publishHelp">
+			<![CDATA[Click <em>Pubblica</em> per pubblicare <strong>%0%</strong> e quindi rendere visibile pubblicamente il suo contenuto.<br/><br />
+      Puoi pubblicare questa pagina e tutte le sue sottopagine spuntando <em>Includi le sottopagine non pubblicate</em> sotto.
+      ]]>
+		</key>
+	</area>
+	<area alias="colorpicker">
+		<key alias="noColors">Non hai configurato nessun colore</key>
+	</area>
+	<area alias="contentPicker">
+		<key alias="allowedItemTypes">Puoi selezionare solo oggetti di tipo: %0%</key>
+		<key alias="pickedTrashedItem">Hai selezionato un elemento eliminato o nel cestino</key>
+		<key alias="pickedTrashedItems"><![CDATA[Hai selezionato più elementi eliminati o nel cestino]]></key>
+	</area>
+	<area alias="mediaPicker">
+		<key alias="deletedItem">Elemento eliminato</key>
+		<key alias="pickedTrashedItem">Hai selezionato un media eliminato o nel cestino</key>
+		<key alias="pickedTrashedItems"><![CDATA[Hai selezionato più elementi eliminati o nel cestino]]></key>
+		<key alias="trashed">Eliminato</key>
+		<key alias="openMedia">Apri nella libreria dei media</key>
+		<key alias="changeMedia">Cambia media</key>
+		<key alias="resetMediaCrop">Resetta i tagli del media</key>
+		<key alias="editMediaEntryLabel">Modifica %0% su %1%</key>
+		<key alias="confirmCancelMediaEntryCreationHeadline">Scartare la creazione?</key>
+		<key alias="confirmCancelMediaEntryCreationMessage"><![CDATA[Sei sicuro di voler cancellare la creazione?]]></key>
+		<key alias="confirmCancelMediaEntryHasChanges">
+			Hai fatto delle modifiche a questo contenuto. Sei sicuro di volerle
+			scartare?
+		</key>
+		<key alias="confirmRemoveMediaEntryMessage">Rimuovere?</key>
+		<key alias="confirmRemoveAllMediaEntryMessage">Rimuovere tutti i media?</key>
+		<key alias="tabClipboard">Appunti</key>
+		<key alias="notAllowed">Non permesso</key>
+	</area>
+	<area alias="relatedlinks">
+		<key alias="enterExternal"><![CDATA[Aggiungi link esterno]]></key>
+		<key alias="chooseInternal"><![CDATA[Aggiungi link interno]]></key>
+		<key alias="caption"><![CDATA[Didascalia]]></key>
+		<key alias="link">Link</key>
+		<key alias="newWindow"><![CDATA[Apri in una nuova finestra]]></key>
+		<key alias="captionPlaceholder">inserisci la didascalia da visualizzare</key>
+		<key alias="externalLinkPlaceholder">Inserisci il link</key>
+	</area>
+	<area alias="imagecropper">
+		<key alias="reset">Resetta tagio</key>
+		<key alias="saveCrop">Salva taglio</key>
+		<key alias="addCrop">Aggiungi nuovo taglio</key>
+		<key alias="updateEditCrop">Fatto</key>
+		<key alias="undoEditCrop">Annulla modifiche</key>
+		<key alias="customCrop">Definite dall'utente</key>
+	</area>
+	<area alias="rollback">
+		<key alias="changes">Modifiche</key>
+		<key alias="headline">Seleziona una versione da confrontare con la versione corrente</key>
+		<key alias="diffHelp">
+			<![CDATA[Qui vengono mostrate le differenze tra la versione corrente e la versione selezionata<br />Il testo <del>in rosso</del> non verrà mostrato nella versione selezionata, <ins>quello in verde verrà aggiunto</ins>]]>
+		</key>
+		<key alias="documentRolledBack"><![CDATA[Il documento è stato riportato alla versione scelta.]]></key>
+		<key alias="htmlHelp">
+			<![CDATA[Qui viene mostrata la versione selezionata in formato html, se vuoi vedere contemporaneamente le differenze tra le due versioni, usa la modalità diff view]]>
+		</key>
+		<key alias="rollbackTo"><![CDATA[Ritorna alla versione]]></key>
+		<key alias="selectVersion"><![CDATA[Seleziona la versione]]></key>
+		<key alias="view"><![CDATA[Vedi]]></key>
+	</area>
+	<area alias="scripts">
+		<key alias="editscript"><![CDATA[Modifica il file di script]]></key>
+	</area>
+	<area alias="sections">
+		<key alias="content">Contenuto</key>
+		<key alias="forms">Forms</key>
+		<key alias="media">Media</key>
+		<key alias="member">Membri</key>
+		<key alias="packages">Pacchetti</key>
+		<key alias="settings">Impostazioni</key>
+		<key alias="translation">Traduzione</key>
+		<key alias="users">Utenti</key>
+	</area>
+	<area alias="help">
+		<key alias="tours">Tours</key>
+		<key alias="theBestUmbracoVideoTutorials">I migliori video tutorial su Umbraco</key>
+		<key alias="umbracoForum">Visita our.umbraco.com</key>
+		<key alias="umbracoTv">Visita umbraco.tv</key>
+	</area>
+	<area alias="settings">
+		<key alias="defaulttemplate"><![CDATA[Template di base]]></key>
+		<key alias="importDocumentTypeHelp">
+			<![CDATA[Importa  un tipo di documento, trova il file con estensione ".udt" sul tuo computer dopo aver cliccato il pulsante "Sfoglia" e poi clicca  "Importa" (ti chiederà una conferma nella prossima schermata)]]>
+		</key>
+		<key alias="newtabname"><![CDATA[Titolo nuova tab]]></key>
+		<key alias="nodetype"><![CDATA[Tipo di nodo]]></key>
+		<key alias="objecttype">Tipo</key>
+		<key alias="stylesheet">Foglio di stile</key>
+		<key alias="script">Script</key>
+		<key alias="tab">Tab</key>
+		<key alias="tabname">Titolo tab</key>
+		<key alias="tabs">Tabs</key>
+		<key alias="contentTypeEnabled">Tipo di contenuto Master abilitato</key>
+		<key alias="contentTypeUses">Questo tipo di contenuto usa</key>
+		<key alias="noPropertiesDefinedOnTab">
+			<![CDATA[Non ci sono proprietà definite per questa tab. Clicca sul link "aggiungi una nuova proprietà" in cima per creare una nuova proprietà.]]>
+		</key>
+		<key alias="createMatchingTemplate">Crea un template corrispondente</key>
+		<key alias="addIcon">Aggiungi icona</key>
+	</area>
+	<area alias="sort">
+		<key alias="sortOrder">Ordinamento</key>
+		<key alias="sortCreationDate">Data creazione</key>
+		<key alias="sortDone"><![CDATA[Ordinamento completato.]]></key>
+		<key alias="sortHelp">
+			<![CDATA[Sposta su o giù le pagine trascinandole per determinarne l'ordinamento. Oppure clicca la testata della colonna per ordinare l'intero gruppo di pagine]]>
+		</key>
+		<key alias="sortPleaseWait">
+			<![CDATA[Si prega di attendere. Gli elementi sono in fase di ordinamento, questo può richiedere del tempo.]]>
+		</key>
+		<key alias="sortEmptyState">Questo elemento non ha elementi figlio da ordinare</key>
+	</area>
+	<area alias="speechBubbles">
+		<key alias="validationFailedHeader">Validazione</key>
+		<key alias="validationFailedMessage">
+			Gli errori di validazione devono essere sistemati prima che l'elemento possa
+			essere salvato
+		</key>
+		<key alias="operationFailedHeader">Fallita</key>
+		<key alias="operationSavedHeader">Salvato</key>
+		<key alias="operationSavedHeaderReloadUser">Salvato. Per vedere le modifiche appena salvate ricarica la pagina</key>
+		<key alias="invalidUserPermissionsText">
+			<![CDATA[Permessi utente non sufficienti, non è stato possibile completare l'operazione]]>
+		</key>
+		<key alias="operationCancelledHeader">Cancellato</key>
+		<key alias="operationCancelledText"><![CDATA[L'operazione è stata cancellata da un add-on di terze parti]]></key>
+		<key alias="contentTypeDublicatePropertyType"><![CDATA[Tipo di proprietà già esistente]]></key>
+		<key alias="contentTypePropertyTypeCreated"><![CDATA[Tipo di proprietà creato]]></key>
+		<key alias="contentTypePropertyTypeCreatedText"><![CDATA[Nome: %0% <br /> Tipo di dato: %1%]]></key>
+		<key alias="contentTypePropertyTypeDeleted"><![CDATA[Tipo di proprietà eliminato]]></key>
+		<key alias="contentTypeSavedHeader">Tipo di documento salvato</key>
+		<key alias="contentTypeTabCreated">Tab creata</key>
+		<key alias="contentTypeTabDeleted">Tab eliminata</key>
+		<key alias="contentTypeTabDeletedText">Tab con id: %0% eliminata</key>
+		<key alias="cssErrorHeader"><![CDATA[Foglio di stile non salvato]]></key>
+		<key alias="cssSavedHeader"><![CDATA[Foglio di stile salvato]]></key>
+		<key alias="cssSavedText"><![CDATA[Foglio di stile salvato correttamente]]></key>
+		<key alias="dataTypeSaved">Tipo di dato salvato</key>
+		<key alias="dictionaryItemSaved"><![CDATA[Elemento del dizionario salvato]]></key>
+		<key alias="editContentPublishedHeader"><![CDATA[Contenuto pubblicato]]></key>
+		<key alias="editContentPublishedText"><![CDATA[e visibile sul sito web]]></key>
+		<key alias="editMultiContentPublishedText">%0% documenti pubblicati e visibili sul sito web</key>
+		<key alias="editVariantPublishedText">%0% pubblicati e visibili sul sito web</key>
+		<key alias="editMultiVariantPublishedText">%0% documenti pubblicati per le lingue %1% e visibili sul sito web</key>
+		<key alias="editContentSavedHeader">Contenuto salvato</key>
+		<key alias="editContentSavedText"><![CDATA[Ricorda di pubblicare per rendere i cambiamenti visibili]]></key>
+		<key alias="editContentScheduledSavedText">
+			<![CDATA[È stata aggiornata una pianificazione per la pubblicazione]]>
+		</key>
+		<key alias="editVariantSavedText">%0% salvata</key>
+		<key alias="editContentSendToPublish"><![CDATA[Invia per l'approvazione]]></key>
+		<key alias="editContentSendToPublishText">Le modifiche sono state inviate per l'approvazione</key>
+		<key alias="editVariantSendToPublishText">%0% modifiche sono state inviate per l'approvazione</key>
+		<key alias="editMediaSaved">Media salvato</key>
+		<key alias="editMediaSavedText">Media salvato senza nessun errore</key>
+		<key alias="editMemberSaved">Membro salvato</key>
+		<key alias="editMemberGroupSaved">Gruppo di Membri salvato</key>
+		<key alias="editStylesheetPropertySaved"><![CDATA[Proprietà del foglio di stile salvata]]></key>
+		<key alias="editStylesheetSaved"><![CDATA[Foglio di stile salvato]]></key>
+		<key alias="editTemplateSaved"><![CDATA[Template salvato]]></key>
+		<key alias="editUserError"><![CDATA[Errore durante il salvataggio dell'utente (verifica il log)]]></key>
+		<key alias="editUserSaved"><![CDATA[Utente salvato]]></key>
+		<key alias="editUserTypeSaved">Tipo di utente salvato</key>
+		<key alias="editUserGroupSaved">Gruppo di utenti salvato</key>
+		<key alias="editCulturesAndHostnamesSaved">Hostnames salvati</key>
+		<key alias="editCulturesAndHostnamesError">Errore durante il salvataggio degli hostnames</key>
+		<key alias="fileErrorHeader"><![CDATA[File non salvato]]></key>
+		<key alias="fileErrorText">
+			<![CDATA[Il file non può essere salvato. Controlla le impostazioni dei permessi sui file]]>
+		</key>
+		<key alias="fileSavedHeader"><![CDATA[File salvato]]></key>
+		<key alias="fileSavedText"><![CDATA[File salvato con successo!]]></key>
+		<key alias="languageSaved"><![CDATA[Lingua salvata]]></key>
+		<key alias="mediaTypeSavedHeader">Tipo di Media salvato</key>
+		<key alias="memberTypeSavedHeader">Tipo di Membro salvato</key>
+		<key alias="memberGroupSavedHeader">Gruppo di Membri salvato</key>
+		<key alias="templateErrorHeader">Template non salvato</key>
+		<key alias="templateErrorText">Per favore controlla di non avere due templates con lo stesso alias</key>
+		<key alias="templateSavedHeader">Template salvato</key>
+		<key alias="templateSavedText">Template salvato con successo!</key>
+		<key alias="contentUnpublished">Contenuto non pubblicato</key>
+		<key alias="contentCultureUnpublished">Variazione di contenuto %0% non pubblicata</key>
+		<key alias="contentMandatoryCultureUnpublished">
+			<![CDATA[La lingua obbligatoria '%0%' è stata non pubblicata. Tutte le lingue per questo elemento di contenuto verranno ora non pubblicate.]]>
+		</key>
+		<key alias="partialViewSavedHeader">Partial view salvata</key>
+		<key alias="partialViewSavedText">Partial view salvata senza errori!</key>
+		<key alias="partialViewErrorHeader">Partial view non salvata</key>
+		<key alias="partialViewErrorText">Errore durante il salvataggio del file.</key>
+		<key alias="permissionsSavedFor">Permessi salvati per</key>
+		<key alias="deleteUserGroupsSuccess">Eliminati %0% gruppi di utenti</key>
+		<key alias="deleteUserGroupSuccess"><![CDATA[%0% è stato eliminato]]></key>
+		<key alias="enableUsersSuccess">Abilitati %0% utenti</key>
+		<key alias="disableUsersSuccess">Disabilitati %0% utenti</key>
+		<key alias="enableUserSuccess"><![CDATA[%0% è ora abilitato]]></key>
+		<key alias="disableUserSuccess"><![CDATA[%0% è ora disabilitato]]></key>
+		<key alias="setUserGroupOnUsersSuccess">I gruppi di utenti sono stati assegnati</key>
+		<key alias="unlockUsersSuccess">Sono stati sbloccati %0% utenti</key>
+		<key alias="unlockUserSuccess"><![CDATA[%0% è ora sbloccato]]></key>
+		<key alias="memberExportedSuccess"><![CDATA[Il Membro è stato esportato in un file]]></key>
+		<key alias="memberExportedError"><![CDATA[Si è verificato un errore durante l'esportazione del membro]]></key>
+		<key alias="deleteUserSuccess"><![CDATA[L'utente %0% è stato eliminato]]></key>
+		<key alias="resendInviteHeader">Invita utenti</key>
+		<key alias="resendInviteSuccess"><![CDATA[L'invito è stato reinviato a %0%]]></key>
+		<key alias="contentReqCulturePublishError">
+			<![CDATA[Impossibile pubblicare il documento, in quanto è richiesto '%0%', ma non è pubblicato]]>
+		</key>
+		<key alias="contentCultureValidationError">Validazione fallita per la lingua '%0%'</key>
+		<key alias="documentTypeExportedSuccess"><![CDATA[Il Tipo di Documento è stato esportato in un file]]></key>
+		<key alias="documentTypeExportedError">
+			<![CDATA[C'è stato un errore durante l'esportazione del Tipo di Documento]]>
+		</key>
+		<key alias="scheduleErrReleaseDate1"><![CDATA[La data di rilascio non può essere passata]]></key>
+		<key alias="scheduleErrReleaseDate2">
+			<![CDATA[Non è possibile pianificare il documento per la pubblicazione poiché è richiesto '%0%', che non è pubblicato]]>
+		</key>
+		<key alias="scheduleErrReleaseDate3">
+			<![CDATA[Non è possibile pianificare il documento per la pubblicazione poiche '%0%' ha una data di pubblicazione posteriore di una lingua non obbligatoria]]>
+		</key>
+		<key alias="scheduleErrExpireDate1"><![CDATA[La data di scadenza non può essere passata]]></key>
+		<key alias="scheduleErrExpireDate2">
+			<![CDATA[La data di scadenza non può essere prima della data di rilascio]]>
+		</key>
+	</area>
+	<area alias="stylesheet">
+		<key alias="addRule">Aggiungi stile</key>
+		<key alias="editRule">Modifica stile</key>
+		<key alias="editorRules">Stili del Rich text editor</key>
+		<key alias="editorRulesHelp">
+			Definisci gli stili che dovranno essere disponibili nel Rich text editor per questo
+			foglio di stile
+		</key>
+		<key alias="editstylesheet"><![CDATA[Modifica foglio di stile]]></key>
+		<key alias="editstylesheetproperty"><![CDATA[Modifica proprietà del foglio di stile]]></key>
+		<key alias="nameHelp"><![CDATA[Nome che identifica lo stile nel rich text editor]]></key>
+		<key alias="preview">Anteprima</key>
+		<key alias="previewHelp"><![CDATA[Come il testo verrà visualizzato nel Rich text editor.]]></key>
+		<key alias="selector">Selettore</key>
+		<key alias="selectorHelp"><![CDATA[Usa la sintassi CSS standard es: h1, .redHeader, .blueText]]></key>
+		<key alias="styles">Stili</key>
+		<key alias="stylesHelp"><![CDATA[Il CSS che verrà applicato nel Rich text editor, e.s. "color:red;"]]></key>
+		<key alias="tabCode">Codice</key>
+		<key alias="tabRules">Rich Text Editor</key>
+	</area>
+	<area alias="template">
+		<key alias="deleteByIdFailed">Impossibile eliminare il template con ID %0%</key>
+		<key alias="edittemplate">Modifica template</key>
+		<key alias="insertSections">Sezioni</key>
+		<key alias="insertContentArea">Inserisci area di contenuto</key>
+		<key alias="insertContentAreaPlaceHolder">Inserisci segnaposto per l'area di contenuto</key>
+		<key alias="insert">Inserisci</key>
+		<key alias="insertDesc">Scegli cosa inserire nel tuo template</key>
+		<key alias="insertDictionaryItem">Elementi del dizionario</key>
+		<key alias="insertDictionaryItemDesc">
+			<![CDATA[Un elemento del dizionario è un segnaposto per un pezzo di testo traducibile, che facilita il design di siti web multi lingua.]]>
+		</key>
+		<key alias="insertMacro">Macro</key>
+		<key alias="insertMacroDesc">
+			<![CDATA[
+            Una macro è un componente configurabile, ottimo per
+            parti riusabili del tuo design, dove hai bisogno di impostare parametri diversi,
+            come galleries, forms e liste.]]>
+		</key>
+		<key alias="insertPageField">Valore</key>
+		<key alias="insertPageFieldDesc">
+			Visualizza il valore di un campo nominato dalla pagina corrente, con delle opzioni
+			per modificare il valore o impostare il valore di fallback.
+		</key>
+		<key alias="insertPartialView">Partial view</key>
+		<key alias="insertPartialViewDesc">
+			<![CDATA[
+            Una partial view è un file di template separato che può essere renderizzato dentro ad un altro
+            template; ottimo per il riutilizzo del markup o per separare template complessi in più files.]]>
+		</key>
+		<key alias="mastertemplate">Master template</key>
+		<key alias="noMaster">No master</key>
+		<key alias="renderBody">Renderizza template figli</key>
+		<key alias="renderBodyDesc">
+			<![CDATA[
+			     Renderizza i contenuti di un template figlio, inserendo un
+			     segnaposto <code>@RenderBody()</code>.
+      		]]>
+		</key>
+		<key alias="defineSection">Definisci una sezione nominata</key>
+		<key alias="defineSectionDesc">
+			<![CDATA[
+         Definisci una parte del tuo template come sezione nominata, avvolgendola in
+          <code>@section { ... }</code>. Questa potrà poi essere renderizzata in una
+          specifica area del padre di questo template, usando <code>@RenderSection</code>.
+      ]]>
+		</key>
+		<key alias="renderSection">Renderizza una sezione nominata</key>
+		<key alias="renderSectionDesc">
+			<![CDATA[
+      Renderizza una sezione nominata di un template figlio, inserendo un segnaposto <code>@RenderSection(name)</code>.
+      Questo renderizzerà un'area di un template figlio avvolta nel corrispondente <code>@section [name]{ ... }</code> definition.
+      ]]>
+		</key>
+		<key alias="sectionName">Nome della sezione</key>
+		<key alias="sectionMandatory"><![CDATA[La sezione è obbligatoria]]></key>
+		<key alias="sectionMandatoryDesc">
+			<![CDATA[
+            	Se obbligatorio, il template figlio dovrà contenere una definizione <code>@section</code>, altrimenti verrà visualizzato un errore.
+		    ]]>
+		</key>
+		<key alias="queryBuilder">Generatore di query</key>
+		<key alias="itemsReturned">oggetti trovati, in</key>
+		<key alias="copyToClipboard">copia negli appunti</key>
+		<key alias="iWant">Voglio</key>
+		<key alias="allContent">tutti i contenuti</key>
+		<key alias="contentOfType">contenuti di tipo "%0%"</key>
+		<key alias="from">da</key>
+		<key alias="websiteRoot">il mio sito web</key>
+		<key alias="where">dove</key>
+		<key alias="and">e</key>
+		<key alias="is"><![CDATA[è]]></key>
+		<key alias="isNot"><![CDATA[non è]]></key>
+		<key alias="before">prima</key>
+		<key alias="beforeIncDate">prima (comprese le date selezionate)</key>
+		<key alias="after">dopo</key>
+		<key alias="afterIncDate">dopo (comprese le date selezionate)</key>
+		<key alias="equals"><![CDATA[è uguale a]]></key>
+		<key alias="doesNotEqual"><![CDATA[non è uguale a]]></key>
+		<key alias="contains">contiene</key>
+		<key alias="doesNotContain">non contiene</key>
+		<key alias="greaterThan">maggiore di</key>
+		<key alias="greaterThanEqual">maggiore di o uguale a</key>
+		<key alias="lessThan">minore di</key>
+		<key alias="lessThanEqual">minore di o uguale a</key>
+		<key alias="id">Id</key>
+		<key alias="name">Nome</key>
+		<key alias="createdDate">Data di creazione</key>
+		<key alias="lastUpdatedDate">Ultima data di aggiornamento</key>
+		<key alias="orderBy">ordina per</key>
+		<key alias="ascending">ascendente</key>
+		<key alias="descending">discendente</key>
+		<key alias="template">Template</key>
+	</area>
+	<area alias="grid">
+		<key alias="media">Immagine</key>
+		<key alias="macro">Macro</key>
+		<key alias="insertControl">Seleziona il tipo di contenuto</key>
+		<key alias="chooseLayout">Seleziona un layout</key>
+		<key alias="addRows">Aggiungi una riga</key>
+		<key alias="addElement">Aggiungi contenuto</key>
+		<key alias="dropElement">Elimina contenuto</key>
+		<key alias="settingsApplied">Impostazioni applicate</key>
+		<key alias="contentNotAllowed"><![CDATA[Questo contenuto non è consentito qui]]></key>
+		<key alias="contentAllowed"><![CDATA[Questo contenuto è consentito qui]]></key>
+		<key alias="clickToEmbed">Clicca per incorporare</key>
+		<key alias="clickToInsertImage">Clicca per inserire un immagine</key>
+		<key alias="clickToInsertMacro">Clicca per inserire una macro</key>
+		<key alias="placeholderImageCaption">Didascalia dell'immagine...</key>
+		<key alias="placeholderWriteHere">Scrivi qui...</key>
+		<key alias="gridLayouts">I Grid Layout</key>
+		<key alias="gridLayoutsDetail">
+			I layout sono l'area globale di lavoro per il grid editor, di solito ti servono
+			solamente uno o due layout differenti
+		</key>
+		<key alias="addGridLayout">Aggiungi un Grid Layout</key>
+		<key alias="editGridLayout">Modifica il Grid Layout</key>
+		<key alias="addGridLayoutDetail">
+			Sistema il layout impostando la larghezza della colonna ed aggiungendo ulteriori
+			sezioni
+		</key>
+		<key alias="rowConfigurations">Configurazioni della riga</key>
+		<key alias="rowConfigurationsDetail">Le righe sono le colonne predefinite disposte orizzontalmente</key>
+		<key alias="addRowConfiguration">Aggiungi configurazione della riga</key>
+		<key alias="editRowConfiguration">Modifica configurazione della riga</key>
+		<key alias="addRowConfigurationDetail">
+			Sistema la riga impostando la larghezza della colonna ed aggiungendo
+			ulteriori colonne
+		</key>
+		<key alias="noConfiguration">Nessuna ulteriore configurazione disponibile</key>
+		<key alias="columns">Colonne</key>
+		<key alias="columnsDetails">Totale combinazioni delle colonne nel grid layout</key>
+		<key alias="settings">Impostazioni</key>
+		<key alias="settingsDetails">Configura le impostazioni che possono essere cambiate dai editori</key>
+		<key alias="styles">Stili</key>
+		<key alias="stylesDetails">Configura i stili che possono essere cambiati dai editori</key>
+		<key alias="allowAllEditors">Permetti tutti i editor</key>
+		<key alias="allowAllRowConfigurations">Permetti tutte le configurazioni della riga</key>
+		<key alias="maxItems">Oggetti massimi</key>
+		<key alias="maxItemsDescription">Lascia vuoto o imposta a 0 per illimitati</key>
+		<key alias="setAsDefault">Imposta come predefinito</key>
+		<key alias="chooseExtra">Scegli aggiuntivi</key>
+		<key alias="chooseDefault">Scegli predefinito</key>
+		<key alias="areAdded">sono stati aggiunti</key>
+		<key alias="warning">Attenzione</key>
+		<key alias="youAreDeleting">Stai eliminando le configurazioni della riga</key>
+		<key alias="deletingARow">
+			Eliminando un nome della configurazione della riga perderai i dati associati a qualsiasi contenuto basato su
+			questa configurazione.
+		</key>
+	</area>
+	<area alias="contentTypeEditor">
+		<key alias="compositions">Composizioni</key>
+		<key alias="group">Gruppi</key>
+		<key alias="noGroups">Non hai aggiunto nessun gruppo</key>
+		<key alias="addGroup">Aggiungi gruppo</key>
+		<key alias="inheritedFrom">Ereditato da</key>
+		<key alias="addProperty"><![CDATA[Aggiungi proprietà]]></key>
+		<key alias="requiredLabel">Etichetta richiesta</key>
+		<key alias="enableListViewHeading">Abilita la vista lista</key>
+		<key alias="enableListViewDescription">
+			Configura l'oggetto per visualizzare una lista dei suoi figli, ordinabili e
+			ricercabili. I figli non saranno visualizzati nell'albero dei contenuti
+		</key>
+		<key alias="allowedTemplatesHeading">Templates abilitati</key>
+		<key alias="allowedTemplatesDescription">
+			Scegli che templates sono abilitati all'utilizzo per i contenuti di questo
+			tipo.
+		</key>
+		<key alias="allowAsRootHeading">Consenti come nodo root</key>
+		<key alias="allowAsRootDescription">
+			Consenti agli editori la creazione di questo tipo di contenuto a livello root.
+		</key>
+		<key alias="childNodesHeading">Tipi di nodi figlio consentiti</key>
+		<key alias="childNodesDescription">
+			Consenti la creazione di contenuti con i tipi specificati sotto il contenuto di
+			questo tipo.
+		</key>
+		<key alias="chooseChildNode">Scegli nodo figlio</key>
+		<key alias="compositionsDescription">
+			<![CDATA[Eredita schede e proprietà da un tipo di documento esistente. Le nuove schede verranno aggiunte al tipo di documento corrente o unite se esiste una scheda con un nome identico.]]>
+		</key>
+		<key alias="compositionInUse">
+			<![CDATA[Questo tipo di contenuto è utlizzato in una composizione, e quindi non può essere composto da se stesso.]]>
+		</key>
+		<key alias="noAvailableCompositions">Non ci sono tipi di contenuto utilizzabili come composizione.</key>
+		<key alias="compositionRemoveWarning">
+			<![CDATA[Rimuovendo una composizione si elimineranno tutti i dati associati ad essa. Una volta salvato il tipo di documento non ci sarà nessun modo di recuperare i dati.]]>
+		</key>
+		<key alias="availableEditors">Crea nuovo</key>
+		<key alias="reuse">Usa esistente</key>
+		<key alias="editorSettings">Impostazioni dell'editor</key>
+		<key alias="searchResultSettings">Configurazioni disponibili</key>
+		<key alias="searchResultEditors">Crea una nuova configurazione</key>
+		<key alias="configuration">Configurazione</key>
+		<key alias="yesDelete">Si, elimina</key>
+		<key alias="movedUnderneath"><![CDATA[è stato spostato sotto]]></key>
+		<key alias="copiedUnderneath"><![CDATA[è stato copiato sotto]]></key>
+		<key alias="folderToMove">Seleziona la cartella da spostare</key>
+		<key alias="folderToCopy">Seleziona la cartella da copiare</key>
+		<key alias="structureBelow">nella struttura sottostante</key>
+		<key alias="allDocumentTypes">Tutti i tipo di documento</key>
+		<key alias="allDocuments">Tutti i documenti</key>
+		<key alias="allMediaItems">Tutti i media</key>
+		<key alias="usingThisDocument">
+			che usano questo tipo di documento verranno eliminati permanentemente, sei sicuro di
+			voler eliminare anche questi?
+		</key>
+		<key alias="usingThisMedia">
+			che usano questo tipo di media verranno eliminati permanentemente, sei sicuro di voler
+			eliminare anche questi?
+		</key>
+		<key alias="usingThisMember">
+			che usano questo tipo di membro verranno eliminati permanentemente, sei sicuro di voler
+			eliminare anche questi?
+		</key>
+		<key alias="andAllDocuments">e tutti i documenti che usano questo tipo</key>
+		<key alias="andAllMediaItems">e tutti i media che usano questo tipo</key>
+		<key alias="andAllMembers">e tutti i membri che usano questo tipo</key>
+		<key alias="memberCanEdit"><![CDATA[Il membro può modificare]]></key>
+		<key alias="memberCanEditDescription">
+			Abilita il membro alla modifica di questo valore dalla pagina del suo
+			profilo.
+		</key>
+		<key alias="isSensitiveData">Dati sensibili</key>
+		<key alias="isSensitiveDataDescription">
+			<![CDATA[Nascondi il valore di questa proprietà dagli editors che non hanno l'accesso per visualizzare i dati sensibili]]>
+		</key>
+		<key alias="showOnMemberProfile">Visualizza sul profilo del membro</key>
+		<key alias="showOnMemberProfileDescription">
+			Permette a questo valore di essere visualizzato sulla pagina del profilo
+			del membro
+		</key>
+		<key alias="tabHasNoSortOrder">la scheda non ha un ordine</key>
+		<key alias="compositionUsageHeading"><![CDATA[Dove è usata questa composizione?]]></key>
+		<key alias="compositionUsageSpecification">
+			<![CDATA[Questa composizione è usata nella composizione dei seguenti tipi di contenuto:]]>
+		</key>
+		<key alias="variantsHeading">Consenti variazioni</key>
+		<key alias="cultureVariantHeading">Consenti variazioni in base alla lingua</key>
+		<key alias="segmentVariantHeading">Consenti segmentazione</key>
+		<key alias="cultureVariantLabel">Varia in base alla cultura</key>
+		<key alias="segmentVariantLabel">Varia per segmenti</key>
+		<key alias="variantsDescription">
+			Consenti agli editors la creazione di contenuto di questo tipo in lingue
+			differenti.
+		</key>
+		<key alias="cultureVariantDescription">Consenti agli editors la creazione di contenuto in diverse lingue.</key>
+		<key alias="segmentVariantDescription">Consenti agli editors la creazione di segmenti per questo contenuto.</key>
+		<key alias="allowVaryByCulture">Consenti variazioni in base alla lingua</key>
+		<key alias="allowVaryBySegment">Consenti segmentazione</key>
+		<key alias="elementType">Tipo di elemento</key>
+		<key alias="elementHeading"><![CDATA[È un tipo di elemento]]></key>
+		<key alias="elementDescription">
+			<![CDATA[Un tipo di elemento è pensato per essere usato ad esempio nel Nested Content, e non nell'albero dei nodi.]]>
+		</key>
+		<key alias="elementCannotToggle">
+			<![CDATA[Un tipo di documento non può essere cambiato in un tipo di elemento una volta che è stato usato per creare uno o più contenuti.]]>
+		</key>
+		<key alias="elementDoesNotSupport"><![CDATA[Questo non è applicabile per un tipo di elemento]]></key>
+		<key alias="propertyHasChanges">
+			<![CDATA[Hai fatto modifiche a questa proprietà. Sei sicuro di volerle scartare?]]>
+		</key>
+		<key alias="displaySettingsHeadline">Aspetto</key>
+		<key alias="displaySettingsLabelOnTop">Etichetta sopra (larghezza intera)</key>
+	</area>
+	<area alias="languages">
+		<key alias="addLanguage">Aggiungi lingua</key>
+		<key alias="mandatoryLanguage">Lingua obbligatoria</key>
+		<key alias="mandatoryLanguageHelp">
+			<![CDATA[Le proprietà in questa lingua devono essere compliate prima che il nodo possa essere pubblicato.]]>
+		</key>
+		<key alias="defaultLanguage">Lingua di default</key>
+		<key alias="defaultLanguageHelp"><![CDATA[Un sito web Umbraco può avere solo una lingua di default.]]></key>
+		<key alias="changingDefaultLanguageWarning">
+			Il cambio della lingua predefinita potrebbe comportare la mancanza di
+			contenuti predefiniti.
+		</key>
+		<key alias="fallsbackToLabel">Ripiega a</key>
+		<key alias="noFallbackLanguageOption">Nessuna lingua alternativa</key>
+		<key alias="fallbackLanguageDescription">
+			<![CDATA[Per consentire ad un contenuto multi-lingua di ripiegare su un altra lingua se il contenuto non è presente nella lingua richiesta, selezionalo qui.]]>
+		</key>
+		<key alias="fallbackLanguage">Lingua alternativa</key>
+		<key alias="none">nessuna</key>
+	</area>
+	<area alias="macro">
+		<key alias="addParameter">Aggiungi parametro</key>
+		<key alias="editParameter">Modifica parametro</key>
+		<key alias="enterMacroName">Inserisci il nome della macro</key>
+		<key alias="parameters">Parametri</key>
+		<key alias="parametersDescription">
+			Definisci i parametri che dovranno essere disponibili utilizzando questa macro.
+		</key>
+		<key alias="selectViewFile">Seleziona il file partial view per la macro</key>
+	</area>
+	<area alias="modelsBuilder">
+		<key alias="buildingModels">Compilazione modelli in corso...</key>
+		<key alias="waitingMessage"><![CDATA[questo potrà impiegare un po' di tempo, non preoccuparti]]></key>
+		<key alias="modelsGenerated">Modelli generati</key>
+		<key alias="modelsGeneratedError">Impossibile generare i modelli</key>
+		<key alias="modelsExceptionInUlog">
+			La generazione dei modelli non è andata a buon fine, consulta i log di Umbraco
+		</key>
+	</area>
+	<area alias="templateEditor">
+		<key alias="addFallbackField">Aggiungi campo alternativo</key>
+		<key alias="fallbackField">Campo alternativo</key>
+		<key alias="addDefaultValue">Aggiungi valore predefinito</key>
+		<key alias="defaultValue">Valore predefinito</key>
+		<key alias="alternativeField">Campo alternativo</key>
+		<key alias="alternativeText">Valore predefinito</key>
+		<key alias="casing"><![CDATA[Maiuscole/Minuscole]]></key>
+		<key alias="encoding">Codifica</key>
+		<key alias="chooseField">Scegli il campo</key>
+		<key alias="convertLineBreaks">Converte le interruzioni di linea</key>
+		<key alias="convertLineBreaksDescription">Si, converti le interruzioni di linea</key>
+		<key alias="convertLineBreaksHelp"><![CDATA[Copia le interruzioni di linea con html-tag &lt;br&gt;]]></key>
+		<key alias="customFields">Campi Personalizzati</key>
+		<key alias="dateOnly">Solo data</key>
+		<key alias="formatAndEncoding">Formato e codifica</key>
+		<key alias="formatAsDate"><![CDATA[In formato data]]></key>
+		<key alias="formatAsDateDescr">Formatta il valore in data, o in data e ora, secondo la cultura corrente</key>
+		<key alias="htmlEncode"><![CDATA[Codifica HTML]]></key>
+		<key alias="htmlEncodeHelp"><![CDATA[Andrà a sostituire i caratteri speciali con il loro equivalente HTML.]]></key>
+		<key alias="insertedAfter"><![CDATA[Sarà inserito dopo il valore del campo]]></key>
+		<key alias="insertedBefore"><![CDATA[Sarà inserito prima del valore del campo]]></key>
+		<key alias="lowercase">Minuscolo</key>
+		<key alias="modifyOutput">Modifica output</key>
+		<key alias="none">Nessuno</key>
+		<key alias="outputSample">Esempio di output</key>
+		<key alias="postContent"><![CDATA[Inserisci dopo il campo]]></key>
+		<key alias="preContent"><![CDATA[Inserisci prima del campo]]></key>
+		<key alias="recursive">Ricorsivo</key>
+		<key alias="recursiveDescr">Si, rendilo ricorsivo</key>
+		<key alias="separator">Separatore</key>
+		<key alias="standardFields">Campi Standard</key>
+		<key alias="uppercase">Maiuscolo</key>
+		<key alias="urlEncode"><![CDATA[Codifica URL]]></key>
+		<key alias="urlEncodeHelp">
+			<![CDATA[Andrà a sostituire i caratteri speciali con il loro equivalente negli URL.]]>
+		</key>
+		<key alias="usedIfAllEmpty"><![CDATA[Sarà usato solo se i valori dei campi sopra sono vuoti]]></key>
+		<key alias="usedIfEmpty"><![CDATA[Questo campo sarà usato soltanto se il campo primario è vuoto]]></key>
+		<key alias="withTime">Data e ora</key>
+	</area>
+	<area alias="translation">
+		<key alias="details">Dettagli di traduzione</key>
+		<key alias="DownloadXmlDTD">Scarica XML DTD</key>
+		<key alias="fields">Campi</key>
+		<key alias="includeSubpages">Includi le sottopagine</key>
+		<key alias="mailBody">
+			<![CDATA[
+      Ciao %0%
+
+      Questa è un'email automatica per informarti che è stata richiesta una traduzione in '%5%' da %2%
+      per il documento il documento '%1%'.
+
+      Vai al http://%3%/translation/details.aspx?id=%4% per effettuare la modifica.
+
+      Oppure effettua il login in Umbraco per avere una panoramica delle attività di traduzione
+      http://%3%
+
+      Buona giornata!
+
+      Saluti dal robot di Umbraco
+    ]]>
+		</key>
+		<key alias="noTranslators">
+			<![CDATA[Non è stato trovato nessun utente con ruolo di traduttore. Crealo prima di inviare il contenuto per la traduzione]]>
+		</key>
+		<key alias="pageHasBeenSendToTranslation"><![CDATA[La pagina '%0%' è stata inviata per la traduzione]]></key>
+		<key alias="sendToTranslate"><![CDATA[Invia la pagina '%0%' per la traduzione]]></key>
+		<key alias="totalWords"><![CDATA[Totale parole]]></key>
+		<key alias="translateTo"><![CDATA[Si traduce in]]></key>
+		<key alias="translationDone"><![CDATA[Traduzione completata.]]></key>
+		<key alias="translationDoneHelp">
+			<![CDATA[È possibile visualizzare in anteprima le pagine che hai appena tradotto, cliccando qui sotto. Se esiste la pagina originale, si otterrà un confronto tra le due pagine.]]>
+		</key>
+		<key alias="translationFailed"><![CDATA[Traduzione non riuscita, il file XML potrebbe essere danneggiato]]></key>
+		<key alias="translationOptions"><![CDATA[Opzioni di traduzione]]></key>
+		<key alias="translator">Traduttore</key>
+		<key alias="uploadTranslationXml"><![CDATA[Carica il file xml di traduzione]]></key>
+	</area>
+	<area alias="treeHeaders">
+		<key alias="content">Contenuti</key>
+		<key alias="contentBlueprints">Modelli di contenuto</key>
+		<key alias="media">Media</key>
+		<key alias="cacheBrowser">Cache Browser</key>
+		<key alias="contentRecycleBin">Cestino</key>
+		<key alias="createdPackages">Pacchetti creati</key>
+		<key alias="dataTypes">Tipi di dato</key>
+		<key alias="dictionary">Dizionario</key>
+		<key alias="installedPackages">Pacchetti installati</key>
+		<key alias="installSkin">Installare skin</key>
+		<key alias="installStarterKit">Installare starter kit</key>
+		<key alias="languages">Lingue</key>
+		<key alias="localPackage">Installa un pacchetto locale</key>
+		<key alias="macros">Macros</key>
+		<key alias="mediaTypes">Tipi di media</key>
+		<key alias="member">Membri</key>
+		<key alias="memberGroups">Gruppi di Membri</key>
+		<key alias="memberRoles">Ruoli</key>
+		<key alias="memberTypes">Tipi di membro</key>
+		<key alias="documentTypes">Tipi di documento</key>
+		<key alias="relationTypes">Tipi di relazione</key>
+		<key alias="packager">Pacchetti</key>
+		<key alias="packages">Pacchetti</key>
+		<key alias="partialViews">Partial Views</key>
+		<key alias="partialViewMacros">Macro Partial Views</key>
+		<key alias="repositories">Installa dal repository</key>
+		<key alias="runway">Installa Runway</key>
+		<key alias="runwayModules">Moduli Runway</key>
+		<key alias="scripting">Files di scripting</key>
+		<key alias="scripts">Scripts</key>
+		<key alias="stylesheets">Fogli di stile</key>
+		<key alias="templates">Templates</key>
+		<key alias="logViewer">Logs</key>
+		<key alias="users">Utenti</key>
+		<key alias="settingsGroup">Impostazioni</key>
+		<key alias="templatingGroup">Templating</key>
+		<key alias="thirdPartyGroup">Terze parti</key>
+	</area>
+	<area alias="update">
+		<key alias="updateAvailable"><![CDATA[Nuovo aggiornamento disponibile]]></key>
+		<key alias="updateDownloadText"><![CDATA[%0% è pronto, clicca qui per il download]]></key>
+		<key alias="updateNoServer"><![CDATA[Non connesso al server]]></key>
+		<key alias="updateNoServerError">
+			<![CDATA[Errore di controllo per l'aggiornamento. Si prega di rivedere lo stack-trace per ulteriori informazioni]]>
+		</key>
+	</area>
+	<area alias="user">
+		<key alias="access">Accesso</key>
+		<key alias="accessHelp">
+			Basandosi sui gruppi assegnati e sui nodi di partenza, l'utente ha accesso ai seguenti
+			nodi
+		</key>
+		<key alias="assignAccess">Assegna accessi</key>
+		<key alias="administrators">Amministratore</key>
+		<key alias="categoryField">Campo Categoria</key>
+		<key alias="createDate">Utente creato il</key>
+		<key alias="changePassword">Cambia la tua password</key>
+		<key alias="changePhoto">Cambia foto</key>
+		<key alias="newPassword">Nuova password</key>
+		<key alias="newPasswordFormatLengthTip">Minimo %0% caratteri!</key>
+		<key alias="newPasswordFormatNonAlphaTip">Dovrebbero esserci almeno %0% caratteri speciali qui.</key>
+		<key alias="noLockouts"><![CDATA[non è stato bloccato]]></key>
+		<key alias="noPasswordChange"><![CDATA[La password non è stata modificata]]></key>
+		<key alias="confirmNewPassword">Conferma la nuova password</key>
+		<key alias="changePasswordDescription">
+			<![CDATA[È possibile modificare la password di accesso al backoffice Umbraco compilando il form sottostante e clicca sul pulsante 'Modifica password']]>
+		</key>
+		<key alias="contentChannel">Contenuto del canale</key>
+		<key alias="createAnotherUser">Crea un altro utente</key>
+		<key alias="createUserHelp">
+			Crea nuovi utenti per dar loro accesso a Umbraco. Quando un nuovo utente viene creato,
+			una nuova password da condividere con l'utente viene generata.
+		</key>
+		<key alias="descriptionField">Campo Descrizione</key>
+		<key alias="disabled">Disabilita l'utente</key>
+		<key alias="documentType">Tipo di Documento</key>
+		<key alias="editors">Editor</key>
+		<key alias="excerptField">Campo Eccezione</key>
+		<key alias="failedPasswordAttempts">Tentativi di accesso falliti</key>
+		<key alias="goToProfile">Vai al profilo dell'utente</key>
+		<key alias="groupsHelp">Crea gruppi per assegnare gli accessi e i permessi</key>
+		<key alias="inviteAnotherUser">Invita un altro utente</key>
+		<key alias="inviteUserHelp">
+			<![CDATA[Invita nuovi utenti per dar loro l'accesso a Umbraco. Un'email contenente le informazioni su come effettuare l'accesso in Umbraco verrà inviata all'utente. Un invito dura per 72 ore.]]>
+		</key>
+		<key alias="language">Lingua</key>
+		<key alias="languageHelp">Imposta la lingua che vedrai nei menu e nei dialoghi</key>
+		<key alias="lastLockoutDate">Data dell'ultimo blocco</key>
+		<key alias="lastLogin">Ultimo login</key>
+		<key alias="lastPasswordChangeDate">Ultima modifica della password</key>
+		<key alias="loginname">Login</key>
+		<key alias="mediastartnode">Nodo di inizio nella sezione Media</key>
+		<key alias="mediastartnodehelp">Limita la libreria multimediale a un nodo iniziale specifico</key>
+		<key alias="mediastartnodes">Nodi di inizio nella sezione Media</key>
+		<key alias="mediastartnodeshelp">
+			<![CDATA[Limita la libreria multimediale a uno o più nodi iniziali specifici]]>
+		</key>
+		<key alias="modules">Sezioni</key>
+		<key alias="noConsole"><![CDATA[Disabilita l'accesso ad Umbraco]]></key>
+		<key alias="noLogin">non ha ancora effettuato l'accesso</key>
+		<key alias="oldPassword">Vecchia password</key>
+		<key alias="password">Password</key>
+		<key alias="resetPassword">Resetta password</key>
+		<key alias="passwordChanged"><![CDATA[La tua password è stata cambiata!]]></key>
+		<key alias="passwordChangedGeneric">Password cambiata</key>
+		<key alias="passwordConfirm"><![CDATA[Si prega di confermare la nuova password]]></key>
+		<key alias="passwordEnterNew"><![CDATA[Inserisci la tua nuova password]]></key>
+		<key alias="passwordIsBlank"><![CDATA[La nuova password non può essere vuota!]]></key>
+		<key alias="passwordCurrent">Password attuale</key>
+		<key alias="passwordInvalid"><![CDATA[La password corrente non è valida]]></key>
+		<key alias="passwordIsDifferent">
+			<![CDATA[C'è una differenza tra la nuova password e la conferma della password. Riprova!]]>
+		</key>
+		<key alias="passwordMismatch"><![CDATA[La password di conferma non corrisponde alla nuova password!]]></key>
+		<key alias="permissionReplaceChildren"><![CDATA[Sostituisci permessi sui nodi figlio]]></key>
+		<key alias="permissionSelectedPages"><![CDATA[Stai modificando i permessi per le seguenti pagine:]]></key>
+		<key alias="permissionSelectPages"><![CDATA[Seleziona le pagine alle quali vuoi modificare i permessi]]></key>
+		<key alias="removePhoto">Rimuovi foto</key>
+		<key alias="permissionsDefault">Permessi predefiniti</key>
+		<key alias="permissionsGranular">Permessi granulari</key>
+		<key alias="permissionsGranularHelp">Imposta i permessi per nodi specifici</key>
+		<key alias="profile">Profilo</key>
+		<key alias="searchAllChildren"><![CDATA[Cerca in tutti i figli]]></key>
+		<key alias="sectionsHelp">Aggiungi sezioni per cui l'utente deve avere accesso</key>
+		<key alias="selectUserGroups">Seleziona gruppi di utenti</key>
+		<key alias="noStartNode">Nodo di partenza non selezionato</key>
+		<key alias="noStartNodes">Nodi di partenza non selezionati</key>
+		<key alias="startnode"><![CDATA[Nodo di inizio della sezione Contenuto]]></key>
+		<key alias="startnodehelp">Limita l'albero dei contenuti a un nodo iniziale specifico</key>
+		<key alias="startnodes">Nodi di inizio del contenuto</key>
+		<key alias="startnodeshelp"><![CDATA[Limita l'albero dei contenuti a uno o più nodi iniziali specifici]]></key>
+		<key alias="updateDate">Ultimo aggiornamento utente</key>
+		<key alias="userCreated"><![CDATA[è stato creato]]></key>
+		<key alias="userCreatedSuccessHelp">
+			<![CDATA[Il nuovo utente è stato creato correttamente. Per effettuare il login in Umbraco utilizza la password sottostante.]]>
+		</key>
+		<key alias="userManagement">Gestione utenti</key>
+		<key alias="username">Username</key>
+		<key alias="userPermissions"><![CDATA[Permessi Utente]]></key>
+		<key alias="usergroup">Gruppo di utenti</key>
+		<key alias="userInvited"><![CDATA[è stato invitato]]></key>
+		<key alias="userInvitedSuccessHelp">
+			<![CDATA[Un invito è stato invitato al nuovo utente con le istruzioni su come effettuare il login in Umbraco.]]>
+		</key>
+		<key alias="userinviteWelcomeMessage">
+			Ciao e benvenuto su Umbraco! In solo 1 minuto sarai pronto a partire, dovrai
+			solamente impostare una password.
+		</key>
+		<key alias="userinviteExpiredMessage">
+			<![CDATA[Benvenuto su Umbraco! Purtroppo il tuo invito è scaduto. Per favore contatta l'amministratore e chiedigli di rispedirlo.]]>
+		</key>
+		<key alias="writer">Autore</key>
+		<key alias="change">Modifica</key>
+		<key alias="yourProfile" version="7.0">Il tuo profilo</key>
+		<key alias="yourHistory" version="7.0"><![CDATA[La tua attività recente]]></key>
+		<key alias="sessionExpires" version="7.0">La sessione scade in</key>
+		<key alias="inviteUser">Invita utente</key>
+		<key alias="createUser">Crea utente</key>
+		<key alias="sendInvite">Invia invito</key>
+		<key alias="backToUsers">Torna agli utenti</key>
+		<key alias="inviteEmailCopySubject">Invito per Umbraco</key>
+		<key alias="inviteEmailCopyFormat">
+			<![CDATA[
+        <html>
+			<head>
+				<meta name='viewport' content='width=device-width'>
+				<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>
+			</head>
+			<body class='' style='font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; color: #392F54; line-height: 22px; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background: #1d1333; margin: 0; padding: 0;' bgcolor='#1d1333'>
+				<style type='text/css'> @media only screen and (max-width: 620px) {table[class=body] h1 {font-size: 28px !important; margin-bottom: 10px !important; } table[class=body] .wrapper {padding: 32px !important; } table[class=body] .article {padding: 32px !important; } table[class=body] .content {padding: 24px !important; } table[class=body] .container {padding: 0 !important; width: 100% !important; } table[class=body] .main {border-left-width: 0 !important; border-radius: 0 !important; border-right-width: 0 !important; } table[class=body] .btn table {width: 100% !important; } table[class=body] .btn a {width: 100% !important; } table[class=body] .img-responsive {height: auto !important; max-width: 100% !important; width: auto !important; } } .btn-primary table td:hover {background-color: #34495e !important; } .btn-primary a:hover {background-color: #34495e !important; border-color: #34495e !important; } .btn  a:visited {color:#FFFFFF;} </style>
+				<table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #1d1333;" bgcolor="#1d1333">
+					<tr>
+						<td style="font-family: sans-serif; font-size: 14px; vertical-align: top; padding: 24px;" valign="top">
+							<table style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+								<tr>
+									<td background="https://umbraco.com/umbraco/assets/img/application/logo.png" bgcolor="#1d1333" width="28" height="28" valign="top" style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
+										<!--[if gte mso 9]> <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:30px;height:30px;"> <v:fill type="tile" src="https://umbraco.com/umbraco/assets/img/application/logo.png" color="#1d1333" /> <v:textbox inset="0,0,0,0"> <![endif]-->
+										<div> </div>
+										<!--[if gte mso 9]> </v:textbox> </v:rect> <![endif]-->
+									</td>
+									<td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top"></td>
+								</tr>
+							</table>
+						</td>
+					</tr>
+				</table>
+				<table border='0' cellpadding='0' cellspacing='0' class='body' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #1d1333;' bgcolor='#1d1333'>
+					<tr>
+						<td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'> </td>
+						<td class='container' style='font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; max-width: 560px; width: 560px; margin: 0 auto; padding: 10px;' valign='top'>
+							<div class='content' style='box-sizing: border-box; display: block; max-width: 560px; margin: 0 auto; padding: 10px;'>
+								<br>
+								<table class='main' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; border-radius: 3px; background: #FFFFFF;' bgcolor='#FFFFFF'>
+									<tr>
+										<td class='wrapper' style='font-family: sans-serif; font-size: 14px; vertical-align: top; box-sizing: border-box; padding: 50px;' valign='top'>
+											<table border='0' cellpadding='0' cellspacing='0' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;'>
+												<tr>
+													<td style='line-height: 24px; font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'>
+														<h1 style='color: #392F54; font-family: sans-serif; font-weight: bold; line-height: 1.4; font-size: 24px; text-align: left; text-transform: capitalize; margin: 0 0 30px;' align='left'>
+															Ciao %0%,
+														</h1>
+														<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+															Sei stato invitato nel Back Office di Umbraco da <a href="mailto:%4%" style="text-decoration: underline; color: #392F54; -ms-word-break: break-all; word-break: break-all;">%1%</a>.
+														</p>
+														<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+															Messaggio da <a href="mailto:%1%" style="text-decoration: none; color: #392F54; -ms-word-break: break-all; word-break: break-all;">%1%</a>:
+															<br/>
+															<em>%2%</em>
+														</p>
+														<table border='0' cellpadding='0' cellspacing='0' class='btn btn-primary' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; box-sizing: border-box;'>
+															<tbody>
+																<tr>
+																	<td align='left' style='font-family: sans-serif; font-size: 14px; vertical-align: top; padding-bottom: 15px;' valign='top'>
+																		<table border='0' cellpadding='0' cellspacing='0' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;'>
+																			<tbody>
+																				<tr>
+																					<td style='font-family: sans-serif; font-size: 14px; vertical-align: top; border-radius: 5px; text-align: center; background: #35C786;' align='center' bgcolor='#35C786' valign='top'>
+																						<a href='%3%' target='_blank' rel='noopener' style='color: #FFFFFF; text-decoration: none; -ms-word-break: break-all; word-break: break-all; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; text-transform: capitalize; background: #35C786; margin: 0; padding: 12px 30px; border: 1px solid #35c786;'>
+																							Clicca questo link per accettare l'invito
+																						</a>
+																					</td>
+																				</tr>
+																			</tbody>
+																		</table>
+																	</td>
+																</tr>
+															</tbody>
+														</table>
+														<p style='max-width: 400px; display: block; color: #392F54; font-family: sans-serif; font-size: 14px; line-height: 20px; font-weight: normal; margin: 15px 0;'>Se non puoi cliccare sul link, copia e incolla questo URL in una nuova finestra del tuo browser:</p>
+															<table border='0' cellpadding='0' cellspacing='0'>
+																<tr>
+																	<td style='-ms-word-break: break-all; word-break: break-all; font-family: sans-serif; font-size: 11px; line-height:14px;'>
+																		<font style="-ms-word-break: break-all; word-break: break-all; font-size: 11px; line-height:14px;">
+																			<a style='-ms-word-break: break-all; word-break: break-all; color: #392F54; text-decoration: underline; font-size: 11px; line-height:15px;' href='%3%'>%3%</a>
+																		</font>
+																	</td>
+																</tr>
+															</table>
+														</p>
+													</td>
+												</tr>
+											</table>
+										</td>
+									</tr>
+								</table>
+								<br><br><br>
+							</div>
+						</td>
+						<td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'> </td>
+					</tr>
+				</table>
+			</body>
+    </html>]]>
+		</key>
+		<key alias="invite">Invita</key>
+		<key alias="defaultInvitationMessage">Sto rinviando l'invito...</key>
+		<key alias="deleteUser">Cancella utente</key>
+		<key alias="deleteUserConfirmation">Sei sicuro di voler cancellare questo account utente?</key>
+		<key alias="stateAll">Tutti</key>
+		<key alias="stateActive">Attivi</key>
+		<key alias="stateDisabled">Disabilitati</key>
+		<key alias="stateLockedOut">Bloccati</key>
+		<key alias="stateInvited">Invitati</key>
+		<key alias="stateInactive">Inattivi</key>
+		<key alias="sortNameAscending">Nome (A-Z)</key>
+		<key alias="sortNameDescending">Nome (Z-A)</key>
+		<key alias="sortCreateDateAscending"><![CDATA[Più vecchi]]></key>
+		<key alias="sortCreateDateDescending"><![CDATA[Più nuovi]]></key>
+		<key alias="sortLastLoginDateDescending">Ultimo login</key>
+		<key alias="noUserGroupsAdded">Non sono stati aggiunti gruppi di utenti</key>
+	</area>
+	<area alias="validation">
+		<key alias="validation">Validazione</key>
+		<key alias="validateAsEmail">Valida come indirizzo email</key>
+		<key alias="validateAsNumber">Valida come numero</key>
+		<key alias="validateAsUrl">Valida come URL</key>
+		<key alias="enterCustomValidation">...oppure inserisci una validazione personalizzata</key>
+		<key alias="fieldIsMandatory"><![CDATA[Il campo è obbligatorio]]></key>
+		<key alias="mandatoryMessage">Inserisci un errore di validazione personalizzato (opzionale)</key>
+		<key alias="validationRegExp">Inserisci una regular expression</key>
+		<key alias="validationRegExpMessage">Inserisci un errore di validazione personalizzato (opzionale)</key>
+		<key alias="minCount">Devi aggiungere almeno</key>
+		<key alias="maxCount">Puoi avere solamente</key>
+		<key alias="addUpTo">Aggiungi fino a</key>
+		<key alias="items">elementi</key>
+		<key alias="urls">URL</key>
+		<key alias="urlsSelected">URL selezionati</key>
+		<key alias="itemsSelected">elementi selezionati</key>
+		<key alias="invalidDate">Data non valida</key>
+		<key alias="invalidNumber"><![CDATA[Non è un numero]]></key>
+		<key alias="invalidNumberStepSize"><![CDATA[Non è un numero di step valido]]></key>
+		<key alias="invalidEmail">Email non valida</key>
+		<key alias="invalidNull"><![CDATA[Il valore non può essere nullo]]></key>
+		<key alias="invalidEmpty"><![CDATA[Il valore non può essere vuoto]]></key>
+		<key alias="invalidPattern"><![CDATA[Il valore non è valido, non corrisponde al pattern corretto]]></key>
+		<key alias="customValidation">Validazione personalizzata</key>
+		<key alias="entriesShort"><![CDATA[Minimo %0% voci, ne richiede <strong>%1%</strong> in più.]]></key>
+		<key alias="entriesExceed"><![CDATA[Massimo %0% voci, <strong>%1%</strong> di troppo.]]></key>
+	</area>
+	<area alias="healthcheck">
+		<!-- The following keys get these tokens passed in:
+   0: Current value
+   1: Recommended value
+   2: XPath
+   3: Configuration file path
+-->
+		<key alias="checkSuccessMessage"><![CDATA[Il valore è impostato al valore raccomandato: '%0%'.]]></key>
+		<key alias="rectifySuccessMessage">
+			<![CDATA[Il valore è impostato a '%1%' per l'XPath '%2%' nel file di configurazione '%3%'.]]>
+		</key>
+		<key alias="checkErrorMessageDifferentExpectedValue">
+			<![CDATA[Mi aspettavo il valore '%1%' per '%2%' nel file di configurazione '%3%', ma ho trovato '%0%'.]]>
+		</key>
+		<key alias="checkErrorMessageUnexpectedValue">
+			<![CDATA[Non mi aspettavo il valore '%0%' per '%2%' nel file di configurazione '%3%'.]]>
+		</key>
+		<!-- The following keys get these tokens passed in:
+   0: Current value
+   1: Recommended value
+-->
+		<key alias="customErrorsCheckSuccessMessage">Gli errori personalizzati sono impostati a '%0%'.</key>
+		<key alias="customErrorsCheckErrorMessage">
+			<![CDATA[Gli errori personalizzati al momento sono impostati a '%0%'. È raccomandato impostarli a '%1%' prima di andare live.]]>
+		</key>
+		<key alias="customErrorsCheckRectifySuccessMessage">Errori personalizzati impostati correttamente a '%0%'.</key>
+		<key alias="macroErrorModeCheckSuccessMessage">I MacroErrors sono impostati a '%0%'.</key>
+		<key alias="macroErrorModeCheckErrorMessage">
+			<![CDATA[I MacroErrors sono impostati a '%0%' che impediranno il caricamento di qualche pagina nel sito se c'è anche solo un errore nella macro. Rettificando questa impostazione verrà impostato il valore '%1%'.]]>
+		</key>
+		<key alias="macroErrorModeCheckRectifySuccessMessage">I MacroErrors sono ora impostati a '%0%'.</key>
+		<!-- The following keys get these tokens passed in:
+   0: Current value
+   1: Recommended value
+   2: Server version
+-->
+		<key alias="trySkipIisCustomErrorsCheckSuccessMessage">
+			<![CDATA[Prova a saltare gli errori personalizzati di IIS è impostato a '%0%' e stai usando la versione '%1%' di IIS.]]>
+		</key>
+		<key alias="trySkipIisCustomErrorsCheckErrorMessage">
+			<![CDATA[Prova a saltare gli errori personalizzati di IIS è al momento '%0%'. È raccomandato impostarlo a '%1%' per la tua versione di IIS (%2%).]]>
+		</key>
+		<key alias="trySkipIisCustomErrorsCheckRectifySuccessMessage">
+			<![CDATA[Prova a saltare gli errori personalizzati di IIS è stato correttamente impostato a '%0%'.]]>
+		</key>
+		<!-- The following keys get predefined tokens passed in that are not all the same, like above -->
+		<key alias="configurationServiceFileNotFound">Il file seguente non esiste: '%0%'.</key>
+		<key alias="configurationServiceNodeNotFound">
+			<![CDATA[Non riesco a trovare <strong>'%0%'</strong> nel file di configurazione <strong>'%1%'</strong>.]]>
+		</key>
+		<key alias="configurationServiceError">
+			<![CDATA[C'è stato un errore, controlla i log per l'errore dettagliato: %0%.]]>
+		</key>
+		<key alias="databaseSchemaValidationCheckDatabaseOk">
+			<![CDATA[Database - Lo schema del database è corretto per questa versione di Umbraco]]>
+		</key>
+		<key alias="databaseSchemaValidationCheckDatabaseErrors">
+			Sono stati trovati %0% problemi con lo schema del database
+			(Controlla i log per dettagli aggiuntivi)
+		</key>
+		<key alias="databaseSchemaValidationCheckDatabaseLogMessage">
+			Sono stati trovati alcuni errori durante la validazione
+			dello schema del database per la versione corrente di Umbraco.
+		</key>
+		<key alias="httpsCheckValidCertificate"><![CDATA[Il certificato SSL del tuo sito web è valido.]]></key>
+		<key alias="httpsCheckInvalidCertificate">Errore di validazione del certificato SSL: '%0%'</key>
+		<key alias="httpsCheckExpiredCertificate"><![CDATA[Il certificato SSL del tuo sito web è scaduto.]]></key>
+		<key alias="httpsCheckExpiringCertificate">
+			<![CDATA[Il certificato SSL del tuo sito web scadrà tra %0% giorni.]]>
+		</key>
+		<key alias="healthCheckInvalidUrl">Errore durante il ping dell'URL %0% - '%1%'</key>
+		<key alias="httpsCheckIsCurrentSchemeHttps">
+			Attualmente %0% stai visualizzando il sito web utilizzando lo schema
+			HTTPS.
+		</key>
+		<key alias="httpsCheckConfigurationRectifyNotPossible">
+			<![CDATA[L'appSetting 'Umbraco.Core.UseHttps' è impostata a 'false' nel file web.config. Quando accederai al sito web usando lo schema HTTPS, il valore dovrà essere impostato a 'true'.]]>
+		</key>
+		<key alias="httpsCheckConfigurationCheckResult">
+			<![CDATA[L'appSetting 'Umbraco.Core.UseHttps' è impostata a '%0%' nel file web.config, i tuoi cookie %1% sono contrassegnati come sicuri.]]>
+		</key>
+		<key alias="httpsCheckEnableHttpsError">
+			Non posso aggiornare l'impostazione 'Umbraco.Core.UseHttps' nel file
+			web.config. Errore: %0%
+		</key>
+		<!-- The following keys don't get tokens passed in -->
+		<key alias="httpsCheckEnableHttpsButton">Abilita HTTPS</key>
+		<key alias="httpsCheckEnableHttpsDescription">
+			Imposta il valore di umbracoSSL a true nelle appSetting del file
+			web.config.
+		</key>
+		<key alias="httpsCheckEnableHttpsSuccess">
+			<![CDATA[L'appSetting 'Umbraco.Core.UseHttps' è ora impostato a 'true' nel file web.config, i tuoi cookies sono contrassegnati come sicuri.]]>
+		</key>
+		<key alias="rectifyButton">Correggi</key>
+		<key alias="cannotRectifyShouldNotEqual">
+			Non posso correggere un controllo con un valore di confronto pari a
+			'ShouldNotEqual'.
+		</key>
+		<key alias="cannotRectifyShouldEqualWithValue">
+			Non posso correggere un controllo con un valore di confronto pari a
+			'ShouldEqual' con un valore fornito.
+		</key>
+		<key alias="valueToRectifyNotProvided"><![CDATA[Il valore per correggere il controllo non è presente.]]></key>
+		<key alias="compilationDebugCheckSuccessMessage"><![CDATA[La modalità di compilazione debug è disabilitata.]]></key>
+		<key alias="compilationDebugCheckErrorMessage">
+			<![CDATA[La modalità di compilazione debug è attualmente abilitata. Si consiglia di disabilitare questa impostazione prima di andare live.]]>
+		</key>
+		<key alias="compilationDebugCheckRectifySuccessMessage">
+			<![CDATA[La modalità di compilazione debug è stata disabilitata con successo.]]>
+		</key>
+		<key alias="traceModeCheckSuccessMessage"><![CDATA[La modalità traccia è disabilitata.]]></key>
+		<key alias="traceModeCheckErrorMessage">
+			<![CDATA[La modalità traccia è abilitata. Si consiglia di disabilitare questa impostazione prima di andare live.]]>
+		</key>
+		<key alias="traceModeCheckRectifySuccessMessage">
+			<![CDATA[La modalità traccia è stata disabilitata con successo.]]>
+		</key>
+		<key alias="folderPermissionsCheckMessage">Tutte le cartelle hanno i permessi corretti impostati.</key>
+		<!-- The following keys get these tokens passed in:
+  0: Comma delimitted list of failed folder paths
+-->
+		<key alias="requiredFolderPermissionFailed">
+			<![CDATA[Le cartelle seguenti devono essere impostate con i permessi di modifica: <strong>%0%</strong>.]]>
+		</key>
+		<key alias="optionalFolderPermissionFailed">
+			<![CDATA[Le cartelle seguenti devono essere impostate con i permessi di modifica per alcune funzionalità di Umbraco: <strong>%0%</strong>. Se non vengono scritte non è necessario intraprendere alcuna azione.]]>
+		</key>
+		<key alias="filePermissionsCheckMessage">Tutti i file hanno i permessi corretti impostati.</key>
+		<!-- The following keys get these tokens passed in:
+  0: Comma delimitted list of failed folder paths
+-->
+		<key alias="requiredFilePermissionFailed">
+			<![CDATA[I files seguenti devono essere impostati con i permessi di modifica: <strong>%0%</strong>.]]>
+		</key>
+		<key alias="optionalFilePermissionFailed">
+			<![CDATA[I files seguenti devono essere impostati con i permessi di modifica per alcune funzionalità di Umbraco: <strong>%0%</strong>. Se non vengono scritti non è necessario intraprendere alcuna azione.]]>
+		</key>
+		<key alias="clickJackingCheckHeaderFound">
+			<![CDATA[L'header o meta-tag <strong>X-Frame-Options</strong> usato per controllare se un sito può essere inserito in un IFRAME da un altro è stato trovato.]]>
+		</key>
+		<key alias="clickJackingCheckHeaderNotFound">
+			<![CDATA[L'header o meta-tag <strong>X-Frame-Options</strong> usato per controllare se un sito può essere inserito in un IFRAME da un altro non è stato trovato.]]>
+		</key>
+		<key alias="setHeaderInConfig">Imposta l'header nella configurazione</key>
+		<key alias="clickJackingSetHeaderInConfigDescription">
+			Aggiunge un valore alla sezione httpProtocol/customHeaders del
+			file web.config per prevenire che un sito possa essere inserito in un IFRAME da altri siti web.
+		</key>
+		<key alias="clickJackingSetHeaderInConfigSuccess">
+			<![CDATA[L'impostazione per creare un header per prevenire l'inserimento del sito in altri siti tramite IFRAME è stata aggiunta al file web.config.]]>
+		</key>
+		<key alias="setHeaderInConfigError">Non posso aggiornare il file web.config. Errore: %0%</key>
+		<key alias="noSniffCheckHeaderFound">
+			<![CDATA[L'header o meta-tag <strong>X-Content-Type-Options</strong> usato per proteggere dalle vulnerabilità per MIME sniffing è stato trovato.]]>
+		</key>
+		<key alias="noSniffCheckHeaderNotFound">
+			<![CDATA[L'header o meta-tag <strong>X-Content-Type-Options</strong> usato per proteggere dalle vulnerabilità per MIME sniffing è stato trovato.]]>
+		</key>
+		<key alias="noSniffSetHeaderInConfigDescription">
+			<![CDATA[Aggiunge un valore alla sezione httpProtocol/customHeaders del file web.config per proteggere dalle vulnerabilità per MIME sniffing.]]>
+		</key>
+		<key alias="noSniffSetHeaderInConfigSuccess">
+			<![CDATA[L'impostazione per creare un header per proteggere dalle vulnerabilità per MIME sniffing è stata aggiunta al file web.config.]]>
+		</key>
+		<key alias="hSTSCheckHeaderFound">
+			<![CDATA[L'header <strong>Strict-Transport-Security</strong>, conosciuto anche come l'header HSTS, è stato trovato.]]>
+		</key>
+		<key alias="hSTSCheckHeaderNotFound">
+			<![CDATA[L'header <strong>Strict-Transport-Security</strong> non è stato trovato.]]>
+		</key>
+		<key alias="hSTSSetHeaderInConfigDescription">
+			Aggiunge l'header 'Strict-Transport-Security' con il valore
+			'max-age=10886400' alla sezione httpProtocol/customHeaders del file web.config. Usa questa correzione solo se
+			avrai i tuoi domini in esecuzione con https per le prossime 18 settimane (minimo).
+		</key>
+		<key alias="hSTSSetHeaderInConfigSuccess"><![CDATA[L'header HSTS è stato aggiunto al file web.config.]]></key>
+		<key alias="xssProtectionCheckHeaderFound">
+			<![CDATA[L'header <strong>X-XSS-Protection</strong> è stato trovato.]]>
+		</key>
+		<key alias="xssProtectionCheckHeaderNotFound">
+			<![CDATA[L'header <strong>X-XSS-Protection</strong> non è stato trovato.]]>
+		</key>
+		<key alias="xssProtectionSetHeaderInConfigDescription">
+			Aggiunge l'header 'X-XSS-Protection' con il valore '1;
+			mode=block' alla sezione httpProtocol/customHeaders del file web.config.
+		</key>
+		<key alias="xssProtectionSetHeaderInConfigSuccess">
+			<![CDATA[L'header X-XSS-Protection è stato aggiunto al file web.config.]]>
+		</key>
+		<!-- The following key get these tokens passed in:
+  0: Comma delimitted list of headers found
+-->
+		<key alias="excessiveHeadersFound">
+			<![CDATA[Gli header seguenti, contenenti informazioni riguardo la tecnologia utilizzata per il sito sono stati trovati: <strong>%0%</strong>.]]>
+		</key>
+		<key alias="excessiveHeadersNotFound">
+			Non sono stati trovati header che rivelano informazioni riguardo alla
+			tecnologia utilizzata per il sito.
+		</key>
+		<key alias="smtpMailSettingsNotFound">
+			<![CDATA[Nel file web.config, system.net/mailsettings non è stato trovato.]]>
+		</key>
+		<key alias="smtpMailSettingsHostNotConfigured">
+			<![CDATA[Nel file web.config, nella sezione system.net/mailsettings, l'host non è stato configurato.]]>
+		</key>
+		<key alias="smtpMailSettingsConnectionSuccess">
+			Le impostazioni SMTP sono state inserite correttamente e il servizio
+			funziona come previsto.
+		</key>
+		<key alias="smtpMailSettingsConnectionFail">
+			<![CDATA[Il server SMTP configurato con l'host '%0%' e la porta '%1%' non può essere raggunto. Per favore controlla che le impostazioni SMTP nel file web.config (sezione system.net/mailsettings) siano corrette.]]>
+		</key>
+		<key alias="notificationEmailsCheckSuccessMessage">
+			<![CDATA[L'email di notifica è stata impostata a <strong>%0%</strong>.]]>
+		</key>
+		<key alias="notificationEmailsCheckErrorMessage">
+			<![CDATA[L'email di notifica è ancora impostata al valore predefinito di <strong>%0%</strong>.]]>
+		</key>
+		<key alias="scheduledHealthCheckEmailBody">
+			<![CDATA[<html><body><p>I risultati dell'Health Check programmato di Umbraco del %0% alle %1% è il seguente:</p>%2%</body></html>]]>
+		</key>
+		<key alias="scheduledHealthCheckEmailSubject">Stato dell'Health Check di Umbraco: %0%</key>
+		<key alias="checkAllGroups">Controlla tutti i gruppi</key>
+		<key alias="checkGroup">Controlla gruppo</key>
+		<key alias="helpText">
+			<![CDATA[
+        <p>L'health checker valuta varie aree del tuo sito per le impostazioni delle migliori pratiche, la configurazione, i potenziali problemi, ecc. Puoi facilmente risolvere i problemi premendo un pulsante.
+        Puoi aggiungere i tuoi health check personalizzati, guarda sulla <a href="https://docs.umbraco.com/umbraco-cms/extending/health-check" target="_blank" rel="noopener" class="btn-link -underline">documentazione per più informazioni</a> riguardo i custom health checks.</p>
+        ]]>
+		</key>
+	</area>
+	<area alias="redirectUrls">
+		<key alias="disableUrlTracker">Disabilita tracciamento degli URL</key>
+		<key alias="enableUrlTracker">Abilita tracciamento degli URL</key>
+		<key alias="culture">Cultura</key>
+		<key alias="originalUrl">URL originale</key>
+		<key alias="redirectedTo">Reindirizzato a</key>
+		<key alias="redirectUrlManagement">Gestione Redirect URL</key>
+		<key alias="panelInformation">I seguenti URL reindirizzano a questo contenuto:</key>
+		<key alias="noRedirects"><![CDATA[Nessun reindirizzamento è stato effettuato]]></key>
+		<key alias="noRedirectsDescription">
+			<![CDATA[Quando una pagina pubblicata viene rinominata o spostata, verrà automaticamente effettuato un reindirizzamento alla nuova pagina.]]>
+		</key>
+		<key alias="confirmRemove">Sei sicuro di voler eliminare il reindirizzamento da '%0%' a '%1%'?</key>
+		<key alias="redirectRemoved">Reindirizzamento URL rimosso.</key>
+		<key alias="redirectRemoveError">Errore durante la rimozione del reindirizzamento URL.</key>
+		<key alias="redirectRemoveWarning"><![CDATA[Questo rimuoverà il reindirizzamento]]></key>
+		<key alias="confirmDisable">Sei sicuro di voler disabilitare il tracciamento degli URL?</key>
+		<key alias="disabledConfirm"><![CDATA[Il tracciamento degli URL è stato disabilitato.]]></key>
+		<key alias="disableError">
+			<![CDATA[Si è verificato un errore disabilitando il tracciamento degli URL. Più informazioni sono disponibili nei file di log.]]>
+		</key>
+		<key alias="enabledConfirm"><![CDATA[Il tracciamento degli URL è stato abilitato.]]></key>
+		<key alias="enableError">
+			<![CDATA[Si è verificato un errore abilitando il tracciamento degli URL. Più informazioni sono disponibili nei file di log.]]>
+		</key>
+	</area>
+	<area alias="emptyStates">
+		<key alias="emptyDictionaryTree">Nessun elemento del dizionario tra cui scegliere</key>
+	</area>
+	<area alias="textbox">
+		<key alias="characters_left"><![CDATA[<strong>%0%</strong> caratteri rimasti.]]></key>
+		<key alias="characters_exceed"><![CDATA[Massimo %0% caratteri, <strong>%1%</strong> di troppo.]]></key>
+	</area>
+	<area alias="recycleBin">
+		<key alias="contentTrashed">
+			Contenuto cestinato con Id: {0} relativo al contenuto principale originale con Id: {1}
+		</key>
+		<key alias="mediaTrashed">Media cestinato con Id: {0} relativo al media principale originale con Id: {1}</key>
+		<key alias="itemCannotBeRestored">Impossibile ripristinare automaticamente questo elemento</key>
+		<key alias="itemCannotBeRestoredHelpText">
+			Non esiste una posizione in cui questo elemento possa essere ripristinato
+			automaticamente. Puoi spostare l'elemento manualmente utilizzando l'albero sottostante.
+		</key>
+		<key alias="wasRestored"><![CDATA[è stato ripristinato sotto]]></key>
+	</area>
+	<area alias="relationType">
+		<key alias="direction">Direzione</key>
+		<key alias="parentToChild">Da genitore a figlio</key>
+		<key alias="bidirectional">Bidirezionale</key>
+		<key alias="parent">Genitore</key>
+		<key alias="child">Figlio</key>
+		<key alias="count">Numero</key>
+		<key alias="relations">Relazioni</key>
+		<key alias="created">Creato</key>
+		<key alias="comment">Commento</key>
+		<key alias="name">Nome</key>
+		<key alias="noRelations">Nessuna relazione per questo tipo di relazione</key>
+		<key alias="tabRelationType">Tipo di relazione</key>
+		<key alias="tabRelations">Relazioni</key>
+	</area>
+	<area alias="dashboardTabs">
+		<key alias="contentIntro">Guida introduttiva</key>
+		<key alias="contentRedirectManager">Gestione Redirect URL</key>
+		<key alias="mediaFolderBrowser">Contenuto</key>
+		<key alias="settingsWelcome">Benvenuto</key>
+		<key alias="settingsExamine">Gestione Examine</key>
+		<key alias="settingsPublishedStatus">Stato di pubblicazione</key>
+		<key alias="settingsModelsBuilder">Models Builder</key>
+		<key alias="settingsHealthCheck">Health Check</key>
+		<key alias="settingsProfiler">Profilazione</key>
+		<key alias="memberIntro">Guida introduttiva</key>
+		<key alias="formsInstall">Installa Umbraco Forms</key>
+	</area>
+	<area alias="visuallyHiddenTexts">
+		<key alias="goBack">Indietro</key>
+		<key alias="activeListLayout">Layout attivo:</key>
+		<key alias="jumpTo">Vai a</key>
+		<key alias="group">gruppo</key>
+		<key alias="passed">passato</key>
+		<key alias="warning">attenzone</key>
+		<key alias="failed">fallito</key>
+		<key alias="suggestion">suggerimento</key>
+		<key alias="checkPassed">Check passato</key>
+		<key alias="checkFailed">Check fallito</key>
+		<key alias="openBackofficeSearch">Apri la ricerca nel backoffice</key>
+		<key alias="openCloseBackofficeHelp">Apri/chiudi l'aiuto del backoffice</key>
+		<key alias="openCloseBackofficeProfileOptions">Apri/chiudi le opzioni del tuo profilo</key>
+		<key alias="assignDomainDescription">Imposta le Culture e gli Hostnames per %0%</key>
+		<key alias="createDescription">Crea nuovo nodo sotto %0%</key>
+		<key alias="protectDescription">Imposta le restrizioni di accesso per %0%</key>
+		<key alias="rightsDescription">Imposta i permessi per %0%</key>
+		<key alias="sortDescription">Modifica l'ordinamento per %0%</key>
+		<key alias="createblueprintDescription">Crea un modello di contenuto basato su %0%</key>
+		<key alias="openContextMenu">Apri il menu contestuale per</key>
+		<key alias="currentLanguage">Lingua corrente</key>
+		<key alias="switchLanguage">Cambia lingua in</key>
+		<key alias="createNewFolder">Crea nuova cartella</key>
+		<key alias="newPartialView">Partial View</key>
+		<key alias="newPartialViewMacro">Partial View Macro</key>
+		<key alias="newMember">Membro</key>
+		<key alias="newDataType">Tipo di dato</key>
+		<key alias="redirectDashboardSearchLabel">Cerca nella dashboard di reindirizzamento</key>
+		<key alias="userGroupSearchLabel">Cerca nella sezione dei gruppi di utenti</key>
+		<key alias="userSearchLabel">Cerca tra gli utenti</key>
+		<key alias="createItem">Crea oggetto</key>
+		<key alias="create">Crea</key>
+		<key alias="edit">Modifica</key>
+		<key alias="name">Nome</key>
+		<key alias="addNewRow">Aggiungi nuova riga</key>
+		<key alias="tabExpand"><![CDATA[Vedi più opzioni]]></key>
+		<key alias="searchOverlayTitle">Cerca nel backoffice di Umbraco</key>
+		<key alias="searchOverlayDescription">Cerca contenuti, media, ecc. nel backoffice.</key>
+		<key alias="searchInputDescription">
+			<![CDATA[Quando sono disponibili dei risultati dal completamento automatico, premere le frecce su e giù oppure utilizzare il tasto TAB e utilizzare il tasto Invio per selezionare.]]>
+		</key>
+		<key alias="path">Percorso:</key>
+		<key alias="foundIn">Trovato in</key>
+		<key alias="hasTranslation">Ha una traduzione</key>
+		<key alias="noTranslation">Traduzione mancante</key>
+		<key alias="dictionaryListCaption">Voci del dizionario</key>
+		<key alias="contextMenuDescription">Seleziona una delle opzioni per modificare il nodo.</key>
+		<key alias="contextDialogDescription">Esegui l'azione %0% sul nodo %1%</key>
+		<key alias="addImageCaption">Aggiungi una descrizione per l'immagine</key>
+		<key alias="searchContentTree">Cerca nell'albero dei contenuti</key>
+		<key alias="maxAmount">Numero massimo</key>
+	</area>
+	<area alias="references">
+		<key alias="tabName">Riferimenti</key>
+		<key alias="DataTypeNoReferences">Questo tipo di dato non ha riferimenti.</key>
+		<key alias="labelUsedByDocumentTypes">Usato nei tipi di documento</key>
+		<key alias="noDocumentTypes">Non ci sono riferimenti a tipi di documento.</key>
+		<key alias="labelUsedByMediaTypes">Usato nei tipi di media</key>
+		<key alias="noMediaTypes">Non ci sono riferimenti a tipi di media.</key>
+		<key alias="labelUsedByMemberTypes">Usato nei tipi di membro</key>
+		<key alias="noMemberTypes">Non ci sono riferimenti a tipi di membro.</key>
+		<key alias="usedByProperties">Usato da</key>
+		<key alias="labelUsedByItems">Correlato ai seguenti elementi</key>
+		<key alias="labelUsedByDocuments">Usato nei documenti</key>
+		<key alias="labelUsedByMembers">Usato nei membri</key>
+		<key alias="labelUsedByMedia">Usato nei media</key>
+	</area>
+	<area alias="logViewer">
+		<key alias="deleteSavedSearch">Elimina ricerca salvata</key>
+		<key alias="logLevels">Livelli di log</key>
+		<key alias="selectAllLogLevelFilters">Seleziona tutto</key>
+		<key alias="deselectAllLogLevelFilters">Deselezionare tutto</key>
+		<key alias="savedSearches">Ricerche salvate</key>
+		<key alias="saveSearch">Salva ricerca</key>
+		<key alias="saveSearchDescription">Inserisci un nome descrittivo per la tua query di ricerca</key>
+		<key alias="filterSearch">Filtra la ricerca</key>
+		<key alias="totalItems">Risultati totali</key>
+		<key alias="timestamp">Timestamp</key>
+		<key alias="level">Livello</key>
+		<key alias="machine">Macchina</key>
+		<key alias="message">Messaggio</key>
+		<key alias="exception">Exception</key>
+		<key alias="properties"><![CDATA[Proprietà]]></key>
+		<key alias="searchWithGoogle">Ricerca con Google</key>
+		<key alias="searchThisMessageWithGoogle">Ricerca questo messaggio con Google</key>
+		<key alias="searchWithBing">Ricerca con Bing</key>
+		<key alias="searchThisMessageWithBing">Ricerca questo messaggio con Bing</key>
+		<key alias="searchOurUmbraco">Ricerca su Our Umbraco</key>
+		<key alias="searchThisMessageOnOurUmbracoForumsAndDocs">
+			Ricerca questo messaggio sui forum e le documentazioni di
+			Our Umbraco
+		</key>
+		<key alias="searchOurUmbracoWithGoogle">Ricerca su Our Umbraco con Google</key>
+		<key alias="searchOurUmbracoForumsUsingGoogle">Ricerca sui forum di Our Umbraco con Google</key>
+		<key alias="searchUmbracoSource">Ricerca nel codice sorgente di Umbraco</key>
+		<key alias="searchWithinUmbracoSourceCodeOnGithub">Ricerca nel codice sorgente di Umbraco su GitHub</key>
+		<key alias="searchUmbracoIssues">Ricerca tra i problemi di Umbraco</key>
+		<key alias="searchUmbracoIssuesOnGithub">Ricerca tra i problemi di Umbraco su GitHub</key>
+		<key alias="deleteThisSearch">Elimina questa ricerca</key>
+		<key alias="findLogsWithRequestId">Trova log con Request ID</key>
+		<key alias="findLogsWithNamespace">Trova log con Namespace</key>
+		<key alias="findLogsWithMachineName">Trova log con Machine Name</key>
+		<key alias="open">Apri</key>
+		<key alias="polling">Polling</key>
+		<key alias="every2">Ogni 2 secondi</key>
+		<key alias="every5">Ogni 5 secondi</key>
+		<key alias="every10">Ogni 10 secondi</key>
+		<key alias="every20">Ogni 20 secondi</key>
+		<key alias="every30">Ogni 30 secondi</key>
+		<key alias="pollingEvery2">Polling ogni 2s</key>
+		<key alias="pollingEvery5">Polling ogni 5s</key>
+		<key alias="pollingEvery10">Polling ogni 10s</key>
+		<key alias="pollingEvery20">Polling ogni 20s</key>
+		<key alias="pollingEvery30">Polling ogni 30s</key>
+	</area>
+	<area alias="clipboard">
+		<key alias="labelForCopyAllEntries">Copia %0%</key>
+		<key alias="labelForArrayOfItemsFrom">%0% da %1%</key>
+		<key alias="labelForArrayOfItems">Lista di %0%</key>
+		<key alias="labelForRemoveAllEntries">Rimuovi tutti gli oggetti</key>
+		<key alias="labelForClearClipboard">Svuota appunti</key>
+	</area>
+	<area alias="propertyActions">
+		<key alias="tooltipForPropertyActionsMenu"><![CDATA[Apri le azioni per le proprietà]]></key>
+		<key alias="tooltipForPropertyActionsMenuClose"><![CDATA[Chiudi le azioni per le proprietà]]></key>
+	</area>
+	<area alias="nuCache">
+		<key alias="wait">Attendi</key>
+		<key alias="refreshStatus">Aggiorna stato</key>
+		<key alias="memoryCache">Memory Cache</key>
+		<key alias="memoryCacheDescription">
+			<![CDATA[
+            Questo pulsante di consente di ricaricare la Memory Cache, ricaricandola completamente dalla cache
+    del database (ma non ricostruisce la cache del database). Questo è relativamente veloce.
+    Usalo quando pensi che la Memory Cache non sia stata aggiornata correttamente, dopo che si sono verificati
+    alcuni eventi che indicherebbero un problema minore di Umbraco.
+    (nota: ricarica la Memory Cache su tutti i server in un Load Balanced environment).
+    ]]>
+		</key>
+		<key alias="reload">Ricarica</key>
+		<key alias="databaseCache">Cache del Database</key>
+		<key alias="databaseCacheDescription">
+			<![CDATA[
+    Questo pulsante ti consente di ricostruire la cache del database, ad esempio le tabelle cmsContentNu.
+    <strong>La ricostruzione può metterci del tempo.</strong>
+    Usalo quando la ricarica della Memory Cache non è sufficiente e pensi che la cache del database non sia
+    stata generata correttamente, che indicherebbe un problema critico di Umbraco.
+    ]]>
+		</key>
+		<key alias="rebuild">Ricostruisci</key>
+		<key alias="internals">Interni</key>
+		<key alias="internalsDescription">
+			<![CDATA[
+    Questo pulsante consente di attivare una raccolta di snapshot NuCache (dopo aver eseguito un GC fullCLR).
+    A meno che tu non sappia cosa significa, probabilmente <em>non</em> hai bisogno di usarlo.
+    ]]>
+		</key>
+		<key alias="collect">Raccogli</key>
+		<key alias="publishedCacheStatus">Stato della Published Cache</key>
+		<key alias="caches">Caches</key>
+	</area>
+	<area alias="profiling">
+		<key alias="performanceProfiling">Profilazione delle performance</key>
+		<key alias="performanceProfilingDescription">
+			<![CDATA[
+                <p>
+                    Umbraco attualmente funziona in modalità debug. Ciò significa che puoi utilizzare il profiler delle prestazioni integrato per valutare le prestazioni durante il rendering delle pagine.
+                </p>
+                <p>
+                    Se vuoi attivare il profiler per il rendering di una pagina specifica, aggiungi semplicemente <strong>umbDebug=true</strong> alla querystring quando richiedi la pagina.
+                </p>
+                <p>
+                    Se vuoi che il profiler sia attivato per impostazione predefinita per tutti i rendering di pagina, puoi utilizzare l'interruttore qui sotto.
+                    Verrà impostato un cookie nel tuo browser, che quindi attiverà automaticamente il profiler.
+                    In altre parole, il profiler sarà attivo per impostazione predefinita solo nel <em>tuo</em> browser, non in quello di tutti gli altri.
+                </p>
+        ]]>
+		</key>
+		<key alias="activateByDefault">Attiva la profilazione per impostazione predefinita</key>
+		<key alias="reminder">Promemoria</key>
+		<key alias="reminderDescription">
+			<![CDATA[
+            <p>
+                Non dovresti mai lasciare che un sito di produzione venga eseguito in modalità debug. La modalità di debug viene disattivata impostando <strong>debug="false"</strong> nell'elemento <strong>&lt;compilation /&gt;</strong> nel file web.config.
+            </p>
+        ]]>
+		</key>
+		<key alias="profilerEnabledDescription">
+			<![CDATA[
+            <p>
+                Umbraco attualmente non viene eseguito in modalità debug, quindi non è possibile utilizzare il profiler integrato. Questo è come dovrebbe essere per un sito produttivo.
+            </p>
+            <p>
+                La modalità di debug viene attivata impostando <strong>debug="true"</strong> nell'elemento <strong>&lt;compilation /&gt;</strong> in web.config.
+            </p>
+        ]]>
+		</key>
+	</area>
+	<area alias="settingsDashboardVideos">
+		<key alias="trainingHeadline">Ore di videoallenamenti su Umbraco sono a solo un click da te</key>
+		<key alias="trainingDescription">
+			<![CDATA[
+        <p>Vuoi padroneggiare Umbraco? Dedica un paio di minuti all'apprendimento di alcune best practice guardando uno di questi video sull'utilizzo di Umbraco. Visita <a href="https://umbraco.tv" target="_blank" rel="noopener">umbraco.tv</a> per altri video su Umbraco</p>
+    ]]>
+		</key>
+		<key alias="getStarted">Per iniziare</key>
+	</area>
+	<area alias="settingsDashboard">
+		<key alias="start">Inizia da qui!</key>
+		<key alias="startDescription">
+			<![CDATA[Questa sezione contiene gli elementi costitutivi del tuo sito Umbraco. Segui i collegamenti sottostanti per saperne di più su come lavorare con gli elementi nella sezione Impostazioni]]>
+		</key>
+		<key alias="more"><![CDATA[Scopri di più]]></key>
+		<key alias="bulletPointOne">
+			<![CDATA[
+            Maggiori informazioni su come lavorare con gli elementi in Impostazioni <a class="btn-link -underline" href="https://docs.umbraco.com/umbraco-cms/fundamentals/backoffice/sections/" target="_blank" rel="noopener">nella documentazione</a> di Our Umbraco
+        ]]>
+		</key>
+		<key alias="bulletPointTwo">
+			<![CDATA[
+            Fai una domanda nel <a class="btn-link -underline" href="https://our.umbraco.com/forum" target="_blank" rel="noopener">Community Forum</a>
+        ]]>
+		</key>
+		<key alias="bulletPointThree">
+			<![CDATA[
+            Guarda i nostri <a class="btn-link -underline" href="https://umbraco.tv" target="_blank" rel="noopener">video tutorial</a> (alcuni sono gratuiti, altri richiedono un abbonamento)
+        ]]>
+		</key>
+		<key alias="bulletPointFour">
+			<![CDATA[
+            Scopri di più sui nostri <a class="btn-link -underline" href="https://umbraco.com/products/" target="_blank" rel="noopener">strumenti per aumentare la produttività e il supporto commerciale</a>
+        ]]>
+		</key>
+		<key alias="bulletPointFive">
+			<![CDATA[
+            Scopri di più sulle opportunità di <a class="btn-link -underline" href="https://umbraco.com/training/" target="_blank" rel="noopener">certificazione</a>
+        ]]>
+		</key>
+	</area>
+	<area alias="startupDashboard">
+		<key alias="fallbackHeadline">Benvenuto nell'amichevole CMS</key>
+		<key alias="fallbackDescription">
+			<![CDATA[Grazie per aver scelto Umbraco! Pensiamo che questo possa essere l'inizio di qualcosa di fantastico. Sebbene all'inizio possa sembrare travolgente, abbiamo fatto molto per rendere la curva di apprendimento il più fluida e veloce possibile.]]>
+		</key>
+	</area>
+	<area alias="formsDashboard">
+		<key alias="formsHeadline">Umbraco Forms</key>
+		<key alias="formsDescription">
+			Crea moduli utilizzando un'interfaccia drag and drop intuitiva. Da semplici moduli di
+			contatto che inviano e-mail a questionari avanzati che si integrano con i sistemi CRM. I tuoi clienti lo
+			adoreranno!
+		</key>
+	</area>
+	<area alias="blockEditor">
+		<key alias="headlineCreateBlock">Scegli tipo di elemento</key>
+		<key alias="headlineAddSettingsElementType">Allega un tipo di elemento delle impostazioni</key>
+		<key alias="headlineAddCustomView">Seleziona vista</key>
+		<key alias="headlineAddCustomStylesheet">Seleziona foglio di stile</key>
+		<key alias="headlineAddThumbnail">Scegli miniatura</key>
+		<key alias="labelcreateNewElementType">Crea nuovo tipo di elemento</key>
+		<key alias="labelCustomStylesheet">Foglio di stile personalizzato</key>
+		<key alias="addCustomStylesheet">Aggiungi foglio di stile</key>
+		<key alias="headlineEditorAppearance">Aspetto dell'editor</key>
+		<key alias="headlineDataModels">Modelli di dati</key>
+		<key alias="headlineCatalogueAppearance">Aspetto del catalogo</key>
+		<key alias="labelBackgroundColor">Colore di sfondo</key>
+		<key alias="labelIconColor">Colore dell'icona</key>
+		<key alias="labelContentElementType">Modello del contenuto</key>
+		<key alias="labelLabelTemplate">Etichetta</key>
+		<key alias="labelCustomView">Vista personalizzata</key>
+		<key alias="labelCustomViewInfoTitle">Mostra la descrizione della vista personalizzata</key>
+		<key alias="labelCustomViewDescription">
+			<![CDATA[Sovrascrivi come questo blocco apparirà nell'UI del backoffice. Seleziona un file .html contenente la tua versione.]]>
+		</key>
+		<key alias="labelSettingsElementType">Modello di impostazioni</key>
+		<key alias="labelEditorSize">Dimensione dell'editor di sovrapposizione</key>
+		<key alias="addCustomView">Aggiungi vista personalizzata</key>
+		<key alias="addSettingsElementType">Aggiungi impostazioni</key>
+		<key alias="labelTemplatePlaceholder">Sovrascrivi modello di etichetta</key>
+		<key alias="confirmDeleteBlockMessage">
+			<![CDATA[Sei sicuro di voler eliminare il contenuto <strong>%0%</strong>?]]>
+		</key>
+		<key alias="confirmDeleteBlockTypeMessage">
+			<![CDATA[Sei sicuro di voler eliminare la configurazione del blocco <strong>%0%</strong>?]]>
+		</key>
+		<key alias="confirmDeleteBlockTypeNotice">
+			<![CDATA[Il contenuto di questo blocco sarà comunque presente, ma la modifica non sarà più possibile e sarà visualizzato come contenuto non supportato.]]>
+		</key>
+		<key alias="blockConfigurationOverlayTitle"><![CDATA[Configurazione di '%0%']]></key>
+		<key alias="thumbnail">Miniatura</key>
+		<key alias="addThumbnail">Aggiungi miniatura</key>
+		<key alias="tabCreateEmpty">Crea vuota</key>
+		<key alias="tabClipboard">Appunti</key>
+		<key alias="tabBlockSettings">Impostazioni</key>
+		<key alias="headlineAdvanced">Avanzate</key>
+		<key alias="forceHideContentEditor">Forza nascondi editor di contenuti</key>
+		<key alias="blockHasChanges">Hai fatto delle modifiche a questo contenuto. Sei sicuro di volerle scartare?</key>
+		<key alias="confirmCancelBlockCreationHeadline">Scartare la creazione?</key>
+		<key alias="confirmCancelBlockCreationMessage"><![CDATA[Sei sicuro di voler cancellare la creazione.]]></key>
+		<key alias="elementTypeDoesNotExistHeadline">Errore!</key>
+		<key alias="elementTypeDoesNotExistDescription">
+			<![CDATA[Il tipo di elemento di questo blocco non esiste più]]>
+		</key>
+		<key alias="addBlock">Aggiungi contenuto</key>
+		<key alias="addThis">Aggiungi %0%</key>
+		<key alias="propertyEditorNotSupported">
+			<![CDATA[La proprietà '%0%' usa l'editor '%1%' che non è supportato nei blocchi.]]>
+		</key>
+	</area>
+	<area alias="contentTemplatesDashboard">
+		<key alias="whatHeadline">Cosa sono i modelli di contenuto?</key>
+		<key alias="whatDescription">
+			I modelli di contenuto sono contenuti predefiniti che possono essere selezionati
+			durante la creazione di un nuovo nodo di contenuto.
+		</key>
+		<key alias="createHeadline">Come creo un modello di contenuto?</key>
+		<key alias="createDescription">
+			<![CDATA[
+            <p>Ci sono due modi per creare un modello di contenuto:</p>
+            <ul>
+                <li>Fare clic con il pulsante destro del mouse su un nodo di contenuto e selezionare "Crea modello di contenuto" per creare un nuovo modello di contenuto.</li>
+                <li>Fare clic con il pulsante destro del mouse sull'albero dei modelli di contenuto nella sezione Impostazioni e selezionare il tipo di documento per il quale si desidera creare un modello di contenuto.</li>
+            </ul>
+            <p>Una volta specificato un nome, gli editors potranno cominciare a usare il tipo di contenuto come base per la nuova pagina.</p>
+        ]]>
+		</key>
+		<key alias="manageHeadline">Come gestisco i modelli di contenuto?</key>
+		<key alias="manageDescription">
+			Puoi modificare ed eliminare i modelli di contenuto dall'albero "Modelli di
+			contenuto" nella sezione Impostazioni. Espandere il tipo di documento su cui si basa il modello di contenuto e
+			fare clic su di esso per modificarlo o eliminarlo.
+		</key>
+	</area>
+	<area alias="preview">
+		<key alias="endLabel">Chiudi</key>
+		<key alias="endTitle">Chiudi anteprima</key>
+		<key alias="openWebsiteLabel">Anteprima sito web</key>
+		<key alias="openWebsiteTitle"><![CDATA[Apri il sito in modalità anteprima]]></key>
+		<key alias="returnToPreviewHeadline">Aprire l'anteprima del sito web?</key>
+		<key alias="returnToPreviewDescription">
+			<![CDATA[Hai chiuso la modalità anteprima. Vuoi abilitarla nuovamente per visualizzare l'ultima versione salvata nel sito web?]]>
+		</key>
+		<key alias="returnToPreviewAcceptButton">Anteprima dell'ultima versione</key>
+		<key alias="returnToPreviewDeclineButton">Visualizza versione pubblicata</key>
+		<key alias="viewPublishedContentHeadline">Vuoi vedere la versione pubblicata?</key>
+		<key alias="viewPublishedContentDescription">
+			<![CDATA[Sei in modalità anteprima, vuoi uscire e vedere la versione pubblicata nel tuo sito web?]]>
+		</key>
+		<key alias="viewPublishedContentAcceptButton">Visualizza versione pubblicata</key>
+		<key alias="viewPublishedContentDeclineButton"><![CDATA[Rimani in modalità anteprima]]></key>
+	</area>
+	<area alias="treeSearch">
+		<key alias="searchResult">oggetto trovato</key>
+		<key alias="searchResults">oggetti trovati</key>
+	</area>
+</language>


### PR DESCRIPTION
Add missing backoffice languages as properties etc. are translated via translation section (e.g. with "#Backoffice Settings"). At the moment the swiss languages always need to be added via the umbraco/Config folder.
