### PR TITLE
Reintroduced a lot of extension methods as obsolete to avoid breaking change

### DIFF
--- a/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
@@ -1904,100 +1904,94 @@ public static class PublishedContentExtensions
 
     #endregion
 
-    // [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
-    // public static IPublishedContent? Ancestor(this IPublishedContent content)
-    // {
-    //     return content.Ancestor(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content));
-    // }
-
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IPublishedContent? Ancestor(this IPublishedContent content, int maxLevel)
     {
-        return content.Ancestor(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), maxLevel);
+        return content.Ancestor(GetPublishedCache(content), GetNavigationQueryService(content), maxLevel);
     }
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IPublishedContent? Ancestor(this IPublishedContent content, string contentTypeAlias)
     {
-        return content.Ancestor(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), contentTypeAlias);
+        return content.Ancestor(GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias);
     }
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static T? Ancestor<T>(this IPublishedContent content, int maxLevel)
         where T : class, IPublishedContent
     {
-        return Ancestor<T>(content, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), maxLevel);
+        return Ancestor<T>(content, GetPublishedCache(content), GetNavigationQueryService(content), maxLevel);
     }
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<IPublishedContent> Ancestors(this IPublishedContent content, int maxLevel)
     {
-        return content.Ancestors(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), maxLevel);
+        return content.Ancestors(GetPublishedCache(content), GetNavigationQueryService(content), maxLevel);
     }
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<IPublishedContent> Ancestors(this IPublishedContent content, string contentTypeAlias)
     {
-        return content.Ancestors(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), contentTypeAlias);
+        return content.Ancestors(GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias);
     }
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<T> Ancestors<T>(this IPublishedContent content)
         where T : class, IPublishedContent
     {
-        return Ancestors<T>(content, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content));
+        return Ancestors<T>(content, GetPublishedCache(content), GetNavigationQueryService(content));
     }
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<T> Ancestors<T>(this IPublishedContent content, int maxLevel)
         where T : class, IPublishedContent
     {
-        return Ancestors<T>(content, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), maxLevel);
+        return Ancestors<T>(content, GetPublishedCache(content), GetNavigationQueryService(content), maxLevel);
     }
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IPublishedContent AncestorOrSelf(this IPublishedContent content, int maxLevel)
     {
-        return AncestorOrSelf(content, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), maxLevel);
+        return AncestorOrSelf(content, GetPublishedCache(content), GetNavigationQueryService(content), maxLevel);
     }
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IPublishedContent AncestorOrSelf(this IPublishedContent content, string contentTypeAlias)
     {
-        return AncestorOrSelf(content, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), contentTypeAlias);
+        return AncestorOrSelf(content, GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias);
     }
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static T? AncestorOrSelf<T>(this IPublishedContent content, int maxLevel)
         where T : class, IPublishedContent
     {
-        return AncestorOrSelf<T>(content, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), maxLevel);
+        return AncestorOrSelf<T>(content, GetPublishedCache(content), GetNavigationQueryService(content), maxLevel);
     }
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<IPublishedContent> AncestorsOrSelf(this IPublishedContent content, int maxLevel)
     {
-        return content.AncestorsOrSelf(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), maxLevel);
+        return content.AncestorsOrSelf(GetPublishedCache(content), GetNavigationQueryService(content), maxLevel);
     }
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<IPublishedContent> AncestorsOrSelf(this IPublishedContent content, string contentTypeAlias)
     {
-        return content.Ancestors(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), contentTypeAlias);
+        return content.Ancestors(GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias);
     }
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<T> AncestorsOrSelf<T>(this IPublishedContent content, int maxLevel)
         where T : class, IPublishedContent
     {
-        return AncestorsOrSelf<T>(content, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), maxLevel);
+        return AncestorsOrSelf<T>(content, GetPublishedCache(content), GetNavigationQueryService(content), maxLevel);
     }
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<IPublishedContent> AncestorsOrSelf(this IPublishedContent content, bool orSelf,
         Func<IPublishedContent, bool>? func)
     {
-        return AncestorsOrSelf(content, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), orSelf, func);
+        return AncestorsOrSelf(content, GetPublishedCache(content), GetNavigationQueryService(content), orSelf, func);
     }
 
     [Obsolete(
@@ -2005,36 +1999,28 @@ public static class PublishedContentExtensions
     public static IEnumerable<IPublishedContent> Breadcrumbs(
         this IPublishedContent content,
         bool andSelf = true) =>
-        content.Breadcrumbs(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
-            GetNavigationQueryService(content), andSelf);
+        content.Breadcrumbs(GetPublishedCache(content), GetNavigationQueryService(content), andSelf);
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<IPublishedContent> Breadcrumbs(
         this IPublishedContent content,
         int minLevel,
         bool andSelf = true) =>
-        content.Breadcrumbs(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
-            GetNavigationQueryService(content), minLevel, andSelf);
+        content.Breadcrumbs(GetPublishedCache(content), GetNavigationQueryService(content), minLevel, andSelf);
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<IPublishedContent> Breadcrumbs<T>(
         this IPublishedContent content,
         bool andSelf = true)
         where T : class, IPublishedContent=>
-        content.Breadcrumbs<T>(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
-            GetNavigationQueryService(content), andSelf);
-
-
-
+        content.Breadcrumbs<T>(GetPublishedCache(content), GetNavigationQueryService(content), andSelf);
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<IPublishedContent> Children(
         this IPublishedContent content,
         IVariationContextAccessor? variationContextAccessor,
         string? culture = null)
-        => Children(content, variationContextAccessor,
-            StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
-            GetNavigationQueryService(content),culture);
+        => Children(content, variationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<IPublishedContent> Children(
@@ -2042,8 +2028,7 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         Func<IPublishedContent, bool> predicate,
         string? culture = null) =>
-        content.Children(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
-            GetNavigationQueryService(content), culture).Where(predicate);
+        content.Children(variationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture).Where(predicate);
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<IPublishedContent> ChildrenOfType(
@@ -2051,7 +2036,7 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         string? contentTypeAlias,
         string? culture = null) =>
-        content.Children(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        content.Children(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), x => x.ContentType.Alias.InvariantEquals(contentTypeAlias),
             culture);
 
@@ -2061,7 +2046,7 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.Children(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        content.Children(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), culture).OfType<T>();
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2074,7 +2059,7 @@ public static class PublishedContentExtensions
         IPublishedUrlProvider publishedUrlProvider,
         string contentTypeAliasFilter = "",
         string? culture = null)
-        => GenerateDataTable(content, variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        => GenerateDataTable(content, variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), contentTypeService, mediaTypeService, memberTypeService, publishedUrlProvider, contentTypeAliasFilter, culture);
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2083,7 +2068,7 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         string docTypeAlias,
         string? culture = null) => parentNodes.SelectMany(x =>
-        x.DescendantsOrSelfOfType(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        x.DescendantsOrSelfOfType(variationContextAccessor, GetPublishedCache(parentNodes.First()),
             GetNavigationQueryService(parentNodes.First()), docTypeAlias, culture));
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2092,7 +2077,7 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         string? culture = null)
         where T : class, IPublishedContent =>
-        parentNodes.SelectMany(x => x.DescendantsOrSelf<T>(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        parentNodes.SelectMany(x => x.DescendantsOrSelf<T>(variationContextAccessor, GetPublishedCache(parentNodes.First()),
             GetNavigationQueryService(parentNodes.First()), culture));
 
 
@@ -2101,7 +2086,7 @@ public static class PublishedContentExtensions
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         string? culture = null) =>
-        content.DescendantsOrSelf(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), false, null, culture);
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2110,7 +2095,7 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         int level,
         string? culture = null) =>
-        content.DescendantsOrSelf(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), false, p => p.Level >= level, culture);
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2118,7 +2103,7 @@ public static class PublishedContentExtensions
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         string contentTypeAlias, string? culture = null) =>
-        content.DescendantsOrSelf(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), false, p => p.ContentType.Alias.InvariantEquals(contentTypeAlias), culture);
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2127,7 +2112,7 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.Descendants(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        content.Descendants(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), culture).OfType<T>();
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2137,7 +2122,7 @@ public static class PublishedContentExtensions
         int level,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.Descendants(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        content.Descendants(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), level, culture).OfType<T>();
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2145,7 +2130,7 @@ public static class PublishedContentExtensions
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         string? culture = null) =>
-        content.DescendantsOrSelf(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), true, null, culture);
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2154,7 +2139,7 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         int level,
         string? culture = null) =>
-        content.DescendantsOrSelf(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), true, p => p.Level >= level, culture);
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2163,7 +2148,7 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         string contentTypeAlias,
         string? culture = null) =>
-        content.DescendantsOrSelf(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), true, p => p.ContentType.Alias.InvariantEquals(contentTypeAlias), culture);
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2172,7 +2157,7 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.DescendantsOrSelf(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), culture).OfType<T>();
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2182,7 +2167,7 @@ public static class PublishedContentExtensions
         int level,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.DescendantsOrSelf(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), level, culture).OfType<T>();
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2190,7 +2175,7 @@ public static class PublishedContentExtensions
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         string? culture = null) =>
-        content.Children(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        content.Children(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), culture)?.FirstOrDefault();
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2199,7 +2184,7 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         int level,
         string? culture = null) => content
-        .EnumerateDescendants(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        .EnumerateDescendants(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), false, culture).FirstOrDefault(x => x.Level == level);
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2208,7 +2193,7 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         string contentTypeAlias,
         string? culture = null) => content
-        .EnumerateDescendants(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        .EnumerateDescendants(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), false, culture)
         .FirstOrDefault(x => x.ContentType.Alias.InvariantEquals(contentTypeAlias));
 
@@ -2218,7 +2203,7 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.EnumerateDescendants(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        content.EnumerateDescendants(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), false, culture).FirstOrDefault(x => x is T) as T;
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2228,7 +2213,7 @@ public static class PublishedContentExtensions
         int level,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.Descendant(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        content.Descendant(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), level, culture) as T;
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2237,7 +2222,7 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         int level,
         string? culture = null) => content
-        .EnumerateDescendants(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        .EnumerateDescendants(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), true, culture).FirstOrDefault(x => x.Level == level);
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2246,7 +2231,7 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         string contentTypeAlias,
         string? culture = null) => content
-        .EnumerateDescendants(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        .EnumerateDescendants(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), true, culture)
         .FirstOrDefault(x => x.ContentType.Alias.InvariantEquals(contentTypeAlias));
 
@@ -2256,7 +2241,7 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.EnumerateDescendants(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        content.EnumerateDescendants(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), true, culture).FirstOrDefault(x => x is T) as T;
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2266,7 +2251,7 @@ public static class PublishedContentExtensions
         int level,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.DescendantOrSelf(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        content.DescendantOrSelf(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), level, culture) as T;
 
 
@@ -2275,7 +2260,7 @@ public static class PublishedContentExtensions
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         string? culture = null) =>
-        content.Children(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        content.Children(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), culture)?.FirstOrDefault();
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2284,7 +2269,7 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         string contentTypeAlias,
         string? culture = null) =>
-        content.ChildrenOfType(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        content.ChildrenOfType(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), contentTypeAlias, culture)?.FirstOrDefault();
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2293,7 +2278,7 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         Func<IPublishedContent, bool> predicate,
         string? culture = null)
-        => content.Children(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        => content.Children(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), predicate, culture)?.FirstOrDefault();
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2302,7 +2287,7 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         Guid uniqueId,
         string? culture = null) => content
-        .Children(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        .Children(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), x => x.Key == uniqueId, culture)?.FirstOrDefault();
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2311,7 +2296,7 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.Children<T>(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        content.Children<T>(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), culture)?.FirstOrDefault();
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2321,7 +2306,7 @@ public static class PublishedContentExtensions
         Func<T, bool> predicate,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.Children<T>(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        content.Children<T>(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), culture)?.FirstOrDefault(predicate);
 
     [Obsolete(
@@ -2330,8 +2315,7 @@ public static class PublishedContentExtensions
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         string? culture = null) =>
-        Siblings(content, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
-            GetNavigationQueryService(content), variationContextAccessor, culture);
+        Siblings(content, GetPublishedCache(content), GetNavigationQueryService(content), variationContextAccessor, culture);
 
     [Obsolete(
         "Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2341,8 +2325,7 @@ public static class PublishedContentExtensions
         string contentTypeAlias,
         string? culture = null) =>
         SiblingsOfType(content, variationContextAccessor,
-            StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
-            GetNavigationQueryService(content), contentTypeAlias, culture);
+            GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias, culture);
 
     [Obsolete(
         "Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2351,18 +2334,14 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         string? culture = null)
         where T : class, IPublishedContent =>
-        Siblings<T>(content, variationContextAccessor,
-            StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
-            GetNavigationQueryService(content), culture);
+        Siblings<T>(content, variationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
 
     [Obsolete(
         "Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<IPublishedContent>? SiblingsAndSelf(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
-        string? culture = null) => SiblingsAndSelf(content,
-        StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
-        GetNavigationQueryService(content), variationContextAccessor, culture);
+        string? culture = null) => SiblingsAndSelf(content, GetPublishedCache(content), GetNavigationQueryService(content), variationContextAccessor, culture);
 
     [Obsolete(
         "Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2370,8 +2349,7 @@ public static class PublishedContentExtensions
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         string contentTypeAlias,
-        string? culture = null) => SiblingsAndSelfOfType(content, variationContextAccessor,
-        StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        string? culture = null) => SiblingsAndSelfOfType(content, variationContextAccessor, GetPublishedCache(content),
         GetNavigationQueryService(content), contentTypeAlias, culture);
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2379,7 +2357,7 @@ public static class PublishedContentExtensions
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         string? culture = null)
-        where T : class, IPublishedContent => SiblingsAndSelf<T>(content, variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        where T : class, IPublishedContent => SiblingsAndSelf<T>(content, variationContextAccessor, GetPublishedCache(content),
         GetNavigationQueryService(content), culture);
 
 
@@ -2395,5 +2373,18 @@ public static class PublishedContentExtensions
                 throw new NotSupportedException("Unsupported content type.");
         }
 
+    }
+
+    private static IPublishedCache GetPublishedCache(IPublishedContent content)
+    {
+        switch (content.ContentType.ItemType)
+        {
+            case PublishedItemType.Content:
+                return StaticServiceProvider.Instance.GetRequiredService<IPublishedContentCache>();
+            case PublishedItemType.Media:
+                return StaticServiceProvider.Instance.GetRequiredService<IPublishedMediaCache>();
+            default:
+                throw new NotSupportedException("Unsupported content type.");
+        }
     }
 }

--- a/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
@@ -2,7 +2,9 @@
 // See LICENSE for more details.
 
 using System.Data;
+using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Models.PublishedContent;
@@ -1898,5 +1900,554 @@ public static class PublishedContentExtensions
     private static Dictionary<string, string> GetAliasesAndNames(IContentTypeBase? contentType) =>
         contentType?.PropertyTypes.ToDictionary(x => x.Alias, x => x.Name) ?? new Dictionary<string, string>();
 
+
+
     #endregion
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IPublishedContent? Ancestor(this IPublishedContent content)
+    {
+        return content.Ancestor(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content));
+    }
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IPublishedContent? Ancestor(this IPublishedContent content, int maxLevel)
+    {
+        return content.Ancestor(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), maxLevel);
+    }
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IPublishedContent? Ancestor(this IPublishedContent content, string contentTypeAlias)
+    {
+        return content.Ancestor(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), contentTypeAlias);
+    }
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static T? Ancestor<T>(this IPublishedContent content)
+        where T : class, IPublishedContent
+    {
+        return Ancestor<T>(content, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content));
+    }
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static T? Ancestor<T>(this IPublishedContent content, int maxLevel)
+        where T : class, IPublishedContent
+    {
+        return Ancestor<T>(content, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), maxLevel);
+    }
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<IPublishedContent> Ancestors(this IPublishedContent content, int maxLevel)
+    {
+        return content.Ancestors(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), maxLevel);
+    }
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<IPublishedContent> Ancestors(this IPublishedContent content)
+    {
+        return content.Ancestors(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content));
+    }
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<IPublishedContent> Ancestors(this IPublishedContent content, string contentTypeAlias)
+    {
+        return content.Ancestors(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), contentTypeAlias);
+    }
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<T> Ancestors<T>(this IPublishedContent content)
+        where T : class, IPublishedContent
+    {
+        return Ancestors<T>(content, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content));
+    }
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<T> Ancestors<T>(this IPublishedContent content, int maxLevel)
+        where T : class, IPublishedContent
+    {
+        return Ancestors<T>(content, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), maxLevel);
+    }
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IPublishedContent AncestorOrSelf(this IPublishedContent content, int maxLevel)
+    {
+        return AncestorOrSelf(content, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), maxLevel);
+    }
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IPublishedContent AncestorOrSelf(this IPublishedContent content, string contentTypeAlias)
+    {
+        return AncestorOrSelf(content, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), contentTypeAlias);
+    }
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static T? AncestorOrSelf<T>(this IPublishedContent content, int maxLevel)
+        where T : class, IPublishedContent
+    {
+        return AncestorOrSelf<T>(content, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), maxLevel);
+    }
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static T? AncestorOrSelf<T>(this IPublishedContent content)
+        where T : class, IPublishedContent
+    {
+        return AncestorOrSelf<T>(content, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content));
+    }
+
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<IPublishedContent> AncestorsOrSelf(this IPublishedContent content, int maxLevel)
+    {
+        return content.AncestorsOrSelf(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), maxLevel);
+    }
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<IPublishedContent> AncestorsOrSelf(this IPublishedContent content)
+    {
+        return content.AncestorsOrSelf(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content));
+    }
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<IPublishedContent> AncestorsOrSelf(this IPublishedContent content, string contentTypeAlias)
+    {
+        return content.Ancestors(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), contentTypeAlias);
+    }
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<T> AncestorsOrSelf<T>(this IPublishedContent content)
+        where T : class, IPublishedContent
+    {
+        return Ancestors<T>(content, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content));
+    }
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<T> AncestorsOrSelf<T>(this IPublishedContent content, int maxLevel)
+        where T : class, IPublishedContent
+    {
+        return AncestorsOrSelf<T>(content, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), maxLevel);
+    }
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<IPublishedContent> AncestorsOrSelf(this IPublishedContent content, bool orSelf,
+        Func<IPublishedContent, bool>? func)
+    {
+        return AncestorsOrSelf(content, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), orSelf, func);
+    }
+
+    [Obsolete(
+        "Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<IPublishedContent> Breadcrumbs(
+        this IPublishedContent content,
+        bool andSelf = true) =>
+        content.Breadcrumbs(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), andSelf);
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<IPublishedContent> Breadcrumbs(
+        this IPublishedContent content,
+        int minLevel,
+        bool andSelf = true) =>
+        content.Breadcrumbs(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), minLevel, andSelf);
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<IPublishedContent> Breadcrumbs<T>(
+        this IPublishedContent content,
+        bool andSelf = true)
+        where T : class, IPublishedContent=>
+        content.Breadcrumbs<T>(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), andSelf);
+
+
+
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<IPublishedContent> Children(
+        this IPublishedContent content,
+        IVariationContextAccessor? variationContextAccessor,
+        string? culture = null)
+        => Children(content, variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content),culture);
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<IPublishedContent> Children(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        Func<IPublishedContent, bool> predicate,
+        string? culture = null) =>
+        content.Children(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), culture).Where(predicate);
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<IPublishedContent> ChildrenOfType(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string? contentTypeAlias,
+        string? culture = null) =>
+        content.Children(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), x => x.ContentType.Alias.InvariantEquals(contentTypeAlias),
+            culture);
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<T> Children<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.Children(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), culture).OfType<T>();
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static DataTable ChildrenAsTable(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IContentTypeService contentTypeService,
+        IMediaTypeService mediaTypeService,
+        IMemberTypeService memberTypeService,
+        IPublishedUrlProvider publishedUrlProvider,
+        string contentTypeAliasFilter = "",
+        string? culture = null)
+        => GenerateDataTable(content, variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), contentTypeService, mediaTypeService, memberTypeService, publishedUrlProvider, contentTypeAliasFilter, culture);
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<IPublishedContent> DescendantsOrSelfOfType(
+        this IEnumerable<IPublishedContent> parentNodes,
+        IVariationContextAccessor variationContextAccessor,
+        string docTypeAlias,
+        string? culture = null) => parentNodes.SelectMany(x =>
+        x.DescendantsOrSelfOfType(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(parentNodes.First()), docTypeAlias, culture));
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<T> DescendantsOrSelf<T>(
+        this IEnumerable<IPublishedContent> parentNodes,
+        IVariationContextAccessor variationContextAccessor,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        parentNodes.SelectMany(x => x.DescendantsOrSelf<T>(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(parentNodes.First()), culture));
+
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<IPublishedContent> Descendants(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string? culture = null) =>
+        content.DescendantsOrSelf(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), false, null, culture);
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<IPublishedContent> Descendants(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        int level,
+        string? culture = null) =>
+        content.DescendantsOrSelf(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), false, p => p.Level >= level, culture);
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<IPublishedContent> DescendantsOfType(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string contentTypeAlias, string? culture = null) =>
+        content.DescendantsOrSelf(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), false, p => p.ContentType.Alias.InvariantEquals(contentTypeAlias), culture);
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<T> Descendants<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.Descendants(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), culture).OfType<T>();
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<T> Descendants<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        int level,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.Descendants(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), level, culture).OfType<T>();
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<IPublishedContent> DescendantsOrSelf(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string? culture = null) =>
+        content.DescendantsOrSelf(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), true, null, culture);
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<IPublishedContent> DescendantsOrSelf(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        int level,
+        string? culture = null) =>
+        content.DescendantsOrSelf(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), true, p => p.Level >= level, culture);
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<IPublishedContent> DescendantsOrSelfOfType(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string contentTypeAlias,
+        string? culture = null) =>
+        content.DescendantsOrSelf(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), true, p => p.ContentType.Alias.InvariantEquals(contentTypeAlias), culture);
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<T> DescendantsOrSelf<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.DescendantsOrSelf(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), culture).OfType<T>();
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<T> DescendantsOrSelf<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        int level,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.DescendantsOrSelf(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), level, culture).OfType<T>();
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IPublishedContent? Descendant(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string? culture = null) =>
+        content.Children(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), culture)?.FirstOrDefault();
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IPublishedContent? Descendant(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        int level,
+        string? culture = null) => content
+        .EnumerateDescendants(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), false, culture).FirstOrDefault(x => x.Level == level);
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IPublishedContent? DescendantOfType(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string contentTypeAlias,
+        string? culture = null) => content
+        .EnumerateDescendants(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), false, culture)
+        .FirstOrDefault(x => x.ContentType.Alias.InvariantEquals(contentTypeAlias));
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static T? Descendant<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.EnumerateDescendants(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), false, culture).FirstOrDefault(x => x is T) as T;
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static T? Descendant<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        int level,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.Descendant(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), level, culture) as T;
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IPublishedContent? DescendantOrSelf(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        int level,
+        string? culture = null) => content
+        .EnumerateDescendants(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), true, culture).FirstOrDefault(x => x.Level == level);
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IPublishedContent? DescendantOrSelfOfType(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string contentTypeAlias,
+        string? culture = null) => content
+        .EnumerateDescendants(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), true, culture)
+        .FirstOrDefault(x => x.ContentType.Alias.InvariantEquals(contentTypeAlias));
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static T? DescendantOrSelf<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.EnumerateDescendants(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), true, culture).FirstOrDefault(x => x is T) as T;
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static T? DescendantOrSelf<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        int level,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.DescendantOrSelf(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), level, culture) as T;
+
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IPublishedContent? FirstChild(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string? culture = null) =>
+        content.Children(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), culture)?.FirstOrDefault();
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IPublishedContent? FirstChildOfType(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string contentTypeAlias,
+        string? culture = null) =>
+        content.ChildrenOfType(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), contentTypeAlias, culture)?.FirstOrDefault();
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IPublishedContent? FirstChild(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        Func<IPublishedContent, bool> predicate,
+        string? culture = null)
+        => content.Children(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), predicate, culture)?.FirstOrDefault();
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IPublishedContent? FirstChild(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        Guid uniqueId,
+        string? culture = null) => content
+        .Children(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), x => x.Key == uniqueId, culture)?.FirstOrDefault();
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static T? FirstChild<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.Children<T>(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), culture)?.FirstOrDefault();
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static T? FirstChild<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        Func<T, bool> predicate,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.Children<T>(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), culture)?.FirstOrDefault(predicate);
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static T? Parent<T>(
+        this IPublishedContent content)
+        where T : class, IPublishedContent =>
+        content.GetParent(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content)) as T;
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IPublishedContent Root(
+        this IPublishedContent content) => content.AncestorOrSelf(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        GetNavigationQueryService(content), 1);
+
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static T? Root<T>(
+        this IPublishedContent content)
+        where T : class, IPublishedContent =>
+        content.AncestorOrSelf<T>(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), 1);
+
+    [Obsolete(
+        "Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<IPublishedContent> Siblings(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string? culture = null) =>
+        Siblings(content, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), variationContextAccessor, culture);
+
+    [Obsolete(
+        "Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<IPublishedContent> SiblingsOfType(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string contentTypeAlias,
+        string? culture = null) =>
+        SiblingsOfType(content, variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), contentTypeAlias, culture);
+
+    [Obsolete(
+        "Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<T> Siblings<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        Siblings<T>(content, variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+            GetNavigationQueryService(content), culture);
+
+    [Obsolete(
+        "Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<IPublishedContent>? SiblingsAndSelf(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string? culture = null) => SiblingsAndSelf(content,
+        StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        GetNavigationQueryService(content), variationContextAccessor, culture);
+
+    [Obsolete(
+        "Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<IPublishedContent> SiblingsAndSelfOfType(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string contentTypeAlias,
+        string? culture = null) => SiblingsAndSelfOfType(content, variationContextAccessor,
+        StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        GetNavigationQueryService(content), contentTypeAlias, culture);
+
+    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    public static IEnumerable<T> SiblingsAndSelf<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string? culture = null)
+        where T : class, IPublishedContent => SiblingsAndSelf<T>(content, variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
+        GetNavigationQueryService(content), culture);
+
+
+    private static INavigationQueryService GetNavigationQueryService(IPublishedContent content)
+    {
+        switch (content.ContentType.ItemType)
+        {
+            case PublishedItemType.Content:
+                return StaticServiceProvider.Instance.GetRequiredService<IDocumentNavigationQueryService>();
+            case PublishedItemType.Media:
+                return StaticServiceProvider.Instance.GetRequiredService<IMediaNavigationQueryService>();
+            default:
+                throw new NotSupportedException("Unsupported content type.");
+        }
+
+    }
 }

--- a/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
@@ -1904,11 +1904,11 @@ public static class PublishedContentExtensions
 
     #endregion
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
-    public static IPublishedContent? Ancestor(this IPublishedContent content)
-    {
-        return content.Ancestor(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content));
-    }
+    // [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+    // public static IPublishedContent? Ancestor(this IPublishedContent content)
+    // {
+    //     return content.Ancestor(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content));
+    // }
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IPublishedContent? Ancestor(this IPublishedContent content, int maxLevel)
@@ -1923,13 +1923,6 @@ public static class PublishedContentExtensions
     }
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
-    public static T? Ancestor<T>(this IPublishedContent content)
-        where T : class, IPublishedContent
-    {
-        return Ancestor<T>(content, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content));
-    }
-
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static T? Ancestor<T>(this IPublishedContent content, int maxLevel)
         where T : class, IPublishedContent
     {
@@ -1940,12 +1933,6 @@ public static class PublishedContentExtensions
     public static IEnumerable<IPublishedContent> Ancestors(this IPublishedContent content, int maxLevel)
     {
         return content.Ancestors(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), maxLevel);
-    }
-
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
-    public static IEnumerable<IPublishedContent> Ancestors(this IPublishedContent content)
-    {
-        return content.Ancestors(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content));
     }
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -1988,36 +1975,15 @@ public static class PublishedContentExtensions
     }
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
-    public static T? AncestorOrSelf<T>(this IPublishedContent content)
-        where T : class, IPublishedContent
-    {
-        return AncestorOrSelf<T>(content, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content));
-    }
-
-
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<IPublishedContent> AncestorsOrSelf(this IPublishedContent content, int maxLevel)
     {
         return content.AncestorsOrSelf(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), maxLevel);
     }
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
-    public static IEnumerable<IPublishedContent> AncestorsOrSelf(this IPublishedContent content)
-    {
-        return content.AncestorsOrSelf(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content));
-    }
-
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<IPublishedContent> AncestorsOrSelf(this IPublishedContent content, string contentTypeAlias)
     {
         return content.Ancestors(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content), contentTypeAlias);
-    }
-
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
-    public static IEnumerable<T> AncestorsOrSelf<T>(this IPublishedContent content)
-        where T : class, IPublishedContent
-    {
-        return Ancestors<T>(content, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(), GetNavigationQueryService(content));
     }
 
     [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
@@ -2357,26 +2323,6 @@ public static class PublishedContentExtensions
         where T : class, IPublishedContent =>
         content.Children<T>(variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
             GetNavigationQueryService(content), culture)?.FirstOrDefault(predicate);
-
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
-    public static T? Parent<T>(
-        this IPublishedContent content)
-        where T : class, IPublishedContent =>
-        content.GetParent(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
-            GetNavigationQueryService(content)) as T;
-
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
-    public static IPublishedContent Root(
-        this IPublishedContent content) => content.AncestorOrSelf(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
-        GetNavigationQueryService(content), 1);
-
-
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
-    public static T? Root<T>(
-        this IPublishedContent content)
-        where T : class, IPublishedContent =>
-        content.AncestorOrSelf<T>(StaticServiceProvider.Instance.GetRequiredService<IPublishedCache>(),
-            GetNavigationQueryService(content), 1);
 
     [Obsolete(
         "Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]

--- a/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs
@@ -22,6 +22,9 @@ public static class FriendlyPublishedContentExtensions
     private static IPublishedContentCache PublishedContentCache { get; } =
         StaticServiceProvider.Instance.GetRequiredService<IPublishedContentCache>();
 
+    private static IPublishedMediaCache PublishedMediaCache { get; } =
+        StaticServiceProvider.Instance.GetRequiredService<IPublishedMediaCache>();
+
     private static IDocumentNavigationQueryService DocumentNavigationQueryService { get; } =
         StaticServiceProvider.Instance.GetRequiredService<IDocumentNavigationQueryService>();
 
@@ -77,6 +80,20 @@ public static class FriendlyPublishedContentExtensions
         }
 
     }
+
+    private static IPublishedCache GetPublishedCache(IPublishedContent content)
+    {
+        switch (content.ContentType.ItemType)
+        {
+            case PublishedItemType.Content:
+                return PublishedContentCache;
+            case PublishedItemType.Media:
+                return PublishedMediaCache;
+            default:
+                throw new NotSupportedException("Unsupported content type.");
+        }
+    }
+
     /// <summary>
     ///     Creates a strongly typed published content model for an internal published content.
     /// </summary>
@@ -223,7 +240,7 @@ public static class FriendlyPublishedContentExtensions
     ///     set to 1.
     /// </remarks>
     public static IPublishedContent Root(this IPublishedContent content)
-        => content.Root(PublishedContentCache, GetNavigationQueryService(content));
+        => content.Root(GetPublishedCache(content), GetNavigationQueryService(content));
 
     /// <summary>
     ///     Gets the root content (ancestor or self at level 1) for the specified <paramref name="content" /> if it's of the
@@ -242,7 +259,7 @@ public static class FriendlyPublishedContentExtensions
     /// </remarks>
     public static T? Root<T>(this IPublishedContent content)
         where T : class, IPublishedContent
-        => content.Root<T>(PublishedContentCache, GetNavigationQueryService(content));
+        => content.Root<T>(GetPublishedCache(content), GetNavigationQueryService(content));
 
     /// <summary>
     ///     Gets the parent of the content item.
@@ -252,7 +269,7 @@ public static class FriendlyPublishedContentExtensions
     /// <returns>The parent of content of the specified content type or <c>null</c>.</returns>
     public static T? Parent<T>(this IPublishedContent content)
         where T : class, IPublishedContent
-        => content.Parent<T>(PublishedContentCache, GetNavigationQueryService(content));
+        => content.Parent<T>(GetPublishedCache(content), GetNavigationQueryService(content));
 
     /// <summary>
     ///     Gets the ancestors of the content.
@@ -261,7 +278,7 @@ public static class FriendlyPublishedContentExtensions
     /// <returns>The ancestors of the content, in down-top order.</returns>
     /// <remarks>Does not consider the content itself.</remarks>
     public static IEnumerable<IPublishedContent> Ancestors(this IPublishedContent content)
-        => content.Ancestors(PublishedContentCache, GetNavigationQueryService(content));
+        => content.Ancestors(GetPublishedCache(content), GetNavigationQueryService(content));
 
     /// <summary>
     ///     Gets the content and its ancestors.
@@ -269,7 +286,7 @@ public static class FriendlyPublishedContentExtensions
     /// <param name="content">The content.</param>
     /// <returns>The content and its ancestors, in down-top order.</returns>
     public static IEnumerable<IPublishedContent> AncestorsOrSelf(this IPublishedContent content)
-        => content.AncestorsOrSelf(PublishedContentCache, GetNavigationQueryService(content));
+        => content.AncestorsOrSelf(GetPublishedCache(content), GetNavigationQueryService(content));
 
     /// <summary>
     ///     Gets the content and its ancestors, of a specified content type.
@@ -280,7 +297,7 @@ public static class FriendlyPublishedContentExtensions
     /// <remarks>May or may not begin with the content itself, depending on its content type.</remarks>
     public static IEnumerable<T> AncestorsOrSelf<T>(this IPublishedContent content)
         where T : class, IPublishedContent
-        => content.AncestorsOrSelf<T>(PublishedContentCache, GetNavigationQueryService(content));
+        => content.AncestorsOrSelf<T>(GetPublishedCache(content), GetNavigationQueryService(content));
 
     /// <summary>
     ///     Gets the ancestor of the content, i.e. its parent.
@@ -288,7 +305,7 @@ public static class FriendlyPublishedContentExtensions
     /// <param name="content">The content.</param>
     /// <returns>The ancestor of the content.</returns>
     public static IPublishedContent? Ancestor(this IPublishedContent content)
-        => content.Ancestor(PublishedContentCache, GetNavigationQueryService(content));
+        => content.Ancestor(GetPublishedCache(content), GetNavigationQueryService(content));
 
     /// <summary>
     ///     Gets the nearest ancestor of the content, of a specified content type.
@@ -299,7 +316,7 @@ public static class FriendlyPublishedContentExtensions
     /// <remarks>Does not consider the content itself. May return <c>null</c>.</remarks>
     public static T? Ancestor<T>(this IPublishedContent content)
         where T : class, IPublishedContent
-        => content.Ancestor<T>(PublishedContentCache, GetNavigationQueryService(content));
+        => content.Ancestor<T>(GetPublishedCache(content), GetNavigationQueryService(content));
 
     /// <summary>
     ///     Gets the content or its nearest ancestor, of a specified content type.
@@ -310,7 +327,7 @@ public static class FriendlyPublishedContentExtensions
     /// <remarks>May or may not return the content itself depending on its content type. May return <c>null</c>.</remarks>
     public static T? AncestorOrSelf<T>(this IPublishedContent content)
         where T : class, IPublishedContent
-        => content.AncestorOrSelf<T>(PublishedContentCache, GetNavigationQueryService(content));
+        => content.AncestorOrSelf<T>(GetPublishedCache(content), GetNavigationQueryService(content));
 
     /// <summary>
     ///     Returns all DescendantsOrSelf of all content referenced
@@ -327,7 +344,7 @@ public static class FriendlyPublishedContentExtensions
     /// </remarks>
     public static IEnumerable<IPublishedContent> DescendantsOrSelfOfType(
         this IEnumerable<IPublishedContent> parentNodes, string docTypeAlias, string? culture = null)
-        => parentNodes.DescendantsOrSelfOfType(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(parentNodes.First()), docTypeAlias, culture);
+        => parentNodes.DescendantsOrSelfOfType(VariationContextAccessor, GetPublishedCache(parentNodes.First()), GetNavigationQueryService(parentNodes.First()), docTypeAlias, culture);
 
     /// <summary>
     ///     Returns all DescendantsOrSelf of all content referenced
@@ -345,77 +362,77 @@ public static class FriendlyPublishedContentExtensions
         this IEnumerable<IPublishedContent> parentNodes,
         string? culture = null)
         where T : class, IPublishedContent
-        => parentNodes.DescendantsOrSelf<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(parentNodes.First()), culture);
+        => parentNodes.DescendantsOrSelf<T>(VariationContextAccessor, GetPublishedCache(parentNodes.First()), GetNavigationQueryService(parentNodes.First()), culture);
 
     public static IEnumerable<IPublishedContent> Descendants(this IPublishedContent content, string? culture = null)
-        => content.Descendants(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
+        => content.Descendants(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
 
     public static IEnumerable<IPublishedContent> Descendants(this IPublishedContent content, int level, string? culture = null)
-        => content.Descendants(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), level, culture);
+        => content.Descendants(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), level, culture);
 
     public static IEnumerable<IPublishedContent> DescendantsOfType(this IPublishedContent content, string contentTypeAlias, string? culture = null)
-        => content.DescendantsOfType(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), contentTypeAlias, culture);
+        => content.DescendantsOfType(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias, culture);
 
     public static IEnumerable<T> Descendants<T>(this IPublishedContent content, string? culture = null)
         where T : class, IPublishedContent
-        => content.Descendants<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
+        => content.Descendants<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
 
     public static IEnumerable<T> Descendants<T>(this IPublishedContent content, int level, string? culture = null)
         where T : class, IPublishedContent
-        => content.Descendants<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), level, culture);
+        => content.Descendants<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), level, culture);
 
     public static IEnumerable<IPublishedContent> DescendantsOrSelf(
         this IPublishedContent content,
         string? culture = null)
-        => content.DescendantsOrSelf(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
+        => content.DescendantsOrSelf(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
 
     public static IEnumerable<IPublishedContent> DescendantsOrSelf(this IPublishedContent content, int level, string? culture = null)
-        => content.DescendantsOrSelf(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), level, culture);
+        => content.DescendantsOrSelf(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), level, culture);
 
     public static IEnumerable<IPublishedContent> DescendantsOrSelfOfType(this IPublishedContent content, string contentTypeAlias, string? culture = null)
-        => content.DescendantsOrSelfOfType(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), contentTypeAlias, culture);
+        => content.DescendantsOrSelfOfType(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias, culture);
 
     public static IEnumerable<T> DescendantsOrSelf<T>(this IPublishedContent content, string? culture = null)
         where T : class, IPublishedContent
-        => content.DescendantsOrSelf<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
+        => content.DescendantsOrSelf<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
 
     public static IEnumerable<T> DescendantsOrSelf<T>(this IPublishedContent content, int level, string? culture = null)
         where T : class, IPublishedContent
-        => content.DescendantsOrSelf<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), level, culture);
+        => content.DescendantsOrSelf<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), level, culture);
 
     public static IPublishedContent? Descendant(this IPublishedContent content, string? culture = null)
-        => content.Descendant(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
+        => content.Descendant(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
 
     public static IPublishedContent? Descendant(this IPublishedContent content, int level, string? culture = null)
-        => content.Descendant(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), level, culture);
+        => content.Descendant(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), level, culture);
 
     public static IPublishedContent? DescendantOfType(this IPublishedContent content, string contentTypeAlias, string? culture = null)
-        => content.DescendantOfType(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), contentTypeAlias, culture);
+        => content.DescendantOfType(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias, culture);
 
     public static T? Descendant<T>(this IPublishedContent content, string? culture = null)
         where T : class, IPublishedContent
-        => content.Descendant<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
+        => content.Descendant<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
 
     public static T? Descendant<T>(this IPublishedContent content, int level, string? culture = null)
         where T : class, IPublishedContent
-        => content.Descendant<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), level, culture);
+        => content.Descendant<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), level, culture);
 
     public static IPublishedContent DescendantOrSelf(this IPublishedContent content, string? culture = null)
         => content.DescendantOrSelf(VariationContextAccessor, culture);
 
     public static IPublishedContent? DescendantOrSelf(this IPublishedContent content, int level, string? culture = null)
-        => content.DescendantOrSelf(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), level, culture);
+        => content.DescendantOrSelf(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), level, culture);
 
     public static IPublishedContent? DescendantOrSelfOfType(this IPublishedContent content, string contentTypeAlias, string? culture = null)
-        => content.DescendantOrSelfOfType(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), contentTypeAlias, culture);
+        => content.DescendantOrSelfOfType(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias, culture);
 
     public static T? DescendantOrSelf<T>(this IPublishedContent content, string? culture = null)
         where T : class, IPublishedContent
-        => content.DescendantOrSelf<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
+        => content.DescendantOrSelf<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
 
     public static T? DescendantOrSelf<T>(this IPublishedContent content, int level, string? culture = null)
         where T : class, IPublishedContent
-        => content.DescendantOrSelf<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), level, culture);
+        => content.DescendantOrSelf<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), level, culture);
 
     /// <summary>
     ///     Gets the children of the content item.
@@ -443,7 +460,7 @@ public static class FriendlyPublishedContentExtensions
     ///     </para>
     /// </remarks>
     public static IEnumerable<IPublishedContent> Children(this IPublishedContent content, string? culture = null)
-        => content.Children(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
+        => content.Children(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
 
     /// <summary>
     ///     Gets the children of the content, filtered by a predicate.
@@ -462,7 +479,7 @@ public static class FriendlyPublishedContentExtensions
         this IPublishedContent content,
         Func<IPublishedContent, bool> predicate,
         string? culture = null)
-        => content.Children(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), predicate, culture);
+        => content.Children(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), predicate, culture);
 
     /// <summary>
     ///     Gets the children of the content, of any of the specified types.
@@ -475,7 +492,7 @@ public static class FriendlyPublishedContentExtensions
     /// <param name="contentTypeAlias">The content type alias.</param>
     /// <returns>The children of the content, of any of the specified types.</returns>
     public static IEnumerable<IPublishedContent>? ChildrenOfType(this IPublishedContent content, string contentTypeAlias, string? culture = null)
-        => content.ChildrenOfType(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), contentTypeAlias, culture);
+        => content.ChildrenOfType(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias, culture);
 
     /// <summary>
     ///     Gets the children of the content, of a given content type.
@@ -492,30 +509,30 @@ public static class FriendlyPublishedContentExtensions
     /// </remarks>
     public static IEnumerable<T>? Children<T>(this IPublishedContent content, string? culture = null)
         where T : class, IPublishedContent
-        => content.Children<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
+        => content.Children<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
 
     public static IPublishedContent? FirstChild(this IPublishedContent content, string? culture = null)
-        => content.FirstChild(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
+        => content.FirstChild(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
 
     /// <summary>
     ///     Gets the first child of the content, of a given content type.
     /// </summary>
     public static IPublishedContent? FirstChildOfType(this IPublishedContent content, string contentTypeAlias, string? culture = null)
-        => content.FirstChildOfType(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), contentTypeAlias, culture);
+        => content.FirstChildOfType(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias, culture);
 
     public static IPublishedContent? FirstChild(this IPublishedContent content, Func<IPublishedContent, bool> predicate, string? culture = null)
-        => content.FirstChild(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), predicate, culture);
+        => content.FirstChild(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), predicate, culture);
 
     public static IPublishedContent? FirstChild(this IPublishedContent content, Guid uniqueId, string? culture = null)
-        => content.FirstChild(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), uniqueId, culture);
+        => content.FirstChild(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), uniqueId, culture);
 
     public static T? FirstChild<T>(this IPublishedContent content, string? culture = null)
         where T : class, IPublishedContent
-        => content.FirstChild<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
+        => content.FirstChild<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
 
     public static T? FirstChild<T>(this IPublishedContent content, Func<T, bool> predicate, string? culture = null)
         where T : class, IPublishedContent
-        => content.FirstChild(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), predicate, culture);
+        => content.FirstChild(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), predicate, culture);
 
     /// <summary>
     ///     Gets the siblings of the content.
@@ -530,7 +547,7 @@ public static class FriendlyPublishedContentExtensions
     ///     <para>Note that in V7 this method also return the content node self.</para>
     /// </remarks>
     public static IEnumerable<IPublishedContent>? Siblings(this IPublishedContent content, string? culture = null)
-        => content.Siblings(PublishedContentCache, GetNavigationQueryService(content), VariationContextAccessor, culture);
+        => content.Siblings(GetPublishedCache(content), GetNavigationQueryService(content), VariationContextAccessor, culture);
 
     /// <summary>
     ///     Gets the siblings of the content, of a given content type.
@@ -546,7 +563,7 @@ public static class FriendlyPublishedContentExtensions
     ///     <para>Note that in V7 this method also return the content node self.</para>
     /// </remarks>
     public static IEnumerable<IPublishedContent>? SiblingsOfType(this IPublishedContent content, string contentTypeAlias, string? culture = null)
-        => content.SiblingsOfType(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), contentTypeAlias, culture);
+        => content.SiblingsOfType(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias, culture);
 
     /// <summary>
     ///     Gets the siblings of the content, of a given content type.
@@ -563,7 +580,7 @@ public static class FriendlyPublishedContentExtensions
     /// </remarks>
     public static IEnumerable<T>? Siblings<T>(this IPublishedContent content, string? culture = null)
         where T : class, IPublishedContent
-        => content.Siblings<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
+        => content.Siblings<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
 
     /// <summary>
     ///     Gets the siblings of the content including the node itself to indicate the position.
@@ -577,7 +594,7 @@ public static class FriendlyPublishedContentExtensions
     public static IEnumerable<IPublishedContent>? SiblingsAndSelf(
         this IPublishedContent content,
         string? culture = null)
-        => content.SiblingsAndSelf(PublishedContentCache, GetNavigationQueryService(content), VariationContextAccessor, culture);
+        => content.SiblingsAndSelf(GetPublishedCache(content), GetNavigationQueryService(content), VariationContextAccessor, culture);
 
     /// <summary>
     ///     Gets the siblings of the content including the node itself to indicate the position, of a given content type.
@@ -593,7 +610,7 @@ public static class FriendlyPublishedContentExtensions
         this IPublishedContent content,
         string contentTypeAlias,
         string? culture = null)
-        => content.SiblingsAndSelfOfType(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), contentTypeAlias, culture);
+        => content.SiblingsAndSelfOfType(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias, culture);
 
     /// <summary>
     ///     Gets the siblings of the content including the node itself to indicate the position, of a given content type.
@@ -607,7 +624,7 @@ public static class FriendlyPublishedContentExtensions
     /// <returns>The siblings of the content including the node itself, of the given content type.</returns>
     public static IEnumerable<T>? SiblingsAndSelf<T>(this IPublishedContent content, string? culture = null)
         where T : class, IPublishedContent
-        => content.SiblingsAndSelf<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
+        => content.SiblingsAndSelf<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
 
     /// <summary>
     ///     Gets the url of the content item.
@@ -642,7 +659,7 @@ public static class FriendlyPublishedContentExtensions
         =>
             content.ChildrenAsTable(
                 VariationContextAccessor,
-                PublishedContentCache,
+                GetPublishedCache(content),
                 GetNavigationQueryService(content),
                 ContentTypeService,
                 MediaTypeService,

--- a/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs
@@ -25,6 +25,9 @@ public static class FriendlyPublishedContentExtensions
     private static IDocumentNavigationQueryService DocumentNavigationQueryService { get; } =
         StaticServiceProvider.Instance.GetRequiredService<IDocumentNavigationQueryService>();
 
+    private static IMediaNavigationQueryService MediaNavigationQueryService { get; } =
+        StaticServiceProvider.Instance.GetRequiredService<IMediaNavigationQueryService>();
+
     private static IPublishedModelFactory PublishedModelFactory { get; } =
         StaticServiceProvider.Instance.GetRequiredService<IPublishedModelFactory>();
 
@@ -61,6 +64,19 @@ public static class FriendlyPublishedContentExtensions
     private static IMemberTypeService MemberTypeService { get; } =
         StaticServiceProvider.Instance.GetRequiredService<IMemberTypeService>();
 
+    private static INavigationQueryService GetNavigationQueryService(IPublishedContent content)
+    {
+        switch (content.ContentType.ItemType)
+        {
+            case PublishedItemType.Content:
+                return DocumentNavigationQueryService;
+            case PublishedItemType.Media:
+                return MediaNavigationQueryService;
+            default:
+                throw new NotSupportedException("Unsupported content type.");
+        }
+
+    }
     /// <summary>
     ///     Creates a strongly typed published content model for an internal published content.
     /// </summary>
@@ -207,7 +223,7 @@ public static class FriendlyPublishedContentExtensions
     ///     set to 1.
     /// </remarks>
     public static IPublishedContent Root(this IPublishedContent content)
-        => content.Root(PublishedContentCache, DocumentNavigationQueryService);
+        => content.Root(PublishedContentCache, GetNavigationQueryService(content));
 
     /// <summary>
     ///     Gets the root content (ancestor or self at level 1) for the specified <paramref name="content" /> if it's of the
@@ -226,7 +242,7 @@ public static class FriendlyPublishedContentExtensions
     /// </remarks>
     public static T? Root<T>(this IPublishedContent content)
         where T : class, IPublishedContent
-        => content.Root<T>(PublishedContentCache, DocumentNavigationQueryService);
+        => content.Root<T>(PublishedContentCache, GetNavigationQueryService(content));
 
     /// <summary>
     ///     Gets the parent of the content item.
@@ -236,7 +252,7 @@ public static class FriendlyPublishedContentExtensions
     /// <returns>The parent of content of the specified content type or <c>null</c>.</returns>
     public static T? Parent<T>(this IPublishedContent content)
         where T : class, IPublishedContent
-        => content.Parent<T>(PublishedContentCache, DocumentNavigationQueryService);
+        => content.Parent<T>(PublishedContentCache, GetNavigationQueryService(content));
 
     /// <summary>
     ///     Gets the ancestors of the content.
@@ -245,7 +261,7 @@ public static class FriendlyPublishedContentExtensions
     /// <returns>The ancestors of the content, in down-top order.</returns>
     /// <remarks>Does not consider the content itself.</remarks>
     public static IEnumerable<IPublishedContent> Ancestors(this IPublishedContent content)
-        => content.Ancestors(PublishedContentCache, DocumentNavigationQueryService);
+        => content.Ancestors(PublishedContentCache, GetNavigationQueryService(content));
 
     /// <summary>
     ///     Gets the content and its ancestors.
@@ -253,7 +269,7 @@ public static class FriendlyPublishedContentExtensions
     /// <param name="content">The content.</param>
     /// <returns>The content and its ancestors, in down-top order.</returns>
     public static IEnumerable<IPublishedContent> AncestorsOrSelf(this IPublishedContent content)
-        => content.AncestorsOrSelf(PublishedContentCache, DocumentNavigationQueryService);
+        => content.AncestorsOrSelf(PublishedContentCache, GetNavigationQueryService(content));
 
     /// <summary>
     ///     Gets the content and its ancestors, of a specified content type.
@@ -264,7 +280,7 @@ public static class FriendlyPublishedContentExtensions
     /// <remarks>May or may not begin with the content itself, depending on its content type.</remarks>
     public static IEnumerable<T> AncestorsOrSelf<T>(this IPublishedContent content)
         where T : class, IPublishedContent
-        => content.AncestorsOrSelf<T>(PublishedContentCache, DocumentNavigationQueryService);
+        => content.AncestorsOrSelf<T>(PublishedContentCache, GetNavigationQueryService(content));
 
     /// <summary>
     ///     Gets the ancestor of the content, i.e. its parent.
@@ -272,7 +288,7 @@ public static class FriendlyPublishedContentExtensions
     /// <param name="content">The content.</param>
     /// <returns>The ancestor of the content.</returns>
     public static IPublishedContent? Ancestor(this IPublishedContent content)
-        => content.Ancestor(PublishedContentCache, DocumentNavigationQueryService);
+        => content.Ancestor(PublishedContentCache, GetNavigationQueryService(content));
 
     /// <summary>
     ///     Gets the nearest ancestor of the content, of a specified content type.
@@ -283,7 +299,7 @@ public static class FriendlyPublishedContentExtensions
     /// <remarks>Does not consider the content itself. May return <c>null</c>.</remarks>
     public static T? Ancestor<T>(this IPublishedContent content)
         where T : class, IPublishedContent
-        => content.Ancestor<T>(PublishedContentCache, DocumentNavigationQueryService);
+        => content.Ancestor<T>(PublishedContentCache, GetNavigationQueryService(content));
 
     /// <summary>
     ///     Gets the content or its nearest ancestor, of a specified content type.
@@ -294,7 +310,7 @@ public static class FriendlyPublishedContentExtensions
     /// <remarks>May or may not return the content itself depending on its content type. May return <c>null</c>.</remarks>
     public static T? AncestorOrSelf<T>(this IPublishedContent content)
         where T : class, IPublishedContent
-        => content.AncestorOrSelf<T>(PublishedContentCache, DocumentNavigationQueryService);
+        => content.AncestorOrSelf<T>(PublishedContentCache, GetNavigationQueryService(content));
 
     /// <summary>
     ///     Returns all DescendantsOrSelf of all content referenced
@@ -311,7 +327,7 @@ public static class FriendlyPublishedContentExtensions
     /// </remarks>
     public static IEnumerable<IPublishedContent> DescendantsOrSelfOfType(
         this IEnumerable<IPublishedContent> parentNodes, string docTypeAlias, string? culture = null)
-        => parentNodes.DescendantsOrSelfOfType(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, docTypeAlias, culture);
+        => parentNodes.DescendantsOrSelfOfType(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(parentNodes.First()), docTypeAlias, culture);
 
     /// <summary>
     ///     Returns all DescendantsOrSelf of all content referenced
@@ -329,77 +345,77 @@ public static class FriendlyPublishedContentExtensions
         this IEnumerable<IPublishedContent> parentNodes,
         string? culture = null)
         where T : class, IPublishedContent
-        => parentNodes.DescendantsOrSelf<T>(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, culture);
+        => parentNodes.DescendantsOrSelf<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(parentNodes.First()), culture);
 
     public static IEnumerable<IPublishedContent> Descendants(this IPublishedContent content, string? culture = null)
-        => content.Descendants(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, culture);
+        => content.Descendants(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
 
     public static IEnumerable<IPublishedContent> Descendants(this IPublishedContent content, int level, string? culture = null)
-        => content.Descendants(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, level, culture);
+        => content.Descendants(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), level, culture);
 
     public static IEnumerable<IPublishedContent> DescendantsOfType(this IPublishedContent content, string contentTypeAlias, string? culture = null)
-        => content.DescendantsOfType(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, contentTypeAlias, culture);
+        => content.DescendantsOfType(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), contentTypeAlias, culture);
 
     public static IEnumerable<T> Descendants<T>(this IPublishedContent content, string? culture = null)
         where T : class, IPublishedContent
-        => content.Descendants<T>(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, culture);
+        => content.Descendants<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
 
     public static IEnumerable<T> Descendants<T>(this IPublishedContent content, int level, string? culture = null)
         where T : class, IPublishedContent
-        => content.Descendants<T>(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, level, culture);
+        => content.Descendants<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), level, culture);
 
     public static IEnumerable<IPublishedContent> DescendantsOrSelf(
         this IPublishedContent content,
         string? culture = null)
-        => content.DescendantsOrSelf(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, culture);
+        => content.DescendantsOrSelf(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
 
     public static IEnumerable<IPublishedContent> DescendantsOrSelf(this IPublishedContent content, int level, string? culture = null)
-        => content.DescendantsOrSelf(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, level, culture);
+        => content.DescendantsOrSelf(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), level, culture);
 
     public static IEnumerable<IPublishedContent> DescendantsOrSelfOfType(this IPublishedContent content, string contentTypeAlias, string? culture = null)
-        => content.DescendantsOrSelfOfType(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, contentTypeAlias, culture);
+        => content.DescendantsOrSelfOfType(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), contentTypeAlias, culture);
 
     public static IEnumerable<T> DescendantsOrSelf<T>(this IPublishedContent content, string? culture = null)
         where T : class, IPublishedContent
-        => content.DescendantsOrSelf<T>(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, culture);
+        => content.DescendantsOrSelf<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
 
     public static IEnumerable<T> DescendantsOrSelf<T>(this IPublishedContent content, int level, string? culture = null)
         where T : class, IPublishedContent
-        => content.DescendantsOrSelf<T>(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, level, culture);
+        => content.DescendantsOrSelf<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), level, culture);
 
     public static IPublishedContent? Descendant(this IPublishedContent content, string? culture = null)
-        => content.Descendant(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, culture);
+        => content.Descendant(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
 
     public static IPublishedContent? Descendant(this IPublishedContent content, int level, string? culture = null)
-        => content.Descendant(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, level, culture);
+        => content.Descendant(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), level, culture);
 
     public static IPublishedContent? DescendantOfType(this IPublishedContent content, string contentTypeAlias, string? culture = null)
-        => content.DescendantOfType(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, contentTypeAlias, culture);
+        => content.DescendantOfType(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), contentTypeAlias, culture);
 
     public static T? Descendant<T>(this IPublishedContent content, string? culture = null)
         where T : class, IPublishedContent
-        => content.Descendant<T>(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, culture);
+        => content.Descendant<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
 
     public static T? Descendant<T>(this IPublishedContent content, int level, string? culture = null)
         where T : class, IPublishedContent
-        => content.Descendant<T>(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, level, culture);
+        => content.Descendant<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), level, culture);
 
     public static IPublishedContent DescendantOrSelf(this IPublishedContent content, string? culture = null)
         => content.DescendantOrSelf(VariationContextAccessor, culture);
 
     public static IPublishedContent? DescendantOrSelf(this IPublishedContent content, int level, string? culture = null)
-        => content.DescendantOrSelf(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, level, culture);
+        => content.DescendantOrSelf(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), level, culture);
 
     public static IPublishedContent? DescendantOrSelfOfType(this IPublishedContent content, string contentTypeAlias, string? culture = null)
-        => content.DescendantOrSelfOfType(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, contentTypeAlias, culture);
+        => content.DescendantOrSelfOfType(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), contentTypeAlias, culture);
 
     public static T? DescendantOrSelf<T>(this IPublishedContent content, string? culture = null)
         where T : class, IPublishedContent
-        => content.DescendantOrSelf<T>(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, culture);
+        => content.DescendantOrSelf<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
 
     public static T? DescendantOrSelf<T>(this IPublishedContent content, int level, string? culture = null)
         where T : class, IPublishedContent
-        => content.DescendantOrSelf<T>(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, level, culture);
+        => content.DescendantOrSelf<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), level, culture);
 
     /// <summary>
     ///     Gets the children of the content item.
@@ -427,7 +443,7 @@ public static class FriendlyPublishedContentExtensions
     ///     </para>
     /// </remarks>
     public static IEnumerable<IPublishedContent> Children(this IPublishedContent content, string? culture = null)
-        => content.Children(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, culture);
+        => content.Children(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
 
     /// <summary>
     ///     Gets the children of the content, filtered by a predicate.
@@ -446,7 +462,7 @@ public static class FriendlyPublishedContentExtensions
         this IPublishedContent content,
         Func<IPublishedContent, bool> predicate,
         string? culture = null)
-        => content.Children(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, predicate, culture);
+        => content.Children(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), predicate, culture);
 
     /// <summary>
     ///     Gets the children of the content, of any of the specified types.
@@ -459,7 +475,7 @@ public static class FriendlyPublishedContentExtensions
     /// <param name="contentTypeAlias">The content type alias.</param>
     /// <returns>The children of the content, of any of the specified types.</returns>
     public static IEnumerable<IPublishedContent>? ChildrenOfType(this IPublishedContent content, string contentTypeAlias, string? culture = null)
-        => content.ChildrenOfType(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, contentTypeAlias, culture);
+        => content.ChildrenOfType(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), contentTypeAlias, culture);
 
     /// <summary>
     ///     Gets the children of the content, of a given content type.
@@ -476,30 +492,30 @@ public static class FriendlyPublishedContentExtensions
     /// </remarks>
     public static IEnumerable<T>? Children<T>(this IPublishedContent content, string? culture = null)
         where T : class, IPublishedContent
-        => content.Children<T>(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, culture);
+        => content.Children<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
 
     public static IPublishedContent? FirstChild(this IPublishedContent content, string? culture = null)
-        => content.FirstChild(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, culture);
+        => content.FirstChild(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
 
     /// <summary>
     ///     Gets the first child of the content, of a given content type.
     /// </summary>
     public static IPublishedContent? FirstChildOfType(this IPublishedContent content, string contentTypeAlias, string? culture = null)
-        => content.FirstChildOfType(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, contentTypeAlias, culture);
+        => content.FirstChildOfType(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), contentTypeAlias, culture);
 
     public static IPublishedContent? FirstChild(this IPublishedContent content, Func<IPublishedContent, bool> predicate, string? culture = null)
-        => content.FirstChild(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, predicate, culture);
+        => content.FirstChild(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), predicate, culture);
 
     public static IPublishedContent? FirstChild(this IPublishedContent content, Guid uniqueId, string? culture = null)
-        => content.FirstChild(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, uniqueId, culture);
+        => content.FirstChild(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), uniqueId, culture);
 
     public static T? FirstChild<T>(this IPublishedContent content, string? culture = null)
         where T : class, IPublishedContent
-        => content.FirstChild<T>(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, culture);
+        => content.FirstChild<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
 
     public static T? FirstChild<T>(this IPublishedContent content, Func<T, bool> predicate, string? culture = null)
         where T : class, IPublishedContent
-        => content.FirstChild(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, predicate, culture);
+        => content.FirstChild(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), predicate, culture);
 
     /// <summary>
     ///     Gets the siblings of the content.
@@ -514,7 +530,7 @@ public static class FriendlyPublishedContentExtensions
     ///     <para>Note that in V7 this method also return the content node self.</para>
     /// </remarks>
     public static IEnumerable<IPublishedContent>? Siblings(this IPublishedContent content, string? culture = null)
-        => content.Siblings(PublishedContentCache, DocumentNavigationQueryService, VariationContextAccessor, culture);
+        => content.Siblings(PublishedContentCache, GetNavigationQueryService(content), VariationContextAccessor, culture);
 
     /// <summary>
     ///     Gets the siblings of the content, of a given content type.
@@ -530,7 +546,7 @@ public static class FriendlyPublishedContentExtensions
     ///     <para>Note that in V7 this method also return the content node self.</para>
     /// </remarks>
     public static IEnumerable<IPublishedContent>? SiblingsOfType(this IPublishedContent content, string contentTypeAlias, string? culture = null)
-        => content.SiblingsOfType(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, contentTypeAlias, culture);
+        => content.SiblingsOfType(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), contentTypeAlias, culture);
 
     /// <summary>
     ///     Gets the siblings of the content, of a given content type.
@@ -547,7 +563,7 @@ public static class FriendlyPublishedContentExtensions
     /// </remarks>
     public static IEnumerable<T>? Siblings<T>(this IPublishedContent content, string? culture = null)
         where T : class, IPublishedContent
-        => content.Siblings<T>(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, culture);
+        => content.Siblings<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
 
     /// <summary>
     ///     Gets the siblings of the content including the node itself to indicate the position.
@@ -561,7 +577,7 @@ public static class FriendlyPublishedContentExtensions
     public static IEnumerable<IPublishedContent>? SiblingsAndSelf(
         this IPublishedContent content,
         string? culture = null)
-        => content.SiblingsAndSelf(PublishedContentCache, DocumentNavigationQueryService, VariationContextAccessor, culture);
+        => content.SiblingsAndSelf(PublishedContentCache, GetNavigationQueryService(content), VariationContextAccessor, culture);
 
     /// <summary>
     ///     Gets the siblings of the content including the node itself to indicate the position, of a given content type.
@@ -577,7 +593,7 @@ public static class FriendlyPublishedContentExtensions
         this IPublishedContent content,
         string contentTypeAlias,
         string? culture = null)
-        => content.SiblingsAndSelfOfType(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, contentTypeAlias, culture);
+        => content.SiblingsAndSelfOfType(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), contentTypeAlias, culture);
 
     /// <summary>
     ///     Gets the siblings of the content including the node itself to indicate the position, of a given content type.
@@ -591,7 +607,7 @@ public static class FriendlyPublishedContentExtensions
     /// <returns>The siblings of the content including the node itself, of the given content type.</returns>
     public static IEnumerable<T>? SiblingsAndSelf<T>(this IPublishedContent content, string? culture = null)
         where T : class, IPublishedContent
-        => content.SiblingsAndSelf<T>(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, culture);
+        => content.SiblingsAndSelf<T>(VariationContextAccessor, PublishedContentCache, GetNavigationQueryService(content), culture);
 
     /// <summary>
     ///     Gets the url of the content item.
@@ -627,7 +643,7 @@ public static class FriendlyPublishedContentExtensions
             content.ChildrenAsTable(
                 VariationContextAccessor,
                 PublishedContentCache,
-                DocumentNavigationQueryService,
+                GetNavigationQueryService(content),
                 ContentTypeService,
                 MediaTypeService,
                 MemberTypeService,
@@ -700,4 +716,5 @@ public static class FriendlyPublishedContentExtensions
         string term,
         string? indexName = null)
         => content.SearchChildren(ExamineManager, UmbracoContextAccessor, term, indexName);
+
 }


### PR DESCRIPTION
### Description
Reintroduces the extensions that is possible on `PublishedContentExtensions`, but as obsolete.

To avoid unnecessary breaking changes

### Appendix
I tested with the following render controller and a doc type called Root.
```cs
using Microsoft.AspNetCore.Mvc;
using Microsoft.AspNetCore.Mvc.ViewEngines;
using Umbraco.Cms.Core.Models.PublishedContent;
using Umbraco.Cms.Core.Routing;
using Umbraco.Cms.Core.Services;
using Umbraco.Cms.Core.Web;
using Umbraco.Cms.Web.Common.Controllers;

namespace Umbraco.Cms.Web.UI;


public class RootController : RenderController
{
    private readonly IVariationContextAccessor _variationContextAccessor;
    private readonly IContentTypeService _contentTypeService;
    private readonly IMediaTypeService _mediaTypeService;
    private readonly IMemberTypeService _memberTypeService;
    private readonly IPublishedUrlProvider _publishedUrlProvider;

    public RootController(
        ILogger<RootController> logger,
        ICompositeViewEngine compositeViewEngine,
        IUmbracoContextAccessor umbracoContextAccessor,
        IVariationContextAccessor variationContextAccessor,
        IContentTypeService contentTypeService,
        IMediaTypeService mediaTypeService,
        IMemberTypeService memberTypeService,
        IPublishedUrlProvider publishedUrlProvider)
        : base(logger, compositeViewEngine, umbracoContextAccessor)
    {
        _variationContextAccessor = variationContextAccessor;
        _contentTypeService = contentTypeService;
        _mediaTypeService = mediaTypeService;
        _memberTypeService = memberTypeService;
        _publishedUrlProvider = publishedUrlProvider;
    }

    public override IActionResult Index()
    {
        if (CurrentPage is null)
        {
            return NotFound();
        }
#pragma warning disable CS0618 // Type or member is obsolete
        _ = CurrentPage.Ancestor();
        _ = CurrentPage.Ancestor(1);
        _ = CurrentPage.Ancestor("root");
        _ = CurrentPage.Ancestor<IPublishedContent>();
        _ = CurrentPage.Ancestor<IPublishedContent>(1);
        _ = CurrentPage.AncestorOrSelf();
        _ = CurrentPage.AncestorOrSelf(1);
        _ = CurrentPage.AncestorOrSelf("root");
        _ = CurrentPage.AncestorOrSelf<IPublishedContent>();
        _ = CurrentPage.AncestorOrSelf<IPublishedContent>(1);
        _ = CurrentPage.Ancestors();
        _ = CurrentPage.Ancestors(1);
        _ = CurrentPage.Ancestors("root");
        _ = CurrentPage.Ancestors<IPublishedContent>();
        _ = CurrentPage.Ancestors<IPublishedContent>(1);
        _ = CurrentPage.AncestorsOrSelf();
        _ = CurrentPage.AncestorsOrSelf(1);
        _ = CurrentPage.AncestorsOrSelf("root");
        _ = CurrentPage.AncestorsOrSelf(true, content => true);
        _ = CurrentPage.AncestorsOrSelf<IPublishedContent>();
        _ = CurrentPage.AncestorsOrSelf<IPublishedContent>(1);
        _ = CurrentPage.Breadcrumbs();
        _ = CurrentPage.Breadcrumbs(false);
        _ = CurrentPage.Breadcrumbs(1);
        _ = CurrentPage.Breadcrumbs(1, false);
        _ = CurrentPage.Breadcrumbs<IPublishedContent>();
        _ = CurrentPage.Breadcrumbs<IPublishedContent>(false);
        _ = CurrentPage.Children(_variationContextAccessor, "da");
        _ = CurrentPage.Children(_variationContextAccessor, content => true, "da");
        _ = CurrentPage.Children<IPublishedContent>(_variationContextAccessor, "da");
        _ = CurrentPage.ChildrenOfType(_variationContextAccessor, "root", "da");
        _ = CurrentPage.ChildrenAsTable(_variationContextAccessor, _contentTypeService, _mediaTypeService, _memberTypeService, _publishedUrlProvider);
        _ = CurrentPage.DescendantsOrSelfOfType(_variationContextAccessor, "root", "da");
        _ = CurrentPage.Children().DescendantsOrSelfOfType(_variationContextAccessor, "root", "da");
        _ = CurrentPage.Children().DescendantsOrSelf<IPublishedContent>(_variationContextAccessor, "da");
        _ = CurrentPage.Descendants(_variationContextAccessor, "da");
        _ = CurrentPage.Descendants(_variationContextAccessor, 1,"da");
        _ = CurrentPage.DescendantsOfType(_variationContextAccessor, "root", "da");
        _ = CurrentPage.DescendantsOfType(_variationContextAccessor, "root", "da");
        _ = CurrentPage.Descendants<IPublishedContent>(_variationContextAccessor, "da");
        _ = CurrentPage.Descendants<IPublishedContent>(_variationContextAccessor, 1,"da");
        _ = CurrentPage.DescendantsOrSelf(_variationContextAccessor, "da");
        _ = CurrentPage.DescendantsOrSelf(_variationContextAccessor, 1,"da");
        _ = CurrentPage.DescendantsOrSelfOfType(_variationContextAccessor, "root", "da");
        _ = CurrentPage.DescendantsOrSelfOfType(_variationContextAccessor, "root", "da");
        _ = CurrentPage.DescendantsOrSelf<IPublishedContent>(_variationContextAccessor, "da");
        _ = CurrentPage.DescendantsOrSelf<IPublishedContent>(_variationContextAccessor, 1,"da");
        _ = CurrentPage.Descendant(_variationContextAccessor, "da");
        _ = CurrentPage.Descendant(_variationContextAccessor, 1,"da");
        _ = CurrentPage.DescendantOfType(_variationContextAccessor, "root", "da");
        _ = CurrentPage.DescendantOfType(_variationContextAccessor, "root", "da");
        _ = CurrentPage.Descendant<IPublishedContent>(_variationContextAccessor, "da");
        _ = CurrentPage.Descendant<IPublishedContent>(_variationContextAccessor, 1,"da");
        _ = CurrentPage.DescendantOrSelf(_variationContextAccessor, "da");
        _ = CurrentPage.DescendantOrSelf(_variationContextAccessor, 1,"da");
        _ = CurrentPage.DescendantOrSelfOfType(_variationContextAccessor, "root", "da");
        _ = CurrentPage.DescendantOrSelfOfType(_variationContextAccessor, "root", "da");
        _ = CurrentPage.DescendantOrSelf<IPublishedContent>(_variationContextAccessor, "da");
        _ = CurrentPage.DescendantOrSelf<IPublishedContent>(_variationContextAccessor, 1,"da");
        _ = CurrentPage.FirstChild(_variationContextAccessor,"da");
        _ = CurrentPage.FirstChildOfType(_variationContextAccessor, "root","da");
        _ = CurrentPage.FirstChild<IPublishedContent>(_variationContextAccessor);
        _ = CurrentPage.FirstChild<IPublishedContent>(_variationContextAccessor, content => true);
        _ = CurrentPage.Parent<IPublishedContent>();
        _ = CurrentPage.Root();
        _ = CurrentPage.Root<IPublishedContent>();
        _ = CurrentPage.Siblings(_variationContextAccessor, "da");
        _ = CurrentPage.Siblings<IPublishedContent>(_variationContextAccessor, "da");
        _ = CurrentPage.SiblingsOfType(_variationContextAccessor, "root", "da");
        _ = CurrentPage.SiblingsAndSelf(_variationContextAccessor, "da");
        _ = CurrentPage.SiblingsAndSelf<IPublishedContent>(_variationContextAccessor, "da");
        _ = CurrentPage.SiblingsAndSelfOfType(_variationContextAccessor, "root", "da");
#pragma warning restore CS0618 // Type or member is obsolete

        // return a 'model' to the selected template/view for this page.
        return CurrentTemplate(CurrentPage);
    }
}
```

