### PR TITLE
Examine index recovery

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/IndexCreatorSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/IndexCreatorSettings.cs
@@ -13,4 +13,9 @@ public class IndexCreatorSettings
     ///     Gets or sets a value for lucene directory factory type.
     /// </summary>
     public LuceneDirectoryFactory LuceneDirectoryFactory { get; set; }
+
+    /// <summary>
+    ///     Enable main index recovery when it gets corrupted
+    /// </summary>
+    public bool EnableRecovery { get; set; } = true;
 }

--- a/src/Umbraco.Core/Configuration/Models/IndexCreatorSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/IndexCreatorSettings.cs
@@ -17,5 +17,5 @@ public class IndexCreatorSettings
     /// <summary>
     ///     Enable main index recovery when it gets corrupted
     /// </summary>
-    public bool EnableRecovery { get; set; } = true;
+    public bool EnableRecovery { get; set; }
 }

--- a/src/Umbraco.Examine.Lucene/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Examine.Lucene/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -2,6 +2,7 @@ using Examine;
 using Examine.Lucene.Directories;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Hosting;
@@ -38,7 +39,11 @@ public static class UmbracoBuilderExtensions
                     s,
                     new object[]
                     {
-                        new DirectoryInfo(tempDir), s.GetRequiredService<IApplicationRoot>().ApplicationRoot
+                        new DirectoryInfo(tempDir),
+                        s.GetRequiredService<IApplicationRoot>().ApplicationRoot,
+                        s.GetRequiredService<ILockFactory>(),
+                        s.GetRequiredService<ILoggerFactory>(),
+                        true,
                     });
             });
 

--- a/src/Umbraco.Examine.Lucene/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Examine.Lucene/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -3,7 +3,9 @@ using Examine.Lucene.Directories;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Hosting;
 
@@ -31,7 +33,7 @@ public static class UmbracoBuilderExtensions
             s =>
             {
                 var baseDir = s.GetRequiredService<IApplicationRoot>().ApplicationRoot;
-
+                IOptions<IndexCreatorSettings> settings = s.GetRequiredService<IOptions<IndexCreatorSettings>>();
                 var tempDir = UmbracoTempEnvFileSystemDirectoryFactory.GetTempPath(
                     s.GetRequiredService<IApplicationIdentifier>(), s.GetRequiredService<IHostingEnvironment>());
 
@@ -43,7 +45,7 @@ public static class UmbracoBuilderExtensions
                         s.GetRequiredService<IApplicationRoot>().ApplicationRoot,
                         s.GetRequiredService<ILockFactory>(),
                         s.GetRequiredService<ILoggerFactory>(),
-                        true,
+                        settings.Value.EnableRecovery,
                     });
             });
 


### PR DESCRIPTION
I think this flag (tryFixMainIndexIfCorrupt) was forgotten to be activated to enable the newly implemented index recovery?

https://github.com/umbraco/Umbraco-CMS/issues/16163
https://github.com/Shazwazza/Examine/blob/release/3.0/src/Examine.Lucene/Directories/SyncedFileSystemDirectoryFactory.cs#L76

UPDATE: only tested this by replacing this activation in a startup of a clients project.
Was able to inject it into a controller and saw the flag was true then so construction should be fine.