### PR TITLE
Introduce methods on new service to have alternative to obsoleted methods

### DIFF
--- a/src/Umbraco.Core/Services/EntityTypeContainerService.cs
+++ b/src/Umbraco.Core/Services/EntityTypeContainerService.cs
@@ -50,6 +50,22 @@ internal abstract class EntityTypeContainerService<TTreeEntity, TEntityContainer
         return await Task.FromResult(_entityContainerRepository.Get(id));
     }
 
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<EntityContainer>> GetAsync(string name, int level)
+    {
+        using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
+        ReadLock(scope);
+        return await Task.FromResult(_entityContainerRepository.Get(name, level));
+    }
+    /// <inheritdoc />
+    public async Task<IEnumerable<EntityContainer>> GetAllAsync()
+    {
+        using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
+        ReadLock(scope);
+        return await Task.FromResult(_entityContainerRepository.GetMany());
+    }
+
     /// <inheritdoc />
     public async Task<EntityContainer?> GetParentAsync(EntityContainer container)
         => await Task.FromResult(GetParent(container));

--- a/src/Umbraco.Core/Services/IEntityTypeContainerService.cs
+++ b/src/Umbraco.Core/Services/IEntityTypeContainerService.cs
@@ -15,6 +15,20 @@ public interface IEntityTypeContainerService<TTreeEntity>
     Task<EntityContainer?> GetAsync(Guid id);
 
     /// <summary>
+    /// Gets containers by name and level
+    /// </summary>
+    /// <param name="name">The name of the containers to get.</param>
+    /// <param name="level">The level in the tree of the containers to get.</param>
+    /// <returns></returns>
+    Task<IEnumerable<EntityContainer>> GetAsync(string name, int level);
+
+    /// <summary>
+    /// Gets all containers
+    /// </summary>
+    /// <returns></returns>
+    Task<IEnumerable<EntityContainer>> GetAllAsync();
+
+    /// <summary>
     /// Gets the parent container of a container
     /// </summary>
     /// <param name="container">The container whose parent container to get.</param>


### PR DESCRIPTION
### Description
Fixes https://github.com/umbraco/Umbraco-CMS/issues/17202

Introduce two methods on the `IEntityTypeContainerService<T>`:
- Task<IEnumerable<EntityContainer>> GetAsync(string name, int level);
- Task<IEnumerable<EntityContainer>> GetAllAsync();

### Test
You can test it out by creating some data type folders and request them, e.g. just in a view like this
```cshtml
@using Umbraco.Cms.Core.Services
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
@inject IDataTypeContainerService DataTypeContainerService;
@{
	Layout = null;

    var x = await DataTypeContainerService.GetAllAsync(); // returns all three
    var y = await DataTypeContainerService.GetAsync("Subfolder", 1); // Returns only the subfolder in the root
    var z = await DataTypeContainerService.GetAsync("Subfolder", 2); // Returns only the subfolder under folder
}
```
In this example I made the following folders
##
- Folder
   - Subfolder
- Subfolder
