### PR TITLE
Fixed last remains of `GetAll` vs `GetMany`

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Item/ItemDocumentTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Item/ItemDocumentTypeItemController.cs
@@ -32,7 +32,7 @@ public class ItemDocumentTypeItemController : DocumentTypeItemControllerBase
             return Ok(Enumerable.Empty<DocumentTypeItemResponseModel>());
         }
 
-        IEnumerable<IContentType> contentTypes = _contentTypeService.GetAll(ids);
+        IEnumerable<IContentType> contentTypes = _contentTypeService.GetMany(ids);
         List<DocumentTypeItemResponseModel> responseModels = _mapper.MapEnumerable<IContentType, DocumentTypeItemResponseModel>(contentTypes);
         return await Task.FromResult(Ok(responseModels));
     }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Item/SearchDocumentTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Item/SearchDocumentTypeItemController.cs
@@ -35,7 +35,7 @@ public class SearchDocumentTypeItemController : DocumentTypeItemControllerBase
             return await Task.FromResult(Ok(new PagedModel<DocumentTypeItemResponseModel> { Total = searchResult.Total }));
         }
 
-        IEnumerable<IContentType> contentTypes = _contentTypeService.GetAll(searchResult.Items.Select(item => item.Key).ToArray().EmptyNull());
+        IEnumerable<IContentType> contentTypes = _contentTypeService.GetMany(searchResult.Items.Select(item => item.Key).ToArray().EmptyNull());
         var result = new PagedModel<DocumentTypeItemResponseModel>
         {
             Items = _mapper.MapEnumerable<IContentType, DocumentTypeItemResponseModel>(contentTypes),

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Tree/DocumentTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Tree/DocumentTypeTreeControllerBase.cs
@@ -29,7 +29,7 @@ public class DocumentTypeTreeControllerBase : FolderTreeControllerBase<DocumentT
     protected override DocumentTypeTreeItemResponseModel[] MapTreeItemViewModels(Guid? parentKey, IEntitySlim[] entities)
     {
         var contentTypes = _contentTypeService
-            .GetAll(entities.Select(entity => entity.Id).ToArray())
+            .GetMany(entities.Select(entity => entity.Id).ToArray())
             .ToDictionary(contentType => contentType.Id);
 
         return entities.Select(entity =>

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/ItemMediaTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/ItemMediaTypeItemController.cs
@@ -32,7 +32,7 @@ public class ItemMediaTypeItemController : MediaTypeItemControllerBase
             return Ok(Enumerable.Empty<MediaTypeItemResponseModel>());
         }
 
-        IEnumerable<IMediaType> mediaTypes = _mediaTypeService.GetAll(ids);
+        IEnumerable<IMediaType> mediaTypes = _mediaTypeService.GetMany(ids);
         List<MediaTypeItemResponseModel> responseModels = _mapper.MapEnumerable<IMediaType, MediaTypeItemResponseModel>(mediaTypes);
         return await Task.FromResult(Ok(responseModels));
     }

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/SearchMediaTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/SearchMediaTypeItemController.cs
@@ -35,7 +35,7 @@ public class SearchMediaTypeItemController : MediaTypeItemControllerBase
             return await Task.FromResult(Ok(new PagedModel<MediaTypeItemResponseModel> { Total = searchResult.Total }));
         }
 
-        IEnumerable<IMediaType> mediaTypes = _mediaTypeService.GetAll(searchResult.Items.Select(item => item.Key).ToArray().EmptyNull());
+        IEnumerable<IMediaType> mediaTypes = _mediaTypeService.GetMany(searchResult.Items.Select(item => item.Key).ToArray().EmptyNull());
         var result = new PagedModel<MediaTypeItemResponseModel>
         {
             Items = _mapper.MapEnumerable<IMediaType, MediaTypeItemResponseModel>(mediaTypes),

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Tree/MediaTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Tree/MediaTypeTreeControllerBase.cs
@@ -30,7 +30,7 @@ public class MediaTypeTreeControllerBase : FolderTreeControllerBase<MediaTypeTre
     protected override MediaTypeTreeItemResponseModel[] MapTreeItemViewModels(Guid? parentKey, IEntitySlim[] entities)
     {
         var mediaTypes = _mediaTypeService
-            .GetAll(entities.Select(entity => entity.Id).ToArray())
+            .GetMany(entities.Select(entity => entity.Id).ToArray())
             .ToDictionary(contentType => contentType.Id);
 
         return entities.Select(entity =>

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Item/ItemMemberTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Item/ItemMemberTypeItemController.cs
@@ -32,7 +32,7 @@ public class ItemMemberTypeItemController : MemberTypeItemControllerBase
             return Ok(Enumerable.Empty<MemberTypeItemResponseModel>());
         }
 
-        IEnumerable<IMemberType> memberTypes = _memberTypeService.GetAll(ids);
+        IEnumerable<IMemberType> memberTypes = _memberTypeService.GetMany(ids);
         List<MemberTypeItemResponseModel> responseModels = _mapper.MapEnumerable<IMemberType, MemberTypeItemResponseModel>(memberTypes);
         return Ok(responseModels);
     }

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Item/SearchMemberTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Item/SearchMemberTypeItemController.cs
@@ -34,7 +34,7 @@ public class SearchMemberTypeItemController : MemberTypeItemControllerBase
             return await Task.FromResult(Ok(new PagedModel<MemberTypeItemResponseModel> { Total = searchResult.Total }));
         }
 
-        IEnumerable<IMemberType> memberTypes = _memberTypeService.GetAll(searchResult.Items.Select(item => item.Key).ToArray());
+        IEnumerable<IMemberType> memberTypes = _memberTypeService.GetMany(searchResult.Items.Select(item => item.Key).ToArray());
         var result = new PagedModel<MemberTypeItemResponseModel>
         {
             Items = _mapper.MapEnumerable<IMemberType, MemberTypeItemResponseModel>(memberTypes),

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Tree/MemberTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Tree/MemberTypeTreeControllerBase.cs
@@ -27,7 +27,7 @@ public class MemberTypeTreeControllerBase : NamedEntityTreeControllerBase<Member
     protected override MemberTypeTreeItemResponseModel[] MapTreeItemViewModels(Guid? parentKey, IEntitySlim[] entities)
     {
         var memberTypes = _memberTypeService
-            .GetAll(entities.Select(entity => entity.Id).ToArray())
+            .GetMany(entities.Select(entity => entity.Id).ToArray())
             .ToDictionary(contentType => contentType.Id);
 
         return entities.Select(entity =>

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/ExecuteTemplateQueryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/ExecuteTemplateQueryController.cs
@@ -60,7 +60,7 @@ public class ExecuteTemplateQueryController : TemplateQueryControllerBase
         timer.Stop();
 
         var contentTypeIconsByKey = _contentTypeService
-            .GetAll(results.Select(content => content.ContentType.Key).Distinct())
+            .GetMany(results.Select(content => content.ContentType.Key).Distinct())
             .ToDictionary(contentType => contentType.Key, contentType => contentType.Icon);
 
         return await Task.FromResult(Ok(new TemplateQueryResultResponseModel

--- a/src/Umbraco.Cms.Api.Management/Factories/DataTypeReferencePresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DataTypeReferencePresentationFactory.cs
@@ -26,9 +26,9 @@ public class DataTypeReferencePresentationFactory : IDataTypeReferencePresentati
     {
         var getContentTypesByObjectType = new Dictionary<string, Func<IEnumerable<Guid>, IEnumerable<IContentTypeBase>>>
         {
-            { UmbracoObjectTypes.DocumentType.GetUdiType(), keys => _contentTypeService.GetAll(keys) },
-            { UmbracoObjectTypes.MediaType.GetUdiType(), keys => _mediaTypeService.GetAll(keys) },
-            { UmbracoObjectTypes.MemberType.GetUdiType(), keys => _memberTypeService.GetAll(keys) }
+            { UmbracoObjectTypes.DocumentType.GetUdiType(), keys => _contentTypeService.GetMany(keys) },
+            { UmbracoObjectTypes.MediaType.GetUdiType(), keys => _mediaTypeService.GetMany(keys) },
+            { UmbracoObjectTypes.MemberType.GetUdiType(), keys => _memberTypeService.GetMany(keys) }
         };
 
         foreach (IGrouping<string, KeyValuePair<Udi, IEnumerable<string>>> usagesByEntityType in dataTypeUsages.GroupBy(u => u.Key.EntityType))

--- a/src/Umbraco.Core/Handlers/WarnDocumentTypeElementSwitchNotificationHandler.cs
+++ b/src/Umbraco.Core/Handlers/WarnDocumentTypeElementSwitchNotificationHandler.cs
@@ -35,7 +35,7 @@ public class WarnDocumentTypeElementSwitchNotificationHandler :
             .Where(e => e.HasIdentity)
             .Select(e => e.Key);
 
-        IEnumerable<IContentType> persistedItems = _contentTypeService.GetAll(updatedKeys);
+        IEnumerable<IContentType> persistedItems = _contentTypeService.GetMany(updatedKeys);
 
         var stateInformation = persistedItems
             .ToDictionary(

--- a/src/Umbraco.Core/Services/ContentTypeEditing/ElementSwitchValidator.cs
+++ b/src/Umbraco.Core/Services/ContentTypeEditing/ElementSwitchValidator.cs
@@ -31,7 +31,7 @@ public class ElementSwitchValidator : IElementSwitchValidator
         }
 
         // if there are any ancestors where IsElement is different from the contentType, the validation fails
-        return await Task.FromResult(_contentTypeService.GetAll(ancestorIds)
+        return await Task.FromResult(_contentTypeService.GetMany(ancestorIds)
             .Any(ancestor => ancestor.IsElement != contentType.IsElement) is false);
     }
 

--- a/src/Umbraco.Core/Services/IContentTypeServiceBase.cs
+++ b/src/Umbraco.Core/Services/IContentTypeServiceBase.cs
@@ -51,9 +51,10 @@ public interface IContentTypeBaseService<TItem> : IContentTypeBaseService, IServ
     /// </summary>
     bool HasContentNodes(int id);
 
-    IEnumerable<TItem> GetAll(params int[] ids);
+    IEnumerable<TItem> GetAll();
+    IEnumerable<TItem> GetMany(params int[] ids);
 
-    IEnumerable<TItem> GetAll(IEnumerable<Guid>? ids);
+    IEnumerable<TItem> GetMany(IEnumerable<Guid>? ids);
 
     IEnumerable<TItem> GetDescendants(int id, bool andSelf); // parent-child axis
 

--- a/src/Umbraco.Infrastructure/Cache/PropertyEditors/BlockEditorElementTypeCache.cs
+++ b/src/Umbraco.Infrastructure/Cache/PropertyEditors/BlockEditorElementTypeCache.cs
@@ -15,7 +15,9 @@ internal sealed class BlockEditorElementTypeCache : IBlockEditorElementTypeCache
         _appCaches = appCaches;
     }
 
-    public IEnumerable<IContentType> GetAll(IEnumerable<Guid> keys)
+    public IEnumerable<IContentType> GetMany(IEnumerable<Guid> keys) => GetAll().Where(elementType => keys.Contains(elementType.Key));
+
+    public IEnumerable<IContentType> GetAll()
     {
         // TODO: make this less dumb; don't fetch all elements, only fetch the items that aren't yet in the cache and amend the cache as more elements are loaded
 
@@ -27,6 +29,6 @@ internal sealed class BlockEditorElementTypeCache : IBlockEditorElementTypeCache
             _appCaches.RequestCache.Set(cacheKey, cachedElements);
         }
 
-        return cachedElements.Where(elementType => keys.Contains(elementType.Key));
+        return cachedElements;
     }
 }

--- a/src/Umbraco.Infrastructure/Cache/PropertyEditors/IBlockEditorElementTypeCache.cs
+++ b/src/Umbraco.Infrastructure/Cache/PropertyEditors/IBlockEditorElementTypeCache.cs
@@ -4,5 +4,6 @@ namespace Umbraco.Cms.Core.Cache.PropertyEditors;
 
 public interface IBlockEditorElementTypeCache
 {
-    IEnumerable<IContentType> GetAll(IEnumerable<Guid> keys);
+    IEnumerable<IContentType> GetMany(IEnumerable<Guid> keys);
+    IEnumerable<IContentType> GetAll();
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorValidatorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorValidatorBase.cs
@@ -32,7 +32,7 @@ public abstract class BlockEditorValidatorBase<TValue, TLayout> : ComplexEditorV
 
         foreach (var group in itemDataGroups)
         {
-            var allElementTypes = _elementTypeCache.GetAll(group.Items.Select(x => x.ContentTypeKey).ToArray()).ToDictionary(x => x.Key);
+            var allElementTypes = _elementTypeCache.GetMany(group.Items.Select(x => x.ContentTypeKey).ToArray()).ToDictionary(x => x.Key);
 
             for (var i = 0; i < group.Items.Count; i++)
             {

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorValues.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorValues.cs
@@ -59,7 +59,7 @@ public class BlockEditorValues<TValue, TLayout>
         // filter out any content that isn't referenced in the layout references
         IEnumerable<Guid> contentTypeKeys = blockEditorData.BlockValue.ContentData.Select(x => x.ContentTypeKey)
             .Union(blockEditorData.BlockValue.SettingsData.Select(x => x.ContentTypeKey)).Distinct();
-        IDictionary<Guid, IContentType> contentTypesDictionary = _elementTypeCache.GetAll(contentTypeKeys).ToDictionary(x=>x.Key);
+        IDictionary<Guid, IContentType> contentTypesDictionary = _elementTypeCache.GetMany(contentTypeKeys).ToDictionary(x=>x.Key);
 
         foreach (BlockItemData block in blockEditorData.BlockValue.ContentData.Where(x =>
                      blockEditorData.References.Any(r => r.ContentKey == x.Key)))

--- a/src/Umbraco.Infrastructure/Search/IndexingNotificationHandler.ContentType.cs
+++ b/src/Umbraco.Infrastructure/Search/IndexingNotificationHandler.ContentType.cs
@@ -109,7 +109,7 @@ public sealed class ContentTypeIndexingNotificationHandler : INotificationHandle
     {
         const int pageSize = 500;
 
-        IEnumerable<IMemberType> memberTypes = _memberTypeService.GetAll(memberTypeIds);
+        IEnumerable<IMemberType> memberTypes = _memberTypeService.GetMany(memberTypeIds);
         foreach (IMemberType memberType in memberTypes)
         {
             var page = 0;


### PR DESCRIPTION
## Description
According to https://github.com/umbraco/Announcements/issues/15 all services' `GetAll` method has changed behavior, but a a few was not migrated yet.

Changed the behavior to not return all items, renamed to `GetMany`, when no keys received. Instead a new `GetAll` method is introduced that do not take any parameters.

