### PR TITLE
Block level variants - search indexing

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/DefaultPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Core/PropertyEditors/DefaultPropertyIndexValueFactory.cs
@@ -1,5 +1,4 @@
 using Umbraco.Cms.Core.Models;
-using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
@@ -9,11 +8,15 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 /// </summary>
 public class DefaultPropertyIndexValueFactory : IPropertyIndexValueFactory
 {
-    public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published,
+    public IEnumerable<IndexValue> GetIndexValues(IProperty property, string? culture, string? segment, bool published,
         IEnumerable<string> availableCultures, IDictionary<Guid, IContentType> contentTypeDictionary)
-    {
-        yield return new KeyValuePair<string, IEnumerable<object?>>(
-            property.Alias,
-            property.GetValue(culture, segment, published).Yield());
-    }
+        =>
+        [
+            new IndexValue
+            {
+                Culture = culture,
+                FieldName = property.Alias,
+                Values = [property.GetValue(culture, segment, published)]
+            }
+        ];
 }

--- a/src/Umbraco.Core/PropertyEditors/IPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Core/PropertyEditors/IPropertyIndexValueFactory.cs
@@ -12,9 +12,9 @@ public interface IPropertyIndexValueFactory
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         Returns key-value pairs, where keys are indexed field names. By default, that would be the property alias,
-    ///         and there would be only one pair, but some implementations (see for instance the grid one) may return more than
-    ///         one pair, with different indexed field names.
+    ///         Returns index values for a given property. By default, a property uses its alias as index field name,
+    ///         and there would be only one index value, but some implementations (see for instance the grid one) may return more than
+    ///         one value, with different indexed field names.
     ///     </para>
     ///     <para>
     ///         And then, values are an enumerable of objects, because each indexed field can in turn have multiple
@@ -22,7 +22,7 @@ public interface IPropertyIndexValueFactory
     ///         more than one value for a given field.
     ///     </para>
     /// </remarks>
-    IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(
+    IEnumerable<IndexValue> GetIndexValues(
         IProperty property,
         string? culture,
         string? segment,

--- a/src/Umbraco.Core/PropertyEditors/IndexValue.cs
+++ b/src/Umbraco.Core/PropertyEditors/IndexValue.cs
@@ -1,0 +1,10 @@
+namespace Umbraco.Cms.Core.PropertyEditors;
+
+public sealed class IndexValue
+{
+    public required string? Culture { get; set; }
+
+    public required string FieldName { get; set; }
+
+    public required IEnumerable<object?> Values { get; set; }
+}

--- a/src/Umbraco.Core/PropertyEditors/JsonPropertyIndexValueFactoryBase.cs
+++ b/src/Umbraco.Core/PropertyEditors/JsonPropertyIndexValueFactoryBase.cs
@@ -27,7 +27,7 @@ public abstract class JsonPropertyIndexValueFactoryBase<TSerialized> : IProperty
         indexingSettings.OnChange(newValue => _indexingSettings = newValue);
     }
 
-    public virtual IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(
+    public virtual IEnumerable<IndexValue> GetIndexValues(
         IProperty property,
         string? culture,
         string? segment,
@@ -35,7 +35,7 @@ public abstract class JsonPropertyIndexValueFactoryBase<TSerialized> : IProperty
         IEnumerable<string> availableCultures,
         IDictionary<Guid, IContentType> contentTypeDictionary)
     {
-        var result = new List<KeyValuePair<string, IEnumerable<object?>>>();
+        var result = new List<IndexValue>();
 
         var propertyValue = property.GetValue(culture, segment, published);
 
@@ -65,7 +65,7 @@ public abstract class JsonPropertyIndexValueFactoryBase<TSerialized> : IProperty
             }
         }
 
-        IEnumerable<KeyValuePair<string, IEnumerable<object?>>> summary = HandleResume(result, property, culture, segment, published);
+        IEnumerable<IndexValue> summary = HandleResume(result, property, culture, segment, published);
         if (_indexingSettings.ExplicitlyIndexEachNestedProperty || ForceExplicitlyIndexEachNestedProperty)
         {
             result.AddRange(summary);
@@ -78,17 +78,17 @@ public abstract class JsonPropertyIndexValueFactoryBase<TSerialized> : IProperty
     /// <summary>
     ///  Method to return a list of summary of the content. By default this returns an empty list
     /// </summary>
-    protected virtual IEnumerable<KeyValuePair<string, IEnumerable<object?>>> HandleResume(
-        List<KeyValuePair<string, IEnumerable<object?>>> result,
+    protected virtual IEnumerable<IndexValue> HandleResume(
+        List<IndexValue> result,
         IProperty property,
         string? culture,
         string? segment,
-        bool published) => Array.Empty<KeyValuePair<string, IEnumerable<object?>>>();
+        bool published) => Array.Empty<IndexValue>();
 
     /// <summary>
     ///  Method that handle the deserialized object.
     /// </summary>
-    protected abstract IEnumerable<KeyValuePair<string, IEnumerable<object?>>> Handle(
+    protected abstract IEnumerable<IndexValue> Handle(
         TSerialized deserializedPropertyValue,
         IProperty property,
         string? culture,

--- a/src/Umbraco.Core/PropertyEditors/NoopPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Core/PropertyEditors/NoopPropertyIndexValueFactory.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 public class NoopPropertyIndexValueFactory : IPropertyIndexValueFactory
 {
     /// <inheritdoc />
-    public IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(IProperty property, string? culture, string? segment, bool published,
+    public IEnumerable<IndexValue> GetIndexValues(IProperty property, string? culture, string? segment, bool published,
         IEnumerable<string> availableCultures, IDictionary<Guid, IContentType> contentTypeDictionary)
-    => Array.Empty<KeyValuePair<string, IEnumerable<object?>>>();
+        => [];
 }

--- a/src/Umbraco.Infrastructure/Examine/BaseValueSetBuilder.cs
+++ b/src/Umbraco.Infrastructure/Examine/BaseValueSetBuilder.cs
@@ -30,18 +30,19 @@ public abstract class BaseValueSetBuilder<TContent> : IValueSetBuilder<TContent>
             return;
         }
 
-        IEnumerable<KeyValuePair<string, IEnumerable<object?>>> indexVals =
+        IEnumerable<IndexValue> indexVals =
             editor.PropertyIndexValueFactory.GetIndexValues(property, culture, segment, PublishedValuesOnly, availableCultures, contentTypeDictionary);
-        foreach (KeyValuePair<string, IEnumerable<object?>> keyVal in indexVals)
+        foreach (IndexValue indexValue in indexVals)
         {
-            if (keyVal.Key.IsNullOrWhiteSpace())
+            if (indexValue.FieldName.IsNullOrWhiteSpace())
             {
                 continue;
             }
 
-            var cultureSuffix = culture == null ? string.Empty : "_" + culture;
+            var indexValueCulture = indexValue.Culture ?? culture;
+            var cultureSuffix = indexValueCulture == null ? string.Empty : "_" + indexValueCulture.ToLowerInvariant();
 
-            foreach (var val in keyVal.Value)
+            foreach (var val in indexValue.Values)
             {
                 switch (val)
                 {
@@ -55,28 +56,28 @@ public abstract class BaseValueSetBuilder<TContent> : IValueSetBuilder<TContent>
                             continue;
                         }
 
-                        var key = $"{keyVal.Key}{cultureSuffix}";
+                        var key = $"{indexValue.FieldName}{cultureSuffix}";
                         if (values?.TryGetValue(key, out IEnumerable<object?>? v) ?? false)
                         {
                             values[key] = new List<object?>(v) { val }.ToArray();
                         }
                         else
                         {
-                            values?.Add($"{keyVal.Key}{cultureSuffix}", val.Yield());
+                            values?.Add($"{indexValue.FieldName}{cultureSuffix}", val.Yield());
                         }
                     }
 
                         break;
                     default:
                         {
-                        var key = $"{keyVal.Key}{cultureSuffix}";
+                        var key = $"{indexValue.FieldName}{cultureSuffix}";
                         if (values?.TryGetValue(key, out IEnumerable<object?>? v) ?? false)
                         {
                             values[key] = new List<object?>(v) { val }.ToArray();
                         }
                         else
                         {
-                            values?.Add($"{keyVal.Key}{cultureSuffix}", val.Yield());
+                            values?.Add($"{indexValue.FieldName}{cultureSuffix}", val.Yield());
                         }
                     }
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyIndexValueFactory.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyIndexValueFactory.cs
@@ -3,14 +3,13 @@
 
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
-using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Core.Serialization;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
-internal sealed class BlockValuePropertyIndexValueFactory :
-    NestedPropertyIndexValueFactoryBase<BlockValuePropertyIndexValueFactory.IndexValueFactoryBlockValue, BlockItemData>,
+internal class BlockValuePropertyIndexValueFactory :
+    NestedPropertyIndexValueFactoryBase<BlockValuePropertyIndexValueFactory.IndexValueFactoryBlockValue>,
     IBlockValuePropertyIndexValueFactory
 {
     public BlockValuePropertyIndexValueFactory(
@@ -21,19 +20,14 @@ internal sealed class BlockValuePropertyIndexValueFactory :
     {
     }
 
-    protected override IContentType? GetContentTypeOfNestedItem(BlockItemData input, IDictionary<Guid, IContentType> contentTypeDictionary)
-        => contentTypeDictionary.TryGetValue(input.ContentTypeKey, out var result) ? result : null;
-
-    protected override IDictionary<string, object?> GetRawProperty(BlockItemData blockItemData)
-        => blockItemData.Values
-            .Where(p => p.Culture is null && p.Segment is null)
-            .ToDictionary(p => p.Alias, p => p.Value);
-
-    protected override IEnumerable<BlockItemData> GetDataItems(IndexValueFactoryBlockValue input) => input.ContentData;
+    protected override IEnumerable<RawDataItem> GetDataItems(IndexValueFactoryBlockValue input, bool published)
+        => GetDataItems(input.ContentData, input.Expose, published);
 
     // we only care about the content data when extracting values for indexing - not the layouts nor the settings
     internal class IndexValueFactoryBlockValue
     {
         public List<BlockItemData> ContentData { get; set; } = new();
+
+        public List<BlockItemVariation> Expose { get; set; } = new();
     }
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyIndexValueFactory.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyIndexValueFactory.cs
@@ -9,7 +9,7 @@ using Umbraco.Cms.Core.Serialization;
 namespace Umbraco.Cms.Core.PropertyEditors;
 
 internal class BlockValuePropertyIndexValueFactory :
-    NestedPropertyIndexValueFactoryBase<BlockValuePropertyIndexValueFactory.IndexValueFactoryBlockValue>,
+    BlockValuePropertyIndexValueFactoryBase<BlockValuePropertyIndexValueFactory.IndexValueFactoryBlockValue>,
     IBlockValuePropertyIndexValueFactory
 {
     public BlockValuePropertyIndexValueFactory(

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyIndexValueFactoryBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyIndexValueFactoryBase.cs
@@ -9,12 +9,11 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
-// TODO KJA: rename to BlockValuePropertyIndexValueFactoryBase
-internal abstract class NestedPropertyIndexValueFactoryBase<TSerialized> : JsonPropertyIndexValueFactoryBase<TSerialized>
+internal abstract class BlockValuePropertyIndexValueFactoryBase<TSerialized> : JsonPropertyIndexValueFactoryBase<TSerialized>
 {
     private readonly PropertyEditorCollection _propertyEditorCollection;
 
-    protected NestedPropertyIndexValueFactoryBase(
+    protected BlockValuePropertyIndexValueFactoryBase(
         PropertyEditorCollection propertyEditorCollection,
         IJsonSerializer jsonSerializer,
         IOptionsMonitor<IndexingSettings> indexingSettings)

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyIndexValueFactory.cs
@@ -8,7 +8,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
-internal class RichTextPropertyIndexValueFactory : NestedPropertyIndexValueFactoryBase<RichTextEditorValue>, IRichTextPropertyIndexValueFactory
+internal class RichTextPropertyIndexValueFactory : BlockValuePropertyIndexValueFactoryBase<RichTextEditorValue>, IRichTextPropertyIndexValueFactory
 {
     private readonly IJsonSerializer _jsonSerializer;
     private readonly ILogger<RichTextPropertyIndexValueFactory> _logger;

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyIndexValueFactory.cs
@@ -2,15 +2,13 @@
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Core.Serialization;
-using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Examine;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
-internal class RichTextPropertyIndexValueFactory : NestedPropertyIndexValueFactoryBase<RichTextEditorValue, BlockItemData>, IRichTextPropertyIndexValueFactory
+internal class RichTextPropertyIndexValueFactory : NestedPropertyIndexValueFactoryBase<RichTextEditorValue>, IRichTextPropertyIndexValueFactory
 {
     private readonly IJsonSerializer _jsonSerializer;
     private readonly ILogger<RichTextPropertyIndexValueFactory> _logger;
@@ -26,18 +24,7 @@ internal class RichTextPropertyIndexValueFactory : NestedPropertyIndexValueFacto
         _logger = logger;
     }
 
-    [Obsolete("Use constructor that doesn't take IContentTypeService, scheduled for removal in V15")]
-    public RichTextPropertyIndexValueFactory(
-        PropertyEditorCollection propertyEditorCollection,
-        IJsonSerializer jsonSerializer,
-        IOptionsMonitor<IndexingSettings> indexingSettings,
-        IContentTypeService contentTypeService,
-        ILogger<RichTextPropertyIndexValueFactory> logger)
-        : this(propertyEditorCollection, jsonSerializer, indexingSettings, logger)
-    {
-    }
-
-    public new IEnumerable<KeyValuePair<string, IEnumerable<object?>>> GetIndexValues(
+    public override IEnumerable<IndexValue> GetIndexValues(
         IProperty property,
         string? culture,
         string? segment,
@@ -48,33 +35,101 @@ internal class RichTextPropertyIndexValueFactory : NestedPropertyIndexValueFacto
         var val = property.GetValue(culture, segment, published);
         if (RichTextPropertyEditorHelper.TryParseRichTextEditorValue(val, _jsonSerializer, _logger, out RichTextEditorValue? richTextEditorValue) is false)
         {
-            yield break;
+            return [];
+        }
+
+        // always index the "raw" value
+        var indexValues = new List<IndexValue>
+        {
+            new IndexValue
+            {
+                Culture = culture,
+                FieldName = $"{UmbracoExamineFieldNames.RawFieldPrefix}{property.Alias}",
+                Values = [richTextEditorValue.Markup]
+            }
+        };
+
+        // the actual content (RTE content without markup, i.e. the actual words) must be indexed under the property alias
+        var richTextWithoutMarkup = richTextEditorValue.Markup.StripHtml();
+        if (richTextEditorValue.Blocks?.ContentData.Any() is not true)
+        {
+            // no blocks; index the content for the culture and be done with it
+            indexValues.Add(new IndexValue
+            {
+                Culture = culture,
+                FieldName = property.Alias,
+                Values = [richTextWithoutMarkup]
+            });
+            return indexValues;
         }
 
         // the "blocks values resume" (the combined searchable text values from all blocks) is stored as a string value under the property alias by the base implementation
-        var blocksIndexValues = base.GetIndexValues(property, culture, segment, published, availableCultures, contentTypeDictionary).ToDictionary(pair => pair.Key, pair => pair.Value);
-        var blocksIndexValuesResume = blocksIndexValues.TryGetValue(property.Alias, out IEnumerable<object?>? blocksIndexValuesResumeValue)
-                ? blocksIndexValuesResumeValue.FirstOrDefault() as string
-                : null;
+        var blocksIndexValuesResumes = base
+            .GetIndexValues(property, culture, segment, published, availableCultures, contentTypeDictionary)
+            .Where(value => value.FieldName == property.Alias)
+            .GroupBy(value => value.Culture?.ToLowerInvariant())
+            .Select(group => new
+            {
+                Culture = group.Key,
+                Resume = string.Join(Environment.NewLine, group.Select(v => v.Values.FirstOrDefault() as string))
+            })
+            .ToArray();
 
-        // index the stripped HTML values combined with "blocks values resume" value
-        yield return new KeyValuePair<string, IEnumerable<object?>>(
-            property.Alias,
-            new object[] { $"{richTextEditorValue.Markup.StripHtml()} {blocksIndexValuesResume}" });
+        // is this RTE sat on culture variant content?
+        if (culture is not null)
+        {
+            // yes, append the "block values resume" for the specific culture only (if present)
+            var blocksResume = blocksIndexValuesResumes
+                .FirstOrDefault(r => r.Culture.InvariantEquals(culture))?
+                .Resume;
 
-        // store the raw value
-        yield return new KeyValuePair<string, IEnumerable<object?>>(
-            $"{UmbracoExamineFieldNames.RawFieldPrefix}{property.Alias}", new object[] { richTextEditorValue.Markup });
+            indexValues.Add(new IndexValue
+            {
+                Culture = culture,
+                FieldName = property.Alias,
+                Values = [$"{richTextWithoutMarkup}{Environment.NewLine}{blocksResume}"]
+            });
+            return indexValues;
+        }
+
+        // is there an invariant "block values resume"? this might happen for purely invariant blocks or in a culture invariant context
+        var invariantResume = blocksIndexValuesResumes
+            .FirstOrDefault(r => r.Culture is null)
+            ?.Resume;
+        if (invariantResume != null)
+        {
+            // yes, append the invariant "block values resume"
+            indexValues.Add(new IndexValue
+            {
+                Culture = culture,
+                FieldName = property.Alias,
+                Values = [$"{richTextWithoutMarkup}{Environment.NewLine}{invariantResume}"]
+            });
+            return indexValues;
+        }
+
+        // at this point we have encountered block level variance - add explicit index values for all "block values resume" cultures found
+        indexValues.AddRange(blocksIndexValuesResumes.Select(resume =>
+            new IndexValue
+            {
+                Culture = resume.Culture,
+                FieldName = property.Alias,
+                Values = [$"{richTextWithoutMarkup}{Environment.NewLine}{resume.Resume}"]
+            }));
+
+        // if one or more cultures did not have any (exposed) blocks, ensure that the RTE content is still indexed for those cultures
+        IEnumerable<string?> missingBlocksResumeCultures = availableCultures.Except(blocksIndexValuesResumes.Select(r => r.Culture), StringComparer.CurrentCultureIgnoreCase);
+        indexValues.AddRange(missingBlocksResumeCultures.Select(missingResumeCulture =>
+            new IndexValue
+            {
+                Culture = missingResumeCulture,
+                FieldName = property.Alias,
+                Values = [richTextWithoutMarkup]
+            }));
+
+        return indexValues;
     }
 
-    protected override IContentType? GetContentTypeOfNestedItem(BlockItemData nestedItem, IDictionary<Guid, IContentType> contentTypeDictionary)
-        => contentTypeDictionary.TryGetValue(nestedItem.ContentTypeKey, out var result) ? result : null;
-
-    protected override IDictionary<string, object?> GetRawProperty(BlockItemData blockItemData)
-        => blockItemData.Values
-            .Where(p => p.Culture is null && p.Segment is null)
-            .ToDictionary(p => p.Alias, p => p.Value);
-
-    protected override IEnumerable<BlockItemData> GetDataItems(RichTextEditorValue input)
-        => input.Blocks?.ContentData ?? new List<BlockItemData>();
+    protected override IEnumerable<RawDataItem> GetDataItems(RichTextEditorValue input, bool published)
+        => GetDataItems(input.Blocks?.ContentData ?? [], input.Blocks?.Expose ?? [], published);
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Indexing.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Indexing.cs
@@ -1,0 +1,399 @@
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Blocks;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.PropertyEditors;
+
+public partial class BlockListElementLevelVariationTests
+{
+    [Test]
+    public async Task Can_Index_Cultures_Independently_Invariant_Blocks()
+    {
+        var elementType = CreateElementType(ContentVariation.Culture);
+        var blockListDataType = await CreateBlockListDataType(elementType);
+        var contentType = CreateContentType(ContentVariation.Culture, blockListDataType);
+
+        var content = CreateContent(
+            contentType,
+            elementType,
+            new List<BlockPropertyValue>
+            {
+                new() { Alias = "invariantText", Value = "The invariant content value" },
+                new() { Alias = "variantText", Value = "The content value (en-US)", Culture = "en-US" },
+                new() { Alias = "variantText", Value = "The content value (da-DK)", Culture = "da-DK" },
+            },
+            new List<BlockPropertyValue>
+            {
+                new() { Alias = "invariantText", Value = "The invariant settings value" },
+                new() { Alias = "variantText", Value = "The settings value (en-US)", Culture = "en-US" },
+                new() { Alias = "variantText", Value = "The settings value (da-DK)", Culture = "da-DK" },
+            },
+            true);
+
+        var editor = blockListDataType.Editor!;
+        var indexValues = editor.PropertyIndexValueFactory.GetIndexValues(
+            content.Properties["blocks"]!,
+            culture: null,
+            segment: null,
+            published: true,
+            availableCultures: ["en-US", "da-DK"],
+            contentTypeDictionary: new Dictionary<Guid, IContentType>
+            {
+                { elementType.Key, elementType }, { contentType.Key, contentType }
+            });
+
+        Assert.AreEqual(2, indexValues.Count());
+
+        AssertIndexValues("en-US");
+        AssertIndexValues("da-DK");
+
+        void AssertIndexValues(string culture)
+        {
+            var indexValue = indexValues.FirstOrDefault(v => v.Culture == culture);
+            Assert.IsNotNull(indexValue);
+            Assert.AreEqual(1, indexValue.Values.Count());
+            var indexedValue = indexValue.Values.First() as string;
+            Assert.IsNotNull(indexedValue);
+            var values = indexedValue.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+            Assert.AreEqual(2, values.Length);
+            Assert.Contains($"The content value ({culture})", values);
+            Assert.Contains("The invariant content value", values);
+        }
+    }
+
+    [Test]
+    public async Task Can_Index_Cultures_Independently_Variant_Blocks()
+    {
+        var elementType = CreateElementType(ContentVariation.Culture);
+        var blockListDataType = await CreateBlockListDataType(elementType);
+        var contentType = CreateContentType(ContentVariation.Culture, blockListDataType, ContentVariation.Culture);
+
+        var content = CreateContent(
+            contentType,
+            elementType,
+            new []
+            {
+                new BlockProperty(
+                    new List<BlockPropertyValue>
+                    {
+                        new() { Alias = "invariantText", Value = "en-US invariantText content value" },
+                        new() { Alias = "variantText", Value = "en-US variantText content value" }
+                    },
+                    new List<BlockPropertyValue>
+                    {
+                        new() { Alias = "invariantText", Value = "en-US invariantText settings value" },
+                        new() { Alias = "variantText", Value = "en-US variantText settings value" }
+                    },
+                    "en-US",
+                    null),
+                new BlockProperty(
+                    new List<BlockPropertyValue>
+                    {
+                        new() { Alias = "invariantText", Value = "da-DK invariantText content value" },
+                        new() { Alias = "variantText", Value = "da-DK variantText content value" }
+                    },
+                    new List<BlockPropertyValue>
+                    {
+                        new() { Alias = "invariantText", Value = "da-DK invariantText settings value" },
+                        new() { Alias = "variantText", Value = "da-DK variantText settings value" }
+                    },
+                    "da-DK",
+                    null)
+            },
+            true);
+
+        AssertIndexValues("en-US");
+        AssertIndexValues("da-DK");
+
+        void AssertIndexValues(string culture)
+        {
+            var editor = blockListDataType.Editor!;
+            var indexValues = editor.PropertyIndexValueFactory.GetIndexValues(
+                content.Properties["blocks"]!,
+                culture: culture,
+                segment: null,
+                published: true,
+                availableCultures: ["en-US", "da-DK"],
+                contentTypeDictionary: new Dictionary<Guid, IContentType>
+                {
+                    { elementType.Key, elementType }, { contentType.Key, contentType }
+                });
+
+            Assert.AreEqual(1, indexValues.Count());
+
+            var indexValue = indexValues.FirstOrDefault(v => v.Culture == culture);
+            Assert.IsNotNull(indexValue);
+            Assert.AreEqual(1, indexValue.Values.Count());
+            var indexedValue = indexValue.Values.First() as string;
+            Assert.IsNotNull(indexedValue);
+            Assert.AreEqual($"{culture} invariantText content value {culture} variantText content value", TrimAndStripNewlines(indexedValue));
+        }
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Can_Handle_Unexposed_Blocks(bool published)
+    {
+        var elementType = CreateElementType(ContentVariation.Culture);
+        var blockListDataType = await CreateBlockListDataType(elementType);
+        var contentType = CreateContentType(ContentVariation.Culture, blockListDataType);
+
+        var content = CreateContent(contentType, elementType, [], false);
+        var blockListValue = BlockListPropertyValue(
+            elementType,
+            [
+                (
+                    Guid.NewGuid(),
+                    Guid.NewGuid(),
+                    new BlockProperty(
+                        new List<BlockPropertyValue> {
+                            new() { Alias = "invariantText", Value = "#1: The invariant content value" },
+                            new() { Alias = "variantText", Value = "#1: The content value in English", Culture = "en-US" },
+                            new() { Alias = "variantText", Value = "#1: The content value in Danish", Culture = "da-DK" }
+                        },
+                        [],
+                        null,
+                        null
+                    )
+                ),
+                (
+                    Guid.NewGuid(),
+                    Guid.NewGuid(),
+                    new BlockProperty(
+                        new List<BlockPropertyValue> {
+                            new() { Alias = "invariantText", Value = "#2: The invariant content value" },
+                            new() { Alias = "variantText", Value = "#2: The content value in English", Culture = "en-US" },
+                            new() { Alias = "variantText", Value = "#2: The content value in Danish", Culture = "da-DK" }
+                        },
+                        [],
+                        null,
+                        null
+                    )
+                )
+            ]
+        );
+
+        // only expose the first block in English and the second block in Danish (to make a difference between published and unpublished index values)
+        blockListValue.Expose =
+        [
+            new() { ContentKey = blockListValue.ContentData[0].Key, Culture = "en-US" },
+            new() { ContentKey = blockListValue.ContentData[1].Key, Culture = "da-DK" },
+        ];
+
+        content.Properties["blocks"]!.SetValue(JsonSerializer.Serialize(blockListValue));
+        ContentService.Save(content);
+
+        PublishContent(content, contentType, ["en-US", "da-DK"]);
+
+        var editor = blockListDataType.Editor!;
+        var indexValues = editor.PropertyIndexValueFactory.GetIndexValues(
+            content.Properties["blocks"]!,
+            culture: null,
+            segment: null,
+            published: published,
+            availableCultures: ["en-US", "da-DK"],
+            contentTypeDictionary: new Dictionary<Guid, IContentType>
+            {
+                { elementType.Key, elementType }, { contentType.Key, contentType }
+            });
+
+        Assert.AreEqual(2, indexValues.Count());
+        var indexValue = indexValues.FirstOrDefault(v => v.Culture == "da-DK");
+        Assert.IsNotNull(indexValue);
+        Assert.AreEqual(1, indexValue.Values.Count());
+        var indexedValue = indexValue.Values.First() as string;
+        Assert.IsNotNull(indexedValue);
+        if (published)
+        {
+            Assert.AreEqual("#2: The invariant content value #2: The content value in Danish", TrimAndStripNewlines(indexedValue));
+        }
+        else
+        {
+            Assert.AreEqual("#1: The invariant content value #1: The content value in Danish #2: The invariant content value #2: The content value in Danish", TrimAndStripNewlines(indexedValue));
+        }
+
+        indexValue = indexValues.FirstOrDefault(v => v.Culture == "en-US");
+        Assert.IsNotNull(indexValue);
+        Assert.AreEqual(1, indexValue.Values.Count());
+        indexedValue = indexValue.Values.First() as string;
+        Assert.IsNotNull(indexedValue);
+        if (published)
+        {
+            Assert.AreEqual("#1: The content value in English #1: The invariant content value", TrimAndStripNewlines(indexedValue));
+        }
+        else
+        {
+            Assert.AreEqual("#1: The invariant content value #1: The content value in English #2: The invariant content value #2: The content value in English", TrimAndStripNewlines(indexedValue));
+        }
+    }
+
+    [TestCase(ContentVariation.Nothing)]
+    [TestCase(ContentVariation.Culture)]
+    public async Task Can_Index_Invariant(ContentVariation elementTypeVariation)
+    {
+        var elementType = CreateElementType(elementTypeVariation);
+        var blockListDataType = await CreateBlockListDataType(elementType);
+        var contentType = CreateContentType(ContentVariation.Nothing, blockListDataType);
+
+        var content = CreateContent(
+            contentType,
+            elementType,
+            new List<BlockPropertyValue>
+            {
+                new() { Alias = "invariantText", Value = "The invariant content value" },
+                new() { Alias = "variantText", Value = "Another invariant content value" }
+            },
+            new List<BlockPropertyValue>
+            {
+                new() { Alias = "invariantText", Value = "The invariant settings value" },
+                new() { Alias = "variantText", Value = "Another invariant settings value" }
+            },
+            true);
+
+        var editor = blockListDataType.Editor!;
+        var indexValues = editor.PropertyIndexValueFactory.GetIndexValues(
+            content.Properties["blocks"]!,
+            culture: null,
+            segment: null,
+            published: true,
+            availableCultures: ["en-US"],
+            contentTypeDictionary: new Dictionary<Guid, IContentType>
+            {
+                { elementType.Key, elementType }, { contentType.Key, contentType }
+            });
+
+        Assert.AreEqual(1, indexValues.Count());
+        var indexValue = indexValues.FirstOrDefault(v => v.Culture is null);
+        Assert.IsNotNull(indexValue);
+        Assert.AreEqual(1, indexValue.Values.Count());
+        var indexedValue = indexValue.Values.First() as string;
+        Assert.IsNotNull(indexedValue);
+        var values = indexedValue.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.AreEqual(2, values.Length);
+        Assert.Contains("The invariant content value", values);
+        Assert.Contains("Another invariant content value", values);
+    }
+
+    [Test]
+    public async Task Can_Index_Cultures_Independently_Nested_Invariant_Blocks()
+    {
+        var nestedElementType = CreateElementType(ContentVariation.Culture);
+        var nestedBlockListDataType = await CreateBlockListDataType(nestedElementType);
+
+        var rootElementType = new ContentTypeBuilder()
+            .WithAlias("myRootElementType")
+            .WithName("My Root Element Type")
+            .WithIsElement(true)
+            .WithContentVariation(ContentVariation.Culture)
+            .AddPropertyType()
+            .WithAlias("invariantText")
+            .WithName("Invariant text")
+            .WithDataTypeId(Constants.DataTypes.Textbox)
+            .WithPropertyEditorAlias(Constants.PropertyEditors.Aliases.TextBox)
+            .WithValueStorageType(ValueStorageType.Nvarchar)
+            .WithVariations(ContentVariation.Nothing)
+            .Done()
+            .AddPropertyType()
+            .WithAlias("variantText")
+            .WithName("Variant text")
+            .WithDataTypeId(Constants.DataTypes.Textbox)
+            .WithPropertyEditorAlias(Constants.PropertyEditors.Aliases.TextBox)
+            .WithValueStorageType(ValueStorageType.Nvarchar)
+            .WithVariations(ContentVariation.Culture)
+            .Done()
+            .AddPropertyType()
+            .WithAlias("nestedBlocks")
+            .WithName("Nested blocks")
+            .WithDataTypeId(nestedBlockListDataType.Id)
+            .WithPropertyEditorAlias(Constants.PropertyEditors.Aliases.BlockList)
+            .WithValueStorageType(ValueStorageType.Ntext)
+            .WithVariations(ContentVariation.Nothing)
+            .Done()
+            .Build();
+        ContentTypeService.Save(rootElementType);
+        var rootBlockListDataType = await CreateBlockListDataType(rootElementType);
+        var contentType = CreateContentType(ContentVariation.Culture, rootBlockListDataType);
+
+        var nestedElementContentKey = Guid.NewGuid();
+        var nestedElementSettingsKey = Guid.NewGuid();
+        var content = CreateContent(
+            contentType,
+            rootElementType,
+            new List<BlockPropertyValue>
+            {
+                new()
+                {
+                    Alias = "nestedBlocks",
+                    Value = BlockListPropertyValue(
+                        nestedElementType,
+                        nestedElementContentKey,
+                        nestedElementSettingsKey,
+                        new BlockProperty(
+                            new List<BlockPropertyValue>
+                            {
+                                new() { Alias = "invariantText", Value = "The first nested invariant content value" },
+                                new() { Alias = "variantText", Value = "The first nested content value in English", Culture = "en-US" },
+                                new() { Alias = "variantText", Value = "The first nested content value in Danish", Culture = "da-DK" },
+                            },
+                            new List<BlockPropertyValue>
+                            {
+                                new() { Alias = "invariantText", Value = "The first nested invariant settings value" },
+                                new() { Alias = "variantText", Value = "The first nested settings value in English", Culture = "en-US" },
+                                new() { Alias = "variantText", Value = "The first nested settings value in Danish", Culture = "da-DK" },
+                            },
+                            null,
+                            null))
+                },
+                new() { Alias = "invariantText", Value = "The first root invariant content value" },
+                new() { Alias = "variantText", Value = "The first root content value in English", Culture = "en-US" },
+                new() { Alias = "variantText", Value = "The first root content value in Danish", Culture = "da-DK" },
+            },
+            [],
+            true);
+
+        var editor = rootBlockListDataType.Editor!;
+        var indexValues = editor.PropertyIndexValueFactory.GetIndexValues(
+            content.Properties["blocks"]!,
+            culture: null,
+            segment: null,
+            published: true,
+            availableCultures: ["en-US"],
+            contentTypeDictionary: new Dictionary<Guid, IContentType>
+            {
+                { nestedElementType.Key, nestedElementType }, { rootElementType.Key, rootElementType }, { contentType.Key, contentType }
+            });
+        Assert.AreEqual(2, indexValues.Count());
+
+        AssertIndexedValues(
+            "en-US",
+            "The first root invariant content value",
+            "The first root content value in English",
+            "The first nested invariant content value",
+            "The first nested content value in English");
+
+        AssertIndexedValues(
+            "da-DK",
+            "The first root invariant content value",
+            "The first root content value in Danish",
+            "The first nested invariant content value",
+            "The first nested content value in Danish");
+
+        void AssertIndexedValues(string culture, params string[] expectedIndexedValues)
+        {
+            var indexValue = indexValues.FirstOrDefault(v => v.Culture == culture);
+            Assert.IsNotNull(indexValue);
+            Assert.AreEqual(1, indexValue.Values.Count());
+            var indexedValue = indexValue.Values.First() as string;
+            Assert.IsNotNull(indexedValue);
+            var values = indexedValue.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+            Assert.AreEqual(expectedIndexedValues.Length, values.Length);
+            Assert.IsTrue(values.ContainsAll(expectedIndexedValues));
+        }
+    }
+
+    private string TrimAndStripNewlines(string value)
+        => value.Replace(Environment.NewLine, " ").Trim();
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/PropertyIndexValueFactoryTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/PropertyIndexValueFactoryTests.cs
@@ -83,12 +83,13 @@ public class PropertyIndexValueFactoryTests : UmbracoIntegrationTest
             contentTypeDictionary: new Dictionary<Guid, IContentType>
             {
                 { elementType.Key, elementType }, { contentType.Key, contentType }
-            }).ToDictionary();
+            });
 
-        Assert.IsTrue(indexValues.TryGetValue("bodyText", out var bodyTextIndexValues));
+        var indexValue = indexValues.FirstOrDefault(v => v.FieldName == "bodyText");
+        Assert.IsNotNull(indexValue);
 
-        Assert.AreEqual(1, bodyTextIndexValues.Count());
-        var bodyTextIndexValue = bodyTextIndexValues.First() as string;
+        Assert.AreEqual(1, indexValue.Values.Count());
+        var bodyTextIndexValue = indexValue.Values.First() as string;
         Assert.IsNotNull(bodyTextIndexValue);
 
         Assert.Multiple(() =>
@@ -122,12 +123,13 @@ public class PropertyIndexValueFactoryTests : UmbracoIntegrationTest
             contentTypeDictionary: new Dictionary<Guid, IContentType>
             {
                 { contentType.Key, contentType }
-            }).ToDictionary();
+            });
 
-        Assert.IsTrue(indexValues.TryGetValue("bodyText", out var bodyTextIndexValues));
+        var indexValue = indexValues.FirstOrDefault(v => v.FieldName == "bodyText");
+        Assert.IsNotNull(indexValue);
 
-        Assert.AreEqual(1, bodyTextIndexValues.Count());
-        var bodyTextIndexValue = bodyTextIndexValues.First() as string;
+        Assert.AreEqual(1, indexValue.Values.Count());
+        var bodyTextIndexValue = indexValue.Values.First() as string;
         Assert.IsNotNull(bodyTextIndexValue);
         Assert.IsTrue(bodyTextIndexValue.Contains("This is some markup"));
     }
@@ -205,12 +207,13 @@ public class PropertyIndexValueFactoryTests : UmbracoIntegrationTest
             contentTypeDictionary: new Dictionary<Guid, IContentType>
             {
                 { elementType.Key, elementType }, { contentType.Key, contentType }
-            }).ToDictionary();
+            });
 
-        Assert.IsTrue(indexValues.TryGetValue("blocks", out var blocksIndexValues));
+        var indexValue = indexValues.FirstOrDefault(v => v.FieldName == "blocks");
+        Assert.IsNotNull(indexValue);
 
-        Assert.AreEqual(1, blocksIndexValues.Count());
-        var blockIndexValue = blocksIndexValues.First() as string;
+        Assert.AreEqual(1, indexValue.Values.Count());
+        var blockIndexValue = indexValue.Values.First() as string;
         Assert.IsNotNull(blockIndexValue);
 
         Assert.Multiple(() =>
@@ -333,12 +336,13 @@ public class PropertyIndexValueFactoryTests : UmbracoIntegrationTest
             contentTypeDictionary: new Dictionary<Guid, IContentType>
             {
                 { elementType.Key, elementType }, { contentType.Key, contentType }
-            }).ToDictionary();
+            });
 
-        Assert.IsTrue(indexValues.TryGetValue("blocks", out var blocksIndexValues));
+        var indexValue = indexValues.FirstOrDefault(v => v.FieldName == "blocks");
+        Assert.IsNotNull(indexValue);
 
-        Assert.AreEqual(1, blocksIndexValues.Count());
-        var blockIndexValue = blocksIndexValues.First() as string;
+        Assert.AreEqual(1, indexValue.Values.Count());
+        var blockIndexValue = indexValue.Values.First() as string;
         Assert.IsNotNull(blockIndexValue);
 
         Assert.Multiple(() =>

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/RichTextElementLevelVariationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/RichTextElementLevelVariationTests.cs
@@ -5,6 +5,7 @@ using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Core.Models.DeliveryApi;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Infrastructure.Examine;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
 
@@ -22,8 +23,8 @@ public class RichTextElementLevelVariationTests : BlockEditorElementVariationTes
     {
         var elementType = CreateElementType(ContentVariation.Culture);
 
-        var blockGridDataType = await CreateRichTextDataType(elementType);
-        var contentType = CreateContentType(blockGridDataType);
+        var rteDataType = await CreateRichTextDataType(elementType);
+        var contentType = CreateContentType(rteDataType);
         var richTextValue = CreateRichTextValue(elementType);
         var content = CreateContent(contentType, richTextValue);
 
@@ -180,8 +181,8 @@ public class RichTextElementLevelVariationTests : BlockEditorElementVariationTes
     {
         var elementType = CreateElementType(ContentVariation.Culture);
 
-        var blockGridDataType = await CreateRichTextDataType(elementType);
-        var contentType = CreateContentType(blockGridDataType);
+        var rteDataType = await CreateRichTextDataType(elementType);
+        var contentType = CreateContentType(rteDataType);
         var richTextValue = CreateRichTextValue(elementType);
         var content = CreateContent(contentType, richTextValue);
 
@@ -285,8 +286,8 @@ public class RichTextElementLevelVariationTests : BlockEditorElementVariationTes
     {
         var elementType = CreateElementType(ContentVariation.Culture);
 
-        var blockGridDataType = await CreateRichTextDataType(elementType);
-        var contentType = CreateContentType(blockGridDataType);
+        var rteDataType = await CreateRichTextDataType(elementType);
+        var contentType = CreateContentType(rteDataType);
         var richTextValue = CreateRichTextValue(elementType);
         var content = CreateContent(contentType, richTextValue);
 
@@ -369,8 +370,8 @@ public class RichTextElementLevelVariationTests : BlockEditorElementVariationTes
     {
         var elementType = CreateElementType(ContentVariation.Culture);
 
-        var blockGridDataType = await CreateRichTextDataType(elementType);
-        var contentType = CreateContentType(blockGridDataType);
+        var rteDataType = await CreateRichTextDataType(elementType);
+        var contentType = CreateContentType(rteDataType);
         var richTextValue = new RichTextEditorValue { Markup = "<p>Markup here</p>", Blocks = null };
         var content = CreateContent(contentType, richTextValue);
 
@@ -398,8 +399,8 @@ public class RichTextElementLevelVariationTests : BlockEditorElementVariationTes
     {
         var elementType = CreateElementType(ContentVariation.Culture);
 
-        var blockGridDataType = await CreateRichTextDataType(elementType);
-        var contentType = CreateContentType(ContentVariation.Nothing, blockGridDataType);
+        var rteDataType = await CreateRichTextDataType(elementType);
+        var contentType = CreateContentType(ContentVariation.Nothing, rteDataType);
         var richTextValue = new RichTextEditorValue { Markup = "<p>Markup here</p>", Blocks = null };
         var content = CreateContent(contentType, richTextValue);
 
@@ -419,6 +420,247 @@ public class RichTextElementLevelVariationTests : BlockEditorElementVariationTes
             Assert.IsNotNull(propertyValue);
             Assert.AreEqual("<p>Markup here</p>", propertyValue.Markup);
             Assert.IsEmpty(propertyValue.Blocks);
+        }
+    }
+
+    [Test]
+    public async Task Can_Index_Cultures_Independently_Invariant_Blocks()
+    {
+        var elementType = CreateElementType(ContentVariation.Culture);
+
+        var rteDataType = await CreateRichTextDataType(elementType);
+        var contentType = CreateContentType(rteDataType);
+        var richTextValue = CreateRichTextValue(elementType);
+        var content = CreateContent(contentType, richTextValue);
+        PublishContent(content, ["en-US", "da-DK"]);
+
+        var editor = rteDataType.Editor!;
+        var indexValues = editor.PropertyIndexValueFactory.GetIndexValues(
+            content.Properties["blocks"]!,
+            culture: null,
+            segment: null,
+            published: true,
+            availableCultures: ["en-US", "da-DK"],
+            contentTypeDictionary: new Dictionary<Guid, IContentType>
+            {
+                { elementType.Key, elementType }, { contentType.Key, contentType }
+            });
+
+        Assert.AreEqual(3, indexValues.Count());
+        Assert.NotNull(indexValues.FirstOrDefault(value => value.FieldName.StartsWith(UmbracoExamineFieldNames.RawFieldPrefix)));
+
+        AssertIndexedValues(
+            "en-US",
+            "Some text.",
+            "More text.",
+            "Even more text.",
+            "The end.",
+            "#1: The first invariant content value",
+            "#1: The first content value in English",
+            "#2: The first invariant content value",
+            "#2: The first content value in English",
+            "#3: The first invariant content value",
+            "#3: The first content value in English");
+
+        AssertIndexedValues(
+            "da-DK",
+            "Some text.",
+            "More text.",
+            "Even more text.",
+            "The end.",
+            "#1: The first invariant content value",
+            "#1: The first content value in Danish",
+            "#2: The first invariant content value",
+            "#2: The first content value in Danish",
+            "#3: The first invariant content value",
+            "#3: The first content value in Danish");
+
+        void AssertIndexedValues(string culture, params string[] expectedIndexedValues)
+        {
+            var indexValue = indexValues.FirstOrDefault(v => v.Culture.InvariantEquals(culture));
+            Assert.IsNotNull(indexValue);
+            Assert.AreEqual(1, indexValue.Values.Count());
+            var indexedValue = indexValue.Values.First() as string;
+            Assert.IsNotNull(indexedValue);
+            var values = indexedValue.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToArray();
+            Assert.AreEqual(expectedIndexedValues.Length, values.Length);
+            Assert.IsTrue(values.ContainsAll(expectedIndexedValues));
+        }
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Can_Index_With_Unexposed_Blocks(bool published)
+    {
+        var elementType = CreateElementType(ContentVariation.Culture);
+
+        var rteDataType = await CreateRichTextDataType(elementType);
+        var contentType = CreateContentType(rteDataType);
+        var richTextValue = CreateRichTextValue(elementType);
+        richTextValue.Blocks!.Expose.RemoveAll(e => e.Culture == "da-DK");
+
+        var content = CreateContent(contentType, richTextValue);
+        PublishContent(content, ["en-US", "da-DK"]);
+
+        var editor = rteDataType.Editor!;
+        var indexValues = editor.PropertyIndexValueFactory.GetIndexValues(
+            content.Properties["blocks"]!,
+            culture: null,
+            segment: null,
+            published: published,
+            availableCultures: ["en-US", "da-DK"],
+            contentTypeDictionary: new Dictionary<Guid, IContentType>
+            {
+                { elementType.Key, elementType }, { contentType.Key, contentType }
+            });
+
+        Assert.AreEqual(3, indexValues.Count());
+        Assert.NotNull(indexValues.FirstOrDefault(value => value.FieldName.StartsWith(UmbracoExamineFieldNames.RawFieldPrefix)));
+
+        if (published)
+        {
+            AssertIndexedValues(
+                "da-DK",
+                "Some text.",
+                "More text.",
+                "Even more text.",
+                "The end.");
+        }
+        else
+        {
+            AssertIndexedValues(
+                "da-DK",
+                "Some text.",
+                "More text.",
+                "Even more text.",
+                "The end.",
+                "#1: The first invariant content value",
+                "#1: The first content value in Danish",
+                "#2: The first invariant content value",
+                "#2: The first content value in Danish",
+                "#3: The first invariant content value",
+                "#3: The first content value in Danish");
+        }
+
+        AssertIndexedValues(
+            "en-US",
+            "Some text.",
+            "More text.",
+            "Even more text.",
+            "The end.",
+            "#1: The first invariant content value",
+            "#1: The first content value in English",
+            "#2: The first invariant content value",
+            "#2: The first content value in English",
+            "#3: The first invariant content value",
+            "#3: The first content value in English");
+
+        void AssertIndexedValues(string culture, params string[] expectedIndexedValues)
+        {
+            var indexValue = indexValues.FirstOrDefault(v => v.Culture.InvariantEquals(culture));
+            Assert.IsNotNull(indexValue);
+            Assert.AreEqual(1, indexValue.Values.Count());
+            var indexedValue = indexValue.Values.First() as string;
+            Assert.IsNotNull(indexedValue);
+            var values = indexedValue.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToArray();
+            Assert.AreEqual(expectedIndexedValues.Length, values.Length);
+            Assert.IsTrue(values.ContainsAll(expectedIndexedValues));
+        }
+    }
+
+    [TestCase(ContentVariation.Culture)]
+    [TestCase(ContentVariation.Nothing)]
+    public async Task Can_Index_Cultures_Independently_Variant_Blocks(ContentVariation elementTypeVariation)
+    {
+        var elementType = CreateElementType(elementTypeVariation);
+
+        var rteDataType = await CreateRichTextDataType(elementType);
+        var contentType = CreateContentType(ContentVariation.Culture, rteDataType, ContentVariation.Culture);
+
+        var englishRichTextValue = CreateInvariantRichTextValue("en-US");
+        var danishRichTextValue = CreateInvariantRichTextValue("da-DK");
+
+        var content = CreateContent(contentType);
+        content.Properties["blocks"]!.SetValue(JsonSerializer.Serialize(englishRichTextValue), "en-US");
+        content.Properties["blocks"]!.SetValue(JsonSerializer.Serialize(danishRichTextValue), "da-DK");
+        ContentService.Save(content);
+
+        PublishContent(content, ["en-US", "da-DK"]);
+
+        var editor = rteDataType.Editor!;
+
+        AssertIndexedValues(
+            "en-US",
+            "Some text for en-US.",
+            "More text for en-US.",
+            "invariantText value for en-US",
+            "variantText value for en-US");
+
+        AssertIndexedValues(
+            "da-DK",
+            "Some text for da-DK.",
+            "More text for da-DK.",
+            "invariantText value for da-DK",
+            "variantText value for da-DK");
+
+        void AssertIndexedValues(string culture, params string[] expectedIndexedValues)
+        {
+            var indexValues = editor.PropertyIndexValueFactory.GetIndexValues(
+                content.Properties["blocks"]!,
+                culture: culture,
+                segment: null,
+                published: true,
+                availableCultures: ["en-US", "da-DK"],
+                contentTypeDictionary: new Dictionary<Guid, IContentType>
+                {
+                    { elementType.Key, elementType }, { contentType.Key, contentType }
+                });
+
+            Assert.AreEqual(2, indexValues.Count());
+            Assert.NotNull(indexValues.FirstOrDefault(value => value.FieldName.StartsWith(UmbracoExamineFieldNames.RawFieldPrefix)));
+
+            var indexValue = indexValues.FirstOrDefault(v => v.Culture.InvariantEquals(culture) && v.FieldName == "blocks");
+            Assert.IsNotNull(indexValue);
+            Assert.AreEqual(1, indexValue.Values.Count());
+            var indexedValue = indexValue.Values.First() as string;
+            Assert.IsNotNull(indexedValue);
+            var values = indexedValue.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToArray();
+            Assert.AreEqual(expectedIndexedValues.Length, values.Length);
+            Assert.IsTrue(values.ContainsAll(expectedIndexedValues));
+        }
+
+        RichTextEditorValue CreateInvariantRichTextValue(string culture)
+        {
+            var contentElementKey = Guid.NewGuid();
+            return new RichTextEditorValue
+            {
+                Markup = $"""
+                          <p>Some text for {culture}.</p>
+                          <umb-rte-block data-content-key="{contentElementKey:D}"><!--Umbraco-Block--></umb-rte-block>
+                          <p>More text for {culture}.</p>
+                          """,
+                Blocks = new RichTextBlockValue([
+                    new RichTextBlockLayoutItem(contentElementKey)
+                ])
+                {
+                    ContentData =
+                    [
+                        new(contentElementKey, elementType.Key, elementType.Alias)
+                        {
+                            Values =
+                            [
+                                new() { Alias = "invariantText", Value = $"invariantText value for {culture}" },
+                                new() { Alias = "variantText", Value = $"variantText value for {culture}" }
+                            ]
+                        }
+                    ],
+                    SettingsData = [],
+                    Expose =
+                    [
+                        new(contentElementKey, culture, null),
+                    ]
+                }
+            };
         }
     }
 
@@ -536,7 +778,7 @@ public class RichTextElementLevelVariationTests : BlockEditorElementVariationTes
         };
     }
 
-    private IContent CreateContent(IContentType contentType, RichTextEditorValue richTextValue)
+    private IContent CreateContent(IContentType contentType, RichTextEditorValue? richTextValue = null)
     {
         var contentBuilder = new ContentBuilder()
             .WithContentType(contentType);
@@ -554,8 +796,11 @@ public class RichTextElementLevelVariationTests : BlockEditorElementVariationTes
 
         var content = contentBuilder.Build();
 
-        var propertyValue = JsonSerializer.Serialize(richTextValue);
-        content.Properties["blocks"]!.SetValue(propertyValue);
+        if (richTextValue is not null)
+        {
+            var propertyValue = JsonSerializer.Serialize(richTextValue);
+            content.Properties["blocks"]!.SetValue(propertyValue);
+        }
 
         ContentService.Save(content);
         return content;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
@@ -158,6 +158,9 @@
     <Compile Update="Umbraco.Core\Services\MediaTypeEditingServiceTests.GetFolderMediaTypes.cs">
       <DependentUpon>MediaTypeEditingServiceTests.cs</DependentUpon>
     </Compile>
+    <Compile Update="Umbraco.Infrastructure\PropertyEditors\BlockListElementLevelVariationTests.Indexing.cs">
+      <DependentUpon>BlockListElementLevelVariationTests.cs</DependentUpon>
+    </Compile>
     <Compile Update="Umbraco.Infrastructure\PropertyEditors\BlockListElementLevelVariationTests.Parsing.cs">
       <DependentUpon>BlockListElementLevelVariationTests.cs</DependentUpon>
     </Compile>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This fixes search indexing for block level variants.

### Testing

Setup various permutations of variant, invariant and block level variant content, and test that search indexing works for these content items.

Pay special attention to block level variance in RTEs, as this has proven rather tricky to handle indexing wise.


### Breaking change

The signature for all property indexing change quite a bit, to allow an invariant property value to yield multiple index values across different language variants. For example, the `IPropertyIndexValueFactory` now yields an `IEnumerable<IndexValue>` instead of `IEnumerable<KeyValuePair<string, IEnumerable<object?>>>`, where the `IndexValue` has language variance built into it.

This change is impossible to do in a backwards compatible fashion, because the current implementation with `KeyValuePair<string, IEnumerable<object?>>` really does not translate well.