### PR TITLE
Fix greedy Install url detection

### DIFF
--- a/src/Umbraco.Core/Routing/UmbracoRequestPaths.cs
+++ b/src/Umbraco.Core/Routing/UmbracoRequestPaths.cs
@@ -148,7 +148,10 @@ public class UmbracoRequestPaths
     /// <summary>
     ///     Checks if the current uri is an install request
     /// </summary>
-    public bool IsInstallerRequest(string absPath) => absPath.InvariantStartsWith(_installPath);
+    public bool IsInstallerRequest(string absPath) =>
+        absPath.InvariantEquals(_installPath)
+        || absPath.InvariantStartsWith(_installPath.EnsureEndsWith('/'))
+        || absPath.InvariantStartsWith(_installPath.EnsureEndsWith('?'));
 
     /// <summary>
     ///     Rudimentary check to see if it's not a server side request

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/UmbracoRequestPathsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/UmbracoRequestPathsTests.cs
@@ -102,9 +102,15 @@ public class UmbracoRequestPathsTests
     [TestCase("http://www.domain.com/install/test/test", true)]
     [TestCase("http://www.domain.com/Install/test/test.aspx", true)]
     [TestCase("http://www.domain.com/install/test/test.js", true)]
+    [TestCase("http://www.domain.com/install?param=value", true)]
     [TestCase("http://www.domain.com/instal", false)]
     [TestCase("http://www.domain.com/umbraco", false)]
     [TestCase("http://www.domain.com/umbraco/umbraco", false)]
+    [TestCase("http://www.domain.com/installation", false)]
+    [TestCase("http://www.domain.com/installation/", false)]
+    [TestCase("http://www.domain.com/installation/test", false)]
+    [TestCase("http://www.domain.com/installation/test.js", false)]
+    [TestCase("http://www.domain.com/installation?param=value", false)]
     public void Is_Installer_Request(string input, bool expected)
     {
         var source = new Uri(input);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #17017

### Description
The logic that determines whether a request path is part of the installer will no longer greedily return true when the first segment of the url starts with the installer path (install), ie: installation

### Testing
As described in the original issue, setup a standard site with everything under 1 "site" node, protect one of the pages directly under the site node with a standard member setup and make sure the name of the page's name starts with `install`.

Unit tests have been added to cover the buggy case and some other possible issues.

### Considerations
This bug is most likely also present in all other active majors.
