### PR TITLE
Create different behaviour for NuGet vulnerability warnings in Release mode and non-Release mode

### DIFF
--- a/src/Umbraco.Cms.Persistence.EFCore.SqlServer/Umbraco.Cms.Persistence.EFCore.SqlServer.csproj
+++ b/src/Umbraco.Cms.Persistence.EFCore.SqlServer/Umbraco.Cms.Persistence.EFCore.SqlServer.csproj
@@ -3,6 +3,16 @@
     <Title>Umbraco CMS - Persistence - Entity Framework Core - SQL Server migrations</Title>
     <Description>Adds support for Entity Framework Core SQL Server migrations to Umbraco CMS.</Description>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- Ensure NuGet vulnerability warnings are not errors in non-Release mode -->
+    <WarningsNotAsErrors>NU1901,NU1902,NU1903,NU1904</WarningsNotAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <!-- Ensure NuGet vulnerability warnings are errors for Release mode -->
+    <WarningsAsErrors>
+      NU1901,NU1902,NU1903,NU1904
+    </WarningsAsErrors>
+  </PropertyGroup>
   <ItemGroup>
     <!-- Take top-level depedendency on Azure.Identity, because Microsoft.EntityFrameworkCore.SqlServer depends on a vulnerable version -->
     <PackageReference Include="Azure.Identity" />

--- a/src/Umbraco.Cms.Persistence.EFCore.Sqlite/Umbraco.Cms.Persistence.EFCore.Sqlite.csproj
+++ b/src/Umbraco.Cms.Persistence.EFCore.Sqlite/Umbraco.Cms.Persistence.EFCore.Sqlite.csproj
@@ -3,6 +3,16 @@
     <Title>Umbraco CMS - Persistence - Entity Framework Core - SQLite migrations</Title>
     <Description>Adds support for Entity Framework Core SQLite migrations to Umbraco CMS.</Description>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- Ensure NuGet vulnerability warnings are not errors in non-Release mode -->
+    <WarningsNotAsErrors>NU1901,NU1902,NU1903,NU1904</WarningsNotAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <!-- Ensure NuGet vulnerability warnings are errors for Release mode -->
+    <WarningsAsErrors>
+      NU1901,NU1902,NU1903,NU1904
+    </WarningsAsErrors>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
   </ItemGroup>

--- a/src/Umbraco.Cms.Persistence.EFCore/Umbraco.Cms.Persistence.EFCore.csproj
+++ b/src/Umbraco.Cms.Persistence.EFCore/Umbraco.Cms.Persistence.EFCore.csproj
@@ -7,6 +7,15 @@
     <!--  TODO: [IDE0270] Simplify null checks, [CS0108] resolve hiding inherited members, [CS1998]
           remove async or make method synchronous, and remove these overrides -->
     <WarningsNotAsErrors>IDE0270,CS0108,CS1998</WarningsNotAsErrors>
+    <!--  TODO: [IDE0270] Simplify null checks, [CS0108] resolve hiding inherited members, [CS1998] remove async or make method synchronous,
+          and remove this override. Ensure NuGet vulnerability warnings are not errors in non-Release mode -->
+    <WarningsNotAsErrors>IDE0270,CS0108,CS1998,NU1901,NU1902,NU1903,NU1904</WarningsNotAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <!-- Ensure NuGet vulnerability warnings are errors for Release mode -->
+    <WarningsAsErrors>
+      NU1901,NU1902,NU1903,NU1904
+    </WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
 

--- a/src/Umbraco.Cms.Persistence.SqlServer/Umbraco.Cms.Persistence.SqlServer.csproj
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Umbraco.Cms.Persistence.SqlServer.csproj
@@ -13,6 +13,20 @@
       SA1405,SA1121,SA1117,SA1116,IDE1006,CS0618,IDE0270,IDE0057,IDE0054,CSO618,IDE0048,
       CS1574
     </WarningsNotAsErrors>
+    <!--  TODO: [SA1405] Simplify null checks, [SA1121] resolve hiding inherited members, [SA1117] remove async or make method
+    synchronous, [IDE1006] fix naming rule violation, [CS0618] handle member obsolete appropriately, [IDE0270] simplify null check,
+    [IDE0057] simplify substring, [IDE0054] use compound assignment, [CSO618] use NVARCARMAX, [IDE0048] add parenthesis for clarity,
+    [CS1574] resolve ML comment cref attribute and remove this override.
+    Ensure NuGet vulnerability warnings are not errors in non-Release mode -->
+    <WarningsNotAsErrors>
+      SA1405,SA1121,SA1117,SA1116,IDE1006,CS0618,IDE0270,IDE0057,IDE0054,CSO618,IDE0048,CS1574,NU1901,NU1902,NU1903,NU1904
+    </WarningsNotAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <!-- Ensure NuGet vulnerability warnings are errors for Release mode -->
+    <WarningsAsErrors>
+      NU1901,NU1902,NU1903,NU1904
+    </WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <!-- Take top-level depedendency on Azure.Identity, because NPoco.SqlServer depends on a vulnerable version -->
@@ -21,10 +35,10 @@
     <!-- Take top-level depedendency on System.Runtime.Caching, because Microsoft.EntityFrameworkCore.SqlServer depends on a vulnerable version -->
     <PackageReference Include="System.Runtime.Caching" />
     <!-- Both OpenIddict.AspNetCore, Npoco.SqlServer and Microsoft.EntityFrameworkCore.SqlServer bring in a vulnerable version of Microsoft.IdentityModel.JsonWebTokens -->
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens"/>
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
 
     <!-- Both  Azure.Identity, Microsoft.EntityFrameworkCore.SqlServer, Dazinator.Extensions.FileProviders bring in legacy versions of System.Text.Encodings.Web  -->
-    <PackageReference Include="System.Text.Encodings.Web"/>
+    <PackageReference Include="System.Text.Encodings.Web" />
 
     <!-- NPoco.SqlServer bring in vulnerable version of Microsoft.Data.SqlClient  -->
     <PackageReference Include="Microsoft.Data.SqlClient" />

--- a/src/Umbraco.Cms.Persistence.Sqlite/Umbraco.Cms.Persistence.Sqlite.csproj
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Umbraco.Cms.Persistence.Sqlite.csproj
@@ -4,8 +4,15 @@
     <Description>Adds support for SQLite to Umbraco CMS.</Description>
   </PropertyGroup>
   <PropertyGroup>
-    <!--  TODO: [CS0114] Resolve hiding inherited members and remove this override -->
-    <WarningsNotAsErrors>CS0114</WarningsNotAsErrors>
+    <!--  TODO: [CS0114] Resolve hiding inherited members and remove this override.
+    Ensure NuGet vulnerability warnings are not errors in non-Release mode -->
+    <WarningsNotAsErrors>CS0114,NU1901,NU1902,NU1903,NU1904</WarningsNotAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <!-- Ensure NuGet vulnerability warnings are errors for Release mode -->
+    <WarningsAsErrors>
+      NU1901,NU1902,NU1903,NU1904
+    </WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" />

--- a/src/Umbraco.Cms/Umbraco.Cms.csproj
+++ b/src/Umbraco.Cms/Umbraco.Cms.csproj
@@ -5,6 +5,18 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- Ensure NuGet vulnerability warnings are not errors in non-Release mode -->
+    <WarningsNotAsErrors>
+      NU1901,NU1902,NU1903,NU1904
+    </WarningsNotAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <!-- Ensure NuGet vulnerability warnings are errors for Release mode -->
+    <WarningsAsErrors>
+      NU1901,NU1902,NU1903,NU1904
+    </WarningsAsErrors>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Umbraco.Cms.Targets\Umbraco.Cms.Targets.csproj" />
     <ProjectReference Include="..\Umbraco.Cms.Imaging.ImageSharp\Umbraco.Cms.Imaging.ImageSharp.csproj" />

--- a/src/Umbraco.Examine.Lucene/Umbraco.Examine.Lucene.csproj
+++ b/src/Umbraco.Examine.Lucene/Umbraco.Examine.Lucene.csproj
@@ -6,8 +6,15 @@
     <RootNamespace>Umbraco.Cms.Infrastructure.Examine</RootNamespace>
   </PropertyGroup>
   <PropertyGroup>
-    <!--  TODO: [CS0618] Handle member obsolete appropriately and remove this override -->
-    <WarningsNotAsErrors>CS0618</WarningsNotAsErrors>
+    <!--  TODO: [CS0618] Handle member obsolete appropriately and remove this override.
+    Ensure NuGet vulnerability warnings are not errors in non-Release mode -->
+    <WarningsNotAsErrors>CS0618,NU1901,NU1902,NU1903,NU1904</WarningsNotAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <!-- Ensure NuGet vulnerability warnings are errors for Release mode -->
+    <WarningsAsErrors>
+      NU1901,NU1902,NU1903,NU1904
+    </WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Examine" />

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -6,8 +6,15 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!--  TODO: [SA1119] Correct unnecessary parenthesis and remove this override -->
-    <WarningsNotAsErrors>SA1119</WarningsNotAsErrors>
+    <!--  TODO: [SA1119] Correct unnecessary parenthesis and remove this override.
+    Ensure NuGet vulnerability warnings are not errors in non-Release mode -->
+    <WarningsNotAsErrors>SA1119,NU1901,NU1902,NU1903,NU1904</WarningsNotAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <!-- Ensure NuGet vulnerability warnings are errors for Release mode -->
+    <WarningsAsErrors>
+      NU1901,NU1902,NU1903,NU1904
+    </WarningsAsErrors>
   </PropertyGroup>
   <Import Project="..\Umbraco.Cms.Targets\buildTransitive\Umbraco.Cms.Targets.props" />
   <Import Project="..\Umbraco.Cms.Targets\buildTransitive\Umbraco.Cms.Targets.targets" />


### PR DESCRIPTION
Initial adjustment of the projects with package vulnerabilities that errored due to https://github.com/advisories/GHSA-qj66-m88j-hmgj 09/10/24.

Changed to ignore the four specific NuGet vulnerability warnings in Debug mode (but not Release) as per [Microsoft docs](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1901-nu1904) (`NU1901,NU1902,NU1903,NU1904`)

Links to [#17235](https://github.com/umbraco/Umbraco-CMS/pull/17235).

### Prerequisites

- [x ] I have added steps to test this contribution in the description below

### Description

- In non-Release mode (e.g. Debug), the following NuGet vulnerability warnings should warn: `NU1901,NU1902,NU1903,NU1904` 
- In Release mode, they should error