### PR TITLE
Fix stylecop errors with function parameters on separate lines

### DIFF
--- a/tests/Umbraco.Tests.Common/Builders/Extensions/BuilderExtensions.cs
+++ b/tests/Umbraco.Tests.Common/Builders/Extensions/BuilderExtensions.cs
@@ -232,8 +232,7 @@ public static class BuilderExtensions
         return builder;
     }
 
-    public static T WithPropertyValues<T>(this T builder, object propertyValues, string? culture = null,
-        string? segment = null)
+    public static T WithPropertyValues<T>(this T builder, object propertyValues, string? culture = null, string? segment = null)
         where T : IWithPropertyValues
     {
         builder.PropertyValues = propertyValues;

--- a/tests/Umbraco.Tests.Common/Builders/MediaTypeEditingBuilder.cs
+++ b/tests/Umbraco.Tests.Common/Builders/MediaTypeEditingBuilder.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Core;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.ContentTypeEditing;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
 using Umbraco.Cms.Tests.Common.Builders.Interfaces;
@@ -41,8 +41,7 @@ public class MediaTypeEditingBuilder : ContentTypeEditingBaseBuilder<MediaTypeEd
             .Build();
     }
 
-    public static MediaTypeCreateModel CreateBasicFolderMediaType(string alias = "basicFolder",
-        string name = "BasicFolder")
+    public static MediaTypeCreateModel CreateBasicFolderMediaType(string alias = "basicFolder", string name = "BasicFolder")
     {
         var builder = new MediaTypeEditingBuilder();
         return (MediaTypeCreateModel)builder


### PR DESCRIPTION
### Prerequisites


### Description

I found that when I built the project in Visual Studio I got StyleCop errors on these two files.  I fixed the errors by making params on one line.  This fix the errors and the project successfully ran.


Also, this is part of Hacktoberfest2024!


