### PR TITLE
Making Culture Invariant When Validating Date to negate deferent formats 

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/Validators/DateTimeValidator.cs
+++ b/src/Umbraco.Core/PropertyEditors/Validators/DateTimeValidator.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors.Validators;
@@ -16,7 +17,7 @@ public class DateTimeValidator : IValueValidator
             yield break;
         }
 
-        if (DateTime.TryParse(value.ToString(), out DateTime dt) == false)
+        if (DateTime.TryParse(value.ToString(), CultureInfo.InvariantCulture, out DateTime dt) == false)
         {
             yield return new ValidationResult(
                 string.Format("The string value {0} cannot be parsed into a DateTime", value),

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/Validators/DateTimeValidatorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/Validators/DateTimeValidatorTests.cs
@@ -1,0 +1,29 @@
+using System.Globalization;
+using NUnit.Framework;
+using Umbraco.Cms.Core.PropertyEditors.Validators;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.PropertyEditors.Validators;
+
+[TestFixture]
+public class DateTimeValidatorTests
+{
+    [TestCase("en-US", "yyyy-MM-dd HH:mm:ss", TestName = "US Thread, DateTimeValidator")]
+    [TestCase("en-US", "dd-MM-yyyy HH:mm:ss", TestName = "US Thread, DateTimeValidator ar-SA format")]
+    [TestCase("ar-SA", "dd-MM-yyyy HH:mm:ss", TestName = "Arabian Saudi Thread, DateTimeValidator")]
+    [TestCase("ar-SA", "yyyy-MM-dd HH:mm:ss", TestName = "Arabian Saudi Thread, DateTimeValidator US format")]
+    public void DateTimeValidatorIsCultureInvariant(string culture, string format)
+    {
+        var dateString = DateTime.Now.ToString(format);
+
+        var cultureInfo = new CultureInfo(culture);
+        Thread.CurrentThread.CurrentCulture = cultureInfo;
+        Thread.CurrentThread.CurrentUICulture = cultureInfo;
+
+        var validator = new DateTimeValidator();
+        var validationResults = validator.Validate(dateString, "DATETIME", new Dictionary<string, object>
+        {
+            ["format"] = format
+        });
+        CollectionAssert.IsEmpty(validationResults);
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [<!-- link to the issue here! -->](https://github.com/umbraco/Umbraco-CMS/issues/17253)

### Description

when having languages such as Arabic as the default culture UI .Net automatic changes the Time format to Hjiri. 
this caused an issue in the back-end validation for all datatype
as Peer the bug  https://github.com/umbraco/Umbraco-CMS/issues/17253

To fix this I just make the convert statement in datetime fallback to the default format which is the old good gregorian format 

![image](https://github.com/user-attachments/assets/4dda8e7e-ca6f-4280-9693-d490c80f9811)


To Test This:

1. Create a new Document type that has date time picker.
2. logout then login for language cookie to reset
3. Make Your Back office default UI Culture Arabic ==> العربية
4. Create a new node from that document type and fill the date
5. Click save and publish successfully 


<!-- Thanks for contributing to Umbraco CMS! -->
