### PR TITLE
Fix incorrect AbsolutePath in GetContentRoute

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Services/RoutingServiceBase.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/RoutingServiceBase.cs
@@ -36,7 +36,7 @@ internal abstract class RoutingServiceBase
     }
 
     protected static string GetContentRoute(DomainAndUri domainAndUri, Uri contentRoute)
-        => $"{domainAndUri.ContentId}{DomainUtilities.PathRelativeToDomain(domainAndUri.Uri, contentRoute.AbsolutePath)}";
+        => $"{domainAndUri.ContentId}{DomainUtilities.PathRelativeToDomain(domainAndUri.Uri, contentRoute.GetAbsolutePathDecoded())}";
 
     protected DomainAndUri? GetDomainAndUriForRoute(Uri contentUrl)
     {


### PR DESCRIPTION
Fixes #16745 

### Description

Previous implementation did not correctly decode Uri into the string - e.g. `'bar%20nix'` into `'bar nix'` 
Original proposal was to pass `contentRoute.AbsolutePath` into the `Uri.UnescapeDataString` function.
Current solution calls to `GetAbsolutePathDecoded` provided on the `Uri` instance via the `UriExtensions` class - meaning that all the unit tests are covered within `UriExtensionsTests`.
