### PR TITLE
V15: Dont seed when in upgrade mode, and maintenance page is enabled

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/NotificationHandlers/SeedingNotificationHandler.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/NotificationHandlers/SeedingNotificationHandler.cs
@@ -1,4 +1,6 @@
-﻿using Umbraco.Cms.Core;
+﻿using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -11,19 +13,21 @@ internal class SeedingNotificationHandler : INotificationAsyncHandler<UmbracoApp
     private readonly IDocumentCacheService _documentCacheService;
     private readonly IMediaCacheService _mediaCacheService;
     private readonly IRuntimeState _runtimeState;
+    private readonly GlobalSettings _globalSettings;
 
-    public SeedingNotificationHandler(IDocumentCacheService documentCacheService, IMediaCacheService mediaCacheService, IRuntimeState runtimeState)
+    public SeedingNotificationHandler(IDocumentCacheService documentCacheService, IMediaCacheService mediaCacheService, IRuntimeState runtimeState, IOptions<GlobalSettings> globalSettings)
     {
         _documentCacheService = documentCacheService;
         _mediaCacheService = mediaCacheService;
         _runtimeState = runtimeState;
+        _globalSettings = globalSettings.Value;
     }
 
     public async Task HandleAsync(UmbracoApplicationStartedNotification notification,
         CancellationToken cancellationToken)
     {
 
-        if (_runtimeState.Level <= RuntimeLevel.Install)
+        if (_runtimeState.Level <= RuntimeLevel.Install || (_runtimeState.Level == RuntimeLevel.Upgrade && _globalSettings.ShowMaintenancePageWhenInUpgradeState))
         {
             return;
         }


### PR DESCRIPTION
# Notes
So a bug was discovered upgrading from 13 to 15, with seeding running while we are migrating, thus causing errors.
The solution is to only run the seeding, when we are in run mode. 
There is however one case were we want to run seeding, and that is when you have the maintenance page disabled, (as in, you still want to access the site while in upgrade state, and thus we want that content to be seeded).
I do however think this case is fine to get errors, as this would also be the case when accessing content, where the data models no longer match, and thus would cause errors anyways.

# How to test
- From a v13 database
- Try to run v15 with unattended upgrades enabled
- The error should no longer occur.