### PR TITLE
Bugfix: Use published template on load from database

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
@@ -886,7 +886,7 @@ WHERE cmsContentNu.nodeId IN (
             dto.VersionId,
             dto.PubVersionDate,
             dto.CreatorId,
-            dto.EditTemplateId == 0 ? null : dto.EditTemplateId,
+            dto.PubTemplateId == 0 ? null : dto.PubTemplateId,
             true,
             deserializedContent?.PropertyData,
             deserializedContent?.CultureData);


### PR DESCRIPTION
### Description
Fixes issue with draft template used for published data.

Basically same logic as here https://github.com/umbraco/Umbraco-CMS/blob/9dfb3005bcd68f5399ee13263bfc462c69b39a66/src/Umbraco.PublishedCache.NuCache/Persistence/NuCacheContentRepository.cs#L950

### Test
- Publish content normally
- Change template and save (without publish) 
- Reboot
- Verify correct template is used