### PR TITLE
V15: Reimplement cache startup handler

### DIFF
--- a/src/Umbraco.Core/PublishedCache/IDatabaseCacheRebuilder.cs
+++ b/src/Umbraco.Core/PublishedCache/IDatabaseCacheRebuilder.cs
@@ -3,4 +3,6 @@
 public interface IDatabaseCacheRebuilder
 {
     void Rebuild();
+
+    void RebuildDatabaseCacheIfSerializerChanged();
 }

--- a/src/Umbraco.PublishedCache.HybridCache/DatabaseCacheRebuilder.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/DatabaseCacheRebuilder.cs
@@ -43,6 +43,7 @@ internal class DatabaseCacheRebuilder : IDatabaseCacheRebuilder
 
     public void RebuildDatabaseCacheIfSerializerChanged()
     {
+        using var scope = _coreScopeProvider.CreateCoreScope();
         NuCacheSerializerType serializer = _nucacheSettings.Value.NuCacheSerializerType;
         var currentSerializerValue = _keyValueService.GetValue(NuCacheSerializerKey);
 
@@ -60,5 +61,7 @@ internal class DatabaseCacheRebuilder : IDatabaseCacheRebuilder
             Rebuild();
             _keyValueService.SetValue(NuCacheSerializerKey, serializer.ToString());
         }
+
+        scope.Complete();
     }
 }

--- a/src/Umbraco.PublishedCache.HybridCache/DatabaseCacheRebuilder.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/DatabaseCacheRebuilder.cs
@@ -1,18 +1,37 @@
-﻿using Umbraco.Cms.Core.PublishedCache;
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Logging;
+using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.HybridCache.Persistence;
 
 namespace Umbraco.Cms.Infrastructure.HybridCache;
 
 internal class DatabaseCacheRebuilder : IDatabaseCacheRebuilder
 {
+    private const string NuCacheSerializerKey = "Umbraco.Web.PublishedCache.NuCache.Serializer";
     private readonly IDatabaseCacheRepository _databaseCacheRepository;
     private readonly ICoreScopeProvider _coreScopeProvider;
+    private readonly IOptions<NuCacheSettings> _nucacheSettings;
+    private readonly IKeyValueService _keyValueService;
+    private readonly ILogger<DatabaseCacheRebuilder> _logger;
+    private readonly IProfilingLogger _profilingLogger;
 
-    public DatabaseCacheRebuilder(IDatabaseCacheRepository databaseCacheRepository, ICoreScopeProvider coreScopeProvider)
+    public DatabaseCacheRebuilder(
+        IDatabaseCacheRepository databaseCacheRepository,
+        ICoreScopeProvider coreScopeProvider,
+        IOptions<NuCacheSettings> nucacheSettings,
+        IKeyValueService keyValueService,
+        ILogger<DatabaseCacheRebuilder> logger, IProfilingLogger profilingLogger)
     {
         _databaseCacheRepository = databaseCacheRepository;
         _coreScopeProvider = coreScopeProvider;
+        _nucacheSettings = nucacheSettings;
+        _keyValueService = keyValueService;
+        _logger = logger;
+        _profilingLogger = profilingLogger;
     }
 
     public void Rebuild()
@@ -20,5 +39,26 @@ internal class DatabaseCacheRebuilder : IDatabaseCacheRebuilder
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
         _databaseCacheRepository.Rebuild();
         scope.Complete();
+    }
+
+    public void RebuildDatabaseCacheIfSerializerChanged()
+    {
+        NuCacheSerializerType serializer = _nucacheSettings.Value.NuCacheSerializerType;
+        var currentSerializerValue = _keyValueService.GetValue(NuCacheSerializerKey);
+
+        if (Enum.TryParse(currentSerializerValue, out NuCacheSerializerType currentSerializer) && serializer == currentSerializer)
+        {
+            return;
+        }
+
+        _logger.LogWarning(
+            "Database cache was serialized using {CurrentSerializer}. Currently configured cache serializer {Serializer}. Rebuilding database cache.",
+            currentSerializer, serializer);
+
+        using (_profilingLogger.TraceDuration<DatabaseCacheRebuilder>($"Rebuilding database cache with {serializer} serializer"))
+        {
+            Rebuild();
+            _keyValueService.SetValue(NuCacheSerializerKey, serializer.ToString());
+        }
     }
 }

--- a/src/Umbraco.PublishedCache.HybridCache/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -71,7 +71,7 @@ public static class UmbracoBuilderExtensions
         builder.AddNotificationAsyncHandler<MediaTypeRefreshedNotification, CacheRefreshingNotificationHandler>();
         builder.AddNotificationAsyncHandler<MediaTypeDeletedNotification, CacheRefreshingNotificationHandler>();
         builder.AddNotificationAsyncHandler<UmbracoApplicationStartedNotification, SeedingNotificationHandler>();
-           builder.AddCacheSeeding();
+        builder.AddCacheSeeding();
         return builder;
     }
 

--- a/src/Umbraco.PublishedCache.HybridCache/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -60,6 +60,7 @@ public static class UmbracoBuilderExtensions
                     throw new IndexOutOfRangeException();
             }
         });
+        builder.AddNotificationAsyncHandler<UmbracoApplicationStartingNotification, HybridCacheStartupNotificationHandler>(); // Need to happen before notification handlers use the cache. Eg. seeding
         builder.Services.AddSingleton<IPropertyCacheCompressionOptions, NoopPropertyCacheCompressionOptions>();
         builder.AddNotificationAsyncHandler<ContentRefreshNotification, CacheRefreshingNotificationHandler>();
         builder.AddNotificationAsyncHandler<ContentDeletedNotification, CacheRefreshingNotificationHandler>();
@@ -70,8 +71,7 @@ public static class UmbracoBuilderExtensions
         builder.AddNotificationAsyncHandler<MediaTypeRefreshedNotification, CacheRefreshingNotificationHandler>();
         builder.AddNotificationAsyncHandler<MediaTypeDeletedNotification, CacheRefreshingNotificationHandler>();
         builder.AddNotificationAsyncHandler<UmbracoApplicationStartedNotification, SeedingNotificationHandler>();
-        builder.AddNotificationAsyncHandler<UmbracoApplicationStartingNotification, HybridCacheStartupNotificationHandler>();
-        builder.AddCacheSeeding();
+           builder.AddCacheSeeding();
         return builder;
     }
 

--- a/src/Umbraco.PublishedCache.HybridCache/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -70,6 +70,7 @@ public static class UmbracoBuilderExtensions
         builder.AddNotificationAsyncHandler<MediaTypeRefreshedNotification, CacheRefreshingNotificationHandler>();
         builder.AddNotificationAsyncHandler<MediaTypeDeletedNotification, CacheRefreshingNotificationHandler>();
         builder.AddNotificationAsyncHandler<UmbracoApplicationStartedNotification, SeedingNotificationHandler>();
+        builder.AddNotificationAsyncHandler<UmbracoApplicationStartingNotification, HybridCacheStartupNotificationHandler>();
         builder.AddCacheSeeding();
         return builder;
     }

--- a/src/Umbraco.PublishedCache.HybridCache/NotificationHandlers/HybridCacheStartupNotificationHandler.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/NotificationHandlers/HybridCacheStartupNotificationHandler.cs
@@ -22,7 +22,7 @@ public class HybridCacheStartupNotificationHandler : INotificationAsyncHandler<U
 
     public Task HandleAsync(UmbracoApplicationStartingNotification notification, CancellationToken cancellationToken)
     {
-        if (_runtimeState.Level == RuntimeLevel.Run)
+        if (_runtimeState.Level > RuntimeLevel.Install)
         {
             _databaseCacheRebuilder.RebuildDatabaseCacheIfSerializerChanged();
         }

--- a/src/Umbraco.PublishedCache.HybridCache/NotificationHandlers/HybridCacheStartupNotificationHandler.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/NotificationHandlers/HybridCacheStartupNotificationHandler.cs
@@ -1,0 +1,40 @@
+﻿using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Infrastructure.HybridCache.NotificationHandlers;
+
+/// <summary>
+///     Rebuilds the database cache if required when the serializer changes
+/// </summary>
+public class HybridCacheStartupNotificationHandler : INotificationAsyncHandler<UmbracoApplicationStartingNotification>
+{
+    private readonly IDatabaseCacheRebuilder _databaseCacheRebuilder;
+    private readonly IRuntimeState _runtimeState;
+
+    public HybridCacheStartupNotificationHandler(IDatabaseCacheRebuilder databaseCacheRebuilder, IRuntimeState runtimeState)
+    {
+        _databaseCacheRebuilder = databaseCacheRebuilder;
+        _runtimeState = runtimeState;
+    }
+
+    public void Handle(UmbracoApplicationStartingNotification notification)
+    {
+        if (_runtimeState.Level == RuntimeLevel.Run)
+        {
+            _databaseCacheRebuilder.RebuildDatabaseCacheIfSerializerChanged();
+        }
+    }
+
+    public Task HandleAsync(UmbracoApplicationStartingNotification notification, CancellationToken cancellationToken)
+    {
+        if (_runtimeState.Level == RuntimeLevel.Run)
+        {
+            _databaseCacheRebuilder.RebuildDatabaseCacheIfSerializerChanged();
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Umbraco.PublishedCache.HybridCache/NotificationHandlers/HybridCacheStartupNotificationHandler.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/NotificationHandlers/HybridCacheStartupNotificationHandler.cs
@@ -20,14 +20,6 @@ public class HybridCacheStartupNotificationHandler : INotificationAsyncHandler<U
         _runtimeState = runtimeState;
     }
 
-    public void Handle(UmbracoApplicationStartingNotification notification)
-    {
-        if (_runtimeState.Level == RuntimeLevel.Run)
-        {
-            _databaseCacheRebuilder.RebuildDatabaseCacheIfSerializerChanged();
-        }
-    }
-
     public Task HandleAsync(UmbracoApplicationStartingNotification notification, CancellationToken cancellationToken)
     {
         if (_runtimeState.Level == RuntimeLevel.Run)


### PR DESCRIPTION
# Notes
- Reimplements the `NuCacheStartupHandler`, now renamed to `HybridCacheStartupNotificationHandler`.
- This will rebuild the cache, if the `NuCacheSettings.NuCacheSerializerType` changes (on startup).

# How to test
- Create some content in umbraco.
- Checkout that content, thus loading it into the cache.
- Stop umbraco, and change the setting in "Umbraco:CMS:Nucache"
```
"NuCache": {
        "NuCacheSerializerType": "JSON"
},
```
- Start umbraco and checkout the content, assert that it still works.