### PR TITLE
append 'YouTube Live' url scheme regex to Youtube embed provider class

### DIFF
--- a/src/Umbraco.Core/Media/EmbedProviders/Youtube.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/Youtube.cs
@@ -14,7 +14,7 @@ public class YouTube : OEmbedProviderBase
 
     public override string ApiEndpoint => "https://www.youtube.com/oembed";
 
-    public override string[] UrlSchemeRegex => new[] { @"youtu.be/.*", @"youtube.com/watch.*", @"youtube.com/shorts/.*" };
+    public override string[] UrlSchemeRegex => new[] { @"youtu.be/.*", @"youtube.com/watch.*", @"youtube.com/shorts/.*", @"youtube.com/live/.*" };
 
     public override Dictionary<string, string> RequestParams => new()
     {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! --> [#16948](https://github.com/umbraco/Umbraco-CMS/issues/16948)

### Description
When trying to embed a youtube live link (youtube.com/live/.*) in a rich text editor, you get an "not supported" error.
To fix this I appended a regex, that matches youtube live links, to the Youtube OEmbed provider class (Umbraco.Cms.Core.Media.EmbedProviders.Youtube).

To test it:

1.  Create a page with a rich text editor property
2.  Try to embed a link to a youtube live video e.g. https://www.youtube.com/live/jfKfPfyJRdk?si=E9dea9hKldX81B83
3.  Save the changes
4. Observe that an error notification isn't popping up
5.  Create a view for the page doctype and render the RTE property content
6.  Observe that the embedded youtube video is rendered and can be played
