### PR TITLE
Fix for #17187, unlock form after unsuccessful save and publish

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -536,9 +536,9 @@
                     if (err && err.status === 400 && err.data) {
                         // content was saved but is invalid.
                         eventsService.emit("content.saved", { content: $scope.content, action: args.action, valid: false });
-                        eventsService.emit("form.unlock");
                     }
 
+                    eventsService.emit("form.unlock");
                     return $q.reject(err);
                 });
         }
@@ -759,7 +759,7 @@
                                 //ensure error messages are displayed
                                 formHelper.showNotifications(err.data);
                                 clearNotifications($scope.content);
-                                
+
                               handleHttpException(err);
                               deferred.reject(err);
                             });


### PR DESCRIPTION
- [x] I have added steps to test this contribution in the description below

Fix for #17187

This PR unlocks the form in the case of a failed Save and Publish, fixing the regression introduced in 13.5.1.

This only fixes the regression itself - there's still an unhandled error, and the UX after a failed save of a new document is not right.

To test, try to Save and Publish a document without filling in some mandatory fields
The document will still be editable after the unsuccessful publish.

 Before: 
https://sharing.clickup.com/clip/p/t9015063813/b1a7fa9b-7bec-41bb-9a21-1a220fe2b259/Umbraco%2013-5-1%20bug.webm
 
 After: 
https://github.com/user-attachments/assets/be9746fd-6e6e-49fd-ba92-dba35c789bac

