### PR TITLE
V15: Rich Text Editor links do not work with query strings and anchors

### DIFF
--- a/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
+++ b/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
@@ -15,11 +15,11 @@ public sealed class HtmlLocalLinkParser
     // <a type="document" href="/{localLink:eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f}" title="other page">other page</a>
     internal static readonly Regex LocalLinkTagPattern = new(
         @"<a(?:.+?type=['""](?<type>(?:document|media))['""].*?href=['""](?<locallink>\/?{localLink:(?<guid>[a-fA-F0-9-]+)}).*?['""]|.*?href=['""](?<locallink>\/?{localLink:(?<guid>[a-fA-F0-9-]+)}).*?['""].*?type=['""](?<type>(?:document|media))['""])[^>]*?>",
-        RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
+        RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace | RegexOptions.Singleline);
 
     internal static readonly Regex LocalLinkPattern = new(
         @"href=['""](?<locallink>\/?(?:\{|\%7B)localLink:(?<guid>[a-zA-Z0-9-://]+)(?:\}|\%7D))",
-        RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
+        RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace | RegexOptions.Singleline);
 
     private readonly IPublishedUrlProvider _publishedUrlProvider;
 

--- a/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
+++ b/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
@@ -18,7 +18,7 @@ public sealed class HtmlLocalLinkParser
         RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
     internal static readonly Regex TypePattern = new(
-        """type=['"](?<type>[a-zA-Z]+)['"]""",
+        """type=['"](?<type>(?:media|document))['"]""",
         RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
     internal static readonly Regex LocalLinkPattern = new(

--- a/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
+++ b/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
@@ -15,7 +15,7 @@ public sealed class HtmlLocalLinkParser
     // <a type="document" href="/{localLink:eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f}" title="other page">other page</a>
     internal static readonly Regex LocalLinkTagPattern = new(
         @"<a.+?href=['""](?<locallink>\/?{localLink:(?<guid>[a-fA-F0-9-]+)})[^>]*?>",
-        RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
+        RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace | RegexOptions.Singleline);
 
     internal static readonly Regex TypePattern = new(
         """type=['"](?<type>(?:media|document))['"]""",

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
@@ -148,8 +148,14 @@ public class HtmlLocalLinkParserTests
         "hello href=\"{localLink:umb://document/9931BDE0AAC34BABB838909A7B47570E}\" world ",
         "hello href=\"/my-test-url\" world ")]
     [TestCase(
+        "hello href=\"{localLink:umb://document/9931BDE0AAC34BABB838909A7B47570E}#anchor\" world ",
+        "hello href=\"/my-test-url#anchor\" world ")]
+    [TestCase(
         "hello href=\"{localLink:umb://media/9931BDE0AAC34BABB838909A7B47570E}\" world ",
         "hello href=\"/media/1001/my-image.jpg\" world ")]
+    [TestCase(
+        "hello href='{localLink:umb://media/9931BDE0AAC34BABB838909A7B47570E}' world ",
+        "hello href='/media/1001/my-image.jpg' world ")]
 
     // This one has an invalid char so won't match.
     [TestCase(
@@ -157,7 +163,7 @@ public class HtmlLocalLinkParserTests
         "hello href=\"{localLink:umb^://document/9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" world ")]
     [TestCase(
         "hello href=\"{localLink:umb://document-type/9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" world ",
-        "hello href=\"#\" world ")]
+        "hello href=\"\" world ")]
     public void ParseLocalLinks(string input, string result)
     {
         // setup a mock URL provider which we'll use for testing

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
@@ -117,6 +117,26 @@ public class HtmlLocalLinkParserTests
     [TestCase(
         "<a href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\"type=\"media\">world</a>",
         "<a href=\"/media/1001/my-image.jpg\" title=\"world\">world</a>")]
+
+    // attributes order should not matter
+    [TestCase(
+        "<a rel=\"noopener\" title=\"world\" type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\">world</a>",
+        "<a rel=\"noopener\" title=\"world\" href=\"/my-test-url\">world</a>")]
+    [TestCase(
+        "<a rel=\"noopener\" title=\"world\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" type=\"document\">world</a>",
+        "<a rel=\"noopener\" title=\"world\" href=\"/my-test-url\">world</a>")]
+    [TestCase(
+        "<a rel=\"noopener\" title=\"world\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}#anchor\" type=\"document\">world</a>",
+        "<a rel=\"noopener\" title=\"world\" href=\"/my-test-url#anchor\">world</a>")]
+
+    // anchors and query strings
+    [TestCase(
+        "<a type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}#anchor\" title=\"world\">world</a>",
+        "<a href=\"/my-test-url#anchor\" title=\"world\">world</a>")]
+    [TestCase(
+        "<a type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}?v=1\" title=\"world\">world</a>",
+        "<a href=\"/my-test-url?v=1\" title=\"world\">world</a>")]
+
     // legacy
     [TestCase(
         "hello href=\"{localLink:1234}\" world ",

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
@@ -140,6 +140,11 @@ public class HtmlLocalLinkParserTests
         "<a type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}?v=1\" title=\"world\">world</a>",
         "<a href=\"/my-test-url?v=1\" title=\"world\">world</a>")]
 
+    // custom type ignored
+    [TestCase(
+        "<a type=\"custom\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>",
+        "<a type=\"custom\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>")]
+
     // legacy
     [TestCase(
         "hello href=\"{localLink:1234}\" world ",

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
@@ -117,6 +117,9 @@ public class HtmlLocalLinkParserTests
     [TestCase(
         "<a href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\"type=\"media\">world</a>",
         "<a href=\"/media/1001/my-image.jpg\" title=\"world\">world</a>")]
+    [TestCase(
+        "<p><a type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a></p><p><a href=\"/{localLink:7e21a725-b905-4c5f-86dc-8c41ec116e39}\" title=\"world\" type=\"media\">world</a></p>",
+        "<p><a href=\"/my-test-url\" title=\"world\">world</a></p><p><a href=\"/media/1001/my-image.jpg\" title=\"world\">world</a></p>")]
 
     // attributes order should not matter
     [TestCase(


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #17219
Fixes #17272
Partly fixes #17009 (which still needs a frontend fix)

### Description

Since the change from UDIs to "localLinks" in the `href` attribute (>=14.1), the pattern matched a little too much in the href section completely ignoring any "extras" such as query strings and anchors after the locallink, which meant that the locallink did not get replaced at all if they were present. This is fixed by limiting the regexp a bit.

Because we are no longer matching the whole `href` attribute but only some of its contents, we need to fix the old pattern. It has been simplified into a main RegExp that finds all a-tags with local links inside, then another regex is run on each component subset to find its `type` attribute value.

I have added more test cases to cover what did not work before. In general, the two paradigms of rich text pattern matching should be:

1. The order of attributes should not matter
2. The only part of the link that should be replaced is `{localLink:<GUID|INT>}` leaving all other parts to itself

This means that links like the following now work:

```html
<a type="document" href="/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}#anchor">Link with anchor</a>

<a type="document" href="/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}?v=1">Link with query</a>

<a title="My title" rel="noreferer" type="document" href="/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}">Link with other attributes</a>

<a 
  type="document"
  href="/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}#anchor">
  Link with anchor
</a>
```