### PR TITLE
Do not rely on NuCache to do key/id lookups

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -506,6 +506,10 @@ stages:
             condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
             workingDirectory: $(Agent.BuildDirectory)/app
 
+          # Ensures we have the package wait-on installed
+          - pwsh: npm install wait-on
+            displayName: Install wait-on package
+
           # Wait for application to start responding to requests
           - pwsh: npx wait-on -v --interval 1000 --timeout 120000 $(ASPNETCORE_URLS)
             displayName: Wait for application

--- a/src/Umbraco.PublishedCache.NuCache/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.PublishedCache.NuCache/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -37,23 +37,7 @@ public static class UmbracoBuilderExtensions
         builder.Services.TryAddSingleton<IPublishedSnapshotStatus, PublishedSnapshotStatus>();
         builder.Services.TryAddTransient<IReservedFieldNamesService, ReservedFieldNamesService>();
 
-        // replace this service since we want to improve the content/media
-        // mapping lookups if we are using nucache.
-        // TODO: Gotta wonder how much this does actually improve perf? It's a lot of weird code to make this happen so hope it's worth it
-        builder.Services.AddUnique<IIdKeyMap>(factory =>
-        {
-            var idkSvc = new IdKeyMap(
-                factory.GetRequiredService<ICoreScopeProvider>(),
-                factory.GetRequiredService<IIdKeyMapRepository>());
-            if (factory.GetRequiredService<IPublishedSnapshotService>() is PublishedSnapshotService
-                publishedSnapshotService)
-            {
-                idkSvc.SetMapper(UmbracoObjectTypes.Document, id => publishedSnapshotService.GetDocumentUid(id), uid => publishedSnapshotService.GetDocumentId(uid));
-                idkSvc.SetMapper(UmbracoObjectTypes.Media, id => publishedSnapshotService.GetMediaUid(id), uid => publishedSnapshotService.GetMediaId(uid));
-            }
-
-            return idkSvc;
-        });
+        builder.Services.AddUnique<IIdKeyMap, IdKeyMap>();
 
         builder.AddNuCacheNotifications();
 


### PR DESCRIPTION
Fixes #17182

### Description
Doing migrations we need to lookup ids for keys and keys for ids. The IIdKeyMap is implemented using Nucache, and if any change to the nucache content happens, it will fail.

This is the safer approach as the comment also says. This changes as already been made in V15


### Test
- Setup v13 with some granular permissions
- Migrate to this branch
- Verify success