### PR TITLE
MNTP: Improve site and root context for dynamic root

### DIFF
--- a/src/Umbraco.Core/DynamicRoot/Origin/RootDynamicRootOriginFinder.cs
+++ b/src/Umbraco.Core/DynamicRoot/Origin/RootDynamicRootOriginFinder.cs
@@ -27,7 +27,9 @@ public class RootDynamicRootOriginFinder : IDynamicRootOriginFinder
             return null;
         }
 
-        var entity = _entityService.Get(query.Context.ParentKey);
+        // when creating new content, CurrentKey will be null - fallback to using ParentKey
+        Guid entityKey = query.Context.CurrentKey ?? query.Context.ParentKey;
+        var entity = _entityService.Get(entityKey);
 
         if (entity is null || _allowedObjectTypes.Contains(entity.NodeObjectType) is false)
         {

--- a/src/Umbraco.Core/DynamicRoot/Origin/SiteDynamicRootOriginFinder.cs
+++ b/src/Umbraco.Core/DynamicRoot/Origin/SiteDynamicRootOriginFinder.cs
@@ -20,12 +20,14 @@ public class SiteDynamicRootOriginFinder : RootDynamicRootOriginFinder
 
     public override Guid? FindOriginKey(DynamicRootNodeQuery query)
     {
-        if (query.OriginAlias != SupportedOriginType || query.Context.CurrentKey.HasValue is false)
+        if (query.OriginAlias != SupportedOriginType)
         {
             return null;
         }
 
-        IEntitySlim? entity = _entityService.Get(query.Context.CurrentKey.Value);
+        // when creating new content, CurrentKey will be null - fallback to using ParentKey
+        Guid entityKey = query.Context.CurrentKey ?? query.Context.ParentKey;
+        IEntitySlim? entity = _entityService.Get(entityKey);
         if (entity is null || entity.NodeObjectType != Constants.ObjectTypes.Document)
         {
             return null;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #15770 (in part)

### Description

This PR fixes the contextual issues for newly created content, raised in [this comment](https://github.com/umbraco/Umbraco-CMS/issues/15770#issuecomment-2076739278) on #15770.

By performing a fallback to the parent key, the "Root" and "Site" qualifiers for dynamic roots also work for content that has yet to be created.

### Testing this PR

Verify that MNTP "Root" and "Site" dynamic roots can be used when creating new content (before it's created, that is).

![image](https://github.com/user-attachments/assets/0d96849c-bc1e-4194-a626-6601b727e9f8)

![image](https://github.com/user-attachments/assets/6f966911-745c-48a5-891d-16d43f74011b)
