### PR TITLE
Issue 17128 - Fix GetMediaByPath when querying for media which has been uploaded with dimensions in the file name

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -5,6 +5,10 @@ parameters:
     displayName: Run SQL Server Integration Tests
     type: boolean
     default: false
+  - name: sqlServerAcceptanceTests
+    displayName: Run SQL Server Acceptance Tests
+    type: boolean
+    default: false
   - name: myGetDeploy
     displayName: Deploy to MyGet
     type: boolean
@@ -549,6 +553,7 @@ stages:
 
       - job:
         displayName: E2E Tests (SQL Server)
+        condition: eq(${{parameters.sqlServerAcceptanceTests}}, True)
         variables:
           # Connection string
           CONNECTIONSTRINGS__UMBRACODBDSN: Data Source=(localdb)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\Umbraco.mdf;Integrated Security=True

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -5,10 +5,6 @@ parameters:
     displayName: Run SQL Server Integration Tests
     type: boolean
     default: false
-  - name: sqlServerAcceptanceTests
-    displayName: Run SQL Server Acceptance Tests
-    type: boolean
-    default: false
   - name: myGetDeploy
     displayName: Deploy to MyGet
     type: boolean
@@ -553,8 +549,6 @@ stages:
 
       - job:
         displayName: E2E Tests (SQL Server)
-        # condition: or(eq(stageDependencies.Build.A.outputs['build.NBGV_PublicRelease'], 'True'), ${{parameters.sqlServerAcceptanceTests}}) # Outcommented due to timeouts
-        condition: eq(${{parameters.sqlServerAcceptanceTests}}, True)
         variables:
           # Connection string
           CONNECTIONSTRINGS__UMBRACODBDSN: Data Source=(localdb)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\Umbraco.mdf;Integrated Security=True
@@ -590,7 +584,8 @@ stages:
           - pwsh: |
               "UMBRACO_USER_LOGIN=$(UMBRACO__CMS__UNATTENDED__UNATTENDEDUSEREMAIL)
               UMBRACO_USER_PASSWORD=$(UMBRACO__CMS__UNATTENDED__UNATTENDEDUSERPASSWORD)
-              URL=$(ASPNETCORE_URLS)" | Out-File .env
+              URL=$(ASPNETCORE_URLS)
+              STORAGE_STAGE_PATH=$(Build.SourcesDirectory)/tests/Umbraco.Tests.AcceptanceTest/playwright/.auth/user.json" | Out-File .env
             displayName: Generate .env
             workingDirectory: $(Build.SourcesDirectory)/tests/Umbraco.Tests.AcceptanceTest
 
@@ -708,7 +703,7 @@ stages:
     dependsOn:
       - Unit
       - Integration
-#      - E2E
+    #      - E2E
     condition: and(succeeded(), or(eq(dependencies.Build.outputs['A.build.NBGV_PublicRelease'], 'True'), ${{parameters.myGetDeploy}}))
     jobs:
       - job:

--- a/build/nightly-E2E-test-pipelines.yml
+++ b/build/nightly-E2E-test-pipelines.yml
@@ -4,12 +4,12 @@ pr: none
 trigger: none
 
 schedules:
-- cron: '0 0 * * *'
-  displayName: Daily midnight build
-  branches:
-    include:
-    - v14/dev
-    - v15/dev
+  - cron: '0 0 * * *'
+    displayName: Daily midnight build
+    branches:
+      include:
+        - v14/dev
+        - v15/dev
 
 variables:
   nodeVersion: 20
@@ -24,8 +24,8 @@ variables:
   NODE_OPTIONS: --max_old_space_size=16384
 
 parameters:
-  - name: runSqlServerE2ETests
-    displayName: Run the SQL Server E2E Tests
+  - name: runSmokeTests
+    displayName: Run the smoke tests
     type: boolean
     default: false
 
@@ -206,7 +206,10 @@ stages:
             workingDirectory: tests/Umbraco.Tests.AcceptanceTest
 
           # Test
-          - pwsh: npm run test --ignore-certificate-errors
+          - ${{ if eq(parameters.runSmokeTests, true) }}:
+              pwsh: npm run smokeTest --ignore-certificate-errors
+            ${{ else }}:
+              pwsh: npm run test --ignore-certificate-errors
             displayName: Run Playwright tests
             continueOnError: true
             workingDirectory: tests/Umbraco.Tests.AcceptanceTest
@@ -242,7 +245,6 @@ stages:
 
       - job:
         displayName: E2E Tests (SQL Server)
-        condition: and(succeeded(), ${{ eq(parameters.runSqlServerE2ETests, true) }})
         timeoutInMinutes: 180
         variables:
           # Connection string
@@ -279,7 +281,8 @@ stages:
           - pwsh: |
               "UMBRACO_USER_LOGIN=$(UMBRACO__CMS__UNATTENDED__UNATTENDEDUSEREMAIL)
               UMBRACO_USER_PASSWORD=$(UMBRACO__CMS__UNATTENDED__UNATTENDEDUSERPASSWORD)
-              URL=$(ASPNETCORE_URLS)" | Out-File .env
+              URL=$(ASPNETCORE_URLS)
+              STORAGE_STAGE_PATH=$(Build.SourcesDirectory)/tests/Umbraco.Tests.AcceptanceTest/playwright/.auth/user.json" | Out-File .env
             displayName: Generate .env
             workingDirectory: $(Build.SourcesDirectory)/tests/Umbraco.Tests.AcceptanceTest
 
@@ -350,7 +353,10 @@ stages:
             workingDirectory: tests/Umbraco.Tests.AcceptanceTest
 
           # Test
-          - pwsh: npm run test --ignore-certificate-errors
+          - ${{ if eq(parameters.runSmokeTests, true) }}:
+              pwsh: npm run smokeTest --ignore-certificate-errors
+            ${{ else }}:
+              pwsh: npm run test --ignore-certificate-errors
             displayName: Run Playwright tests
             continueOnError: true
             workingDirectory: tests/Umbraco.Tests.AcceptanceTest

--- a/build/nightly-build-trigger.yml
+++ b/build/nightly-build-trigger.yml
@@ -26,7 +26,7 @@ steps:
     useSameBranch: true
     waitForQueuedBuildsToFinish: false
     storeInEnvironmentVariable: false
-    templateParameters: 'sqlServerIntegrationTests: true, sqlServerAcceptanceTests: true, forceReleaseTestFilter: true, myGetDeploy: true, isNightly: true'
+    templateParameters: 'sqlServerIntegrationTests: true, forceReleaseTestFilter: true, myGetDeploy: true, isNightly: true'
     authenticationMethod: 'OAuth Token'
     enableBuildInQueueCondition: false
     dependentOnSuccessfulBuildCondition: false

--- a/src/Umbraco.Cms.Imaging.ImageSharp/ConfigureImageSharpMiddlewareOptions.cs
+++ b/src/Umbraco.Cms.Imaging.ImageSharp/ConfigureImageSharpMiddlewareOptions.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Headers;
 using Microsoft.Extensions.Options;
@@ -48,16 +49,32 @@ public sealed class ConfigureImageSharpMiddlewareOptions : IConfigureOptions<Ima
                 return Task.CompletedTask;
             }
 
-            int width = context.Parser.ParseValue<int>(context.Commands.GetValueOrDefault(ResizeWebProcessor.Width), context.Culture);
-            if (width <= 0 || width > _imagingSettings.Resize.MaxWidth)
+            if (context.Commands.Contains(ResizeWebProcessor.Width))
             {
-                context.Commands.Remove(ResizeWebProcessor.Width);
+                if (!int.TryParse(
+                    context.Commands.GetValueOrDefault(ResizeWebProcessor.Width),
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out var width)
+                || width < 0
+                || width >= _imagingSettings.Resize.MaxWidth)
+                {
+                    context.Commands.Remove(ResizeWebProcessor.Width);
+                }
             }
 
-            int height = context.Parser.ParseValue<int>(context.Commands.GetValueOrDefault(ResizeWebProcessor.Height), context.Culture);
-            if (height <= 0 || height > _imagingSettings.Resize.MaxHeight)
+            if (context.Commands.Contains(ResizeWebProcessor.Height))
             {
-                context.Commands.Remove(ResizeWebProcessor.Height);
+                if (!int.TryParse(
+                    context.Commands.GetValueOrDefault(ResizeWebProcessor.Height),
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out var height)
+                || height < 0
+                || height >= _imagingSettings.Resize.MaxHeight)
+                {
+                    context.Commands.Remove(ResizeWebProcessor.Height);
+                }
             }
 
             return Task.CompletedTask;

--- a/src/Umbraco.Core/Extensions/UdiGetterExtensions.cs
+++ b/src/Umbraco.Core/Extensions/UdiGetterExtensions.cs
@@ -8,7 +8,7 @@ using Umbraco.Cms.Core.Models.Entities;
 namespace Umbraco.Extensions;
 
 /// <summary>
-/// Provides extension methods that return udis for Umbraco entities.
+/// Provides extension methods that return UDIs for Umbraco entities.
 /// </summary>
 public static class UdiGetterExtensions
 {
@@ -19,11 +19,177 @@ public static class UdiGetterExtensions
     /// <returns>
     /// The entity identifier of the entity.
     /// </returns>
-    public static GuidUdi GetUdi(this ITemplate entity)
+    public static Udi GetUdi(this IEntity entity)
     {
         ArgumentNullException.ThrowIfNull(entity);
 
-        return new GuidUdi(Constants.UdiEntityType.Template, entity.Key).EnsureClosed();
+        return entity switch
+        {
+            // Concrete types
+            EntityContainer container => container.GetUdi(),
+            Script script => script.GetUdi(),
+            Stylesheet stylesheet => stylesheet.GetUdi(),
+            // Interfaces
+            IContentBase contentBase => contentBase.GetUdi(),
+            IContentTypeComposition contentTypeComposition => contentTypeComposition.GetUdi(),
+            IDataType dataType => dataType.GetUdi(),
+            IDictionaryItem dictionaryItem => dictionaryItem.GetUdi(),
+            ILanguage language => language.GetUdi(),
+            IMemberGroup memberGroup => memberGroup.GetUdi(),
+            IPartialView partialView => partialView.GetUdi(),
+            IRelationType relationType => relationType.GetUdi(),
+            ITemplate template => template.GetUdi(),
+            IWebhook webhook => webhook.GetUdi(),
+            _ => throw new NotSupportedException($"Entity type {entity.GetType().FullName} is not supported."),
+        };
+    }
+
+    /// <summary>
+    /// Gets the entity identifier of the entity.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
+    public static GuidUdi GetUdi(this EntityContainer entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        string entityType;
+        if (entity.ContainedObjectType == Constants.ObjectTypes.DataType)
+        {
+            entityType = Constants.UdiEntityType.DataTypeContainer;
+        }
+        else if (entity.ContainedObjectType == Constants.ObjectTypes.DocumentType)
+        {
+            entityType = Constants.UdiEntityType.DocumentTypeContainer;
+        }
+        else if (entity.ContainedObjectType == Constants.ObjectTypes.MediaType)
+        {
+            entityType = Constants.UdiEntityType.MediaTypeContainer;
+        }
+        else if (entity.ContainedObjectType == Constants.ObjectTypes.DocumentBlueprint)
+        {
+            entityType = Constants.UdiEntityType.DocumentBlueprintContainer;
+        }
+        else
+        {
+            throw new NotSupportedException($"Contained object type {entity.ContainedObjectType} is not supported.");
+        }
+
+        return new GuidUdi(entityType, entity.Key).EnsureClosed();
+    }
+
+    /// <summary>
+    /// Gets the entity identifier of the entity.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
+    public static StringUdi GetUdi(this Script entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        return GetUdiFromPath(Constants.UdiEntityType.Script, entity.Path);
+    }
+
+    /// <summary>
+    /// Gets the entity identifier of the entity.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
+    public static StringUdi GetUdi(this Stylesheet entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        return GetUdiFromPath(Constants.UdiEntityType.Stylesheet, entity.Path);
+    }
+
+    /// <summary>
+    /// Gets the entity identifier of the entity.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
+    public static GuidUdi GetUdi(this IContentBase entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        return entity switch
+        {
+            IContent content => content.GetUdi(),
+            IMedia media => media.GetUdi(),
+            IMember member => member.GetUdi(),
+            _ => throw new NotSupportedException($"Content base type {entity.GetType().FullName} is not supported."),
+        };
+    }
+
+    /// <summary>
+    /// Gets the entity identifier of the entity.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
+    public static GuidUdi GetUdi(this IContent entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        string entityType = entity.Blueprint ? Constants.UdiEntityType.DocumentBlueprint : Constants.UdiEntityType.Document;
+
+        return new GuidUdi(entityType, entity.Key).EnsureClosed();
+    }
+
+    /// <summary>
+    /// Gets the entity identifier of the entity.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
+    public static GuidUdi GetUdi(this IMedia entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        return new GuidUdi(Constants.UdiEntityType.Media, entity.Key).EnsureClosed();
+    }
+
+    /// <summary>
+    /// Gets the entity identifier of the entity.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
+    public static GuidUdi GetUdi(this IMember entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        return new GuidUdi(Constants.UdiEntityType.Member, entity.Key).EnsureClosed();
+    }
+
+    /// <summary>
+    /// Gets the entity identifier of the entity.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
+    public static GuidUdi GetUdi(this IContentTypeComposition entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        return entity switch
+        {
+            IContentType contentType => contentType.GetUdi(),
+            IMediaType mediaType => mediaType.GetUdi(),
+            IMemberType memberType => memberType.GetUdi(),
+            _ => throw new NotSupportedException($"Composition type {entity.GetType().FullName} is not supported."),
+        };
     }
 
     /// <summary>
@@ -75,170 +241,11 @@ public static class UdiGetterExtensions
     /// <returns>
     /// The entity identifier of the entity.
     /// </returns>
-    public static GuidUdi GetUdi(this IMemberGroup entity)
-    {
-        ArgumentNullException.ThrowIfNull(entity);
-
-        return new GuidUdi(Constants.UdiEntityType.MemberGroup, entity.Key).EnsureClosed();
-    }
-
-    /// <summary>
-    /// Gets the entity identifier of the entity.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <returns>
-    /// The entity identifier of the entity.
-    /// </returns>
-    public static GuidUdi GetUdi(this IContentTypeComposition entity)
-    {
-        ArgumentNullException.ThrowIfNull(entity);
-
-        string entityType = entity switch
-        {
-            IContentType => Constants.UdiEntityType.DocumentType,
-            IMediaType => Constants.UdiEntityType.MediaType,
-            IMemberType => Constants.UdiEntityType.MemberType,
-            _ => throw new NotSupportedException(string.Format("Composition type {0} is not supported.", entity.GetType().FullName)),
-        };
-
-        return new GuidUdi(entityType, entity.Key).EnsureClosed();
-    }
-
-    /// <summary>
-    /// Gets the entity identifier of the entity.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <returns>
-    /// The entity identifier of the entity.
-    /// </returns>
     public static GuidUdi GetUdi(this IDataType entity)
     {
         ArgumentNullException.ThrowIfNull(entity);
 
         return new GuidUdi(Constants.UdiEntityType.DataType, entity.Key).EnsureClosed();
-    }
-
-    /// <summary>
-    /// Gets the entity identifier of the entity.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <returns>
-    /// The entity identifier of the entity.
-    /// </returns>
-    public static GuidUdi GetUdi(this EntityContainer entity)
-    {
-        ArgumentNullException.ThrowIfNull(entity);
-
-        string entityType;
-        if (entity.ContainedObjectType == Constants.ObjectTypes.DataType)
-        {
-            entityType = Constants.UdiEntityType.DataTypeContainer;
-        }
-        else if (entity.ContainedObjectType == Constants.ObjectTypes.DocumentType)
-        {
-            entityType = Constants.UdiEntityType.DocumentTypeContainer;
-        }
-        else if (entity.ContainedObjectType == Constants.ObjectTypes.MediaType)
-        {
-            entityType = Constants.UdiEntityType.MediaTypeContainer;
-        }
-        else if (entity.ContainedObjectType == Constants.ObjectTypes.DocumentBlueprint)
-        {
-            entityType = Constants.UdiEntityType.DocumentBlueprintContainer;
-        }
-        else
-        {
-            throw new NotSupportedException(string.Format("Contained object type {0} is not supported.", entity.ContainedObjectType));
-        }
-
-        return new GuidUdi(entityType, entity.Key).EnsureClosed();
-    }
-
-    /// <summary>
-    /// Gets the entity identifier of the entity.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <returns>
-    /// The entity identifier of the entity.
-    /// </returns>
-    public static GuidUdi GetUdi(this IMedia entity)
-    {
-        ArgumentNullException.ThrowIfNull(entity);
-
-        return new GuidUdi(Constants.UdiEntityType.Media, entity.Key).EnsureClosed();
-    }
-
-    /// <summary>
-    /// Gets the entity identifier of the entity.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <returns>
-    /// The entity identifier of the entity.
-    /// </returns>
-    public static GuidUdi GetUdi(this IContent entity)
-    {
-        ArgumentNullException.ThrowIfNull(entity);
-
-        string entityType = entity.Blueprint ? Constants.UdiEntityType.DocumentBlueprint : Constants.UdiEntityType.Document;
-
-        return new GuidUdi(entityType, entity.Key).EnsureClosed();
-    }
-
-    /// <summary>
-    /// Gets the entity identifier of the entity.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <returns>
-    /// The entity identifier of the entity.
-    /// </returns>
-    public static GuidUdi GetUdi(this IMember entity)
-    {
-        ArgumentNullException.ThrowIfNull(entity);
-
-        return new GuidUdi(Constants.UdiEntityType.Member, entity.Key).EnsureClosed();
-    }
-
-    /// <summary>
-    /// Gets the entity identifier of the entity.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <returns>
-    /// The entity identifier of the entity.
-    /// </returns>
-    public static StringUdi GetUdi(this Stylesheet entity)
-    {
-        ArgumentNullException.ThrowIfNull(entity);
-
-        return GetUdiFromPath(Constants.UdiEntityType.Stylesheet, entity.Path);
-    }
-
-    /// <summary>
-    /// Gets the entity identifier of the entity.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <returns>
-    /// The entity identifier of the entity.
-    /// </returns>
-    public static StringUdi GetUdi(this Script entity)
-    {
-        ArgumentNullException.ThrowIfNull(entity);
-
-        return GetUdiFromPath(Constants.UdiEntityType.Script, entity.Path);
-    }
-
-    /// <summary>
-    /// Gets the UDI from a path.
-    /// </summary>
-    /// <param name="entityType">The type of the entity.</param>
-    /// <param name="path">The path.</param>
-    /// <returns>
-    /// The entity identifier of the entity.
-    /// </returns>
-    private static StringUdi GetUdiFromPath(string entityType, string path)
-    {
-        string id = path.TrimStart(Constants.CharArrays.ForwardSlash).Replace("\\", "/");
-
-        return new StringUdi(entityType, id).EnsureClosed();
     }
 
     /// <summary>
@@ -262,11 +269,11 @@ public static class UdiGetterExtensions
     /// <returns>
     /// The entity identifier of the entity.
     /// </returns>
-    public static StringUdi GetUdi(this IPartialView entity)
+    public static StringUdi GetUdi(this ILanguage entity)
     {
         ArgumentNullException.ThrowIfNull(entity);
 
-        return GetUdiFromPath(Constants.UdiEntityType.PartialView, entity.Path);
+        return new StringUdi(Constants.UdiEntityType.Language, entity.IsoCode).EnsureClosed();
     }
 
     /// <summary>
@@ -276,19 +283,25 @@ public static class UdiGetterExtensions
     /// <returns>
     /// The entity identifier of the entity.
     /// </returns>
-    public static GuidUdi GetUdi(this IContentBase entity)
+    public static GuidUdi GetUdi(this IMemberGroup entity)
     {
         ArgumentNullException.ThrowIfNull(entity);
 
-        string type = entity switch
-        {
-            IContent => Constants.UdiEntityType.Document,
-            IMedia => Constants.UdiEntityType.Media,
-            IMember => Constants.UdiEntityType.Member,
-            _ => throw new NotSupportedException(string.Format("Content base type {0} is not supported.", entity.GetType().FullName)),
-        };
+        return new GuidUdi(Constants.UdiEntityType.MemberGroup, entity.Key).EnsureClosed();
+    }
 
-        return new GuidUdi(type, entity.Key).EnsureClosed();
+    /// <summary>
+    /// Gets the entity identifier of the entity.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
+    public static StringUdi GetUdi(this IPartialView entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        return GetUdiFromPath(Constants.UdiEntityType.PartialView, entity.Path);
     }
 
     /// <summary>
@@ -312,6 +325,20 @@ public static class UdiGetterExtensions
     /// <returns>
     /// The entity identifier of the entity.
     /// </returns>
+    public static GuidUdi GetUdi(this ITemplate entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        return new GuidUdi(Constants.UdiEntityType.Template, entity.Key).EnsureClosed();
+    }
+
+    /// <summary>
+    /// Gets the entity identifier of the entity.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
     public static GuidUdi GetUdi(this IWebhook entity)
     {
         ArgumentNullException.ThrowIfNull(entity);
@@ -320,56 +347,17 @@ public static class UdiGetterExtensions
     }
 
     /// <summary>
-    /// Gets the entity identifier of the entity.
+    /// Gets the UDI from a path.
     /// </summary>
-    /// <param name="entity">The entity.</param>
+    /// <param name="entityType">The type of the entity.</param>
+    /// <param name="path">The path.</param>
     /// <returns>
     /// The entity identifier of the entity.
     /// </returns>
-    public static StringUdi GetUdi(this ILanguage entity)
+    private static StringUdi GetUdiFromPath(string entityType, string path)
     {
-        ArgumentNullException.ThrowIfNull(entity);
+        string id = path.TrimStart(Constants.CharArrays.ForwardSlash).Replace("\\", "/");
 
-        return new StringUdi(Constants.UdiEntityType.Language, entity.IsoCode).EnsureClosed();
-    }
-
-    /// <summary>
-    /// Gets the entity identifier of the entity.
-    /// </summary>
-    /// <param name="entity">The entity.</param>
-    /// <returns>
-    /// The entity identifier of the entity.
-    /// </returns>
-    public static Udi GetUdi(this IEntity entity)
-    {
-        ArgumentNullException.ThrowIfNull(entity);
-
-        return entity switch
-        {
-            // Concrete types
-            EntityContainer container => container.GetUdi(),
-            Stylesheet stylesheet => stylesheet.GetUdi(),
-            Script script => script.GetUdi(),
-            // Content types
-            IContentType contentType => contentType.GetUdi(),
-            IMediaType mediaType => mediaType.GetUdi(),
-            IMemberType memberType => memberType.GetUdi(),
-            IContentTypeComposition contentTypeComposition => contentTypeComposition.GetUdi(),
-            // Content
-            IContent content => content.GetUdi(),
-            IMedia media => media.GetUdi(),
-            IMember member => member.GetUdi(),
-            IContentBase contentBase => contentBase.GetUdi(),
-            // Other
-            IDataType dataTypeComposition => dataTypeComposition.GetUdi(),
-            IDictionaryItem dictionaryItem => dictionaryItem.GetUdi(),
-            ILanguage language => language.GetUdi(),
-            IMemberGroup memberGroup => memberGroup.GetUdi(),
-            IPartialView partialView => partialView.GetUdi(),
-            IRelationType relationType => relationType.GetUdi(),
-            ITemplate template => template.GetUdi(),
-            IWebhook webhook => webhook.GetUdi(),
-            _ => throw new NotSupportedException(string.Format("Entity type {0} is not supported.", entity.GetType().FullName)),
-        };
+        return new StringUdi(entityType, id).EnsureClosed();
     }
 }

--- a/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
+++ b/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
@@ -14,11 +14,15 @@ public sealed class HtmlLocalLinkParser
     // <a type="media" href="/{localLink:7e21a725-b905-4c5f-86dc-8c41ec116e39}" title="media">media</a>
     // <a type="document" href="/{localLink:eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f}" title="other page">other page</a>
     internal static readonly Regex LocalLinkTagPattern = new(
-        @"<a\s+(?:(?:(?:type=['""](?<type>document|media)['""].*?(?<locallink>href=[""']/{localLink:(?<guid>[a-fA-F0-9-]+)})[""'])|((?<locallink>href=[""']/{localLink:(?<guid>[a-fA-F0-9-]+)})[""'].*?type=(['""])(?<type>document|media)(?:['""])))|(?:(?:type=['""](?<type>document|media)['""])|(?:(?<locallink>href=[""']/{localLink:[a-fA-F0-9-]+})[""'])))[^>]*>",
+        @"<a.+?href=['""](?<locallink>\/?{localLink:(?<guid>[a-fA-F0-9-]+)})[^>]*?>",
+        RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace | RegexOptions.Singleline);
+
+    internal static readonly Regex TypePattern = new(
+        """type=['"](?<type>(?:media|document))['"]""",
         RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
     internal static readonly Regex LocalLinkPattern = new(
-        @"href=""[/]?(?:\{|\%7B)localLink:([a-zA-Z0-9-://]+)(?:\}|\%7D)",
+        @"href=['""](?<locallink>\/?(?:\{|\%7B)localLink:(?<guid>[a-zA-Z0-9-://]+)(?:\}|\%7D))",
         RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
     private readonly IPublishedUrlProvider _publishedUrlProvider;
@@ -84,24 +88,20 @@ public sealed class HtmlLocalLinkParser
         {
             if (tagData.Udi is not null)
             {
-                var newLink = "#";
-                if (tagData.Udi?.EntityType == Constants.UdiEntityType.Document)
+                var newLink = tagData.Udi?.EntityType switch
                 {
-                    newLink = _publishedUrlProvider.GetUrl(tagData.Udi.Guid);
-                }
-                else if (tagData.Udi?.EntityType == Constants.UdiEntityType.Media)
-                {
-                    newLink = _publishedUrlProvider.GetMediaUrl(tagData.Udi.Guid);
-                }
-
+                    Constants.UdiEntityType.Document => _publishedUrlProvider.GetUrl(tagData.Udi.Guid),
+                    Constants.UdiEntityType.Media => _publishedUrlProvider.GetMediaUrl(tagData.Udi.Guid),
+                    _ => ""
+                };
 
                 text = StripTypeAttributeFromTag(text, tagData.Udi!.EntityType);
-                text = text.Replace(tagData.TagHref, "href=\"" + newLink);
+                text = text.Replace(tagData.TagHref, newLink);
             }
             else if (tagData.IntId.HasValue)
             {
                 var newLink = _publishedUrlProvider.GetUrl(tagData.IntId.Value);
-                text = text.Replace(tagData.TagHref, "href=\"" + newLink);
+                text = text.Replace(tagData.TagHref, newLink);
             }
         }
 
@@ -109,7 +109,7 @@ public sealed class HtmlLocalLinkParser
     }
 
     // under normal circumstances, the type attribute is preceded by a space
-    // to cover the rare occasion where it isn't, we first replace with a a space and then without.
+    // to cover the rare occasion where it isn't, we first replace with a space and then without.
     private string StripTypeAttributeFromTag(string tag, string type) =>
         tag.Replace($" type=\"{type}\"", string.Empty)
             .Replace($"type=\"{type}\"", string.Empty);
@@ -119,21 +119,22 @@ public sealed class HtmlLocalLinkParser
         MatchCollection localLinkTagMatches = LocalLinkTagPattern.Matches(text);
         foreach (Match linkTag in localLinkTagMatches)
         {
-            if (linkTag.Groups.Count < 1)
+            if (Guid.TryParse(linkTag.Groups["guid"].Value, out Guid guid) is false)
             {
                 continue;
             }
 
-            if (Guid.TryParse(linkTag.Groups["guid"].Value, out Guid guid) is false)
+            // Find the type attribute
+            Match typeMatch = TypePattern.Match(linkTag.Value);
+            if (typeMatch.Success is false)
             {
                 continue;
             }
 
             yield return new LocalLinkTag(
                 null,
-                new GuidUdi(linkTag.Groups["type"].Value, guid),
-                linkTag.Groups["locallink"].Value,
-                linkTag.Value);
+                new GuidUdi(typeMatch.Groups["type"].Value, guid),
+                linkTag.Groups["locallink"].Value);
         }
 
         // also return legacy results for values that have not been migrated
@@ -150,24 +151,25 @@ public sealed class HtmlLocalLinkParser
         MatchCollection tags = LocalLinkPattern.Matches(text);
         foreach (Match tag in tags)
         {
-            if (tag.Groups.Count > 0)
+            if (tag.Groups.Count <= 0)
             {
-                var id = tag.Groups[1].Value; // .Remove(tag.Groups[1].Value.Length - 1, 1);
+                continue;
+            }
 
-                // The id could be an int or a UDI
-                if (UdiParser.TryParse(id, out Udi? udi))
-                {
-                    var guidUdi = udi as GuidUdi;
-                    if (guidUdi is not null)
-                    {
-                        yield return new LocalLinkTag(null, guidUdi, tag.Value, null);
-                    }
-                }
+            var id = tag.Groups["guid"].Value;
 
-                if (int.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intId))
+            // The id could be an int or a UDI
+            if (UdiParser.TryParse(id, out Udi? udi))
+            {
+                if (udi is GuidUdi guidUdi)
                 {
-                    yield return new LocalLinkTag (intId, null, tag.Value, null);
+                    yield return new LocalLinkTag(null, guidUdi, tag.Groups["locallink"].Value);
                 }
+            }
+
+            if (int.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intId))
+            {
+                yield return new LocalLinkTag (intId, null, tag.Groups["locallink"].Value);
             }
         }
     }
@@ -181,20 +183,10 @@ public sealed class HtmlLocalLinkParser
             TagHref = tagHref;
         }
 
-        public LocalLinkTag(int? intId, GuidUdi? udi, string tagHref, string? fullTag)
-        {
-            IntId = intId;
-            Udi = udi;
-            TagHref = tagHref;
-            FullTag = fullTag;
-        }
-
         public int? IntId { get; }
 
         public GuidUdi? Udi { get; }
 
         public string TagHref { get; }
-
-        public string? FullTag { get; }
     }
 }

--- a/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
+++ b/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
@@ -92,7 +92,7 @@ public sealed class HtmlLocalLinkParser
                 {
                     Constants.UdiEntityType.Document => _publishedUrlProvider.GetUrl(tagData.Udi.Guid),
                     Constants.UdiEntityType.Media => _publishedUrlProvider.GetMediaUrl(tagData.Udi.Guid),
-                    _ => ""
+                    _ => string.Empty,
                 };
 
                 text = StripTypeAttributeFromTag(text, tagData.Udi!.EntityType);

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -67,15 +67,15 @@ public class UmbracoPlan : MigrationPlan
 
         // To 14.0.0
         To<V_14_0_0.AddPropertyEditorUiAliasColumn>("{419827A0-4FCE-464B-A8F3-247C6092AF55}");
-        To<V_14_0_0.AddGuidsToUserGroups>("{69E12556-D9B3-493A-8E8A-65EC89FB658D}");
-        To<V_14_0_0.AddUserGroup2PermisionTable>("{F2B16CD4-F181-4BEE-81C9-11CF384E6025}");
-        To<V_14_0_0.AddGuidsToUsers>("{A8E01644-9F2E-4988-8341-587EF5B7EA69}");
+        To<NoopMigration>("{69E12556-D9B3-493A-8E8A-65EC89FB658D}");
+        To<NoopMigration>("{F2B16CD4-F181-4BEE-81C9-11CF384E6025}");
+        To<NoopMigration>("{A8E01644-9F2E-4988-8341-587EF5B7EA69}");
         To<V_14_0_0.UpdateDefaultGuidsOfCreatedPackages>("{E073DBC0-9E8E-4C92-8210-9CB18364F46E}");
         To<V_14_0_0.RenameTechnologyLeakingPropertyEditorAliases>("{80D282A4-5497-47FF-991F-BC0BCE603121}");
         To<V_14_0_0.MigrateSchduledPublishesToUtc>("{96525697-E9DC-4198-B136-25AD033442B8}");
         To<V_14_0_0.AddListViewKeysToDocumentTypes>("{7FC5AC9B-6F56-415B-913E-4A900629B853}");
         To<V_14_0_0.MigrateDataTypeConfigurations>("{1539A010-2EB5-4163-8518-4AE2AA98AFC6}");
-        To<V_14_0_0.MigrateCharPermissionsToStrings>("{C567DE81-DF92-4B99-BEA8-CD34EF99DA5D}");
+        To<NoopMigration>("{C567DE81-DF92-4B99-BEA8-CD34EF99DA5D}");
         To<V_14_0_0.DeleteMacroTables>("{0D82C836-96DD-480D-A924-7964E458BD34}");
         To<V_14_0_0.MoveDocumentBlueprintsToFolders>("{1A0FBC8A-6FC6-456C-805C-B94816B2E570}");
         To<V_14_0_0.MigrateTours>("{302DE171-6D83-4B6B-B3C0-AC8808A16CA1}");

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPremigrationPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPremigrationPlan.cs
@@ -53,5 +53,9 @@ public class UmbracoPremigrationPlan : MigrationPlan
 
         // To 14.0.0
         To<V_14_0_0.UpdateToOpenIddictV5>("{76FBF80E-37E6-462E-ADC1-25668F56151D}");
+        To<V_14_0_0.AddGuidsToUserGroups>("{37CF4AC3-8489-44BC-A7E8-64908FEEC656}");
+        To<V_14_0_0.AddUserGroup2PermisionTable>("{7BCB5352-B2ED-4D4B-B27D-ECDED930B50A}");
+        To<V_14_0_0.AddGuidsToUsers>("{3E69BF9B-BEAB-41B1-BB11-15383CCA1C7F}");
+        To<V_14_0_0.MigrateCharPermissionsToStrings>("{F12C609B-86B9-4386-AFA4-78E02857247C}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddGuidsToUserGroups.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddGuidsToUserGroups.cs
@@ -20,6 +20,12 @@ public class AddGuidsToUserGroups : UnscopedMigrationBase
 
     protected override void Migrate()
     {
+        // If the new column already exists we'll do nothing.
+        if (ColumnExists(Constants.DatabaseSchema.Tables.UserGroup, NewColumnName))
+        {
+            return;
+        }
+
         // SQL server can simply add the column, but for SQLite this won't work,
         // so we'll have to create a new table and copy over data.
         if (DatabaseType != DatabaseType.SQLite)
@@ -36,11 +42,6 @@ public class AddGuidsToUserGroups : UnscopedMigrationBase
         using IScope scope = _scopeProvider.CreateScope();
         using IDisposable notificationSuppression = scope.Notifications.Suppress();
         ScopeDatabase(scope);
-
-        if (ColumnExists(Constants.DatabaseSchema.Tables.UserGroup, NewColumnName))
-        {
-            return;
-        }
 
         var columns = SqlSyntax.GetColumnsInSchema(Context.Database).ToList();
         AddColumnIfNotExists<UserGroupDto>(columns, NewColumnName);
@@ -67,12 +68,6 @@ public class AddGuidsToUserGroups : UnscopedMigrationBase
         using IScope scope = _scopeProvider.CreateScope();
         using IDisposable notificationSuppression = scope.Notifications.Suppress();
         ScopeDatabase(scope);
-
-        // If the new column already exists we'll do nothing.
-        if (ColumnExists(Constants.DatabaseSchema.Tables.UserGroup, NewColumnName))
-        {
-            return;
-        }
 
         // This isn't pretty,
         // But since you cannot alter columns, we have to copy the data over and delete the old table.

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddGuidsToUserGroups.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddGuidsToUserGroups.cs
@@ -23,6 +23,7 @@ public class AddGuidsToUserGroups : UnscopedMigrationBase
         // If the new column already exists we'll do nothing.
         if (ColumnExists(Constants.DatabaseSchema.Tables.UserGroup, NewColumnName))
         {
+            Context.Complete();
             return;
         }
 
@@ -31,10 +32,12 @@ public class AddGuidsToUserGroups : UnscopedMigrationBase
         if (DatabaseType != DatabaseType.SQLite)
         {
             MigrateSqlServer();
+            Context.Complete();
             return;
         }
 
         MigrateSqlite();
+        Context.Complete();
     }
 
     private void MigrateSqlServer()

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddGuidsToUsers.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddGuidsToUsers.cs
@@ -26,6 +26,12 @@ internal class AddGuidsToUsers : UnscopedMigrationBase
 
     protected override void Migrate()
     {
+        if (ColumnExists(Constants.DatabaseSchema.Tables.User, NewColumnName))
+        {
+            Context.Complete();
+            return;
+        }
+
         InvalidateBackofficeUserAccess = true;
         using IScope scope = _scopeProvider.CreateScope();
         using IDisposable notificationSuppression = scope.Notifications.Suppress();
@@ -75,11 +81,6 @@ internal class AddGuidsToUsers : UnscopedMigrationBase
 
     private void MigrateSqlite()
     {
-        if (ColumnExists(Constants.DatabaseSchema.Tables.User, NewColumnName))
-        {
-            return;
-        }
-
         /*
          * We commit the initial transaction started by the scope. This is required in order to disable the foreign keys.
          * We then begin a new transaction, this transaction will be committed or rolled back by the scope, like normal.

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaRepository.cs
@@ -311,20 +311,20 @@ public class MediaRepository : ContentRepositoryBase<int, IMedia, MediaRepositor
 
     public IMedia? GetMediaByPath(string mediaPath)
     {
-        var umbracoFileValue = mediaPath;
         const string pattern = ".*[_][0-9]+[x][0-9]+[.].*";
         var isResized = Regex.IsMatch(mediaPath, pattern);
+        var originalMediaPath = string.Empty;
 
         // If the image has been resized we strip the "_403x328" of the original "/media/1024/koala_403x328.jpg" URL.
         if (isResized)
         {
             var underscoreIndex = mediaPath.LastIndexOf('_');
             var dotIndex = mediaPath.LastIndexOf('.');
-            umbracoFileValue = string.Concat(mediaPath[..underscoreIndex], mediaPath[dotIndex..]);
+            originalMediaPath = string.Concat(mediaPath[..underscoreIndex], mediaPath[dotIndex..]);
         }
 
         Sql<ISqlContext> sql = GetBaseQuery(QueryType.Single, joinMediaVersion: true)
-            .Where<MediaVersionDto>(x => x.Path == umbracoFileValue)
+            .Where<MediaVersionDto>(x => x.Path == mediaPath || (isResized && x.Path == originalMediaPath))
             .SelectTop(1);
 
         ContentDto? dto = Database.Fetch<ContentDto>(sql).FirstOrDefault();

--- a/tests/Umbraco.Tests.AcceptanceTest/fixtures/packageLibrary/package.xml
+++ b/tests/Umbraco.Tests.AcceptanceTest/fixtures/packageLibrary/package.xml
@@ -11,8 +11,6 @@
   <Stylesheets />
   <Scripts />
   <PartialViews />
-  <Macros />
-  <MacroPartialViews />
   <DictionaryItems />
   <Languages />
   <DataTypes />

--- a/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
@@ -7,8 +7,8 @@
       "name": "acceptancetest",
       "hasInstallScript": true,
       "dependencies": {
-        "@umbraco/json-models-builders": "^2.0.17",
-        "@umbraco/playwright-testhelpers": "^2.0.0-beta.82",
+        "@umbraco/json-models-builders": "^2.0.20",
+        "@umbraco/playwright-testhelpers": "^2.0.0-beta.84",
         "camelize": "^1.0.0",
         "dotenv": "^16.3.1",
         "node-fetch": "^2.6.7"
@@ -55,21 +55,21 @@
       }
     },
     "node_modules/@umbraco/json-models-builders": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@umbraco/json-models-builders/-/json-models-builders-2.0.18.tgz",
-      "integrity": "sha512-VC2KCuWVhae0HzVpo9RrOQt6zZSQqSpWqwCoKYYwmhRz/SYo6hARV6sH2ceEFsQwGqqJvakXuUWzlJK7bFqK1Q==",
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/@umbraco/json-models-builders/-/json-models-builders-2.0.20.tgz",
+      "integrity": "sha512-LmTtklne1HlhMr1nALA+P5FrjIC9jL3A6Pcxj4dy+IPnTgnU2vMYaQIfE8wwz5Z5fZ5AAhWx/Zpdi8xCTbVSuQ==",
       "license": "MIT",
       "dependencies": {
         "camelize": "^1.0.1"
       }
     },
     "node_modules/@umbraco/playwright-testhelpers": {
-      "version": "2.0.0-beta.82",
-      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-2.0.0-beta.82.tgz",
-      "integrity": "sha512-VkArVyvkKuTwJJH8eCHSvbho4H1Owx2ifidVuPyN8EVGDWbxOTb5i9jmtFjJnfDg9mg50JhRYKas4lUGvy1pBA==",
+      "version": "2.0.0-beta.84",
+      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-2.0.0-beta.84.tgz",
+      "integrity": "sha512-vH13Lg48knTkkLVTwhMXUKTOdjtmixFj0wF5Qhgb++13u4AVDb+oW+TbFwTjSYaLeNMraq5Uhwmto/XuJPs2Rw==",
       "license": "MIT",
       "dependencies": {
-        "@umbraco/json-models-builders": "2.0.18",
+        "@umbraco/json-models-builders": "2.0.20",
         "node-fetch": "^2.6.7"
       }
     },

--- a/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@umbraco/json-models-builders": "^2.0.20",
-        "@umbraco/playwright-testhelpers": "^2.0.0-beta.84",
+        "@umbraco/playwright-testhelpers": "^2.0.0-beta.86",
         "camelize": "^1.0.0",
         "dotenv": "^16.3.1",
         "node-fetch": "^2.6.7"
@@ -64,10 +64,9 @@
       }
     },
     "node_modules/@umbraco/playwright-testhelpers": {
-      "version": "2.0.0-beta.84",
-      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-2.0.0-beta.84.tgz",
-      "integrity": "sha512-vH13Lg48knTkkLVTwhMXUKTOdjtmixFj0wF5Qhgb++13u4AVDb+oW+TbFwTjSYaLeNMraq5Uhwmto/XuJPs2Rw==",
-      "license": "MIT",
+      "version": "2.0.0-beta.86",
+      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-2.0.0-beta.86.tgz",
+      "integrity": "sha512-tF7nJCMgBJwaPtxWAuDOJ9lc3T11aO6ped9AxzAJTmzFdSJG16w8jzjWiNgCaU2xRsw5fRyos+I1YrFW249vLw==",
       "dependencies": {
         "@umbraco/json-models-builders": "2.0.20",
         "node-fetch": "^2.6.7"

--- a/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
@@ -7,8 +7,8 @@
       "name": "acceptancetest",
       "hasInstallScript": true,
       "dependencies": {
-        "@umbraco/json-models-builders": "^2.0.20",
-        "@umbraco/playwright-testhelpers": "^2.0.0-beta.86",
+        "@umbraco/json-models-builders": "^2.0.21",
+        "@umbraco/playwright-testhelpers": "^2.0.0-beta.90",
         "camelize": "^1.0.0",
         "dotenv": "^16.3.1",
         "node-fetch": "^2.6.7"
@@ -55,20 +55,19 @@
       }
     },
     "node_modules/@umbraco/json-models-builders": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/@umbraco/json-models-builders/-/json-models-builders-2.0.20.tgz",
-      "integrity": "sha512-LmTtklne1HlhMr1nALA+P5FrjIC9jL3A6Pcxj4dy+IPnTgnU2vMYaQIfE8wwz5Z5fZ5AAhWx/Zpdi8xCTbVSuQ==",
-      "license": "MIT",
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/@umbraco/json-models-builders/-/json-models-builders-2.0.21.tgz",
+      "integrity": "sha512-/8jf444B8XjYMJ4mdun6Nc1GD6z4VTOAMi/foRKNwDu6H+UEVx8KcFfwel+M1rQOz1OULyIsf+XJDYc7TMujOA==",
       "dependencies": {
         "camelize": "^1.0.1"
       }
     },
     "node_modules/@umbraco/playwright-testhelpers": {
-      "version": "2.0.0-beta.86",
-      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-2.0.0-beta.86.tgz",
-      "integrity": "sha512-tF7nJCMgBJwaPtxWAuDOJ9lc3T11aO6ped9AxzAJTmzFdSJG16w8jzjWiNgCaU2xRsw5fRyos+I1YrFW249vLw==",
+      "version": "2.0.0-beta.90",
+      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-2.0.0-beta.90.tgz",
+      "integrity": "sha512-H55F9gttpQR8Fah77gxWxX3S/PY539r82tQRDbo6GgPHeilSVmLXcgesZ+2cgLaAQ406D6JGDvJVqIZukmEzuQ==",
       "dependencies": {
-        "@umbraco/json-models-builders": "2.0.20",
+        "@umbraco/json-models-builders": "2.0.21",
         "node-fetch": "^2.6.7"
       }
     },

--- a/tests/Umbraco.Tests.AcceptanceTest/package.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@umbraco/json-models-builders": "^2.0.20",
-    "@umbraco/playwright-testhelpers": "^2.0.0-beta.84",
+    "@umbraco/playwright-testhelpers": "^2.0.0-beta.86",
     "camelize": "^1.0.0",
     "dotenv": "^16.3.1",
     "node-fetch": "^2.6.7"

--- a/tests/Umbraco.Tests.AcceptanceTest/package.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package.json
@@ -18,8 +18,8 @@
     "typescript": "^4.8.3"
   },
   "dependencies": {
-    "@umbraco/json-models-builders": "^2.0.17",
-    "@umbraco/playwright-testhelpers": "^2.0.0-beta.82",
+    "@umbraco/json-models-builders": "^2.0.20",
+    "@umbraco/playwright-testhelpers": "^2.0.0-beta.84",
     "camelize": "^1.0.0",
     "dotenv": "^16.3.1",
     "node-fetch": "^2.6.7"

--- a/tests/Umbraco.Tests.AcceptanceTest/package.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package.json
@@ -18,8 +18,8 @@
     "typescript": "^4.8.3"
   },
   "dependencies": {
-    "@umbraco/json-models-builders": "^2.0.20",
-    "@umbraco/playwright-testhelpers": "^2.0.0-beta.86",
+    "@umbraco/json-models-builders": "^2.0.21",
+    "@umbraco/playwright-testhelpers": "^2.0.0-beta.90",
     "camelize": "^1.0.0",
     "dotenv": "^16.3.1",
     "node-fetch": "^2.6.7"

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/Content.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/Content.spec.ts
@@ -1,4 +1,4 @@
-﻿import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+﻿import {ConstantHelper, NotificationConstantHelper, test} from '@umbraco/playwright-testhelpers';
 import {expect} from "@playwright/test";
 
 let documentTypeId = '';
@@ -32,7 +32,7 @@ test('can create empty content', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.content.clickSaveButton();
 
   // Assert
-  await umbracoUi.content.isSuccessNotificationVisible();
+  await umbracoUi.content.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   expect(await umbracoApi.document.doesNameExist(contentName)).toBeTruthy();
   const contentData = await umbracoApi.document.getByName(contentName);
   expect(contentData.variants[0].state).toBe(expectedState);
@@ -54,6 +54,8 @@ test('can save and publish empty content', {tag: '@smoke'}, async ({umbracoApi, 
 
   // Assert
   await umbracoUi.content.doesSuccessNotificationsHaveCount(2);
+  await umbracoUi.content.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
+  await umbracoUi.content.doesSuccessNotificationHaveText(NotificationConstantHelper.success.published);
   expect(await umbracoApi.document.doesNameExist(contentName)).toBeTruthy();
   const contentData = await umbracoApi.document.getByName(contentName);
   expect(contentData.variants[0].state).toBe(expectedState);
@@ -75,7 +77,7 @@ test('can create content', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.content.clickSaveButton();
 
   // Assert
-  await umbracoUi.content.isSuccessNotificationVisible();
+  await umbracoUi.content.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   expect(await umbracoApi.document.doesNameExist(contentName)).toBeTruthy();
   const contentData = await umbracoApi.document.getByName(contentName);
   expect(contentData.values[0].value).toBe(contentText);
@@ -96,7 +98,7 @@ test('can rename content', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.content.clickSaveButton();
 
   // Assert
-  await umbracoUi.content.isSuccessNotificationVisible();
+  await umbracoUi.content.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const updatedContentData = await umbracoApi.document.get(contentId);
   expect(updatedContentData.variants[0].name).toEqual(contentName);
 });
@@ -116,7 +118,7 @@ test('can update content', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.content.clickSaveButton();
 
   // Assert
-  await umbracoUi.content.isSuccessNotificationVisible();
+  await umbracoUi.content.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const updatedContentData = await umbracoApi.document.get(contentId);
   expect(updatedContentData.variants[0].name).toEqual(contentName);
   expect(updatedContentData.values[0].value).toBe(contentText);
@@ -135,7 +137,7 @@ test('can publish content', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.content.clickPublishButton();
 
   // Assert
-  await umbracoUi.content.isSuccessNotificationVisible();
+  await umbracoUi.content.doesSuccessNotificationHaveText(NotificationConstantHelper.success.published);
   const contentData = await umbracoApi.document.getByName(contentName);
   expect(contentData.variants[0].state).toBe('Published');
 });
@@ -156,7 +158,7 @@ test('can unpublish content', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) =
   await umbracoUi.content.clickConfirmToUnpublishButton();
 
   // Assert
-  await umbracoUi.content.isSuccessNotificationVisible();
+  await umbracoUi.content.doesSuccessNotificationHaveText(NotificationConstantHelper.success.unpublished);
   const contentData = await umbracoApi.document.getByName(contentName);
   expect(contentData.variants[0].state).toBe('Draft');
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/ContentWithDocumentTypeProperties/ContentWithAllowAtRoot.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/ContentWithDocumentTypeProperties/ContentWithAllowAtRoot.spec.ts
@@ -1,0 +1,27 @@
+﻿import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+
+const documentTypeName = 'TestDocumentTypeForContent';
+
+test.beforeEach(async ({umbracoApi, umbracoUi}) => {
+  await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
+  await umbracoUi.goToBackOffice();
+});
+
+test.afterEach(async ({umbracoApi}) => {
+  await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
+});
+
+test('cannot create content if allow at root is disabled', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const noAllowedDocumentTypeAvailableMessage = 'There are no allowed Document Types available for creating content here';
+  await umbracoApi.documentType.createDefaultDocumentType(documentTypeName);
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+
+  // Act
+  await umbracoUi.content.clickActionsMenuAtRoot();
+  await umbracoUi.content.clickCreateButton();
+
+  // Assert
+  await umbracoUi.content.isDocumentTypeNameVisible(documentTypeName, false);
+  await umbracoUi.content.doesModalHaveText(noAllowedDocumentTypeAvailableMessage);
+});

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/ContentWithDocumentTypeProperties/ContentWithAllowAtRoot.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/ContentWithDocumentTypeProperties/ContentWithAllowAtRoot.spec.ts
@@ -13,7 +13,6 @@ test.afterEach(async ({umbracoApi}) => {
 
 test('cannot create content if allow at root is disabled', async ({umbracoApi, umbracoUi}) => {
   // Arrange
-  const noAllowedDocumentTypeAvailableMessage = 'There are no allowed Document Types available for creating content here';
   await umbracoApi.documentType.createDefaultDocumentType(documentTypeName);
   await umbracoUi.content.goToSection(ConstantHelper.sections.content);
 
@@ -23,5 +22,4 @@ test('cannot create content if allow at root is disabled', async ({umbracoApi, u
 
   // Assert
   await umbracoUi.content.isDocumentTypeNameVisible(documentTypeName, false);
-  await umbracoUi.content.doesModalHaveText(noAllowedDocumentTypeAvailableMessage);
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/ContentWithDocumentTypeProperties/ContentWithAllowVaryByCulture.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/ContentWithDocumentTypeProperties/ContentWithAllowVaryByCulture.spec.ts
@@ -1,0 +1,128 @@
+﻿import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+import {expect} from "@playwright/test";
+
+const contentName = 'TestContent';
+const documentTypeName = 'TestDocumentTypeForContent';
+const secondLanguageName = 'Danish';
+
+test.beforeEach(async ({umbracoApi}) => {
+  await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
+  await umbracoApi.document.ensureNameNotExists(contentName);
+  await umbracoApi.language.ensureNameNotExists(secondLanguageName);
+  await umbracoApi.language.createDanishLanguage();
+});
+
+test.afterEach(async ({umbracoApi}) => {
+  await umbracoApi.document.ensureNameNotExists(contentName); 
+  await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
+  await umbracoApi.language.ensureNameNotExists(secondLanguageName);
+});
+
+test('can create content with allow vary by culture enabled', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  await umbracoApi.documentType.createDocumentTypeWithAllowVaryByCulture(documentTypeName);
+  await umbracoUi.goToBackOffice();
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+
+  // Act
+  await umbracoUi.content.clickActionsMenuAtRoot();
+  await umbracoUi.content.clickCreateButton();
+  await umbracoUi.content.chooseDocumentType(documentTypeName);
+  await umbracoUi.content.enterContentName(contentName);
+  await umbracoUi.content.clickSaveButton();
+  await umbracoUi.content.clickSaveAndCloseButton();
+  
+  // Assert
+  await umbracoUi.content.isSuccessNotificationVisible();
+  expect(await umbracoApi.document.doesNameExist(contentName)).toBeTruthy();
+});
+
+test('can create content with names that vary by culture', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const danishContentName = 'Test indhold';
+  const documentTypeId = await umbracoApi.documentType.createDocumentTypeWithAllowVaryByCulture(documentTypeName);
+  await umbracoApi.document.createDefaultDocumentWithEnglishCulture(contentName, documentTypeId);
+  await umbracoUi.goToBackOffice();
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+
+  // Act
+  await umbracoUi.content.goToContentWithName(contentName);
+  await umbracoUi.content.clickVariantSelectorButton();
+  await umbracoUi.content.clickVariantAddModeButton();
+  await umbracoUi.content.enterContentName(danishContentName);
+  await umbracoUi.content.clickSaveButton();
+  await umbracoUi.content.clickSaveAndCloseButton();
+  
+  // Assert
+  await umbracoUi.content.isSuccessNotificationVisible();
+  expect(await umbracoApi.document.doesNameExist(danishContentName)).toBeTruthy();
+  const contentData = await umbracoApi.document.getByName(danishContentName);
+  expect(contentData.variants.length).toBe(2);
+  expect(contentData.variants[0].name).toBe(contentName);
+  expect(contentData.variants[1].name).toBe(danishContentName);
+});
+
+test('can create content with names that vary by culture and content that is invariant', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const danishContentName = 'Test indhold';
+  const textContent = 'This is a test text';
+  const danishTextContent = 'Dette er testtekst';
+  const dataTypeName = 'Textstring';
+  const dataTypeData = await umbracoApi.dataType.getByName(dataTypeName);
+  const documentTypeId = await umbracoApi.documentType.createDocumentTypeWithPropertyEditor(documentTypeName, dataTypeName, dataTypeData.id, 'Test Group', false);
+  await umbracoApi.document.createDocumentWithEnglishCultureAndTextContent(contentName, documentTypeId, textContent, dataTypeName);
+  await umbracoUi.goToBackOffice();
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+
+  // Act
+  await umbracoUi.content.goToContentWithName(contentName);
+  await umbracoUi.content.clickVariantSelectorButton();
+  await umbracoUi.content.clickVariantAddModeButton();
+  await umbracoUi.content.enterContentName(danishContentName);
+  await umbracoUi.content.enterTextstring(danishTextContent);
+  await umbracoUi.content.clickSaveButton();
+  await umbracoUi.content.clickSaveAndCloseButton();
+  
+  // Assert
+  await umbracoUi.content.isSuccessNotificationVisible();
+  expect(await umbracoApi.document.doesNameExist(danishContentName)).toBeTruthy();
+  const contentData = await umbracoApi.document.getByName(danishContentName);
+  expect(contentData.variants.length).toBe(2);
+  expect(contentData.variants[0].name).toBe(contentName);
+  expect(contentData.variants[1].name).toBe(danishContentName);
+  expect(contentData.values.length).toBe(1);
+  expect(contentData.values[0].value).toBe(danishTextContent);
+});
+
+test('can create content with names and content that vary by culture', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const danishContentName = 'Test indhold';
+  const textContent = 'This is a test text';
+  const danishTextContent = 'Dette er testtekst';
+  const dataTypeName = 'Textstring';
+  const dataTypeData = await umbracoApi.dataType.getByName(dataTypeName);
+  const documentTypeId = await umbracoApi.documentType.createDocumentTypeWithPropertyEditor(documentTypeName, dataTypeName, dataTypeData.id, 'Test Group', true);
+  await umbracoApi.document.createDocumentWithEnglishCultureAndTextContent(contentName, documentTypeId, textContent, dataTypeName, true);
+  await umbracoUi.goToBackOffice();
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+
+  // Act
+  await umbracoUi.content.goToContentWithName(contentName);
+  await umbracoUi.content.clickVariantSelectorButton();
+  await umbracoUi.content.clickVariantAddModeButton();
+  await umbracoUi.content.enterContentName(danishContentName);
+  await umbracoUi.content.enterTextstring(danishTextContent);
+  await umbracoUi.content.clickSaveButton();
+  await umbracoUi.content.clickSaveAndCloseButton();
+  
+  // Assert
+  await umbracoUi.content.isSuccessNotificationVisible();
+  expect(await umbracoApi.document.doesNameExist(danishContentName)).toBeTruthy();
+  const contentData = await umbracoApi.document.getByName(danishContentName);
+  expect(contentData.variants.length).toBe(2);
+  expect(contentData.variants[0].name).toBe(contentName);
+  expect(contentData.variants[1].name).toBe(danishContentName);
+  expect(contentData.values.length).toBe(2);
+  expect(contentData.values[0].value).toBe(textContent);
+  expect(contentData.values[1].value).toBe(danishTextContent);
+});

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/ContentWithDocumentTypeProperties/ContentWithAllowedChildNodes.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/ContentWithDocumentTypeProperties/ContentWithAllowedChildNodes.spec.ts
@@ -1,0 +1,98 @@
+﻿import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+import {expect} from "@playwright/test";
+
+const contentName = 'TestContent';
+const documentTypeName = 'TestDocumentTypeForContent';
+
+test.beforeEach(async ({umbracoApi, umbracoUi}) => {
+  await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
+  await umbracoApi.document.ensureNameNotExists(contentName);
+  await umbracoUi.goToBackOffice();
+});
+
+test.afterEach(async ({umbracoApi}) => {
+  await umbracoApi.document.ensureNameNotExists(contentName); 
+  await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
+});
+
+test('can create content with allowed child node enabled', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const childDocumentTypeName = 'Test Child Document Type';
+  const childDocumentTypeId = await umbracoApi.documentType.createDefaultDocumentType(childDocumentTypeName);
+  await umbracoApi.documentType.createDocumentTypeWithAllowedChildNode(documentTypeName, childDocumentTypeId);
+  await umbracoUi.goToBackOffice();
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+
+  // Act
+  await umbracoUi.content.clickActionsMenuAtRoot();
+  await umbracoUi.content.clickCreateButton();
+  await umbracoUi.content.chooseDocumentType(documentTypeName);
+  await umbracoUi.content.enterContentName(contentName);
+  await umbracoUi.content.clickSaveButton();
+  
+  // Assert
+  await umbracoUi.content.isSuccessNotificationVisible();
+  expect(await umbracoApi.document.doesNameExist(contentName)).toBeTruthy();
+
+  // Clean
+  await umbracoApi.documentType.ensureNameNotExists(childDocumentTypeName);
+});
+
+test('cannot create child content if allowed child node is disabled', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const noAllowedDocumentTypeAvailableMessage = 'There are no allowed Document Types available for creating content here';
+  const documentTypeId = await umbracoApi.documentType.createDefaultDocumentTypeWithAllowAsRoot(documentTypeName);
+  await umbracoApi.document.createDefaultDocument(contentName, documentTypeId);
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+
+  // Act
+  await umbracoUi.content.clickActionsMenuForContent(contentName);
+  await umbracoUi.content.clickCreateButton();
+
+  // Assert
+  await umbracoUi.content.isDocumentTypeNameVisible(documentTypeName, false);
+  await umbracoUi.content.doesModalHaveText(noAllowedDocumentTypeAvailableMessage);
+});
+
+test('can create multiple child nodes with different document types', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const firstChildDocumentTypeName = 'First Child Document Type';
+  const secondChildDocumentTypeName = 'Second Child Document Type';
+  const firstChildContentName = 'First Child Content';
+  const secondChildContentName = 'Second Child Content';
+  const firstChildDocumentTypeId = await umbracoApi.documentType.createDefaultDocumentType(firstChildDocumentTypeName);
+  const secondChildDocumentTypeId = await umbracoApi.documentType.createDefaultDocumentType(secondChildDocumentTypeName);
+  const documentTypeId = await umbracoApi.documentType.createDocumentTypeWithAllowedTwoChildNodes(documentTypeName, firstChildDocumentTypeId, secondChildDocumentTypeId);
+  const contentId = await umbracoApi.document.createDefaultDocument(contentName, documentTypeId);
+  await umbracoApi.document.createDefaultDocumentWithParent(firstChildContentName, firstChildDocumentTypeId, contentId);
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+
+  // Act
+  await umbracoUi.content.clickActionsMenuForContent(contentName);
+  await umbracoUi.content.clickCreateButton();
+  await umbracoUi.content.chooseDocumentType(secondChildDocumentTypeName);
+  // This wait is needed
+  await umbracoUi.waitForTimeout(500);
+  await umbracoUi.content.enterContentName(secondChildContentName);
+  await umbracoUi.content.clickSaveButton();
+
+  // Assert
+  await umbracoUi.content.isSuccessNotificationVisible();
+  expect(await umbracoApi.document.doesNameExist(secondChildContentName)).toBeTruthy();
+  const childData = await umbracoApi.document.getChildren(contentId);
+  expect(childData.length).toBe(2);
+  expect(childData[0].variants[0].name).toBe(firstChildContentName);
+  expect(childData[1].variants[0].name).toBe(secondChildContentName);
+  // verify that the child content displays in the tree after reloading children
+  await umbracoUi.content.clickActionsMenuForContent(contentName);
+  await umbracoUi.content.clickReloadButton();
+  await umbracoUi.content.clickCaretButtonForContentName(contentName);
+  await umbracoUi.content.doesContentTreeHaveName(firstChildContentName);
+  await umbracoUi.content.doesContentTreeHaveName(secondChildContentName);
+
+  // Clean
+  await umbracoApi.document.ensureNameNotExists(firstChildContentName);
+  await umbracoApi.document.ensureNameNotExists(secondChildContentName);
+  await umbracoApi.documentType.ensureNameNotExists(firstChildDocumentTypeName);
+  await umbracoApi.documentType.ensureNameNotExists(secondChildDocumentTypeName);
+});

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/ContentWithDocumentTypeProperties/ContentWithAllowedTemplates.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/ContentWithDocumentTypeProperties/ContentWithAllowedTemplates.spec.ts
@@ -1,0 +1,66 @@
+﻿import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+import {expect} from "@playwright/test";
+
+const contentName = 'TestContent';
+const documentTypeName = 'TestDocumentTypeForContent';
+const templateName = 'TestTemplate';
+let templateId = '';
+
+test.beforeEach(async ({umbracoApi}) => {
+  await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
+  await umbracoApi.document.ensureNameNotExists(contentName);
+  await umbracoApi.template.ensureNameNotExists(templateName);
+  templateId = await umbracoApi.template.createDefaultTemplate(templateName);
+});
+
+test.afterEach(async ({umbracoApi}) => {
+  await umbracoApi.document.ensureNameNotExists(contentName); 
+  await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
+  await umbracoApi.template.ensureNameNotExists(templateName);
+});
+
+test('can create content with an allowed template', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  await umbracoApi.documentType.createDocumentTypeWithAllowedTemplate(documentTypeName, templateId, true);
+  await umbracoUi.goToBackOffice();
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+
+  // Act
+  await umbracoUi.content.clickActionsMenuAtRoot();
+  await umbracoUi.content.clickCreateButton();
+  await umbracoUi.content.chooseDocumentType(documentTypeName);
+  await umbracoUi.content.enterContentName(contentName);
+  await umbracoUi.content.clickSaveButton();
+  
+  // Assert
+  await umbracoUi.content.isSuccessNotificationVisible();
+  expect(await umbracoApi.document.doesNameExist(contentName)).toBeTruthy();
+  const contentData = await umbracoApi.document.getByName(contentName);
+  expect(contentData.template.id).toBe(templateId);
+});
+
+test('can create content with multiple allowed templates', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const defaultTemplateName = 'TestDefaultTemplate';
+  await umbracoApi.template.ensureNameNotExists(defaultTemplateName);
+  const defaultTemplateId = await umbracoApi.template.createDefaultTemplate(templateName);
+  await umbracoApi.documentType.createDocumentTypeWithTwoAllowedTemplates(documentTypeName, templateId, defaultTemplateId, true, defaultTemplateId);
+  await umbracoUi.goToBackOffice();
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+
+  // Act
+  await umbracoUi.content.clickActionsMenuAtRoot();
+  await umbracoUi.content.clickCreateButton();
+  await umbracoUi.content.chooseDocumentType(documentTypeName);
+  await umbracoUi.content.enterContentName(contentName);
+  await umbracoUi.content.clickSaveButton();
+  
+  // Assert
+  await umbracoUi.content.isSuccessNotificationVisible();
+  expect(await umbracoApi.document.doesNameExist(contentName)).toBeTruthy();
+  const contentData = await umbracoApi.document.getByName(contentName);
+  expect(contentData.template.id).toBe(defaultTemplateId);
+
+  // Clean
+  await umbracoApi.template.ensureNameNotExists(defaultTemplateName);
+});

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/ContentWithDocumentTypeProperties/ContentWithCollections.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/ContentWithDocumentTypeProperties/ContentWithCollections.spec.ts
@@ -1,0 +1,138 @@
+﻿import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+import {expect} from "@playwright/test";
+
+const contentName = 'TestContent';
+const documentTypeName = 'TestDocumentTypeForContent';
+const childDocumentTypeName = 'TestChildDocumentType';
+const firstChildContentName = 'First Child Content';
+const secondChildContentName = 'Second Child Content';
+const dataTypeName = 'List View - Content';
+let dataTypeData;
+
+test.beforeEach(async ({umbracoApi}) => {
+  await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
+  await umbracoApi.document.ensureNameNotExists(contentName);
+  dataTypeData  = await umbracoApi.dataType.getByName(dataTypeName);
+});
+
+test.afterEach(async ({umbracoApi}) => {
+  await umbracoApi.document.ensureNameNotExists(contentName); 
+  await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
+});
+
+test('can create content configured as a collection', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const noItemsToShowMessage = 'There are no items to show in the list.';
+  await umbracoApi.documentType.createDocumentTypeWithCollectionId(documentTypeName, dataTypeData.id);
+  await umbracoUi.goToBackOffice();
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+
+  // Act
+  await umbracoUi.content.clickActionsMenuAtRoot();
+  await umbracoUi.content.clickCreateButton();
+  await umbracoUi.content.chooseDocumentType(documentTypeName);
+  await umbracoUi.content.enterContentName(contentName);
+  await umbracoUi.content.clickSaveButton();
+  
+  // Assert
+  await umbracoUi.content.isSuccessNotificationVisible();
+  await umbracoUi.content.isTabNameVisible('Collection');
+  await umbracoUi.content.doesDocumentWorkspaceHaveText(noItemsToShowMessage);
+  expect(await umbracoApi.document.doesNameExist(contentName)).toBeTruthy();
+});
+
+test('can create child content in a collection', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const expectedNames = [firstChildContentName];
+  const childDocumentTypeId = await umbracoApi.documentType.createDefaultDocumentType(childDocumentTypeName);
+  const documentTypeId = await umbracoApi.documentType.createDocumentTypeWithAllowedChildNodeAndCollectionId(documentTypeName, childDocumentTypeId, dataTypeData.id);
+  const contentId = await umbracoApi.document.createDefaultDocument(contentName, documentTypeId);
+  await umbracoUi.goToBackOffice();
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+
+  // Act
+  await umbracoUi.content.clickActionsMenuForContent(contentName);
+  await umbracoUi.content.clickCreateButton();
+  await umbracoUi.content.chooseDocumentType(childDocumentTypeName);
+  // This wait is needed
+  await umbracoUi.waitForTimeout(500);
+  await umbracoUi.content.enterContentName(firstChildContentName);
+  await umbracoUi.content.clickSaveButton();
+
+  // Assert
+  const childData = await umbracoApi.document.getChildren(contentId);
+  expect(childData.length).toBe(expectedNames.length);
+  expect(childData[0].variants[0].name).toBe(firstChildContentName);
+  // verify that the child content displays in collection list after reloading tree
+  await umbracoUi.waitForTimeout(1000);
+  await umbracoUi.content.clickActionsMenuForContent(contentName);
+  await umbracoUi.content.clickReloadButton();
+  await umbracoUi.content.goToContentWithName(contentName);
+  await umbracoUi.content.doesDocumentTableColumnNameValuesMatch(expectedNames);
+
+  // Clean
+  await umbracoApi.document.ensureNameNotExists(firstChildContentName);
+  await umbracoApi.documentType.ensureNameNotExists(childDocumentTypeName);
+});
+
+test('can create multiple child nodes in a collection', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const expectedNames = [secondChildContentName, firstChildContentName];
+  const childDocumentTypeId = await umbracoApi.documentType.createDefaultDocumentType(childDocumentTypeName);
+  const documentTypeId = await umbracoApi.documentType.createDocumentTypeWithAllowedChildNodeAndCollectionId(documentTypeName, childDocumentTypeId, dataTypeData.id);
+  const contentId = await umbracoApi.document.createDefaultDocument(contentName, documentTypeId);
+  await umbracoApi.document.createDefaultDocumentWithParent(firstChildContentName, childDocumentTypeId, contentId);
+  await umbracoUi.goToBackOffice();
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+
+  // Act
+  await umbracoUi.content.clickActionsMenuForContent(contentName);
+  await umbracoUi.content.clickCreateButton();
+  await umbracoUi.content.chooseDocumentType(childDocumentTypeName);
+  // This wait is needed
+  await umbracoUi.waitForTimeout(500);
+  await umbracoUi.content.enterContentName(secondChildContentName);
+  await umbracoUi.content.clickSaveButton();
+
+  // Assert
+  const childData = await umbracoApi.document.getChildren(contentId);
+  expect(childData.length).toBe(expectedNames.length);
+  expect(childData[0].variants[0].name).toBe(firstChildContentName);
+  expect(childData[1].variants[0].name).toBe(secondChildContentName);
+  // verify that the child content displays in collection list after reloading tree
+  await umbracoUi.waitForTimeout(1000);
+  await umbracoUi.content.clickActionsMenuForContent(contentName);
+  await umbracoUi.content.clickReloadButton();
+  await umbracoUi.content.goToContentWithName(contentName);
+  await umbracoUi.content.doesDocumentTableColumnNameValuesMatch(expectedNames);
+
+  // Clean
+  await umbracoApi.document.ensureNameNotExists(firstChildContentName);
+  await umbracoApi.document.ensureNameNotExists(secondChildContentName);
+  await umbracoApi.documentType.ensureNameNotExists(childDocumentTypeName);
+});
+
+test('can search in a collection of content', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const searchKeyword = 'First';
+  const expectedSearchResult = [firstChildContentName];
+  const childDocumentTypeId = await umbracoApi.documentType.createDefaultDocumentType(childDocumentTypeName);
+  const documentTypeId = await umbracoApi.documentType.createDocumentTypeWithAllowedChildNodeAndCollectionId(documentTypeName, childDocumentTypeId, dataTypeData.id);
+  const contentId = await umbracoApi.document.createDefaultDocument(contentName, documentTypeId);
+  await umbracoApi.document.createDefaultDocumentWithParent(firstChildContentName, childDocumentTypeId, contentId);
+  await umbracoApi.document.createDefaultDocumentWithParent(secondChildContentName, childDocumentTypeId, contentId);
+  await umbracoUi.goToBackOffice();
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+
+  // Act
+  await umbracoUi.content.goToContentWithName(contentName);
+  await umbracoUi.content.searchByKeywordInCollection(searchKeyword);
+
+  // Assert
+  await umbracoUi.content.doesDocumentTableColumnNameValuesMatch(expectedSearchResult);
+
+  // Clean
+  await umbracoApi.document.ensureNameNotExists(firstChildContentName);
+  await umbracoApi.document.ensureNameNotExists(secondChildContentName);
+  await umbracoApi.documentType.ensureNameNotExists(childDocumentTypeName);
+});

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/ContentWithListViewContent.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/ContentWithListViewContent.spec.ts
@@ -1,0 +1,393 @@
+import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+import {expect} from "@playwright/test";
+
+const contentName = 'TestContent';
+const documentTypeName = 'TestDocumentTypeForContent';
+const dataTypeName = 'List View - Content Custom';
+const childDocumentTypeName = 'ChildDocumentTypeForContent';
+const childContentName = 'ChildContent';
+
+test.beforeEach(async ({umbracoApi, umbracoUi}) => {
+  await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
+  await umbracoApi.document.ensureNameNotExists(contentName);
+  await umbracoApi.dataType.ensureNameNotExists(dataTypeName);
+  await umbracoApi.documentType.ensureNameNotExists(childDocumentTypeName);
+  await umbracoUi.goToBackOffice();
+});
+
+test.afterEach(async ({umbracoApi}) => {
+  await umbracoApi.document.ensureNameNotExists(contentName);
+  await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
+  await umbracoApi.dataType.ensureNameNotExists(dataTypeName);
+  await umbracoApi.documentType.ensureNameNotExists(childDocumentTypeName);
+});
+
+test('can create content with the list view data type', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const expectedState = 'Draft';
+  const defaultListViewDataTypeName = 'List View - Content';
+  const childDocumentTypeId = await umbracoApi.documentType.createDefaultDocumentType(childDocumentTypeName);
+  const dataTypeData = await umbracoApi.dataType.getByName(defaultListViewDataTypeName);
+  await umbracoApi.documentType.createDocumentTypeWithAPropertyEditorAndAnAllowedChildNode(documentTypeName, defaultListViewDataTypeName, dataTypeData.id, childDocumentTypeId);
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+
+  // Act
+  await umbracoUi.content.clickActionsMenuAtRoot();
+  await umbracoUi.content.clickCreateButton();
+  await umbracoUi.content.chooseDocumentType(documentTypeName);
+  await umbracoUi.content.enterContentName(contentName);
+  await umbracoUi.content.clickSaveButton();
+
+  // Assert
+  await umbracoUi.content.isSuccessNotificationVisible();
+  expect(await umbracoApi.document.doesNameExist(contentName)).toBeTruthy();
+  const contentData = await umbracoApi.document.getByName(contentName);
+  expect(contentData.variants[0].state).toBe(expectedState);
+  expect(await umbracoApi.document.getChildrenAmount(contentData.id)).toEqual(0);
+});
+
+test('can publish content with the list view data type', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const expectedState = 'Published';
+  const childDocumentTypeId = await umbracoApi.documentType.createDefaultDocumentType(childDocumentTypeName);
+  await umbracoApi.dataType.createListViewContentDataType(dataTypeName);
+  const dataTypeData = await umbracoApi.dataType.getByName(dataTypeName);
+  const documentTypeId = await umbracoApi.documentType.createDocumentTypeWithAPropertyEditorAndAnAllowedChildNode(documentTypeName, dataTypeName, dataTypeData.id, childDocumentTypeId);
+  const documentId = await umbracoApi.document.createDefaultDocument(contentName, documentTypeId);
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+
+  // Act
+  await umbracoUi.content.goToContentWithName(contentName);
+  await umbracoUi.content.clickSaveAndPublishButton();
+
+  // Assert
+  await umbracoUi.content.doesSuccessNotificationsHaveCount(2);
+  expect(await umbracoApi.document.doesNameExist(contentName)).toBeTruthy();
+  const contentData = await umbracoApi.document.getByName(contentName);
+  expect(contentData.variants[0].state).toBe(expectedState);
+  expect(await umbracoApi.document.getChildrenAmount(documentId)).toEqual(0);
+});
+
+test('can create content with a child in the list', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const childDocumentTypeId = await umbracoApi.documentType.createDefaultDocumentType(childDocumentTypeName);
+  await umbracoApi.dataType.createListViewContentDataType(dataTypeName);
+  const dataTypeData = await umbracoApi.dataType.getByName(dataTypeName);
+  const documentTypeId = await umbracoApi.documentType.createDocumentTypeWithAPropertyEditorAndAnAllowedChildNode(documentTypeName, dataTypeName, dataTypeData.id, childDocumentTypeId);
+  const documentId = await umbracoApi.document.createDefaultDocument(contentName, documentTypeId);
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+  await umbracoUi.content.goToContentWithName(contentName);
+
+  // Act
+  await umbracoUi.content.clickCreateContentWithName(childDocumentTypeName);
+  await umbracoUi.content.enterNameInContainer(childContentName);
+  await umbracoUi.content.clickSaveModalButton();
+
+  // Assert
+  await umbracoUi.content.isSuccessNotificationVisible();
+  expect(await umbracoApi.document.doesNameExist(contentName)).toBeTruthy();
+  expect(await umbracoApi.document.getChildrenAmount(documentId)).toEqual(1);
+});
+
+test('can publish content with a child in the list', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const expectedState = 'Published';
+  const childDocumentTypeId = await umbracoApi.documentType.createDefaultDocumentType(childDocumentTypeName);
+  await umbracoApi.dataType.createListViewContentDataType(dataTypeName);
+  const dataTypeData = await umbracoApi.dataType.getByName(dataTypeName);
+  const documentTypeId = await umbracoApi.documentType.createDocumentTypeWithAPropertyEditorAndAnAllowedChildNode(documentTypeName, dataTypeName, dataTypeData.id, childDocumentTypeId);
+  const documentId = await umbracoApi.document.createDefaultDocument(contentName, documentTypeId);
+  await umbracoApi.document.createDefaultDocumentWithParent(childContentName, childDocumentTypeId, documentId);
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+  await umbracoUi.content.goToContentWithName(contentName);
+
+  // Act
+  await umbracoUi.content.clickSaveAndPublishButton();
+  await umbracoUi.content.goToContentInListViewWithName(childContentName);
+  await umbracoUi.content.clickContainerSaveAndPublishButton();
+
+  // Assert
+  await umbracoUi.content.doesSuccessNotificationsHaveCount(2);
+  expect(await umbracoApi.document.doesNameExist(contentName)).toBeTruthy();
+  const contentData = await umbracoApi.document.getByName(contentName);
+  expect(contentData.variants[0].state).toBe(expectedState);
+  expect(await umbracoApi.document.getChildrenAmount(documentId)).toEqual(1);
+  // Checks if child is published
+  const childContentData = await umbracoApi.document.getByName(childContentName);
+  expect(childContentData.variants[0].state).toBe(expectedState);
+});
+
+test('can not publish child in a list when parent is not published', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const expectedState = 'Draft';
+  const childDocumentTypeId = await umbracoApi.documentType.createDefaultDocumentType(childDocumentTypeName);
+  await umbracoApi.dataType.createListViewContentDataType(dataTypeName);
+  const dataTypeData = await umbracoApi.dataType.getByName(dataTypeName);
+  const documentTypeId = await umbracoApi.documentType.createDocumentTypeWithAPropertyEditorAndAnAllowedChildNode(documentTypeName, dataTypeName, dataTypeData.id, childDocumentTypeId);
+  const documentId = await umbracoApi.document.createDefaultDocument(contentName, documentTypeId);
+  await umbracoApi.document.createDefaultDocumentWithParent(childContentName, childDocumentTypeId, documentId);
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+  await umbracoUi.content.goToContentWithName(contentName);
+
+  // Act
+  await umbracoUi.content.goToContentInListViewWithName(childContentName);
+  await umbracoUi.content.clickContainerSaveAndPublishButton();
+
+  // Assert
+  // Content created, but not published
+  await umbracoUi.content.doesSuccessNotificationsHaveCount(1);
+  await umbracoUi.content.isErrorNotificationVisible();
+  const contentData = await umbracoApi.document.getByName(contentName);
+  expect(contentData.variants[0].state).toBe(expectedState);
+  expect(await umbracoApi.document.getChildrenAmount(documentId)).toEqual(1);
+  // Checks if child is still in draft
+  const childContentData = await umbracoApi.document.getByName(childContentName);
+  expect(childContentData.variants[0].state).toBe(expectedState);
+});
+
+test('child is removed from list after child content is deleted', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const childDocumentTypeId = await umbracoApi.documentType.createDefaultDocumentType(childDocumentTypeName);
+  await umbracoApi.dataType.createListViewContentDataType(dataTypeName);
+  const dataTypeData = await umbracoApi.dataType.getByName(dataTypeName);
+  const documentTypeId = await umbracoApi.documentType.createDocumentTypeWithAPropertyEditorAndAnAllowedChildNode(documentTypeName, dataTypeName, dataTypeData.id, childDocumentTypeId);
+  const documentId = await umbracoApi.document.createDefaultDocument(contentName, documentTypeId);
+  await umbracoApi.document.createDefaultDocumentWithParent(childContentName, childDocumentTypeId, documentId);
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+  expect(await umbracoApi.document.getChildrenAmount(documentId)).toEqual(1);
+
+  // Act
+  await umbracoUi.content.clickCaretButtonForContentName(contentName);
+  await umbracoUi.content.clickActionsMenuForContent(childContentName);
+  await umbracoUi.content.clickTrashButton();
+  await umbracoUi.content.clickConfirmTrashButton();
+  await umbracoUi.content.goToContentWithName(contentName);
+  await umbracoUi.content.doesListViewHaveNoItemsInList();
+
+  // Assert
+  expect(await umbracoApi.document.getChildrenAmount(documentId)).toEqual(0);
+  expect(await umbracoApi.document.doesNameExist(childContentName)).toBeFalsy();
+});
+
+test('can sort list by name', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const childDocumentTypeId = await umbracoApi.documentType.createDefaultDocumentType(childDocumentTypeName);
+  const secondChildContentName = 'ASecondChildContent';
+  await umbracoApi.dataType.createListViewContentDataType(dataTypeName);
+  const dataTypeData = await umbracoApi.dataType.getByName(dataTypeName);
+  const documentTypeId = await umbracoApi.documentType.createDocumentTypeWithAPropertyEditorAndAnAllowedChildNode(documentTypeName, dataTypeName, dataTypeData.id, childDocumentTypeId);
+  const documentId = await umbracoApi.document.createDefaultDocument(contentName, documentTypeId);
+  await umbracoApi.document.createDefaultDocumentWithParent(childContentName, childDocumentTypeId, documentId);
+  await umbracoApi.document.createDefaultDocumentWithParent(secondChildContentName, childDocumentTypeId, documentId);
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+  const childAmountBeforeDelete = await umbracoApi.document.getChildrenAmount(documentId);
+  expect(childAmountBeforeDelete).toEqual(2);
+  await umbracoUi.content.goToContentWithName(contentName);
+
+  // Act
+  await umbracoUi.content.clickNameButtonInListView();
+
+  // Assert
+  expect(await umbracoApi.document.getChildrenAmount(documentId)).toEqual(2);
+  await umbracoUi.content.doesFirstItemInListViewHaveName(secondChildContentName);
+});
+
+test('can publish child content from list', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const expectedState = 'Published';
+  const childDocumentTypeId = await umbracoApi.documentType.createDefaultDocumentType(childDocumentTypeName);
+  await umbracoApi.dataType.createListViewContentDataTypeWithAllPermissions(dataTypeName);
+  const dataTypeData = await umbracoApi.dataType.getByName(dataTypeName);
+  const documentTypeId = await umbracoApi.documentType.createDocumentTypeWithAPropertyEditorAndAnAllowedChildNode(documentTypeName, dataTypeName, dataTypeData.id, childDocumentTypeId);
+  const documentId = await umbracoApi.document.createDefaultDocument(contentName, documentTypeId);
+  await umbracoApi.document.createDefaultDocumentWithParent(childContentName, childDocumentTypeId, documentId);
+  const publishData = {"publishSchedules": [{"culture": null}]};
+  await umbracoApi.document.publish(documentId, publishData);
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+  await umbracoUi.content.goToContentWithName(contentName);
+
+  // Act
+  await umbracoUi.content.selectContentWithNameInListView(childContentName);
+  await umbracoUi.content.clickPublishSelectedListItems();
+
+  // Assert
+  await umbracoUi.content.isSuccessNotificationVisible();
+  expect(await umbracoApi.document.getChildrenAmount(documentId)).toEqual(1);
+  const childContentData = await umbracoApi.document.getByName(childContentName);
+  expect(childContentData.variants[0].state).toBe(expectedState);
+});
+
+test('can not publish child content from list when parent is not published', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const expectedState = 'Draft';
+  const childDocumentTypeId = await umbracoApi.documentType.createDefaultDocumentType(childDocumentTypeName);
+  await umbracoApi.dataType.createListViewContentDataTypeWithAllPermissions(dataTypeName);
+  const dataTypeData = await umbracoApi.dataType.getByName(dataTypeName);
+  const documentTypeId = await umbracoApi.documentType.createDocumentTypeWithAPropertyEditorAndAnAllowedChildNode(documentTypeName, dataTypeName, dataTypeData.id, childDocumentTypeId);
+  const documentId = await umbracoApi.document.createDefaultDocument(contentName, documentTypeId);
+  await umbracoApi.document.createDefaultDocumentWithParent(childContentName, childDocumentTypeId, documentId);
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+  await umbracoUi.content.goToContentWithName(contentName);
+
+  // Act
+  await umbracoUi.content.selectContentWithNameInListView(childContentName);
+  await umbracoUi.content.clickPublishSelectedListItems();
+
+  // Assert
+  await umbracoUi.content.isErrorNotificationVisible();
+  const childContentData = await umbracoApi.document.getByName(childContentName);
+  expect(childContentData.variants[0].state).toBe(expectedState);
+});
+
+test('can unpublish child content from list', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const expectedState = 'Draft';
+  const childDocumentTypeId = await umbracoApi.documentType.createDefaultDocumentType(childDocumentTypeName);
+  await umbracoApi.dataType.createListViewContentDataTypeWithAllPermissions(dataTypeName);
+  const dataTypeData = await umbracoApi.dataType.getByName(dataTypeName);
+  const documentTypeId = await umbracoApi.documentType.createDocumentTypeWithAPropertyEditorAndAnAllowedChildNode(documentTypeName, dataTypeName, dataTypeData.id, childDocumentTypeId);
+  const documentId = await umbracoApi.document.createDefaultDocument(contentName, documentTypeId);
+  const childDocumentId = await umbracoApi.document.createDefaultDocumentWithParent(childContentName, childDocumentTypeId, documentId);
+  const publishData = {"publishSchedules": [{"culture": null}]};
+  await umbracoApi.document.publish(documentId, publishData);
+  await umbracoApi.document.publish(childDocumentId, publishData);
+  const childContentDataBeforeUnpublished = await umbracoApi.document.getByName(childContentName);
+  expect(childContentDataBeforeUnpublished.variants[0].state).toBe('Published');
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+  await umbracoUi.content.goToContentWithName(contentName);
+
+  // Act
+  await umbracoUi.content.selectContentWithNameInListView(childContentName);
+  await umbracoUi.content.clickUnpublishSelectedListItems();
+  await umbracoUi.content.clickConfirmToUnpublishButton();
+
+  // Assert
+  await umbracoUi.content.isSuccessNotificationVisible();
+  const childContentData = await umbracoApi.document.getByName(childContentName);
+  expect(childContentData.variants[0].state).toBe(expectedState);
+});
+
+test('can duplicate child content in list', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const secondDocumentName = 'SecondDocument';
+  await umbracoApi.document.ensureNameNotExists(secondDocumentName);
+  const childDocumentTypeId = await umbracoApi.documentType.createDefaultDocumentType(childDocumentTypeName);
+  await umbracoApi.dataType.createListViewContentDataTypeWithAllPermissions(dataTypeName);
+  const dataTypeData = await umbracoApi.dataType.getByName(dataTypeName);
+  const documentTypeId = await umbracoApi.documentType.createDocumentTypeWithAPropertyEditorAndAnAllowedChildNode(documentTypeName, dataTypeName, dataTypeData.id, childDocumentTypeId);
+  const documentId = await umbracoApi.document.createDefaultDocument(contentName, documentTypeId);
+  const secondDocumentId = await umbracoApi.document.createDefaultDocument(secondDocumentName, documentTypeId);
+  await umbracoApi.document.createDefaultDocumentWithParent(childContentName, childDocumentTypeId, documentId);
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+  await umbracoUi.content.goToContentWithName(contentName);
+
+  // Act
+  await umbracoUi.content.selectContentWithNameInListView(childContentName);
+  await umbracoUi.content.clickDuplicateToSelectedListItems();
+  await umbracoUi.content.selectDocumentWithNameAtRoot(secondDocumentName);
+
+  // Assert
+  await umbracoUi.content.isSuccessNotificationVisible();
+  await umbracoUi.content.doesFirstItemInListViewHaveName(childContentName);
+  await umbracoUi.content.goToContentWithName(secondDocumentName);
+  await umbracoUi.content.doesFirstItemInListViewHaveName(childContentName);
+  // Checks firstContentNode
+  expect(await umbracoApi.document.getChildrenAmount(documentId)).toEqual(1);
+  // Checks secondContentNode
+  expect(await umbracoApi.document.getChildrenAmount(secondDocumentId)).toEqual(1);
+});
+
+test('can move child content in list', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const secondDocumentName = 'SecondDocument';
+  await umbracoApi.document.ensureNameNotExists(secondDocumentName);
+  const childDocumentTypeId = await umbracoApi.documentType.createDefaultDocumentType(childDocumentTypeName);
+  await umbracoApi.dataType.createListViewContentDataTypeWithAllPermissions(dataTypeName);
+  const dataTypeData = await umbracoApi.dataType.getByName(dataTypeName);
+  const documentTypeId = await umbracoApi.documentType.createDocumentTypeWithAPropertyEditorAndAnAllowedChildNode(documentTypeName, dataTypeName, dataTypeData.id, childDocumentTypeId);
+  const documentId = await umbracoApi.document.createDefaultDocument(contentName, documentTypeId);
+  const secondDocumentId = await umbracoApi.document.createDefaultDocument(secondDocumentName, documentTypeId);
+  await umbracoApi.document.createDefaultDocumentWithParent(childContentName, childDocumentTypeId, documentId);
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+  await umbracoUi.content.goToContentWithName(contentName);
+
+  // Act
+  await umbracoUi.content.selectContentWithNameInListView(childContentName);
+  await umbracoUi.content.clickMoveToSelectedListItems();
+  await umbracoUi.content.selectDocumentWithNameAtRoot(secondDocumentName);
+
+  // Assert
+  await umbracoUi.content.isSuccessNotificationVisible();
+  await umbracoUi.content.doesListViewContainCount(0);
+  await umbracoUi.content.goToContentWithName(secondDocumentName);
+  await umbracoUi.content.doesFirstItemInListViewHaveName(childContentName);
+  // Checks firstContentNode
+  expect(await umbracoApi.document.getChildrenAmount(documentId)).toEqual(0);
+  // Checks secondContentNode
+  expect(await umbracoApi.document.getChildrenAmount(secondDocumentId)).toEqual(1);
+});
+
+test('can trash child content in list', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const childDocumentTypeId = await umbracoApi.documentType.createDefaultDocumentType(childDocumentTypeName);
+  await umbracoApi.dataType.createListViewContentDataTypeWithAllPermissions(dataTypeName);
+  const dataTypeData = await umbracoApi.dataType.getByName(dataTypeName);
+  const documentTypeId = await umbracoApi.documentType.createDocumentTypeWithAPropertyEditorAndAnAllowedChildNode(documentTypeName, dataTypeName, dataTypeData.id, childDocumentTypeId);
+  const documentId = await umbracoApi.document.createDefaultDocument(contentName, documentTypeId);
+  await umbracoApi.document.createDefaultDocumentWithParent(childContentName, childDocumentTypeId, documentId);
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+  await umbracoUi.content.goToContentWithName(contentName);
+
+  // Act
+  await umbracoUi.content.selectContentWithNameInListView(childContentName);
+  await umbracoUi.content.clickTrashSelectedListItems();
+  await umbracoUi.content.clickConfirmTrashButton();
+
+  // Assert
+  await umbracoUi.content.isSuccessNotificationVisible();
+  await umbracoUi.content.doesListViewContainCount(0);
+  expect(await umbracoApi.document.getChildrenAmount(documentId)).toEqual(0);
+  await umbracoUi.content.isItemVisibleInRecycleBin(childContentName);
+});
+
+test('can search for child content in list', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const secondChildName = 'SecondChildDocument';
+  await umbracoApi.document.ensureNameNotExists(secondChildName);
+  const childDocumentTypeId = await umbracoApi.documentType.createDefaultDocumentType(childDocumentTypeName);
+  await umbracoApi.dataType.createListViewContentDataTypeWithAllPermissions(dataTypeName);
+  const dataTypeData = await umbracoApi.dataType.getByName(dataTypeName);
+  const documentTypeId = await umbracoApi.documentType.createDocumentTypeWithAPropertyEditorAndAnAllowedChildNode(documentTypeName, dataTypeName, dataTypeData.id, childDocumentTypeId);
+  const documentId = await umbracoApi.document.createDefaultDocument(contentName, documentTypeId);
+  await umbracoApi.document.createDefaultDocumentWithParent(childContentName, childDocumentTypeId, documentId);
+  await umbracoApi.document.createDefaultDocumentWithParent(secondChildName, childDocumentTypeId, documentId);
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+  await umbracoUi.content.goToContentWithName(contentName);
+  await umbracoUi.content.doesListViewContainCount(2);
+
+  // Act
+  await umbracoUi.content.searchByKeywordInCollection(childContentName);
+
+  // Assert
+  await umbracoUi.content.doesListViewContainCount(1);
+  await umbracoUi.content.doesFirstItemInListViewHaveName(childContentName);
+});
+
+test('can change from list view to grid view in list', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const childDocumentTypeId = await umbracoApi.documentType.createDefaultDocumentType(childDocumentTypeName);
+  await umbracoApi.dataType.createListViewContentDataTypeWithAllPermissions(dataTypeName);
+  const dataTypeData = await umbracoApi.dataType.getByName(dataTypeName);
+  const documentTypeId = await umbracoApi.documentType.createDocumentTypeWithAPropertyEditorAndAnAllowedChildNode(documentTypeName, dataTypeName, dataTypeData.id, childDocumentTypeId);
+  const documentId = await umbracoApi.document.createDefaultDocument(contentName, documentTypeId);
+  await umbracoApi.document.createDefaultDocumentWithParent(childContentName, childDocumentTypeId, documentId);
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+  await umbracoUi.content.goToContentWithName(contentName);
+  await umbracoUi.content.isDocumentListViewVisible();
+
+  // Act
+  await umbracoUi.content.changeToGridView();
+
+  // Assert
+  await umbracoUi.content.isDocumentGridViewVisible();
+});

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/CultureAndHostnames.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/CultureAndHostnames.spec.ts
@@ -108,6 +108,7 @@ test('can add culture and hostname for multiple languages', async ({umbracoApi, 
   // Act
   await umbracoUi.content.clickActionsMenuForContent(contentName);
   await umbracoUi.content.clickCultureAndHostnamesButton();
+  await umbracoUi.waitForTimeout(500);
   await umbracoUi.content.clickAddNewDomainButton();
   await umbracoUi.content.enterDomain(domainName, 0);
   await umbracoUi.content.selectDomainLanguageOption(languageName, 0);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/DataType.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/DataType.spec.ts
@@ -1,4 +1,4 @@
-﻿import {test} from '@umbraco/playwright-testhelpers';
+﻿import {NotificationConstantHelper, test} from '@umbraco/playwright-testhelpers';
 import {expect} from "@playwright/test";
 
 const dataTypeName = 'TestDataType';
@@ -24,7 +24,7 @@ test('can create a data type', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) 
   await umbracoUi.dataType.clickSaveButton();
 
   // Assert
-  await umbracoUi.dataType.isSuccessNotificationVisible();
+  await umbracoUi.dataType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   expect(await umbracoApi.dataType.doesNameExist(dataTypeName)).toBeTruthy();
 });
 
@@ -41,6 +41,7 @@ test('can rename a data type', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) 
   await umbracoUi.dataType.clickSaveButton();
 
   // Assert
+  await umbracoUi.dataType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   expect(await umbracoApi.dataType.doesNameExist(dataTypeName)).toBeTruthy();
   expect(await umbracoApi.dataType.doesNameExist(wrongDataTypeName)).toBeFalsy();
 });
@@ -55,7 +56,7 @@ test('can delete a data type', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) 
   await umbracoUi.dataType.deleteDataType(dataTypeName);
 
   // Assert
-  await umbracoUi.dataType.isSuccessNotificationVisible();
+  await umbracoUi.dataType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.deleted);
   expect(await umbracoApi.dataType.doesNameExist(dataTypeName)).toBeFalsy();
 });
 
@@ -75,6 +76,7 @@ test('can change property editor in a data type', {tag: '@smoke'}, async ({umbra
   await umbracoUi.dataType.clickSaveButton();
 
   // Assert
+  await umbracoUi.dataType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   expect(await umbracoApi.dataType.doesNameExist(dataTypeName)).toBeTruthy();
   const dataTypeData = await umbracoApi.dataType.getByName(dataTypeName);
   expect(dataTypeData.editorAlias).toBe(updatedEditorAlias);
@@ -110,7 +112,7 @@ test('can change settings', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => 
   await umbracoUi.dataType.clickSaveButton();
 
   // Assert
-  await umbracoUi.dataType.isSuccessNotificationVisible();
+  await umbracoUi.dataType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const dataTypeData = await umbracoApi.dataType.getByName(dataTypeName);
   expect(dataTypeData.values).toContainEqual(expectedDataTypeValues);
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/DataTypeFolder.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/DataTypeFolder.spec.ts
@@ -1,4 +1,4 @@
-﻿import {test} from '@umbraco/playwright-testhelpers';
+﻿import {NotificationConstantHelper, test} from '@umbraco/playwright-testhelpers';
 import {expect} from "@playwright/test";
 
 const dataTypeName = 'TestDataType';
@@ -23,7 +23,8 @@ test('can create a data type folder', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.dataType.createFolder(dataTypeFolderName);
 
   // Assert
-  expect(await umbracoApi.dataType.doesFolderExist(dataTypeFolderName)).toBeTruthy();
+  await umbracoUi.dataType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderCreated);
+  expect(await umbracoApi.dataType.doesNameExist(dataTypeFolderName)).toBeTruthy();
 });
 
 test('can rename a data type folder', async ({umbracoApi, umbracoUi}) => {
@@ -41,6 +42,7 @@ test('can rename a data type folder', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.dataType.clickConfirmRenameFolderButton();
 
   // Assert
+  await umbracoUi.dataType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderUpdated);
   expect(await umbracoApi.dataType.doesNameExist(dataTypeFolderName)).toBeTruthy();
   expect(await umbracoApi.dataType.doesNameExist(wrongDataTypeFolderName)).toBeFalsy();
 });
@@ -55,6 +57,7 @@ test('can delete a data type folder', {tag: '@smoke'}, async ({umbracoApi, umbra
   await umbracoUi.dataType.deleteDataTypeFolder(dataTypeFolderName);
 
   // Assert
+  await umbracoUi.dataType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderDeleted);
   expect(await umbracoApi.dataType.doesNameExist(dataTypeFolderName)).toBeFalsy();
 });
 
@@ -75,6 +78,7 @@ test('can create a data type in a folder', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.dataType.clickSaveButton();
 
   // Assert
+  await umbracoUi.dataType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   expect(await umbracoApi.dataType.doesNameExist(dataTypeName)).toBeTruthy();
   const dataTypeChildren = await umbracoApi.dataType.getChildren(dataTypeFolderId);
   expect(dataTypeChildren[0].name).toBe(dataTypeName);
@@ -94,6 +98,7 @@ test('can create a folder in a folder', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.dataType.createFolder(childFolderName);
 
   // Assert
+  await umbracoUi.dataType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderCreated);
   expect(await umbracoApi.dataType.doesNameExist(childFolderName)).toBeTruthy();
   const dataTypeChildren = await umbracoApi.dataType.getChildren(dataTypeFolderId);
   expect(dataTypeChildren[0].name).toBe(childFolderName);
@@ -114,7 +119,7 @@ test('can create a folder in a folder in a folder', async ({umbracoApi, umbracoU
   await umbracoUi.dataType.createFolder(childOfChildFolderName);
 
   // Assert
-  await umbracoUi.dataType.isSuccessNotificationVisible();
+  await umbracoUi.dataType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderCreated);
   expect(await umbracoApi.dataType.doesNameExist(childOfChildFolderName)).toBeTruthy();
   const childrenFolderData = await umbracoApi.dataType.getChildren(childFolderId);
   expect(childrenFolderData[0].name).toBe(childOfChildFolderName);
@@ -135,7 +140,7 @@ test('cannot delete a non-empty data type folder', async ({umbracoApi, umbracoUi
   await umbracoUi.dataType.deleteDataTypeFolder(dataTypeFolderName);
 
   // Assert
-  await umbracoUi.dataType.isErrorNotificationVisible();
+  await umbracoUi.dataType.doesErrorNotificationHaveText(NotificationConstantHelper.error.notEmptyFolder);
   expect(await umbracoApi.dataType.doesNameExist(dataTypeName)).toBeTruthy();
   expect(await umbracoApi.dataType.doesNameExist(dataTypeFolderName)).toBeTruthy();
   const dataTypeChildren = await umbracoApi.dataType.getChildren(dataTypeFolderId);
@@ -161,7 +166,7 @@ test('can move a data type to a data type folder', async ({umbracoApi, umbracoUi
   await umbracoUi.dataType.moveDataTypeToFolder(dataTypeFolderName);
 
   // Assert
-  await umbracoUi.dataType.isSuccessNotificationVisible();
+  await umbracoUi.dataType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.moved);
   const dataTypeInFolder = await umbracoApi.dataType.getChildren(dataTypeFolderId);
   expect(dataTypeInFolder[0].id).toEqual(dataTypeId);
 
@@ -184,7 +189,7 @@ test('can duplicate a data type to a data type folder', async ({umbracoApi, umbr
   await umbracoUi.dataType.duplicateDataTypeToFolder(dataTypeFolderName);
 
   // Assert
-  await umbracoUi.dataType.isSuccessNotificationVisible();
+  await umbracoUi.dataType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.duplicated);
   const dataTypeInFolder = await umbracoApi.dataType.getChildren(dataTypeFolderId);
   expect(dataTypeInFolder[0].name).toEqual(dataTypeName + ' (copy)');
   expect(await umbracoApi.dataType.doesNameExist(dataTypeName)).toBeTruthy();

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/DataTypeFolder.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/DataTypeFolder.spec.ts
@@ -23,7 +23,7 @@ test('can create a data type folder', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.dataType.createFolder(dataTypeFolderName);
 
   // Assert
-  expect(await umbracoApi.dataType.doesNameExist(dataTypeFolderName)).toBeTruthy();
+  expect(await umbracoApi.dataType.doesFolderExist(dataTypeFolderName)).toBeTruthy();
 });
 
 test('can rename a data type folder', async ({umbracoApi, umbracoUi}) => {

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Dictionary/Dictionary.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Dictionary/Dictionary.spec.ts
@@ -1,4 +1,4 @@
-﻿import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+﻿import {ConstantHelper, NotificationConstantHelper, test} from '@umbraco/playwright-testhelpers';
 import {expect} from "@playwright/test";
 
 const dictionaryName = 'TestDictionaryItem';
@@ -24,7 +24,7 @@ test('can create a dictionary item', async ({umbracoApi, umbracoUi}) => {
 
   // Assert
   expect(await umbracoApi.dictionary.doesNameExist(dictionaryName)).toBeTruthy();
-  await umbracoUi.dictionary.isSuccessNotificationVisible();
+  await umbracoUi.dictionary.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   await umbracoUi.dictionary.clickLeftArrowButton();
   // Verify the dictionary item displays in the tree and in the list
   await umbracoUi.dictionary.isDictionaryTreeItemVisible(dictionaryName);
@@ -42,7 +42,7 @@ test('can delete a dictionary item', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.dictionary.deleteDictionary();
 
   // Assert
-  await umbracoUi.dictionary.isSuccessNotificationVisible();
+  await umbracoUi.dictionary.doesSuccessNotificationHaveText(NotificationConstantHelper.success.deleted);
   expect(await umbracoApi.dictionary.doesNameExist(dictionaryName)).toBeFalsy();
   // Verify the dictionary item does not display in the tree
   await umbracoUi.dictionary.isDictionaryTreeItemVisible(dictionaryName, false);
@@ -64,7 +64,7 @@ test('can create a dictionary item in a dictionary', {tag: '@smoke'}, async ({um
   await umbracoUi.dictionary.clickSaveButton();
 
   // Assert
-  await umbracoUi.dictionary.isSuccessNotificationVisible();
+  await umbracoUi.dictionary.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   const dictionaryChildren = await umbracoApi.dictionary.getChildren(parentDictionaryId);
   expect(dictionaryChildren[0].name).toEqual(dictionaryName);
   await umbracoUi.dictionary.clickLeftArrowButton();

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Media/Media.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Media/Media.spec.ts
@@ -192,7 +192,7 @@ test('can trash a media item', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.media.clickConfirmTrashButton();
 
   // Assert
-  await umbracoUi.media.isMediaItemVisibleInRecycleBin(mediaFileName);
+  await umbracoUi.media.isItemVisibleInRecycleBin(mediaFileName);
   expect(await umbracoApi.media.doesNameExist(mediaFileName)).toBeFalsy();
   expect(await umbracoApi.media.doesMediaItemExistInRecycleBin(mediaFileName)).toBeTruthy();
 
@@ -212,7 +212,8 @@ test('can restore a media item from the recycle bin', async ({umbracoApi, umbrac
   await umbracoUi.media.restoreMediaItem(mediaFileName);
 
   // Assert
-  await umbracoUi.media.isMediaItemVisibleInRecycleBin(mediaFileName, false);
+  await umbracoUi.media.isItemVisibleInRecycleBin(mediaFileName, false);
+  await umbracoUi.media.reloadMediaTree();
   await umbracoUi.media.isTreeItemVisible(mediaFileName);
   expect(await umbracoApi.media.doesNameExist(mediaFileName)).toBeTruthy();
   expect(await umbracoApi.media.doesMediaItemExistInRecycleBin(mediaFileName)).toBeFalsy();
@@ -229,11 +230,11 @@ test('can delete a media item from the recycle bin', async ({umbracoApi, umbraco
   await umbracoUi.media.goToSection(ConstantHelper.sections.media);
 
   // Act
-  await umbracoUi.media.isMediaItemVisibleInRecycleBin(mediaFileName);
+  await umbracoUi.media.isItemVisibleInRecycleBin(mediaFileName);
   await umbracoUi.media.deleteMediaItem(mediaFileName);
 
   // Assert
-  await umbracoUi.media.isMediaItemVisibleInRecycleBin(mediaFileName, false);
+  await umbracoUi.media.isItemVisibleInRecycleBin(mediaFileName, false);
   expect(await umbracoApi.media.doesNameExist(mediaFileName)).toBeFalsy();
   expect(await umbracoApi.media.doesMediaItemExistInRecycleBin(mediaFileName)).toBeFalsy();
 });
@@ -246,12 +247,12 @@ test('can empty the recycle bin', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.media.goToSection(ConstantHelper.sections.media);
 
   // Act
-  await umbracoUi.media.isMediaItemVisibleInRecycleBin(mediaFileName);
+  await umbracoUi.media.isItemVisibleInRecycleBin(mediaFileName);
   await umbracoUi.media.clickEmptyRecycleBinButton();
   await umbracoUi.media.clickConfirmEmptyRecycleBinButton();
 
   // Assert
-  await umbracoUi.media.isMediaItemVisibleInRecycleBin(mediaFileName, false);
+  await umbracoUi.media.isItemVisibleInRecycleBin(mediaFileName, false);
   expect(await umbracoApi.media.doesNameExist(mediaFileName)).toBeFalsy();
   expect(await umbracoApi.media.doesMediaItemExistInRecycleBin(mediaFileName)).toBeFalsy();
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Media/Media.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Media/Media.spec.ts
@@ -1,4 +1,4 @@
-import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+import {ConstantHelper, NotificationConstantHelper, test} from '@umbraco/playwright-testhelpers';
 import {expect} from '@playwright/test';
 
 const mediaFileName = 'TestMediaFile';
@@ -45,7 +45,7 @@ test('can rename a media file', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.media.clickSaveButton();
 
   // Assert
-  await umbracoUi.media.isSuccessNotificationVisible();
+  await umbracoUi.media.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   await umbracoUi.media.isTreeItemVisible(mediaFileName);
   expect(await umbracoApi.media.doesNameExist(mediaFileName)).toBeTruthy();
 });
@@ -73,7 +73,7 @@ for (const mediaFileType of mediaFileTypes) {
     await umbracoUi.media.clickSaveButton();
 
     // Assert
-    await umbracoUi.media.isSuccessNotificationVisible();
+    await umbracoUi.media.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
     await umbracoUi.media.isTreeItemVisible(mediaFileType.fileName);
     expect(await umbracoApi.media.doesNameExist(mediaFileType.fileName)).toBeTruthy();
 
@@ -93,7 +93,7 @@ test.skip('can delete a media file', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.media.deleteMediaItem(mediaFileName);
 
   // Assert
-  await umbracoUi.media.isSuccessNotificationVisible();
+  await umbracoUi.media.doesSuccessNotificationHaveText(NotificationConstantHelper.success.deleted);
   await umbracoUi.media.isTreeItemVisible(mediaFileName, false);
   expect(await umbracoApi.media.doesNameExist(mediaFileName)).toBeFalsy();
 });
@@ -110,7 +110,7 @@ test('can create a folder', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.media.clickSaveButton();
 
   // Assert
-  await umbracoUi.media.isSuccessNotificationVisible();
+  await umbracoUi.media.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderCreated);
   await umbracoUi.media.isTreeItemVisible(folderName);
   expect(await umbracoApi.media.doesNameExist(folderName)).toBeTruthy();
 
@@ -132,6 +132,7 @@ test.skip('can delete a folder', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.media.clickConfirmToDeleteButton();
 
   // Assert
+  await umbracoUi.media.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderDeleted);
   await umbracoUi.media.isTreeItemVisible(folderName, false);
   expect(await umbracoApi.media.doesNameExist(folderName)).toBeFalsy();
 });
@@ -151,7 +152,7 @@ test('can create a folder in a folder', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.media.clickSaveButton();
 
   // Assert
-  await umbracoUi.media.isSuccessNotificationVisible();
+  await umbracoUi.media.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderCreated);
   await umbracoUi.media.isTreeItemVisible(parentFolderName);
   await umbracoUi.media.clickMediaCaretButtonForName(parentFolderName);
   await umbracoUi.media.isTreeItemVisible(folderName);
@@ -192,6 +193,7 @@ test('can trash a media item', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.media.clickConfirmTrashButton();
 
   // Assert
+  await umbracoUi.media.doesSuccessNotificationHaveText(NotificationConstantHelper.success.movedToRecycleBin);
   await umbracoUi.media.isItemVisibleInRecycleBin(mediaFileName);
   expect(await umbracoApi.media.doesNameExist(mediaFileName)).toBeFalsy();
   expect(await umbracoApi.media.doesMediaItemExistInRecycleBin(mediaFileName)).toBeTruthy();
@@ -212,6 +214,7 @@ test('can restore a media item from the recycle bin', async ({umbracoApi, umbrac
   await umbracoUi.media.restoreMediaItem(mediaFileName);
 
   // Assert
+  await umbracoUi.media.doesSuccessNotificationHaveText(NotificationConstantHelper.success.restored);
   await umbracoUi.media.isItemVisibleInRecycleBin(mediaFileName, false);
   await umbracoUi.media.reloadMediaTree();
   await umbracoUi.media.isTreeItemVisible(mediaFileName);
@@ -234,6 +237,7 @@ test('can delete a media item from the recycle bin', async ({umbracoApi, umbraco
   await umbracoUi.media.deleteMediaItem(mediaFileName);
 
   // Assert
+  await umbracoUi.media.doesSuccessNotificationHaveText(NotificationConstantHelper.success.deleted);
   await umbracoUi.media.isItemVisibleInRecycleBin(mediaFileName, false);
   expect(await umbracoApi.media.doesNameExist(mediaFileName)).toBeFalsy();
   expect(await umbracoApi.media.doesMediaItemExistInRecycleBin(mediaFileName)).toBeFalsy();
@@ -252,6 +256,7 @@ test('can empty the recycle bin', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.media.clickConfirmEmptyRecycleBinButton();
 
   // Assert
+  await umbracoUi.media.doesSuccessNotificationHaveText(NotificationConstantHelper.success.emptiedRecycleBin);
   await umbracoUi.media.isItemVisibleInRecycleBin(mediaFileName, false);
   expect(await umbracoApi.media.doesNameExist(mediaFileName)).toBeFalsy();
   expect(await umbracoApi.media.doesMediaItemExistInRecycleBin(mediaFileName)).toBeFalsy();

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Members/MemberGroups.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Members/MemberGroups.spec.ts
@@ -1,4 +1,4 @@
-﻿import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+﻿import {ConstantHelper, NotificationConstantHelper, test} from '@umbraco/playwright-testhelpers';
 import {expect} from "@playwright/test";
 
 const memberGroupName = 'Test Member Group';
@@ -13,7 +13,7 @@ test.afterEach(async ({umbracoApi}) => {
   await umbracoApi.memberGroup.ensureNameNotExists(memberGroupName);
 });
 
-test('can create a member group', {tag: '@smoke'}, async ({page, umbracoApi, umbracoUi}) => {
+test('can create a member group', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
   // Act
   await umbracoUi.memberGroup.clickMemberGroupsTab();
   await umbracoUi.memberGroup.clickMemberGroupCreateButton();
@@ -21,7 +21,7 @@ test('can create a member group', {tag: '@smoke'}, async ({page, umbracoApi, umb
   await umbracoUi.memberGroup.clickSaveButton();
 
   // Assert
-  await umbracoUi.memberGroup.isSuccessNotificationVisible();
+  await umbracoUi.memberGroup.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   await umbracoUi.memberGroup.clickLeftArrowButton();
   await umbracoUi.memberGroup.isMemberGroupNameVisible(memberGroupName);
   expect(await umbracoApi.memberGroup.doesNameExist(memberGroupName)).toBeTruthy();
@@ -34,7 +34,7 @@ test('cannot create member group with empty name', async ({umbracoApi, umbracoUi
   await umbracoUi.memberGroup.clickSaveButton();
 
   // Assert
-  await umbracoUi.memberGroup.isErrorNotificationVisible();
+  await umbracoUi.memberGroup.doesErrorNotificationHaveText(NotificationConstantHelper.error.emptyName);
   expect(await umbracoApi.memberGroup.doesNameExist(memberGroupName)).toBeFalsy();
 });
 
@@ -46,12 +46,12 @@ test.skip('cannot create member group with duplicate name', async ({umbracoApi, 
 
   // Act
   await umbracoUi.memberGroup.clickMemberGroupsTab();
-  await umbracoUi.memberGroup.clickCreateButton(true);
+  await umbracoUi.memberGroup.clickCreateButton();
   await umbracoUi.memberGroup.enterMemberGroupName(memberGroupName);
   await umbracoUi.memberGroup.clickSaveButton();
 
   // Assert
-  await umbracoUi.memberGroup.isErrorNotificationVisible();
+  await umbracoUi.memberGroup.doesErrorNotificationHaveText(NotificationConstantHelper.error.duplicateName);
 });
 
 // TODO: Remove skip when the front-end is ready. Currently it is impossible to delete a member group.

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Members/Members.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Members/Members.spec.ts
@@ -1,4 +1,4 @@
-﻿import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+﻿import {ConstantHelper, NotificationConstantHelper, test} from '@umbraco/playwright-testhelpers';
 import {expect} from "@playwright/test";
 
 let memberId = '';
@@ -38,7 +38,7 @@ test('can create a member', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => 
   await umbracoUi.member.clickSaveButton();
 
   // Assert
-  await umbracoUi.member.isSuccessNotificationVisible();
+  await umbracoUi.member.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   expect(await umbracoApi.member.doesNameExist(memberName)).toBeTruthy();
 });
 
@@ -55,7 +55,7 @@ test('can edit comments', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.member.clickSaveButton();
 
   // Assert
-  await umbracoUi.member.isSuccessNotificationVisible();
+  await umbracoUi.member.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const memberData = await umbracoApi.member.get(memberId);
   expect(memberData.values[0].value).toBe(comment);
 });
@@ -73,7 +73,7 @@ test('can edit username', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.member.clickSaveButton();
 
   // Assert
-  await umbracoUi.member.isSuccessNotificationVisible();
+  await umbracoUi.member.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const memberData = await umbracoApi.member.get(memberId);
   expect(memberData.username).toBe(updatedUsername);
 });
@@ -91,7 +91,7 @@ test('can edit email', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.member.clickSaveButton();
 
   // Assert
-  await umbracoUi.member.isSuccessNotificationVisible();
+  await umbracoUi.member.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const memberData = await umbracoApi.member.get(memberId);
   expect(memberData.email).toBe(updatedEmail);
 });
@@ -111,7 +111,7 @@ test('can edit password', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.member.clickSaveButton();
 
   // Assert
-  await umbracoUi.member.isSuccessNotificationVisible();
+  await umbracoUi.member.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
 });
 
 test('can add member group', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
@@ -129,7 +129,7 @@ test('can add member group', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) =>
   await umbracoUi.member.clickSaveButton();
 
   // Assert
-  await umbracoUi.member.isSuccessNotificationVisible();
+  await umbracoUi.member.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const memberData = await umbracoApi.member.get(memberId);
   expect(memberData.groups[0]).toBe(memberGroupId);
 
@@ -153,7 +153,7 @@ test('can remove member group', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.member.clickSaveButton();
 
   // Assert
-  await umbracoUi.member.isSuccessNotificationVisible();
+  await umbracoUi.member.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const memberData = await umbracoApi.member.get(memberId);
   expect(memberData.groups.length).toBe(0);
 
@@ -197,7 +197,7 @@ test('can enable approved', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.member.clickSaveButton();
 
   // Assert
-  await umbracoUi.member.isSuccessNotificationVisible();
+  await umbracoUi.member.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const memberData = await umbracoApi.member.get(memberId);
   expect(memberData.isApproved).toBe(true);
 });
@@ -215,7 +215,7 @@ test('can delete member', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.memberGroup.clickConfirmToDeleteButton();
 
   // Assert
-  await umbracoUi.member.isSuccessNotificationVisible();
+  await umbracoUi.member.doesSuccessNotificationHaveText(NotificationConstantHelper.success.deleted);
   expect(await umbracoApi.member.doesNameExist(memberName)).toBeFalsy();
 });
 
@@ -236,7 +236,7 @@ test('cannot create member with invalid email', async ({umbracoApi, umbracoUi}) 
   await umbracoUi.member.clickSaveButton();
 
   // Assert
-  await umbracoUi.member.isErrorNotificationVisible();
+  await umbracoUi.member.doesErrorNotificationHaveText(NotificationConstantHelper.error.invalidEmail);
   expect(await umbracoApi.member.doesNameExist(memberName)).toBeFalsy();
 });
 

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Packages/CreatedPackages.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Packages/CreatedPackages.spec.ts
@@ -15,127 +15,122 @@ test.afterEach(async ({umbracoApi}) => {
   await umbracoApi.package.ensureNameNotExists(packageName);
 });
 
-test.skip('can create a empty package', {tag: '@smoke'}, async ({umbracoUi}) => {
+test('can create a empty package', {tag: '@smoke'}, async ({umbracoUi}) => {
   // Act
   await umbracoUi.package.clickCreatePackageButton();
   await umbracoUi.package.enterPackageName(packageName);
-  await umbracoUi.package.clickSaveChangesToPackageButton();
+  await umbracoUi.package.clickCreateButton();
 
   // Assert
+  await umbracoUi.package.isSuccessNotificationVisible();
+  await umbracoUi.package.clickCreatedTab();
   await umbracoUi.package.isPackageNameVisible(packageName);
 });
 
-test.skip('can update package name', async ({umbracoApi, umbracoUi}) => {
+test('can update package name', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const wrongPackageName = 'WrongPackageName';
   await umbracoApi.package.ensureNameNotExists(wrongPackageName);
   await umbracoApi.package.createEmptyPackage(wrongPackageName);
   await umbracoUi.reloadPage();
+  await umbracoUi.package.goToSection(ConstantHelper.sections.packages);
+  await umbracoUi.package.clickCreatedTab();
 
   // Act
   await umbracoUi.package.clickExistingPackageName(wrongPackageName);
   await umbracoUi.package.enterPackageName(packageName);
-  await umbracoUi.package.clickSaveChangesToPackageButton();
+  await umbracoUi.package.clickUpdateButton();
 
   // Assert
+  await umbracoUi.package.isSuccessNotificationVisible();
+  await umbracoUi.package.clickCreatedTab();
   await umbracoUi.package.isPackageNameVisible(packageName);
   expect(umbracoApi.package.doesNameExist(packageName)).toBeTruthy();
 });
 
-test.skip('can delete a package', async ({umbracoApi, umbracoUi}) => {
+test('can delete a package', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   await umbracoApi.package.createEmptyPackage(packageName);
   await umbracoUi.reloadPage();
+  await umbracoUi.package.clickCreatedTab();
 
   // Act
   await umbracoUi.package.clickDeleteButtonForPackageName(packageName);
-  await umbracoUi.package.clickDeleteExactLabel();
+  await umbracoUi.package.clickConfirmToDeleteButton();
 
   // Assert
+  await umbracoUi.package.clickCreatedTab();
   await umbracoUi.package.isPackageNameVisible(packageName, false);
   expect(await umbracoApi.package.doesNameExist(packageName)).toBeFalsy();
 });
 
-// TODO: Update the locators for the choose button. If it is updated or not
-// TODO: Remove .skip when the test is able to run. Currently it is not possible to add content to a package
-test.skip('can create a package with content', async ({page, umbracoApi, umbracoUi}) => {
+test('can create a package with content', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const documentTypeName = 'TestDocumentType';
   const documentName = 'TestDocument';
   await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
-  await umbracoApi.package.createEmptyPackage(packageName);
   const documentTypeId = await umbracoApi.documentType.createDefaultDocumentTypeWithAllowAsRoot(documentTypeName);
   const documentId = await umbracoApi.document.createDefaultDocument(documentName, documentTypeId);
-  await umbracoUi.reloadPage();
 
   // Act
-  await umbracoUi.package.clickExistingPackageName(packageName);
-  // The frontend has updated the button name to "Choose" of "Add". But they are a bit unsure if they want to change it to select instead.
-  // So for the moment I have used the page instead of our UiHelper. Because it is easier to change the locator.
-  // await umbracoUi.package.clickAddContentToPackageButton();
-  await page.locator('[label="Content"] >> [label="Choose"]').click();
+  await umbracoUi.package.clickCreatePackageButton();
+  await umbracoUi.package.enterPackageName(packageName);
+  await umbracoUi.package.clickAddContentToPackageButton();
   await umbracoUi.package.clickLabelWithName(documentName);
-  await umbracoUi.package.clickChooseBtn();
-  await umbracoUi.package.clickSaveChangesToPackageButton();
+  await umbracoUi.package.clickChooseContainerButton();
+  await umbracoUi.package.clickCreateButton();
 
   // Assert
+  await umbracoUi.package.isSuccessNotificationVisible();
   const packageData = await umbracoApi.package.getByName(packageName);
   expect(packageData.contentNodeId == documentId).toBeTruthy();
-  await umbracoUi.package.clickExistingPackageName(packageName);
-  expect(umbracoUi.package.isButtonWithNameVisible(documentName + ' ' + documentId)).toBeTruthy();
+  expect(umbracoUi.package.isButtonWithNameVisible(documentName)).toBeTruthy();
 
   // Clean
   await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
 });
 
-// Currently unable to run this test. Because you are not able to save a mediaId
-test.skip('can create a package with media', async ({umbracoApi, umbracoUi}) => {
+test('can create a package with media', async ({umbracoApi, umbracoUi}) => {
   // Arrange
-  const mediaTypeName = 'TestMediaType';
   const mediaName = 'TestMedia';
-  await umbracoApi.mediaType.ensureNameNotExists(mediaTypeName);
-  await umbracoApi.package.createEmptyPackage(packageName);
-  const mediaTypeId = await umbracoApi.mediaType.createDefaultMediaType(mediaTypeName);
-  const mediaId = await umbracoApi.media.createDefaultMedia(mediaName, mediaTypeId);
-  await umbracoUi.reloadPage();
+  await umbracoApi.media.ensureNameNotExists(mediaName);
+  const mediaId = await umbracoApi.media.createDefaultMediaFile(mediaName);
 
   // Act
-  await umbracoUi.package.clickExistingPackageName(packageName);
+  await umbracoUi.package.clickCreatePackageButton();
+  await umbracoUi.package.enterPackageName(packageName);
   await umbracoUi.package.clickAddMediaToPackageButton();
-  await umbracoUi.package.clickCaretButton();
-  await umbracoUi.package.clickLabelWithName(mediaName);
+  await umbracoUi.media.selectMediaByName(mediaName);
   await umbracoUi.package.clickSubmitButton();
-  await umbracoUi.package.clickSaveChangesToPackageButton();
+  await umbracoUi.package.clickCreateButton();
 
   // Assert
-  await umbracoUi.package.clickExistingPackageName(packageName);
-  expect(umbracoUi.package.isButtonWithNameVisible(mediaTypeName + ' ' + mediaId)).toBeTruthy();
+  await umbracoUi.package.isSuccessNotificationVisible();
+  expect(umbracoUi.package.isTextWithExactNameVisible(mediaName)).toBeTruthy();
   const packageData = await umbracoApi.package.getByName(packageName);
   expect(packageData.mediaIds[0] == mediaId).toBeTruthy();
 
   // Clean
-  await umbracoApi.mediaType.ensureNameNotExists(mediaTypeName);
+  await umbracoApi.media.ensureNameNotExists(mediaName);
 });
 
-test.skip('can create a package with document types', async ({umbracoApi, umbracoUi}) => {
+test('can create a package with document types', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const documentTypeName = 'TestDocumentType';
   await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
-  await umbracoApi.package.createEmptyPackage(packageName);
   const documentTypeId = await umbracoApi.documentType.createDefaultDocumentTypeWithAllowAsRoot(documentTypeName);
-  await umbracoUi.reloadPage();
 
   // Act
-  await umbracoUi.package.clickExistingPackageName(packageName);
+  await umbracoUi.package.clickCreatePackageButton();
+  await umbracoUi.package.enterPackageName(packageName);
   await umbracoUi.package.clickAddDocumentTypeToPackageButton();
-  await umbracoUi.package.clickCaretButton();
   await umbracoUi.package.clickLabelWithName(documentTypeName);
-  await umbracoUi.package.clickSubmitButton();
-  await umbracoUi.package.clickSaveChangesToPackageButton();
+  await umbracoUi.package.clickChooseContainerButton();
+  await umbracoUi.package.clickCreateButton();
 
   // Assert
-  await umbracoUi.package.clickExistingPackageName(packageName);
-  expect(umbracoUi.package.isButtonWithNameVisible(documentTypeName + ' ' + documentTypeId)).toBeTruthy();
+  await umbracoUi.package.isSuccessNotificationVisible();
+  expect(umbracoUi.package.isButtonWithNameVisible(documentTypeName)).toBeTruthy();
   const packageData = await umbracoApi.package.getByName(packageName);
   expect(packageData.documentTypes[0] == documentTypeId).toBeTruthy();
 
@@ -143,26 +138,23 @@ test.skip('can create a package with document types', async ({umbracoApi, umbrac
   await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
 });
 
-// TODO: Remove .skip when the test is able to run. Currently waiting for button
-test.skip('can create a package with media types', async ({umbracoApi, umbracoUi}) => {
+test('can create a package with media types', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const mediaTypeName = 'TestMediaType';
   await umbracoApi.mediaType.ensureNameNotExists(mediaTypeName);
-  await umbracoApi.package.createEmptyPackage(packageName);
   const mediaTypeId = await umbracoApi.mediaType.createDefaultMediaType(mediaTypeName);
-  await umbracoUi.reloadPage();
 
   // Act
-  await umbracoUi.package.clickExistingPackageName(packageName);
+  await umbracoUi.package.clickCreatePackageButton();
+  await umbracoUi.package.enterPackageName(packageName);
   await umbracoUi.package.clickAddMediaTypeToPackageButton();
-  await umbracoUi.package.clickCaretButton();
-  await umbracoUi.package.clickLabelWithName(mediaTypeName);
-  await umbracoUi.package.clickSubmitButton()
-  await umbracoUi.package.clickSaveChangesToPackageButton();
+  await umbracoUi.package.clickButtonWithName(mediaTypeName, true);
+  await umbracoUi.package.clickChooseContainerButton();
+  await umbracoUi.package.clickCreateButton();
 
   // Assert
-  await umbracoUi.package.clickExistingPackageName(packageName);
-  expect(umbracoUi.package.isButtonWithNameVisible(mediaTypeName + ' ' + mediaTypeId)).toBeTruthy();
+  await umbracoUi.package.isSuccessNotificationVisible();
+  expect(umbracoUi.package.isButtonWithNameVisible(mediaTypeName)).toBeTruthy();
   const packageData = await umbracoApi.package.getByName(packageName);
   expect(packageData.mediaTypes[0] == mediaTypeId).toBeTruthy();
 
@@ -170,25 +162,23 @@ test.skip('can create a package with media types', async ({umbracoApi, umbracoUi
   await umbracoApi.mediaType.ensureNameNotExists(mediaTypeName);
 });
 
-// TODO: Remove .skip when the test is able to run. After adding a language to a package and saving. The language is not saved or anything.
-test.skip('can create a package with languages', async ({umbracoApi, umbracoUi}) => {
+test('can create a package with languages', async ({umbracoApi, umbracoUi}) => {
   // Arrange
-  const languageId = await umbracoApi.language.createDefaultDanishLanguage();
-  await umbracoApi.package.createEmptyPackage(packageName);
-  await umbracoUi.reloadPage();
+  await umbracoApi.language.ensureNameNotExists('Danish');
+  const languageId = await umbracoApi.language.createDanishLanguage();
   const languageData = await umbracoApi.language.get(languageId);
   const languageName = languageData.name;
 
   // Act
-  await umbracoUi.package.clickExistingPackageName(packageName);
+  await umbracoUi.package.clickCreatePackageButton();
+  await umbracoUi.package.enterPackageName(packageName);
   await umbracoUi.package.clickAddLanguageToPackageButton();
-  await umbracoUi.package.clickCaretButton();
-  await umbracoUi.package.clickLabelWithName(languageName);
-  await umbracoUi.package.clickSubmitButton()
-  await umbracoUi.package.clickSaveChangesToPackageButton();
+  await umbracoUi.package.clickButtonWithName(languageName);
+  await umbracoUi.package.clickSubmitButton();
+  await umbracoUi.package.clickCreateButton();
 
   // Assert
-  await umbracoUi.package.clickExistingPackageName(packageName);
+  await umbracoUi.package.isSuccessNotificationVisible();
   expect(umbracoUi.package.isButtonWithNameVisible(languageName + ' ' + languageId)).toBeTruthy();
   const packageData = await umbracoApi.package.getByName(packageName);
   expect(packageData.languages[0] == languageId).toBeTruthy();
@@ -197,76 +187,69 @@ test.skip('can create a package with languages', async ({umbracoApi, umbracoUi})
   await umbracoApi.language.ensureNameNotExists(languageName);
 });
 
-// TODO: Remove .skip when the test is able to run. Currently waiting for button
-test.skip('can create a package with dictionary', async ({umbracoApi, umbracoUi}) => {
+test('can create a package with dictionary', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const dictionaryName = 'TestDictionary';
-  await umbracoApi.dictionary.createDefaultDictionary(dictionaryName);
-  await umbracoApi.package.createEmptyPackage(packageName);
-  await umbracoUi.reloadPage();
+  const dictionaryId = await umbracoApi.dictionary.createDefaultDictionary(dictionaryName);
 
   // Act
-  await umbracoUi.package.clickExistingPackageName(packageName);
+  await umbracoUi.package.clickCreatePackageButton();
+  await umbracoUi.package.enterPackageName(packageName);
   await umbracoUi.package.clickAddDictionaryToPackageButton();
-  await umbracoUi.package.clickCaretButton();
-  await umbracoUi.package.clickLabelWithName(dictionaryName);
-  await umbracoUi.package.clickSubmitButton()
-  await umbracoUi.package.clickSaveChangesToPackageButton();
+  await umbracoUi.package.clickButtonWithName(dictionaryName);
+  await umbracoUi.package.clickChooseContainerButton();
+  await umbracoUi.package.clickCreateButton();
 
   // Assert
-  await umbracoUi.package.clickExistingPackageName(packageName);
+  await umbracoUi.package.isSuccessNotificationVisible();
   expect(umbracoUi.package.isButtonWithNameVisible(dictionaryName)).toBeTruthy();
   const packageData = await umbracoApi.package.getByName(packageName);
-  expect(packageData.dictionaryItems[0] == dictionaryName).toBeTruthy();
+  expect(packageData.dictionaryItems[0] == dictionaryId).toBeTruthy();
 
   // Clean
   await umbracoApi.dictionary.ensureNameNotExists(dictionaryName);
 });
 
-// TODO: Remove .skip when the test is able to run. After adding a dataType to a package and saving. The datatype is not saved or anything.
-test.skip('can create a package with data types', async ({umbracoApi, umbracoUi}) => {
+test('can create a package with data types', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const dataTypeName = 'TestDataType';
+  await umbracoApi.dataType.ensureNameNotExists(dataTypeName);
   const dataTypeId = await umbracoApi.dataType.createDateTypeDataType(dataTypeName);
-  await umbracoApi.package.createEmptyPackage(packageName);
-  await umbracoUi.reloadPage();
 
   // Act
-  await umbracoUi.package.clickExistingPackageName(packageName);
+  await umbracoUi.package.clickCreatePackageButton();
+  await umbracoUi.package.enterPackageName(packageName);
   await umbracoUi.package.clickAddDataTypesToPackageButton();
-  await umbracoUi.package.clickCaretButton();
   await umbracoUi.package.clickLabelWithName(dataTypeName);
-  await umbracoUi.package.clickSubmitButton()
-  await umbracoUi.package.clickSaveChangesToPackageButton();
+  await umbracoUi.package.clickChooseContainerButton();
+  await umbracoUi.package.clickCreateButton();
 
   // Assert
-  await umbracoUi.package.clickExistingPackageName(packageName);
+  await umbracoUi.package.isSuccessNotificationVisible();
   expect(umbracoUi.package.isButtonWithNameVisible(dataTypeName)).toBeTruthy();
   const packageData = await umbracoApi.package.getByName(packageName);
   expect(packageData.dataTypes[0] == dataTypeId).toBeTruthy();
 
   // Clean
-  await umbracoApi.dictionary.ensureNameNotExists(dataTypeName);
+  await umbracoApi.dataType.ensureNameNotExists(dataTypeName);
 });
 
-// TODO: Remove .skip when the test is able to run. Currently waiting for button
-test.skip('can create a package with templates', async ({umbracoApi, umbracoUi}) => {
+test('can create a package with templates', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const templateName = 'TestTemplate';
+  await umbracoApi.template.ensureNameNotExists(templateName);
   const templateId = await umbracoApi.template.createDefaultTemplate(templateName);
-  await umbracoApi.package.createEmptyPackage(packageName);
-  await umbracoUi.reloadPage();
 
   // Act
-  await umbracoUi.package.clickExistingPackageName(packageName);
+  await umbracoUi.package.clickCreatePackageButton();
+  await umbracoUi.package.enterPackageName(packageName);
   await umbracoUi.package.clickAddTemplatesToPackageButton();
-  await umbracoUi.package.clickCaretButton();
   await umbracoUi.package.clickLabelWithName(templateName);
-  await umbracoUi.package.clickSubmitButton()
-  await umbracoUi.package.clickSaveChangesToPackageButton();
+  await umbracoUi.package.clickChooseContainerButton();
+  await umbracoUi.package.clickCreateButton();
 
   // Assert
-  await umbracoUi.package.clickExistingPackageName(packageName);
+  await umbracoUi.package.isSuccessNotificationVisible();
   expect(umbracoUi.package.isButtonWithNameVisible(templateName)).toBeTruthy();
   const packageData = await umbracoApi.package.getByName(packageName);
   expect(packageData.templates[0] == templateId).toBeTruthy();
@@ -275,24 +258,22 @@ test.skip('can create a package with templates', async ({umbracoApi, umbracoUi})
   await umbracoApi.template.ensureNameNotExists(templateName);
 });
 
-// TODO: Remove .skip when the test is able to run. Currently waiting for button
-test.skip('can create a package with stylesheets', async ({umbracoApi, umbracoUi}) => {
+test('can create a package with stylesheets', async ({umbracoApi, umbracoUi}) => {
   // Arrange
-  const stylesheetName = 'TestStylesheet';
+  const stylesheetName = 'TestStylesheet.css';
+  await umbracoApi.stylesheet.ensureNameNotExists(stylesheetName);
   const stylesheetId = await umbracoApi.stylesheet.createDefaultStylesheet(stylesheetName);
-  await umbracoApi.package.createEmptyPackage(packageName);
-  await umbracoUi.reloadPage();
 
   // Act
-  await umbracoUi.package.clickExistingPackageName(packageName);
+  await umbracoUi.package.clickCreatePackageButton();
+  await umbracoUi.package.enterPackageName(packageName);
   await umbracoUi.package.clickAddStylesheetToPackageButton();
-  await umbracoUi.package.clickCaretButton();
   await umbracoUi.package.clickLabelWithName(stylesheetName);
-  await umbracoUi.package.clickSubmitButton()
-  await umbracoUi.package.clickSaveChangesToPackageButton();
+  await umbracoUi.package.clickChooseContainerButton();
+  await umbracoUi.package.clickCreateButton();
 
   // Assert
-  await umbracoUi.package.clickExistingPackageName(packageName);
+  await umbracoUi.package.isSuccessNotificationVisible();
   expect(umbracoUi.package.isButtonWithNameVisible(stylesheetName)).toBeTruthy();
   const packageData = await umbracoApi.package.getByName(packageName);
   expect(packageData.stylesheets[0] == stylesheetId).toBeTruthy();
@@ -301,24 +282,22 @@ test.skip('can create a package with stylesheets', async ({umbracoApi, umbracoUi
   await umbracoApi.stylesheet.ensureNameNotExists(stylesheetName);
 });
 
-// TODO: Remove .skip when the test is able to run. Currently waiting for button
-test.skip('can create a package with scripts', async ({umbracoApi, umbracoUi}) => {
+test('can create a package with scripts', async ({umbracoApi, umbracoUi}) => {
   // Arrange
-  const scriptName = 'TestScripts';
+  const scriptName = 'TestScripts.js';
+  await umbracoApi.script.ensureNameNotExists(scriptName);
   const scriptId = await umbracoApi.script.createDefaultScript(scriptName);
-  await umbracoApi.package.createEmptyPackage(packageName);
-  await umbracoUi.reloadPage();
 
   // Act
-  await umbracoUi.package.clickExistingPackageName(packageName);
+  await umbracoUi.package.clickCreatePackageButton();
+  await umbracoUi.package.enterPackageName(packageName);
   await umbracoUi.package.clickAddScriptToPackageButton();
-  await umbracoUi.package.clickCaretButton();
   await umbracoUi.package.clickLabelWithName(scriptName);
-  await umbracoUi.package.clickSubmitButton()
-  await umbracoUi.package.clickSaveChangesToPackageButton();
+  await umbracoUi.package.clickChooseContainerButton();
+  await umbracoUi.package.clickCreateButton();
 
   // Assert
-  await umbracoUi.package.clickExistingPackageName(packageName);
+  await umbracoUi.package.isSuccessNotificationVisible();
   expect(umbracoUi.package.isButtonWithNameVisible(scriptName)).toBeTruthy();
   const packageData = await umbracoApi.package.getByName(packageName);
   expect(packageData.scripts[0] == scriptId).toBeTruthy();
@@ -327,35 +306,30 @@ test.skip('can create a package with scripts', async ({umbracoApi, umbracoUi}) =
   await umbracoApi.script.ensureNameNotExists(scriptName);
 });
 
-// TODO: Remove .skip when the test is able to run. Currently waiting for button
-test.skip('can create a package with partial views', async ({umbracoApi, umbracoUi}) => {
+test('can create a package with partial views', async ({umbracoApi, umbracoUi}) => {
   // Arrange
-  const partialViewName = 'TestPartialView';
+  const partialViewName = 'TestPartialView.cshtml';
   const partialViewId = await umbracoApi.partialView.createDefaultPartialView(partialViewName);
-  await umbracoApi.package.createEmptyPackage(packageName);
-  await umbracoUi.reloadPage();
 
   // Act
-  await umbracoUi.package.clickExistingPackageName(packageName);
+  await umbracoUi.package.clickCreatePackageButton();
+  await umbracoUi.package.enterPackageName(packageName);
   await umbracoUi.package.clickAddPartialViewToPackageButton();
-  await umbracoUi.package.clickCaretButton();
   await umbracoUi.package.clickLabelWithName(partialViewName);
-  await umbracoUi.package.clickSubmitButton()
-  await umbracoUi.package.clickSaveChangesToPackageButton();
+  await umbracoUi.package.clickChooseContainerButton();
+  await umbracoUi.package.clickCreateButton();
 
   // Assert
-  await umbracoUi.package.clickExistingPackageName(packageName);
+  await umbracoUi.package.isSuccessNotificationVisible();
   expect(umbracoUi.package.isButtonWithNameVisible(partialViewName)).toBeTruthy();
   const packageData = await umbracoApi.package.getByName(packageName);
   expect(packageData.partialViews[0] == partialViewId).toBeTruthy();
 
   // Clean
-  await umbracoApi.package.ensureNameNotExists(packageName);
+  await umbracoApi.partialView.ensureNameNotExists(partialViewName);
 });
 
-// Currently you are not able to download a package
-//TODO: Remove skip when the frontend is ready
-test.skip('can download a package', async ({umbracoApi, umbracoUi}) => {
+test('can download a package', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const packageId = await umbracoApi.package.createEmptyPackage(packageName);
   await umbracoUi.reloadPage();

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Packages/InstalledPackages.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Packages/InstalledPackages.spec.ts
@@ -1,8 +1,6 @@
 import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
 
-// We can't install any packages so we do not have any installed.
-//TODO: Remove skip when the frontend is ready
-test.skip('can see no package have been installed', async ({page, umbracoUi}) => {
+test('can see the umbraco package is installed', async ({umbracoUi}) => {
   // Arrange
   await umbracoUi.goToBackOffice();
   await umbracoUi.package.goToSection(ConstantHelper.sections.packages);
@@ -11,5 +9,5 @@ test.skip('can see no package have been installed', async ({page, umbracoUi}) =>
   await umbracoUi.package.clickInstalledTab();
 
   // Assert
-  await umbracoUi.package.isTextNoPackagesHaveBeenInstalledVisible();
+  await umbracoUi.package.isUmbracoBackofficePackageVisible();
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Packages/PackagesPackages.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Packages/PackagesPackages.spec.ts
@@ -1,6 +1,5 @@
 import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
 
-// The MarketPlace is a iFrame we are using from the DXP team, so it is not something we should test. This test is just checking if we have the IFrame
 test('can see the marketplace', async ({umbracoUi}) => {
   // Arrange
   await umbracoUi.goToBackOffice();

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Packages/PackagesPackages.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Packages/PackagesPackages.spec.ts
@@ -10,5 +10,6 @@ test('can see the marketplace', async ({umbracoUi}) => {
   await umbracoUi.package.clickPackagesTab();
 
   // Assert
+  await umbracoUi.waitForTimeout(1000);
   await umbracoUi.package.isMarketPlaceIFrameVisible();
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/RenderingContent/RenderingContentWithTextstring.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/RenderingContent/RenderingContentWithTextstring.spec.ts
@@ -1,0 +1,43 @@
+﻿import {test} from '@umbraco/playwright-testhelpers';
+
+const contentName = 'Test Rendering Content';
+const documentTypeName = 'TestDocumentTypeForContent';
+const dataTypeName = 'Textstring';
+const templateName = 'TestTemplateForContent';
+let dataTypeData;
+
+test.beforeEach(async ({umbracoApi}) => {
+  dataTypeData = await umbracoApi.dataType.getByName(dataTypeName); 
+});
+
+test.afterEach(async ({umbracoApi}) => {
+  await umbracoApi.document.ensureNameNotExists(contentName); 
+  await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
+  await umbracoApi.template.ensureNameNotExists(templateName);
+});
+
+const textstrings = [
+  {type: 'an empty textstring', value: ''},
+  {type: 'a non-empty textstring', value: 'Welcome to Umbraco site'},
+  {type: 'a textstring contains special characters', value: '@#^&*()_+[]{};:"<>,./?'},
+  {type: 'a numeric textstring', value: '0123456789'},
+  {type: 'a textstring contains an SQL injection', value: "' OR '1'='1'; --"},
+  {type: 'a textstring contains a cross-site scripting', value: "<script>alert('XSS')</script>"}
+];
+
+for (const textstring of textstrings) {
+  test(`can render content with ${textstring.type}`, async ({umbracoApi, umbracoUi}) => {
+    // Arrange
+    const textstringValue = textstring.value;
+    await umbracoApi.document.createPublishedDocumentWithValue(contentName, textstringValue, dataTypeData.id, documentTypeName, templateName);
+    const contentData = await umbracoApi.document.getByName(contentName);
+    const contentURL = contentData.urls[0].url;
+
+    // Act
+    await umbracoUi.contentRender.navigateToRenderedContentPage(contentURL);
+
+    // Assert
+    await umbracoUi.contentRender.doesContentRenderValueHaveText(textstringValue);
+  });
+}
+

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/DocumentBlueprint/DocumentBlueprint.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/DocumentBlueprint/DocumentBlueprint.spec.ts
@@ -1,4 +1,4 @@
-﻿import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+﻿import {ConstantHelper, NotificationConstantHelper, test} from '@umbraco/playwright-testhelpers';
 import {expect} from "@playwright/test";
 
 const documentBlueprintName = 'TestDocumentBlueprints';
@@ -29,7 +29,7 @@ test('can create a document blueprint from the settings menu', {tag: '@smoke'}, 
   await umbracoUi.documentBlueprint.clickSaveButton();
 
   // Assert
-  await umbracoUi.documentBlueprint.isSuccessNotificationVisible();
+  await umbracoUi.documentBlueprint.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   expect(await umbracoApi.documentBlueprint.doesNameExist(documentBlueprintName)).toBeTruthy();
   await umbracoUi.documentBlueprint.isDocumentBlueprintRootTreeItemVisible(documentBlueprintName, true);
 });
@@ -48,6 +48,7 @@ test('can rename a document blueprint', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.documentBlueprint.clickSaveButton();
 
   // Assert
+  await umbracoUi.documentBlueprint.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   expect(await umbracoApi.documentBlueprint.doesNameExist(documentBlueprintName)).toBeTruthy();
   expect(await umbracoApi.documentBlueprint.doesNameExist(wrongDocumentBlueprintName)).toBeFalsy();
   await umbracoUi.documentBlueprint.isDocumentBlueprintRootTreeItemVisible(documentBlueprintName, true, false);
@@ -67,7 +68,7 @@ test('can delete a document blueprint', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.documentBlueprint.clickConfirmToDeleteButton();
 
   // Assert
-  await umbracoUi.documentBlueprint.isSuccessNotificationVisible();
+  await umbracoUi.documentBlueprint.doesSuccessNotificationHaveText(NotificationConstantHelper.success.deleted);
   expect(await umbracoApi.documentBlueprint.doesNameExist(documentBlueprintName)).toBeFalsy();
   await umbracoUi.documentBlueprint.isDocumentBlueprintRootTreeItemVisible(documentBlueprintName, false, false);
 });
@@ -85,7 +86,7 @@ test('can create a document blueprint from the content menu', async ({umbracoApi
   await umbracoUi.content.clickSaveModalButton();
 
   // Assert
-  await umbracoUi.content.isSuccessNotificationVisible();
+  await umbracoUi.documentBlueprint.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   expect(await umbracoApi.documentBlueprint.doesNameExist(documentBlueprintName)).toBeTruthy();
   await umbracoUi.documentBlueprint.goToSettingsTreeItem('Document Blueprints');
   await umbracoUi.documentBlueprint.isDocumentBlueprintRootTreeItemVisible(documentBlueprintName, true);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/DocumentType/DocumentType.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/DocumentType/DocumentType.spec.ts
@@ -1,4 +1,4 @@
-﻿import {AliasHelper, ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+﻿import {AliasHelper, ConstantHelper, NotificationConstantHelper, test} from '@umbraco/playwright-testhelpers';
 import {expect} from '@playwright/test';
 
 const documentTypeName = 'TestDocumentType';
@@ -24,7 +24,7 @@ test('can create a document type', {tag: '@smoke'}, async ({umbracoApi, umbracoU
   await umbracoUi.documentType.clickSaveButton();
 
   // Assert
-  await umbracoUi.documentType.isSuccessNotificationVisible();
+  await umbracoUi.documentType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   expect(await umbracoApi.documentType.doesNameExist(documentTypeName)).toBeTruthy();
   await umbracoUi.documentType.reloadTree('Document Types');
   await umbracoUi.documentType.isDocumentTreeItemVisible(documentTypeName);
@@ -43,7 +43,7 @@ test('can create a document type with a template', {tag: '@smoke'}, async ({umbr
   await umbracoUi.documentType.clickSaveButton();
 
   // Assert
-  // Checks if both the success notification for document Types and teh template are visible
+  // Checks if both the success notification for document Types and the template are visible
   await umbracoUi.documentType.doesSuccessNotificationsHaveCount(2);
   // Checks if the documentType contains the template
   const documentTypeData = await umbracoApi.documentType.getByName(documentTypeName);
@@ -67,7 +67,7 @@ test('can create a element type', {tag: '@smoke'}, async ({umbracoApi, umbracoUi
   await umbracoUi.documentType.clickSaveButton();
 
   // Assert
-  await umbracoUi.documentType.isSuccessNotificationVisible();
+  await umbracoUi.documentType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   expect(await umbracoApi.documentType.doesNameExist(documentTypeName)).toBeTruthy();
   // Checks if the isElement is true
   const documentTypeData = await umbracoApi.documentType.getByName(documentTypeName);
@@ -87,7 +87,7 @@ test('can rename a document type', {tag: '@smoke'}, async ({umbracoApi, umbracoU
   await umbracoUi.documentType.clickSaveButton();
 
   // Assert
-  await umbracoUi.documentType.isSuccessNotificationVisible();
+  await umbracoUi.documentType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   expect(await umbracoApi.documentType.doesNameExist(documentTypeName)).toBeTruthy();
   await umbracoUi.documentType.isDocumentTreeItemVisible(wrongName, false);
   await umbracoUi.documentType.isDocumentTreeItemVisible(documentTypeName);
@@ -108,7 +108,7 @@ test('can update the alias for a document type', async ({umbracoApi, umbracoUi})
   await umbracoUi.documentType.clickSaveButton();
 
   // Assert
-  await umbracoUi.documentType.isSuccessNotificationVisible();
+  await umbracoUi.documentType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   await umbracoUi.documentType.isDocumentTreeItemVisible(documentTypeName, true);
   const documentTypeDataNew = await umbracoApi.documentType.getByName(documentTypeName);
   expect(documentTypeDataNew.alias).toBe(newAlias);
@@ -126,7 +126,7 @@ test('can add an icon for a document type', {tag: '@smoke'}, async ({umbracoApi,
   await umbracoUi.documentType.clickSaveButton();
 
   // Assert
-  await umbracoUi.documentType.isSuccessNotificationVisible();
+  await umbracoUi.documentType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const documentTypeData = await umbracoApi.documentType.getByName(documentTypeName);
   expect(documentTypeData.icon).toBe(bugIcon);
   await umbracoUi.documentType.isDocumentTreeItemVisible(documentTypeName, true);
@@ -145,6 +145,6 @@ test('can delete a document type', {tag: '@smoke'}, async ({umbracoApi, umbracoU
   await umbracoUi.documentType.clickConfirmToDeleteButton();
 
   // Assert
-  await umbracoUi.documentType.isSuccessNotificationVisible();
+  await umbracoUi.documentType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.deleted);
   expect(await umbracoApi.documentType.doesNameExist(documentTypeName)).toBeFalsy();
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/DocumentType/DocumentTypeDesignTab.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/DocumentType/DocumentTypeDesignTab.spec.ts
@@ -397,7 +397,7 @@ test('can enable validation for a property in a document type', async ({umbracoA
 test('can allow vary by culture for a property in a document type', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const dataTypeData = await umbracoApi.dataType.getByName(dataTypeName);
-  await umbracoApi.documentType.createDocumentTypeWithPropertyEditor(documentTypeName, dataTypeName, dataTypeData.id, groupName, true);
+  await umbracoApi.documentType.createDocumentTypeWithPropertyEditor(documentTypeName, dataTypeName, dataTypeData.id, groupName, false);
   await umbracoUi.documentType.goToSection(ConstantHelper.sections.settings);
 
   // Act

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/DocumentType/DocumentTypeFolder.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/DocumentType/DocumentTypeFolder.spec.ts
@@ -1,4 +1,4 @@
-﻿import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+﻿import {ConstantHelper, NotificationConstantHelper, test} from '@umbraco/playwright-testhelpers';
 import {expect} from '@playwright/test';
 
 const documentFolderName = 'TestFolder';
@@ -22,7 +22,7 @@ test('can create a empty document type folder', {tag: '@smoke'}, async ({umbraco
   await umbracoUi.documentType.clickCreateFolderButton();
 
   // Assert
-  await umbracoUi.documentType.isSuccessNotificationVisible();
+  await umbracoUi.documentType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderCreated);
   const folder = await umbracoApi.documentType.getByName(documentFolderName);
   expect(folder.name).toBe(documentFolderName);
   // Checks if the folder is in the root
@@ -41,7 +41,7 @@ test('can delete a document type folder', {tag: '@smoke'}, async ({umbracoApi, u
   await umbracoUi.documentType.deleteFolder();
 
   // Assert
-  await umbracoUi.documentType.isSuccessNotificationVisible();
+  await umbracoUi.documentType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderDeleted);
   await umbracoApi.documentType.doesNameExist(documentFolderName);
   await umbracoUi.documentType.isDocumentTreeItemVisible(documentFolderName, false);
 });
@@ -61,7 +61,7 @@ test('can rename a document type folder', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.documentType.clickConfirmRenameFolderButton();
 
   // Assert
-  await umbracoUi.documentType.isSuccessNotificationVisible();
+  await umbracoUi.documentType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderUpdated);
   const folder = await umbracoApi.documentType.getByName(documentFolderName);
   expect(folder.name).toBe(documentFolderName);
   await umbracoUi.documentType.isDocumentTreeItemVisible(oldFolderName, false);
@@ -84,7 +84,7 @@ test('can create a document type folder in a folder', async ({umbracoApi, umbrac
   await umbracoUi.documentType.clickCreateFolderButton();
 
   // Assert
-  await umbracoUi.documentType.isSuccessNotificationVisible();
+  await umbracoUi.documentType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderCreated);
   const folder = await umbracoApi.documentType.getByName(childFolderName);
   expect(folder.name).toBe(childFolderName);
   // Checks if the parentFolder contains the ChildFolder as a child
@@ -115,7 +115,7 @@ test('can create a folder in a folder in a folder', {tag: '@smoke'}, async ({umb
   await umbracoUi.documentType.clickCreateFolderButton();
 
   // Assert
-  await umbracoUi.documentType.isSuccessNotificationVisible();
+  await umbracoUi.documentType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderCreated);
   await umbracoUi.documentType.reloadTree(parentFolderName);
   await umbracoUi.documentType.isDocumentTreeItemVisible(documentFolderName);
   const grandParentChildren = await umbracoApi.documentType.getChildren(grandParentFolderId);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/DocumentType/DocumentTypeTemplatesTab.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/DocumentType/DocumentTypeTemplatesTab.spec.ts
@@ -16,7 +16,6 @@ test.afterEach(async ({umbracoApi}) => {
 test('can add an allowed template to a document type', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
   // Arrange
   await umbracoApi.documentType.createDefaultDocumentType(documentTypeName);
-  await umbracoApi.template.ensureNameNotExists(templateName);
   const templateId = await umbracoApi.template.createDefaultTemplate(templateName);
   await umbracoUi.documentType.goToSection(ConstantHelper.sections.settings);
 
@@ -39,28 +38,27 @@ test('can add an allowed template to a document type', {tag: '@smoke'}, async ({
 
 test('can set an allowed template as default for document type', async ({umbracoApi, umbracoUi}) => {
   // Arrange
-  await umbracoApi.template.ensureNameNotExists(templateName);
-  const templateId = await umbracoApi.template.createDefaultTemplate(templateName);
-  await umbracoApi.documentType.createDocumentTypeWithAllowedTemplate(documentTypeName, templateId);
+  const secondTemplateName = 'Test Second Template';
+  const firstTemplateId = await umbracoApi.template.createDefaultTemplate(templateName);
+  const secondTemplateId = await umbracoApi.template.createDefaultTemplate(secondTemplateName);
+  await umbracoApi.documentType.createDocumentTypeWithTwoAllowedTemplates(documentTypeName, firstTemplateId, secondTemplateId, true, firstTemplateId);
   await umbracoUi.documentType.goToSection(ConstantHelper.sections.settings);
 
   // Act
   await umbracoUi.documentType.goToDocumentType(documentTypeName);
   await umbracoUi.documentType.clickDocumentTypeTemplatesTab();
-  await umbracoUi.documentType.clickDefaultTemplateButton();
+  await umbracoUi.documentType.clickSetAsDefaultButton();
   await umbracoUi.documentType.clickSaveButton();
 
   // Assert
   await umbracoUi.documentType.isSuccessNotificationVisible();
   const documentTypeData = await umbracoApi.documentType.getByName(documentTypeName);
-  expect(documentTypeData.allowedTemplates[0].id).toBe(templateId);
-  expect(documentTypeData.defaultTemplate.id).toBe(templateId);
+  expect(documentTypeData.defaultTemplate.id).toBe(secondTemplateId);
 });
 
 // When removing a template, the defaultTemplateId is set to "" which is not correct
 test.skip('can remove an allowed template from a document type', async ({umbracoApi, umbracoUi}) => {
   // Arrange
-  await umbracoApi.template.ensureNameNotExists(templateName);
   const templateId = await umbracoApi.template.createDefaultTemplate(templateName);
   await umbracoApi.documentType.createDocumentTypeWithAllowedTemplate(documentTypeName, templateId);
   await umbracoUi.documentType.goToSection(ConstantHelper.sections.settings);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Language/Language.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Language/Language.spec.ts
@@ -1,4 +1,4 @@
-import {test} from '@umbraco/playwright-testhelpers';
+import {NotificationConstantHelper, test} from '@umbraco/playwright-testhelpers';
 import {expect} from "@playwright/test";
 
 const languageName = 'Arabic';
@@ -25,7 +25,7 @@ test('can add language', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.language.clickSaveButton();
 
   // Assert
-  await umbracoUi.language.isSuccessNotificationVisible();
+  await umbracoUi.language.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   expect(await umbracoApi.language.doesExist(isoCode)).toBeTruthy();
   // Verify the created language displays in the list
   await umbracoUi.language.clickLanguagesMenu();
@@ -44,7 +44,7 @@ test('can update default language option', {tag: '@smoke'}, async ({umbracoApi, 
   await umbracoUi.language.clickSaveButton();
 
   // Assert
-  await umbracoUi.language.isSuccessNotificationVisible();
+  await umbracoUi.language.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const languageData = await umbracoApi.language.get(isoCode);
   expect(languageData.isDefault).toBe(true);
 
@@ -67,7 +67,7 @@ test('can update mandatory language option', async ({umbracoApi, umbracoUi}) => 
   await umbracoUi.language.clickSaveButton();
 
   // Assert
-  await umbracoUi.language.isSuccessNotificationVisible();
+  await umbracoUi.language.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const languageData = await umbracoApi.language.get(isoCode);
   expect(languageData.isMandatory).toBe(true);
 });
@@ -82,7 +82,7 @@ test('can delete language', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => 
   await umbracoUi.language.removeLanguageByName(languageName);
 
   // Assert
-  await umbracoUi.language.isSuccessNotificationVisible();
+  await umbracoUi.language.doesSuccessNotificationHaveText(NotificationConstantHelper.success.deleted);
   expect(await umbracoApi.language.doesExist(isoCode)).toBeFalsy();
   await umbracoUi.language.isLanguageNameVisible(languageName, false);
 });
@@ -99,7 +99,7 @@ test('can remove fallback language', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.language.clickSaveButton();
 
   // Act
-  await umbracoUi.language.isSuccessNotificationVisible();
+  await umbracoUi.language.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const languageData = await umbracoApi.language.get(isoCode);
   expect(languageData.fallbackIsoCode).toBeFalsy();
 });
@@ -117,7 +117,7 @@ test('can add fallback language', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.language.clickSaveButton();
 
   // Act
-  await umbracoUi.language.isSuccessNotificationVisible();
+  await umbracoUi.language.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const languageData = await umbracoApi.language.get(isoCode);
   expect(languageData.fallbackIsoCode).toBe(defaultLanguageIsoCode);
 });
@@ -134,5 +134,5 @@ test('cannot add a language with duplicate ISO code', async ({umbracoApi, umbrac
   await umbracoUi.language.clickSaveButton();
 
   // Assert
-  await umbracoUi.language.isErrorNotificationVisible();
+  await umbracoUi.language.doesErrorNotificationHaveText(NotificationConstantHelper.error.duplicateISOcode);
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/MediaType/MediaType.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/MediaType/MediaType.spec.ts
@@ -1,5 +1,5 @@
 import {expect} from "@playwright/test";
-import {AliasHelper, ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+import {AliasHelper, ConstantHelper, NotificationConstantHelper, test} from '@umbraco/playwright-testhelpers';
 
 const mediaTypeName = 'TestMediaType';
 
@@ -22,7 +22,7 @@ test('can create a media type', {tag: '@smoke'}, async ({umbracoApi, umbracoUi})
   await umbracoUi.mediaType.clickSaveButton();
 
   // Assert
-  await umbracoUi.mediaType.isSuccessNotificationVisible();
+  await umbracoUi.mediaType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   expect(await umbracoApi.mediaType.doesNameExist(mediaTypeName)).toBeTruthy();
 });
 
@@ -38,7 +38,7 @@ test('can rename a media type', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.mediaType.clickSaveButton();
 
   // Assert
-  await umbracoUi.mediaType.isSuccessNotificationVisible();
+  await umbracoUi.mediaType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   expect(await umbracoApi.mediaType.doesNameExist(mediaTypeName)).toBeTruthy();
 });
 
@@ -56,7 +56,7 @@ test('can update the alias for a media type', async ({umbracoApi, umbracoUi}) =>
   await umbracoUi.mediaType.clickSaveButton();
 
   // Assert
-  await umbracoUi.mediaType.isSuccessNotificationVisible();
+  await umbracoUi.mediaType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const mediaTypeData = await umbracoApi.mediaType.getByName(mediaTypeName);
   expect(mediaTypeData.alias).toBe(updatedAlias);
 });
@@ -72,7 +72,7 @@ test('can add an icon for a media type', {tag: '@smoke'}, async ({umbracoApi, um
   await umbracoUi.mediaType.clickSaveButton();
 
   // Assert
-  await umbracoUi.mediaType.isSuccessNotificationVisible();
+  await umbracoUi.mediaType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const mediaTypeData = await umbracoApi.mediaType.getByName(mediaTypeName);
   expect(mediaTypeData.icon).toBe(bugIcon);
   await umbracoUi.mediaType.isTreeItemVisible(mediaTypeName, true);
@@ -89,6 +89,6 @@ test('can delete a media type', {tag: '@smoke'}, async ({umbracoApi, umbracoUi})
   await umbracoUi.mediaType.clickConfirmToDeleteButton();
 
   // Assert
-  await umbracoUi.mediaType.isSuccessNotificationVisible();
+  await umbracoUi.mediaType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.deleted);
   expect(await umbracoApi.mediaType.doesNameExist(mediaTypeName)).toBeFalsy();
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/MediaType/MediaTypeFolder.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/MediaType/MediaTypeFolder.spec.ts
@@ -1,4 +1,4 @@
-import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+import {ConstantHelper, NotificationConstantHelper, test} from '@umbraco/playwright-testhelpers';
 import {expect} from "@playwright/test";
 
 const mediaTypeFolderName = 'TestMediaTypeFolder';
@@ -19,7 +19,7 @@ test('can create a empty media type folder', async ({umbracoApi, umbracoUi}) => 
   await umbracoUi.mediaType.createFolder(mediaTypeFolderName);
 
   // Assert
-  await umbracoUi.mediaType.isSuccessNotificationVisible();
+  await umbracoUi.mediaType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderCreated);
   const folder = await umbracoApi.mediaType.getByName(mediaTypeFolderName);
   expect(folder.name).toBe(mediaTypeFolderName);
   // Checks if the folder is in the root
@@ -37,7 +37,7 @@ test('can delete a media type folder', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.mediaType.deleteFolder();
 
   // Assert
-  await umbracoUi.mediaType.isSuccessNotificationVisible();
+  await umbracoUi.mediaType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderDeleted);
   expect(await umbracoApi.mediaType.doesNameExist(mediaTypeFolderName)).toBeFalsy();
 });
 
@@ -55,7 +55,7 @@ test('can rename a media type folder', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.mediaType.clickConfirmRenameFolderButton();
 
   // Assert
-  await umbracoUi.mediaType.isSuccessNotificationVisible();
+  await umbracoUi.mediaType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderUpdated);
   const folder = await umbracoApi.mediaType.getByName(mediaTypeFolderName);
   expect(folder.name).toBe(mediaTypeFolderName);
 });
@@ -72,6 +72,7 @@ test('can create a media type folder in a folder', async ({umbracoApi, umbracoUi
   await umbracoUi.mediaType.createFolder(childFolderName);
 
   // Assert
+  await umbracoUi.mediaType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderCreated);
   await umbracoUi.mediaType.clickCaretButtonForName(mediaTypeFolderName);
   await umbracoUi.mediaType.isTreeItemVisible(childFolderName, true);
   const parentFolderChildren = await umbracoApi.mediaType.getChildren(parentFolderId);
@@ -97,6 +98,7 @@ test('can create a media type folder in a folder in a folder', async ({umbracoAp
   await umbracoUi.mediaType.createFolder(childFolderName);
 
   // Assert
+  await umbracoUi.mediaType.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderCreated);
   await umbracoUi.mediaType.clickCaretButtonForName(mediaTypeFolderName);
   await umbracoUi.mediaType.isTreeItemVisible(childFolderName, true);
   const grandParentFolderChildren = await umbracoApi.mediaType.getChildren(grandParentFolderId);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/PartialView/PartialView.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/PartialView/PartialView.spec.ts
@@ -1,4 +1,4 @@
-﻿import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+﻿import {ConstantHelper, NotificationConstantHelper, test} from '@umbraco/playwright-testhelpers';
 import {expect} from "@playwright/test";
 
 const partialViewName = 'TestPartialView';
@@ -26,7 +26,7 @@ test('can create an empty partial view', {tag: '@smoke'}, async ({umbracoApi, um
   await umbracoUi.partialView.clickSaveButton();
 
   // Assert
-  await umbracoUi.partialView.isSuccessNotificationVisible();
+  await umbracoUi.partialView.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   expect(await umbracoApi.partialView.doesNameExist(partialViewFileName)).toBeTruthy();
   // Verify the new partial view is displayed under the Partial Views section
   await umbracoUi.partialView.isPartialViewRootTreeItemVisible(partialViewFileName);
@@ -46,7 +46,7 @@ test('can create a partial view from snippet', async ({umbracoApi, umbracoUi}) =
   await umbracoUi.partialView.clickSaveButton();
 
   // Assert
-  await umbracoUi.partialView.isSuccessNotificationVisible();
+  await umbracoUi.partialView.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   expect(await umbracoApi.partialView.doesExist(partialViewFileName)).toBeTruthy();
   const partialViewData = await umbracoApi.partialView.getByName(partialViewFileName);
 
@@ -80,7 +80,7 @@ test('can rename a partial view', {tag: '@smoke'}, async ({umbracoApi, umbracoUi
   await umbracoUi.partialView.rename(partialViewName);
 
   // Assert
-  await umbracoUi.partialView.isSuccessNotificationVisible();
+  await umbracoUi.partialView.doesSuccessNotificationHaveText(NotificationConstantHelper.success.renamed);
   expect(await umbracoApi.partialView.doesNameExist(partialViewFileName)).toBeTruthy();
   expect(await umbracoApi.partialView.doesNameExist(wrongPartialViewFileName)).toBeFalsy();
   // Verify the old partial view is NOT displayed under the Partial Views section
@@ -107,7 +107,7 @@ test.skip('can update a partial view content', {tag: '@smoke'}, async ({umbracoA
   await umbracoUi.partialView.clickSaveButton();
 
   // Assert
-  await umbracoUi.partialView.isSuccessNotificationVisible();
+  await umbracoUi.partialView.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const updatedPartialView = await umbracoApi.partialView.getByName(partialViewFileName);
   expect(updatedPartialView.content).toBe(updatedPartialViewContent);
 });
@@ -147,7 +147,7 @@ test.skip('can use query builder with Order By statement for a partial view', as
   await umbracoUi.partialView.clickSaveButton();
 
   // Assert
-  await umbracoUi.partialView.isSuccessNotificationVisible();
+  await umbracoUi.partialView.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const updatedPartialView = await umbracoApi.partialView.getByName(partialViewFileName);
   expect(updatedPartialView.content).toBe(expectedTemplateContent);
 });
@@ -188,7 +188,7 @@ test('can use query builder with Where statement for a partial view', async ({um
   await umbracoUi.partialView.clickSaveButton();
 
   // Assert
-  await umbracoUi.partialView.isSuccessNotificationVisible();
+  await umbracoUi.partialView.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const updatedPartialView = await umbracoApi.partialView.getByName(partialViewFileName);
   expect(updatedPartialView.content).toBe(expectedTemplateContent);
 });
@@ -210,7 +210,7 @@ test.skip('can insert dictionary item into a partial view', async ({umbracoApi, 
   await umbracoUi.partialView.clickSaveButton();
 
   // Assert
-  await umbracoUi.partialView.isSuccessNotificationVisible();
+  await umbracoUi.partialView.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const partialViewData = await umbracoApi.partialView.getByName(partialViewFileName);
   expect(partialViewData.content).toBe(partialViewContent);
 });
@@ -230,7 +230,7 @@ test.skip('can insert value into a partial view', async ({umbracoApi, umbracoUi}
   await umbracoUi.template.clickSaveButton();
 
   // Assert
-  await umbracoUi.partialView.isSuccessNotificationVisible();
+  await umbracoUi.partialView.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const partialViewData = await umbracoApi.partialView.getByName(partialViewFileName);
   expect(partialViewData.content).toBe(partialViewContent);
 });
@@ -246,7 +246,7 @@ test('can delete a partial view', {tag: '@smoke'}, async ({umbracoApi, umbracoUi
   await umbracoUi.partialView.clickDeleteAndConfirmButton();
 
   // Assert
-  await umbracoUi.partialView.isSuccessNotificationVisible();
+  await umbracoUi.partialView.doesSuccessNotificationHaveText(NotificationConstantHelper.success.deleted);
   expect(await umbracoApi.partialView.doesExist(partialViewFileName)).toBeFalsy();
   // Verify the partial view is NOT displayed under the Partial Views section
   await umbracoUi.partialView.clickRootFolderCaretButton();

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/PartialView/PartialView.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/PartialView/PartialView.spec.ts
@@ -180,6 +180,7 @@ test('can use query builder with Where statement for a partial view', async ({um
 
   // Act
   await umbracoUi.partialView.openPartialViewAtRoot(partialViewFileName);
+  await umbracoUi.waitForTimeout(500);
   await umbracoUi.partialView.addQueryBuilderWithWhereStatement(propertyAliasValue, operatorValue, constrainValue);
   // Verify that the code is shown
   await umbracoUi.partialView.isQueryBuilderCodeShown(expectedCode);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/PartialView/PartialViewFolder.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/PartialView/PartialViewFolder.spec.ts
@@ -1,4 +1,4 @@
-﻿import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+﻿import {ConstantHelper, NotificationConstantHelper, test} from '@umbraco/playwright-testhelpers';
 import {expect} from "@playwright/test";
 
 const partialViewName = 'TestPartialView';
@@ -23,7 +23,7 @@ test('can create a folder', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.partialView.createFolder(folderName);
 
   // Assert
-  await umbracoUi.partialView.isSuccessNotificationVisible();
+  await umbracoUi.partialView.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderCreated);
   expect(await umbracoApi.partialView.doesFolderExist(folderName)).toBeTruthy();
   // Verify the partial view folder is displayed under the Partial Views section
   await umbracoUi.partialView.clickRootFolderCaretButton();
@@ -65,7 +65,7 @@ test('can create a partial view in a folder', async ({umbracoApi, umbracoUi}) =>
   await umbracoUi.partialView.clickSaveButton();
 
   // Assert
-  await umbracoUi.partialView.isSuccessNotificationVisible();
+  await umbracoUi.partialView.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   const childrenData = await umbracoApi.partialView.getChildren(folderPath);
   expect(childrenData[0].name).toEqual(partialViewFileName);
   // Verify the partial view is displayed in the folder under the Partial Views section
@@ -94,7 +94,7 @@ test('can create a partial view in a folder in a folder', async ({umbracoApi, um
   await umbracoUi.partialView.clickSaveButton();
 
   // Assert
-  await umbracoUi.partialView.isSuccessNotificationVisible();
+  await umbracoUi.partialView.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   const childFolderChildrenData = await umbracoApi.partialView.getChildren(childFolderPath);
   expect(childFolderChildrenData[0].name).toEqual(partialViewFileName);
 
@@ -114,7 +114,7 @@ test('can create a folder in a folder', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.partialView.createFolder(childFolderName);
 
   // Assert
-  await umbracoUi.partialView.isSuccessNotificationVisible();
+  await umbracoUi.partialView.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderCreated);
   expect(await umbracoApi.partialView.doesNameExist(childFolderName)).toBeTruthy();
   const partialViewChildren = await umbracoApi.partialView.getChildren('/' + folderName);
   expect(partialViewChildren[0].path).toBe('/' + folderName + '/' + childFolderName);
@@ -137,7 +137,7 @@ test('can create a folder in a folder in a folder', {tag: '@smoke'}, async ({umb
   await umbracoUi.partialView.createFolder(childOfChildFolderName);
 
   // Assert
-  await umbracoUi.partialView.isSuccessNotificationVisible();
+  await umbracoUi.partialView.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderCreated);
   expect(await umbracoApi.partialView.doesNameExist(childOfChildFolderName)).toBeTruthy();
   const partialViewChildren = await umbracoApi.partialView.getChildren('/' + folderName + '/' + childFolderName);
   expect(partialViewChildren[0].path).toBe('/' + folderName + '/' + childFolderName + '/' + childOfChildFolderName);
@@ -158,5 +158,5 @@ test('cannot delete non-empty folder', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.partialView.deleteFolder();
 
   // Assert
-  await umbracoUi.script.isErrorNotificationVisible();
+  await umbracoUi.partialView.doesErrorNotificationHaveText(NotificationConstantHelper.error.notEmpty);
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Script/Script.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Script/Script.spec.ts
@@ -1,4 +1,4 @@
-﻿import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+﻿import {ConstantHelper, NotificationConstantHelper, test} from '@umbraco/playwright-testhelpers';
 import {expect} from '@playwright/test';
 
 const scriptName = 'TestScript.js';
@@ -25,7 +25,7 @@ test('can create a empty script', {tag: '@smoke'}, async ({umbracoApi, umbracoUi
   await umbracoUi.script.clickSaveButton();
 
   // Assert
-  await umbracoUi.script.isSuccessNotificationVisible();
+  await umbracoUi.script.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   expect(await umbracoApi.script.doesNameExist(scriptName)).toBeTruthy();
   await umbracoUi.script.isScriptRootTreeItemVisible(scriptName);
 });
@@ -44,7 +44,7 @@ test('can create a script with content', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.script.clickSaveButton();
 
   // Assert
-  await umbracoUi.script.isSuccessNotificationVisible();
+  await umbracoUi.script.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   expect(await umbracoApi.script.doesNameExist(scriptName)).toBeTruthy();
   const scriptData = await umbracoApi.script.getByName(scriptName);
   expect(scriptData.content).toBe(scriptContent);
@@ -63,7 +63,7 @@ test('can update a script', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => 
   await umbracoUi.script.clickSaveButton();
 
   // Assert
-  await umbracoUi.script.isSuccessNotificationVisible();
+  await umbracoUi.script.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const updatedScript = await umbracoApi.script.get(scriptPath);
   expect(updatedScript.content).toBe(updatedScriptContent);
 });
@@ -79,7 +79,7 @@ test('can delete a script', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => 
   await umbracoUi.script.clickDeleteAndConfirmButton();
 
   // Assert
-  await umbracoUi.script.isSuccessNotificationVisible();
+  await umbracoUi.script.doesSuccessNotificationHaveText(NotificationConstantHelper.success.deleted);
   expect(await umbracoApi.script.doesNameExist(scriptName)).toBeFalsy();
   await umbracoUi.script.isScriptRootTreeItemVisible(scriptName, false, false);
 });
@@ -96,7 +96,7 @@ test('can rename a script', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.script.rename(scriptName);
 
   // Assert
-  await umbracoUi.script.isSuccessNotificationVisible();
+  await umbracoUi.script.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   expect(await umbracoApi.script.doesNameExist(scriptName)).toBeTruthy();
   expect(await umbracoApi.script.doesNameExist(wrongScriptName)).toBeFalsy();
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Script/ScriptFolder.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Script/ScriptFolder.spec.ts
@@ -1,4 +1,4 @@
-﻿import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+﻿import {ConstantHelper, NotificationConstantHelper, test} from '@umbraco/playwright-testhelpers';
 import {expect} from '@playwright/test';
 
 const scriptName = 'TestScript.js';
@@ -24,7 +24,7 @@ test('can create a folder', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => 
   await umbracoUi.waitForTimeout(1000);
 
   // Assert
-  await umbracoUi.script.isSuccessNotificationVisible();
+  await umbracoUi.script.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderCreated);
   expect(await umbracoApi.script.doesFolderExist(scriptFolderName)).toBeTruthy();
   await umbracoUi.script.isScriptRootTreeItemVisible(scriptFolderName);
 });
@@ -40,7 +40,7 @@ test('can delete a folder', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => 
   await umbracoUi.script.deleteFolder();
 
   // Assert
-  await umbracoUi.script.isSuccessNotificationVisible();
+  await umbracoUi.script.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderDeleted);
   expect(await umbracoApi.script.doesFolderExist(scriptFolderName)).toBeFalsy();
   await umbracoUi.script.isScriptRootTreeItemVisible(scriptFolderName, false, false);
 });
@@ -61,7 +61,7 @@ test('can create a script in a folder', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.script.clickSaveButton();
 
   // Assert
-  await umbracoUi.script.isSuccessNotificationVisible();
+  await umbracoUi.script.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   expect(await umbracoApi.script.doesNameExist(scriptName)).toBeTruthy();
   const scriptChildren = await umbracoApi.script.getChildren('/' + scriptFolderName);
   expect(scriptChildren[0].path).toBe('/' + scriptFolderName + '/' + scriptName);
@@ -83,7 +83,7 @@ test('can create a folder in a folder', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.script.createFolder(childFolderName);
 
   // Assert
-  await umbracoUi.script.isSuccessNotificationVisible();
+  await umbracoUi.script.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderCreated);
   expect(await umbracoApi.script.doesNameExist(childFolderName)).toBeTruthy();
   const scriptChildren = await umbracoApi.script.getChildren('/' + scriptFolderName);
   expect(scriptChildren[0].path).toBe('/' + scriptFolderName + '/' + childFolderName);
@@ -106,7 +106,7 @@ test('can create a folder in a folder in a folder', {tag: '@smoke'}, async ({umb
   await umbracoUi.script.createFolder(childOfChildFolderName);
 
   // Assert
-  await umbracoUi.script.isSuccessNotificationVisible();
+  await umbracoUi.script.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderCreated);
   expect(await umbracoApi.script.doesNameExist(childOfChildFolderName)).toBeTruthy();
   const scriptChildren = await umbracoApi.script.getChildren('/' + scriptFolderName + '/' + childFolderName);
   expect(scriptChildren[0].path).toBe('/' + scriptFolderName + '/' + childFolderName + '/' + childOfChildFolderName);
@@ -131,7 +131,7 @@ test('can create a script in a folder in a folder', async ({umbracoApi, umbracoU
   await umbracoUi.script.clickSaveButton();
 
   // Assert
-  await umbracoUi.script.isSuccessNotificationVisible();
+  await umbracoUi.script.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   expect(await umbracoApi.script.doesNameExist(scriptName)).toBeTruthy();
   const scriptChildren = await umbracoApi.script.getChildren('/' + scriptFolderName + '/' + childFolderName);
   expect(scriptChildren[0].path).toBe('/' + scriptFolderName + '/' + childFolderName + '/' + scriptName);
@@ -152,5 +152,5 @@ test('cannot delete non-empty folder', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.script.deleteFolder();
 
   // Assert
-  await umbracoUi.script.isErrorNotificationVisible();
+  await umbracoUi.script.doesErrorNotificationHaveText(NotificationConstantHelper.error.notEmpty);
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Stylesheet/Stylesheet.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Stylesheet/Stylesheet.spec.ts
@@ -1,4 +1,4 @@
-﻿import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+﻿import {ConstantHelper, NotificationConstantHelper, test} from '@umbraco/playwright-testhelpers';
 import {expect} from '@playwright/test';
 
 const stylesheetName = 'TestStyleSheetFile.css';
@@ -27,7 +27,7 @@ test('can create a empty stylesheet', {tag: '@smoke'}, async ({umbracoApi, umbra
   await umbracoUi.stylesheet.clickSaveButton();
 
   // Assert
-  await umbracoUi.stylesheet.isSuccessNotificationVisible();
+  await umbracoUi.stylesheet.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   expect(await umbracoApi.stylesheet.doesNameExist(stylesheetName)).toBeTruthy();
   await umbracoUi.stylesheet.isStylesheetRootTreeItemVisible(stylesheetName);
 });
@@ -46,7 +46,7 @@ test('can create a stylesheet with content', async ({umbracoApi, umbracoUi}) => 
   await umbracoUi.stylesheet.clickSaveButton();
 
   // Assert
-  await umbracoUi.stylesheet.isSuccessNotificationVisible();
+  await umbracoUi.stylesheet.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   expect(await umbracoApi.stylesheet.doesNameExist(stylesheetName)).toBeTruthy();
   const stylesheetData = await umbracoApi.stylesheet.getByName(stylesheetName);
   expect(stylesheetData.content).toEqual(stylesheetContent);
@@ -67,7 +67,7 @@ test.skip('can create a new Rich Text Editor stylesheet file', {tag: '@smoke'}, 
   await umbracoUi.stylesheet.clickSaveButton();
 
   // Assert
-  await umbracoUi.stylesheet.isSuccessNotificationVisible();
+  await umbracoUi.stylesheet.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   expect(await umbracoApi.stylesheet.doesExist(stylesheetName)).toBeTruthy();
   const stylesheetData = await umbracoApi.stylesheet.getByName(stylesheetName);
   expect(stylesheetData.content).toEqual(stylesheetContent);
@@ -87,7 +87,7 @@ test.skip('can update a stylesheet', {tag: '@smoke'}, async ({umbracoApi, umbrac
   await umbracoUi.stylesheet.clickSaveButton();
 
   // Assert
-  await umbracoUi.stylesheet.isSuccessNotificationVisible();
+  await umbracoUi.stylesheet.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const stylesheetData = await umbracoApi.stylesheet.getByName(stylesheetName);
   expect(stylesheetData.content).toEqual(stylesheetContent);
 });
@@ -103,7 +103,7 @@ test('can delete a stylesheet', {tag: '@smoke'}, async ({umbracoApi, umbracoUi})
   await umbracoUi.stylesheet.clickDeleteAndConfirmButton();
 
   // Assert
-  await umbracoUi.stylesheet.isSuccessNotificationVisible();
+  await umbracoUi.stylesheet.doesSuccessNotificationHaveText(NotificationConstantHelper.success.deleted);
   expect(await umbracoApi.stylesheet.doesNameExist(stylesheetName)).toBeFalsy();
   await umbracoUi.stylesheet.isStylesheetRootTreeItemVisible(stylesheetName, false, false);
 });
@@ -121,7 +121,7 @@ test('can rename a stylesheet', {tag: '@smoke'}, async ({umbracoApi, umbracoUi})
   await umbracoUi.stylesheet.rename(stylesheetName);
 
   // Assert
-  await umbracoUi.stylesheet.isSuccessNotificationVisible();
+  await umbracoUi.stylesheet.doesSuccessNotificationHaveText(NotificationConstantHelper.success.renamed);
   expect(await umbracoApi.stylesheet.doesNameExist(stylesheetName)).toBeTruthy();
   expect(await umbracoApi.stylesheet.doesNameExist(wrongStylesheetName)).toBeFalsy();
 });
@@ -143,7 +143,7 @@ test('can edit rich text editor styles', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.stylesheet.clickSaveButton();
 
   // Assert
-  await umbracoUi.stylesheet.isSuccessNotificationVisible();
+  await umbracoUi.stylesheet.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const stylesheetData = await umbracoApi.stylesheet.getByName(stylesheetName);
   expect(stylesheetData.content).toEqual(newStylesheetContent);
 });
@@ -161,7 +161,7 @@ test('can remove rich text editor styles', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.stylesheet.clickSaveButton();
 
   // Assert
-  await umbracoUi.stylesheet.isSuccessNotificationVisible();
+  await umbracoUi.stylesheet.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const stylesheetData = await umbracoApi.stylesheet.getByName(stylesheetName);
   expect(stylesheetData.content).toEqual('');
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Stylesheet/StylesheetFolder.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Stylesheet/StylesheetFolder.spec.ts
@@ -1,4 +1,4 @@
-﻿import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+﻿import {ConstantHelper, NotificationConstantHelper, test} from '@umbraco/playwright-testhelpers';
 import {expect} from '@playwright/test';
 
 const stylesheetName = 'TestStyleSheetFile.css';
@@ -24,7 +24,7 @@ test('can create a folder', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.waitForTimeout(1000);
 
   // Assert
-  await umbracoUi.stylesheet.isSuccessNotificationVisible();
+  await umbracoUi.stylesheet.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderCreated);
   expect(await umbracoApi.stylesheet.doesFolderExist(stylesheetFolderName)).toBeTruthy();
   await umbracoUi.stylesheet.isStylesheetRootTreeItemVisible(stylesheetFolderName);
 });
@@ -40,7 +40,7 @@ test('can delete a folder', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => 
   await umbracoUi.stylesheet.deleteFolder();
 
   // Assert
-  await umbracoUi.stylesheet.isSuccessNotificationVisible();
+  await umbracoUi.stylesheet.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderDeleted);
   expect(await umbracoApi.stylesheet.doesFolderExist(stylesheetFolderName)).toBeFalsy();
   await umbracoUi.stylesheet.isStylesheetRootTreeItemVisible(stylesheetFolderName, false, false);
 });
@@ -57,7 +57,7 @@ test('can create a folder in a folder', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.stylesheet.createFolder(childFolderName);
 
   //Assert
-  await umbracoUi.stylesheet.isSuccessNotificationVisible();
+  await umbracoUi.stylesheet.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderCreated);
   expect(await umbracoApi.stylesheet.doesNameExist(childFolderName)).toBeTruthy();
   const styleChildren = await umbracoApi.stylesheet.getChildren('/' + stylesheetFolderName);
   expect(styleChildren[0].path).toBe('/' + stylesheetFolderName + '/' + childFolderName);
@@ -80,7 +80,7 @@ test('can create a folder in a folder in a folder', {tag: '@smoke'}, async ({umb
   await umbracoUi.stylesheet.createFolder(childOfChildFolderName);
 
   //Assert
-  await umbracoUi.stylesheet.isSuccessNotificationVisible();
+  await umbracoUi.stylesheet.doesSuccessNotificationHaveText(NotificationConstantHelper.success.folderCreated);
   expect(await umbracoApi.stylesheet.doesNameExist(childOfChildFolderName)).toBeTruthy();
   const styleChildren = await umbracoApi.stylesheet.getChildren('/' + stylesheetFolderName + '/' + childFolderName);
   expect(styleChildren[0].path).toBe('/' + stylesheetFolderName + '/' + childFolderName + '/' + childOfChildFolderName);
@@ -104,7 +104,7 @@ test('can create a stylesheet in a folder', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.stylesheet.clickSaveButton();
 
   // Assert
-  await umbracoUi.stylesheet.isSuccessNotificationVisible();
+  await umbracoUi.stylesheet.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   expect(await umbracoApi.stylesheet.doesNameExist(stylesheetName)).toBeTruthy();
   const stylesheetChildren = await umbracoApi.stylesheet.getChildren('/' + stylesheetFolderName);
   expect(stylesheetChildren[0].path).toBe('/' + stylesheetFolderName + '/' + stylesheetName);
@@ -133,7 +133,7 @@ test('can create a stylesheet in a folder in a folder', async ({umbracoApi, umbr
   await umbracoUi.stylesheet.clickSaveButton();
 
   // Assert
-  await umbracoUi.stylesheet.isSuccessNotificationVisible();
+  await umbracoUi.stylesheet.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   expect(await umbracoApi.stylesheet.doesNameExist(stylesheetName)).toBeTruthy();
   const stylesheetChildren = await umbracoApi.stylesheet.getChildren('/' + stylesheetFolderName + '/' + childFolderName);
   expect(stylesheetChildren[0].path).toBe('/' + stylesheetFolderName + '/' + childFolderName + '/' + stylesheetName);
@@ -156,5 +156,5 @@ test('cannot delete non-empty folder', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.stylesheet.deleteFolder();
 
   //Assert
-  await umbracoUi.stylesheet.isErrorNotificationVisible();
+  await umbracoUi.stylesheet.doesErrorNotificationHaveText(NotificationConstantHelper.error.notEmpty);
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Template/Templates.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Template/Templates.spec.ts
@@ -1,4 +1,4 @@
-﻿import {AliasHelper, ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+﻿import {AliasHelper, ConstantHelper, NotificationConstantHelper, test} from '@umbraco/playwright-testhelpers';
 import {expect} from "@playwright/test";
 
 const templateName = 'TestTemplate';
@@ -24,7 +24,7 @@ test('can create a template', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) =
   await umbracoUi.template.clickSaveButton();
 
   // Assert
-  await umbracoUi.template.isSuccessNotificationVisible();
+  await umbracoUi.template.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   expect(await umbracoApi.template.doesNameExist(templateName)).toBeTruthy();
   await umbracoUi.template.isTemplateRootTreeItemVisible(templateName);
 });
@@ -42,7 +42,7 @@ test('can update content of a template', {tag: '@smoke'}, async ({umbracoApi, um
   await umbracoUi.template.clickSaveButton();
 
   // Assert
-  await umbracoUi.template.isSuccessNotificationVisible();
+  await umbracoUi.template.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   // Checks if the template was updated
   const updatedTemplate = await umbracoApi.template.getByName(templateName);
   expect(updatedTemplate.content).toBe(updatedTemplateContent);
@@ -62,7 +62,7 @@ test('can rename a template', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.template.clickSaveButton();
 
   // Assert
-  await umbracoUi.template.isSuccessNotificationVisible();
+  await umbracoUi.template.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const templateData = await umbracoApi.template.get(templateId);
   expect(templateData.name).toBe(templateName);
 });
@@ -78,7 +78,7 @@ test('can delete a template', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.template.clickDeleteAndConfirmButton();
 
   // Assert
-  await umbracoUi.template.isSuccessNotificationVisible();
+  await umbracoUi.template.doesSuccessNotificationHaveText(NotificationConstantHelper.success.deleted);
   expect(await umbracoApi.template.doesNameExist(templateName)).toBeFalsy();
   await umbracoUi.template.isTemplateRootTreeItemVisible(templateName, false);
 });
@@ -98,7 +98,7 @@ test('can set a template as master template', async ({umbracoApi, umbracoUi}) =>
   await umbracoUi.template.clickSaveButton();
 
   // Assert
-  await umbracoUi.template.isSuccessNotificationVisible();
+  await umbracoUi.template.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   await umbracoUi.template.isMasterTemplateNameVisible(templateName);
   // Checks if the childTemplate has the masterTemplate set
   const childTemplateData = await umbracoApi.template.getByName(childTemplateName);
@@ -125,7 +125,7 @@ test('can remove a master template', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.template.clickSaveButton();
 
   // Assert
-  await umbracoUi.template.isSuccessNotificationVisible();
+  await umbracoUi.template.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   await umbracoUi.template.isMasterTemplateNameVisible('No master');
   const childTemplate = await umbracoApi.template.getByName(childTemplateName);
   expect(childTemplate.masterTemplate).toBe(null);
@@ -169,7 +169,7 @@ test.skip('can use query builder with Order By statement for a template', async 
   await umbracoUi.template.clickSaveButton();
 
   // Assert
-  await umbracoUi.template.isSuccessNotificationVisible();
+  await umbracoUi.template.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const templateData = await umbracoApi.template.getByName(templateName);
   expect(templateData.content).toBe(expectedTemplateContent);
 });
@@ -209,7 +209,7 @@ test('can use query builder with Where statement for a template', async ({umbrac
   await umbracoUi.template.clickSaveButton();
 
   // Assert
-  await umbracoUi.template.isSuccessNotificationVisible();
+  await umbracoUi.template.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const templateData = await umbracoApi.template.getByName(templateName);
   expect(templateData.content).toBe(expectedTemplateContent);
 });
@@ -229,7 +229,7 @@ test('can insert sections - render child template into a template', async ({umbr
   await umbracoUi.template.clickSaveButton();
 
   // Assert
-  await umbracoUi.template.isSuccessNotificationVisible();
+  await umbracoUi.template.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const templateData = await umbracoApi.template.getByName(templateName);
   expect(templateData.content).toBe(templateContent);
 });
@@ -250,7 +250,7 @@ test('can insert sections - render a named section into a template', async ({umb
   await umbracoUi.template.clickSaveButton();
 
   // Assert
-  await umbracoUi.template.isSuccessNotificationVisible();
+  await umbracoUi.template.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const templateData = await umbracoApi.template.getByName(templateName);
   expect(templateData.content).toBe(templateContent);
 });
@@ -292,7 +292,7 @@ test('can insert dictionary item into a template', async ({umbracoApi, umbracoUi
   await umbracoUi.template.clickSaveButton();
 
   // Assert
-  await umbracoUi.template.isSuccessNotificationVisible();
+  await umbracoUi.template.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const templateData = await umbracoApi.template.getByName(templateName);
   expect(templateData.content).toBe(templateContent);
 
@@ -317,7 +317,7 @@ test('can insert partial view into a template', async ({umbracoApi, umbracoUi}) 
   await umbracoUi.template.clickSaveButton();
 
   // Assert
-  await umbracoUi.template.isSuccessNotificationVisible();
+  await umbracoUi.template.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const templateData = await umbracoApi.template.getByName(templateName);
   expect(templateData.content).toBe(templateContent);
 });
@@ -337,7 +337,7 @@ test.skip('can insert value into a template', async ({umbracoApi, umbracoUi}) =>
   await umbracoUi.template.clickSaveButton();
 
   // Assert
-  await umbracoUi.template.isSuccessNotificationVisible();
+  await umbracoUi.template.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const templateData = await umbracoApi.template.getByName(templateName);
   expect(templateData.content).toBe(templateContent);
 });
@@ -381,5 +381,7 @@ test('cannot create a template with an empty name', {tag: '@smoke'}, async ({umb
 
   // Assert
   await umbracoUi.template.isErrorNotificationVisible();
+  // TODO: Uncomment this when the front-end updates the error message
+  //await umbracoUi.template.doesErrorNotificationHaveText(NotificationConstantHelper.error.emptyName);
   expect(await umbracoApi.template.doesNameExist(templateName)).toBeFalsy();
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Template/Templates.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Template/Templates.spec.ts
@@ -201,6 +201,7 @@ test('can use query builder with Where statement for a template', async ({umbrac
 
   // Act
   await umbracoUi.template.goToTemplate(templateName);
+  await umbracoUi.waitForTimeout(500);
   await umbracoUi.template.addQueryBuilderWithWhereStatement(propertyAliasValue, operatorValue, constrainValue);
   // Verify that the code is shown
   await umbracoUi.template.isQueryBuilderCodeShown(expectedCode);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/Permissions/ContentStartNodes.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/Permissions/ContentStartNodes.spec.ts
@@ -1,0 +1,97 @@
+import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+import {expect} from '@playwright/test';
+
+const testUser = {
+  name: 'Test User',
+  email: 'verySecureEmail@123.test',
+  password: 'verySecurePassword123',
+};
+
+const userGroupName = 'TestUserGroup';
+
+const rootDocumentTypeName = 'RootDocumentType';
+const childDocumentTypeOneName = 'ChildDocumentTypeOne';
+const childDocumentTypeTwoName = 'ChildDocumentTypeTwo';
+let childDocumentTypeOneId = null;
+let rootDocumentTypeId = null;
+
+let testUserCookieAndToken = {cookie: "", accessToken: "", refreshToken: ""};
+
+let rootDocumentId = null;
+let childDocumentOneId = null;
+const rootDocumentName = 'RootDocument';
+const childDocumentOneName = 'ChildDocumentOne';
+const childDocumentTwoName = 'ChildDocumentTwo';
+
+let userGroupId = null;
+
+test.beforeEach(async ({umbracoApi}) => {
+  await umbracoApi.documentType.ensureNameNotExists(rootDocumentTypeName);
+  await umbracoApi.documentType.ensureNameNotExists(childDocumentTypeOneName);
+  await umbracoApi.documentType.ensureNameNotExists(childDocumentTypeTwoName);
+  await umbracoApi.user.ensureNameNotExists(testUser.name);
+  await umbracoApi.userGroup.ensureNameNotExists(userGroupName);
+  childDocumentTypeOneId = await umbracoApi.documentType.createDefaultDocumentType(childDocumentTypeOneName);
+  const childDocumentTypeTwoId = await umbracoApi.documentType.createDefaultDocumentType(childDocumentTypeTwoName);
+  rootDocumentTypeId = await umbracoApi.documentType.createDocumentTypeWithAllowedTwoChildNodes(rootDocumentTypeName, childDocumentTypeOneId, childDocumentTypeTwoId);
+  rootDocumentId = await umbracoApi.document.createDefaultDocument(rootDocumentName, rootDocumentTypeId);
+  childDocumentOneId = await umbracoApi.document.createDefaultDocumentWithParent(childDocumentOneName, childDocumentTypeOneId, rootDocumentId);
+  await umbracoApi.document.createDefaultDocumentWithParent(childDocumentTwoName, childDocumentTypeTwoId, rootDocumentId);
+  userGroupId = await umbracoApi.userGroup.createSimpleUserGroupWithContentSection(userGroupName);
+});
+
+test.afterEach(async ({umbracoApi}) => {
+  // Ensure we are logged in to admin
+  await umbracoApi.loginToAdminUser(testUserCookieAndToken.cookie, testUserCookieAndToken.accessToken, testUserCookieAndToken.refreshToken);
+  await umbracoApi.documentType.ensureNameNotExists(rootDocumentTypeName);
+  await umbracoApi.documentType.ensureNameNotExists(childDocumentTypeOneName);
+  await umbracoApi.documentType.ensureNameNotExists(childDocumentTypeTwoName);
+  await umbracoApi.userGroup.ensureNameNotExists(userGroupName);
+});
+
+test('can see root start node and children', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  await umbracoApi.user.setUserPermissions(testUser.name, testUser.email, testUser.password, userGroupId, [rootDocumentId]);
+  testUserCookieAndToken = await umbracoApi.user.loginToUser(testUser.name, testUser.email, testUser.password);
+  await umbracoUi.goToBackOffice();
+
+  // Act
+  await umbracoUi.user.goToSection(ConstantHelper.sections.content, false);
+
+  // Assert
+  await umbracoUi.content.isContentVisible(rootDocumentName);
+  await umbracoUi.content.clickCaretButtonForContentName(rootDocumentName);
+  await umbracoUi.content.isChildContentVisible(rootDocumentName, childDocumentOneName);
+  await umbracoUi.content.isChildContentVisible(rootDocumentName, childDocumentTwoName);
+});
+
+test('can see parent of start node but not access it', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  await umbracoApi.user.setUserPermissions(testUser.name, testUser.email, testUser.password, userGroupId, [childDocumentOneId]);
+  testUserCookieAndToken = await umbracoApi.user.loginToUser(testUser.name, testUser.email, testUser.password);
+  await umbracoUi.goToBackOffice();
+
+  // Act
+  await umbracoUi.user.goToSection(ConstantHelper.sections.content, false);
+
+  // Assert
+  await umbracoUi.content.isContentVisible(rootDocumentName);
+  await umbracoUi.content.goToContentWithName(rootDocumentName);
+  await umbracoUi.content.isTextWithMessageVisible('The authenticated user do not have access to this resource');
+  await umbracoUi.content.clickCaretButtonForContentName(rootDocumentName);
+  await umbracoUi.content.isChildContentVisible(rootDocumentName, childDocumentOneName);
+  await umbracoUi.content.isChildContentVisible(rootDocumentName, childDocumentTwoName, false);
+});
+
+test('can not see any content when no start nodes specified', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  await umbracoApi.user.setUserPermissions(testUser.name, testUser.email, testUser.password, userGroupId);
+  testUserCookieAndToken = await umbracoApi.user.loginToUser(testUser.name, testUser.email, testUser.password);
+  await umbracoUi.goToBackOffice();
+
+  // Act
+  await umbracoUi.user.goToSection(ConstantHelper.sections.content, false);
+
+  // Assert
+  await umbracoUi.content.isContentVisible(rootDocumentName, false);
+});

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/Permissions/MediaStartNodes.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/Permissions/MediaStartNodes.spec.ts
@@ -1,0 +1,88 @@
+import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+
+const testUser = {
+  name: 'Test User',
+  email: 'verySecureEmail@123.test',
+  password: 'verySecurePassword123',
+};
+
+const userGroupName = 'TestUserGroup';
+let userGroupId = null;
+
+let testUserCookieAndToken = {cookie: "", accessToken: "", refreshToken: ""};
+
+let rootFolderId = null;
+let childFolderOneId = null;
+const rootFolderName = 'RootFolder';
+const childFolderOneName = 'ChildFolderOne';
+const childFolderTwoName = 'ChildFolderTwo';
+
+test.beforeEach(async ({umbracoApi}) => {
+  await umbracoApi.user.ensureNameNotExists(testUser.name);
+  await umbracoApi.userGroup.ensureNameNotExists(userGroupName);
+  await umbracoApi.media.ensureNameNotExists(rootFolderName);
+  await umbracoApi.media.ensureNameNotExists(childFolderOneName);
+  await umbracoApi.media.ensureNameNotExists(childFolderTwoName);
+  rootFolderId = await umbracoApi.media.createDefaultMediaFolder(rootFolderName);
+  childFolderOneId = await umbracoApi.media.createDefaultMediaFolderAndParentId(childFolderOneName, rootFolderId);
+  await umbracoApi.media.createDefaultMediaFolderAndParentId(childFolderTwoName, rootFolderId);
+  userGroupId = await umbracoApi.userGroup.createUserGroupWithMediaSection(userGroupName);
+});
+
+test.afterEach(async ({umbracoApi}) => {
+  // Ensure we are logged in to admin
+  await umbracoApi.loginToAdminUser(testUserCookieAndToken.cookie, testUserCookieAndToken.accessToken, testUserCookieAndToken.refreshToken);
+  await umbracoApi.user.ensureNameNotExists(testUser.name);
+  await umbracoApi.userGroup.ensureNameNotExists(userGroupName);
+  await umbracoApi.media.ensureNameNotExists(rootFolderName);
+  await umbracoApi.media.ensureNameNotExists(childFolderOneName);
+  await umbracoApi.media.ensureNameNotExists(childFolderTwoName);
+});
+
+test('can see root media start node and children', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  await umbracoApi.user.setUserPermissions(testUser.name, testUser.email, testUser.password, userGroupId, [], false, [rootFolderId]);
+  testUserCookieAndToken = await umbracoApi.user.loginToUser(testUser.name, testUser.email, testUser.password);
+  await umbracoUi.goToBackOffice();
+
+  // Act
+  await umbracoUi.user.goToSection(ConstantHelper.sections.media, false);
+
+  // Assert
+  await umbracoUi.media.isMediaVisible(rootFolderName);
+  await umbracoUi.media.clickCaretButtonForMediaName(rootFolderName);
+  await umbracoUi.media.isChildMediaVisible(rootFolderName, childFolderOneName);
+  await umbracoUi.media.isChildMediaVisible(rootFolderName, childFolderTwoName);
+});
+
+test('can see parent of start node but not access it', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  await umbracoApi.user.setUserPermissions(testUser.name, testUser.email, testUser.password, userGroupId, [], false, [childFolderOneId]);
+  testUserCookieAndToken = await umbracoApi.user.loginToUser(testUser.name, testUser.email, testUser.password);
+  await umbracoUi.goToBackOffice();
+
+  // Act
+  await umbracoUi.user.goToSection(ConstantHelper.sections.media, false);
+
+  // Assert
+  await umbracoUi.media.isMediaVisible(rootFolderName);
+  await umbracoUi.waitForTimeout(500);
+  await umbracoUi.media.goToMediaWithName(rootFolderName);
+  await umbracoUi.media.isTextWithMessageVisible('The authenticated user do not have access to this resource');
+  await umbracoUi.media.clickCaretButtonForMediaName(rootFolderName);
+  await umbracoUi.media.isChildMediaVisible(rootFolderName, childFolderOneName);
+  await umbracoUi.media.isChildMediaVisible(rootFolderName, childFolderTwoName, false);
+});
+
+test('can not see any media when no media start nodes specified', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  await umbracoApi.user.setUserPermissions(testUser.name, testUser.email, testUser.password, userGroupId);
+  testUserCookieAndToken = await umbracoApi.user.loginToUser(testUser.name, testUser.email, testUser.password);
+  await umbracoUi.goToBackOffice();
+
+  // Act
+  await umbracoUi.user.goToSection(ConstantHelper.sections.media, false);
+
+  // Assert
+  await umbracoUi.media.isMediaVisible(rootFolderName, false);
+});

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/Permissions/UICulture.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/Permissions/UICulture.spec.ts
@@ -1,0 +1,49 @@
+import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+
+const testUser = {
+  name: 'Test User',
+  email: 'verySecureEmail@123.test',
+  password: 'verySecurePassword123',
+};
+
+const userGroupName = 'TestUserGroup';
+
+let testUserCookieAndToken = {cookie: "", accessToken: "", refreshToken: ""};
+let userGroupId = null;
+
+test.beforeEach(async ({umbracoApi}) => {
+  await umbracoApi.user.ensureNameNotExists(testUser.name);
+  await umbracoApi.userGroup.ensureNameNotExists(userGroupName);
+  userGroupId = await umbracoApi.userGroup.createSimpleUserGroupWithContentSection(userGroupName);
+});
+
+test.afterEach(async ({umbracoApi}) => {
+  // Ensure we are logged in to admin
+  await umbracoApi.loginToAdminUser(testUserCookieAndToken.cookie, testUserCookieAndToken.accessToken, testUserCookieAndToken.refreshToken);
+  await umbracoApi.userGroup.ensureNameNotExists(userGroupName);
+});
+
+test('can see correct translation for content in english', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  await umbracoApi.user.setUserPermissions(testUser.name, testUser.email, testUser.password, userGroupId, [], true, [], false, 'en-us');
+  testUserCookieAndToken = await umbracoApi.user.loginToUser(testUser.name, testUser.email, testUser.password);
+
+  // Act
+  await umbracoUi.goToBackOffice();
+
+  // Assert
+  await umbracoUi.user.isSectionWithNameVisible(ConstantHelper.sections.content, false);
+});
+
+test('can see correct translation for content in danish', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  await umbracoApi.user.setUserPermissions(testUser.name, testUser.email, testUser.password, userGroupId, [], true, [], false, 'da-dk');
+  testUserCookieAndToken = await umbracoApi.user.loginToUser(testUser.name, testUser.email, testUser.password);
+
+  // Act
+  await umbracoUi.goToBackOffice();
+
+  // Assert
+  // Indhold is the Danish translation of Content
+  await umbracoUi.user.isSectionWithNameVisible('Indhold', true);
+});

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/User.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/User.spec.ts
@@ -1,4 +1,4 @@
-import {ConstantHelper, test} from '@umbraco/playwright-testhelpers';
+import {ConstantHelper, NotificationConstantHelper, test} from '@umbraco/playwright-testhelpers';
 import {expect} from '@playwright/test';
 
 const nameOfTheUser = 'TestUser';
@@ -28,7 +28,7 @@ test('can create a user', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.user.clickCreateUserButton();
 
   // Assert
-  await umbracoUi.user.isSuccessNotificationVisible();
+  await umbracoUi.user.doesSuccessNotificationHaveText(NotificationConstantHelper.success.created);
   expect(await umbracoApi.user.doesNameExist(nameOfTheUser)).toBeTruthy();
 });
 
@@ -46,7 +46,7 @@ test('can rename a user', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.user.clickSaveButton();
 
   // Assert
-  await umbracoUi.user.isSuccessNotificationVisible();
+  await umbracoUi.user.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   expect(await umbracoApi.user.doesNameExist(nameOfTheUser)).toBeTruthy();
 });
 
@@ -62,7 +62,7 @@ test('can delete a user', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.user.clickConfirmToDeleteButton();
 
   // Assert
-  await umbracoUi.user.isSuccessNotificationVisible();
+  await umbracoUi.user.doesSuccessNotificationHaveText(NotificationConstantHelper.success.deleted);
   expect(await umbracoApi.user.doesNameExist(nameOfTheUser)).toBeFalsy();
   // Checks if the user is deleted from the list
   await umbracoUi.user.clickUsersTabButton();
@@ -85,8 +85,7 @@ test('can add multiple user groups to a user', async ({umbracoApi, umbracoUi}) =
   await umbracoUi.user.clickSaveButton();
 
   // Assert
-  await umbracoUi.user.isSuccessNotificationVisible();
-  const userData = await umbracoApi.user.getByName(nameOfTheUser);
+  await umbracoUi.user.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   expect(await umbracoApi.user.doesUserContainUserGroupIds(nameOfTheUser, [userGroupWriters.id, userGroupTranslators.id])).toBeTruthy();
 });
 
@@ -103,7 +102,7 @@ test('can remove a user group from a user', {tag: '@smoke'}, async ({umbracoApi,
   await umbracoUi.user.clickSaveButton();
 
   // Assert
-  await umbracoUi.user.isSuccessNotificationVisible();
+  await umbracoUi.user.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const userData = await umbracoApi.user.getByName(nameOfTheUser);
   expect(userData.userGroupIds).toEqual([]);
 });
@@ -121,7 +120,7 @@ test('can update culture for a user', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.user.clickSaveButton();
 
   // Assert
-  await umbracoUi.user.isSuccessNotificationVisible();
+  await umbracoUi.user.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const userData = await umbracoApi.user.getByName(nameOfTheUser);
   expect(userData.languageIsoCode).toEqual(danishIsoCode);
 });
@@ -146,7 +145,7 @@ test('can add a content start node to a user', {tag: '@smoke'}, async ({umbracoA
   await umbracoUi.user.clickSaveButton();
 
   // Assert
-  await umbracoUi.user.isSuccessNotificationVisible();
+  await umbracoUi.user.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   expect(await umbracoApi.user.doesUserContainContentStartNodeIds(nameOfTheUser, [documentId])).toBeTruthy();
 
   // Clean
@@ -181,7 +180,7 @@ test('can add multiple content start nodes for a user', async ({umbracoApi, umbr
   await umbracoUi.user.clickSaveButton();
 
   // Assert
-  await umbracoUi.user.isSuccessNotificationVisible();
+  await umbracoUi.user.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   expect(await umbracoApi.user.doesUserContainContentStartNodeIds(nameOfTheUser, [documentId, secondDocumentId])).toBeTruthy();
 
   // Clean
@@ -214,7 +213,7 @@ test('can remove a content start node from a user', {tag: '@smoke'}, async ({umb
   await umbracoUi.user.clickSaveButton();
 
   // Assert
-  await umbracoUi.user.isSuccessNotificationVisible();
+  await umbracoUi.user.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   expect(await umbracoApi.user.doesUserContainContentStartNodeIds(nameOfTheUser, [documentId])).toBeFalsy();
 
   // Clean
@@ -239,7 +238,7 @@ test('can add media start nodes for a user', {tag: '@smoke'}, async ({umbracoApi
   await umbracoUi.user.clickSaveButton();
 
   // Assert
-  await umbracoUi.user.isSuccessNotificationVisible();
+  await umbracoUi.user.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   expect(await umbracoApi.user.doesUserContainMediaStartNodeIds(nameOfTheUser, [mediaId])).toBeTruthy();
 
   // Clean
@@ -271,7 +270,7 @@ test('can add multiple media start nodes for a user', async ({umbracoApi, umbrac
   await umbracoUi.user.clickSaveButton();
 
   // Assert
-  await umbracoUi.user.isSuccessNotificationVisible();
+  await umbracoUi.user.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   expect(await umbracoApi.user.doesUserContainMediaStartNodeIds(nameOfTheUser, [firstMediaId, secondMediaId])).toBeTruthy();
 
   // Clean
@@ -300,7 +299,7 @@ test('can remove a media start node from a user', async ({umbracoApi, umbracoUi}
   await umbracoUi.user.clickSaveButton();
 
   // Assert
-  await umbracoUi.user.isSuccessNotificationVisible();
+  await umbracoUi.user.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   expect(await umbracoApi.user.doesUserContainMediaStartNodeIds(nameOfTheUser, [mediaId])).toBeFalsy();
 
   // Clean
@@ -319,7 +318,7 @@ test('can allow access to all documents for a user', async ({umbracoApi, umbraco
   await umbracoUi.user.clickSaveButton();
 
   // Assert
-  await umbracoUi.user.isSuccessNotificationVisible();
+  await umbracoUi.user.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const userData = await umbracoApi.user.getByName(nameOfTheUser);
   expect(userData.hasDocumentRootAccess).toBeTruthy()
 });
@@ -336,7 +335,7 @@ test('can allow access to all media for a user', async ({umbracoApi, umbracoUi})
   await umbracoUi.user.clickSaveButton();
 
   // Assert
-  await umbracoUi.user.isSuccessNotificationVisible();
+  await umbracoUi.user.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const userData = await umbracoApi.user.getByName(nameOfTheUser);
   expect(userData.hasMediaRootAccess).toBeTruthy();
 });
@@ -422,7 +421,7 @@ test('can disable a user', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.user.clickConfirmDisableButton();
 
   // Assert
-  await umbracoUi.user.isSuccessNotificationVisible();
+  await umbracoUi.user.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   expect(umbracoUi.user.isUserDisabledTextVisible()).toBeTruthy();
   const userData = await umbracoApi.user.getByName(nameOfTheUser);
   expect(userData.state).toBe(disabledStatus);
@@ -442,7 +441,7 @@ test('can enable a user', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.user.clickConfirmEnableButton();
 
   // Assert
-  await umbracoUi.user.isSuccessNotificationVisible();
+  await umbracoUi.user.doesSuccessNotificationHaveText(NotificationConstantHelper.success.userDisabled);
   await umbracoUi.user.isUserActiveTextVisible();
   // The state of the user is not enabled. The reason for this is that the user has not logged in, resulting in the state Inactive.
   const userData = await umbracoApi.user.getByName(nameOfTheUser);
@@ -461,7 +460,7 @@ test('can add an avatar to a user', {tag: '@smoke'}, async ({umbracoApi, umbraco
   await umbracoUi.user.changePhotoWithFileChooser(filePath);
 
   // Assert
-  await umbracoUi.user.isSuccessNotificationVisible();
+  await umbracoUi.user.doesSuccessNotificationHaveText(NotificationConstantHelper.success.avatarUploaded);
   const userData = await umbracoApi.user.getByName(nameOfTheUser);
   expect(userData.avatarUrls).not.toHaveLength(0);
 });
@@ -478,7 +477,7 @@ test('can remove an avatar from a user', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.user.clickRemovePhotoButton();
 
   // Assert
-  await umbracoUi.user.isSuccessNotificationVisible();
+  await umbracoUi.user.doesSuccessNotificationHaveText(NotificationConstantHelper.success.saved);
   const userData = await umbracoApi.user.getByName(nameOfTheUser);
   expect(userData.avatarUrls).toHaveLength(0);
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/User.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/User.spec.ts
@@ -117,7 +117,7 @@ test('can update culture for a user', async ({umbracoApi, umbracoUi}) => {
 
   // Act
   await umbracoUi.user.clickUserWithName(nameOfTheUser);
-  await umbracoUi.user.selectUserLanguage('Dansk');
+  await umbracoUi.user.selectUserLanguage('Dansk (Danmark)');
   await umbracoUi.user.clickSaveButton();
 
   // Assert

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/User.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/User.spec.ts
@@ -4,13 +4,16 @@ import {expect} from '@playwright/test';
 const nameOfTheUser = 'TestUser';
 const userEmail = 'TestUser@EmailTest.test';
 const defaultUserGroupName = 'Writers';
+let userCount = null;
 
 test.beforeEach(async ({umbracoUi, umbracoApi}) => {
   await umbracoUi.goToBackOffice();
   await umbracoApi.user.ensureNameNotExists(nameOfTheUser);
 });
 
-test.afterEach(async ({umbracoApi}) => {
+test.afterEach(async ({umbracoApi, umbracoUi}) => {
+  // Waits so we can try to avoid db locks
+  await umbracoUi.waitForTimeout(500);
   await umbracoApi.user.ensureNameNotExists(nameOfTheUser);
 });
 
@@ -501,10 +504,11 @@ test('can search for a user', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const userGroup = await umbracoApi.userGroup.getByName(defaultUserGroupName);
   await umbracoApi.user.createDefaultUser(nameOfTheUser, userEmail, [userGroup.id]);
+  userCount = await umbracoApi.user.getUsersCount();
   await umbracoUi.user.goToSection(ConstantHelper.sections.users);
 
   // Act
-  await umbracoUi.user.doesUserSectionContainUserAmount(2);
+  await umbracoUi.user.doesUserSectionContainUserAmount(userCount);
   await umbracoUi.user.searchInUserSection(nameOfTheUser);
 
   // Assert
@@ -519,10 +523,11 @@ test('can filter by status', async ({umbracoApi, umbracoUi}) => {
   const inactiveStatus = 'Inactive';
   const userGroup = await umbracoApi.userGroup.getByName(defaultUserGroupName);
   await umbracoApi.user.createDefaultUser(nameOfTheUser, userEmail, [userGroup.id]);
+  userCount = await umbracoApi.user.getUsersCount();
   await umbracoUi.user.goToSection(ConstantHelper.sections.users);
 
   // Act
-  await umbracoUi.user.doesUserSectionContainUserAmount(2);
+  await umbracoUi.user.doesUserSectionContainUserAmount(userCount);
   await umbracoUi.user.filterByStatusName(inactiveStatus);
 
   // Assert
@@ -537,10 +542,11 @@ test('can filter by user groups', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const userGroup = await umbracoApi.userGroup.getByName(defaultUserGroupName);
   await umbracoApi.user.createDefaultUser(nameOfTheUser, userEmail, [userGroup.id]);
+  userCount = await umbracoApi.user.getUsersCount();
   await umbracoUi.user.goToSection(ConstantHelper.sections.users);
 
   // Act
-  await umbracoUi.user.doesUserSectionContainUserAmount(2);
+  await umbracoUi.user.doesUserSectionContainUserAmount(userCount);
   await umbracoUi.user.filterByGroupName(defaultUserGroupName);
 
   // Assert
@@ -554,16 +560,17 @@ test('can order by newest user', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const userGroup = await umbracoApi.userGroup.getByName(defaultUserGroupName);
   await umbracoApi.user.createDefaultUser(nameOfTheUser, userEmail, [userGroup.id]);
+  userCount = await umbracoApi.user.getUsersCount();
   await umbracoUi.user.goToSection(ConstantHelper.sections.users);
 
   // Act
-  await umbracoUi.user.doesUserSectionContainUserAmount(2);
+  await umbracoUi.user.doesUserSectionContainUserAmount(userCount);
   await umbracoUi.user.orderByNewestUser();
 
   // Assert
   // Wait for filtering to be done
   await umbracoUi.waitForTimeout(200);
-  await umbracoUi.user.doesUserSectionContainUserAmount(2);
+  await umbracoUi.user.doesUserSectionContainUserAmount(userCount);
   await umbracoUi.user.isUserWithNameTheFirstUserInList(nameOfTheUser);
 });
 

--- a/tests/Umbraco.Tests.Common/Builders/ContentBuilder.cs
+++ b/tests/Umbraco.Tests.Common/Builders/ContentBuilder.cs
@@ -53,6 +53,7 @@ public class ContentBuilder
     private int? _sortOrder;
     private bool? _trashed;
     private DateTime? _updateDate;
+    private bool? _blueprint;
     private int? _versionId;
 
     DateTime? IWithCreateDateBuilder.CreateDate
@@ -145,6 +146,13 @@ public class ContentBuilder
         set => _updateDate = value;
     }
 
+    public ContentBuilder WithBlueprint(bool blueprint)
+    {
+        _blueprint = blueprint;
+
+        return this;
+    }
+
     public ContentBuilder WithVersionId(int versionId)
     {
         _versionId = versionId;
@@ -217,6 +225,7 @@ public class ContentBuilder
     {
         var id = _id ?? 0;
         var versionId = _versionId ?? 0;
+        var blueprint = _blueprint ?? false;
         var key = _key ?? Guid.NewGuid();
         var parentId = _parentId ?? -1;
         var parent = _parent;
@@ -253,6 +262,7 @@ public class ContentBuilder
 
         content.Id = id;
         content.VersionId = versionId;
+        content.Blueprint = blueprint;
         content.Key = key;
         content.CreateDate = createDate;
         content.UpdateDate = updateDate;

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/UdiGetterExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/UdiGetterExtensionsTests.cs
@@ -3,6 +3,7 @@
 
 using NUnit.Framework;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
@@ -13,15 +14,22 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Extensions;
 [TestFixture]
 public class UdiGetterExtensionsTests
 {
-    [TestCase("style.css", "umb://stylesheet/style.css")]
-    [TestCase("editor\\style.css", "umb://stylesheet/editor/style.css")]
-    [TestCase("editor/style.css", "umb://stylesheet/editor/style.css")]
-    public void GetUdiForStylesheet(string path, string expected)
+    [TestCase(Constants.ObjectTypes.Strings.DataType, "6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://data-type-container/6ad82c70685c4e049b36d81bd779d16f")]
+    [TestCase(Constants.ObjectTypes.Strings.DocumentType, "6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://document-type-container/6ad82c70685c4e049b36d81bd779d16f")]
+    [TestCase(Constants.ObjectTypes.Strings.MediaType, "6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://media-type-container/6ad82c70685c4e049b36d81bd779d16f")]
+    [TestCase(Constants.ObjectTypes.Strings.DocumentBlueprint, "6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://document-blueprint-container/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForEntityContainer(Guid containedObjectType, Guid key, string expected)
     {
-        var builder = new StylesheetBuilder();
-        var stylesheet = builder.WithPath(path).Build();
-        var result = stylesheet.GetUdi();
-        Assert.AreEqual(expected, result.ToString());
+        EntityContainer entity = new EntityContainer(containedObjectType)
+        {
+            Key = key
+        };
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
     }
 
     [TestCase("script.js", "umb://script/script.js")]
@@ -29,10 +37,195 @@ public class UdiGetterExtensionsTests
     [TestCase("editor/script.js", "umb://script/editor/script.js")]
     public void GetUdiForScript(string path, string expected)
     {
-        var builder = new ScriptBuilder();
-        var script = builder.WithPath(path).Build();
-        var result = script.GetUdi();
-        Assert.AreEqual(expected, result.ToString());
+        Script entity = new ScriptBuilder()
+            .WithPath(path)
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("style.css", "umb://stylesheet/style.css")]
+    [TestCase("editor\\style.css", "umb://stylesheet/editor/style.css")]
+    [TestCase("editor/style.css", "umb://stylesheet/editor/style.css")]
+    public void GetUdiForStylesheet(string path, string expected)
+    {
+        Stylesheet entity = new StylesheetBuilder()
+            .WithPath(path)
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", false, "umb://document/6ad82c70685c4e049b36d81bd779d16f")]
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", true, "umb://document-blueprint/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForContent(Guid key, bool blueprint, string expected)
+    {
+        Content entity = new ContentBuilder()
+            .WithKey(key)
+            .WithBlueprint(blueprint)
+            .WithContentType(ContentTypeBuilder.CreateBasicContentType())
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IContentBase)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://media/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForMedia(Guid key, string expected)
+    {
+        Media entity = new MediaBuilder()
+            .WithKey(key)
+            .WithMediaType(MediaTypeBuilder.CreateImageMediaType())
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IContentBase)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://member/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForMember(Guid key, string expected)
+    {
+        Member entity = new MemberBuilder()
+            .WithKey(key)
+            .WithMemberType(MemberTypeBuilder.CreateSimpleMemberType())
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IContentBase)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://document-type/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForContentType(Guid key, string expected)
+    {
+        IContentType entity = new ContentTypeBuilder()
+            .WithKey(key)
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IContentTypeComposition)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://media-type/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForMediaType(Guid key, string expected)
+    {
+        IMediaType entity = new MediaTypeBuilder()
+            .WithKey(key)
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IContentTypeComposition)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://member-type/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForMemberType(Guid key, string expected)
+    {
+        IMemberType entity = new MemberTypeBuilder()
+            .WithKey(key)
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IContentTypeComposition)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://data-type/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForDataType(Guid key, string expected)
+    {
+        DataType entity = new DataTypeBuilder()
+            .WithKey(key)
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://dictionary-item/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForDictionaryItem(Guid key, string expected)
+    {
+        DictionaryItem entity = new DictionaryItemBuilder()
+            .WithKey(key)
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("en-US", "umb://language/en-US")]
+    [TestCase("en", "umb://language/en")]
+    public void GetUdiForLanguage(string isoCode, string expected)
+    {
+        ILanguage entity = new LanguageBuilder()
+            .WithCultureInfo(isoCode)
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://member-group/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForMemberGroup(Guid key, string expected)
+    {
+        MemberGroup entity = new MemberGroupBuilder()
+            .WithKey(key)
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
     }
 
     [TestCase("test.cshtml", "umb://partial-view/test.cshtml")]
@@ -40,26 +233,53 @@ public class UdiGetterExtensionsTests
     [TestCase("editor/test.cshtml", "umb://partial-view/editor/test.cshtml")]
     public void GetUdiForPartialView(string path, string expected)
     {
-        var builder = new PartialViewBuilder();
-        var partialView = builder
+        IPartialView entity = new PartialViewBuilder()
             .WithPath(path)
             .Build();
-        var result = partialView.GetUdi();
-        Assert.AreEqual(expected, result.ToString());
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://relation-type/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForRelationType(Guid key, string expected)
+    {
+        IRelationTypeWithIsDependency entity = new RelationTypeBuilder()
+            .WithKey(key)
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://template/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForTemplate(Guid key, string expected)
+    {
+        ITemplate entity = new TemplateBuilder()
+            .WithKey(key)
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
     }
 
     [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://webhook/6ad82c70685c4e049b36d81bd779d16f")]
-    public void GetUdiForWebhook(string key, string expected)
+    public void GetUdiForWebhook(Guid key, string expected)
     {
-        var builder = new WebhookBuilder();
-        var webhook = builder
-            .WithKey(Guid.Parse(key))
+        Webhook entity = new WebhookBuilder()
+            .WithKey(key)
             .Build();
 
-        Udi result = webhook.GetUdi();
-        Assert.AreEqual(expected, result.ToString());
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
 
-        result = ((IEntity)webhook).GetUdi();
-        Assert.AreEqual(expected, result.ToString());
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
@@ -119,6 +119,34 @@ public class HtmlLocalLinkParserTests
     [TestCase(
         "<a href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\"type=\"media\">world</a>",
         "<a href=\"/media/1001/my-image.jpg\" title=\"world\">world</a>")]
+    [TestCase(
+        "<p><a type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a></p><p><a href=\"/{localLink:7e21a725-b905-4c5f-86dc-8c41ec116e39}\" title=\"world\" type=\"media\">world</a></p>",
+        "<p><a href=\"/my-test-url\" title=\"world\">world</a></p><p><a href=\"/media/1001/my-image.jpg\" title=\"world\">world</a></p>")]
+
+    // attributes order should not matter
+    [TestCase(
+        "<a rel=\"noopener\" title=\"world\" type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\">world</a>",
+        "<a rel=\"noopener\" title=\"world\" href=\"/my-test-url\">world</a>")]
+    [TestCase(
+        "<a rel=\"noopener\" title=\"world\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" type=\"document\">world</a>",
+        "<a rel=\"noopener\" title=\"world\" href=\"/my-test-url\">world</a>")]
+    [TestCase(
+        "<a rel=\"noopener\" title=\"world\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}#anchor\" type=\"document\">world</a>",
+        "<a rel=\"noopener\" title=\"world\" href=\"/my-test-url#anchor\">world</a>")]
+
+    // anchors and query strings
+    [TestCase(
+        "<a type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}#anchor\" title=\"world\">world</a>",
+        "<a href=\"/my-test-url#anchor\" title=\"world\">world</a>")]
+    [TestCase(
+        "<a type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}?v=1\" title=\"world\">world</a>",
+        "<a href=\"/my-test-url?v=1\" title=\"world\">world</a>")]
+
+    // custom type ignored
+    [TestCase(
+        "<a type=\"custom\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>",
+        "<a type=\"custom\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>")]
+
     // legacy
     [TestCase(
         "hello href=\"{localLink:1234}\" world ",
@@ -130,8 +158,14 @@ public class HtmlLocalLinkParserTests
         "hello href=\"{localLink:umb://document/9931BDE0AAC34BABB838909A7B47570E}\" world ",
         "hello href=\"/my-test-url\" world ")]
     [TestCase(
+        "hello href=\"{localLink:umb://document/9931BDE0AAC34BABB838909A7B47570E}#anchor\" world ",
+        "hello href=\"/my-test-url#anchor\" world ")]
+    [TestCase(
         "hello href=\"{localLink:umb://media/9931BDE0AAC34BABB838909A7B47570E}\" world ",
         "hello href=\"/media/1001/my-image.jpg\" world ")]
+    [TestCase(
+        "hello href='{localLink:umb://media/9931BDE0AAC34BABB838909A7B47570E}' world ",
+        "hello href='/media/1001/my-image.jpg' world ")]
 
     // This one has an invalid char so won't match.
     [TestCase(
@@ -139,7 +173,7 @@ public class HtmlLocalLinkParserTests
         "hello href=\"{localLink:umb^://document/9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" world ")]
     [TestCase(
         "hello href=\"{localLink:umb://document-type/9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" world ",
-        "hello href=\"#\" world ")]
+        "hello href=\"\" world ")]
     public void ParseLocalLinks(string input, string result)
     {
         // setup a mock URL provider which we'll use for testing


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes:

Fixes #17128 

### Description

This PR fixes the issue raised in #17128 where media is uploaded to the media library with dimensions in the file name but then cannot be queried using IMediaService.GetMediaByPath (see issue details for more information).

All tests have run and pass.

## Steps to Test

1. Upload a file to the media library which has the name in the format [name]_[width]x[height].[ext], i.e. test_200x200.jpg.
2. Add the following code into a template to test that the GetMediaByPath finds the media item:

```
    @inject IMediaService MediaService;

    var media = MediaService.GetMediaByPath("add path to media file here which includes the dimensions");

    if (media != null)
    {
        <p>Media Found! @media.Id</p>
    }
    else
    {
        <p>Media not found!</p>
    }
```

3. Repeat the same test with an image that does not contain the dimensions in the file name to ensure this gets returned by GetMediaByPath.

## Notes

To be honest, I can't find what may have originally created media files with dimensions in the name, it looks like something must have done this in the past when uploading (so resized images are supported).  I can't see where this is done or if it's legacy code so I couldn't see how to test this aspect.

I've completed this PR on v14 but it will need merging into v13 and v15 as well.