### PR TITLE
Issue 17128 - Fix GetMediaByPath when querying for media which has been uploaded with dimensions in the file name

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaRepository.cs
@@ -305,20 +305,20 @@ public class MediaRepository : ContentRepositoryBase<int, IMedia, MediaRepositor
 
     public IMedia? GetMediaByPath(string mediaPath)
     {
-        var umbracoFileValue = mediaPath;
         const string pattern = ".*[_][0-9]+[x][0-9]+[.].*";
         var isResized = Regex.IsMatch(mediaPath, pattern);
+        var originalMediaPath = string.Empty;
 
         // If the image has been resized we strip the "_403x328" of the original "/media/1024/koala_403x328.jpg" URL.
         if (isResized)
         {
             var underscoreIndex = mediaPath.LastIndexOf('_');
             var dotIndex = mediaPath.LastIndexOf('.');
-            umbracoFileValue = string.Concat(mediaPath.Substring(0, underscoreIndex), mediaPath.Substring(dotIndex));
+            originalMediaPath = string.Concat(mediaPath.Substring(0, underscoreIndex), mediaPath.Substring(dotIndex));
         }
 
         Sql<ISqlContext> sql = GetBaseQuery(QueryType.Single, joinMediaVersion: true)
-            .Where<MediaVersionDto>(x => x.Path == umbracoFileValue)
+            .Where<MediaVersionDto>(x => x.Path == mediaPath || (isResized && x.Path == originalMediaPath))
             .SelectTop(1);
 
         ContentDto? dto = Database.Fetch<ContentDto>(sql).FirstOrDefault();


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes:

Fixes #17128 

### Description

This PR fixes the issue raised in #17128 where media is uploaded to the media library with dimensions in the file name but then cannot be queried using IMediaService.GetMediaByPath (see issue details for more information).

All tests have run and pass.

## Steps to Test

1. Upload a file to the media library which has the name in the format [name]_[width]x[height].[ext], i.e. test_200x200.jpg.
2. Add the following code into a template to test that the GetMediaByPath finds the media item:

```
    @inject IMediaService MediaService;

    var media = MediaService.GetMediaByPath("add path to media file here which includes the dimensions");

    if (media != null)
    {
        <p>Media Found! @media.Id</p>
    }
    else
    {
        <p>Media not found!</p>
    }
```

3. Repeat the same test with an image that does not contain the dimensions in the file name to ensure this gets returned by GetMediaByPath.

## Notes

To be honest, I can't find what may have originally created media files with dimensions in the name, it looks like something must have done this in the past when uploading (so resized images are supported).  I can't see where this is done or if it's legacy code so I couldn't see how to test this aspect.

I've completed this PR on v13 but it will need merging into v14 and v15 as well.