### PR TITLE
Chore: Adds condition to `<TreatWarningsAsErrors>` for not in Debug mode

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors Condition="'$(Configuration)' != 'Debug'">true</TreatWarningsAsErrors>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>


### PR DESCRIPTION
### Description

Adds a condition to enable the `<TreatWarningsAsErrors>` when not in "Debug" compilation mode, (e.g. "Release", or other).

This is to help towards bypassing NuGet dependency vulnerability checks during active development builds.
