### PR TITLE
Fix #16659 - Unwanted node modules copying

### DIFF
--- a/src/Umbraco.Cms.Targets/buildTransitive/Umbraco.Cms.Targets.targets
+++ b/src/Umbraco.Cms.Targets/buildTransitive/Umbraco.Cms.Targets.targets
@@ -32,7 +32,7 @@
   <!-- Include App_Plugins content in output/publish directories -->
   <Target Name="IncludeAppPluginsContent" BeforeTargets="GetCopyToOutputDirectoryItems;GetCopyToPublishDirectoryItems">
     <ItemGroup>
-      <_AppPluginsFiles Include="App_Plugins\**" />
+      <_AppPluginsFiles Include="App_Plugins\**" Exclude="App_Plugins\**\node_modules\**" />
       <ContentWithTargetPath Include="@(_AppPluginsFiles)" Exclude="@(ContentWithTargetPath)" TargetPath="%(Identity)" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #16659 

### Description
As noted in #16659, everything from `App_Plugins` is copied into the web output. This is unneeded and in the case of the `node_modules` directory unwanted behavior, these files are sources and not output that Umbracco needs to serve packages/extensions.

- The old behavior has led to many of the "path too long" errors we've been seeing while building extensions. 
- It also makes the regular `dotnet build` step needlessly long on the first run as it needs to copy over loads of small files. 
- This also affects `dotnet publish` commands, the whole `node_modules` folder is included in the published output that people will try to put on a server, again leading to very slow copying times AND path too long errors

The new behavior avoids all these problems.

### Reproduction
- Set up a v15 RC2 site
- Add these files in the directory where the `csproj` file is [App_Plugins.zip](https://github.com/user-attachments/files/17473543/App_Plugins.zip)
- Run a `dotnet build` for this `csproj` file and note that in `bin\Debug\net9.0\App_Plugins\vanilla-extension` a `node_modules` folder appears
- Completely delete the `bin\Debug` folder
- Check out this PR locally and build the NuGet packages with the command: `dotnet pack --configuration Release --output .\release\`
  - Note: run this command in the directory where `umbraco.sln` is located, you will see a `release` directory appearing which will contain the NuGet outputs for Umbraco
- Copy the path of the `release` directory produced above, for example: `E:\Dev\Umbraco-CMS15\release`
- In your existing v15 RC2 site, where the `csproj` file is, run the following command: `dotnet add package Umbraco.Cms --prerelease --source E:\Dev\Umbraco-CMS15\release` (the `--source` path is the one you copied in the last step).
- Now run another `dotnet build` and note that the `node_modules` directory is NOT in the `bin\Debug\net9.0\App_Plugins\vanilla-extension` directory

Here's a video of the steps I took to verify the before and after behavior:

https://github.com/user-attachments/assets/6469e314-78b7-4390-a2cf-8e7e3130171c


