### PR TITLE
Account for AllowEditInvariantFromNonDefault when updating properties

### DIFF
--- a/src/Umbraco.Core/Services/ContentEditingService.cs
+++ b/src/Umbraco.Core/Services/ContentEditingService.cs
@@ -152,6 +152,7 @@ internal sealed class ContentEditingService
                 {
                     var currentValue = existingContent?.Properties.First(x => x.Alias == property.Alias).GetValue(null, null, false);
 
+                    // If we are not allowed to edit invariant properties, overwrite the edited property value with the current property value.
                     if(_contentSettings.AllowEditInvariantFromNonDefault is false)
                     {
                         property.SetValue(currentValue, null, null);

--- a/src/Umbraco.Core/Services/ContentEditingService.cs
+++ b/src/Umbraco.Core/Services/ContentEditingService.cs
@@ -159,7 +159,7 @@ internal sealed class ContentEditingService
                     // If we are not allowed to edit invariant properties, overwrite the edited property value with the current property value.
                     if (_contentSettings.AllowEditInvariantFromNonDefault is false && culture == defaultLanguage?.IsoCode)
                     {
-                        mergedValue = dataEditor.MergePartialPropertyValueForCulture(currentValue, editedValue, null);
+                        mergedValue = dataEditor.MergePartialPropertyValueForCulture(currentValue, mergedValue, null);
                     }
 
                     property.SetValue(mergedValue, null, null);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Editing.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Editing.cs
@@ -12,6 +12,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.PropertyEditors;
 
 public partial class BlockListElementLevelVariationTests
 {
+
     [TestCase(true)]
     [TestCase(false)]
     public async Task Can_Handle_Limited_User_Access_To_Languages_With_AllowEditInvariantFromNonDefault(bool updateWithLimitedUserAccess)

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.cs
@@ -18,6 +18,10 @@ public partial class BlockListElementLevelVariationTests : BlockEditorElementVar
         TestsRequiringAllowEditInvariantFromNonDefault.Add(nameof(Can_Publish_Invariant_Properties_Without_Default_Culture_With_AllowEditInvariantFromNonDefault));
         TestsRequiringAllowEditInvariantFromNonDefault.Add(nameof(Can_Handle_Limited_User_Access_To_Languages_With_AllowEditInvariantFromNonDefault));
         TestsRequiringAllowEditInvariantFromNonDefault.Add(nameof(Can_Handle_Limited_User_Access_To_Languages_In_Nested_Blocks_Without_Access_With_AllowEditInvariantFromNonDefault));
+        TestsRequiringAllowEditInvariantFromNonDefault.Add(nameof(Can_Handle_Limited_User_Access_To_Languages_With_AllowEditInvariantFromNonDefault) + "(True)");
+        TestsRequiringAllowEditInvariantFromNonDefault.Add(nameof(Can_Handle_Limited_User_Access_To_Languages_With_AllowEditInvariantFromNonDefault) + "(False)");
+        TestsRequiringAllowEditInvariantFromNonDefault.Add(nameof(Can_Handle_Limited_User_Access_To_Languages_In_Nested_Blocks_Without_Access_With_AllowEditInvariantFromNonDefault) + "(True)");
+        TestsRequiringAllowEditInvariantFromNonDefault.Add(nameof(Can_Handle_Limited_User_Access_To_Languages_In_Nested_Blocks_Without_Access_With_AllowEditInvariantFromNonDefault) + "(False)");
     }
 
     private IJsonSerializer JsonSerializer => GetRequiredService<IJsonSerializer>();


### PR DESCRIPTION
# Notes
- This now uses the `AllowEditInvariantFromNonDefault` to check when we have to overwrite the edited value.

# How to test
- Create multiple languages
- Create User with access to only 1 language (has to be a non default one)
- Create a Doctype with allow variance, with 2 properties, one variant and one invariant
- Create a document in each language
- Login with the user you just updated
- Update both the variant and invariant properties in the language you have access to, you should not be able to edit the invariant property, and it should not change.