### PR TITLE
V14: Reintroduce BackOfficeUserManagerAuditer

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeController.cs
@@ -185,9 +185,12 @@ public class BackOfficeController : SecurityControllerBase
     [MapToApiVersion("1.0")]
     public async Task<IActionResult> Signout(CancellationToken cancellationToken)
     {
-        var userName = await GetUserNameFromAuthCookie();
+        AuthenticateResult cookieAuthResult = await HttpContext.AuthenticateAsync(Constants.Security.BackOfficeAuthenticationType);
+        var userName = cookieAuthResult.Principal?.Identity?.Name;
+        var userId = cookieAuthResult.Principal?.Identity?.GetUserId();
 
         await _backOfficeSignInManager.SignOutAsync();
+        _backOfficeUserManager.NotifyLogoutSuccess(cookieAuthResult.Principal ?? User, userId);
 
         _logger.LogInformation(
             "User {UserName} from IP address {RemoteIpAddress} has logged out",

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/AuditLogBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/AuditLogBuilderExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.Security;
 using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Notifications;
 
 namespace Umbraco.Cms.Api.Management.DependencyInjection;
 
@@ -9,6 +11,13 @@ internal static class AuditLogBuilderExtensions
     internal static IUmbracoBuilder AddAuditLogs(this IUmbracoBuilder builder)
     {
         builder.Services.AddTransient<IAuditLogPresentationFactory, AuditLogPresentationFactory>();
+        builder.AddNotificationHandler<UserLoginSuccessNotification, BackOfficeUserManagerAuditer>();
+        builder.AddNotificationHandler<UserLogoutSuccessNotification, BackOfficeUserManagerAuditer>();
+        builder.AddNotificationHandler<UserLoginFailedNotification, BackOfficeUserManagerAuditer>();
+        builder.AddNotificationHandler<UserForgotPasswordRequestedNotification, BackOfficeUserManagerAuditer>();
+        builder.AddNotificationHandler<UserForgotPasswordChangedNotification, BackOfficeUserManagerAuditer>();
+        builder.AddNotificationHandler<UserPasswordChangedNotification, BackOfficeUserManagerAuditer>();
+        builder.AddNotificationHandler<UserPasswordResetNotification, BackOfficeUserManagerAuditer>();
 
         return builder;
     }

--- a/src/Umbraco.Cms.Api.Management/Security/BackOfficeUserManagerAuditer.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/BackOfficeUserManagerAuditer.cs
@@ -1,0 +1,150 @@
+﻿using System.Globalization;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Web.Common.Security;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.Security;
+
+/// <summary>
+///     Binds to notifications to write audit logs for the <see cref="BackOfficeUserManager" />
+/// </summary>
+internal sealed class BackOfficeUserManagerAuditer :
+    INotificationHandler<UserLoginSuccessNotification>,
+    INotificationHandler<UserLogoutSuccessNotification>,
+    INotificationHandler<UserLoginFailedNotification>,
+    INotificationHandler<UserForgotPasswordRequestedNotification>,
+    INotificationHandler<UserForgotPasswordChangedNotification>,
+    INotificationHandler<UserPasswordChangedNotification>,
+    INotificationHandler<UserPasswordResetNotification>
+{
+    private readonly IAuditService _auditService;
+    private readonly IUserService _userService;
+
+    public BackOfficeUserManagerAuditer(IAuditService auditService, IUserService userService)
+    {
+        _auditService = auditService;
+        _userService = userService;
+    }
+
+    public void Handle(UserForgotPasswordChangedNotification notification) =>
+        WriteAudit(
+            notification.PerformingUserId,
+            notification.AffectedUserId,
+            notification.IpAddress,
+            "umbraco/user/password/forgot/change",
+            "password forgot/change");
+
+    public void Handle(UserForgotPasswordRequestedNotification notification) =>
+        WriteAudit(
+            notification.PerformingUserId,
+            notification.AffectedUserId,
+            notification.IpAddress,
+            "umbraco/user/password/forgot/request",
+            "password forgot/request");
+
+    public void Handle(UserLoginFailedNotification notification) =>
+        WriteAudit(
+            notification.PerformingUserId,
+            "0",
+            notification.IpAddress,
+            "umbraco/user/sign-in/failed",
+            "login failed",
+            string.Empty);
+
+    public void Handle(UserLoginSuccessNotification notification)
+        => WriteAudit(
+            notification.PerformingUserId,
+            notification.AffectedUserId,
+            notification.IpAddress,
+            "umbraco/user/sign-in/login",
+            "login success");
+
+    public void Handle(UserLogoutSuccessNotification notification)
+        => WriteAudit(
+            notification.PerformingUserId,
+            notification.AffectedUserId,
+            notification.IpAddress,
+            "umbraco/user/sign-in/logout",
+            "logout success");
+
+    public void Handle(UserPasswordChangedNotification notification) =>
+        WriteAudit(
+            notification.PerformingUserId,
+            notification.AffectedUserId,
+            notification.IpAddress,
+            "umbraco/user/password/change",
+            "password change");
+
+    public void Handle(UserPasswordResetNotification notification) =>
+        WriteAudit(
+            notification.PerformingUserId,
+            notification.AffectedUserId,
+            notification.IpAddress,
+            "umbraco/user/password/reset",
+            "password reset");
+
+    private static string FormatEmail(IMembershipUser? user) =>
+        user is null ? string.Empty : user.Email.IsNullOrWhiteSpace() ? string.Empty : $"<{user.Email}>";
+
+    private void WriteAudit(
+        string performingId,
+        string? affectedId,
+        string ipAddress,
+        string eventType,
+        string eventDetails,
+        string? affectedDetails = null)
+    {
+        IUser? performingUser = null;
+        if (int.TryParse(performingId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var asInt))
+        {
+            performingUser = _userService.GetUserById(asInt);
+        }
+
+        var performingDetails = performingUser == null
+            ? $"User UNKNOWN:{performingId}"
+            : $"User \"{performingUser.Name}\" {FormatEmail(performingUser)}";
+
+        if (!int.TryParse(performingId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var performingIdAsInt))
+        {
+            performingIdAsInt = 0;
+        }
+
+        if (!int.TryParse(affectedId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var affectedIdAsInt))
+        {
+            affectedIdAsInt = 0;
+        }
+
+        WriteAudit(performingIdAsInt, performingDetails, affectedIdAsInt, ipAddress, eventType, eventDetails, affectedDetails);
+    }
+
+    private void WriteAudit(
+        int performingId,
+        string performingDetails,
+        int affectedId,
+        string ipAddress,
+        string eventType,
+        string eventDetails,
+        string? affectedDetails = null)
+    {
+        if (affectedDetails == null)
+        {
+            IUser? affectedUser = _userService.GetUserById(affectedId);
+            affectedDetails = affectedUser == null
+                ? $"User UNKNOWN:{affectedId}"
+                : $"User \"{affectedUser.Name}\" {FormatEmail(affectedUser)}";
+        }
+
+        _auditService.Write(
+            performingId,
+            performingDetails,
+            ipAddress,
+            DateTime.UtcNow,
+            affectedId,
+            affectedDetails,
+            eventType,
+            eventDetails);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/17308

# Notes
- Looks like `BackOfficeUserManagerAuditer` was removed during the backoffice update from v13 to v14, and this causes the missing audit logs

# How to test
- Follow steps in original issue.