### PR TITLE
Replaced deprecated navigator.platform with navigator.userAgent for platform detection.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/drawers/help/help.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/drawers/help/help.controller.js
@@ -67,7 +67,7 @@
               if(browserInfo != null){
                 vm.systemInfo.push({name :"Browser", data: browserInfo.name + " " + browserInfo.version});
               }
-              vm.systemInfo.push({name :"Browser OS", data: getPlatform()});
+              vm.systemInfo.push({name :"Browser (user agent)", data: getPlatform()});
             } );
             tourService.getGroupedTours().then(function(groupedTours) {
                 vm.tours = groupedTours;
@@ -257,7 +257,7 @@
         }
 
         function getPlatform() {
-          return window.navigator.platform;
+          return navigator.userAgent;
         }
 
         evts.push(eventsService.on("appState.tour.complete", function (event, tour) {


### PR DESCRIPTION
This fixes #13156 

### Description
Browser OS information uses the deprecated method navigator.platform. So I replaced it with `navigator.userAgent`, exactly the same as how it is used in umbraco v15.

**Note:** Though the issue is reported for v10 and v11. It is present in v13 LTS as well.

### How to test
1. Log into the Umbraco Backoffice.
2. Click on the Help icon in the top right of the screen.
3. View the System Information from the sidebar that appears.
4. Check the Browser (user agent) string

![image](https://github.com/user-attachments/assets/f88e1003-c468-4bda-97c6-03ef5c5202d7)

