### PR TITLE
v15: Add check for is master template

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/TemplateControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/TemplateControllerBase.cs
@@ -38,6 +38,10 @@ public class TemplateControllerBase : ManagementApiControllerBase
                 .WithTitle("Master template not found")
                 .WithDetail("The master template referenced in the template was not found.")
                 .Build()),
+            TemplateOperationStatus.IsReferencedMasterTemplate => BadRequest(problemDetailsBuilder
+                .WithTitle("Template is master template.")
+                .WithDetail("This template is referenced as a master template, and thus cannot be deleted.")
+                .Build()),
             _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown template operation status.")
                 .Build()),

--- a/src/Umbraco.Core/Services/OperationStatus/TemplateOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/TemplateOperationStatus.cs
@@ -8,5 +8,6 @@ public enum TemplateOperationStatus
     DuplicateAlias,
     TemplateNotFound,
     MasterTemplateNotFound,
-    CircularMasterTemplateReference
+    CircularMasterTemplateReference,
+    IsReferencedMasterTemplate
 }

--- a/src/Umbraco.Core/Services/TemplateService.cs
+++ b/src/Umbraco.Core/Services/TemplateService.cs
@@ -404,6 +404,12 @@ public class TemplateService : RepositoryService, ITemplateService
                 return Attempt.FailWithStatus<ITemplate?, TemplateOperationStatus>(TemplateOperationStatus.TemplateNotFound, null);
             }
 
+            if (template.IsMasterTemplate)
+            {
+                scope.Complete();
+                return Attempt.FailWithStatus<ITemplate?, TemplateOperationStatus>(TemplateOperationStatus.IsReferencedMasterTemplate, null);
+            }
+
             EventMessages eventMessages = EventMessagesFactory.Get();
             var deletingNotification = new TemplateDeletingNotification(template, eventMessages);
             if (scope.Notifications.PublishCancelable(deletingNotification))


### PR DESCRIPTION
# Notes
- Adds validation check, to check for `IsMasterTemplate`.

# How to test
- Create a template
- Create another template, and reference the first as a master template
- Try to delete the first template, you should no longer be able to.