### PR TITLE
V15: Adding not null when annotation

### DIFF
--- a/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
+++ b/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Navigation;
 using Umbraco.Cms.Core.Persistence.Repositories;
@@ -64,11 +65,10 @@ internal abstract class ContentNavigationServiceBase
     public bool TryGetSiblingsKeysInBin(Guid key, out IEnumerable<Guid> siblingsKeys)
         => TryGetSiblingsKeysFromStructure(_recycleBinNavigationStructure, key, out siblingsKeys);
 
-    public bool TryGetLevel(Guid contentKey, out int? level)
+    public bool TryGetLevel(Guid contentKey, [NotNullWhen(true)] out int? level)
     {
         level = 1;
-        Guid? parentKey;
-        if (TryGetParentKey(contentKey, out parentKey) is false)
+        if (TryGetParentKey(contentKey, out Guid? parentKey) is false)
         {
             level = null;
             return false;

--- a/src/Umbraco.Core/Services/Navigation/INavigationQueryService.cs
+++ b/src/Umbraco.Core/Services/Navigation/INavigationQueryService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Services.Navigation;
@@ -44,5 +45,5 @@ public interface INavigationQueryService
 
     bool TryGetSiblingsKeys(Guid key, out IEnumerable<Guid> siblingsKeys);
 
-    bool TryGetLevel(Guid contentKey, out int? level);
+    bool TryGetLevel(Guid contentKey, [NotNullWhen(true)] out int? level);
 }


### PR DESCRIPTION
## Details
- Since the `level` param was made nullable in https://github.com/umbraco/Umbraco-CMS/pull/17375, we can use the `[NotNullWhen(true)]` annotation. This PR adds that.