### PR TITLE
V15: Make default max payload size more friendly 

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -30,7 +30,12 @@ public static class UmbracoBuilderExtensions
     public static IUmbracoBuilder AddUmbracoHybridCache(this IUmbracoBuilder builder)
     {
 #pragma warning disable EXTEXP0018
-        builder.Services.AddHybridCache();
+        builder.Services.AddHybridCache(options =>
+        {
+            // We'll be a bit friendlier and default this to a higher value, you quickly hit the 1MB limit with a few languages and especially blocks.
+            // This can be overwritten later if needed.
+            options.MaximumPayloadBytes = 1024 * 1024 * 100; // 100MB
+        });
 #pragma warning restore EXTEXP0018
         builder.Services.AddSingleton<IDatabaseCacheRepository, DatabaseCacheRepository>();
         builder.Services.AddSingleton<IPublishedContentCache, DocumentCache>();


### PR DESCRIPTION
Defaults the cache `MaximumPayloadBytes` to  100MB instead of 1 MB, otherwise large content nodes may throw an error, especially if there's multiple languages and large properties like blockgrid is used. 

This setting can always be overwritten using 

```C#
public class MyComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
#pragma warning disable EXTEXP0018
        builder.Services.AddOptions<HybridCacheOptions>().Configure(x =>
        {
            x.MaximumPayloadBytes = 1024*1024;
        });
#pragma warning restore EXTEXP0018
    }
}
```
