### PR TITLE
Obsolete content dashboard settings

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/ContentDashboardSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ContentDashboardSettings.cs
@@ -6,6 +6,7 @@ namespace Umbraco.Cms.Core.Configuration;
 /// <summary>
 ///     Typed configuration options for content dashboard settings.
 /// </summary>
+[Obsolete("Scheduled for removal in v16, dashboard manipulation is now done trough frontend extensions.")]
 [UmbracoOptions(Constants.Configuration.ConfigContentDashboard)]
 public class ContentDashboardSettings
 {

--- a/tools/Umbraco.JsonSchema/UmbracoCmsSchema.cs
+++ b/tools/Umbraco.JsonSchema/UmbracoCmsSchema.cs
@@ -67,6 +67,7 @@ internal class UmbracoCmsSchema
 
         public required LegacyPasswordMigrationSettings LegacyPasswordMigration { get; set; }
 
+        [Obsolete("Scheduled for removal in v16, dashboard manipulation is now done trough frontend extensions.")]
         public required ContentDashboardSettings ContentDashboard { get; set; }
 
         public required HelpPageSettings HelpPage { get; set; }


### PR DESCRIPTION
These settings are no longer referenced in the backend code and the manipulation of dashboards should be handled trough front-end extensions