### PR TITLE
Fix security scheme issues in Delivery API OpenAPI spec

### DIFF
--- a/src/Umbraco.Cms.Api.Common/OpenApi/RemoveSecuritySchemesDocumentFilter.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/RemoveSecuritySchemesDocumentFilter.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Umbraco.Cms.Api.Common.OpenApi;
+
+/// <summary>
+/// This filter explicitly removes all security schemes from a named OpenAPI document.
+/// </summary>
+public class RemoveSecuritySchemesDocumentFilter : IDocumentFilter
+{
+    private readonly string _documentName;
+
+    public RemoveSecuritySchemesDocumentFilter(string documentName)
+        => _documentName = documentName;
+
+    public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+    {
+        if (context.DocumentName != _documentName)
+        {
+            return;
+        }
+
+        swaggerDoc.Components.SecuritySchemes.Clear();
+    }
+}

--- a/src/Umbraco.Cms.Api.Delivery/Configuration/ConfigureUmbracoDeliveryApiSwaggerGenOptions.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Configuration/ConfigureUmbracoDeliveryApiSwaggerGenOptions.cs
@@ -21,6 +21,7 @@ public class ConfigureUmbracoDeliveryApiSwaggerGenOptions: IConfigureOptions<Swa
             });
 
         swaggerGenOptions.DocumentFilter<MimeTypeDocumentFilter>(DeliveryApiConfiguration.ApiName);
+        swaggerGenOptions.DocumentFilter<RemoveSecuritySchemesDocumentFilter>(DeliveryApiConfiguration.ApiName);
 
         swaggerGenOptions.OperationFilter<SwaggerContentDocumentationFilter>();
         swaggerGenOptions.OperationFilter<SwaggerMediaDocumentationFilter>();

--- a/src/Umbraco.Cms.Api.Delivery/Configuration/ConfigureUmbracoMemberAuthenticationDeliveryApiSwaggerGenOptions.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Configuration/ConfigureUmbracoMemberAuthenticationDeliveryApiSwaggerGenOptions.cs
@@ -17,33 +17,16 @@ namespace Umbraco.Cms.Api.Delivery.Configuration;
 /// </remarks>
 public class ConfigureUmbracoMemberAuthenticationDeliveryApiSwaggerGenOptions : IConfigureOptions<SwaggerGenOptions>
 {
-    private const string AuthSchemeName = "Umbraco Member";
+    private const string AuthSchemeName = "UmbracoMember";
 
     public void Configure(SwaggerGenOptions options)
     {
-        options.AddSecurityDefinition(
-            AuthSchemeName,
-            new OpenApiSecurityScheme
-            {
-                In = ParameterLocation.Header,
-                Name = AuthSchemeName,
-                Type = SecuritySchemeType.OAuth2,
-                Description = "Umbraco Member Authentication",
-                Flows = new OpenApiOAuthFlows
-                {
-                    AuthorizationCode = new OpenApiOAuthFlow
-                    {
-                        AuthorizationUrl = new Uri(Paths.MemberApi.AuthorizationEndpoint, UriKind.Relative),
-                        TokenUrl = new Uri(Paths.MemberApi.TokenEndpoint, UriKind.Relative)
-                    }
-                }
-            });
-
         // add security requirements for content API operations
+        options.DocumentFilter<DeliveryApiSecurityFilter>();
         options.OperationFilter<DeliveryApiSecurityFilter>();
     }
 
-    private class DeliveryApiSecurityFilter : SwaggerFilterBase<ContentApiControllerBase>, IOperationFilter
+    private class DeliveryApiSecurityFilter : SwaggerFilterBase<ContentApiControllerBase>, IOperationFilter, IDocumentFilter
     {
         public void Apply(OpenApiOperation operation, OperationFilterContext context)
         {
@@ -69,6 +52,32 @@ public class ConfigureUmbracoMemberAuthenticationDeliveryApiSwaggerGenOptions : 
                     }
                 }
             };
+        }
+
+        public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+        {
+            if (context.DocumentName != DeliveryApiConfiguration.ApiName)
+            {
+                return;
+            }
+
+            swaggerDoc.Components.SecuritySchemes.Add(
+                AuthSchemeName,
+                new OpenApiSecurityScheme
+                {
+                    In = ParameterLocation.Header,
+                    Name = AuthSchemeName,
+                    Type = SecuritySchemeType.OAuth2,
+                    Description = "Umbraco Member Authentication",
+                    Flows = new OpenApiOAuthFlows
+                    {
+                        AuthorizationCode = new OpenApiOAuthFlow
+                        {
+                            AuthorizationUrl = new Uri(Paths.MemberApi.AuthorizationEndpoint, UriKind.Relative),
+                            TokenUrl = new Uri(Paths.MemberApi.TokenEndpoint, UriKind.Relative)
+                        }
+                    }
+                });
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #17300

### Description

The Delivery API OpenAPI spec wrongfully includes the back-office security scheme, because this is added to all OpenAPI specs by default.

This PR ensures that the Delivery API OpenAPI spec has _no_ security scheme by default, but still allows for opting into the Umbraco member security scheme as [per the docs](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api#testing-with-swagger).

The Umbraco member security scheme has been renamed from `Umbraco Member` to `UmbracoMember`,  as whitespaces are not allowed in OpenAPI security scheme identifiers.

### Testing this PR

1. Verify that the Delivery API OpenAPI spec does _not_ include any security schemes by default.
2. Verify that it's possible to opt into the Umbraco member security scheme.
3. For both of the above, use an OpenAPI schema validator (for example https://editor.swagger.io/ or https://validator.swagger.io/)  to ensure the validity of the spec.
4. Verify that this PR has no impact on the Management API OpenAPI spec.