### PR TITLE
Prevent Delivery API output cache configuration from affecting other controllers

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Caching/NoOutputCachePolicy.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Caching/NoOutputCachePolicy.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.OutputCaching;
+
+namespace Umbraco.Cms.Api.Delivery.Caching;
+
+internal sealed class NoOutputCachePolicy : IOutputCachePolicy
+{
+    ValueTask IOutputCachePolicy.CacheRequestAsync(OutputCacheContext context, CancellationToken cancellationToken)
+    {
+        context.EnableOutputCaching = false;
+
+        return ValueTask.CompletedTask;
+    }
+
+    ValueTask IOutputCachePolicy.ServeFromCacheAsync(OutputCacheContext context, CancellationToken cancellationToken)
+        => ValueTask.CompletedTask;
+
+    ValueTask IOutputCachePolicy.ServeResponseAsync(OutputCacheContext context, CancellationToken cancellationToken)
+        => ValueTask.CompletedTask;
+}

--- a/src/Umbraco.Cms.Api.Delivery/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Delivery/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -105,7 +105,7 @@ public static class UmbracoBuilderExtensions
 
         builder.Services.AddOutputCache(options =>
         {
-            options.AddBasePolicy(_ => { });
+            options.AddBasePolicy(build => build.AddPolicy<NoOutputCachePolicy>());
 
             if (outputCacheSettings.ContentDuration.TotalSeconds > 0)
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

It seems that [enabling output caching](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/output-caching) for the Delivery API causes other custom API controllers to have a one minute output cache. That's not really ideal.

This PR fixes the issue by explicitly applying a "no cache" policy as the default policy when enabling output caching for the Delivery API.

### Testing this PR

First and foremost, make sure the Delivery API produces output without output caching by default. An easy way to test this is to replace the default property editor value converter for text strings with one that outputs the current date and time - like this:

```cs
using Umbraco.Cms.Core;
using Umbraco.Cms.Core.Models.PublishedContent;
using Umbraco.Cms.Core.PropertyEditors;

namespace Umbraco.Cms.Web.UI.Custom;

public class MyTextStringValueConverter : PropertyValueConverterBase
{
    public override bool IsConverter(IPublishedPropertyType propertyType)
        => propertyType.EditorAlias == Constants.PropertyEditors.Aliases.TextBox;

    public override object ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
        => DateTime.Now.ToString();

    public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType)
        => PropertyCacheLevel.None;

    public override bool? IsValue(object? value, PropertyValueLevel level)
        => true;
}
```

Now enable output caching for the Delivery API:

```json
  "Umbraco": {
    "CMS": {
      "DeliveryApi": {
        "Enabled": true,
        "OutputCache": {
          "Enabled": true,
          "ContentDuration": "00:00:30",
          "MediaDuration": "01:00:00"
        }
      },
      ...
```

Add a custom controller that also outputs the current date and time:

```cs
using Microsoft.AspNetCore.Mvc;

namespace Umbraco.Cms.Web.UI.Custom;

[ApiController]
public class TestController : Controller
{
    [Route("/test/caching")]
    public IActionResult Test() => Ok(DateTime.Now);
}
```

Verify that:

1. The custom controller is unaffected by the configured output caching (date and time changes for each request).
2. The Delivery API response is output cached (date and time only changes every 30 seconds).