### PR TITLE
Use TryParse when parsing ID from claims

### DIFF
--- a/src/Umbraco.Core/Extensions/ClaimsIdentityExtensions.cs
+++ b/src/Umbraco.Core/Extensions/ClaimsIdentityExtensions.cs
@@ -330,7 +330,10 @@ public static class ClaimsIdentityExtensions
         var firstValue = identity.FindFirstValue(ClaimTypes.NameIdentifier);
         if (firstValue is not null)
         {
-            return int.Parse(firstValue, CultureInfo.InvariantCulture);
+            if (int.TryParse(firstValue, CultureInfo.InvariantCulture, out var id))
+            {
+                return id;
+            }
         }
 
         return null;


### PR DESCRIPTION
Issue: 17383

### Prerequisites

- [ ] Add an external login provider (I tested with EntraID) 

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/17383

### Description
After some investigation, I found that the issue lies in the GetId method in Umbraco.Extensions.ClaimsIdentityExtensions.

The identity, after the external login from Entra ID, already contains a NameIdentifier claim. The format of this claim is not an integer; therefore, int.Parse will throw an error.

I tried changing int.Parse to int.TryParse. This will leave the UserId as null until Umbraco fills the NameIdentifier claim with the correct userID. This fixed the error for Entra ID, but I don’t know if this could cause other issues with other providers.

<!-- Thanks for contributing to Umbraco CMS! -->
