### PR TITLE
Updated lucene net replicator package 

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -95,5 +95,7 @@
     <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.0-rc.2.24473.5" />
     <!-- NPoco.SqlServer bring in vulnerable version of Microsoft.Data.SqlClient  -->
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+    <!-- Examine.Lucene bring in a vulnerable version of Lucene.Net.Replicator -->
+    <PackageVersion Include="Lucene.Net.Replicator" Version="4.8.0-beta00017" />
   </ItemGroup>
 </Project>

--- a/src/Umbraco.Examine.Lucene/Umbraco.Examine.Lucene.csproj
+++ b/src/Umbraco.Examine.Lucene/Umbraco.Examine.Lucene.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="Examine" />
     <!-- Take top-level depedendency on System.Security.Cryptography.Xml, because Examine depends on a vulnerable version -->
     <PackageReference Include="System.Security.Cryptography.Xml" />
+    <!-- Take top-level depedendency on Lucene.Net.Replicator-->
+    <PackageReference Include="Lucene.Net.Replicator" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
It was updated to 4.8.0-beta00017 to avoid package vulnerability 