### PR TITLE
Fix out of memory file upload of 2gb+ files introduced by #14657 SVG xss

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/MediaController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MediaController.cs
@@ -788,8 +788,7 @@ public class MediaController : ContentControllerBase
                     continue;
                 }
 
-                using var stream = new MemoryStream();
-                await formFile.CopyToAsync(stream);
+                await using var stream = formFile.OpenReadStream();
                 if (_fileStreamSecurityValidator != null && _fileStreamSecurityValidator.IsConsideredSafe(stream) == false)
                 {
                     tempFiles.Notifications.Add(new BackOfficeNotification(


### PR DESCRIPTION
According to the [v13 docs](https://docs.umbraco.com/umbraco-cms/13.latest-lts/reference/configuration/maximumuploadsizesettings) you can set the max filesize using maxAllowedContentLength to 4GB, however when you drag/drop a 2gb+ file in the media library it will throw an out of memory error.

This bug was introduced with the security SVG XSS hotfix #14657 by using a MemoryStream which has a max size of 2GB instead of the FileStream which does allow for 4GB files.

