### PR TITLE
V14: Add JsonPropertyName to label configuration 

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/LabelConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/LabelConfiguration.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Umbraco.Cms.Core.PropertyEditors;
 
 /// <summary>
@@ -6,5 +8,6 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 public class LabelConfiguration : IConfigureValueType
 {
     [ConfigurationField(Constants.PropertyEditors.ConfigurationKeys.DataValueType)]
+    [JsonPropertyName("umbracoDataValueType")]
     public string ValueType { get; set; } = ValueTypes.String;
 }


### PR DESCRIPTION
Fixes: #17192 and #16613

The issue arose after using concrete configuration objects. specifically from #13605.

The issue is that in the database, and in what the frontend sends the configuration key is `umbracoDataValueType`, however, the property in the configuration object is called `ValueType`, this means that when we serialize/deserialize in `ConfigurationEditorOfTConfiguration.ToConfigurationObject` the value isn't deserialized into the property properly, and it always defaults to `"STRING"`.

To fix this I've added the `JsonPropertyName` to ensure proper serialization, however, this fix doesn't feel quite right, but I'm having a hard time finding a better solution given the whole serialize/deserialize situation. It seems like in the past this is what the `ConfigurationField` was used for, which can also be seen in `DiscoverFields` .

The "most correct" approach would probably be to re-implement `ToConfigurationObject` without using JSON and taking `LabelConfiguration` into account; however, this is a bit beyond the scope of this bugfix, I think.


## Testing

1. Run the site with source code models generator
2. Generate models
3. Enure the `Image` models `UmbracoHeight` is of type integer.

---
_This item has been added to our backlog AB#46951_