### PR TITLE
Fix block based types to not use their storage value type

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyValueEditor.cs
@@ -35,7 +35,9 @@ public abstract class BlockEditorPropertyValueEditor<TValue, TLayout> : BlockVal
         IIOHelper ioHelper)
         : this(propertyEditors, dataValueReferenceFactories, dataTypeConfigurationCache, shortStringHelper, jsonSerializer,
             StaticServiceProvider.Instance.GetRequiredService<BlockEditorVarianceHandler>(),
-            StaticServiceProvider.Instance.GetRequiredService<ILanguageService>())
+            StaticServiceProvider.Instance.GetRequiredService<ILanguageService>(),
+            ioHelper,
+            attribute)
     {
     }
 
@@ -46,8 +48,10 @@ public abstract class BlockEditorPropertyValueEditor<TValue, TLayout> : BlockVal
         IShortStringHelper shortStringHelper,
         IJsonSerializer jsonSerializer,
         BlockEditorVarianceHandler blockEditorVarianceHandler,
-        ILanguageService languageService)
-        : base(propertyEditors, dataTypeConfigurationCache, shortStringHelper, jsonSerializer, dataValueReferenceFactories, blockEditorVarianceHandler, languageService) =>
+        ILanguageService languageService,
+        IIOHelper ioHelper,
+        DataEditorAttribute attribute)
+        : base(propertyEditors, dataTypeConfigurationCache, shortStringHelper, jsonSerializer, dataValueReferenceFactories, blockEditorVarianceHandler, languageService, ioHelper, attribute) =>
         _jsonSerializer = jsonSerializer;
 
     /// <inheritdoc />

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockGridPropertyEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockGridPropertyEditorBase.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.DataAnnotations;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Cache.PropertyEditors;
+using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Core.Models.Validation;
@@ -37,11 +38,12 @@ public abstract class BlockGridPropertyEditorBase : DataEditor
     #region Value Editor
 
     protected override IDataValueEditor CreateValueEditor() =>
-        DataValueEditorFactory.Create<BlockGridEditorPropertyValueEditor>();
+        DataValueEditorFactory.Create<BlockGridEditorPropertyValueEditor>(Attribute!);
 
     internal class BlockGridEditorPropertyValueEditor : BlockEditorPropertyValueEditor<BlockGridValue, BlockGridLayoutItem>
     {
         public BlockGridEditorPropertyValueEditor(
+            DataEditorAttribute attribute,
             PropertyEditorCollection propertyEditors,
             DataValueReferenceFactoryCollection dataValueReferenceFactories,
             IDataTypeConfigurationCache dataTypeConfigurationCache,
@@ -52,8 +54,9 @@ public abstract class BlockGridPropertyEditorBase : DataEditor
             IBlockEditorElementTypeCache elementTypeCache,
             IPropertyValidationService propertyValidationService,
             BlockEditorVarianceHandler blockEditorVarianceHandler,
-            ILanguageService languageService)
-            : base(propertyEditors, dataValueReferenceFactories, dataTypeConfigurationCache, shortStringHelper, jsonSerializer, blockEditorVarianceHandler, languageService)
+            ILanguageService languageService,
+            IIOHelper ioHelper)
+            : base(propertyEditors, dataValueReferenceFactories, dataTypeConfigurationCache, shortStringHelper, jsonSerializer, blockEditorVarianceHandler, languageService, ioHelper, attribute)
         {
             BlockEditorValues = new BlockEditorValues<BlockGridValue, BlockGridLayoutItem>(new BlockGridEditorDataConverter(jsonSerializer), elementTypeCache, logger);
             Validators.Add(new BlockEditorValidator<BlockGridValue, BlockGridLayoutItem>(propertyValidationService, BlockEditorValues, elementTypeCache));

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditorBase.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Cache.PropertyEditors;
+using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Core.Models.Validation;
@@ -47,11 +48,12 @@ public abstract class BlockListPropertyEditorBase : DataEditor
     protected virtual BlockEditorDataConverter<BlockListValue, BlockListLayoutItem> CreateBlockEditorDataConverter() => new BlockListEditorDataConverter(_jsonSerializer);
 
     protected override IDataValueEditor CreateValueEditor() =>
-        DataValueEditorFactory.Create<BlockListEditorPropertyValueEditor>(CreateBlockEditorDataConverter());
+        DataValueEditorFactory.Create<BlockListEditorPropertyValueEditor>(Attribute!, CreateBlockEditorDataConverter());
 
     internal class BlockListEditorPropertyValueEditor : BlockEditorPropertyValueEditor<BlockListValue, BlockListLayoutItem>
     {
         public BlockListEditorPropertyValueEditor(
+            DataEditorAttribute attribute,
             BlockEditorDataConverter<BlockListValue, BlockListLayoutItem> blockEditorDataConverter,
             PropertyEditorCollection propertyEditors,
             DataValueReferenceFactoryCollection dataValueReferenceFactories,
@@ -63,8 +65,10 @@ public abstract class BlockListPropertyEditorBase : DataEditor
             IJsonSerializer jsonSerializer,
             IPropertyValidationService propertyValidationService,
             BlockEditorVarianceHandler blockEditorVarianceHandler,
-            ILanguageService languageService)
-            : base(propertyEditors, dataValueReferenceFactories, dataTypeConfigurationCache, shortStringHelper, jsonSerializer, blockEditorVarianceHandler, languageService)
+            ILanguageService languageService,
+            IIOHelper ioHelper
+            )
+            : base(propertyEditors, dataValueReferenceFactories, dataTypeConfigurationCache, shortStringHelper, jsonSerializer, blockEditorVarianceHandler, languageService, ioHelper, attribute)
         {
             BlockEditorValues = new BlockEditorValues<BlockListValue, BlockListLayoutItem>(blockEditorDataConverter, elementTypeCache, logger);
             Validators.Add(new BlockEditorValidator<BlockListValue, BlockListLayoutItem>(propertyValidationService, BlockEditorValues, elementTypeCache));

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
@@ -42,7 +42,10 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
             jsonSerializer,
             dataValueReferenceFactoryCollection,
             StaticServiceProvider.Instance.GetRequiredService<BlockEditorVarianceHandler>(),
-            StaticServiceProvider.Instance.GetRequiredService<ILanguageService>())
+            StaticServiceProvider.Instance.GetRequiredService<ILanguageService>(),
+            ioHelper,
+            attribute
+            )
     {
     }
 
@@ -53,8 +56,10 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
         IJsonSerializer jsonSerializer,
         DataValueReferenceFactoryCollection dataValueReferenceFactoryCollection,
         BlockEditorVarianceHandler blockEditorVarianceHandler,
-        ILanguageService languageService)
-        : base(shortStringHelper, jsonSerializer)
+        ILanguageService languageService,
+        IIOHelper ioHelper,
+        DataEditorAttribute attribute)
+        : base(shortStringHelper, jsonSerializer, ioHelper, attribute)
     {
         _propertyEditors = propertyEditors;
         _dataTypeConfigurationCache = dataTypeConfigurationCache;

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
@@ -65,7 +65,7 @@ public class RichTextPropertyEditor : DataEditor
     /// </summary>
     /// <returns></returns>
     protected override IDataValueEditor CreateValueEditor() =>
-        DataValueEditorFactory.Create<RichTextPropertyValueEditor>();
+        DataValueEditorFactory.Create<RichTextPropertyValueEditor>(Attribute!);
 
     protected override IConfigurationEditor CreateConfigurationEditor() =>
         new RichTextConfigurationEditor(_ioHelper);
@@ -87,6 +87,7 @@ public class RichTextPropertyEditor : DataEditor
         private readonly ILogger<RichTextPropertyValueEditor> _logger;
 
         public RichTextPropertyValueEditor(
+            DataEditorAttribute attribute,
             PropertyEditorCollection propertyEditors,
             IDataTypeConfigurationCache dataTypeReadCache,
             ILogger<RichTextPropertyValueEditor> logger,
@@ -102,8 +103,9 @@ public class RichTextPropertyEditor : DataEditor
             DataValueReferenceFactoryCollection dataValueReferenceFactoryCollection,
             IRichTextRequiredValidator richTextRequiredValidator,
             BlockEditorVarianceHandler blockEditorVarianceHandler,
-            ILanguageService languageService)
-            : base(propertyEditors, dataTypeReadCache, shortStringHelper, jsonSerializer, dataValueReferenceFactoryCollection, blockEditorVarianceHandler, languageService)
+            ILanguageService languageService,
+            IIOHelper ioHelper)
+            : base(propertyEditors, dataTypeReadCache, shortStringHelper, jsonSerializer, dataValueReferenceFactoryCollection, blockEditorVarianceHandler, languageService, ioHelper, attribute)
         {
             _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
             _imageSourceParser = imageSourceParser;

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueEditorReuseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueEditorReuseTests.cs
@@ -39,8 +39,9 @@ public class DataValueEditorReuseTests
         var blockVarianceHandler = new BlockEditorVarianceHandler(Mock.Of<ILanguageService>());
         _dataValueEditorFactoryMock
             .Setup(m =>
-                m.Create<BlockListPropertyEditorBase.BlockListEditorPropertyValueEditor>(It.IsAny<BlockEditorDataConverter<BlockListValue, BlockListLayoutItem>>()))
+                m.Create<BlockListPropertyEditorBase.BlockListEditorPropertyValueEditor>(It.IsAny<DataEditorAttribute>(), It.IsAny<BlockEditorDataConverter<BlockListValue, BlockListLayoutItem>>()))
             .Returns(() => new BlockListPropertyEditorBase.BlockListEditorPropertyValueEditor(
+                new DataEditorAttribute("a"),
                 new BlockListEditorDataConverter(Mock.Of<IJsonSerializer>()),
                 _propertyEditorCollection,
                 _dataValueReferenceFactories,
@@ -52,7 +53,9 @@ public class DataValueEditorReuseTests
                 Mock.Of<IJsonSerializer>(),
                 Mock.Of<IPropertyValidationService>(),
                 blockVarianceHandler,
-                Mock.Of<ILanguageService>()));
+                Mock.Of<ILanguageService>(),
+                Mock.Of<IIOHelper>()
+                ));
     }
 
     [Test]
@@ -109,7 +112,7 @@ public class DataValueEditorReuseTests
         Assert.NotNull(dataValueEditor2);
         Assert.AreNotSame(dataValueEditor1, dataValueEditor2);
         _dataValueEditorFactoryMock.Verify(
-            m => m.Create<BlockListPropertyEditorBase.BlockListEditorPropertyValueEditor>(It.IsAny<BlockEditorDataConverter<BlockListValue, BlockListLayoutItem>>()),
+            m => m.Create<BlockListPropertyEditorBase.BlockListEditorPropertyValueEditor>(It.IsAny<DataEditorAttribute>(), It.IsAny<BlockEditorDataConverter<BlockListValue, BlockListLayoutItem>>()),
             Times.Exactly(2));
     }
 
@@ -131,7 +134,7 @@ public class DataValueEditorReuseTests
         Assert.AreEqual("config", ((DataValueEditor)dataValueEditor2).ConfigurationObject);
         Assert.AreNotSame(dataValueEditor1, dataValueEditor2);
         _dataValueEditorFactoryMock.Verify(
-            m => m.Create<BlockListPropertyEditorBase.BlockListEditorPropertyValueEditor>(It.IsAny<BlockEditorDataConverter<BlockListValue, BlockListLayoutItem>>()),
+            m => m.Create<BlockListPropertyEditorBase.BlockListEditorPropertyValueEditor>(It.IsAny<DataEditorAttribute>(), It.IsAny<BlockEditorDataConverter<BlockListValue, BlockListLayoutItem>>()),
             Times.Exactly(2));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/17430

### Description
Due to a wrong base constructor used, was the attribute defining the storage type not used for block based types.
