### PR TITLE
Fix wrong urls returned from Url() extension and do not show unavailable paths on info tab

### DIFF
--- a/src/Umbraco.Core/Services/DocumentUrlService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlService.cs
@@ -548,8 +548,15 @@ public class DocumentUrlService : IDocumentUrlService
                     Dictionary<string, Domain> domainDictionary = await domainDictionaryTask;
                     if (domainDictionary.TryGetValue(culture, out Domain? domain))
                     {
-                        foundDomain = domain;
-                        break;
+                        Attempt<Guid> domainKeyAttempt = _idKeyMap.GetKeyForId(domain.ContentId, UmbracoObjectTypes.Document);
+                        if (domainKeyAttempt.Success)
+                        {
+                            if (_publishStatusQueryService.IsDocumentPublished(domainKeyAttempt.Result, culture))
+                            {
+                                foundDomain = domain;
+                                break;
+                            }
+                        }
                     }
                 }
 

--- a/src/Umbraco.Core/Services/DocumentUrlService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlService.cs
@@ -488,6 +488,12 @@ public class DocumentUrlService : IDocumentUrlService
             }
         }
 
+        if (_globalSettings.ForceCombineUrlPathLeftToRight
+            || CultureInfo.GetCultureInfo(cultureOrDefault).TextInfo.IsRightToLeft is false)
+        {
+            urlSegments.Reverse();
+        }
+
         if (foundDomain is not null)
         {
             //we found a domain, and not to construct the route in the funny legacy way


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/17443
### Description
Fixes two bugs

1.  A bug that made the urls available on the info tab, even when the domain-item was not published in the specific culture

1. The bug mentioned in https://github.com/umbraco/Umbraco-CMS/issues/17443 where url segments was combined right-to-left no matter culture