### PR TITLE
V15: Fix reload memory cache endpoint

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/CollectPublishedCacheController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/CollectPublishedCacheController.cs
@@ -1,7 +1,6 @@
 ﻿using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Core.PublishedCache;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PublishedCache;
 
@@ -14,6 +13,6 @@ public class CollectPublishedCacheController : PublishedCacheControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<IActionResult> Collect(CancellationToken cancellationToken)
     {
-        return Ok();
+        return StatusCode(501);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/CollectPublishedCacheController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/CollectPublishedCacheController.cs
@@ -10,9 +10,9 @@ public class CollectPublishedCacheController : PublishedCacheControllerBase
 {
     [HttpPost("collect")]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status501NotImplemented)]
     public async Task<IActionResult> Collect(CancellationToken cancellationToken)
     {
-        return StatusCode(501);
+        return StatusCode(StatusCodes.Status501NotImplemented);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/StatusPublishedCacheController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/StatusPublishedCacheController.cs
@@ -1,7 +1,6 @@
 ﻿using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Core.PublishedCache;
 
 namespace Umbraco.Cms.Api.Management.Controllers.PublishedCache;
 
@@ -13,5 +12,7 @@ public class StatusPublishedCacheController : PublishedCacheControllerBase
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
     public async Task<ActionResult<string>> Status(CancellationToken cancellationToken)
-        => await Task.FromResult(Ok("Obsoleted"));
+    {
+        return StatusCode(501);
+    }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/StatusPublishedCacheController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/StatusPublishedCacheController.cs
@@ -10,9 +10,9 @@ public class StatusPublishedCacheController : PublishedCacheControllerBase
 {
     [HttpGet("status")]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status501NotImplemented)]
     public async Task<ActionResult<string>> Status(CancellationToken cancellationToken)
     {
-        return StatusCode(501);
+        return StatusCode(StatusCodes.Status501NotImplemented);
     }
 }

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/ContentCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/ContentCacheRefresher.cs
@@ -88,6 +88,15 @@ public sealed class ContentCacheRefresher : PayloadCacheRefresherBase<ContentCac
 
         foreach (JsonPayload payload in payloads)
         {
+            if (payload.Id != default)
+            {
+                // By INT Id
+                isolatedCache.Clear(RepositoryCacheKeys.GetKey<IContent, int>(payload.Id));
+
+                // By GUID Key
+                isolatedCache.Clear(RepositoryCacheKeys.GetKey<IContent, Guid?>(payload.Key));
+            }
+
             // remove those that are in the branch
             if (payload.ChangeTypes.HasTypesAny(TreeChangeTypes.RefreshBranch | TreeChangeTypes.Remove))
             {
@@ -109,12 +118,6 @@ public sealed class ContentCacheRefresher : PayloadCacheRefresherBase<ContentCac
             HandlePublishedAsync(payload, CancellationToken.None).GetAwaiter().GetResult();
             if (payload.Id != default)
             {
-                // By INT Id
-                isolatedCache.Clear(RepositoryCacheKeys.GetKey<IContent, int>(payload.Id));
-
-                // By GUID Key
-                isolatedCache.Clear(RepositoryCacheKeys.GetKey<IContent, Guid?>(payload.Key));
-
                 _idKeyMap.ClearCache(payload.Id);
             }
             if (payload.Key.HasValue)


### PR DESCRIPTION
# Notes
- Moves the check for ID further down, as all the cache refreshing have logic for (when TreeChangeTypes.RefreshAll) where an id is not needed

# How to test
- Use the endpoints either from swagger, or in the Published Status management dashboard in settings. 