### PR TITLE
Include create date in audit item

### DIFF
--- a/src/Umbraco.Core/Models/AuditItem.cs
+++ b/src/Umbraco.Core/Models/AuditItem.cs
@@ -7,6 +7,21 @@ public sealed class AuditItem : EntityBase, IAuditItem
     /// <summary>
     ///     Initializes a new instance of the <see cref="AuditItem" /> class.
     /// </summary>
+    public AuditItem(int objectId, AuditType type, int userId, string? entityType, DateTime createDate, string? comment = null, string? parameters = null)
+    {
+        DisableChangeTracking();
+
+        Id = objectId;
+        Comment = comment;
+        AuditType = type;
+        UserId = userId;
+        EntityType = entityType;
+        Parameters = parameters;
+        CreateDate = createDate;
+
+        EnableChangeTracking();
+    }
+
     public AuditItem(int objectId, AuditType type, int userId, string? entityType, string? comment = null, string? parameters = null)
     {
         DisableChangeTracking();

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/AuditRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/AuditRepository.cs
@@ -29,7 +29,7 @@ internal class AuditRepository : EntityRepositoryBase<int, IAuditItem>, IAuditRe
 
         List<LogDto>? dtos = Database.Fetch<LogDto>(sql);
 
-        return dtos.Select(x => new AuditItem(x.NodeId, Enum<AuditType>.Parse(x.Header), x.UserId ?? Constants.Security.UnknownUserId, x.EntityType, x.Comment, x.Parameters)).ToList();
+        return dtos.Select(x => new AuditItem(x.NodeId, Enum<AuditType>.Parse(x.Header), x.UserId ?? Constants.Security.UnknownUserId, x.EntityType, x.Datestamp, x.Comment, x.Parameters)).ToList();
     }
 
     public void CleanLogs(int maximumAgeOfLogsInMinutes)
@@ -104,7 +104,7 @@ internal class AuditRepository : EntityRepositoryBase<int, IAuditItem>, IAuditRe
         totalRecords = page.TotalItems;
 
         var items = page.Items.Select(
-            dto => new AuditItem(dto.NodeId, Enum<AuditType>.ParseOrNull(dto.Header) ?? AuditType.Custom, dto.UserId ?? Constants.Security.UnknownUserId, dto.EntityType, dto.Comment, dto.Parameters)).ToList();
+            dto => new AuditItem(dto.NodeId, Enum<AuditType>.ParseOrNull(dto.Header) ?? AuditType.Custom, dto.UserId ?? Constants.Security.UnknownUserId, dto.EntityType, dto.Datestamp, dto.Comment, dto.Parameters)).ToList();
 
         // map the DateStamp
         for (var i = 0; i < items.Count; i++)
@@ -144,12 +144,12 @@ internal class AuditRepository : EntityRepositoryBase<int, IAuditItem>, IAuditRe
     protected override IAuditItem? PerformGet(int id)
     {
         Sql<ISqlContext> sql = GetBaseQuery(false);
-        sql.Where(GetBaseWhereClause(), new { Id = id });
+        sql.Where(GetBaseWhereClause(), new { id = id });
 
         LogDto? dto = Database.First<LogDto>(sql);
         return dto == null
             ? null
-            : new AuditItem(dto.NodeId, Enum<AuditType>.Parse(dto.Header), dto.UserId ?? Constants.Security.UnknownUserId, dto.EntityType, dto.Comment, dto.Parameters);
+            : new AuditItem(dto.NodeId, Enum<AuditType>.Parse(dto.Header), dto.UserId ?? Constants.Security.UnknownUserId, dto.EntityType, dto.Datestamp, dto.Comment, dto.Parameters);
     }
 
     protected override IEnumerable<IAuditItem> PerformGetAll(params int[]? ids) => throw new NotImplementedException();
@@ -162,7 +162,7 @@ internal class AuditRepository : EntityRepositoryBase<int, IAuditItem>, IAuditRe
 
         List<LogDto>? dtos = Database.Fetch<LogDto>(sql);
 
-        return dtos.Select(x => new AuditItem(x.NodeId, Enum<AuditType>.Parse(x.Header), x.UserId ?? Constants.Security.UnknownUserId, x.EntityType, x.Comment, x.Parameters)).ToList();
+        return dtos.Select(x => new AuditItem(x.NodeId, Enum<AuditType>.Parse(x.Header), x.UserId ?? Constants.Security.UnknownUserId, x.EntityType, x.Datestamp,  x.Comment, x.Parameters)).ToList();
     }
 
     protected override Sql<ISqlContext> GetBaseQuery(bool isCount)
@@ -184,7 +184,7 @@ internal class AuditRepository : EntityRepositoryBase<int, IAuditItem>, IAuditRe
         return sql;
     }
 
-    protected override string GetBaseWhereClause() => "id = @id";
+    protected override string GetBaseWhereClause() => "umbracoLog.id = @id";
 
     protected override IEnumerable<string> GetDeleteClauses() => throw new NotImplementedException();
 }


### PR DESCRIPTION
Fixes #16998 

The datestamp was never set as the create date in the `AuditItem` entity.

## Testing

1. Create and publish some content.
2. Request the audit log
3. Ensure that the `CreateDate` is set

I used this composer

```C#
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Notifications;
using Umbraco.Cms.Core.Services;

namespace Umbraco.Cms.Web.UI;

public class Test : INotificationHandler<UmbracoApplicationStartedNotification>
{
    private readonly IAuditService _auditService;

    public Test(IAuditService auditService)
    {
        _auditService = auditService;
    }

    public void Handle(UmbracoApplicationStartedNotification notification)
    {
        var logs = _auditService.GetLogs(1059);
    }
}


public class Comp : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.AddNotificationHandler<UmbracoApplicationStartedNotification, Test>();
    }
}

```