### PR TITLE
Fixed issue with double reversed url segments

### DIFF
--- a/src/Umbraco.Core/Services/DocumentUrlService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlService.cs
@@ -597,7 +597,6 @@ public class DocumentUrlService : IDocumentUrlService
     private string GetFullUrl(bool isRootFirstItem, List<string> reversedUrlSegments, Domain? foundDomain)
     {
         var urlSegments = new List<string>(reversedUrlSegments);
-        urlSegments.Reverse();
 
         if (foundDomain is not null)
         {

--- a/src/Umbraco.Core/Services/DocumentUrlService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlService.cs
@@ -488,8 +488,9 @@ public class DocumentUrlService : IDocumentUrlService
             }
         }
 
-        if (_globalSettings.ForceCombineUrlPathLeftToRight
-            || CultureInfo.GetCultureInfo(cultureOrDefault).TextInfo.IsRightToLeft is false)
+        var leftToRight = _globalSettings.ForceCombineUrlPathLeftToRight
+                          || CultureInfo.GetCultureInfo(cultureOrDefault).TextInfo.IsRightToLeft is false;
+        if (leftToRight)
         {
             urlSegments.Reverse();
         }
@@ -501,7 +502,7 @@ public class DocumentUrlService : IDocumentUrlService
         }
 
         var isRootFirstItem = GetTopMostRootKey(isDraft, cultureOrDefault) == ancestorsOrSelfKeysArray.Last();
-        return GetFullUrl(isRootFirstItem, urlSegments, null);
+        return GetFullUrl(isRootFirstItem, urlSegments, null, leftToRight);
     }
 
     public bool HasAny()
@@ -584,14 +585,15 @@ public class DocumentUrlService : IDocumentUrlService
 
            var isRootFirstItem = GetTopMostRootKey(false, culture) == ancestorsOrSelfKeysArray.Last();
 
-           if (_globalSettings.ForceCombineUrlPathLeftToRight
-               || CultureInfo.GetCultureInfo(culture).TextInfo.IsRightToLeft is false)
+           var leftToRight = _globalSettings.ForceCombineUrlPathLeftToRight
+                             || CultureInfo.GetCultureInfo(culture).TextInfo.IsRightToLeft is false;
+           if (leftToRight)
            {
                urlSegments.Reverse();
            }
 
            result.Add(new UrlInfo(
-               text: GetFullUrl(isRootFirstItem, urlSegments, foundDomain),
+               text: GetFullUrl(isRootFirstItem, urlSegments, foundDomain, leftToRight),
                isUrl: hasUrlInCulture,
                culture: culture
            ));
@@ -601,7 +603,7 @@ public class DocumentUrlService : IDocumentUrlService
         return result;
     }
 
-    private string GetFullUrl(bool isRootFirstItem, List<string> segments, Domain? foundDomain)
+    private string GetFullUrl(bool isRootFirstItem, List<string> segments, Domain? foundDomain, bool leftToRight)
     {
         var urlSegments = new List<string>(segments);
 
@@ -610,7 +612,18 @@ public class DocumentUrlService : IDocumentUrlService
             return foundDomain.Name.EnsureEndsWith("/") + string.Join('/', urlSegments);
         }
 
-        return '/' + string.Join('/', urlSegments.Skip(_globalSettings.HideTopLevelNodeFromPath && isRootFirstItem ? 1 : 0));
+        var hideTopLevel = _globalSettings.HideTopLevelNodeFromPath && isRootFirstItem;
+        if (leftToRight)
+        {
+            return '/' + string.Join('/', urlSegments.Skip(hideTopLevel ? 1 : 0));
+        }
+
+        if (hideTopLevel)
+        {
+            urlSegments.RemoveAt(urlSegments.Count - 1);
+        }
+
+        return '/' + string.Join('/', urlSegments);
     }
 
     public async Task CreateOrUpdateUrlSegmentsWithDescendantsAsync(Guid key)

--- a/src/Umbraco.Core/Services/DocumentUrlService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlService.cs
@@ -583,6 +583,13 @@ public class DocumentUrlService : IDocumentUrlService
            }
 
            var isRootFirstItem = GetTopMostRootKey(false, culture) == ancestorsOrSelfKeysArray.Last();
+
+           if (_globalSettings.ForceCombineUrlPathLeftToRight
+               || CultureInfo.GetCultureInfo(culture).TextInfo.IsRightToLeft is false)
+           {
+               urlSegments.Reverse();
+           }
+
            result.Add(new UrlInfo(
                text: GetFullUrl(isRootFirstItem, urlSegments, foundDomain),
                isUrl: hasUrlInCulture,
@@ -594,9 +601,9 @@ public class DocumentUrlService : IDocumentUrlService
         return result;
     }
 
-    private string GetFullUrl(bool isRootFirstItem, List<string> reversedUrlSegments, Domain? foundDomain)
+    private string GetFullUrl(bool isRootFirstItem, List<string> segments, Domain? foundDomain)
     {
-        var urlSegments = new List<string>(reversedUrlSegments);
+        var urlSegments = new List<string>(segments);
 
         if (foundDomain is not null)
         {


### PR DESCRIPTION
### Description
After https://github.com/umbraco/Umbraco-CMS/issues/17443 the urls without a domain is reversed twice.

### Tests
- Setup structure without setting a domain. E.g. the starter kit and verify urls looks correct both inbound and outbound