### PR TITLE
Removed a series of obsolete attributes

### DIFF
--- a/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
@@ -1905,125 +1905,112 @@ public static class PublishedContentExtensions
 
     #endregion
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IPublishedContent? Ancestor(this IPublishedContent content, int maxLevel)
     {
         return content.Ancestor(GetPublishedCache(content), GetNavigationQueryService(content), maxLevel);
     }
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IPublishedContent? Ancestor(this IPublishedContent content, string contentTypeAlias)
     {
         return content.Ancestor(GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias);
     }
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static T? Ancestor<T>(this IPublishedContent content, int maxLevel)
         where T : class, IPublishedContent
     {
         return Ancestor<T>(content, GetPublishedCache(content), GetNavigationQueryService(content), maxLevel);
     }
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IEnumerable<IPublishedContent> Ancestors(this IPublishedContent content, int maxLevel)
     {
         return content.Ancestors(GetPublishedCache(content), GetNavigationQueryService(content), maxLevel);
     }
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IEnumerable<IPublishedContent> Ancestors(this IPublishedContent content, string contentTypeAlias)
     {
         return content.Ancestors(GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias);
     }
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IEnumerable<T> Ancestors<T>(this IPublishedContent content)
         where T : class, IPublishedContent
     {
         return Ancestors<T>(content, GetPublishedCache(content), GetNavigationQueryService(content));
     }
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IEnumerable<T> Ancestors<T>(this IPublishedContent content, int maxLevel)
         where T : class, IPublishedContent
     {
         return Ancestors<T>(content, GetPublishedCache(content), GetNavigationQueryService(content), maxLevel);
     }
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IPublishedContent AncestorOrSelf(this IPublishedContent content, int maxLevel)
     {
         return AncestorOrSelf(content, GetPublishedCache(content), GetNavigationQueryService(content), maxLevel);
     }
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IPublishedContent AncestorOrSelf(this IPublishedContent content, string contentTypeAlias)
     {
         return AncestorOrSelf(content, GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias);
     }
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static T? AncestorOrSelf<T>(this IPublishedContent content, int maxLevel)
         where T : class, IPublishedContent
     {
         return AncestorOrSelf<T>(content, GetPublishedCache(content), GetNavigationQueryService(content), maxLevel);
     }
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<IPublishedContent> AncestorsOrSelf(this IPublishedContent content, int maxLevel)
     {
         return content.AncestorsOrSelf(GetPublishedCache(content), GetNavigationQueryService(content), maxLevel);
     }
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<IPublishedContent> AncestorsOrSelf(this IPublishedContent content, string contentTypeAlias)
     {
         return content.Ancestors(GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias);
     }
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<T> AncestorsOrSelf<T>(this IPublishedContent content, int maxLevel)
         where T : class, IPublishedContent
     {
         return AncestorsOrSelf<T>(content, GetPublishedCache(content), GetNavigationQueryService(content), maxLevel);
     }
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<IPublishedContent> AncestorsOrSelf(this IPublishedContent content, bool orSelf,
         Func<IPublishedContent, bool>? func)
     {
         return AncestorsOrSelf(content, GetPublishedCache(content), GetNavigationQueryService(content), orSelf, func);
     }
 
-    [Obsolete(
-        "Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<IPublishedContent> Breadcrumbs(
         this IPublishedContent content,
         bool andSelf = true) =>
         content.Breadcrumbs(GetPublishedCache(content), GetNavigationQueryService(content), andSelf);
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<IPublishedContent> Breadcrumbs(
         this IPublishedContent content,
         int minLevel,
         bool andSelf = true) =>
         content.Breadcrumbs(GetPublishedCache(content), GetNavigationQueryService(content), minLevel, andSelf);
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<IPublishedContent> Breadcrumbs<T>(
         this IPublishedContent content,
         bool andSelf = true)
         where T : class, IPublishedContent=>
         content.Breadcrumbs<T>(GetPublishedCache(content), GetNavigationQueryService(content), andSelf);
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<IPublishedContent> Children(
         this IPublishedContent content,
         IVariationContextAccessor? variationContextAccessor,
         string? culture = null)
         => Children(content, variationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<IPublishedContent> Children(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2031,7 +2018,6 @@ public static class PublishedContentExtensions
         string? culture = null) =>
         content.Children(variationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture).Where(predicate);
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<IPublishedContent> ChildrenOfType(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2041,7 +2027,6 @@ public static class PublishedContentExtensions
             GetNavigationQueryService(content), x => x.ContentType.Alias.InvariantEquals(contentTypeAlias),
             culture);
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<T> Children<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2050,7 +2035,6 @@ public static class PublishedContentExtensions
         content.Children(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), culture).OfType<T>();
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static DataTable ChildrenAsTable(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2063,7 +2047,6 @@ public static class PublishedContentExtensions
         => GenerateDataTable(content, variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), contentTypeService, mediaTypeService, memberTypeService, publishedUrlProvider, contentTypeAliasFilter, culture);
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
     public static IEnumerable<IPublishedContent> DescendantsOrSelfOfType(
         this IEnumerable<IPublishedContent> parentNodes,
         IVariationContextAccessor variationContextAccessor,
@@ -2072,7 +2055,7 @@ public static class PublishedContentExtensions
         x.DescendantsOrSelfOfType(variationContextAccessor, GetPublishedCache(parentNodes.First()),
             GetNavigationQueryService(parentNodes.First()), docTypeAlias, culture));
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IEnumerable<T> DescendantsOrSelf<T>(
         this IEnumerable<IPublishedContent> parentNodes,
         IVariationContextAccessor variationContextAccessor,
@@ -2082,7 +2065,7 @@ public static class PublishedContentExtensions
             GetNavigationQueryService(parentNodes.First()), culture));
 
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IEnumerable<IPublishedContent> Descendants(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2090,7 +2073,7 @@ public static class PublishedContentExtensions
         content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), false, null, culture);
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IEnumerable<IPublishedContent> Descendants(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2099,7 +2082,7 @@ public static class PublishedContentExtensions
         content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), false, p => p.Level >= level, culture);
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IEnumerable<IPublishedContent> DescendantsOfType(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2107,7 +2090,7 @@ public static class PublishedContentExtensions
         content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), false, p => p.ContentType.Alias.InvariantEquals(contentTypeAlias), culture);
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IEnumerable<T> Descendants<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2116,7 +2099,7 @@ public static class PublishedContentExtensions
         content.Descendants(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), culture).OfType<T>();
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IEnumerable<T> Descendants<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2126,7 +2109,7 @@ public static class PublishedContentExtensions
         content.Descendants(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), level, culture).OfType<T>();
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IEnumerable<IPublishedContent> DescendantsOrSelf(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2134,7 +2117,7 @@ public static class PublishedContentExtensions
         content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), true, null, culture);
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IEnumerable<IPublishedContent> DescendantsOrSelf(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2143,7 +2126,7 @@ public static class PublishedContentExtensions
         content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), true, p => p.Level >= level, culture);
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IEnumerable<IPublishedContent> DescendantsOrSelfOfType(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2152,7 +2135,7 @@ public static class PublishedContentExtensions
         content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), true, p => p.ContentType.Alias.InvariantEquals(contentTypeAlias), culture);
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IEnumerable<T> DescendantsOrSelf<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2161,7 +2144,7 @@ public static class PublishedContentExtensions
         content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), culture).OfType<T>();
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IEnumerable<T> DescendantsOrSelf<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2171,7 +2154,7 @@ public static class PublishedContentExtensions
         content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), level, culture).OfType<T>();
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IPublishedContent? Descendant(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2179,7 +2162,7 @@ public static class PublishedContentExtensions
         content.Children(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), culture)?.FirstOrDefault();
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IPublishedContent? Descendant(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2188,7 +2171,7 @@ public static class PublishedContentExtensions
         .EnumerateDescendants(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), false, culture).FirstOrDefault(x => x.Level == level);
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IPublishedContent? DescendantOfType(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2198,7 +2181,7 @@ public static class PublishedContentExtensions
             GetNavigationQueryService(content), false, culture)
         .FirstOrDefault(x => x.ContentType.Alias.InvariantEquals(contentTypeAlias));
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static T? Descendant<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2207,7 +2190,7 @@ public static class PublishedContentExtensions
         content.EnumerateDescendants(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), false, culture).FirstOrDefault(x => x is T) as T;
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static T? Descendant<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2217,7 +2200,7 @@ public static class PublishedContentExtensions
         content.Descendant(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), level, culture) as T;
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IPublishedContent? DescendantOrSelf(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2226,7 +2209,7 @@ public static class PublishedContentExtensions
         .EnumerateDescendants(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), true, culture).FirstOrDefault(x => x.Level == level);
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IPublishedContent? DescendantOrSelfOfType(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2236,7 +2219,7 @@ public static class PublishedContentExtensions
             GetNavigationQueryService(content), true, culture)
         .FirstOrDefault(x => x.ContentType.Alias.InvariantEquals(contentTypeAlias));
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static T? DescendantOrSelf<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2245,7 +2228,7 @@ public static class PublishedContentExtensions
         content.EnumerateDescendants(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), true, culture).FirstOrDefault(x => x is T) as T;
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static T? DescendantOrSelf<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2256,7 +2239,7 @@ public static class PublishedContentExtensions
             GetNavigationQueryService(content), level, culture) as T;
 
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IPublishedContent? FirstChild(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2264,7 +2247,7 @@ public static class PublishedContentExtensions
         content.Children(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), culture)?.FirstOrDefault();
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IPublishedContent? FirstChildOfType(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2273,7 +2256,7 @@ public static class PublishedContentExtensions
         content.ChildrenOfType(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), contentTypeAlias, culture)?.FirstOrDefault();
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IPublishedContent? FirstChild(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2282,7 +2265,7 @@ public static class PublishedContentExtensions
         => content.Children(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), predicate, culture)?.FirstOrDefault();
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IPublishedContent? FirstChild(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2291,7 +2274,7 @@ public static class PublishedContentExtensions
         .Children(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), x => x.Key == uniqueId, culture)?.FirstOrDefault();
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static T? FirstChild<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2300,7 +2283,7 @@ public static class PublishedContentExtensions
         content.Children<T>(variationContextAccessor, GetPublishedCache(content),
             GetNavigationQueryService(content), culture)?.FirstOrDefault();
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static T? FirstChild<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2353,7 +2336,7 @@ public static class PublishedContentExtensions
         string? culture = null) => SiblingsAndSelfOfType(content, variationContextAccessor, GetPublishedCache(content),
         GetNavigationQueryService(content), contentTypeAlias, culture);
 
-    [Obsolete("Please use IPublishedCache and IDocumentNavigationQueryService or IMediaNavigationQueryService directly. This will be removed in a future version of Umbraco")]
+
     public static IEnumerable<T> SiblingsAndSelf<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,


### PR DESCRIPTION
### Description
This PR removes a lot of obsolete attributes from the extension methods.

As long as you would like to actually have IPublishedContent returned, this is stille the most effective way.
We need to document cases where you only need the keys.