### PR TITLE
Explicit cache entry settings and expose cache settings in json schema

### DIFF
--- a/src/Umbraco.Core/Constants-Configuration.cs
+++ b/src/Umbraco.Core/Constants-Configuration.cs
@@ -66,7 +66,6 @@ public static partial class Constants
         public const string ConfigPackageManifests = ConfigPrefix + "PackageManifests";
         public const string ConfigWebhook = ConfigPrefix + "Webhook";
         public const string ConfigCache = ConfigPrefix + "Cache";
-        public const string ConfigCacheEntry = ConfigCache + ":Entry";
 
         public static class NamedOptions
         {
@@ -79,13 +78,6 @@ public static partial class Constants
                 public const string MediaTypes = "MediaTypes";
 
                 public const string MemberTypes = "MemberTypes";
-            }
-
-            public static class CacheEntry
-            {
-                public const string Document = "Document";
-
-                public const string Media = "Media";
             }
         }
     }

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Configuration.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Configuration.cs
@@ -104,10 +104,6 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.Configure<InstallDefaultDataSettings>(
             Constants.Configuration.NamedOptions.InstallDefaultData.MemberTypes,
             builder.Config.GetSection($"{Constants.Configuration.ConfigInstallDefaultData}:{Constants.Configuration.NamedOptions.InstallDefaultData.MemberTypes}"));
-        builder.Services.Configure<CacheEntrySettings>(Constants.Configuration.NamedOptions.CacheEntry.Media,
-            builder.Config.GetSection($"{Constants.Configuration.ConfigCacheEntry}:{Constants.Configuration.NamedOptions.CacheEntry.Media}"));
-        builder.Services.Configure<CacheEntrySettings>(Constants.Configuration.NamedOptions.CacheEntry.Document,
-            builder.Config.GetSection($"{Constants.Configuration.ConfigCacheEntry}:{Constants.Configuration.NamedOptions.CacheEntry.Document}"));
 
         return builder;
     }

--- a/src/Umbraco.Core/Models/CacheEntrySettings.cs
+++ b/src/Umbraco.Core/Models/CacheEntrySettings.cs
@@ -16,4 +16,5 @@ public class CacheEntrySettings
 
     [DefaultValue(StaticSeedCacheDuration)]
     public  TimeSpan SeedCacheDuration { get; set; } = TimeSpan.Parse(StaticSeedCacheDuration);
+
 }

--- a/src/Umbraco.Core/Models/CacheSettings.cs
+++ b/src/Umbraco.Core/Models/CacheSettings.cs
@@ -25,4 +25,13 @@ public class CacheSettings
     [Obsolete("Use Cache:Entry:Document:SeedCacheDuration instead")]
     [DefaultValue(StaticSeedCacheDuration)]
     public TimeSpan SeedCacheDuration { get; set; } = TimeSpan.Parse(StaticSeedCacheDuration);
+
+    public CacheEntry Entry { get; set; } = new CacheEntry();
+
+    public class CacheEntry
+    {
+        public CacheEntrySettings Document { get; set; } = new CacheEntrySettings();
+
+        public CacheEntrySettings Media { get; set; } = new CacheEntrySettings();
+    }
 }

--- a/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
@@ -24,7 +24,7 @@ internal sealed class DocumentCacheService : IDocumentCacheService
     private readonly IEnumerable<IDocumentSeedKeyProvider> _seedKeyProviders;
     private readonly IPublishedModelFactory _publishedModelFactory;
     private readonly IPreviewService _previewService;
-    private readonly CacheEntrySettings _cacheEntrySettings;
+    private readonly CacheSettings _cacheSettings;
     private HashSet<Guid>? _seedKeys;
     private HashSet<Guid> SeedKeys
     {
@@ -54,7 +54,7 @@ internal sealed class DocumentCacheService : IDocumentCacheService
         IPublishedContentFactory publishedContentFactory,
         ICacheNodeFactory cacheNodeFactory,
         IEnumerable<IDocumentSeedKeyProvider> seedKeyProviders,
-        IOptionsMonitor<CacheEntrySettings> cacheEntrySettings,
+        IOptions<CacheSettings> cacheSettings,
         IPublishedModelFactory publishedModelFactory,
         IPreviewService previewService)
     {
@@ -67,7 +67,7 @@ internal sealed class DocumentCacheService : IDocumentCacheService
         _seedKeyProviders = seedKeyProviders;
         _publishedModelFactory = publishedModelFactory;
         _previewService = previewService;
-        _cacheEntrySettings = cacheEntrySettings.Get(Constants.Configuration.NamedOptions.CacheEntry.Document);
+        _cacheSettings = cacheSettings.Value;
     }
 
     public async Task<IPublishedContent?> GetByKeyAsync(Guid key, bool? preview = null)
@@ -221,8 +221,8 @@ internal sealed class DocumentCacheService : IDocumentCacheService
 
     private HybridCacheEntryOptions GetSeedEntryOptions() => new()
     {
-        Expiration = _cacheEntrySettings.SeedCacheDuration,
-        LocalCacheExpiration = _cacheEntrySettings.SeedCacheDuration
+        Expiration = _cacheSettings.SeedCacheDuration,
+        LocalCacheExpiration = _cacheSettings.SeedCacheDuration
     };
 
     private HybridCacheEntryOptions GetEntryOptions(Guid key)
@@ -234,8 +234,8 @@ internal sealed class DocumentCacheService : IDocumentCacheService
 
         return new HybridCacheEntryOptions
         {
-            Expiration = _cacheEntrySettings.RemoteCacheDuration,
-            LocalCacheExpiration = _cacheEntrySettings.LocalCacheDuration,
+            Expiration = _cacheSettings.Entry.Document.RemoteCacheDuration,
+            LocalCacheExpiration = _cacheSettings.Entry.Document.LocalCacheDuration,
         };
     }
 

--- a/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
@@ -221,8 +221,8 @@ internal sealed class DocumentCacheService : IDocumentCacheService
 
     private HybridCacheEntryOptions GetSeedEntryOptions() => new()
     {
-        Expiration = _cacheSettings.SeedCacheDuration,
-        LocalCacheExpiration = _cacheSettings.SeedCacheDuration
+        Expiration = _cacheSettings.Entry.Document.SeedCacheDuration,
+        LocalCacheExpiration = _cacheSettings.Entry.Document.SeedCacheDuration
     };
 
     private HybridCacheEntryOptions GetEntryOptions(Guid key)

--- a/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
@@ -23,7 +23,7 @@ internal class MediaCacheService : IMediaCacheService
     private readonly ICacheNodeFactory _cacheNodeFactory;
     private readonly IEnumerable<IMediaSeedKeyProvider> _seedKeyProviders;
     private readonly IPublishedModelFactory _publishedModelFactory;
-    private readonly CacheEntrySettings _cacheEntrySettings;
+    private readonly CacheSettings _cacheSettings;
 
     private HashSet<Guid>? _seedKeys;
     private HashSet<Guid> SeedKeys
@@ -55,7 +55,7 @@ internal class MediaCacheService : IMediaCacheService
         ICacheNodeFactory cacheNodeFactory,
         IEnumerable<IMediaSeedKeyProvider> seedKeyProviders,
         IPublishedModelFactory publishedModelFactory,
-        IOptionsMonitor<CacheEntrySettings> cacheEntrySettings)
+        IOptions<CacheSettings> cacheSettings)
     {
         _databaseCacheRepository = databaseCacheRepository;
         _idKeyMap = idKeyMap;
@@ -65,7 +65,7 @@ internal class MediaCacheService : IMediaCacheService
         _cacheNodeFactory = cacheNodeFactory;
         _seedKeyProviders = seedKeyProviders;
         _publishedModelFactory = publishedModelFactory;
-        _cacheEntrySettings = cacheEntrySettings.Get(Constants.Configuration.NamedOptions.CacheEntry.Media);
+        _cacheSettings = cacheSettings.Value;
     }
 
     public async Task<IPublishedContent?> GetByKeyAsync(Guid key)
@@ -268,16 +268,16 @@ internal class MediaCacheService : IMediaCacheService
 
         return new HybridCacheEntryOptions
         {
-            Expiration = _cacheEntrySettings.RemoteCacheDuration,
-            LocalCacheExpiration = _cacheEntrySettings.LocalCacheDuration,
+            Expiration = _cacheSettings.Entry.Media.RemoteCacheDuration,
+            LocalCacheExpiration = _cacheSettings.Entry.Media.LocalCacheDuration,
         };
     }
 
 
     private HybridCacheEntryOptions GetSeedEntryOptions() => new()
     {
-        Expiration = _cacheEntrySettings.SeedCacheDuration,
-        LocalCacheExpiration = _cacheEntrySettings.SeedCacheDuration,
+        Expiration = _cacheSettings.SeedCacheDuration,
+        LocalCacheExpiration = _cacheSettings.SeedCacheDuration,
     };
 
     private string GetCacheKey(Guid key, bool preview) => preview ? $"{key}+draft" : $"{key}";

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheMockTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheMockTests.cs
@@ -94,8 +94,6 @@ public class DocumentHybridCacheMockTests : UmbracoIntegrationTestWithContent
             });
 
         _mockedNucacheRepository.Setup(r => r.DeleteContentItemAsync(It.IsAny<int>()));
-        var optionsMonitorMock = new Mock<IOptionsMonitor<CacheEntrySettings>>();
-        optionsMonitorMock.Setup(x => x.Get(It.IsAny<string>())).Returns(new CacheEntrySettings());
 
         _mockDocumentCacheService = new DocumentCacheService(
             _mockedNucacheRepository.Object,
@@ -105,7 +103,7 @@ public class DocumentHybridCacheMockTests : UmbracoIntegrationTestWithContent
             GetRequiredService<IPublishedContentFactory>(),
             GetRequiredService<ICacheNodeFactory>(),
             GetSeedProviders(),
-            optionsMonitorMock.Object,
+            new OptionsWrapper<CacheSettings>(new CacheSettings()),
             GetRequiredService<IPublishedModelFactory>(),
             GetRequiredService<IPreviewService>());
 

--- a/tools/Umbraco.JsonSchema/UmbracoCmsSchema.cs
+++ b/tools/Umbraco.JsonSchema/UmbracoCmsSchema.cs
@@ -1,5 +1,6 @@
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Models;
 
 internal class UmbracoCmsSchema
 {
@@ -79,5 +80,6 @@ internal class UmbracoCmsSchema
         public required MarketplaceSettings Marketplace { get; set; }
 
         public required WebhookSettings Webhook { get; set; }
+        public required CacheSettings Cache { get; set; }
     }
 }


### PR DESCRIPTION
### Description
Exposes the cache settings in the json-schema file. To make it completely explicit I changed from named options to regular entries in the settings class.

### Test
- Ensure the Cache settings are exposed
- Ensure the cache logic works as expected