### PR TITLE
Hotfix: observe expose with blocks variant id

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entry.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entry.context.ts
@@ -577,7 +577,7 @@ export abstract class UmbBlockEntryContext<
 		if (!variantId || !this.#contentKey) return;
 		// TODO: Handle variantId changes
 		this.observe(
-			this._manager?.hasExposeOf(this.#contentKey),
+			this._manager?.hasExposeOf(this.#contentKey, variantId),
 			(hasExpose) => {
 				this.#hasExpose.setValue(hasExpose);
 			},

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-manager.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-manager.context.ts
@@ -189,8 +189,7 @@ export abstract class UmbBlockManagerContext<
 		);
 	}
 
-	hasExposeOf(contentKey: string) {
-		const variantId = this.#variantId.getValue();
+	hasExposeOf(contentKey: string, variantId: UmbVariantId) {
 		if (!variantId) return;
 		return this.#exposes.asObservablePart((source) =>
 			source.some((x) => x.contentKey === contentKey && variantId.compare(x)),

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
@@ -118,19 +118,19 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 			);
 
 			this.observe(
-				this.contentKey,
-				(contentKey) => {
-					if (!contentKey) return;
+				observeMultiple([this.contentKey, this.variantId]),
+				([contentKey, variantId]) => {
+					if (!contentKey || !variantId) return;
 
 					this.observe(
-						manager.hasExposeOf(contentKey),
+						manager.hasExposeOf(contentKey, variantId),
 						(exposed) => {
 							this.#exposed.setValue(exposed);
 						},
 						'observeHasExpose',
 					);
 				},
-				'observeContentKey',
+				'observeContentKeyAndVariantId',
 			);
 		}).asPromise();
 


### PR DESCRIPTION
To make UI for Invariant Blocks work with the new Expose feature, the UI needs to observe the expose property with its own Variant ID instead of the Managers.

This fixes, so an Invariant Block UI is displayed accordingly to its expose state.

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
