### PR TITLE
Bugfix: Document Workspace Info Links error

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/views/info/document-workspace-view-info-links.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/views/info/document-workspace-view-info-links.element.ts
@@ -48,8 +48,7 @@ export class UmbDocumentWorkspaceViewInfoLinksElement extends UmbLitElement {
 
 	async #requestUrls() {
 		if (this._isNew) return;
-
-		if (!this._unique) throw new Error('Document unique is required');
+		if (!this._unique) return;
 
 		const { data } = await this.#documentUrlRepository.requestItems([this._unique]);
 


### PR DESCRIPTION
### Description

When navigating away from the Document Workspace Info view, the Links component will throw an error as the `_unique` is `undefined`.

Given how `observeMultiple` works, it should be expected that `_unique` may be `undefined` when navigating away from the Info view, so rather than throw a console error, we don't attempt to request the link URLs.
