### PR TITLE
Support for SMTP OAuth authentication through easier IEmailSenderClient implementation

### DIFF
--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -46,6 +46,7 @@ using Umbraco.Cms.Infrastructure.HealthChecks;
 using Umbraco.Cms.Infrastructure.HostedServices;
 using Umbraco.Cms.Infrastructure.Install;
 using Umbraco.Cms.Infrastructure.Mail;
+using Umbraco.Cms.Infrastructure.Mail.Interfaces;
 using Umbraco.Cms.Infrastructure.Manifest;
 using Umbraco.Cms.Infrastructure.Migrations;
 using Umbraco.Cms.Infrastructure.Migrations.Install;
@@ -172,14 +173,18 @@ public static partial class UmbracoBuilderExtensions
 
         builder.Services.AddSingleton<IContentLastChanceFinder, ContentFinderByConfigured404>();
 
+        builder.Services.AddTransient<IEmailSenderClient, BasicSmtpEmailSenderClient>();
+
         // replace
         builder.Services.AddSingleton<IEmailSender, EmailSender>(
             services => new EmailSender(
                 services.GetRequiredService<ILogger<EmailSender>>(),
                 services.GetRequiredService<IOptionsMonitor<GlobalSettings>>(),
                 services.GetRequiredService<IEventAggregator>(),
+                services.GetRequiredService<IEmailSenderClient>(),
                 services.GetService<INotificationHandler<SendEmailNotification>>(),
-                services.GetService<INotificationAsyncHandler<SendEmailNotification>>()));
+                services.GetService<INotificationAsyncHandler<SendEmailNotification>>()
+                ));
         builder.Services.AddTransient<IUserInviteSender, EmailUserInviteSender>();
         builder.Services.AddTransient<IUserForgotPasswordSender, EmailUserForgotPasswordSender>();
 

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -183,8 +183,8 @@ public static partial class UmbracoBuilderExtensions
                 services.GetRequiredService<IEventAggregator>(),
                 services.GetRequiredService<IEmailSenderClient>(),
                 services.GetService<INotificationHandler<SendEmailNotification>>(),
-                services.GetService<INotificationAsyncHandler<SendEmailNotification>>()
-                ));
+                services.GetService<INotificationAsyncHandler<SendEmailNotification>>()));
+
         builder.Services.AddTransient<IUserInviteSender, EmailUserInviteSender>();
         builder.Services.AddTransient<IUserForgotPasswordSender, EmailUserForgotPasswordSender>();
 

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -181,6 +181,7 @@ public static partial class UmbracoBuilderExtensions
                 services.GetRequiredService<ILogger<EmailSender>>(),
                 services.GetRequiredService<IOptionsMonitor<GlobalSettings>>(),
                 services.GetRequiredService<IEventAggregator>(),
+                services.GetRequiredService<IEmailSenderClient>(),
                 services.GetService<INotificationHandler<SendEmailNotification>>(),
                 services.GetService<INotificationAsyncHandler<SendEmailNotification>>()
                 ));

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -181,7 +181,6 @@ public static partial class UmbracoBuilderExtensions
                 services.GetRequiredService<ILogger<EmailSender>>(),
                 services.GetRequiredService<IOptionsMonitor<GlobalSettings>>(),
                 services.GetRequiredService<IEventAggregator>(),
-                services.GetRequiredService<IEmailSenderClient>(),
                 services.GetService<INotificationHandler<SendEmailNotification>>(),
                 services.GetService<INotificationAsyncHandler<SendEmailNotification>>()
                 ));

--- a/src/Umbraco.Infrastructure/Extensions/EmailMessageExtensions.cs
+++ b/src/Umbraco.Infrastructure/Extensions/EmailMessageExtensions.cs
@@ -4,7 +4,7 @@ using Umbraco.Cms.Core.Models.Email;
 
 namespace Umbraco.Cms.Infrastructure.Extensions;
 
-public static class EmailMessageExtensions
+internal static class EmailMessageExtensions
 {
     public static MimeMessage ToMimeMessage(this EmailMessage mailMessage, string configuredFromAddress)
     {

--- a/src/Umbraco.Infrastructure/Extensions/EmailMessageExtensions.cs
+++ b/src/Umbraco.Infrastructure/Extensions/EmailMessageExtensions.cs
@@ -4,7 +4,7 @@ using Umbraco.Cms.Core.Models.Email;
 
 namespace Umbraco.Cms.Infrastructure.Extensions;
 
-internal static class EmailMessageExtensions
+public static class EmailMessageExtensions
 {
     public static MimeMessage ToMimeMessage(this EmailMessage mailMessage, string configuredFromAddress)
     {

--- a/src/Umbraco.Infrastructure/Mail/BasicSmtpEmailSenderClient.cs
+++ b/src/Umbraco.Infrastructure/Mail/BasicSmtpEmailSenderClient.cs
@@ -1,0 +1,46 @@
+using System.Net.Mail;
+using Microsoft.Extensions.Options;
+using MimeKit;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Infrastructure.Mail.Interfaces;
+using SecureSocketOptions = MailKit.Security.SecureSocketOptions;
+using SmtpClient = MailKit.Net.Smtp.SmtpClient;
+
+namespace Umbraco.Cms.Infrastructure.Mail
+{
+    /// <summary>
+    ///    A basic SMTP email sender client using MailKits SMTP client
+    /// </summary>
+    public class BasicSmtpEmailSenderClient : IEmailSenderClient
+    {
+        private readonly GlobalSettings _globalSettings;
+        public BasicSmtpEmailSenderClient(IOptionsMonitor<GlobalSettings> globalSettings)
+        {
+            _globalSettings = globalSettings.CurrentValue;
+        }
+
+        public async Task SendAsync(MimeMessage? message) {
+            using var client = new SmtpClient();
+
+            await client.ConnectAsync(
+                _globalSettings.Smtp!.Host,
+            _globalSettings.Smtp.Port,
+                (SecureSocketOptions)(int)_globalSettings.Smtp.SecureSocketOptions);
+
+            if (!string.IsNullOrWhiteSpace(_globalSettings.Smtp.Username) &&
+            !string.IsNullOrWhiteSpace(_globalSettings.Smtp.Password))
+            {
+                await client.AuthenticateAsync(_globalSettings.Smtp.Username, _globalSettings.Smtp.Password);
+            }
+
+            if (_globalSettings.Smtp.DeliveryMethod == SmtpDeliveryMethod.Network)
+            {
+                await client.SendAsync(message);
+            }
+            else
+            {
+                client.Send(message);
+            }
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Mail/BasicSmtpEmailSenderClient.cs
+++ b/src/Umbraco.Infrastructure/Mail/BasicSmtpEmailSenderClient.cs
@@ -1,7 +1,8 @@
 using System.Net.Mail;
 using Microsoft.Extensions.Options;
-using MimeKit;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Models.Email;
+using Umbraco.Cms.Infrastructure.Extensions;
 using Umbraco.Cms.Infrastructure.Mail.Interfaces;
 using SecureSocketOptions = MailKit.Security.SecureSocketOptions;
 using SmtpClient = MailKit.Net.Smtp.SmtpClient;
@@ -9,7 +10,7 @@ using SmtpClient = MailKit.Net.Smtp.SmtpClient;
 namespace Umbraco.Cms.Infrastructure.Mail
 {
     /// <summary>
-    ///    A basic SMTP email sender client using MailKits SMTP client
+    ///    A basic SMTP email sender client using MailKits SMTP client.
     /// </summary>
     public class BasicSmtpEmailSenderClient : IEmailSenderClient
     {
@@ -19,7 +20,8 @@ namespace Umbraco.Cms.Infrastructure.Mail
             _globalSettings = globalSettings.CurrentValue;
         }
 
-        public async Task SendAsync(MimeMessage? message) {
+        public async Task SendAsync(EmailMessage message)
+        {
             using var client = new SmtpClient();
 
             await client.ConnectAsync(
@@ -33,13 +35,15 @@ namespace Umbraco.Cms.Infrastructure.Mail
                 await client.AuthenticateAsync(_globalSettings.Smtp.Username, _globalSettings.Smtp.Password);
             }
 
+            var mimeMessage = message.ToMimeMessage(_globalSettings.Smtp!.From);
+
             if (_globalSettings.Smtp.DeliveryMethod == SmtpDeliveryMethod.Network)
             {
-                await client.SendAsync(message);
+                await client.SendAsync(mimeMessage);
             }
             else
             {
-                client.Send(message);
+                client.Send(mimeMessage);
             }
         }
     }

--- a/src/Umbraco.Infrastructure/Mail/EmailSender.cs
+++ b/src/Umbraco.Infrastructure/Mail/EmailSender.cs
@@ -2,11 +2,13 @@
 // See LICENSE for more details.
 
 using MailKit.Net.Smtp;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MimeKit;
 using MimeKit.IO;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Mail;
 using Umbraco.Cms.Core.Models.Email;
@@ -30,9 +32,8 @@ public class EmailSender : IEmailSender
     public EmailSender(
         ILogger<EmailSender> logger,
         IOptionsMonitor<GlobalSettings> globalSettings,
-        IEventAggregator eventAggregator,
-        IEmailSenderClient emailSenderClient)
-        : this(logger, globalSettings, eventAggregator, emailSenderClient,null, null)
+        IEventAggregator eventAggregator)
+        : this(logger, globalSettings, eventAggregator, null, null)
     {
     }
 
@@ -40,7 +41,6 @@ public class EmailSender : IEmailSender
         ILogger<EmailSender> logger,
         IOptionsMonitor<GlobalSettings> globalSettings,
         IEventAggregator eventAggregator,
-        IEmailSenderClient emailSenderClient,
         INotificationHandler<SendEmailNotification>? handler1,
         INotificationAsyncHandler<SendEmailNotification>? handler2)
     {
@@ -48,7 +48,7 @@ public class EmailSender : IEmailSender
         _eventAggregator = eventAggregator;
         _globalSettings = globalSettings.CurrentValue;
         _notificationHandlerRegistered = handler1 is not null || handler2 is not null;
-        _emailSenderClient = emailSenderClient;
+        _emailSenderClient = StaticServiceProvider.Instance.GetRequiredService<IEmailSenderClient>();
         globalSettings.OnChange(x => _globalSettings = x);
     }
 

--- a/src/Umbraco.Infrastructure/Mail/EmailSender.cs
+++ b/src/Umbraco.Infrastructure/Mail/EmailSender.cs
@@ -29,14 +29,17 @@ public class EmailSender : IEmailSender
     private readonly bool _notificationHandlerRegistered;
     private GlobalSettings _globalSettings;
     private readonly IEmailSenderClient _emailSenderClient;
+
+    [Obsolete("Please use the non-obsolete constructor. Will be removed in V17.")]
     public EmailSender(
         ILogger<EmailSender> logger,
         IOptionsMonitor<GlobalSettings> globalSettings,
         IEventAggregator eventAggregator)
-        : this(logger, globalSettings, eventAggregator, null, null)
+        : this(logger, globalSettings, eventAggregator,null, null)
     {
     }
 
+    [Obsolete("Please use the non-obsolete constructor. Will be removed in V17.")]
     public EmailSender(
         ILogger<EmailSender> logger,
         IOptionsMonitor<GlobalSettings> globalSettings,
@@ -49,6 +52,23 @@ public class EmailSender : IEmailSender
         _globalSettings = globalSettings.CurrentValue;
         _notificationHandlerRegistered = handler1 is not null || handler2 is not null;
         _emailSenderClient = StaticServiceProvider.Instance.GetRequiredService<IEmailSenderClient>();
+        globalSettings.OnChange(x => _globalSettings = x);
+    }
+
+    [ActivatorUtilitiesConstructor]
+    public EmailSender(
+        ILogger<EmailSender> logger,
+        IOptionsMonitor<GlobalSettings> globalSettings,
+        IEventAggregator eventAggregator,
+        IEmailSenderClient emailSenderClient,
+        INotificationHandler<SendEmailNotification>? handler1,
+        INotificationAsyncHandler<SendEmailNotification>? handler2)
+    {
+        _logger = logger;
+        _eventAggregator = eventAggregator;
+        _globalSettings = globalSettings.CurrentValue;
+        _notificationHandlerRegistered = handler1 is not null || handler2 is not null;
+        _emailSenderClient = emailSenderClient;
         globalSettings.OnChange(x => _globalSettings = x);
     }
 

--- a/src/Umbraco.Infrastructure/Mail/EmailSender.cs
+++ b/src/Umbraco.Infrastructure/Mail/EmailSender.cs
@@ -153,9 +153,7 @@ public class EmailSender : IEmailSender
             while (true);
         }
 
-        var mailMessage = message.ToMimeMessage(_globalSettings.Smtp!.From);
-
-        await _emailSenderClient.SendAsync(mailMessage);
+        await _emailSenderClient.SendAsync(message);
     }
 
 }

--- a/src/Umbraco.Infrastructure/Mail/EmailSender.cs
+++ b/src/Umbraco.Infrastructure/Mail/EmailSender.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using System.Net.Mail;
 using MailKit.Net.Smtp;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -13,8 +12,7 @@ using Umbraco.Cms.Core.Mail;
 using Umbraco.Cms.Core.Models.Email;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Infrastructure.Extensions;
-using SecureSocketOptions = MailKit.Security.SecureSocketOptions;
-using SmtpClient = MailKit.Net.Smtp.SmtpClient;
+using Umbraco.Cms.Infrastructure.Mail.Interfaces;
 
 namespace Umbraco.Cms.Infrastructure.Mail;
 
@@ -28,12 +26,13 @@ public class EmailSender : IEmailSender
     private readonly ILogger<EmailSender> _logger;
     private readonly bool _notificationHandlerRegistered;
     private GlobalSettings _globalSettings;
-
+    private readonly IEmailSenderClient _emailSenderClient;
     public EmailSender(
         ILogger<EmailSender> logger,
         IOptionsMonitor<GlobalSettings> globalSettings,
-        IEventAggregator eventAggregator)
-        : this(logger, globalSettings, eventAggregator, null, null)
+        IEventAggregator eventAggregator,
+        IEmailSenderClient emailSenderClient)
+        : this(logger, globalSettings, eventAggregator, emailSenderClient,null, null)
     {
     }
 
@@ -41,6 +40,7 @@ public class EmailSender : IEmailSender
         ILogger<EmailSender> logger,
         IOptionsMonitor<GlobalSettings> globalSettings,
         IEventAggregator eventAggregator,
+        IEmailSenderClient emailSenderClient,
         INotificationHandler<SendEmailNotification>? handler1,
         INotificationAsyncHandler<SendEmailNotification>? handler2)
     {
@@ -48,6 +48,7 @@ public class EmailSender : IEmailSender
         _eventAggregator = eventAggregator;
         _globalSettings = globalSettings.CurrentValue;
         _notificationHandlerRegistered = handler1 is not null || handler2 is not null;
+        _emailSenderClient = emailSenderClient;
         globalSettings.OnChange(x => _globalSettings = x);
     }
 
@@ -152,29 +153,9 @@ public class EmailSender : IEmailSender
             while (true);
         }
 
-        using var client = new SmtpClient();
+        var mailMessage = message.ToMimeMessage(_globalSettings.Smtp!.From);
 
-        await client.ConnectAsync(
-            _globalSettings.Smtp!.Host,
-            _globalSettings.Smtp.Port,
-            (SecureSocketOptions)(int)_globalSettings.Smtp.SecureSocketOptions);
-
-        if (!string.IsNullOrWhiteSpace(_globalSettings.Smtp.Username) &&
-            !string.IsNullOrWhiteSpace(_globalSettings.Smtp.Password))
-        {
-            await client.AuthenticateAsync(_globalSettings.Smtp.Username, _globalSettings.Smtp.Password);
-        }
-
-        var mailMessage = message.ToMimeMessage(_globalSettings.Smtp.From);
-        if (_globalSettings.Smtp.DeliveryMethod == SmtpDeliveryMethod.Network)
-        {
-            await client.SendAsync(mailMessage);
-        }
-        else
-        {
-            client.Send(mailMessage);
-        }
-
-        await client.DisconnectAsync(true);
+        await _emailSenderClient.SendAsync(mailMessage);
     }
+
 }

--- a/src/Umbraco.Infrastructure/Mail/Interfaces/IEmailSenderClient.cs
+++ b/src/Umbraco.Infrastructure/Mail/Interfaces/IEmailSenderClient.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MimeKit;
+
+namespace Umbraco.Cms.Infrastructure.Mail.Interfaces
+{
+    public interface IEmailSenderClient
+    {
+        public Task SendAsync(MimeMessage? message);
+    }
+}

--- a/src/Umbraco.Infrastructure/Mail/Interfaces/IEmailSenderClient.cs
+++ b/src/Umbraco.Infrastructure/Mail/Interfaces/IEmailSenderClient.cs
@@ -7,8 +7,16 @@ using MimeKit;
 
 namespace Umbraco.Cms.Infrastructure.Mail.Interfaces
 {
+    /// <summary>
+    /// Client for sending an email from a MimeMessage
+    /// </summary>
     public interface IEmailSenderClient
     {
+        /// <summary>
+        /// Sends the email message
+        /// </summary>
+        /// <param name="message"></param>
+        /// <returns></returns>
         public Task SendAsync(MimeMessage? message);
     }
 }

--- a/src/Umbraco.Infrastructure/Mail/Interfaces/IEmailSenderClient.cs
+++ b/src/Umbraco.Infrastructure/Mail/Interfaces/IEmailSenderClient.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using MimeKit;
+using Umbraco.Cms.Core.Models.Email;
 
 namespace Umbraco.Cms.Infrastructure.Mail.Interfaces
 {
@@ -17,6 +12,6 @@ namespace Umbraco.Cms.Infrastructure.Mail.Interfaces
         /// </summary>
         /// <param name="message"></param>
         /// <returns></returns>
-        public Task SendAsync(MimeMessage? message);
+        public Task SendAsync(EmailMessage message);
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/TestHelpers/TestHelper.cs
+++ b/tests/Umbraco.Tests.UnitTests/TestHelpers/TestHelper.cs
@@ -35,6 +35,7 @@ using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Infrastructure.Mail;
+using Umbraco.Cms.Infrastructure.Mail.Interfaces;
 using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Infrastructure.Persistence.Mappers;
 using Umbraco.Cms.Persistence.SqlServer.Services;
@@ -80,7 +81,7 @@ public static class TestHelper
 
     public static UriUtility UriUtility => s_testHelperInternal.UriUtility;
 
-    public static IEmailSender EmailSender { get; } = new EmailSender(new NullLogger<EmailSender>(), new TestOptionsMonitor<GlobalSettings>(new GlobalSettings()), Mock.Of<IEventAggregator>());
+    public static IEmailSender EmailSender { get; } = new EmailSender(new NullLogger<EmailSender>(), new TestOptionsMonitor<GlobalSettings>(new GlobalSettings()), Mock.Of<IEventAggregator>(),null,null, Mock.Of<IEmailSenderClient>());
 
     public static ITypeFinder GetTypeFinder() => s_testHelperInternal.GetTypeFinder();
 

--- a/tests/Umbraco.Tests.UnitTests/TestHelpers/TestHelper.cs
+++ b/tests/Umbraco.Tests.UnitTests/TestHelpers/TestHelper.cs
@@ -81,7 +81,7 @@ public static class TestHelper
 
     public static UriUtility UriUtility => s_testHelperInternal.UriUtility;
 
-    public static IEmailSender EmailSender { get; } = new EmailSender(new NullLogger<EmailSender>(), new TestOptionsMonitor<GlobalSettings>(new GlobalSettings()), Mock.Of<IEventAggregator>(), null,null);
+    public static IEmailSender EmailSender { get; } = new EmailSender(new NullLogger<EmailSender>(), new TestOptionsMonitor<GlobalSettings>(new GlobalSettings()), Mock.Of<IEventAggregator>(), Mock.Of<IEmailSenderClient>(), null,null);
 
     public static ITypeFinder GetTypeFinder() => s_testHelperInternal.GetTypeFinder();
 

--- a/tests/Umbraco.Tests.UnitTests/TestHelpers/TestHelper.cs
+++ b/tests/Umbraco.Tests.UnitTests/TestHelpers/TestHelper.cs
@@ -81,7 +81,7 @@ public static class TestHelper
 
     public static UriUtility UriUtility => s_testHelperInternal.UriUtility;
 
-    public static IEmailSender EmailSender { get; } = new EmailSender(new NullLogger<EmailSender>(), new TestOptionsMonitor<GlobalSettings>(new GlobalSettings()), Mock.Of<IEventAggregator>(),null,null, Mock.Of<IEmailSenderClient>());
+    public static IEmailSender EmailSender { get; } = new EmailSender(new NullLogger<EmailSender>(), new TestOptionsMonitor<GlobalSettings>(new GlobalSettings()), Mock.Of<IEventAggregator>(), Mock.Of<IEmailSenderClient>(), null,null);
 
     public static ITypeFinder GetTypeFinder() => s_testHelperInternal.GetTypeFinder();
 

--- a/tests/Umbraco.Tests.UnitTests/TestHelpers/TestHelper.cs
+++ b/tests/Umbraco.Tests.UnitTests/TestHelpers/TestHelper.cs
@@ -81,7 +81,7 @@ public static class TestHelper
 
     public static UriUtility UriUtility => s_testHelperInternal.UriUtility;
 
-    public static IEmailSender EmailSender { get; } = new EmailSender(new NullLogger<EmailSender>(), new TestOptionsMonitor<GlobalSettings>(new GlobalSettings()), Mock.Of<IEventAggregator>(), Mock.Of<IEmailSenderClient>(), null,null);
+    public static IEmailSender EmailSender { get; } = new EmailSender(new NullLogger<EmailSender>(), new TestOptionsMonitor<GlobalSettings>(new GlobalSettings()), Mock.Of<IEventAggregator>(), null,null);
 
     public static ITypeFinder GetTypeFinder() => s_testHelperInternal.GetTypeFinder();
 


### PR DESCRIPTION
### Prerequisites

- [x ] I have added steps to test this contribution in the description below

This pull request is a response to the following discussion  [Support for SMTP OAuth authentication](https://github.com/umbraco/Umbraco-CMS/discussions/17142)

### Description
This pull-request separates til SmtpClient out from EmailSender.cs to it's own abstraction of IEmailSenderClient/BasicSmtpEmailSenderClient to make it easier for package-authors and umbraco developers to support more ways of sending out e-mails without Umbraco having to take on supporting every variation of OAuth authentication imaginable.

The linked discussion contains more details as to why and actual OAuth2 implementation for SMTP doesn't seem feasible.

The pull request will allow developers to replace the client like so (microsoft.graph example)

```csharp
public class MicrosoftGraphEmailClientComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.Services.AddTransient<IEmailSenderClient, MicrosoftGraphEmailClient>();
    }
}
public class MicrosoftGraphEmailClient : IEmailSenderClient
{
    private ClientSecretCredential? credentials;
    public MicrosoftGraphEmailClient()
    {
        var tenantId = "<tenant-id>";

        // Values from app registration
        var clientId = "<client-id>";
        var clientSecret = "<client-secret>";

        // using Azure.Identity;
        var options = new TokenCredentialOptions
        {
            AuthorityHost = AzureAuthorityHosts.AzurePublicCloud
        };

        credentials = new ClientSecretCredential(
            tenantId, clientId, clientSecret, options);

        if (credentials == null)
        {
            throw new ArgumentNullException(nameof(credentials));
        }
    }

    public async Task SendAsync(MimeMessage? mimeMessage)
    {
        if (mimeMessage == null)
        {
            throw new ArgumentNullException(nameof(mimeMessage));
        }

        var scopes = new[] { "https://graph.microsoft.com/.default" };

        var graphClient = new GraphServiceClient(credentials, scopes);

        var stream = new MemoryStream();
        mimeMessage.WriteTo(stream);

        var base64content = Convert.ToBase64String(stream.ToArray());
        var ri = graphClient.Users[mimeMessage.From.ToString()].SendMail.ToPostRequestInformation(new SendMailPostRequestBody());

        ri.Headers.Clear();// replace the json content header
        ri.SetStreamContent(new MemoryStream(Encoding.UTF8.GetBytes(base64content)), "text/plain");

        var result = await graphClient.RequestAdapter.SendAsync<Message>(ri, Message.CreateFromDiscriminatorValue);
    }
}

```


### Test

Ideally -nothing- should have changed in Umbraco except it now exposes IEmailSenderClient as an easier integration point.

This leaves Umbraco's logic for building the messag intact but allows developers to take on the responsibility of sending it out.