### PR TITLE
Hotfix: Validate form control on pristine change

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/context/validation-messages.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/context/validation-messages.manager.ts
@@ -16,7 +16,7 @@ export class UmbValidationMessagesManager {
 	messages = this.#messages.asObservable();
 
 	debug(logName: string) {
-		this.#messages.asObservable().subscribe((x) => console.log(logName, x, this.#translators));
+		this.#messages.asObservable().subscribe((x) => console.log(logName, x));
 	}
 
 	getHasAnyMessages(): boolean {
@@ -86,6 +86,9 @@ export class UmbValidationMessagesManager {
 
 	removeMessageByKey(key: string): void {
 		this.#messages.removeOne(key);
+	}
+	removeMessageByKeys(keys: Array<string>): void {
+		this.#messages.filter((x) => keys.indexOf(x.key) === -1);
 	}
 	removeMessagesByTypeAndPath(type: UmbValidationMessageType, path: string): void {
 		//path = path.toLowerCase();

--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/bind-server-validation-to-form-control.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/bind-server-validation-to-form-control.controller.ts
@@ -31,11 +31,8 @@ export class UmbBindServerValidationToFormControl extends UmbControllerBase {
 			if (!defaultMemoization(this.#value, value)) {
 				this.#value = value;
 				// Only remove server validations from validation context [NL]
-				this.#messages.forEach((message) => {
-					if (message.type === 'server') {
-						this.#context?.messages.removeMessageByKey(message.key);
-					}
-				});
+				const toRemove = this.#messages.filter((x) => x.type === 'server').map((msg) => msg.key);
+				this.#context?.messages.removeMessageByKeys(toRemove);
 			}
 		}
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/validation.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/validation.controller.ts
@@ -135,9 +135,7 @@ export class UmbValidationController extends UmbControllerBase implements UmbVal
 					if (this.#parentMessages) {
 						// Remove the local messages that does not exist in the parent anymore:
 						const toRemove = this.#parentMessages.filter((msg) => !msgs.find((m) => m.key === msg.key));
-						toRemove.forEach((msg) => {
-							this.messages.removeMessageByKey(msg.key);
-						});
+						this.#parent!.messages.removeMessageByKeys(toRemove.map((msg) => msg.key));
 					}
 					this.#parentMessages = msgs;
 					msgs.forEach((msg) => {
@@ -157,9 +155,7 @@ export class UmbValidationController extends UmbControllerBase implements UmbVal
 					if (this.#localMessages) {
 						// Remove the parent messages that does not exist locally anymore:
 						const toRemove = this.#localMessages.filter((msg) => !msgs.find((m) => m.key === msg.key));
-						toRemove.forEach((msg) => {
-							this.#parent!.messages.removeMessageByKey(msg.key);
-						});
+						this.#parent!.messages.removeMessageByKeys(toRemove.map((msg) => msg.key));
 					}
 					this.#localMessages = msgs;
 					msgs.forEach((msg) => {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/mixins/form-control.mixin.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/mixins/form-control.mixin.ts
@@ -146,7 +146,7 @@ export function UmbFormControlMixin<
 		public set pristine(value: boolean) {
 			if (this._pristine !== value) {
 				this._pristine = value;
-				this.#dispatchValidationState();
+				this._runValidators();
 			}
 		}
 		public get pristine(): boolean {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/types.ts
@@ -24,7 +24,6 @@ export interface UmbDocumentDetailModel extends UmbContentDetailModel {
 	entityType: UmbDocumentEntityType;
 	isTrashed: boolean;
 	template: { unique: string } | null;
-	unique: string;
 	urls: Array<UmbDocumentUrlInfoModel>;
 	values: Array<UmbDocumentValueModel>;
 	variants: Array<UmbDocumentVariantModel>;


### PR DESCRIPTION
Validate on pristine change to avoid empty messages floating the system.

As well optimizing some of the general implementation.

**This fixes the following case:**

- Have a variant document with Block List (should not vary, no mandatory or validation configured)
- Add a Blocks.
- Save & Publish
- Open Split view, and see validation issues appearing.

This will fix the case so no validation issues appears.