### PR TITLE
Fix invalid culture on delivery api request

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Services/RequestCultureService.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/RequestCultureService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Net.Http.Headers;
+using StackExchange.Profiling.Internal;
 using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
 
@@ -17,8 +18,13 @@ internal sealed partial class RequestCultureService : RequestHeaderHandler, IReq
     /// <inheritdoc />
     public string? GetRequestedCulture()
     {
-        var acceptLanguage = GetHeaderValue(HeaderNames.AcceptLanguage) ?? string.Empty;
-        return ValidLanguageHeaderRegex().IsMatch(acceptLanguage) ? acceptLanguage : null;
+        var acceptLanguage = GetHeaderValue(HeaderNames.AcceptLanguage);
+        if (acceptLanguage.IsNullOrWhiteSpace())
+        {
+            return null;
+        }
+
+        return ValidLanguageHeaderRegex().IsMatch(acceptLanguage!) ? acceptLanguage : null;
     }
 
     /// <inheritdoc />

--- a/src/Umbraco.Cms.Api.Delivery/Services/RequestCultureService.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/RequestCultureService.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Net.Http.Headers;
-using StackExchange.Profiling.Internal;
 using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
 
@@ -18,13 +17,8 @@ internal sealed partial class RequestCultureService : RequestHeaderHandler, IReq
     /// <inheritdoc />
     public string? GetRequestedCulture()
     {
-        var acceptLanguage = GetHeaderValue(HeaderNames.AcceptLanguage);
-        if (acceptLanguage.IsNullOrWhiteSpace())
-        {
-            return null;
-        }
-
-        return ValidLanguageHeaderRegex().IsMatch(acceptLanguage!) ? acceptLanguage : null;
+        var acceptLanguage = GetHeaderValue(HeaderNames.AcceptLanguage) ?? string.Empty;
+        return ValidLanguageHeaderRegex().IsMatch(acceptLanguage) ? acceptLanguage : null;
     }
 
     /// <inheritdoc />

--- a/src/Umbraco.Core/DeliveryApi/ApiPublishedContentCache.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiPublishedContentCache.cs
@@ -80,9 +80,18 @@ public sealed class ApiPublishedContentCache : IApiPublishedContentCache
             }
         }
 
+        var requestCulture = _requestCultureService.GetRequestedCulture();
+
+        if (requestCulture?.Trim().Length <= 0)
+        {
+            // documentUrlService does not like empty strings
+            // todo: align culture null vs empty string behaviour across the codebase
+            requestCulture = null;
+        }
+
         Guid? documentKey = _documentUrlService.GetDocumentKeyByRoute(
             route,
-            _requestCultureService.GetRequestedCulture(),
+            requestCulture,
             documentStartNodeId,
             _requestPreviewService.IsPreview()
         );


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/17476

Since the underlying code expects `null`, `*` or a valid culture, I found it best to handle this in the Delivery api code that determines what culture was set on the request.

###Testing
Check the reproduction steps in the linked issue, but be sure to either run raw curl commands or run it trough postman as the swagger UI adds language headers to the request. And don't forget to test the negatives either 😉 