### PR TITLE
Fixes to redirect management

### DIFF
--- a/src/Umbraco.Core/Services/DocumentUrlService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlService.cs
@@ -441,7 +441,7 @@ public class DocumentUrlService : IDocumentUrlService
             return "#";
         }
 
-        if(isDraft is false && culture != null && _publishStatusQueryService.IsDocumentPublished(documentKey, culture) is false)
+        if(isDraft is false && string.IsNullOrWhiteSpace(culture) is false && _publishStatusQueryService.IsDocumentPublished(documentKey, culture) is false)
         {
             return "#";
         }

--- a/src/Umbraco.Infrastructure/Routing/RedirectTracker.cs
+++ b/src/Umbraco.Infrastructure/Routing/RedirectTracker.cs
@@ -64,7 +64,7 @@ namespace Umbraco.Cms.Infrastructure.Routing
                 {
                     try
                     {
-                        var route = _publishedUrlProvider.GetUrl(publishedContent.Id, UrlMode.Relative, culture);
+                        var route = _publishedUrlProvider.GetUrl(publishedContent.Id, UrlMode.Relative, culture).TrimEnd(Constants.CharArrays.ForwardSlash);
 
                         if (IsValidRoute(route))
                         {
@@ -75,7 +75,7 @@ namespace Umbraco.Cms.Infrastructure.Routing
                             // Retry using all languages, if this is invariant but has a variant ancestor.
                             foreach (string languageIsoCode in languageIsoCodes.Value)
                             {
-                                route = _publishedUrlProvider.GetUrl(publishedContent.Id, UrlMode.Relative, languageIsoCode);
+                                route = _publishedUrlProvider.GetUrl(publishedContent.Id, UrlMode.Relative, languageIsoCode).TrimEnd(Constants.CharArrays.ForwardSlash);
                                 if (IsValidRoute(route))
                                 {
                                     oldRoutes[(publishedContent.Id, languageIsoCode)] = (publishedContent.Key, route);
@@ -103,7 +103,7 @@ namespace Umbraco.Cms.Infrastructure.Routing
             {
                 try
                 {
-                    var newRoute = _publishedUrlProvider.GetUrl(contentKey, UrlMode.Relative,  culture);
+                    var newRoute = _publishedUrlProvider.GetUrl(contentKey, UrlMode.Relative,  culture).TrimEnd(Constants.CharArrays.ForwardSlash);
                     if (!IsValidRoute(newRoute) || oldRoute == newRoute)
                     {
                         continue;

--- a/src/Umbraco.Infrastructure/Routing/RedirectTracker.cs
+++ b/src/Umbraco.Infrastructure/Routing/RedirectTracker.cs
@@ -20,7 +20,7 @@ namespace Umbraco.Cms.Infrastructure.Routing
         private readonly IPublishedContentCache _contentCache;
         private readonly IDocumentNavigationQueryService _navigationQueryService;
         private readonly ILogger<RedirectTracker> _logger;
-        private readonly IDocumentUrlService _documentUrlService;
+        private readonly IPublishedUrlProvider _publishedUrlProvider;
 
         public RedirectTracker(
             IVariationContextAccessor variationContextAccessor,
@@ -29,7 +29,7 @@ namespace Umbraco.Cms.Infrastructure.Routing
             IPublishedContentCache contentCache,
             IDocumentNavigationQueryService navigationQueryService,
             ILogger<RedirectTracker> logger,
-            IDocumentUrlService documentUrlService)
+            IPublishedUrlProvider publishedUrlProvider)
         {
             _variationContextAccessor = variationContextAccessor;
             _localizationService = localizationService;
@@ -37,7 +37,7 @@ namespace Umbraco.Cms.Infrastructure.Routing
             _contentCache = contentCache;
             _navigationQueryService = navigationQueryService;
             _logger = logger;
-            _documentUrlService = documentUrlService;
+            _publishedUrlProvider = publishedUrlProvider;
         }
 
         /// <inheritdoc/>
@@ -64,7 +64,8 @@ namespace Umbraco.Cms.Infrastructure.Routing
                 {
                     try
                     {
-                        var route = _contentCache.GetRouteById(publishedContent.Id, culture);
+                        var route = _publishedUrlProvider.GetUrl(publishedContent.Id, UrlMode.Relative, culture);
+
                         if (IsValidRoute(route))
                         {
                             oldRoutes[(publishedContent.Id, culture)] = (publishedContent.Key, route);
@@ -74,7 +75,7 @@ namespace Umbraco.Cms.Infrastructure.Routing
                             // Retry using all languages, if this is invariant but has a variant ancestor.
                             foreach (string languageIsoCode in languageIsoCodes.Value)
                             {
-                                route = _contentCache.GetRouteById(publishedContent.Id, languageIsoCode);
+                                route = _publishedUrlProvider.GetUrl(publishedContent.Id, UrlMode.Relative, languageIsoCode);
                                 if (IsValidRoute(route))
                                 {
                                     oldRoutes[(publishedContent.Id, languageIsoCode)] = (publishedContent.Key, route);
@@ -102,7 +103,7 @@ namespace Umbraco.Cms.Infrastructure.Routing
             {
                 try
                 {
-                    var newRoute = _documentUrlService.GetLegacyRouteFormat(contentKey, culture, false);
+                    var newRoute = _publishedUrlProvider.GetUrl(contentKey, UrlMode.Relative,  culture);
                     if (!IsValidRoute(newRoute) || oldRoute == newRoute)
                     {
                         continue;


### PR DESCRIPTION
### Description
Fixed issue with redirects due to culture being empty string when null was expected.

Furthermore, using IPublishedUrlProvider instead of DocumentUrlService directly. to ensure you can use your own routing stuff


### Tests
- Ensure redirects are created as expected when publishing under new names.

