### PR TITLE
Hotfix: Media section modal is not closed and the media tree is not updated immediately after creating an media folder/ item

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace.context.ts
@@ -188,7 +188,7 @@ export class UmbMediaWorkspaceContext
 				path: UMB_CREATE_MEDIA_WORKSPACE_PATH_PATTERN.toString(),
 				component: () => import('./media-workspace-editor.element.js'),
 				setup: async (_component, info) => {
-					const parentEntityType = info.match.params.entityType;
+					const parentEntityType = info.match.params.parentEntityType;
 					const parentUnique = info.match.params.parentUnique === 'null' ? null : info.match.params.parentUnique;
 					const mediaTypeUnique = info.match.params.mediaTypeUnique;
 					await this.create({ entityType: parentEntityType, unique: parentUnique }, mediaTypeUnique);


### PR DESCRIPTION
The media section modal is not closed and the media tree is not updated immediately after creating a media folder/ item

Fix: When creating a new media item we used the wrong URL param to get the parent entity type. 

https://github.com/user-attachments/assets/273cd77d-de79-4541-b356-56383441f10b

