### PR TITLE
Hotfix: Tiptap toolbar data fix

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -209,7 +209,10 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 
 				h1,
 				h2,
-				h3 {
+				h3,
+				h4,
+				h5,
+				h6 {
 					margin-top: 0;
 					margin-bottom: 0.5em;
 				}
@@ -230,6 +233,13 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				img {
 					&.ProseMirror-selectednode {
 						outline: 3px solid var(--uui-color-focus);
+					}
+				}
+
+				li {
+					> p {
+						margin: 0;
+						padding: 0;
 					}
 				}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/tiptap-toolbar.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/tiptap-toolbar.element.ts
@@ -62,24 +62,19 @@ export class UmbTiptapToolbarElement extends UmbLitElement {
 	}
 
 	override render() {
-		return html`${map(this.toolbar, (row, rowIndex) =>
-			map(
-				row,
-				(group, groupIndex) => html`
-					${map(group, (alias, aliasIndex) => {
-						const newRow = rowIndex !== 0 && groupIndex === 0 && aliasIndex === 0;
-						const component = this._lookup?.get(alias);
-						if (!component) return nothing;
-						return html`
-							<div class="item" ?data-new-row=${newRow} style=${newRow ? 'grid-column: 1 / span 3' : ''}>
-								${component}
-							</div>
-						`;
-					})}
-					<div class="separator"></div>
+		return html`
+			${map(
+				this.toolbar,
+				(row) => html`
+					<div class="row">
+						${map(
+							row,
+							(group) => html`<div class="group">${map(group, (alias) => this._lookup?.get(alias) ?? nothing)}</div>`,
+						)}
+					</div>
 				`,
-			),
-		)} `;
+			)}
+		`;
 	}
 
 	static override readonly styles = css`
@@ -95,30 +90,35 @@ export class UmbTiptapToolbarElement extends UmbLitElement {
 			border-bottom-right-radius: 0;
 			background-color: var(--uui-color-surface);
 			color: var(--color-text);
-			display: grid;
-			grid-template-columns: repeat(auto-fill, 10px);
-			grid-auto-flow: row;
+
+			display: flex;
+			flex-direction: column;
+
 			position: sticky;
 			top: -25px;
 			left: 0px;
 			right: 0px;
-			padding: var(--uui-size-space-3);
+			padding: var(--uui-size-3);
 			z-index: 9999999;
 		}
 
-		.item {
-			grid-column: span 3;
-		}
+		.row {
+			display: flex;
+			flex-direction: row;
 
-		.separator {
-			background-color: var(--uui-color-border);
-			width: 1px;
-			place-self: center;
-			height: 22px;
-		}
-		.separator:last-child,
-		.separator:has(+ [data-new-row]) {
-			display: none;
+			.group {
+				display: inline-flex;
+				align-items: stretch;
+
+				&:not(:last-child)::after {
+					content: '';
+					background-color: var(--uui-color-border);
+					width: 1px;
+					place-self: center;
+					height: 22px;
+					margin: 0 var(--uui-size-3);
+				}
+			}
 		}
 	`;
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/toolbar/tiptap-toolbar-button.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/toolbar/tiptap-toolbar-button.element.ts
@@ -46,6 +46,7 @@ export class UmbTiptapToolbarButtonElement extends UmbLitElement {
 				look=${this.isActive ? 'outline' : 'default'}
 				label=${ifDefined(this.manifest?.meta.label)}
 				title=${this.manifest?.meta.label ? this.localize.string(this.manifest.meta.label) : ''}
+				?disabled=${this.api && this.editor && this.api.isDisabled(this.editor)}
 				@click=${() => (this.api && this.editor ? this.api.execute(this.editor) : null)}>
 				${when(
 					this.manifest?.meta.icon,

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/base.ts
@@ -34,6 +34,8 @@ export abstract class UmbTiptapExtensionApiBase extends UmbControllerBase implem
 }
 
 export abstract class UmbTiptapToolbarElementApiBase extends UmbControllerBase implements UmbTiptapToolbarElementApi {
+	#enabledExtensions?: Array<string>;
+
 	/**
 	 * The manifest for the extension.
 	 */
@@ -46,8 +48,10 @@ export abstract class UmbTiptapToolbarElementApiBase extends UmbControllerBase i
 
 	/**
 	 * A method to execute the toolbar element action.
+	 * @see {ManifestTiptapToolbarExtension}
+	 * @param {Editor} editor The editor instance.
 	 */
-	public abstract execute(editor: Editor): void;
+	public abstract execute(editor?: Editor): void;
 
 	/**
 	 * Informs the toolbar element if it is active or not. It uses the manifest meta alias to check if the toolbar element is active.
@@ -55,7 +59,21 @@ export abstract class UmbTiptapToolbarElementApiBase extends UmbControllerBase i
 	 * @param {Editor} editor The editor instance.
 	 * @returns {boolean} Returns true if the toolbar element is active.
 	 */
-	public isActive(editor: Editor) {
-		return editor && this.manifest?.meta.alias ? editor?.isActive(this.manifest.meta.alias) : false;
+	public isActive(editor?: Editor): boolean {
+		return editor && this.manifest?.meta.alias ? editor?.isActive(this.manifest.meta.alias) === true : false;
+	}
+
+	/**
+	 * Informs the toolbar element if it is disabled or not.
+	 * @see {ManifestTiptapToolbarExtension}
+	 * @param {Editor} editor The editor instance.
+	 * @returns {boolean} Returns true if the toolbar element is disabled.
+	 */
+	isDisabled(editor?: Editor): boolean {
+		if (!editor) return true;
+		if (!this.#enabledExtensions) {
+			this.#enabledExtensions = this.configuration?.getValueByAlias<string[]>('extensions') ?? [];
+		}
+		return this.manifest?.forExtensions?.every((ext) => this.#enabledExtensions?.includes(ext)) === false;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/types.ts
@@ -42,10 +42,15 @@ export interface UmbTiptapToolbarElementApi extends UmbApi, UmbTiptapExtensionAr
 	/**
 	 * Executes the toolbar element action.
 	 */
-	execute(editor: Editor): void;
+	execute(editor?: Editor): void;
 
 	/**
 	 * Checks if the toolbar element is active.
 	 */
-	isActive(editor: Editor): boolean;
+	isActive(editor?: Editor): boolean;
+
+	/**
+	 * Checks if the toolbar element is disabled.
+	 */
+	isDisabled(editor?: Editor): boolean;
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap/components/property-editor-ui-tiptap-extensions-configuration.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap/components/property-editor-ui-tiptap-extensions-configuration.element.ts
@@ -109,7 +109,7 @@ export class UmbPropertyEditorUiTiptapExtensionsConfigurationElement
 				label: 'Rich Text Essentials',
 				icon: 'icon-browser-window',
 				group: '#tiptap_extGroup_formatting',
-				description: 'This is a core extension, it must be enabled',
+				description: 'This is a core extension, it is always enabled by default.',
 			});
 
 			if (!this.value) {

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap/components/property-editor-ui-tiptap-toolbar-configuration.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap/components/property-editor-ui-tiptap-toolbar-configuration.element.ts
@@ -36,7 +36,7 @@ export class UmbPropertyEditorUiTiptapToolbarConfigurationElement
 	set value(value: UmbTiptapToolbarValue | undefined) {
 		if (!value) value = [[[]]];
 		if (value === this.#value) return;
-		this.#context.setToolbar(value);
+		this.#value = value;
 	}
 	get value(): UmbTiptapToolbarValue | undefined {
 		return this.#value?.map((rows) => rows.map((groups) => [...groups]));
@@ -64,6 +64,10 @@ export class UmbPropertyEditorUiTiptapToolbarConfigurationElement
 				propertyContext.setValue(this.#value);
 			});
 		});
+	}
+
+	protected override firstUpdated() {
+		this.#context.setToolbar(this.value);
 	}
 
 	#onClick(item: UmbTiptapToolbarExtension) {

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap/components/property-editor-ui-tiptap-toolbar-configuration.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap/components/property-editor-ui-tiptap-toolbar-configuration.element.ts
@@ -36,10 +36,10 @@ export class UmbPropertyEditorUiTiptapToolbarConfigurationElement
 	set value(value: UmbTiptapToolbarValue | undefined) {
 		if (!value) value = [[[]]];
 		if (value === this.#value) return;
-		this.#value = value;
+		this.#value = this.#context.migrateTinyMceToolbar(value);
 	}
 	get value(): UmbTiptapToolbarValue | undefined {
-		return this.#value?.map((rows) => rows.map((groups) => [...groups]));
+		return this.#context.cloneToolbarValue(this.#value);
 	}
 	#value?: UmbTiptapToolbarValue;
 

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap/contexts/tiptap-toolbar-configuration.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap/contexts/tiptap-toolbar-configuration.context.ts
@@ -28,6 +28,49 @@ export class UmbTiptapToolbarConfigurationContext extends UmbContextBase<UmbTipt
 	#toolbar = new UmbArrayState<UmbTiptapToolbarRowViewModel>([], (x) => x.unique);
 	public readonly toolbar = this.#toolbar.asObservable();
 
+	/** @deprecated This will be removed in Umbraco 16. */
+	#tinyMceToolbarMapping: Record<string, string | null> = {
+		undo: 'Umb.Tiptap.Toolbar.Undo',
+		redo: 'Umb.Tiptap.Toolbar.Redo',
+		cut: null,
+		copy: null,
+		paste: null,
+		styles: null,
+		fontname: null,
+		fontsize: null,
+		forecolor: null,
+		backcolor: null,
+		blockquote: 'Umb.Tiptap.Toolbar.Blockquote',
+		formatblock: null,
+		removeformat: 'Umb.Tiptap.Toolbar.ClearFormatting',
+		bold: 'Umb.Tiptap.Toolbar.Bold',
+		italic: 'Umb.Tiptap.Toolbar.Italic',
+		underline: 'Umb.Tiptap.Toolbar.Underline',
+		strikethrough: 'Umb.Tiptap.Toolbar.Strike',
+		alignleft: 'Umb.Tiptap.Toolbar.TextAlignLeft',
+		aligncenter: 'Umb.Tiptap.Toolbar.TextAlignCenter',
+		alignright: 'Umb.Tiptap.Toolbar.TextAlignRight',
+		alignjustify: 'Umb.Tiptap.Toolbar.TextAlignJustify',
+		bullist: 'Umb.Tiptap.Toolbar.BulletList',
+		numlist: 'Umb.Tiptap.Toolbar.OrderedList',
+		outdent: null,
+		indent: null,
+		anchor: null,
+		table: 'Umb.Tiptap.Toolbar.Table',
+		hr: 'Umb.Tiptap.Toolbar.HorizontalRule',
+		subscript: 'Umb.Tiptap.Toolbar.Subscript',
+		superscript: 'Umb.Tiptap.Toolbar.Superscript',
+		charmap: null,
+		rtl: null,
+		ltr: null,
+		link: 'Umb.Tiptap.Toolbar.Link',
+		unlink: 'Umb.Tiptap.Toolbar.Unlink',
+		sourcecode: 'Umb.Tiptap.Toolbar.SourceEditor',
+		umbmediapicker: 'Umb.Tiptap.Toolbar.MediaPicker',
+		umbembeddialog: 'Umb.Tiptap.Toolbar.EmbeddedMedia',
+		umbblockpicker: 'Umb.Tiptap.Toolbar.BlockPicker',
+	};
+
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_TIPTAP_TOOLBAR_CONFIGURATION_CONTEXT);
 
@@ -64,6 +107,11 @@ export class UmbTiptapToolbarConfigurationContext extends UmbContextBase<UmbTipt
 				'_observeExtensions',
 			);
 		});
+	}
+
+	public cloneToolbarValue(value?: UmbTiptapToolbarValue | null): UmbTiptapToolbarValue {
+		if (!this.isValidToolbarValue(value)) return [[[]]];
+		return value.map((row) => row.map((group) => [...group]));
 	}
 
 	public filterExtensions(query: string): Array<UmbTiptapToolbarExtension> {
@@ -130,6 +178,24 @@ export class UmbTiptapToolbarConfigurationContext extends UmbContextBase<UmbTipt
 		const toolbar = [...this.#toolbar.getValue()];
 		toolbar.splice(rowIndex, 0, { unique: UmbId.new(), data: [{ unique: UmbId.new(), data: [] }] });
 		this.#toolbar.setValue(toolbar);
+	}
+
+	/** @deprecated This will be removed in Umbraco 16. */
+	public migrateTinyMceToolbar(value?: UmbTiptapToolbarValue | Array<string> | null): UmbTiptapToolbarValue {
+		if (this.isValidToolbarValue(value)) return value;
+
+		const items: Array<string> = [];
+
+		if (Array.isArray(value) && value.length > 0 && typeof value[0] === 'string') {
+			for (const alias of value) {
+				const mapping = this.#tinyMceToolbarMapping[alias];
+				if (mapping) {
+					items.push(mapping);
+				}
+			}
+		}
+
+		return [[items]];
 	}
 
 	public moveToolbarItem(from: [number, number, number], to: [number, number, number]) {


### PR DESCRIPTION
### Description

In a scenario where a user would like to switch back from Tiptap to TinyMCE, the data structure of the "toolbar" configuration triggered an infinite loop, causing the browser tab to become unresponsive. This PR resolves that issue.

In doing so, we found that it is possible to attempt the migration of a TinyMCE toolbar configuration over to the new Tiptap toolbar data structure. To note, not all toolbar features are available, (e.g. style select, character map, et al), but the majority are available.

It was also noticed that the Tiptap toolbar (on the property-editor) was still displaying buttons as enabled regardless whether the underlying Tiptap Extension had been registered. This PR adds support to disable toolbar buttons if the Tiptap Extension is unavailable.