### PR TITLE
Allow removing the default template from doc types

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/workspace/document-type/document-type-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/workspace/document-type/document-type-workspace.context.ts
@@ -216,7 +216,7 @@ export class UmbDocumentTypeWorkspaceContext
 		this.structure.updateOwnerContentType({ allowedTemplates });
 	}
 
-	setDefaultTemplate(defaultTemplate: { id: string }) {
+	setDefaultTemplate(defaultTemplate: { id: string } | null) {
 		this.structure.updateOwnerContentType({ defaultTemplate });
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/workspace/document-type/views/templates/document-type-workspace-view-templates.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/workspace/document-type/views/templates/document-type-workspace-view-templates.element.ts
@@ -70,7 +70,7 @@ export class UmbDocumentTypeWorkspaceViewTemplatesElement extends UmbLitElement 
 					return { id };
 				}) ?? [];
 		this.#workspaceContext?.setAllowedTemplateIds(idsWithoutRoot);
-		this.#workspaceContext?.setDefaultTemplate({ id: input.defaultUnique });
+		this.#workspaceContext?.setDefaultTemplate(input.defaultUnique ? { id: input.defaultUnique } : null);
 	}
 
 	override render() {


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/17513
### Description
Fixed issue where it was not possible to remove the last (default) template from a doc type.

The issue was because the payload was wrong 
```json
{
...
   "defaultTemplate": {
      "id": ""
   }
...
}
```

instead of the expected
```json
{
...
   "defaultTemplate": null
...
}
```
