### PR TITLE
Hotfix: Tiptap media upload, prevent pasted HTML fragments

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/core/media-upload.extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/core/media-upload.extension.ts
@@ -69,6 +69,12 @@ export default class UmbTiptapMediaUploadExtensionApi extends UmbTiptapExtension
 					});
 
 					host.addEventListener('paste', (event) => {
+						const htmlContent = event.clipboardData?.getData('text/html');
+						if (htmlContent) {
+							// If there is HTML content, exit early to prevent uploading the remote file(s).
+							return;
+						}
+
 						const files = event.clipboardData?.files;
 						if (!files) return;
 


### PR DESCRIPTION
### Description

Fixes #17505.

When using the browser's "Copy image" feature, a HTML fragment is copied to the Clipboard, when pasting this into the Tiptap RTE, both the Image and Media Upload extensions were being triggered, showing duplicate images (one remote, one uploaded).

This fix prevents any image references that are pasted in from a HTML fragment to be uploaded to the server. The original (source) URL will be used for external image references.
