### PR TITLE
Remove explicit `ExamineIndexRebuilder` service registration and make class internal

### DIFF
--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/SearchManagementBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/SearchManagementBuilderExtensions.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Umbraco.Cms.Core.DependencyInjection;
-using Umbraco.Cms.Infrastructure.Examine;
+using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.Services;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Infrastructure.Examine;
 using Umbraco.Cms.Infrastructure.Services;
 
 namespace Umbraco.Cms.Api.Management.DependencyInjection;
@@ -17,8 +17,8 @@ public static class SearchManagementBuilderExtensions
 
         // Add factories
         builder.Services.AddTransient<IIndexDiagnosticsFactory, IndexDiagnosticsFactory>();
-        builder.Services.AddTransient<IIndexRebuilder, ExamineIndexRebuilder>();
         builder.Services.AddTransient<IIndexPresentationFactory, IndexPresentationFactory>();
+
         return builder;
     }
 }

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Examine.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Examine.cs
@@ -63,8 +63,6 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddUnique<IDeliveryApiContentIndexHelper, DeliveryApiContentIndexHelper>();
         builder.Services.AddSingleton<IDeliveryApiIndexingHandler, DeliveryApiIndexingHandler>();
 
-        builder.Services.AddSingleton<ExamineIndexRebuilder>();  //TODO remove in Umbraco 15. Only the interface should be in the service provider
-
         builder.Services.AddUnique<IDeliveryApiCompositeIdHandler, DeliveryApiCompositeIdHandler>();
 
         builder.AddNotificationHandler<ContentCacheRefresherNotification, ContentIndexingNotificationHandler>();

--- a/src/Umbraco.Infrastructure/Examine/ExamineIndexRebuilder.cs
+++ b/src/Umbraco.Infrastructure/Examine/ExamineIndexRebuilder.cs
@@ -10,8 +10,7 @@ using Umbraco.Cms.Infrastructure.HostedServices;
 
 namespace Umbraco.Cms.Infrastructure.Examine;
 
-[Obsolete("This will be removed in Umbraco 15. Use IIndexRebuilder instead.")] // Main reason for this is to remove it form the service container. Maybe even make this internal
-public class ExamineIndexRebuilder : IIndexRebuilder
+internal sealed class ExamineIndexRebuilder : IIndexRebuilder
 {
     private readonly IBackgroundTaskQueue _backgroundTaskQueue;
     private readonly IExamineManager _examineManager;
@@ -50,7 +49,7 @@ public class ExamineIndexRebuilder : IIndexRebuilder
         return _populators.Any(x => x.IsRegistered(index));
     }
 
-    public virtual void RebuildIndex(string indexName, TimeSpan? delay = null, bool useBackgroundThread = true)
+    public void RebuildIndex(string indexName, TimeSpan? delay = null, bool useBackgroundThread = true)
     {
         if (delay == null)
         {
@@ -85,7 +84,7 @@ public class ExamineIndexRebuilder : IIndexRebuilder
         }
     }
 
-    public virtual void RebuildIndexes(bool onlyEmptyIndexes, TimeSpan? delay = null, bool useBackgroundThread = true)
+    public void RebuildIndexes(bool onlyEmptyIndexes, TimeSpan? delay = null, bool useBackgroundThread = true)
     {
         if (delay == null)
         {

--- a/src/Umbraco.Infrastructure/Examine/RebuildOnStartupHandler.cs
+++ b/src/Umbraco.Infrastructure/Examine/RebuildOnStartupHandler.cs
@@ -28,27 +28,6 @@ public sealed class RebuildOnStartupHandler : INotificationHandler<UmbracoReques
     private readonly ISyncBootStateAccessor _syncBootStateAccessor;
     private readonly IIndexRebuilder _indexRebuilder;
 
-    [Obsolete("Use non-obsolete constructor. This is scheduled for removal in Umbraco 15.")]
-    public RebuildOnStartupHandler(
-        ISyncBootStateAccessor syncBootStateAccessor,
-        ExamineIndexRebuilder backgroundIndexRebuilder,
-        IRuntimeState runtimeState)
-        : this(syncBootStateAccessor, (IIndexRebuilder) backgroundIndexRebuilder, runtimeState)
-    {
-
-    }
-
-    [Obsolete("Use non-obsolete constructor. This is scheduled for removal in Umbraco 15.")]
-    public RebuildOnStartupHandler(
-        ISyncBootStateAccessor syncBootStateAccessor,
-        ExamineIndexRebuilder backgroundIndexRebuilder,
-        IIndexRebuilder indexRebuilder,
-        IRuntimeState runtimeState)
-        : this(syncBootStateAccessor, indexRebuilder, runtimeState)
-    {
-
-    }
-
     public RebuildOnStartupHandler(
         ISyncBootStateAccessor syncBootStateAccessor,
         IIndexRebuilder indexRebuilder,

--- a/src/Umbraco.Infrastructure/Suspendable.cs
+++ b/src/Umbraco.Infrastructure/Suspendable.cs
@@ -82,7 +82,7 @@ public static class Suspendable
             _suspended = true;
         }
 
-        public static void ResumeIndexers(ExamineIndexRebuilder backgroundIndexRebuilder)
+        public static void ResumeIndexers(IIndexRebuilder backgroundIndexRebuilder)
         {
             _suspended = false;
 

--- a/src/Umbraco.Infrastructure/Suspendable.cs
+++ b/src/Umbraco.Infrastructure/Suspendable.cs
@@ -7,52 +7,18 @@ namespace Umbraco.Cms.Infrastructure;
 
 public static class Suspendable
 {
+    [Obsolete("The PageCacheRefresher is not used anymore and will be removed in a future version.")]
     public static class PageCacheRefresher
     {
-        private static bool _tried;
-        private static bool _suspended;
+        public static bool CanRefreshDocumentCacheFromDatabase => false;
 
-        public static bool CanRefreshDocumentCacheFromDatabase
-        {
-            get
-            {
-                // trying a full refresh
-                if (_suspended == false)
-                {
-                    return true;
-                }
-
-                _tried = true; // remember we tried
-                return false;
-            }
-        }
-
-        // trying a partial update
-        // ok if not suspended, or if we haven't done a full already
-        public static bool CanUpdateDocumentCache => _suspended == false || _tried == false;
+        public static bool CanUpdateDocumentCache => true;
 
         public static void SuspendDocumentCache()
-        {
-            StaticApplicationLogging.Logger.LogInformation("Suspend document cache.");
-            _suspended = true;
-        }
+        { }
 
         public static void ResumeDocumentCache(CacheRefresherCollection cacheRefresherCollection)
-        {
-            _suspended = false;
-
-            StaticApplicationLogging.Logger.LogInformation("Resume document cache (reload:{Tried}).", _tried);
-
-            if (_tried == false)
-            {
-                return;
-            }
-
-            _tried = false;
-
-            ICacheRefresher? pageRefresher = cacheRefresherCollection[ContentCacheRefresher.UniqueId];
-            pageRefresher?.RefreshAll();
-        }
+        { }
     }
 
     // This is really needed at all since the only place this is used is in ExamineComponent and that already maintains a flag of whether it suspsended or not

--- a/tests/Umbraco.Tests.Integration/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/tests/Umbraco.Tests.Integration/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using Examine;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -20,7 +19,6 @@ using Umbraco.Cms.Core.Runtime;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Infrastructure.Examine;
-using Umbraco.Cms.Infrastructure.HostedServices;
 using Umbraco.Cms.Persistence.EFCore.Locking;
 using Umbraco.Cms.Persistence.EFCore.Scoping;
 using Umbraco.Cms.Tests.Common.TestHelpers.Stubs;
@@ -145,31 +143,16 @@ public static class UmbracoBuilderExtensions
     }
 
     // replace the default so there is no background index rebuilder
-    private class TestBackgroundIndexRebuilder : ExamineIndexRebuilder
+    private class TestBackgroundIndexRebuilder : IIndexRebuilder
     {
-        public TestBackgroundIndexRebuilder(
-            IMainDom mainDom,
-            IRuntimeState runtimeState,
-            ILogger<ExamineIndexRebuilder> logger,
-            IExamineManager examineManager,
-            IEnumerable<IIndexPopulator> populators,
-            IBackgroundTaskQueue backgroundTaskQueue)
-            : base(
-            mainDom,
-            runtimeState,
-            logger,
-            examineManager,
-            populators,
-            backgroundTaskQueue)
-        {
-        }
+        public bool CanRebuild(string indexName) => false;
 
-        public override void RebuildIndex(string indexName, TimeSpan? delay = null, bool useBackgroundThread = true)
+        public void RebuildIndex(string indexName, TimeSpan? delay = null, bool useBackgroundThread = true)
         {
             // noop
         }
 
-        public override void RebuildIndexes(bool onlyEmptyIndexes, TimeSpan? delay = null, bool useBackgroundThread = true)
+        public void RebuildIndexes(bool onlyEmptyIndexes, TimeSpan? delay = null, bool useBackgroundThread = true)
         {
             // noop
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Deploy uses `Suspendable.ExamineEvents.ResumeIndexers(...)` to resume suspended indexing after deployments, but this method still required the obsoleted `ExamineIndexRebuilder` type. I've updated this overload to accept the `IIndexRebuilder` instead and also obsoleted the unused `Suspendable.PageCacheRefresher` (if used, it would call `ContentCacheRefresher.RefreshAll()` that throws a `NotSupportedException`, so I've also made it a no-op call).

As per obsoletion messages and comments, I've removed the explicit `ExamineIndexRebuilder` service registration and make the class internal (so the `IIndexRebuilder` interface needs to be used/injected instead).

Testing can be done by simply checking whether all tests still succeed and optionally manually rebuilding the indexes from the backoffice and testing the search functionality.