### PR TITLE
V15: Implement not-implemented methods for media cache

### DIFF
--- a/src/Umbraco.Core/PublishedCache/IMediaCacheService.cs
+++ b/src/Umbraco.Core/PublishedCache/IMediaCacheService.cs
@@ -26,4 +26,5 @@ public interface IMediaCacheService
     Task SeedAsync(CancellationToken cancellationToken);
 
     void Rebuild(IReadOnlyCollection<int> contentTypeIds);
+    IEnumerable<IPublishedContent> GetByContentType(IPublishedContentType contentType);
 }

--- a/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
@@ -259,6 +259,17 @@ internal class MediaCacheService : IMediaCacheService
         scope.Complete();
     }
 
+    public IEnumerable<IPublishedContent> GetByContentType(IPublishedContentType contentType)
+    {
+        using ICoreScope scope = _scopeProvider.CreateCoreScope();
+        IEnumerable<ContentCacheNode> nodes = _databaseCacheRepository.GetContentByContentTypeKey([contentType.Key], ContentCacheDataSerializerEntityType.Media);
+        scope.Complete();
+
+        return nodes
+            .Select(x => _publishedContentFactory.ToIPublishedContent(x, x.IsDraft).CreateModel(_publishedModelFactory))
+            .WhereNotNull();
+    }
+
     private HybridCacheEntryOptions GetEntryOptions(Guid key)
     {
         if (SeedKeys.Contains(key))

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheMockTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheMockTests.cs
@@ -6,6 +6,7 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentPublishing;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.Navigation;
@@ -107,7 +108,11 @@ public class DocumentHybridCacheMockTests : UmbracoIntegrationTestWithContent
             GetRequiredService<IPublishedModelFactory>(),
             GetRequiredService<IPreviewService>());
 
-        _mockedCache = new DocumentCache(_mockDocumentCacheService, GetRequiredService<IPublishedContentTypeCache>());
+        _mockedCache = new DocumentCache(_mockDocumentCacheService,
+            GetRequiredService<IPublishedContentTypeCache>(),
+            GetRequiredService<IDocumentNavigationQueryService>(),
+            GetRequiredService<IDocumentUrlService>(),
+            new Lazy<IPublishedUrlProvider>(GetRequiredService<IPublishedUrlProvider>));
     }
 
     // We want to be able to alter the settings for the providers AFTER the test has started


### PR DESCRIPTION
# Notes
- Implements the rest of the `NotImplemented` methods for media cache.
- Removes use of StaticServiceProvider in document cache

# How to test, 
- To test the publish URL provider in document cache, you can use `@Model.GetCultureFromDomains()` in the template
- To test the media cache, use the delivery API to query the media.