### PR TITLE
Hotfix: expose using block variant

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/context/block-list-entries.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/context/block-list-entries.context.ts
@@ -8,6 +8,7 @@ import { UmbBooleanState } from '@umbraco-cms/backoffice/observable-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/router';
 import { UMB_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
+import type { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 
 export class UmbBlockListEntriesContext extends UmbBlockEntriesContext<
 	typeof UMB_BLOCK_LIST_MANAGER_CONTEXT,
@@ -149,11 +150,7 @@ export class UmbBlockListEntriesContext extends UmbBlockEntriesContext<
 		originData: UmbBlockListWorkspaceOriginData,
 	) {
 		await this._retrieveManager;
-		const success = this._manager?.insert(layoutEntry, content, settings, originData) ?? false;
-		if (success) {
-			this._manager?.setOneExpose(layoutEntry.contentKey);
-		}
-		return success;
+		return this._manager?.insert(layoutEntry, content, settings, originData) ?? false;
 	}
 
 	// create Block?

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entry.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entry.context.ts
@@ -575,7 +575,6 @@ export abstract class UmbBlockEntryContext<
 	#gotVariantId() {
 		const variantId = this.#variantId.getValue();
 		if (!variantId || !this.#contentKey) return;
-		// TODO: Handle variantId changes
 		this.observe(
 			this._manager?.hasExposeOf(this.#contentKey, variantId),
 			(hasExpose) => {
@@ -615,8 +614,9 @@ export abstract class UmbBlockEntryContext<
 	}
 
 	public expose() {
-		if (!this.#contentKey) return;
-		this._manager?.setOneExpose(this.#contentKey);
+		const variantId = this.#variantId.getValue();
+		if (!variantId || !this.#contentKey) return;
+		this._manager?.setOneExpose(this.#contentKey, variantId);
 	}
 
 	//copy

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-manager.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-manager.context.ts
@@ -45,6 +45,9 @@ export abstract class UmbBlockManagerContext<
 	setVariantId(variantId: UmbVariantId | undefined) {
 		this.#variantId.setValue(variantId);
 	}
+	getVariantId(): UmbVariantId | undefined {
+		return this.#variantId.getValue();
+	}
 
 	readonly #structures: Array<UmbContentTypeStructureManager> = [];
 
@@ -213,8 +216,7 @@ export abstract class UmbBlockManagerContext<
 	setOneSettings(settingsData: UmbBlockDataModel) {
 		this.#settings.appendOne(settingsData);
 	}
-	setOneExpose(contentKey: string) {
-		const variantId = this.#variantId.getValue();
+	setOneExpose(contentKey: string, variantId: UmbVariantId) {
 		if (!variantId) return;
 		this.#exposes.appendOne({ contentKey, ...variantId.toObject() });
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
@@ -467,12 +467,14 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 
 	expose() {
 		const contentKey = this.#layout.value?.contentKey;
-		if (!contentKey) throw new Error('Cannot expose block that does not exist.');
+		if (!contentKey) throw new Error('Failed to expose block, missing content key.');
 		this.#expose(contentKey);
 	}
 
 	#expose(unique: string) {
-		this.#blockManager?.setOneExpose(unique);
+		const variantId = this.#variantId.getValue();
+		if (!variantId) throw new Error('Failed to expose block, missing variant id.');
+		this.#blockManager?.setOneExpose(unique, variantId);
 	}
 
 	#modalRejected = () => {


### PR DESCRIPTION
An oversight in relation to hot fix of https://github.com/umbraco/Umbraco-CMS/pull/17482

Its needed to ensure that we in general always use the Block Variant ID, as this one can de different depending on the configuration of the Block Element.

This fixes this case:

Have a project with two languages.
Create a document type that varies by culture with a property with a Block Editor of choice.
Create a Block using a Element that does not vary by culture.
Create a document with one block.
Experience that the block was not exposed — this has been fixed as of this PR (so it gets exposed)
Notice in calls to the server that the expose entry for the Block was with a culture, and with this fix it is without.

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
