### PR TITLE
Only allow ClientIds of 255 characters for the Client Credentials

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/User/ClientCredentials/ClientCredentialsUserControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/ClientCredentials/ClientCredentialsUserControllerBase.cs
@@ -20,7 +20,7 @@ public abstract class ClientCredentialsUserControllerBase : UserControllerBase
                 .Build()),
             BackOfficeUserClientCredentialsOperationStatus.InvalidClientId => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid client ID")
-                .WithDetail("The specified client ID is invalid. A valid client ID can only contain [a-z], [A-Z], [0-9], and [-._~].")
+                .WithDetail("The specified client ID is invalid. A valid client ID can only contain [a-z], [A-Z], [0-9], and [-._~]. Furthermore, including the prefix it cannot be longer than 255 characters.")
                 .Build()),
             _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown client credentials operation status.")

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -2677,7 +2677,7 @@ internal partial class UserService : RepositoryService, IUserService
         }
     }
 
-    [GeneratedRegex(@"^[\w\d\-\._~]*$")]
+    [GeneratedRegex(@"^[\w\d\-\._~]{1,255}$")]
     private static partial Regex ValidClientId();
 
     #endregion

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/UserServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/UserServiceTests.cs
@@ -1004,6 +1004,7 @@ public class UserServiceTests : UmbracoIntegrationTest
     [TestCase("@", UserClientCredentialsOperationStatus.InvalidClientId)]
     [TestCase("[", UserClientCredentialsOperationStatus.InvalidClientId)]
     [TestCase("]", UserClientCredentialsOperationStatus.InvalidClientId)]
+    [TestCase("More_Than_255_characters_012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789", UserClientCredentialsOperationStatus.InvalidClientId)]
     public async Task Can_Use_Only_Unreserved_Characters_For_ClientId(string clientId, UserClientCredentialsOperationStatus expectedResult)
     {
         // Arrange


### PR DESCRIPTION
[Fixes](https://github.com/umbraco/Umbraco-CMS/commit/8c1e9da8e37ce7a49f95975cbe5a23154636d7e8) https://github.com/umbraco/Umbraco-CMS/issues/17506

### Description
Returns `InvalidClientId` status when the clientID is longer than 255 characters