### PR TITLE
Fixes to templates: Do not allow deletion of masters and  ensure file names are pascal case

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,8 +33,8 @@
   <!-- Package Validation -->
   <PropertyGroup>
     <GenerateCompatibilitySuppressionFile>false</GenerateCompatibilitySuppressionFile>
-    <EnablePackageValidation>false</EnablePackageValidation>
-    <PackageValidationBaselineVersion>14.0.0</PackageValidationBaselineVersion>
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>15.0.0</PackageValidationBaselineVersion>
     <EnableStrictModeForCompatibleFrameworksInPackage>true</EnableStrictModeForCompatibleFrameworksInPackage>
     <EnableStrictModeForCompatibleTfms>true</EnableStrictModeForCompatibleTfms>
   </PropertyGroup>

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/TemplateControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/TemplateControllerBase.cs
@@ -38,6 +38,10 @@ public class TemplateControllerBase : ManagementApiControllerBase
                 .WithTitle("Master template not found")
                 .WithDetail("The master template referenced in the template was not found.")
                 .Build()),
+            TemplateOperationStatus.MasterTemplateCannotBeDeleted => BadRequest(problemDetailsBuilder
+                .WithTitle("Master template cannot be deleted")
+                .WithDetail("The master templates cannot be deleted. Please ensure the template is not a master template before you delete.")
+                .Build()),
             _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown template operation status.")
                 .Build()),

--- a/src/Umbraco.Core/IO/ViewHelper.cs
+++ b/src/Umbraco.Core/IO/ViewHelper.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.DependencyInjection;
@@ -90,7 +91,7 @@ public class ViewHelper : IViewHelper
         return t.Content;
     }
 
-    public string ViewPath(string alias) => _viewFileSystem.GetRelativePath(alias.Replace(" ", string.Empty) + ".cshtml");
+    public string ViewPath(string alias) => _viewFileSystem.GetRelativePath(CultureInfo.InvariantCulture.TextInfo.ToTitleCase(alias.Replace(" ", string.Empty)) + ".cshtml");
 
     private string SaveTemplateToFile(ITemplate template)
     {

--- a/src/Umbraco.Core/Services/OperationStatus/TemplateOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/TemplateOperationStatus.cs
@@ -8,5 +8,6 @@ public enum TemplateOperationStatus
     DuplicateAlias,
     TemplateNotFound,
     MasterTemplateNotFound,
-    CircularMasterTemplateReference
+    CircularMasterTemplateReference,
+    MasterTemplateCannotBeDeleted,
 }

--- a/src/Umbraco.Core/Services/TemplateService.cs
+++ b/src/Umbraco.Core/Services/TemplateService.cs
@@ -404,6 +404,12 @@ public class TemplateService : RepositoryService, ITemplateService
                 return Attempt.FailWithStatus<ITemplate?, TemplateOperationStatus>(TemplateOperationStatus.TemplateNotFound, null);
             }
 
+            if (template.IsMasterTemplate)
+            {
+                scope.Complete();
+                return Attempt.FailWithStatus<ITemplate?, TemplateOperationStatus>(TemplateOperationStatus.MasterTemplateCannotBeDeleted, null);
+            }
+
             EventMessages eventMessages = EventMessagesFactory.Get();
             var deletingNotification = new TemplateDeletingNotification(template, eventMessages);
             if (scope.Notifications.PublishCancelable(deletingNotification))

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/TemplateServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/TemplateServiceTests.cs
@@ -195,7 +195,7 @@ public class TemplateServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
-    public async Task Deleting_Master_Template_Also_Deletes_Children()
+    public async Task Master_Template_Cannot_Be_Deleted()
     {
         Attempt<ITemplate, TemplateOperationStatus> result = await TemplateService.CreateAsync("Parent", "parent", "test", Constants.Security.SuperUserKey);
         Assert.IsTrue(result.Success);
@@ -207,10 +207,8 @@ public class TemplateServiceTests : UmbracoIntegrationTest
         Assert.AreEqual("parent", child.MasterTemplateAlias);
 
         result = await TemplateService.DeleteAsync(parent.Key, Constants.Security.SuperUserKey);
-        Assert.IsTrue(result.Success);
-
-        child = await TemplateService.GetAsync(child.Key);
-        Assert.Null(child);
+        Assert.IsFalse(result.Success);
+        Assert.That(result.Status, Is.EqualTo(TemplateOperationStatus.MasterTemplateCannotBeDeleted));
     }
 
     [Test]

--- a/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
@@ -6,7 +6,7 @@
     <Description>Contains helper classes for integration tests with Umbraco CMS, including all internal integration tests.</Description>
     <RootNamespace>Umbraco.Cms.Tests.Integration</RootNamespace>
     <IsPackable>true</IsPackable>
-    <EnablePackageValidation>$(BaseEnablePackageValidation)</EnablePackageValidation>
+    <EnablePackageValidation>false</EnablePackageValidation>
     <NoWarn>NU5100</NoWarn>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/17458
Fixes https://github.com/umbraco/Umbraco-CMS/issues/16443

### Description
Template file names should be Pascal-case. We can do this my having a titlecase on the original alias.

Furthermore, ensure templates cannot be delete when it is a master template

### Tests
- See original issues but use swagger to delete a master template