### PR TITLE
TinyMCE readonly mode

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.component.js
@@ -276,7 +276,7 @@
 
                 // Readonly mode
                 baseLineConfigObj.toolbar = vm.readonly ? false : baseLineConfigObj.toolbar;
-                baseLineConfigObj.readonly = vm.readonly ? 1 : baseLineConfigObj.readonly;
+                baseLineConfigObj.readonly = vm.readonly ? true : baseLineConfigObj.readonly;
 
                 // We need to wait for DOM to have rendered before we can find the element by ID.
                 $timeout(function () {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes issues described here https://github.com/umbraco/Umbraco-CMS/discussions/17531

### Description
TinyMCE property editor supports readonly mode, but it didn't work, because it sets `readonly: 1`.
According to documentation https://www.tiny.cloud/docs/tinymce/6/editor-important-options/#readonly `readonly` is a boolean property, so value should be `true/false`.

Readonly mode of TinyMCE allows to select/highlight text, but not edit, insert/paste, use toolbar actions or shortcuts to modify content.

**Before**

![chrome_rs1TTFa7by](https://github.com/user-attachments/assets/a19f1581-afce-419a-b7e8-dd1137bb95ca)

**After**

![image](https://github.com/user-attachments/assets/39904a1f-09b2-4c14-b879-d319d74792b9)


Tested with TheStarterKit package and include the following `SendingContentNotification` handler and composer in `Umbraco.Web.UI` project: [Test.zip](https://github.com/user-attachments/files/17781839/Test.zip)

It may not strictly require to set `toolbar: false`, but perhaps it was so make it simpler in readonly mode?

```
// Readonly mode
//baseLineConfigObj.toolbar = vm.readonly ? false : baseLineConfigObj.toolbar;
baseLineConfigObj.readonly = vm.readonly ? true : baseLineConfigObj.readonly;
```

With this code it looks like this:

![image](https://github.com/user-attachments/assets/0ea6cad7-aea7-434f-aeeb-5b09eae2f043)
