### PR TITLE
V14: Use decimal in slider property editor

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/SliderPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/SliderPropertyEditor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System.Globalization;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Editors;
@@ -51,8 +52,8 @@ public class SliderPropertyEditor : DataEditor
 
         public override object? ToEditor(IProperty property, string? culture = null, string? segment = null)
         {
-            // value is stored as a string - either a single integer value
-            // or a two integer values separated by comma (for range sliders)
+            // value is stored as a string - either a single decimal value
+            // or a two decimal values separated by comma (for range sliders)
             var value = property.GetValue(culture, segment);
             if (value is not string stringValue)
             {
@@ -61,7 +62,7 @@ public class SliderPropertyEditor : DataEditor
 
             var parts = stringValue.Split(Constants.CharArrays.Comma);
             var parsed = parts
-                .Select(s => int.TryParse(s, out var i) ? i : (int?)null)
+                .Select(s => decimal.TryParse(s, NumberStyles.Number, CultureInfo.InvariantCulture, out var i) ? i : (decimal?)null)
                 .Where(i => i != null)
                 .Select(i => i!.Value)
                 .ToArray();
@@ -78,9 +79,9 @@ public class SliderPropertyEditor : DataEditor
 
         internal class SliderRange
         {
-            public int From { get; set; }
+            public decimal From { get; set; }
 
-            public int To { get; set; }
+            public decimal To { get; set; }
 
             public override string ToString() => From == To ? $"{From}" : $"{From},{To}";
         }

--- a/src/Umbraco.Infrastructure/PropertyEditors/SliderPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/SliderPropertyEditor.cs
@@ -83,7 +83,7 @@ public class SliderPropertyEditor : DataEditor
 
             public decimal To { get; set; }
 
-            public override string ToString() => From == To ? $"{From}" : $"{From},{To}";
+            public override string ToString() => From == To ? $"{From.ToString(CultureInfo.InvariantCulture)}" : $"{From.ToString(CultureInfo.InvariantCulture)},{To.ToString(CultureInfo.InvariantCulture)}";
         }
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/SliderValueEditorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/SliderValueEditorTests.cs
@@ -24,10 +24,6 @@ public class SliderValueEditorTests
         123m,
         123,
         -123,
-        123.45d,
-        "123.45",
-        "1.234,56",
-        "1.2.3.4",
         "something",
         true,
         new object(),
@@ -50,7 +46,8 @@ public class SliderValueEditorTests
     [TestCase("0", 0)]
     [TestCase("-1", -1)]
     [TestCase("123456789", 123456789)]
-    public void Can_Parse_Single_Value_To_Editor(string value, int expected)
+    [TestCase("123.45", 123.45)]
+    public void Can_Parse_Single_Value_To_Editor(string value, decimal expected)
     {
         var toEditor = ToEditor(value) as SliderPropertyEditor.SliderPropertyValueEditor.SliderRange;
         Assert.IsNotNull(toEditor);
@@ -62,7 +59,10 @@ public class SliderValueEditorTests
     [TestCase("0,0", 0, 0)]
     [TestCase("-1,-1", -1, -1)]
     [TestCase("10,123456789", 10, 123456789)]
-    public void Can_Parse_Range_Value_To_Editor(string value, int expectedFrom, int expectedTo)
+    [TestCase("1.234,56", 1.234, 56)]
+    [TestCase("4,6.234", 4, 6.234)]
+    [TestCase("10.45,15.3", 10.45, 15.3)]
+    public void Can_Parse_Range_Value_To_Editor(string value, decimal expectedFrom, decimal expectedTo)
     {
         var toEditor = ToEditor(value) as SliderPropertyEditor.SliderPropertyValueEditor.SliderRange;
         Assert.IsNotNull(toEditor);
@@ -75,7 +75,11 @@ public class SliderValueEditorTests
     [TestCase(0, 0, "0")]
     [TestCase(-10, -10, "-10")]
     [TestCase(10, 123456789, "10,123456789")]
-    public void Can_Parse_Valid_Value_From_Editor(int from, int to, string expectedResult)
+    [TestCase(1.5, 1.5, "1.5")]
+    [TestCase(0, 0.5, "0,0.5")]
+    [TestCase(5, 5.4, "5,5.4")]
+    [TestCase(0.5, 0.6, "0.5,0.6")]
+    public void Can_Parse_Valid_Value_From_Editor(decimal from, decimal to, string expectedResult)
     {
         var value = JsonNode.Parse($"{{\"from\": {from}, \"to\": {to}}}");
         var fromEditor = FromEditor(value) as string;

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/SliderValueEditorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/SliderValueEditorTests.cs
@@ -6,7 +6,6 @@ using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Editors;
 using Umbraco.Cms.Core.PropertyEditors;
-using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Infrastructure.Serialization;
 
@@ -15,11 +14,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.PropertyEditors;
 [TestFixture]
 public class SliderValueEditorTests
 {
-    // annoyingly we can't use decimals etc. in attributes, so we can't turn these into test cases :(
-    private List<object?> _invalidValues = new();
-
-    [SetUp]
-    public void SetUp() => _invalidValues = new List<object?>
+    public static object[] InvalidCaseData = new object[]
     {
         123m,
         123,
@@ -32,14 +27,11 @@ public class SliderValueEditorTests
         new GuidUdi(Constants.UdiEntityType.Document, Guid.NewGuid())
     };
 
-    [Test]
-    public void Can_Handle_Invalid_Values_From_Editor()
+    [TestCaseSource(nameof(InvalidCaseData))]
+    public void Can_Handle_Invalid_Values_From_Editor(object value)
     {
-        foreach (var value in _invalidValues)
-        {
-            var fromEditor = FromEditor(value);
-            Assert.IsNull(fromEditor, message: $"Failed for: {value}");
-        }
+        var fromEditor = FromEditor(value);
+        Assert.IsNull(fromEditor);
     }
 
     [TestCase("1", 1)]
@@ -86,14 +78,11 @@ public class SliderValueEditorTests
         Assert.AreEqual(expectedResult, fromEditor);
     }
 
-    [Test]
-    public void Can_Handle_Invalid_Values_To_Editor()
+    [TestCaseSource(nameof(InvalidCaseData))]
+    public void Can_Handle_Invalid_Values_To_Editor(object value)
     {
-        foreach (var value in _invalidValues)
-        {
-            var toEditor = ToEditor(value);
-            Assert.IsNull(toEditor, message: $"Failed for: {value}");
-        }
+        var toEditor = ToEditor(value);
+        Assert.IsNull(toEditor, message: $"Failed for: {value}");
     }
 
     [Test]


### PR DESCRIPTION
Fixes the backend part of #17546.

The issue was that the `SliderPropertyEditor` assumed that sliders could not be decimal values; however, they can. This can also be seen in the `SliderValueConverter` and in the models generated by the model builder, which all assume a `Decimal` value. 

This fixes the backend issues, however, the UI looks quite weird still, when not in range mode the decimals aren't showing, and when in range mode they show but aren't properly formatted showing float imprecision I.E `0.30000000001`. Edit: This turned out to be a UUI bug, I've made a fix that has already been merged in UUI


For testing see original issue