### PR TITLE
Run both cms and package migrations in upgrader

### DIFF
--- a/src/Umbraco.Infrastructure/Install/UnattendedUpgrader.cs
+++ b/src/Umbraco.Infrastructure/Install/UnattendedUpgrader.cs
@@ -1,5 +1,9 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Exceptions;
 using Umbraco.Cms.Core.Logging;
@@ -23,19 +27,39 @@ public class UnattendedUpgrader : INotificationAsyncHandler<RuntimeUnattendedUpg
     private readonly IProfilingLogger _profilingLogger;
     private readonly IRuntimeState _runtimeState;
     private readonly IUmbracoVersion _umbracoVersion;
+    private readonly UnattendedSettings _unattendedSettings;
 
     public UnattendedUpgrader(
         IProfilingLogger profilingLogger,
         IUmbracoVersion umbracoVersion,
         DatabaseBuilder databaseBuilder,
         IRuntimeState runtimeState,
-        PackageMigrationRunner packageMigrationRunner)
+        PackageMigrationRunner packageMigrationRunner,
+        IOptions<UnattendedSettings> unattendedSettings)
     {
         _profilingLogger = profilingLogger ?? throw new ArgumentNullException(nameof(profilingLogger));
         _umbracoVersion = umbracoVersion ?? throw new ArgumentNullException(nameof(umbracoVersion));
         _databaseBuilder = databaseBuilder ?? throw new ArgumentNullException(nameof(databaseBuilder));
         _runtimeState = runtimeState ?? throw new ArgumentNullException(nameof(runtimeState));
         _packageMigrationRunner = packageMigrationRunner;
+        _unattendedSettings = unattendedSettings.Value;
+    }
+
+    [Obsolete("Use constructor that takes IOptions<UnattendedSettings>, this will be removed in V16")]
+    public UnattendedUpgrader(
+        IProfilingLogger profilingLogger,
+        IUmbracoVersion umbracoVersion,
+        DatabaseBuilder databaseBuilder,
+        IRuntimeState runtimeState,
+        PackageMigrationRunner packageMigrationRunner)
+    : this(
+        profilingLogger,
+        umbracoVersion,
+        databaseBuilder,
+        runtimeState,
+        packageMigrationRunner,
+        StaticServiceProvider.Instance.GetRequiredService<IOptions<UnattendedSettings>>())
+    {
     }
 
     public Task HandleAsync(RuntimeUnattendedUpgradeNotification notification, CancellationToken cancellationToken)
@@ -46,55 +70,26 @@ public class UnattendedUpgrader : INotificationAsyncHandler<RuntimeUnattendedUpg
             {
                 case RuntimeLevelReason.UpgradeMigrations:
                 {
-                    var plan = new UmbracoPlan(_umbracoVersion);
-                    using (!_profilingLogger.IsEnabled(Core.Logging.LogLevel.Verbose) ? null : _profilingLogger.TraceDuration<UnattendedUpgrader>(
-                               "Starting unattended upgrade.",
-                               "Unattended upgrade completed."))
-                    {
-                        DatabaseBuilder.Result? result = _databaseBuilder.UpgradeSchemaAndData(plan);
-                        if (result?.Success == false)
-                        {
-                            var innerException = new UnattendedInstallException(
-                                "An error occurred while running the unattended upgrade.\n" + result.Message);
-                            _runtimeState.Configure(RuntimeLevel.BootFailed, RuntimeLevelReason.BootFailedOnException, innerException);
-                        }
+                    RunUpgrade(notification);
 
-                        notification.UnattendedUpgradeResult =
-                            RuntimeUnattendedUpgradeNotification.UpgradeResult.CoreUpgradeComplete;
+                    // If we errored out when upgrading don't do anything.
+                    if (notification.UnattendedUpgradeResult is RuntimeUnattendedUpgradeNotification.UpgradeResult.HasErrors)
+                    {
+                        return Task.CompletedTask;
+                    }
+
+                    // It's entirely possible that there's both a core upgrade and package migrations to run, so try and run package migrations too.
+                    // but only if upgrade unattended is enabled.
+                    if (_unattendedSettings.UpgradeUnattended)
+                    {
+                        RunPackageMigrations(notification);
                     }
                 }
 
                 break;
                 case RuntimeLevelReason.UpgradePackageMigrations:
                 {
-                    if (!_runtimeState.StartupState.TryGetValue(
-                        RuntimeState.PendingPackageMigrationsStateKey,
-                        out var pm)
-                        || pm is not IReadOnlyList<string> pendingMigrations)
-                    {
-                        throw new InvalidOperationException(
-                            $"The required key {RuntimeState.PendingPackageMigrationsStateKey} does not exist in startup state");
-                    }
-
-                    if (pendingMigrations.Count == 0)
-                    {
-                        throw new InvalidOperationException(
-                            "No pending migrations found but the runtime level reason is " +
-                            RuntimeLevelReason.UpgradePackageMigrations);
-                    }
-
-                    try
-                    {
-                        _packageMigrationRunner.RunPackagePlans(pendingMigrations);
-                        notification.UnattendedUpgradeResult = RuntimeUnattendedUpgradeNotification.UpgradeResult
-                            .PackageMigrationComplete;
-                    }
-                    catch (Exception ex)
-                    {
-                        SetRuntimeError(ex);
-                        notification.UnattendedUpgradeResult =
-                            RuntimeUnattendedUpgradeNotification.UpgradeResult.HasErrors;
-                    }
+                    RunPackageMigrations(notification);
                 }
 
                 break;
@@ -104,6 +99,64 @@ public class UnattendedUpgrader : INotificationAsyncHandler<RuntimeUnattendedUpg
         }
 
         return Task.CompletedTask;
+    }
+
+    private void RunPackageMigrations(RuntimeUnattendedUpgradeNotification notification)
+    {
+        if (_runtimeState.StartupState.TryGetValue(
+                RuntimeState.PendingPackageMigrationsStateKey,
+                out var pm) is false
+            || pm is not IReadOnlyList<string> pendingMigrations)
+        {
+            throw new InvalidOperationException(
+                $"The required key {RuntimeState.PendingPackageMigrationsStateKey} does not exist in startup state");
+        }
+
+        if (pendingMigrations.Count == 0)
+        {
+            // If we determined we needed to run package migrations but there are none, this is an error
+            if (_runtimeState.Reason is RuntimeLevelReason.UpgradePackageMigrations)
+            {
+                throw new InvalidOperationException(
+                    "No pending migrations found but the runtime level reason is " +
+                    RuntimeLevelReason.UpgradePackageMigrations);
+            }
+
+            return;
+        }
+
+        try
+        {
+            _packageMigrationRunner.RunPackagePlans(pendingMigrations);
+            notification.UnattendedUpgradeResult = RuntimeUnattendedUpgradeNotification.UpgradeResult
+                .PackageMigrationComplete;
+        }
+        catch (Exception ex)
+        {
+            SetRuntimeError(ex);
+            notification.UnattendedUpgradeResult =
+                RuntimeUnattendedUpgradeNotification.UpgradeResult.HasErrors;
+        }
+    }
+
+    private void RunUpgrade(RuntimeUnattendedUpgradeNotification notification)
+    {
+        var plan = new UmbracoPlan(_umbracoVersion);
+        using (!_profilingLogger.IsEnabled(Core.Logging.LogLevel.Verbose) ? null : _profilingLogger.TraceDuration<UnattendedUpgrader>(
+                   "Starting unattended upgrade.",
+                   "Unattended upgrade completed."))
+        {
+            DatabaseBuilder.Result? result = _databaseBuilder.UpgradeSchemaAndData(plan);
+            if (result?.Success == false)
+            {
+                var innerException = new UnattendedInstallException(
+                    "An error occurred while running the unattended upgrade.\n" + result.Message);
+                _runtimeState.Configure(RuntimeLevel.BootFailed, RuntimeLevelReason.BootFailedOnException, innerException);
+            }
+
+            notification.UnattendedUpgradeResult =
+                RuntimeUnattendedUpgradeNotification.UpgradeResult.CoreUpgradeComplete;
+        }
     }
 
     private void SetRuntimeError(Exception exception)

--- a/src/Umbraco.Infrastructure/Install/UnattendedUpgrader.cs
+++ b/src/Umbraco.Infrastructure/Install/UnattendedUpgrader.cs
@@ -80,7 +80,7 @@ public class UnattendedUpgrader : INotificationAsyncHandler<RuntimeUnattendedUpg
 
                     // It's entirely possible that there's both a core upgrade and package migrations to run, so try and run package migrations too.
                     // but only if upgrade unattended is enabled.
-                    if (_unattendedSettings.UpgradeUnattended)
+                    if (_unattendedSettings.PackageMigrationsUnattended)
                     {
                         RunPackageMigrations(notification);
                     }

--- a/src/Umbraco.Infrastructure/Runtime/RuntimeState.cs
+++ b/src/Umbraco.Infrastructure/Runtime/RuntimeState.cs
@@ -325,18 +325,17 @@ public class RuntimeState : IRuntimeState
                 // All will be prefixed with the same key.
                 IReadOnlyDictionary<string, string?>? keyValues = database.GetFromKeyValueTable(Constants.Conventions.Migrations.KeyValuePrefix);
 
-                // This could need both an upgrade AND package migrations to execute but
-                // we will process them one at a time, first the upgrade, then the package migrations.
+                // This could need both an upgrade AND package migrations to execute, so always add any pending package migrations
+                IReadOnlyList<string> packagesRequiringMigration = _packageMigrationState.GetPendingPackageMigrations(keyValues);
+                _startupState[PendingPackageMigrationsStateKey] = packagesRequiringMigration;
+
                 if (DoesUmbracoRequireUpgrade(keyValues))
                 {
                     return UmbracoDatabaseState.NeedsUpgrade;
                 }
 
-                IReadOnlyList<string> packagesRequiringMigration = _packageMigrationState.GetPendingPackageMigrations(keyValues);
                 if (packagesRequiringMigration.Count > 0)
                 {
-                    _startupState[PendingPackageMigrationsStateKey] = packagesRequiringMigration;
-
                     return UmbracoDatabaseState.NeedsPackageMigration;
                 }
             }


### PR DESCRIPTION
Fixes #17436 

The problem was that the upgrader only ever ran either CMS upgrades or package upgrades, this has been updated so both are run if needed. 

Not that the CMS and package upgrades run in their own separate scopes, so it's safe to do it in a single notification handler 😄 

## Testing

Add both a CMS NoopMigration in `UmbracoPlan` and a package plan, unable unattended upgrades, and ensure both are run if needed. 


Example package migration plan 

```C#
using Umbraco.Cms.Core.Packaging;
using Umbraco.Cms.Infrastructure.Migrations;

namespace Umbraco.Cms.Web.UI;

public class MyMigrationPlan : PackageMigrationPlan
{
    public MyMigrationPlan() : base("MyPackage")
    {
    }

    protected override void DefinePlan() {
        To<NoopMigration>(Guid.Parse("AD8AF4BF-9AE1-42BC-9709-CA64891BA92D"));
    }
}
````
