### PR TITLE
Add ASCII file name conversion

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/RequestHandlerSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/RequestHandlerSettings.cs
@@ -15,6 +15,7 @@ public class RequestHandlerSettings
 {
     internal const bool StaticAddTrailingSlash = true;
     internal const string StaticConvertUrlsToAscii = "try";
+    internal const string StaticConvertFileNamesToAscii = "false";
     internal const bool StaticEnableDefaultCharReplacements = true;
 
     internal static readonly CharItem[] DefaultCharCollection =
@@ -72,6 +73,22 @@ public class RequestHandlerSettings
     ///     Gets a value indicating whether URLs should be tried to be converted to ASCII.
     /// </summary>
     public bool ShouldTryConvertUrlsToAscii => ConvertUrlsToAscii.InvariantEquals("try");
+
+    /// <summary>
+    ///     Gets or sets a value indicating whether to convert file names to ASCII (valid values: "true", "try" or "false").
+    /// </summary>
+    [DefaultValue(StaticConvertFileNamesToAscii)]
+    public string ConvertFileNamesToAscii { get; set; } = StaticConvertFileNamesToAscii;
+
+    /// <summary>
+    ///     Gets a value indicating whether URLs should be converted to ASCII.
+    /// </summary>
+    public bool ShouldConvertFileNamesToAscii => ConvertFileNamesToAscii.InvariantEquals("true");
+
+    /// <summary>
+    ///     Gets a value indicating whether URLs should be tried to be converted to ASCII.
+    /// </summary>
+    public bool ShouldTryConvertFileNamesToAscii => ConvertFileNamesToAscii.InvariantEquals("try");
 
     /// <summary>
     ///     Disable all default character replacements

--- a/src/Umbraco.Core/Strings/DefaultShortStringHelperConfig.cs
+++ b/src/Umbraco.Core/Strings/DefaultShortStringHelperConfig.cs
@@ -74,10 +74,19 @@ public class DefaultShortStringHelperConfig
         {
             urlSegmentConvertTo = CleanStringType.Ascii;
         }
-
-        if (requestHandlerSettings.ShouldTryConvertUrlsToAscii)
+        else if (requestHandlerSettings.ShouldTryConvertUrlsToAscii)
         {
             urlSegmentConvertTo = CleanStringType.TryAscii;
+        }
+
+        CleanStringType fileNameSegmentConvertTo = CleanStringType.Utf8;
+        if (requestHandlerSettings.ShouldConvertFileNamesToAscii)
+        {
+            fileNameSegmentConvertTo = CleanStringType.Ascii;
+        }
+        else if (requestHandlerSettings.ShouldTryConvertFileNamesToAscii)
+        {
+            fileNameSegmentConvertTo = CleanStringType.TryAscii;
         }
 
         return WithConfig(CleanStringType.UrlSegment, new Config
@@ -92,7 +101,7 @@ public class DefaultShortStringHelperConfig
         {
             PreFilter = ApplyUrlReplaceCharacters,
             IsTerm = (c, leading) => char.IsLetterOrDigit(c) || c == '_', // letter, digit or underscore
-            StringType = CleanStringType.Utf8 | CleanStringType.LowerCase,
+            StringType = fileNameSegmentConvertTo | CleanStringType.LowerCase,
             BreakTermsOnUpper = false,
             Separator = '-',
         }).WithConfig(CleanStringType.Alias, new Config


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #15939

### Description

#15939 describes a difference between how content URL segments and media file names are encoded. However, the issue description is slightly off point - and as it happens, the difference is a feature 😄 albeit a somewhat confusing one, specially when char replacements are added to the mix.

Starting with the latter, with `RequestHandler:EnableDefaultCharReplacements` set to `true` (which is the default), specific characters to be replaced with URL friendly alternatives (e.g. "å" is replaced by "aa" in the default configuration). These char replacements apply to both URL segments and file paths.

On top of the char replacements we have `RequestHandler:ConvertUrlsToAscii`, which is set to `"try"` by default. This setting _only_ affects the URL segment encoding, and causes all non-ASCII chars to be replaced by an ASCII char.

As a result, a content page named "ÅÅ Øø Ææ Ã" will yield the URL segment "aaaa-oeoe-aeae-a", whereas uploading file named "ÅÅ Øø Ææ Ã.png" will yield the media file name "aaaa-oeoe-aeae-ã.png".

At this time there is no way to obtain an ASCII encoded file name, and that is what this PR addresses: It adds the option to configure `RequestHandler:ConvertFileNamesToAscii` as the media file name counterpart to content URL segments.

The new configuration works the same as `RequestHandler:ConvertUrlsToAscii`. It accepts the values `"try"`, `"true"` and `"false"`. To retain the current functionality, the default value for `RequestHandler:ConvertFileNamesToAscii` is `"false"` 

### Future considerations

In reality, we would actually like to have file names ASCII encoded by default. We will likely change the default behaviour of `RequestHandler:ConvertFileNamesToAscii` in an upcoming major release. Keep an eye out for the announcements 😄 

### Testing this PR

Start by testing _without_ adding `RequestHandler:ConvertFileNamesToAscii` to app settings. Verify that the current behaviour persists (char conversions are applied to file names but ASCII conversion is not).

Add `RequestHandler:ConvertFileNamesToAscii` to app settings:
- the config values `"try"` and `"true"` should both yield ASCII conversion.
- the config value `"false"` should retain the current behaviour (same as not adding `RequestHandler:ConvertFileNamesToAscii` to app settings).


