### PR TITLE
V15: Apply content type filtering to self too

### DIFF
--- a/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
@@ -2469,7 +2469,10 @@ public static class PublishedContentExtensions
     {
         if (orSelf)
         {
-            yield return content;
+            if (contentTypeAlias is null || content.ContentType.Alias == contentTypeAlias)
+            {
+                yield return content;
+            }
         }
 
         var nodeExists = contentTypeAlias is null
@@ -2501,7 +2504,10 @@ public static class PublishedContentExtensions
     {
         if (orSelf)
         {
-            yield return content;
+            if (contentTypeAlias is null || content.ContentType.Alias == contentTypeAlias)
+            {
+                yield return content;
+            }
         }
 
         var nodeExists = contentTypeAlias is null


### PR DESCRIPTION
## Details
- Calling `content.DescendantsOrSelfOfType(...)` or `content.AncestorsOrSelf(..., "contentTypeAlias")` wasn't taking the content type alias into consideration for the self node - this PR fixes that.

## Test
- Create 2 simple document types with template - give one of them a colourful icon so you can easily distinguish it in the content tree;
- Create a nested content tree where you mix the content types;
- Use the following code in both templates and just modify the value of the content type alias:
```cshtml
@using Umbraco.Cms.Web.Common.PublishedModels;
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
@using Umbraco.Cms.Core.PublishedCache
@using Umbraco.Cms.Core.Routing
@using Umbraco.Cms.Core.Services.Navigation
@using Umbraco.Extensions

@inject IPublishedValueFallback PublishedValueFallback
@inject IPublishedUrlProvider PublishedUrlProvider
@inject IVariationContextAccessor VariationContextAccessor
@inject IPublishedContentCache PublishedContentCache
@inject IDocumentNavigationQueryService DocumentNavigationQueryService
@{
	Layout = null;
}

<h1>Hello from "@Model.Value("title")"</h1>

@{
	var ancestorsOrSelfOfType = Model.AncestorsOrSelf(PublishedContentCache, DocumentNavigationQueryService, "page1").Where(x => x.IsVisible(PublishedValueFallback)).ToArray();
	
	var descendantsOrSelfOfType = Model.DescendantsOrSelfOfType(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, "page1").Where(x => x.IsVisible(PublishedValueFallback)).ToArray();
	
	var siblingsOrSelfOfType = Model.SiblingsAndSelfOfType(VariationContextAccessor, PublishedContentCache, DocumentNavigationQueryService, "page1").Where(x => x.IsVisible(PublishedValueFallback)).ToArray();

	var selection = ancestorsOrSelfOfType; @* CHANGE THIS *@
 }

@if (selection?.Length > 0)
{
    @foreach (var item in selection)
    {
        <li>
	    <a href="@item.Url(PublishedUrlProvider)">@item.Name</a>
	</li>
    }
}
```

- Verify that the different content type aliases include/exclude self from the result, i.e. that the content type filtering is applied to self too.