### PR TITLE
Fix RTE console error when blocks are not available

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.component.js
@@ -349,8 +349,8 @@
           if(modelObject) {
             modelObject.update(vm.model.value.blocks, $scope);
             vm.tinyMceEditor.fire('updateBlocks');
+            onLoaded();
           }
-          onLoaded();
       }
 
       function ensurePropertyValue(newVal) {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #16011

### Description

See #16011 for an issue description 😄 

### Testing this PR

1. Blocks in RTEs should still work for content.
2. There should be no issues creating new media items with RTEs.
   - Test this both by uploading media directly to a media folder, and by creating media items explicitly (as outlined in the linked issue).


**Friendly testing note:** Blocks in RTEs are not supported for media items, so don't spend time trying to get them to work there 😛 
