### PR TITLE
Handle "all slashes" routes

### DIFF
--- a/src/Umbraco.Core/Routing/UriUtility.cs
+++ b/src/Umbraco.Core/Routing/UriUtility.cs
@@ -111,6 +111,12 @@ public sealed class UriUtility
         if (path != "/")
         {
             path = path.TrimEnd(Constants.CharArrays.ForwardSlash);
+
+            // perform fallback to root if the path was all slashes (i.e. https://some.where//////)
+            if (path == string.Empty)
+            {
+                path = "/";
+            }
         }
 
         return uri.Rewrite(path);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/UriUtilityTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/UriUtilityTests.cs
@@ -23,7 +23,9 @@ public class UriUtilityTests
 
     // test that the trailing slash goes but not on hostname
     [TestCase("http://LocalHost/", "http://localhost/")]
+    [TestCase("http://LocalHost/////", "http://localhost/")]
     [TestCase("http://LocalHost/Home/", "http://localhost/home")]
+    [TestCase("http://LocalHost/Home/////", "http://localhost/home")]
     [TestCase("http://LocalHost/Home/?x=y", "http://localhost/home?x=y")]
     [TestCase("http://LocalHost/Home/Sub1/", "http://localhost/home/sub1")]
     [TestCase("http://LocalHost/Home/Sub1/?x=y", "http://localhost/home/sub1?x=y")]


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #16585

### Description

The content routing has a strange discrepancy in routing:

- When requesting `http://some.where/path/////`, the routing resolves `http://some.where/path`
- When requesting `http://some.where/////`, the routing explodes 💥

See #16585 for details.

### Testing this PR

Content routing should work both at root and page level, despite being requested with multiple trailing slashes.