### PR TITLE
V15: Collection: Adds "Name" to Order By options

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/collection/views/grid/document-grid-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/collection/views/grid/document-grid-collection-view.element.ts
@@ -158,7 +158,7 @@ export class UmbDocumentGridCollectionViewElement extends UmbLitElement {
 		const value = getPropertyValueByAlias(item, column.alias);
 		return html`
 			<li>
-				<span>${column.header}:</span>
+				<span>${this.localize.string(column.header)}:</span>
 				${when(
 					column.nameTemplate,
 					() => html`<umb-ufm-render inline .markdown=${column.nameTemplate} .value=${{ value }}></umb-ufm-render>`,

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/collection/views/table/document-table-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/collection/views/table/document-table-collection-view.element.ts
@@ -128,7 +128,7 @@ export class UmbDocumentTableCollectionViewElement extends UmbLitElement {
 		if (this._userDefinedProperties && this._userDefinedProperties.length > 0) {
 			const userColumns: Array<UmbTableColumn> = this._userDefinedProperties.map((item) => {
 				return {
-					name: item.header,
+					name: this.localize.string(item.header),
 					alias: item.alias,
 					elementName: item.elementName,
 					labelTemplate: item.nameTemplate,

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/views/table/media-table-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/views/table/media-table-collection-view.element.ts
@@ -118,7 +118,7 @@ export class UmbMediaTableCollectionViewElement extends UmbLitElement {
 		if (this._userDefinedProperties && this._userDefinedProperties.length > 0) {
 			const userColumns: Array<UmbTableColumn> = this._userDefinedProperties.map((item) => {
 				return {
-					name: item.header,
+					name: this.localize.string(item.header),
 					alias: item.alias,
 					elementName: item.elementName,
 					allowSorting: true,

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/order-by/order-by.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/order-by/order-by.element.ts
@@ -31,11 +31,15 @@ export class UmbPropertyEditorUICollectionOrderByElement extends UmbLitElement i
 				await workspace.propertyValueByAlias<Array<UmbCollectionColumnConfiguration>>('includeProperties'),
 				(includeProperties) => {
 					if (!includeProperties) return;
-					this._options = includeProperties.map((property) => ({
+					const options = includeProperties.map((property) => ({
 						name: property.header,
 						value: property.alias,
 						selected: property.alias === this.value,
 					}));
+					this._options = [
+						{ name: this.localize.term('general_name'), value: 'name', selected: 'name' === this.value },
+						...options,
+					];
 				},
 				'_observeIncludeProperties',
 			);


### PR DESCRIPTION
### Description

Fixes #17461.

Given that "Name" is a default column in both the Document and Media collections, the option to set the Name as the default sorting column was not possible.  This PR adds the "Name" option to the Order By select configuration.

This PR also adds localization support to the column header labels.