### PR TITLE
V15: Show a loader during the login procedures rather than oddly styled content

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/apps/app/app-oauth.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/app/app-oauth.element.ts
@@ -1,0 +1,45 @@
+import { html, customElement, property } from '@umbraco-cms/backoffice/external/lit';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+
+import './app-error.element.js';
+
+/**
+ * A full page error element that can be used either solo or for instance as the error 500 page and BootFailed
+ */
+@customElement('umb-app-oauth')
+export class UmbAppOauthElement extends UmbLitElement {
+
+	/**
+	 * Set to true if the login failed. A message will be shown instead of the loader.
+	 * @attr
+	 */
+	@property({ type: Boolean })
+	failure = false;
+
+	override render() {
+		// If we have a message, we show the error page
+		// this is most likely happening inside a popup
+		if (this.failure) {
+			return html`<umb-app-error
+				.errorHeadline=${this.localize.term('general_login')}
+				.errorMessage=${this.localize.term('errors_externalLoginFailed')}
+				hide-back-button></umb-app-error>`;
+		}
+
+		// If we don't have a message, we show the loader, this is most likely happening in the main app
+		// for the normal login flow
+		return html`
+			<umb-body-layout id="loader" style="align-items:center;">
+				<uui-loader></uui-loader>
+			</umb-body-layout>
+		`;
+	}
+}
+
+export default UmbAppOauthElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-app-oauth': UmbAppOauthElement;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
@@ -20,7 +20,9 @@ import {
 } from '@umbraco-cms/backoffice/extension-registry';
 import { filter, first, firstValueFrom } from '@umbraco-cms/backoffice/external/rxjs';
 import { hasOwnOpener, retrieveStoredPath } from '@umbraco-cms/backoffice/utils';
-import UmbAppOauthElement from "./app-oauth.element.ts";
+import type { UmbAppOauthElement } from "./app-oauth.element.js";
+
+import './app-oauth.element.js';
 
 @customElement('umb-app')
 export class UmbAppElement extends UmbLitElement {

--- a/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
@@ -20,6 +20,7 @@ import {
 } from '@umbraco-cms/backoffice/extension-registry';
 import { filter, first, firstValueFrom } from '@umbraco-cms/backoffice/external/rxjs';
 import { hasOwnOpener, retrieveStoredPath } from '@umbraco-cms/backoffice/utils';
+import UmbAppOauthElement from "./app-oauth.element.ts";
 
 @customElement('umb-app')
 export class UmbAppElement extends UmbLitElement {
@@ -60,31 +61,27 @@ export class UmbAppElement extends UmbLitElement {
 		},
 		{
 			path: 'oauth_complete',
-			component: () => import('./app-error.element.js'),
+			component: () => import('./app-oauth.element.js'),
 			setup: (component) => {
 				if (!this.#authContext) {
-					throw new Error('[Fatal] Auth context is not available');
+					(component as UmbAppOauthElement).failure = true;
+					console.error('[Fatal] Auth context is not available');
+					return;
 				}
 
 				const searchParams = new URLSearchParams(window.location.search);
 				const hasCode = searchParams.has('code');
-				(component as UmbAppErrorElement).hideBackButton = true;
-				(component as UmbAppErrorElement).errorHeadline = this.localize.term('general_login');
+				if (!hasCode) {
+					(component as UmbAppOauthElement).failure = true;
+					console.error('[Fatal] No code in query parameters');
+					return;
+				}
 
-				// If there is an opener, we are in a popup window, and we should show a different message
-				// than if we are in the main window. If we are in the main window, we should redirect to the root.
+				// If we are in the main window (i.e. no opener), we should redirect to the root after the authorization request is completed.
 				// The authorization request will be completed in the active window (main or popup) and the authorization signal will be sent.
 				// If we are in a popup window, the storage event in UmbAuthContext will catch the signal and close the window.
 				// If we are in the main window, the signal will be caught right here and the user will be redirected to the root.
-				if (hasOwnOpener(this.backofficePath)) {
-					(component as UmbAppErrorElement).errorMessage = hasCode
-						? this.localize.term('errors_externalLoginSuccess')
-						: this.localize.term('errors_externalLoginFailed');
-				} else {
-					(component as UmbAppErrorElement).errorMessage = hasCode
-						? this.localize.term('errors_externalLoginRedirectSuccess')
-						: this.localize.term('errors_externalLoginFailed');
-
+				if (!hasOwnOpener(this.backofficePath)) {
 					this.observe(this.#authContext.authorizationSignal, () => {
 						// Redirect to the saved state or root
 						const url = retrieveStoredPath();
@@ -99,7 +96,7 @@ export class UmbAppElement extends UmbLitElement {
 				}
 
 				// Complete the authorization request, which will send the authorization signal
-				this.#authContext.completeAuthorizationRequest();
+				this.#authContext.completeAuthorizationRequest().catch(() => undefined);
 			},
 		},
 		{

--- a/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
@@ -20,7 +20,7 @@ import {
 } from '@umbraco-cms/backoffice/extension-registry';
 import { filter, first, firstValueFrom } from '@umbraco-cms/backoffice/external/rxjs';
 import { hasOwnOpener, retrieveStoredPath } from '@umbraco-cms/backoffice/utils';
-import type { UmbAppOauthElement } from "./app-oauth.element.js";
+import type { UmbAppOauthElement } from './app-oauth.element.js';
 
 import './app-oauth.element.js';
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/utils/path/has-own-opener.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/utils/path/has-own-opener.function.ts
@@ -22,11 +22,11 @@ export function hasOwnOpener(pathname?: string, windowLike: Window = globalThis.
 			return false;
 		}
 
-		if (pathname && openerLocation.pathname !== pathname) {
-			return false;
+		if (pathname && openerLocation.pathname.startsWith(pathname)) {
+			return true;
 		}
 
-		return true;
+		return false;
 	} catch {
 		// If there is a security error, it means that the opener is from a different origin, so we let it fall through
 		return false;


### PR DESCRIPTION
### Description

Fixes #17453

* Shows only a loader for a normal login flow
* Shows the umb-app-error component only if the flow fails (either in the main window or a popup)
* Fixes an error where `hasOwnOpener` did not work (at least not on the Vite server)

### How to test

1. Log in as normal and verify that you do not see a "flash of oddly styled content" but instead a uui-loader (you probably have to slow down the network requests)
2. Try and force a session timeout, e.g. by changing the access_token in Local Storage and performing some request, e.g. going to a content page
3. You should now see the login timeout overlay
4. Verify that the popup is closed after login and that you only see a loader inside the popup

**Hint:** You can force the "login landing page" by going to https://localhost:44339/umbraco/oauth_complete and appending `?code=test` to see the success variant and omitting the `?code` parameter to see the failure variant.