### PR TITLE
Support minimal APIs in OpenAPI spec and Swagger UI

### DIFF
--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -266,6 +266,7 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.ConfigureOptions<ConfigureApiVersioningOptions>();
         builder.Services.ConfigureOptions<ConfigureApiExplorerOptions>();
         builder.Services.AddApiVersioning().AddApiExplorer();
+        builder.Services.AddEndpointsApiExplorer();
         builder.Services.ConfigureOptions<UmbracoMvcConfigureOptions>();
         builder.Services.ConfigureOptions<UmbracoRequestLocalizationOptions>();
         builder.Services.TryAddEnumerable(ServiceDescriptor


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This is a simplified (alternate) approach to #15383 

All credits go to @nikcio for excellent investigation 🚀 

### Testing this PR

Custom APIs and OpenAPI docs are required to test this PR.

**Add this to configure a custom OpenAPI doc called "My API":**

```csharp
public class MyCustomSchemaOptions : IConfigureOptions<SwaggerGenOptions>
{
    public void Configure(SwaggerGenOptions swaggerGenOptions)
    {
        swaggerGenOptions.SwaggerDoc(
            "My API",
            new OpenApiInfo
            {
                Title = "My API pretty-name",
                Version = "1",
                Description = "All endpoints for My API"
            });
    }
}

public class MyCustomSchemaOptionsComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
        => builder.Services.ConfigureOptions<MyCustomSchemaOptions>();
}
```

**Add this to `Program.cs` to setup minimal APIs:**

```csharp
ApiVersionSet apiVersionSet = app.NewApiVersionSet("My API")
    .HasApiVersion(new ApiVersion(1))
    .ReportApiVersions()
    .Build();

app.MapGet("api/MyMinimal/get", () => "Hello World!");

app.MapGet("api/grouped/MyMinimal/get", () => "Hello World!")
    .WithGroupName("My Group")
    .WithApiVersionSet(apiVersionSet);

app.MapGet("api/notgrouped/MyMinimal/get", () => "Hello World!")
    .WithGroupName("Not My Group");
```

**Add this to setup "traditional" APIs:**

```csharp
using Microsoft.AspNetCore.Mvc;
using Microsoft.Extensions.Options;
using Microsoft.OpenApi.Models;
using Swashbuckle.AspNetCore.SwaggerGen;
using Umbraco.Cms.Api.Common.Attributes;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Web.Common.Controllers;

namespace Umbraco.Cms.Web.UI;

[ApiController]
[Route("api/[controller]")]
public class TestController : ControllerBase
{
    [HttpGet]
    public string Get()
    {
        return "Hello World";
    }
}

/// <summary>
/// Not part of Swagger schema as the Api Explorer doesn't support conventional routing that the <see cref="UmbracoApiController"/> is based on: https://stackoverflow.com/a/62810131/7153801
/// </summary>
public class TestUmbracoApiController : UmbracoApiController
{
    [HttpGet]
    public string Get()
    {
        return "Hello World";
    }
}

[ApiController]
[Route("api/[controller]")]
[ApiExplorerSettings(GroupName = "My Group")]
public class TestGroupController : ControllerBase
{
    [HttpGet]
    public string Get()
    {
        return "Hello World";
    }
}

[ApiController]
[Route("api/[controller]")]
[MapToApi("My API")]
public class TestMapToController : ControllerBase
{
    [HttpGet]
    public string Get()
    {
        return "Hello World";
    }
}

/// <summary>
/// Not part of Swagger schema as the Api Explorer doesn't support conventional routing that the <see cref="UmbracoApiController"/> is based on: https://stackoverflow.com/a/62810131/7153801
/// </summary>
[MapToApi("My API")]
public class TestMapToUmbracoApiController : UmbracoApiController
{
    [HttpGet]
    public string Get()
    {
        return "Hello World";
    }
}

[ApiController]
[Route("api/[controller]")]
[ApiExplorerSettings(GroupName = "Not found My Group")]
public class TestNotFoundGroupController : ControllerBase
{
    [HttpGet]
    public string Get()
    {
        return "Hello World";
    }
}
```

Now verify that:

- The minimal APIs are included in the OpenAPI spec:
   - `api/grouped/MyMinimal/get` is added to the "My API" OpenAPI doc.
   - `api/MyMinimal/get` and `api/notgrouped/MyMinimal/get` are included in the default OpenAPI doc.
- The "traditional" APIs are included in the OpenAPI spec:
   - `TestMapToController` is explicitly mapped to "My API" with the `[MapToApi]` annotation, so it should appear in the "My API" OpenAPI doc.
   - All controllers that inherit from `UmbracoApiController` should be omitted from the OpenAPI spec, because they cannot be routed (see code comments).
   - The rest of the controllers should be included in the default OpenAPI doc.

It should look something like this:

![image](https://github.com/user-attachments/assets/af9d2751-5155-45c0-8be3-4b68e88e3dbf)

![image](https://github.com/user-attachments/assets/1ff30261-547a-4f2e-936f-2d8f6ce3d6c9)
