### PR TITLE
V15: Add information to item endpoints

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Factories/DocumentPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DocumentPresentationFactory.cs
@@ -22,19 +22,22 @@ internal sealed class DocumentPresentationFactory : IDocumentPresentationFactory
     private readonly ITemplateService _templateService;
     private readonly IPublicAccessService _publicAccessService;
     private readonly TimeProvider _timeProvider;
+    private readonly IIdKeyMap _idKeyMap;
 
     public DocumentPresentationFactory(
         IUmbracoMapper umbracoMapper,
         IDocumentUrlFactory documentUrlFactory,
         ITemplateService templateService,
         IPublicAccessService publicAccessService,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        IIdKeyMap idKeyMap)
     {
         _umbracoMapper = umbracoMapper;
         _documentUrlFactory = documentUrlFactory;
         _templateService = templateService;
         _publicAccessService = publicAccessService;
         _timeProvider = timeProvider;
+        _idKeyMap = idKeyMap;
     }
 
     public async Task<DocumentResponseModel> CreateResponseModelAsync(IContent content)
@@ -73,10 +76,14 @@ internal sealed class DocumentPresentationFactory : IDocumentPresentationFactory
 
     public DocumentItemResponseModel CreateItemResponseModel(IDocumentEntitySlim entity)
     {
+        Attempt<Guid> parentKeyAttempt = _idKeyMap.GetKeyForId(entity.ParentId, UmbracoObjectTypes.Document);
+
         var responseModel = new DocumentItemResponseModel
         {
             Id = entity.Key,
-            IsTrashed = entity.Trashed
+            IsTrashed = entity.Trashed,
+            Parent = parentKeyAttempt.Success ? new ReferenceByIdModel { Id = parentKeyAttempt.Result } : null,
+            HasChildren = entity.HasChildren,
         };
 
         responseModel.IsProtected = _publicAccessService.IsProtected(entity.Path);

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -36738,6 +36738,7 @@
       "DocumentItemResponseModel": {
         "required": [
           "documentType",
+          "hasChildren",
           "id",
           "isProtected",
           "isTrashed",
@@ -36753,6 +36754,17 @@
             "type": "boolean"
           },
           "isProtected": {
+            "type": "boolean"
+          },
+          "parent": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ReferenceByIdModel"
+              }
+            ],
+            "nullable": true
+          },
+          "hasChildren": {
             "type": "boolean"
           },
           "documentType": {
@@ -38895,6 +38907,7 @@
       },
       "MediaItemResponseModel": {
         "required": [
+          "hasChildren",
           "id",
           "isTrashed",
           "mediaType",
@@ -38907,6 +38920,17 @@
             "format": "uuid"
           },
           "isTrashed": {
+            "type": "boolean"
+          },
+          "parent": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ReferenceByIdModel"
+              }
+            ],
+            "nullable": true
+          },
+          "hasChildren": {
             "type": "boolean"
           },
           "mediaType": {

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/Item/DocumentItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/Item/DocumentItemResponseModel.cs
@@ -10,6 +10,10 @@ public class DocumentItemResponseModel : ItemResponseModelBase
 
     public bool IsProtected { get; set; }
 
+    public ReferenceByIdModel? Parent { get; set; }
+
+    public bool HasChildren { get; set; }
+
     public DocumentTypeReferenceResponseModel DocumentType { get; set; } = new();
 
     public IEnumerable<DocumentVariantItemResponseModel> Variants { get; set; } = Enumerable.Empty<DocumentVariantItemResponseModel>();

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Media/Item/MediaItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Media/Item/MediaItemResponseModel.cs
@@ -8,6 +8,10 @@ public class MediaItemResponseModel : ItemResponseModelBase
 {
     public bool IsTrashed { get; set; }
 
+    public ReferenceByIdModel? Parent { get; set; }
+
+    public bool HasChildren { get; set; }
+
     public MediaTypeReferenceResponseModel MediaType { get; set; } = new();
 
     public IEnumerable<VariantItemResponseModel> Variants { get; set; } = Enumerable.Empty<VariantItemResponseModel>();


### PR DESCRIPTION
Adds structural information to the document and media item endpoints, specifically `parentId` and `hasChildren`.

## Testing

Create a document and media item with children, and without

Ensure that the child has the parent key, and the parent has `hasChildren` set to true. and the one without has neither