### PR TITLE
V13: Dropzone, upload complete callback with processed file array

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/upload/umbfiledropzone.directive.js
@@ -116,7 +116,7 @@ angular.module("umbraco.directives")
               if (scope.totalMessages === 0) {
                 if (scope.filesUploaded) {
                   //queue is empty, trigger the done action
-                  scope.filesUploaded(scope.done);
+                  scope.filesUploaded(scope.processed);
                 }
 
                 //auto-clear the done queue after 3 secs

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-media-grid.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-media-grid.less
@@ -29,7 +29,7 @@
 
     > div {
         overflow: hidden;
-        border-radius: @baseBorderRadius;
+        border-radius: 0 0 @baseBorderRadius @baseBorderRadius;
     }
 
 }
@@ -106,6 +106,7 @@
    position: relative;
    object-fit: contain;
    height: 100%;
+   border-radius: @baseBorderRadius;
 }
 
 .umb-media-grid__item-image-placeholder {


### PR DESCRIPTION
### Description

When uploading files via the Media Picker modal's dropzone, the uploaded items were not being auto-selected. This is because the processed file references were not being passed back to the `fileUploaded` callback in the `umb-file-dropzone` directive.

Fixes #17395 
Fixes #16786

Also, added a minor cosmetic fix for the `border-radius` of uploaded images inside the media card.