### PR TITLE
Fix create child issue in list view with infinite editor (#13355).

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/listview/listview.controller.js
@@ -781,7 +781,7 @@ function listViewController($scope, $interpolate, $routeParams, $injector, $time
       $scope.options.allowBulkDelete;
 
     if ($scope.isTrashed === false) {
-      getContentTypesCallback(id).then(function (listViewAllowedTypes) {
+      getContentTypesCallback($scope.contentId).then(function (listViewAllowedTypes) {
         $scope.listViewAllowedTypes = listViewAllowedTypes;
 
         var blueprints = false;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #13355 

### Description
The linked issue is for v10 but I ran into the same issue in 13.5.2.

Based on @dKumarmj 's analysis in the issue I have tried to fix the problem.

Instead of using the id in the route to fetch the allowed child items we should use the contentId from the scope which represents the active item in the infinite editor.

With this fix in place the repro steps in the issue now work as expected, i.e. it is possible to create a third level item under the second level.
