### PR TITLE
V15: Utilizing content type filtering for navigation data instead of `.OfType<T>()`

### DIFF
--- a/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
@@ -2458,6 +2458,23 @@ public static class PublishedContentExtensions
             : contentNodes.Where(x => x.IsInvariantOrHasCulture(culture));
     }
 
+    /// <summary>
+    ///     Gets the content type alias from the PublishedModelAttribute of a specified type.
+    /// </summary>
+    /// <typeparam name="T">The content type.</typeparam>
+    /// <returns>The content type alias.</returns>
+    private static string GetContentTypeAliasForType<T>()
+        where T : class, IPublishedContent
+    {
+        PublishedModelAttribute? attribute = typeof(T).GetCustomAttribute<PublishedModelAttribute>(false);
+        if (attribute is null)
+        {
+            throw new InvalidOperationException($"The type {typeof(T).FullName} does not have the {nameof(PublishedModelAttribute)}, so the content type alias cannot be inferred.");
+        }
+
+        return attribute.ContentTypeAlias;
+    }
+
     private static IEnumerable<IPublishedContent> EnumerateDescendantsOrSelfInternal(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,

--- a/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
@@ -581,8 +581,12 @@ public static class PublishedContentExtensions
         this IPublishedContent content,
         IPublishedCache publishedCache,
         INavigationQueryService navigationQueryService)
-        where T : class, IPublishedContent =>
-        content.Ancestors(publishedCache, navigationQueryService).OfType<T>();
+        where T : class, IPublishedContent
+    {
+        var contentTypeAlias = GetContentTypeAliasForType<T>();
+
+        return content.EnumerateAncestorsOrSelfInternal<T>(publishedCache, navigationQueryService, false, contentTypeAlias);
+    }
 
     /// <summary>
     ///     Gets the ancestors of the content, at a level lesser or equal to a specified level, and of a specified content
@@ -606,8 +610,14 @@ public static class PublishedContentExtensions
         IPublishedCache publishedCache,
         INavigationQueryService navigationQueryService,
         int maxLevel)
-        where T : class, IPublishedContent =>
-        content.Ancestors(publishedCache, navigationQueryService, maxLevel).OfType<T>();
+        where T : class, IPublishedContent
+    {
+        var contentTypeAlias = GetContentTypeAliasForType<T>();
+
+        IEnumerable<T> ancestors = content.EnumerateAncestorsOrSelfInternal<T>(publishedCache, navigationQueryService, false, contentTypeAlias);
+
+        return ancestors.Where(n => n.Level <= maxLevel);
+    }
 
     /// <summary>
     ///     Gets the content and its ancestors.
@@ -677,8 +687,12 @@ public static class PublishedContentExtensions
         this IPublishedContent content,
         IPublishedCache publishedCache,
         INavigationQueryService navigationQueryService)
-        where T : class, IPublishedContent =>
-        content.AncestorsOrSelf(publishedCache, navigationQueryService).OfType<T>();
+        where T : class, IPublishedContent
+    {
+        var contentTypeAlias = GetContentTypeAliasForType<T>();
+
+        return content.EnumerateAncestorsOrSelfInternal<T>(publishedCache, navigationQueryService, true, contentTypeAlias);
+    }
 
     /// <summary>
     ///     Gets the content and its ancestor, at a lever lesser or equal to a specified level, and of a specified content
@@ -699,8 +713,14 @@ public static class PublishedContentExtensions
         IPublishedCache publishedCache,
         INavigationQueryService navigationQueryService,
         int maxLevel)
-        where T : class, IPublishedContent =>
-        content.AncestorsOrSelf(publishedCache, navigationQueryService, maxLevel).OfType<T>();
+        where T : class, IPublishedContent
+    {
+        var contentTypeAlias = GetContentTypeAliasForType<T>();
+
+        IEnumerable<T> ancestorsOrSelf = content.EnumerateAncestorsOrSelfInternal<T>(publishedCache, navigationQueryService, true, contentTypeAlias);
+
+        return ancestorsOrSelf.Where(n => n.Level <= maxLevel);
+    }
 
     /// <summary>
     ///     Gets the ancestor of the content, ie its parent.

--- a/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
@@ -564,7 +564,7 @@ public static class PublishedContentExtensions
     {
         ArgumentNullException.ThrowIfNull(content);
 
-        return content.EnumerateAncestorsOrSelfInternal(publishedCache, navigationQueryService, false, contentTypeAlias);
+        return content.EnumerateAncestorsOrSelfInternal<IPublishedContent>(publishedCache, navigationQueryService, false, contentTypeAlias);
     }
 
     /// <summary>
@@ -660,7 +660,7 @@ public static class PublishedContentExtensions
     {
         ArgumentNullException.ThrowIfNull(content);
 
-        return content.EnumerateAncestorsOrSelfInternal(publishedCache, navigationQueryService, true, contentTypeAlias);
+        return content.EnumerateAncestorsOrSelfInternal<IPublishedContent>(publishedCache, navigationQueryService, true, contentTypeAlias);
     }
 
     /// <summary>
@@ -749,7 +749,7 @@ public static class PublishedContentExtensions
         ArgumentNullException.ThrowIfNull(content);
 
         return content
-            .EnumerateAncestorsOrSelfInternal(publishedCache, navigationQueryService, false, contentTypeAlias)
+            .EnumerateAncestorsOrSelfInternal<IPublishedContent>(publishedCache, navigationQueryService, false, contentTypeAlias)
             .FirstOrDefault();
     }
 
@@ -832,7 +832,7 @@ public static class PublishedContentExtensions
         ArgumentNullException.ThrowIfNull(content);
 
         return content
-            .EnumerateAncestorsOrSelfInternal(publishedCache, navigationQueryService, true, contentTypeAlias)
+            .EnumerateAncestorsOrSelfInternal<IPublishedContent>(publishedCache, navigationQueryService, true, contentTypeAlias)
             .FirstOrDefault() ?? content;
     }
 
@@ -897,7 +897,7 @@ public static class PublishedContentExtensions
     {
         ArgumentNullException.ThrowIfNull(content);
 
-        return content.EnumerateAncestorsOrSelfInternal(publishedCache, navigationQueryService, orSelf);
+        return content.EnumerateAncestorsOrSelfInternal<IPublishedContent>(publishedCache, navigationQueryService, orSelf);
     }
 
     #endregion

--- a/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
@@ -2,6 +2,7 @@
 // See LICENSE for more details.
 
 using System.Data;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;


### PR DESCRIPTION
## Details
_WIP_

## Test