### PR TITLE
V15: Make system media types clonable

### DIFF
--- a/src/Umbraco.Core/Services/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
+++ b/src/Umbraco.Core/Services/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
@@ -947,8 +947,18 @@ public abstract class ContentTypeServiceBase<TRepository, TItem> : ContentTypeSe
                 // this is illegal
                 //var copyingb = (ContentTypeCompositionBase) copying;
                 // but we *know* it has to be a ContentTypeCompositionBase anyways
-                var copyingb = (ContentTypeCompositionBase) (object)copying;
-                copy = (TItem) (object) copyingb.DeepCloneWithResetIdentities(alias);
+
+                // TODO: Fix back to only calling the copyingb.DeepCloneWithResetIdentities when
+                // when ContentTypeBase.DeepCloneWithResetIdentities is overrideable.
+                if (copying is IMediaType mediaTypeToCope)
+                {
+                    copy = (TItem)mediaTypeToCope.DeepCloneWithResetIdentities(alias);
+                }
+                else
+                {
+                    var copyingb = (ContentTypeCompositionBase) (object)copying;
+                    copy = (TItem) (object) copyingb.DeepCloneWithResetIdentities(alias);
+                }
 
                 copy.Name = copy.Name + " (copy)"; // might not be unique
 


### PR DESCRIPTION
# Notes
- Makes system media types clonable
- Note that the solution is kinda hacky. We cannot change the alias of a system media types, and thus this PR, enables changing of the alias of a system media type, only if we're cloning.
- We also need to make the `ContentTypeBase.DeepCloneWithResetIdentities` overrideable, so we don't have to have this weird function in `MediaType`.

# How to test
- Try to copy the "Folder" Media type.