### PR TITLE
V15: Debug missing contexts

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/debug/context-debug.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/debug/context-debug.controller.ts
@@ -18,11 +18,8 @@ export class UmbContextDebugController extends UmbControllerBase {
 		);
 	}
 
-	readonly #onContextDebug = async (event: any) => {
-		// Wait a frame to allow the event to bubble up and collect all the async instances
-		await new Promise((resolve) => setTimeout(resolve, 0));
-
-		// Once we got to the outer most component <umb-app>
+	#onContextDebug = (event: any) => {
+		// Once we got to the outter most component <umb-app>
 		// we can send the event containing all the contexts
 		// we have collected whilst coming up through the DOM
 		// and pass it back down to the callback in

--- a/src/Umbraco.Web.UI.Client/src/packages/core/debug/context-debug.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/debug/context-debug.controller.ts
@@ -18,8 +18,11 @@ export class UmbContextDebugController extends UmbControllerBase {
 		);
 	}
 
-	#onContextDebug = (event: any) => {
-		// Once we got to the outter most component <umb-app>
+	readonly #onContextDebug = async (event: any) => {
+		// Wait a frame to allow the event to bubble up and collect all the async instances
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		// Once we got to the outer most component <umb-app>
 		// we can send the event containing all the contexts
 		// we have collected whilst coming up through the DOM
 		// and pass it back down to the callback in

--- a/src/Umbraco.Web.UI.Client/src/packages/core/debug/debug.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/debug/debug.element.ts
@@ -3,7 +3,7 @@ import { css, customElement, html, map, nothing, property, state, when } from '@
 import { contextData, UmbContextDebugRequest } from '@umbraco-cms/backoffice/context-api';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
-import type { UmbDebugContextData, UmbDebugContextItemData } from '@umbraco-cms/backoffice/context-api';
+import type { UmbDebugContextItemData } from '@umbraco-cms/backoffice/context-api';
 import type { UmbModalManagerContext } from '@umbraco-cms/backoffice/modal';
 
 @customElement('umb-debug')
@@ -15,7 +15,7 @@ export class UmbDebugElement extends UmbLitElement {
 	dialog = false;
 
 	@state()
-	private _contextData = Array<UmbDebugContextData>();
+	private _contexts = new Map<any, any>();
 
 	@state()
 	private _debugPaneOpen = false;
@@ -37,11 +37,7 @@ export class UmbDebugElement extends UmbLitElement {
 				// to the root of <umb-app> which then uses the callback prop
 				// of this event that has been raised to assign the contexts
 				// back to this property of the WebComponent
-
-				// Massage the data into a simplier array of objects
-				// from a function in the context-api.
-				this._contextData = contextData(contexts);
-				this.requestUpdate('_contextData');
+				this._contexts = contexts;
 			}),
 		);
 	}
@@ -92,8 +88,9 @@ export class UmbDebugElement extends UmbLitElement {
 	}
 
 	#renderContextAliases() {
+		const data = contextData(this._contexts);
 		return html`<div class="events">
-			${map(this._contextData, (context) => {
+			${map(data, (context) => {
 				return html`
 					<details>
 						<summary><strong>${context.alias}</strong></summary>


### PR DESCRIPTION
### Description

Fixes #17410

This pull request addresses issue #17410 by enhancing how asynchronous contexts are handled during the UmbContextDebugRequest event. Some contexts, such as globalContexts, do not react instantly to the event, causing incomplete debug information. The solution implemented in this pull request involves storing the inner `event.instances` map in a state property and rendering it out on the fly instead, which ensures that Lit can figure out the changes to the object.

**Before (3 contexts on the news dashboard)**
![Screenshot 2024-11-26 at 16 27 00](https://github.com/user-attachments/assets/9ed4320c-7b9f-4a3c-a5df-593ac244dfa7)

**After (83 contexts available)**
![Screenshot 2024-11-26 at 16 28 10](https://github.com/user-attachments/assets/7e1e7cce-fa58-4b3b-8273-0ac3a7f64ee1)

### How to test
1. Add <umb-debug visible></umb-debug> to the news dashboard or in a modal.
2. Verify that all contexts are accurately displayed.


