### PR TITLE
Change meta tag "apple-mobile-web-app-capable" with "mobile-web-app-c…

### DIFF
--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoBackOffice/Index.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoBackOffice/Index.cshtml
@@ -28,7 +28,7 @@
     <base href="@backOfficePath.EnsureEndsWith('/')" />
     <link rel="icon" type="image/svg+xml" href="@backOfficeAssetsPath/assets/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="apple-mobile-web-app-capable" content="yes"/>
+    <meta name="mobile-web-app-capable" content="yes"/>
     <meta name="robots" content="noindex, nofollow"/>
     <meta name="pinterest" content="nopin"/>
     <title>Umbraco</title>

--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoLogin/Index.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoLogin/Index.cshtml
@@ -40,7 +40,7 @@
     <base href="@backOfficePath.EnsureEndsWith('/')"/>
     <link rel="icon" type="image/svg+xml" href="~/umbraco/login/favicon.svg"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <meta name="apple-mobile-web-app-capable" content="yes"/>
+    <meta name="mobile-web-app-capable" content="yes"/>
     <meta name="robots" content="noindex, nofollow"/>
     <meta name="pinterest" content="nopin"/>
     <title>Umbraco</title>

--- a/src/Umbraco.Web.UI.Login/index.html
+++ b/src/Umbraco.Web.UI.Login/index.html
@@ -5,7 +5,7 @@
   <base href="/"/>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <meta name="apple-mobile-web-app-capable" content="yes"/>
+  <meta name="mobile-web-app-capable" content="yes"/>
   <meta name="robots" content="noindex, nofollow"/>
   <meta name="pinterest" content="nopin"/>
   <title>Umbraco</title>


### PR DESCRIPTION
### Description

According to Google Chrome the meta "apple-mobile-web-app-capable" is deprecated. And should be replaced with "mobile-web-app-capable"

![image](https://github.com/user-attachments/assets/8b7eb6eb-3ac3-48d1-976b-436c76625dbf)

If this is not enough. A manifest.json file could be an add-on to this fix.
[https://forums.developer.apple.com/forums/thread/36820](url)