### PR TITLE
Fix copy document with descendants onto self

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -2695,8 +2695,11 @@ public class ContentService : RepositoryService, IContentService
                 var total = long.MaxValue;
                 while (page * pageSize < total)
                 {
+                    // when copying a branch into itself, the copy of a root would be seen as a descendant
+                    // and would be copied again => filter it out.
                     IEnumerable<IContent> descendants =
-                        GetPagedDescendants(content.Id, page++, pageSize, out total);
+                        GetPagedDescendants(content.Id, page++, pageSize, out total)
+                            .Where(descendant => descendant.Id != copy.Id);
                     foreach (IContent descendant in descendants)
                     {
                         // if parent has not been copied, skip, else gets its copy id

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -2695,13 +2695,17 @@ public class ContentService : RepositoryService, IContentService
                 var total = long.MaxValue;
                 while (page * pageSize < total)
                 {
-                    // when copying a branch into itself, the copy of a root would be seen as a descendant
-                    // and would be copied again => filter it out.
                     IEnumerable<IContent> descendants =
-                        GetPagedDescendants(content.Id, page++, pageSize, out total)
-                            .Where(descendant => descendant.Id != copy.Id);
+                        GetPagedDescendants(content.Id, page++, pageSize, out total);
                     foreach (IContent descendant in descendants)
                     {
+                        // when copying a branch into itself, the copy of a root would be seen as a descendant
+                        // and would be copied again => filter it out.
+                        if (descendant.Id == copy.Id)
+                        {
+                            continue;
+                        }
+
                         // if parent has not been copied, skip, else gets its copy id
                         if (idmap.TryGetValue(descendant.ParentId, out parentId) == false)
                         {


### PR DESCRIPTION
### Description
In v14+ it is possible to target the origin of a branch copy. There is a bug though where it copies the origin twice instead of just once.

Setup
![image](https://github.com/user-attachments/assets/74c1c309-5f16-424b-89cf-8ec350eb009e)

Faulty behavior
![image](https://github.com/user-attachments/assets/056d7de4-365d-4496-8988-a048beb3cc08)

Fixed behavior
![image](https://github.com/user-attachments/assets/f7243520-4b62-4343-9863-5242981ee116)
