### PR TITLE
Bugfix: Redirect when server file is renamed

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/entity-action/entity-action.event.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/entity-action/entity-action.event.ts
@@ -4,19 +4,21 @@ import type { UmbEntityModel } from '@umbraco-cms/backoffice/entity';
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface UmbEntityActionEventArgs extends UmbEntityModel {}
 
-export class UmbEntityActionEvent extends UmbControllerEvent {
-	#args: UmbEntityActionEventArgs;
+export class UmbEntityActionEvent<
+	ArgsType extends UmbEntityActionEventArgs = UmbEntityActionEventArgs,
+> extends UmbControllerEvent {
+	protected _args: ArgsType;
 
-	public constructor(type: string, args: UmbEntityActionEventArgs) {
+	public constructor(type: string, args: ArgsType) {
 		super(type);
-		this.#args = args;
+		this._args = args;
 	}
 
 	getEntityType(): string {
-		return this.#args.entityType;
+		return this._args.entityType;
 	}
 
 	getUnique(): string | null {
-		return this.#args.unique;
+		return this._args.unique;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/event/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/event/index.ts
@@ -1,0 +1,2 @@
+export * from './server-file-renamed.entity-event.js';
+export type * from './types.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/event/server-file-renamed.entity-event.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/event/server-file-renamed.entity-event.ts
@@ -1,0 +1,18 @@
+import type { UmbServerFileRenamedEventArgs } from './types.js';
+import { UmbEntityActionEvent } from '@umbraco-cms/backoffice/entity-action';
+
+export class UmbServerFileRenamedEntityEvent extends UmbEntityActionEvent<UmbServerFileRenamedEventArgs> {
+	static readonly TYPE = 'server-file-renamed';
+
+	constructor(args: UmbServerFileRenamedEventArgs) {
+		super(UmbServerFileRenamedEntityEvent.TYPE, args);
+	}
+
+	getNewUnique(): string {
+		return this._args.newUnique;
+	}
+
+	getNewName(): string {
+		return this._args.newName;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/event/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/event/types.ts
@@ -1,0 +1,6 @@
+import type { UmbEntityActionEventArgs } from '@umbraco-cms/backoffice/entity-action';
+
+export interface UmbServerFileRenamedEventArgs extends UmbEntityActionEventArgs {
+	newUnique: string;
+	newName: string;
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/index.ts
@@ -1,3 +1,4 @@
 export type * from './types.js';
 export * from './rename-server-file.action.js';
 export * from './rename-server-file-repository-base.js';
+export * from './event/index.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/index.ts
@@ -2,3 +2,4 @@ export type * from './types.js';
 export * from './rename-server-file.action.js';
 export * from './rename-server-file-repository-base.js';
 export * from './event/index.js';
+export * from './workspace-redirect/index.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/modal/rename-server-file-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/modal/rename-server-file-modal.element.ts
@@ -81,6 +81,11 @@ export class UmbRenameModalElement extends UmbModalBaseElement<UmbRenameModalDat
 		const { data } = await this.#renameRepository.rename(this.data.unique, name);
 
 		if (data) {
+			this.value = {
+				name: data.name,
+				unique: data.unique,
+			};
+
 			this._submitModal();
 		} else {
 			this._rejectModal();

--- a/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/modal/rename-server-file-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/modal/rename-server-file-modal.element.ts
@@ -7,6 +7,7 @@ import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import { UmbExtensionApiInitializer } from '@umbraco-cms/backoffice/extension-api';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import type { UmbItemRepository } from '@umbraco-cms/backoffice/repository';
+import { umbFocus } from '@umbraco-cms/backoffice/lit-element';
 
 @customElement('umb-rename-modal')
 export class UmbRenameModalElement extends UmbModalBaseElement<UmbRenameModalData, UmbRenameServerFileModalValue> {
@@ -107,7 +108,8 @@ export class UmbRenameModalElement extends UmbModalBaseElement<UmbRenameModalDat
 									value=${this._name}
 									placeholder="Enter new name..."
 									required
-									required-message="Name is required"></uui-input>
+									required-message="Name is required"
+									${umbFocus()}></uui-input>
 							</uui-form-layout-item>
 						</form>
 					</uui-form>

--- a/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/modal/rename-server-file-modal.token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/modal/rename-server-file-modal.token.ts
@@ -7,8 +7,10 @@ export interface UmbRenameModalData {
 	unique: string;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface UmbRenameServerFileModalValue {}
+export interface UmbRenameServerFileModalValue {
+	unique: string;
+	name: string;
+}
 
 export const UMB_RENAME_SERVER_FILE_MODAL = new UmbModalToken<UmbRenameModalData, UmbRenameServerFileModalValue>(
 	UMB_RENAME_SERVER_FILE_MODAL_ALIAS,

--- a/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/rename-server-file.action.kind.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/rename-server-file.action.kind.ts
@@ -16,6 +16,7 @@ export const manifest: UmbExtensionManifestKind = {
 		meta: {
 			icon: 'icon-edit',
 			label: '#actions_rename',
+			additionalOptions: true,
 			renameRepositoryAlias: '',
 			itemRepositoryAlias: '',
 		},

--- a/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/rename-server-file.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/rename-server-file.action.ts
@@ -1,5 +1,6 @@
 import { UMB_RENAME_SERVER_FILE_MODAL } from './modal/rename-server-file-modal.token.js';
 import type { MetaEntityActionRenameServerFileKind } from './types.js';
+import { UmbServerFileRenamedEntityEvent } from './event/index.js';
 import { UmbEntityActionBase, UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice/entity-action';
 import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
@@ -17,15 +18,29 @@ export class UmbRenameEntityAction extends UmbEntityActionBase<MetaEntityActionR
 			},
 		});
 
-		await modalContext.onSubmit();
+		try {
+			const res = await modalContext.onSubmit();
 
-		const actionEventContext = await this.getContext(UMB_ACTION_EVENT_CONTEXT);
-		const event = new UmbRequestReloadStructureForEntityEvent({
-			unique: this.args.unique,
-			entityType: this.args.entityType,
-		});
+			const actionEventContext = await this.getContext(UMB_ACTION_EVENT_CONTEXT);
+			const event = new UmbRequestReloadStructureForEntityEvent({
+				unique: this.args.unique,
+				entityType: this.args.entityType,
+			});
 
-		actionEventContext.dispatchEvent(event);
+			actionEventContext.dispatchEvent(event);
+
+			const event2 = new UmbServerFileRenamedEntityEvent({
+				unique: this.args.unique,
+				entityType: this.args.entityType,
+				newName: res.name,
+				newUnique: res.unique,
+			});
+
+			actionEventContext.dispatchEvent(event2);
+		} catch (error) {
+			// TODO: Handle error
+			console.log(error);
+		}
 	}
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/workspace-redirect/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/workspace-redirect/index.ts
@@ -1,0 +1,1 @@
+export * from './workspace-redirect.controller.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/workspace-redirect/workspace-redirect.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/workspace-redirect/workspace-redirect.controller.ts
@@ -1,0 +1,64 @@
+import { UmbServerFileRenamedEntityEvent } from '../event/index.js';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
+import type { UmbRouterSlotElement } from '@umbraco-cms/backoffice/router';
+import { ensurePathEndsWithSlash, umbUrlPatternToString } from '@umbraco-cms/backoffice/utils';
+import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
+import type { UmbSubmittableWorkspaceContextBase } from '@umbraco-cms/backoffice/workspace';
+
+export const UmbServerFileRenameWorkspaceRedirectControllerAlias = Symbol(
+	'ServerFileRenameWorkspaceRedirectControllerAlias',
+);
+
+export class UmbServerFileRenameWorkspaceRedirectController extends UmbControllerBase {
+	#actionEventContext?: typeof UMB_ACTION_EVENT_CONTEXT.TYPE;
+	#workspaceContext: UmbSubmittableWorkspaceContextBase<unknown>;
+	#router: UmbRouterSlotElement;
+
+	constructor(
+		host: UmbControllerHost,
+		workspaceContext: UmbSubmittableWorkspaceContextBase<unknown>,
+		router: UmbRouterSlotElement,
+	) {
+		super(host, UmbServerFileRenameWorkspaceRedirectControllerAlias);
+
+		this.#workspaceContext = workspaceContext;
+		this.#router = router;
+
+		this.consumeContext(UMB_ACTION_EVENT_CONTEXT, (context) => {
+			this.#actionEventContext = context;
+
+			if (this.#actionEventContext) {
+				this.#actionEventContext.removeEventListener(UmbServerFileRenamedEntityEvent.TYPE, this.#onFileRenamed);
+				this.#actionEventContext.addEventListener(UmbServerFileRenamedEntityEvent.TYPE, this.#onFileRenamed);
+			}
+		});
+	}
+
+	#onFileRenamed = ((event: UmbServerFileRenamedEntityEvent) => {
+		if (!this.#router) throw new Error('Router is required for this controller.');
+
+		// Don't redirect if the event is not for the current entity
+		const currentUnique = this.#workspaceContext.getUnique();
+		const eventUnique = event.getUnique();
+		if (currentUnique !== eventUnique) return;
+
+		const newUnique = event.getNewUnique();
+		if (!newUnique) throw new Error('New unique is required for this event.');
+
+		const routerPath = this.#router.absoluteRouterPath;
+		if (!routerPath) throw new Error('Router path is required for this controller.');
+
+		const newPath: string = umbUrlPatternToString(ensurePathEndsWithSlash(routerPath) + 'edit/:unique', {
+			unique: newUnique,
+		});
+
+		this.destroy();
+		window.history.pushState({}, '', newPath);
+	}) as EventListener;
+
+	public override destroy(): void {
+		super.destroy();
+		this.#actionEventContext?.removeEventListener(UmbServerFileRenamedEntityEvent.TYPE, this.#onFileRenamed);
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/workspace-redirect/workspace-redirect.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/workspace-redirect/workspace-redirect.controller.ts
@@ -54,7 +54,7 @@ export class UmbServerFileRenameWorkspaceRedirectController extends UmbControlle
 		});
 
 		this.destroy();
-		window.history.pushState({}, '', newPath);
+		window.history.replaceState({}, '', newPath);
 	}) as EventListener;
 
 	public override destroy(): void {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/workspace-redirect/workspace-redirect.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/workspace-redirect/workspace-redirect.controller.ts
@@ -54,7 +54,7 @@ export class UmbServerFileRenameWorkspaceRedirectController extends UmbControlle
 		});
 
 		this.destroy();
-		window.history.replaceState({}, '', newPath);
+		window.history.replaceState(null, '', newPath);
 	}) as EventListener;
 
 	public override destroy(): void {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/entity-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/entity-detail-workspace-base.ts
@@ -90,7 +90,7 @@ export abstract class UmbEntityDetailWorkspaceContextBase<
 	 * @returns { string | undefined } The unique identifier
 	 */
 	getUnique(): UmbEntityUnique | undefined {
-		return this.getData()?.unique;
+		return this.#entityContext.getUnique();
 	}
 
 	setUnique(unique: string) {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/entity-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/entity-detail-workspace-base.ts
@@ -242,6 +242,7 @@ export abstract class UmbEntityDetailWorkspaceContextBase<
 			throw error?.message ?? 'Repository did not return data after create.';
 		}
 
+		this.#entityContext.setUnique(data.unique);
 		this._data.setPersisted(data);
 		this._data.setCurrent(data);
 

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/workspace/partial-view-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/workspace/partial-view-workspace-editor.element.ts
@@ -1,7 +1,7 @@
 import { getQuerySnippet } from '../../utils/index.js';
 import type { UmbTemplatingInsertMenuElement } from '../../local-components/insert-menu/index.js';
 import { UMB_PARTIAL_VIEW_WORKSPACE_CONTEXT } from './partial-view-workspace.context-token.js';
-import { css, customElement, html, query, state } from '@umbraco-cms/backoffice/external/lit';
+import { css, customElement, html, nothing, query, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement, umbFocus } from '@umbraco-cms/backoffice/lit-element';
 import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 import { UMB_TEMPLATE_QUERY_BUILDER_MODAL } from '@umbraco-cms/backoffice/template';
@@ -107,6 +107,10 @@ export class UmbPartialViewWorkspaceEditorElement extends UmbLitElement {
 	}
 
 	#renderCodeEditor() {
+		if (this._content === undefined) {
+			return nothing;
+		}
+
 		return html`
 			<umb-code-editor
 				id="content"

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/workspace/partial-view-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/workspace/partial-view-workspace.context.ts
@@ -17,6 +17,7 @@ import {
 import { tryExecuteAndNotify } from '@umbraco-cms/backoffice/resources';
 import { PartialViewService } from '@umbraco-cms/backoffice/external/backend-api';
 import type { IRoutingInfo, PageComponent } from '@umbraco-cms/backoffice/router';
+import { UmbServerFileRenameWorkspaceRedirectController } from '@umbraco-cms/backoffice/server-file-system';
 
 export interface UmbPartialViewWorkspaceContextCreateArgs
 	extends UmbEntityDetailWorkspaceContextCreateArgs<UmbPartialViewDetailModel> {
@@ -73,6 +74,12 @@ export class UmbPartialViewWorkspaceContext
 				setup: (component: PageComponent, info: IRoutingInfo) => {
 					const unique = info.match.params.unique;
 					this.load(unique);
+
+					new UmbServerFileRenameWorkspaceRedirectController(
+						this,
+						this,
+						this.getHostElement().shadowRoot!.querySelector('umb-router-slot')!,
+					);
 				},
 			},
 		]);

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/workspace/script-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/workspace/script-workspace-editor.element.ts
@@ -89,11 +89,6 @@ export class UmbScriptWorkspaceEditorElement extends UmbLitElement {
 
 	static override styles = [
 		css`
-			:host {
-				display: block;
-				width: 100%;
-			}
-
 			umb-code-editor {
 				--editor-height: calc(100dvh - 260px);
 			}

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/workspace/script-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/workspace/script-workspace-editor.element.ts
@@ -24,18 +24,9 @@ export class UmbScriptWorkspaceEditorElement extends UmbLitElement {
 
 		this.consumeContext(UMB_SCRIPT_WORKSPACE_CONTEXT, (context) => {
 			this.#context = context;
-
-			this.observe(this.#context.name, (name) => {
-				this._name = name;
-			});
-
-			this.observe(this.#context.content, (content) => {
-				this._content = content;
-			});
-
-			this.observe(this.#context.isNew, (isNew) => {
-				this._isNew = isNew;
-			});
+			this.observe(this.#context.name, (name) => (this._name = name));
+			this.observe(this.#context.content, (content) => (this._content = content));
+			this.observe(this.#context.isNew, (isNew) => (this._isNew = isNew));
 		});
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/workspace/script-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/workspace/script-workspace-editor.element.ts
@@ -1,5 +1,5 @@
 import { UMB_SCRIPT_WORKSPACE_CONTEXT } from './script-workspace.context-token.js';
-import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
+import { css, html, customElement, state, nothing } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement, umbFocus } from '@umbraco-cms/backoffice/lit-element';
 import type { UmbCodeEditorElement } from '@umbraco-cms/backoffice/code-editor';
 import type { UUIInputElement } from '@umbraco-cms/backoffice/external/uui';
@@ -74,6 +74,10 @@ export class UmbScriptWorkspaceEditorElement extends UmbLitElement {
 	}
 
 	#renderCodeEditor() {
+		if (this._content === undefined) {
+			return nothing;
+		}
+
 		return html`
 			<umb-code-editor
 				id="content"

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/workspace/script-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/workspace/script-workspace-editor.element.ts
@@ -45,22 +45,33 @@ export class UmbScriptWorkspaceEditorElement extends UmbLitElement {
 	override render() {
 		return html`
 			<umb-entity-detail-workspace-editor>
-				<div id="workspace-header" slot="header">
-					<uui-input
-						placeholder=${this.localize.term('placeholders_entername')}
-						.value=${this._name}
-						@input=${this.#onNameInput}
-						label=${this.localize.term('placeholders_entername')}
-						?readonly=${this._isNew === false}
-						${umbFocus()}>
-					</uui-input>
-				</div>
-				<uui-box>
-					<!-- the div below in the header is to make the box display nicely with code editor -->
-					<div slot="header"></div>
-					${this.#renderCodeEditor()}
-				</uui-box>
+				${this.#renderHeader()} ${this.#renderBody()}
 			</umb-entity-detail-workspace-editor>
+		`;
+	}
+
+	#renderHeader() {
+		return html`
+			<div id="workspace-header" slot="header">
+				<uui-input
+					placeholder=${this.localize.term('placeholders_entername')}
+					.value=${this._name}
+					@input=${this.#onNameInput}
+					label=${this.localize.term('placeholders_entername')}
+					?readonly=${this._isNew === false}
+					${umbFocus()}>
+				</uui-input>
+			</div>
+		`;
+	}
+
+	#renderBody() {
+		return html`
+			<uui-box>
+				<!-- the div below in the header is to make the box display nicely with code editor -->
+				<div slot="header"></div>
+				${this.#renderCodeEditor()}
+			</uui-box>
 		`;
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/workspace/script-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/workspace/script-workspace.context.ts
@@ -11,6 +11,9 @@ import {
 	UmbWorkspaceIsNewRedirectController,
 } from '@umbraco-cms/backoffice/workspace';
 import type { IRoutingInfo, PageComponent } from '@umbraco-cms/backoffice/router';
+import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
+import { UmbServerFileRenamedEntityEvent } from '@umbraco-cms/backoffice/server-file-system';
+import { ensurePathEndsWithSlash, umbUrlPatternToString } from '@umbraco-cms/backoffice/utils';
 
 export class UmbScriptWorkspaceContext
 	extends UmbEntityDetailWorkspaceContextBase<UmbScriptDetailModel, UmbScriptDetailRepository>
@@ -19,11 +22,22 @@ export class UmbScriptWorkspaceContext
 	public readonly name = this._data.createObservablePartOfCurrent((data) => data?.name);
 	public readonly content = this._data.createObservablePartOfCurrent((data) => data?.content);
 
+	#actionEventContext?: typeof UMB_ACTION_EVENT_CONTEXT.TYPE;
+
 	constructor(host: UmbControllerHost) {
 		super(host, {
 			workspaceAlias: UMB_SCRIPT_WORKSPACE_ALIAS,
 			entityType: UMB_SCRIPT_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_SCRIPT_DETAIL_REPOSITORY_ALIAS,
+		});
+
+		this.consumeContext(UMB_ACTION_EVENT_CONTEXT, (context) => {
+			this.#actionEventContext = context;
+
+			if (this.#actionEventContext) {
+				this.#actionEventContext.removeEventListener(UmbServerFileRenamedEntityEvent.TYPE, this.#onFileRenamed);
+				this.#actionEventContext.addEventListener(UmbServerFileRenamedEntityEvent.TYPE, this.#onFileRenamed);
+			}
 		});
 
 		this.routes.setRoutes([
@@ -69,6 +83,32 @@ export class UmbScriptWorkspaceContext
 	 */
 	public setContent(value: string) {
 		this._data.updateCurrent({ content: value });
+	}
+
+	#onFileRenamed = ((event: UmbServerFileRenamedEntityEvent) => {
+		const currentUnique = this.getUnique();
+		const eventUnique = event.getUnique();
+		if (currentUnique !== eventUnique) return;
+
+		const newUnique = event.getNewUnique();
+		if (!newUnique) throw new Error('New unique is required for this event.');
+
+		const router = this.getHostElement().shadowRoot!.querySelector('umb-router-slot')!;
+
+		if (router) {
+			const routerPath = router.absoluteRouterPath;
+			if (routerPath) {
+				const newPath: string = umbUrlPatternToString(ensurePathEndsWithSlash(routerPath) + 'edit/:unique', {
+					unique: newUnique,
+				});
+				window.history.pushState({}, '', newPath);
+			}
+		}
+	}) as EventListener;
+
+	public override destroy(): void {
+		super.destroy();
+		this.#actionEventContext?.removeEventListener(UmbServerFileRenamedEntityEvent.TYPE, this.#onFileRenamed);
 	}
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/workspace/script-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/workspace/script-workspace.context.ts
@@ -11,9 +11,7 @@ import {
 	UmbWorkspaceIsNewRedirectController,
 } from '@umbraco-cms/backoffice/workspace';
 import type { IRoutingInfo, PageComponent } from '@umbraco-cms/backoffice/router';
-import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
-import { UmbServerFileRenamedEntityEvent } from '@umbraco-cms/backoffice/server-file-system';
-import { ensurePathEndsWithSlash, umbUrlPatternToString } from '@umbraco-cms/backoffice/utils';
+import { UmbServerFileRenameWorkspaceRedirectController } from '@umbraco-cms/backoffice/server-file-system';
 
 export class UmbScriptWorkspaceContext
 	extends UmbEntityDetailWorkspaceContextBase<UmbScriptDetailModel, UmbScriptDetailRepository>
@@ -22,22 +20,11 @@ export class UmbScriptWorkspaceContext
 	public readonly name = this._data.createObservablePartOfCurrent((data) => data?.name);
 	public readonly content = this._data.createObservablePartOfCurrent((data) => data?.content);
 
-	#actionEventContext?: typeof UMB_ACTION_EVENT_CONTEXT.TYPE;
-
 	constructor(host: UmbControllerHost) {
 		super(host, {
 			workspaceAlias: UMB_SCRIPT_WORKSPACE_ALIAS,
 			entityType: UMB_SCRIPT_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_SCRIPT_DETAIL_REPOSITORY_ALIAS,
-		});
-
-		this.consumeContext(UMB_ACTION_EVENT_CONTEXT, (context) => {
-			this.#actionEventContext = context;
-
-			if (this.#actionEventContext) {
-				this.#actionEventContext.removeEventListener(UmbServerFileRenamedEntityEvent.TYPE, this.#onFileRenamed);
-				this.#actionEventContext.addEventListener(UmbServerFileRenamedEntityEvent.TYPE, this.#onFileRenamed);
-			}
 		});
 
 		this.routes.setRoutes([
@@ -62,6 +49,12 @@ export class UmbScriptWorkspaceContext
 				setup: (component: PageComponent, info: IRoutingInfo) => {
 					const unique = info.match.params.unique;
 					this.load(unique);
+
+					new UmbServerFileRenameWorkspaceRedirectController(
+						this,
+						this,
+						this.getHostElement().shadowRoot!.querySelector('umb-router-slot')!,
+					);
 				},
 			},
 		]);
@@ -83,32 +76,6 @@ export class UmbScriptWorkspaceContext
 	 */
 	public setContent(value: string) {
 		this._data.updateCurrent({ content: value });
-	}
-
-	#onFileRenamed = ((event: UmbServerFileRenamedEntityEvent) => {
-		const currentUnique = this.getUnique();
-		const eventUnique = event.getUnique();
-		if (currentUnique !== eventUnique) return;
-
-		const newUnique = event.getNewUnique();
-		if (!newUnique) throw new Error('New unique is required for this event.');
-
-		const router = this.getHostElement().shadowRoot!.querySelector('umb-router-slot')!;
-
-		if (router) {
-			const routerPath = router.absoluteRouterPath;
-			if (routerPath) {
-				const newPath: string = umbUrlPatternToString(ensurePathEndsWithSlash(routerPath) + 'edit/:unique', {
-					unique: newUnique,
-				});
-				window.history.pushState({}, '', newPath);
-			}
-		}
-	}) as EventListener;
-
-	public override destroy(): void {
-		super.destroy();
-		this.#actionEventContext?.removeEventListener(UmbServerFileRenamedEntityEvent.TYPE, this.#onFileRenamed);
 	}
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/workspace/script-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/workspace/script-workspace.context.ts
@@ -62,7 +62,7 @@ export class UmbScriptWorkspaceContext
 
 	/**
 	 * @description Set the name of the script
-	 * @param {string} value
+	 * @param {string} value The name of the script
 	 * @memberof UmbScriptWorkspaceContext
 	 */
 	public setName(value: string) {
@@ -71,7 +71,7 @@ export class UmbScriptWorkspaceContext
 
 	/**
 	 * @description Set the content of the script
-	 * @param {string} value
+	 * @param {string} value The content of the script
 	 * @memberof UmbScriptWorkspaceContext
 	 */
 	public setContent(value: string) {

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/workspace/stylesheet-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/workspace/stylesheet-workspace-editor.element.ts
@@ -12,67 +12,64 @@ export class UmbStylesheetWorkspaceEditorElement extends UmbLitElement {
 	@state()
 	private _name?: string;
 
-	#workspaceContext?: typeof UMB_STYLESHEET_WORKSPACE_CONTEXT.TYPE;
+	#context?: typeof UMB_STYLESHEET_WORKSPACE_CONTEXT.TYPE;
 
 	constructor() {
 		super();
 
 		this.consumeContext(UMB_STYLESHEET_WORKSPACE_CONTEXT, (context) => {
-			this.#workspaceContext = context;
-
-			this.observe(this.#workspaceContext.name, (name) => (this._name = name), '_observeStylesheetName');
-
-			this.observe(this.#workspaceContext.isNew, (isNew) => {
-				this._isNew = isNew;
-			});
+			this.#context = context;
+			this.observe(this.#context.name, (name) => (this._name = name));
+			this.observe(this.#context.isNew, (isNew) => (this._isNew = isNew));
 		});
 	}
 
-	#onNameChange(event: UUIInputEvent) {
+	#onNameInput(event: UUIInputEvent) {
 		const target = event.target as UUIInputElement;
 		const value = target.value as string;
-		this.#workspaceContext?.setName(value);
+		this.#context?.setName(value);
 	}
 
 	override render() {
-		return this._isNew !== undefined
-			? html`
-					<umb-workspace-editor>
-						<div id="header" slot="header">
-							<uui-input
-								placeholder="Enter stylesheet name..."
-								label="Stylesheet name"
-								id="name"
-								.value=${this._name}
-								@input="${this.#onNameChange}"
-								?readonly=${this._isNew === false}
-								${umbFocus()}>
-							</uui-input>
-						</div>
-					</umb-workspace-editor>
-				`
-			: nothing;
+		return html` <umb-entity-detail-workspace-editor> ${this.#renderHeader()} </umb-entity-detail-workspace-editor> `;
+	}
+
+	#renderHeader() {
+		return html`
+			<div id="workspace-header" slot="header">
+				<uui-input
+					placeholder=${this.localize.term('placeholders_entername')}
+					.value=${this._name}
+					@input=${this.#onNameInput}
+					label=${this.localize.term('placeholders_entername')}
+					?readonly=${this._isNew === false}
+					${umbFocus()}>
+				</uui-input>
+			</div>
+		`;
 	}
 
 	static override styles = [
 		UmbTextStyles,
 		css`
-			:host {
-				display: block;
-				width: 100%;
-				height: 100%;
+			umb-code-editor {
+				--editor-height: calc(100dvh - 260px);
 			}
 
-			#header {
-				display: flex;
-				flex: 1 1 auto;
-				flex-direction: column;
+			uui-box {
+				min-height: calc(100dvh - 260px);
+				margin: var(--uui-size-layout-1);
+				--uui-box-default-padding: 0;
+				/* remove header border bottom as code editor looks better in this box */
+				--uui-color-divider-standalone: transparent;
 			}
 
-			#name {
+			#workspace-header {
 				width: 100%;
-				flex: 1 1 auto;
-				align-items: center;
+			}
+
+			uui-input {
+				width: 100%;
 			}
 		`,
 	];

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/workspace/stylesheet-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/workspace/stylesheet-workspace-editor.element.ts
@@ -1,6 +1,6 @@
 import { UMB_STYLESHEET_WORKSPACE_CONTEXT } from './stylesheet-workspace.context-token.js';
 import type { UUIInputElement, UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
-import { css, html, customElement, state, nothing } from '@umbraco-cms/backoffice/external/lit';
+import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement, umbFocus } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/workspace/stylesheet-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/workspace/stylesheet-workspace.context.ts
@@ -1,42 +1,32 @@
-import { UmbStylesheetDetailRepository } from '../repository/stylesheet-detail.repository.js';
+import type { UmbStylesheetDetailRepository } from '../repository/stylesheet-detail.repository.js';
 import type { UmbStylesheetDetailModel } from '../types.js';
 import { UMB_STYLESHEET_ENTITY_TYPE } from '../entity.js';
+import { UMB_STYLESHEET_DETAIL_REPOSITORY_ALIAS } from '../repository/index.js';
 import { UMB_STYLESHEET_WORKSPACE_ALIAS } from './manifests.js';
 import { UmbStylesheetWorkspaceEditorElement } from './stylesheet-workspace-editor.element.js';
 import {
 	type UmbSubmittableWorkspaceContext,
-	UmbSubmittableWorkspaceContextBase,
 	UmbWorkspaceIsNewRedirectController,
 	type UmbRoutableWorkspaceContext,
+	UmbEntityDetailWorkspaceContextBase,
 } from '@umbraco-cms/backoffice/workspace';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import { UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
-import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
-import {
-	UmbRequestReloadChildrenOfEntityEvent,
-	UmbRequestReloadStructureForEntityEvent,
-} from '@umbraco-cms/backoffice/entity-action';
 import type { IRoutingInfo, PageComponent } from '@umbraco-cms/backoffice/router';
+import type { UmbEntityModel } from '@umbraco-cms/backoffice/entity';
 
 export class UmbStylesheetWorkspaceContext
-	extends UmbSubmittableWorkspaceContextBase<UmbStylesheetDetailModel>
+	extends UmbEntityDetailWorkspaceContextBase<UmbStylesheetDetailModel, UmbStylesheetDetailRepository>
 	implements UmbSubmittableWorkspaceContext, UmbRoutableWorkspaceContext
 {
-	public readonly repository = new UmbStylesheetDetailRepository(this);
-
-	#parent = new UmbObjectState<{ entityType: string; unique: string | null } | undefined>(undefined);
-	readonly parentUnique = this.#parent.asObservablePart((parent) => (parent ? parent.unique : undefined));
-	readonly parentEntityType = this.#parent.asObservablePart((parent) => (parent ? parent.entityType : undefined));
-
-	#data = new UmbObjectState<UmbStylesheetDetailModel | undefined>(undefined);
-	readonly data = this.#data.asObservable();
-	readonly unique = this.#data.asObservablePart((data) => data?.unique);
-	readonly entityType = this.#data.asObservablePart((data) => data?.entityType);
-	readonly name = this.#data.asObservablePart((data) => data?.name);
-	readonly content = this.#data.asObservablePart((data) => data?.content);
+	public readonly name = this._data.createObservablePartOfCurrent((data) => data?.name);
+	public readonly content = this._data.createObservablePartOfCurrent((data) => data?.content);
 
 	constructor(host: UmbControllerHost) {
-		super(host, UMB_STYLESHEET_WORKSPACE_ALIAS);
+		super(host, {
+			workspaceAlias: UMB_STYLESHEET_WORKSPACE_ALIAS,
+			entityType: UMB_STYLESHEET_ENTITY_TYPE,
+			detailRepositoryAlias: UMB_STYLESHEET_DETAIL_REPOSITORY_ALIAS,
+		});
 
 		this.routes.setRoutes([
 			{
@@ -45,7 +35,7 @@ export class UmbStylesheetWorkspaceContext
 				setup: async (component: PageComponent, info: IRoutingInfo) => {
 					const parentEntityType = info.match.params.entityType;
 					const parentUnique = info.match.params.parentUnique === 'null' ? null : info.match.params.parentUnique;
-					await this.create({ entityType: parentEntityType, unique: parentUnique });
+					await this.createScaffold({ parent: { entityType: parentEntityType, unique: parentUnique } });
 
 					new UmbWorkspaceIsNewRedirectController(
 						this,
@@ -66,103 +56,33 @@ export class UmbStylesheetWorkspaceContext
 		]);
 	}
 
-	protected override resetState(): void {
-		super.resetState();
-		this.#data.setValue(undefined);
+	/**
+	 * @description Set the name of the stylesheet
+	 * @param {string} value The name of the stylesheet
+	 * @memberof UmbStylesheetWorkspaceContext
+	 */
+	public setName(value: string) {
+		this._data.updateCurrent({ name: value });
 	}
 
-	getEntityType(): string {
-		return UMB_STYLESHEET_ENTITY_TYPE;
+	/**
+	 * @description Set the content of the stylesheet
+	 * @param {string} value The content of the stylesheet
+	 * @memberof UmbStylesheetWorkspaceContext
+	 */
+	public setContent(value: string) {
+		this._data.updateCurrent({ content: value });
 	}
 
-	getUnique() {
-		const data = this.getData();
-		if (!data) throw new Error('Data is missing');
-		return data.unique;
-	}
-
-	getData() {
-		return this.#data.getValue();
-	}
-
-	setName(value: string) {
-		this.#data.update({ name: value });
-	}
-
-	setContent(value: string) {
-		this.#data.update({ content: value });
-	}
-
-	async load(unique: string) {
-		this.resetState();
-		const { data, asObservable } = await this.repository.requestByUnique(unique);
-
-		if (data) {
-			this.setIsNew(false);
-			this.#data.setValue(data);
-
-			this.observe(asObservable(), (data) => this.onDetailStoreChanges(data), 'umbDetailStoreObserver');
-		}
-	}
-
-	onDetailStoreChanges(data: UmbStylesheetDetailModel | undefined) {
-		// Data is removed from the store
-		// TODO: revisit. We need to handle what should happen when the data is removed from the store
-		if (data === undefined) {
-			this.#data.setValue(undefined);
-		}
-	}
-
-	async create(parent: { entityType: string; unique: string | null }) {
-		this.resetState();
-		this.#parent.setValue(parent);
-		const { data } = await this.repository.createScaffold();
-
-		if (data) {
-			this.setIsNew(true);
-			this.#data.setValue(data);
-		}
-	}
-
-	public async submit() {
-		if (!this.#data.value) throw new Error('Data is missing');
-
-		if (this.getIsNew()) {
-			const parent = this.#parent.getValue();
-			if (!parent) throw new Error('Parent is not set');
-			const { error, data } = await this.repository.create(this.#data.value, parent.unique);
-			if (error) {
-				throw new Error(error.message);
-			}
-			this.#data.setValue(data);
-			this.setIsNew(false);
-
-			// TODO: this might not be the right place to alert the tree, but it works for now
-			const eventContext = await this.getContext(UMB_ACTION_EVENT_CONTEXT);
-			const event = new UmbRequestReloadChildrenOfEntityEvent({
-				entityType: parent.entityType,
-				unique: parent.unique,
-			});
-			eventContext.dispatchEvent(event);
-		} else {
-			const { error, data } = await this.repository.save(this.#data.value);
-			if (error) {
-				throw new Error(error.message);
-			}
-			this.#data.setValue(data);
-
-			const eventContext = await this.getContext(UMB_ACTION_EVENT_CONTEXT);
-			const event = new UmbRequestReloadStructureForEntityEvent({
-				unique: this.getUnique()!,
-				entityType: this.getEntityType(),
-			});
-			eventContext.dispatchEvent(event);
-		}
-	}
-
-	public override destroy(): void {
-		this.#data.destroy();
-		super.destroy();
+	/**
+	 * @description Create a new stylesheet
+	 * @deprecated Use `createScaffold` instead. Will be removed in v17.
+	 * @param { UmbEntityModel } parent The parent entity
+	 * @param { string } parent.entityType The entity type of the parent
+	 * @param { UmbEntityUnique } parent.unique The unique identifier of the parent
+	 */
+	async create(parent: UmbEntityModel) {
+		await this.createScaffold({ parent });
 	}
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/workspace/stylesheet-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/workspace/stylesheet-workspace.context.ts
@@ -13,6 +13,7 @@ import {
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { IRoutingInfo, PageComponent } from '@umbraco-cms/backoffice/router';
 import type { UmbEntityModel } from '@umbraco-cms/backoffice/entity';
+import { UmbServerFileRenameWorkspaceRedirectController } from '@umbraco-cms/backoffice/server-file-system';
 
 export class UmbStylesheetWorkspaceContext
 	extends UmbEntityDetailWorkspaceContextBase<UmbStylesheetDetailModel, UmbStylesheetDetailRepository>
@@ -51,6 +52,12 @@ export class UmbStylesheetWorkspaceContext
 					// TODO: Decode uniques [NL]
 					const unique = info.match.params.unique;
 					this.load(unique);
+
+					new UmbServerFileRenameWorkspaceRedirectController(
+						this,
+						this,
+						this.getHostElement().shadowRoot!.querySelector('umb-router-slot')!,
+					);
 				},
 			},
 		]);

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/workspace/views/code-editor/stylesheet-code-editor-workspace-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/workspace/views/code-editor/stylesheet-code-editor-workspace-view.element.ts
@@ -1,6 +1,6 @@
 import type { UmbStylesheetWorkspaceContext } from '../../stylesheet-workspace.context.js';
 import { UMB_STYLESHEET_WORKSPACE_CONTEXT } from '../../stylesheet-workspace.context-token.js';
-import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
+import { css, html, customElement, state, nothing } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { UmbCodeEditorElement } from '@umbraco-cms/backoffice/code-editor';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
@@ -40,6 +40,10 @@ export class UmbStylesheetCodeEditorWorkspaceViewElement extends UmbLitElement {
 	}
 
 	#renderCodeEditor() {
+		if (this._content === undefined) {
+			return nothing;
+		}
+
 		return html`
 			<umb-code-editor
 				id="content"


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/16488

This (PR) addresses the issue where a renamed file system workspace enters an "undefined" state. The problem arises because the file name serves as the unique identifier for the workspace. When the file name is changed, the unique identifier is also changed, causing the workspace to become "undefined." To resolve this, we need to notify the workspace about both the unique before the change and after the change, allowing us to target the correct workspace and redirect it to the new path.

The PR introduces the `UmbServerFileRenameWorkspaceRedirectController`, which listens for a `ServerFileRenamed` action event. This event includes both the previous and new uniques. If the currently open workspace matches the event, the controller will redirect it to the new location.

What to test:
* Ensure that if you rename a file system file (script, stylesheet, or partial view) that is currently open that it will redirect the workspace to the new location.


https://github.com/user-attachments/assets/159bcf9d-342f-4611-bf53-9c4022a8c81f

