### PR TITLE
V13: Lead char gets removed when reopening a link in the rich text editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -1216,10 +1216,9 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
             target: anchor.attr("target")
           };
 
-          // drop the lead char from the anchor text, if it has a value
           var anchorVal = anchor[0].dataset.anchor;
           if (anchorVal) {
-            currentTarget.anchor = anchorVal.substring(1);
+            currentTarget.anchor = anchorVal;
           }
 
           //locallink detection, we do this here, to avoid poluting the editorService


### PR DESCRIPTION
### Description

Fixes #17573

The lead char should be kept (`#` or `?`) even when re-opening a link. Otherwise, the editors will not be able to see whether it is an anchor or a querystring, nor will they be able to edit it. The placeholder of the field also suggests that the editor put in a `#` or `?` to indicate whether it is an anchor or a querystring.