### PR TITLE
v14: DecimalConverter - add check for integer

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/DecimalValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/DecimalValueConverter.cs
@@ -37,6 +37,12 @@ public class DecimalValueConverter : PropertyValueConverterBase
             return Convert.ToDecimal(sourceDouble);
         }
 
+        // is it a integer?
+        if (source is int sourceInteger)
+        {
+            return Convert.ToDecimal(sourceInteger);
+        }
+
         // is it a string?
         if (source is string sourceString)
         {

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/DecimalValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/DecimalValueConverter.cs
@@ -37,7 +37,7 @@ public class DecimalValueConverter : PropertyValueConverterBase
             return Convert.ToDecimal(sourceDouble);
         }
 
-        // is it a integer?
+        // is it an integer?
         if (source is int sourceInteger)
         {
             return Convert.ToDecimal(sourceInteger);


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/17655

# Notes
- When in a block and using Model.Value(), the actual value gets passed (integer), and thus we were missing a check for that in the converter, this PR remedies that

# How to test
- Follow steps in original issue, or if you want a quick test:
- Create an element type with a decimal property called "dec"
- Create a doc type with allowed as root, with a decimal property called "decimal", and a blocklist using the prior element type called "blocklist"
- Create content with that doc type, with the values being whole numbers (aka integers).
- Use this template for the doc type:
```
@using Umbraco.Cms.Core.Models.Blocks
@using Umbraco.Cms.Web.Common.PublishedModels;
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
@{
    Layout = null;
    BlockListModel model = null!;
    if (Model.Value("blocklist") is BlockListModel blockListModel)
    {
        model = blockListModel;
    }
}

@Model.Value("decimal")

@foreach (var block in model)
{
    <p>@block.Content.Value("dec")</p>;
}
```