### PR TITLE
Fixes https://github.com/umbraco/Umbraco-CMS/issues/17614

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/templating/local-components/insert-menu/insert-menu.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/local-components/insert-menu/insert-menu.element.ts
@@ -37,7 +37,9 @@ export class UmbTemplatingInsertMenuElement extends UmbLitElement {
 
 		switch (type) {
 			case CodeSnippetType.partialView: {
-				this.value = getInsertPartialSnippet(value);
+				const regex = /^%2F|%25dot%25cshtml$/g;
+				const prettyPath = value.replace(regex, '').replace(/%2F/g, '/');
+				this.value = getInsertPartialSnippet(prettyPath);
 				this.#dispatchInsertEvent();
 				break;
 			}

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/modals/templating-item-picker/templating-item-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/modals/templating-item-picker/templating-item-picker-modal.element.ts
@@ -53,10 +53,8 @@ export class UmbTemplatingItemPickerModalElement extends UmbModalBaseElement<
 
 		if (!value) return;
 
-		const regex = /^%2F|%25dot%25cshtml$/g;
-		const prettyPath = value.replace(regex, '').replace(/%2F/g, '/');
 		this.value = {
-			value: prettyPath,
+			value: value,
 			type: CodeSnippetType.partialView,
 		};
 		this.modalContext?.submit();


### PR DESCRIPTION
### Description
Fixes https://github.com/umbraco/Umbraco-CMS/issues/17614
Loved logic that removes file name stuff when inserting partial views to a place where it is used by both ways to insert the partial view.

View shows both work now:


https://github.com/user-attachments/assets/83d34c83-2d76-4e4e-9bef-2a42fd6f13eb



