### PR TITLE
V15 QA add parallelization of e2e tests

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -436,16 +436,16 @@ stages:
           matrix:
             LinuxShard1Of2:
               vmImage: "ubuntu-latest"
-              testCommand: "npx playwright test DefaultConfig --grep "@smoke" --shard=1/2 --ignore-certificate-errors"
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\"--shard=1/2 --ignore-certificate-errors"
             LinuxShard2Of2:
               vmImage: "ubuntu-latest"
-              testCommand: "npx playwright test DefaultConfig --grep "@smoke" --shard=2/2 --ignore-certificate-errors"
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=2/2 --ignore-certificate-errors"
             WindowsShard1Of2:
               vmImage: "windows-latest"
-              testCommand: "npx playwright test DefaultConfig --grep "@smoke" --shard=1/2 --ignore-certificate-errors"
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=1/2 --ignore-certificate-errors"
             WindowsShard2Of2:
               vmImage: "windows-latest"
-              testCommand: "npx playwright test DefaultConfig --grep "@smoke" --shard=2/2 --ignore-certificate-errors"
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=2/2 --ignore-certificate-errors"
         pool:
           vmImage: $(vmImage)
         steps:

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -434,18 +434,18 @@ stages:
           CONNECTIONSTRINGS__UMBRACODBDSN_PROVIDERNAME: Microsoft.Data.Sqlite
         strategy:
           matrix:
-            LinuxShard1Of2:
+            LinuxPart1Of2:
               vmImage: "ubuntu-latest"
-              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\"--shard=1/2 --ignore-certificate-errors"
-            LinuxShard2Of2:
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\"--shard=1/2"
+            LinuxPart2Of2:
               vmImage: "ubuntu-latest"
-              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=2/2 --ignore-certificate-errors"
-            WindowsShard1Of2:
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=2/2"
+            WindowsPart1Of2:
               vmImage: "windows-latest"
-              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=1/2 --ignore-certificate-errors"
-            WindowsShard2Of2:
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=1/2"
+            WindowsPart2Of2:
               vmImage: "windows-latest"
-              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=2/2 --ignore-certificate-errors"
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=2/2"
         pool:
           vmImage: $(vmImage)
         steps:
@@ -571,13 +571,23 @@ stages:
           CONNECTIONSTRINGS__UMBRACODBDSN_PROVIDERNAME: Microsoft.Data.SqlClient
         strategy:
           matrix:
-            ${{ if eq(parameters.sqlServerLinuxAcceptanceTests, True) }} :
-              Linux:
+            ${{ if eq(parameters.sqlServerLinuxAcceptanceTests, True) }}:
+              LinuxPart1Of2:
+                testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=1/2"
                 vmImage: "ubuntu-latest"
                 SA_PASSWORD: $(UMBRACO__CMS__UNATTENDED__UNATTENDEDUSERPASSWORD)
                 CONNECTIONSTRINGS__UMBRACODBDSN: "Server=(local);Database=Umbraco;User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
-            Windows:
+              LinuxPart2Of2:
+                testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=2/2"
+                vmImage: "ubuntu-latest"
+                SA_PASSWORD: $(UMBRACO__CMS__UNATTENDED__UNATTENDEDUSERPASSWORD)
+                CONNECTIONSTRINGS__UMBRACODBDSN: "Server=(local);Database=Umbraco;User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
+            WindowsPart1Of2:
               vmImage: "windows-latest"
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=1/2"
+            WindowsPart2Of2:
+              vmImage: "windows-latest"
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=2/2"
         pool:
           vmImage: $(vmImage)
         steps:
@@ -669,7 +679,7 @@ stages:
             workingDirectory: tests/Umbraco.Tests.AcceptanceTest
 
           # Test
-          - pwsh: npm run smokeTest --ignore-certificate-errors
+          - pwsh: $(testCommand)
             displayName: Run Playwright tests
             continueOnError: true
             workingDirectory: tests/Umbraco.Tests.AcceptanceTest

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -434,18 +434,24 @@ stages:
           CONNECTIONSTRINGS__UMBRACODBDSN_PROVIDERNAME: Microsoft.Data.Sqlite
         strategy:
           matrix:
-            LinuxPart1Of2:
+            LinuxPart1Of3:
               vmImage: "ubuntu-latest"
-              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\"--shard=1/2"
-            LinuxPart2Of2:
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\"--shard=1/3"
+            LinuxPart2Of3:
               vmImage: "ubuntu-latest"
-              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=2/2"
-            WindowsPart1Of2:
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=2/3"
+            LinuxPart3Of3:
+              vmImage: "ubuntu-latest"
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=3/3"
+            WindowsPart1Of3:
               vmImage: "windows-latest"
-              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=1/2"
-            WindowsPart2Of2:
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=1/3"
+            WindowsPart2Of3:
               vmImage: "windows-latest"
-              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=2/2"
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=2/3"
+            WindowsPart3Of3:
+              vmImage: "windows-latest"
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=3/3"
         pool:
           vmImage: $(vmImage)
         steps:
@@ -572,22 +578,30 @@ stages:
         strategy:
           matrix:
             ${{ if eq(parameters.sqlServerLinuxAcceptanceTests, True) }}:
-              LinuxPart1Of2:
-                testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=1/2"
+              LinuxPart1Of3:
+                testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=1/3"
                 vmImage: "ubuntu-latest"
                 SA_PASSWORD: $(UMBRACO__CMS__UNATTENDED__UNATTENDEDUSERPASSWORD)
                 CONNECTIONSTRINGS__UMBRACODBDSN: "Server=(local);Database=Umbraco;User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
-              LinuxPart2Of2:
-                testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=2/2"
+              LinuxPart2Of3:
+                testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=2/3"
                 vmImage: "ubuntu-latest"
                 SA_PASSWORD: $(UMBRACO__CMS__UNATTENDED__UNATTENDEDUSERPASSWORD)
                 CONNECTIONSTRINGS__UMBRACODBDSN: "Server=(local);Database=Umbraco;User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
-            WindowsPart1Of2:
+              LinuxPart3Of3:
+                testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=3/3"
+                vmImage: "ubuntu-latest"
+                SA_PASSWORD: $(UMBRACO__CMS__UNATTENDED__UNATTENDEDUSERPASSWORD)
+                CONNECTIONSTRINGS__UMBRACODBDSN: "Server=(local);Database=Umbraco;User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
+            WindowsPart1Of3:
               vmImage: "windows-latest"
-              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=1/2"
-            WindowsPart2Of2:
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=1/3"
+            WindowsPart2Of3:
               vmImage: "windows-latest"
-              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=2/2"
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=2/3"
+            WindowsPart3Of3:
+              vmImage: "windows-latest"
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=3/3"
         pool:
           vmImage: $(vmImage)
         steps:

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -434,10 +434,18 @@ stages:
           CONNECTIONSTRINGS__UMBRACODBDSN_PROVIDERNAME: Microsoft.Data.Sqlite
         strategy:
           matrix:
-            Linux:
+            LinuxShard1Of2:
               vmImage: "ubuntu-latest"
-            Windows:
+              testCommand: "npx playwright test DefaultConfig --grep "@smoke" --shard=1/2 --ignore-certificate-errors"
+            LinuxShard2Of2:
+              vmImage: "ubuntu-latest"
+              testCommand: "npx playwright test DefaultConfig --grep "@smoke" --shard=2/2 --ignore-certificate-errors"
+            WindowsShard1Of2:
               vmImage: "windows-latest"
+              testCommand: "npx playwright test DefaultConfig --grep "@smoke" --shard=1/2 --ignore-certificate-errors"
+            WindowsShard2Of2:
+              vmImage: "windows-latest"
+              testCommand: "npx playwright test DefaultConfig --grep "@smoke" --shard=2/2 --ignore-certificate-errors"
         pool:
           vmImage: $(vmImage)
         steps:
@@ -521,7 +529,7 @@ stages:
             workingDirectory: tests/Umbraco.Tests.AcceptanceTest
 
           # Test
-          - pwsh: npm run smokeTestSqlite --ignore-certificate-errors
+          - pwsh: $(testCommand)
             displayName: Run Playwright tests
             continueOnError: true
             workingDirectory: tests/Umbraco.Tests.AcceptanceTest

--- a/build/nightly-E2E-test-pipelines.yml
+++ b/build/nightly-E2E-test-pipelines.yml
@@ -117,22 +117,22 @@ stages:
           matrix:
             LinuxPart1Of3:
               vmImage: "ubuntu-latest"
-              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\"--shard=1/3"
+              testCommand: "npx playwright test DefaultConfig --shard=1/3"
             LinuxPart2Of3:
               vmImage: "ubuntu-latest"
-              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=2/3"
+              testCommand: "npx playwright test DefaultConfig --shard=2/3"
             LinuxPart3Of3:
               vmImage: "ubuntu-latest"
-              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=3/3"
+              testCommand: "npx playwright test DefaultConfig --shard=3/3"
             WindowsPart1Of3:
               vmImage: "windows-latest"
-              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=1/3"
+              testCommand: "npx playwright test DefaultConfig --shard=1/3"
             WindowsPart2Of3:
               vmImage: "windows-latest"
-              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=2/3"
+              testCommand: "npx playwright test DefaultConfig --shard=2/3"
             WindowsPart3Of3:
               vmImage: "windows-latest"
-              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=3/3"
+              testCommand: "npx playwright test DefaultConfig --shard=3/3"
         pool:
           vmImage: $(vmImage)
         steps:
@@ -267,29 +267,29 @@ stages:
         strategy:
           matrix:
             LinuxPart1Of3:
-              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=1/3"
+              testCommand: "npx playwright test DefaultConfig --grep-invert \"Users\" --shard=1/3"
               vmImage: "ubuntu-latest"
               SA_PASSWORD: $(UMBRACO__CMS__UNATTENDED__UNATTENDEDUSERPASSWORD)
               CONNECTIONSTRINGS__UMBRACODBDSN: "Server=(local);Database=Umbraco;User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
             LinuxPart2Of3:
-              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=2/3"
+              testCommand: "npx playwright test DefaultConfig --grep-invert \"Users\" --shard=2/3"
               vmImage: "ubuntu-latest"
               SA_PASSWORD: $(UMBRACO__CMS__UNATTENDED__UNATTENDEDUSERPASSWORD)
               CONNECTIONSTRINGS__UMBRACODBDSN: "Server=(local);Database=Umbraco;User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
             LinuxPart3Of3:
-              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=3/3"
+              testCommand: "npx playwright test DefaultConfig  --grep-invert \"Users\" --shard=3/3"
               vmImage: "ubuntu-latest"
               SA_PASSWORD: $(UMBRACO__CMS__UNATTENDED__UNATTENDEDUSERPASSWORD)
               CONNECTIONSTRINGS__UMBRACODBDSN: "Server=(local);Database=Umbraco;User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
             WindowsPart1Of3:
               vmImage: "windows-latest"
-              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=1/3"
+              testCommand: "npx playwright test DefaultConfig --grep-invert \"Users\" --shard=1/3"
             WindowsPart2Of3:
               vmImage: "windows-latest"
-              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=2/3"
+              testCommand: "npx playwright test DefaultConfig --grep-invert \"Users\" --shard=2/3"
             WindowsPart3Of3:
               vmImage: "windows-latest"
-              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=3/3"
+              testCommand: "npx playwright test DefaultConfig --grep-invert \"Users\" --shard=3/3"
         pool:
           vmImage: $(vmImage)
         steps:

--- a/build/nightly-E2E-test-pipelines.yml
+++ b/build/nightly-E2E-test-pipelines.yml
@@ -23,12 +23,6 @@ variables:
   npm_config_cache: $(Pipeline.Workspace)/.npm_client
   NODE_OPTIONS: --max_old_space_size=16384
 
-parameters:
-  - name: runSmokeTests
-    displayName: Run the smoke tests
-    type: boolean
-    default: false
-
 stages:
   ###############################################
   ## Build
@@ -220,10 +214,7 @@ stages:
             workingDirectory: tests/Umbraco.Tests.AcceptanceTest
 
           # Test
-          - ${{ if eq(parameters.runSmokeTests, true) }}:
-              pwsh: npm run smokeTestSqlite --ignore-certificate-errors
-            ${{ else }}:
-              pwsh: npm run testSqlite --ignore-certificate-errors
+          - pwsh: $(testCommand)
             displayName: Run Playwright tests
             continueOnError: true
             workingDirectory: tests/Umbraco.Tests.AcceptanceTest
@@ -385,10 +376,7 @@ stages:
             workingDirectory: tests/Umbraco.Tests.AcceptanceTest
 
           # Test
-          - ${{ if eq(parameters.runSmokeTests, true) }}:
-              pwsh: npm run smokeTest --ignore-certificate-errors
-            ${{ else }}:
-              pwsh: npm run test --ignore-certificate-errors
+          - pwsh: $(testCommand)
             displayName: Run Playwright tests
             continueOnError: true
             workingDirectory: tests/Umbraco.Tests.AcceptanceTest

--- a/build/nightly-E2E-test-pipelines.yml
+++ b/build/nightly-E2E-test-pipelines.yml
@@ -271,25 +271,25 @@ stages:
               vmImage: "ubuntu-latest"
               SA_PASSWORD: $(UMBRACO__CMS__UNATTENDED__UNATTENDEDUSERPASSWORD)
               CONNECTIONSTRINGS__UMBRACODBDSN: "Server=(local);Database=Umbraco;User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
-              LinuxPart2Of3:
-                testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=2/3"
-                vmImage: "ubuntu-latest"
-                SA_PASSWORD: $(UMBRACO__CMS__UNATTENDED__UNATTENDEDUSERPASSWORD)
-                CONNECTIONSTRINGS__UMBRACODBDSN: "Server=(local);Database=Umbraco;User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
-              LinuxPart3Of3:
-                testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=3/3"
-                vmImage: "ubuntu-latest"
-                SA_PASSWORD: $(UMBRACO__CMS__UNATTENDED__UNATTENDEDUSERPASSWORD)
-                CONNECTIONSTRINGS__UMBRACODBDSN: "Server=(local);Database=Umbraco;User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
-              WindowsPart1Of3:
-                vmImage: "windows-latest"
-                testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=1/3"
-              WindowsPart2Of3:
-                vmImage: "windows-latest"
-                testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=2/3"
-              WindowsPart3Of3:
-                vmImage: "windows-latest"
-                testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=3/3"
+            LinuxPart2Of3:
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=2/3"
+              vmImage: "ubuntu-latest"
+              SA_PASSWORD: $(UMBRACO__CMS__UNATTENDED__UNATTENDEDUSERPASSWORD)
+              CONNECTIONSTRINGS__UMBRACODBDSN: "Server=(local);Database=Umbraco;User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
+            LinuxPart3Of3:
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=3/3"
+              vmImage: "ubuntu-latest"
+              SA_PASSWORD: $(UMBRACO__CMS__UNATTENDED__UNATTENDEDUSERPASSWORD)
+              CONNECTIONSTRINGS__UMBRACODBDSN: "Server=(local);Database=Umbraco;User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
+            WindowsPart1Of3:
+              vmImage: "windows-latest"
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=1/3"
+            WindowsPart2Of3:
+              vmImage: "windows-latest"
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=2/3"
+            WindowsPart3Of3:
+              vmImage: "windows-latest"
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=3/3"
         pool:
           vmImage: $(vmImage)
         steps:

--- a/build/nightly-E2E-test-pipelines.yml
+++ b/build/nightly-E2E-test-pipelines.yml
@@ -115,10 +115,24 @@ stages:
           CONNECTIONSTRINGS__UMBRACODBDSN_PROVIDERNAME: Microsoft.Data.Sqlite
         strategy:
           matrix:
-            Linux:
-              vmImage: 'ubuntu-latest'
-            Windows:
-              vmImage: 'windows-latest'
+            LinuxPart1Of3:
+              vmImage: "ubuntu-latest"
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\"--shard=1/3"
+            LinuxPart2Of3:
+              vmImage: "ubuntu-latest"
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=2/3"
+            LinuxPart3Of3:
+              vmImage: "ubuntu-latest"
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=3/3"
+            WindowsPart1Of3:
+              vmImage: "windows-latest"
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=1/3"
+            WindowsPart2Of3:
+              vmImage: "windows-latest"
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=2/3"
+            WindowsPart3Of3:
+              vmImage: "windows-latest"
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --shard=3/3"
         pool:
           vmImage: $(vmImage)
         steps:
@@ -252,12 +266,30 @@ stages:
           CONNECTIONSTRINGS__UMBRACODBDSN_PROVIDERNAME: Microsoft.Data.SqlClient
         strategy:
           matrix:
-            Linux:
-              vmImage: 'ubuntu-latest'
+            LinuxPart1Of3:
+              testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=1/3"
+              vmImage: "ubuntu-latest"
               SA_PASSWORD: $(UMBRACO__CMS__UNATTENDED__UNATTENDEDUSERPASSWORD)
-              CONNECTIONSTRINGS__UMBRACODBDSN: 'Server=(local);Database=Umbraco;User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True'
-            Windows:
-              vmImage: 'windows-latest'
+              CONNECTIONSTRINGS__UMBRACODBDSN: "Server=(local);Database=Umbraco;User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
+              LinuxPart2Of3:
+                testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=2/3"
+                vmImage: "ubuntu-latest"
+                SA_PASSWORD: $(UMBRACO__CMS__UNATTENDED__UNATTENDEDUSERPASSWORD)
+                CONNECTIONSTRINGS__UMBRACODBDSN: "Server=(local);Database=Umbraco;User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
+              LinuxPart3Of3:
+                testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=3/3"
+                vmImage: "ubuntu-latest"
+                SA_PASSWORD: $(UMBRACO__CMS__UNATTENDED__UNATTENDEDUSERPASSWORD)
+                CONNECTIONSTRINGS__UMBRACODBDSN: "Server=(local);Database=Umbraco;User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
+              WindowsPart1Of3:
+                vmImage: "windows-latest"
+                testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=1/3"
+              WindowsPart2Of3:
+                vmImage: "windows-latest"
+                testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=2/3"
+              WindowsPart3Of3:
+                vmImage: "windows-latest"
+                testCommand: "npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\" --shard=3/3"
         pool:
           vmImage: $(vmImage)
         steps:

--- a/tests/Umbraco.Tests.AcceptanceTest/playwright.config.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/playwright.config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
       use: {
         ...devices['Desktop Chrome'],
         // Use prepared auth state.
+        ignoreHTTPSErrors: true,
         storageState: STORAGE_STATE,
       },
     },

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Template/Templates.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Template/Templates.spec.ts
@@ -84,7 +84,7 @@ test('can delete a template', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.template.isTemplateRootTreeItemVisible(templateName, false);
 });
 
-test('can set a template as master template', async ({umbracoApi, umbracoUi}) => {
+test('can set a template as master template', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const childTemplateName = 'ChildTemplate';
   await umbracoApi.template.ensureNameNotExists(childTemplateName);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Template/Templates.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Template/Templates.spec.ts
@@ -84,7 +84,7 @@ test('can delete a template', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.template.isTemplateRootTreeItemVisible(templateName, false);
 });
 
-test('can set a template as master template', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+test('can set a template as master template', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const childTemplateName = 'ChildTemplate';
   await umbracoApi.template.ensureNameNotExists(childTemplateName);


### PR DESCRIPTION
We have updated our pipeline to run our E2E in parralization to decreased the time it takes for out tests to run. To do this we have implemented the usage of [Sharding  ](https://playwright.dev/docs/test-sharding)from playwright, which allows us to split our tests up. Currently we have split our tests into 3 shards