### PR TITLE
Hotfix: unnecessary Discard Changes dialog for RTEs

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/rte/components/rte-base.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/rte/components/rte-base.element.ts
@@ -37,6 +37,16 @@ export abstract class UmbPropertyEditorUiRteElementBase extends UmbLitElement im
 		},
 	})
 	public set value(value: UmbPropertyEditorUiValueType | undefined) {
+		if (!value) {
+			this._value = undefined;
+			this._markup = '';
+			this.#managerContext.setLayouts([]);
+			this.#managerContext.setContents([]);
+			this.#managerContext.setSettings([]);
+			this.#managerContext.setExposes([]);
+			return;
+		}
+
 		const buildUpValue: Partial<UmbPropertyEditorUiValueType> = value ? { ...value } : {};
 		buildUpValue.markup ??= '';
 		buildUpValue.blocks ??= { layout: {}, contentData: [], settingsData: [], expose: [] };

--- a/src/Umbraco.Web.UI.Client/src/packages/rte/components/rte-base.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/rte/components/rte-base.element.ts
@@ -146,31 +146,8 @@ export abstract class UmbPropertyEditorUiRteElementBase extends UmbLitElement im
 			this.observe(this.#managerContext.exposes, (exposes) => {
 				this.#setBlocksValue({ ...this._value.blocks, expose: exposes });
 			});
-
-			// The above could potentially be replaced with a single observeMultiple call, but it is not done for now to avoid potential issues with the order of the updates.
-			/*this.observe(
-				observeMultiple([
-					this.#managerContext.layouts,
-					this.#managerContext.contents,
-					this.#managerContext.settings,
-					this.#managerContext.exposes,
-				]).pipe(debounceTime(20)),
-				([layouts, contents, settings, exposes]) => {
-					this._value = {
-						...this._value,
-						blocks: {
-							layout: { [UMB_BLOCK_RTE_PROPERTY_EDITOR_SCHEMA_ALIAS]: layouts },
-							contentData: contents,
-							settingsData: settings,
-							expose: exposes,
-						},
-					};
-
-					this._fireChangeEvent();
-				},
-				'motherObserver',
-			);*/
 		});
+
 		this.consumeContext(UMB_PROPERTY_DATASET_CONTEXT, (context) => {
 			this.#managerContext.setVariantId(context.getVariantId());
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/rte/components/rte-base.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/rte/components/rte-base.element.ts
@@ -10,9 +10,11 @@ import type {
 import {
 	UmbBlockRteEntriesContext,
 	UmbBlockRteManagerContext,
+	type UmbBlockRteLayoutModel,
 	type UmbBlockRteTypeModel,
 } from '@umbraco-cms/backoffice/block-rte';
 import { UMB_PROPERTY_CONTEXT, UMB_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
+import type { UmbBlockValueType } from '@umbraco-cms/backoffice/block';
 
 // eslint-disable-next-line local-rules/enforce-element-suffix-on-element-class-name
 export abstract class UmbPropertyEditorUiRteElementBase extends UmbLitElement implements UmbPropertyEditorUiElement {
@@ -127,23 +129,22 @@ export abstract class UmbPropertyEditorUiRteElementBase extends UmbLitElement im
 
 			// Observe the value of the property and update the editor value.
 			this.observe(this.#managerContext.layouts, (layouts) => {
-				this._value = {
-					...this._value,
-					blocks: { ...this._value.blocks, layout: { [UMB_BLOCK_RTE_PROPERTY_EDITOR_SCHEMA_ALIAS]: layouts } },
-				};
-				this._fireChangeEvent();
+				this.#setBlocksValue({
+					...this._value.blocks,
+					layout: { [UMB_BLOCK_RTE_PROPERTY_EDITOR_SCHEMA_ALIAS]: layouts },
+				});
 			});
+
 			this.observe(this.#managerContext.contents, (contents) => {
-				this._value = { ...this._value, blocks: { ...this._value.blocks, contentData: contents } };
-				this._fireChangeEvent();
+				this.#setBlocksValue({ ...this._value.blocks, contentData: contents });
 			});
+
 			this.observe(this.#managerContext.settings, (settings) => {
-				this._value = { ...this._value, blocks: { ...this._value.blocks, settingsData: settings } };
-				this._fireChangeEvent();
+				this.#setBlocksValue({ ...this._value.blocks, settingsData: settings });
 			});
+
 			this.observe(this.#managerContext.exposes, (exposes) => {
-				this._value = { ...this._value, blocks: { ...this._value.blocks, expose: exposes } };
-				this._fireChangeEvent();
+				this.#setBlocksValue({ ...this._value.blocks, expose: exposes });
 			});
 
 			// The above could potentially be replaced with a single observeMultiple call, but it is not done for now to avoid potential issues with the order of the updates.
@@ -189,6 +190,15 @@ export abstract class UmbPropertyEditorUiRteElementBase extends UmbLitElement im
 		unusedBlocks.forEach((blockLayout) => {
 			this.#managerContext.removeOneLayout(blockLayout.contentKey);
 		});
+	}
+
+	#setBlocksValue(blocksValue: UmbBlockValueType<UmbBlockRteLayoutModel>) {
+		this._value = {
+			...this._value,
+			blocks: blocksValue,
+		};
+
+		this._fireChangeEvent();
 	}
 
 	protected _fireChangeEvent() {

--- a/src/Umbraco.Web.UI.Client/src/packages/rte/components/rte-base.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/rte/components/rte-base.element.ts
@@ -71,10 +71,7 @@ export abstract class UmbPropertyEditorUiRteElementBase extends UmbLitElement im
 	protected _config?: UmbPropertyEditorConfigCollection;
 
 	@state()
-	protected _value: UmbPropertyEditorUiValueType = {
-		markup: '',
-		blocks: { layout: {}, contentData: [], settingsData: [], expose: [] },
-	};
+	protected _value?: UmbPropertyEditorUiValueType | undefined;
 
 	/**
 	 * Separate state for markup, to avoid re-rendering/re-setting the value of the Tiptap editor when the value does not really change.
@@ -129,22 +126,26 @@ export abstract class UmbPropertyEditorUiRteElementBase extends UmbLitElement im
 
 			// Observe the value of the property and update the editor value.
 			this.observe(this.#managerContext.layouts, (layouts) => {
-				this.#setBlocksValue({
-					...this._value.blocks,
-					layout: { [UMB_BLOCK_RTE_PROPERTY_EDITOR_SCHEMA_ALIAS]: layouts },
-				});
+				const blocksValue = this._value
+					? { ...this._value.blocks, layout: { [UMB_BLOCK_RTE_PROPERTY_EDITOR_SCHEMA_ALIAS]: layouts } }
+					: undefined;
+
+				this.#setBlocksValue(blocksValue);
 			});
 
 			this.observe(this.#managerContext.contents, (contents) => {
-				this.#setBlocksValue({ ...this._value.blocks, contentData: contents });
+				const blocksValue = this._value ? { ...this._value.blocks, contentData: contents } : undefined;
+				this.#setBlocksValue(blocksValue);
 			});
 
 			this.observe(this.#managerContext.settings, (settings) => {
-				this.#setBlocksValue({ ...this._value.blocks, settingsData: settings });
+				const blocksValue = this._value ? { ...this._value.blocks, settingsData: settings } : undefined;
+				this.#setBlocksValue(blocksValue);
 			});
 
 			this.observe(this.#managerContext.exposes, (exposes) => {
-				this.#setBlocksValue({ ...this._value.blocks, expose: exposes });
+				const blocksValue = this._value ? { ...this._value.blocks, expose: exposes } : undefined;
+				this.#setBlocksValue(blocksValue);
 			});
 		});
 
@@ -169,7 +170,11 @@ export abstract class UmbPropertyEditorUiRteElementBase extends UmbLitElement im
 		});
 	}
 
-	#setBlocksValue(blocksValue: UmbBlockValueType<UmbBlockRteLayoutModel>) {
+	#setBlocksValue(blocksValue?: UmbBlockValueType<UmbBlockRteLayoutModel>) {
+		if (!blocksValue || !this._value) {
+			return;
+		}
+
 		this._value = {
 			...this._value,
 			blocks: blocksValue,

--- a/src/Umbraco.Web.UI.Client/src/packages/rte/components/rte-base.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/rte/components/rte-base.element.ts
@@ -126,9 +126,10 @@ export abstract class UmbPropertyEditorUiRteElementBase extends UmbLitElement im
 
 			// Observe the value of the property and update the editor value.
 			this.observe(this.#managerContext.layouts, (layouts) => {
-				const blocksValue = this._value
-					? { ...this._value.blocks, layout: { [UMB_BLOCK_RTE_PROPERTY_EDITOR_SCHEMA_ALIAS]: layouts } }
-					: undefined;
+				const blocksValue =
+					this._value && layouts?.length > 0
+						? { ...this._value.blocks, layout: { [UMB_BLOCK_RTE_PROPERTY_EDITOR_SCHEMA_ALIAS]: layouts } }
+						: undefined;
 
 				this.#setBlocksValue(blocksValue);
 			});

--- a/src/Umbraco.Web.UI.Client/src/packages/tiny-mce/property-editors/tiny-mce/property-editor-ui-tiny-mce.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiny-mce/property-editors/tiny-mce/property-editor-ui-tiny-mce.element.ts
@@ -12,10 +12,11 @@ export class UmbPropertyEditorUITinyMceElement extends UmbPropertyEditorUiRteEle
 	#onChange(event: CustomEvent & { target: UmbInputTinyMceElement }) {
 		const value = typeof event.target.value === 'string' ? event.target.value : '';
 
-		// If we don't get any markup value we consider the value to be undefined, and don't update the value.
+		// If we don't get any markup clear the property editor value.
 		if (value === '') {
-			this._value = undefined;
+			this.value = undefined;
 			this._fireChangeEvent();
+			return;
 		}
 
 		// Clone the DOM, to remove the classes and attributes on the original:
@@ -44,10 +45,12 @@ export class UmbPropertyEditorUITinyMceElement extends UmbPropertyEditorUiRteEle
 
 		this._latestMarkup = markup;
 
-		this._value = {
-			...this._value,
-			markup: markup,
-		};
+		this._value = this._value
+			? {
+					...this._value,
+					markup: markup,
+				}
+			: undefined;
 
 		this._fireChangeEvent();
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/tiny-mce/property-editors/tiny-mce/property-editor-ui-tiny-mce.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiny-mce/property-editors/tiny-mce/property-editor-ui-tiny-mce.element.ts
@@ -12,6 +12,12 @@ export class UmbPropertyEditorUITinyMceElement extends UmbPropertyEditorUiRteEle
 	#onChange(event: CustomEvent & { target: UmbInputTinyMceElement }) {
 		const value = typeof event.target.value === 'string' ? event.target.value : '';
 
+		// If we don't get any markup value we consider the value to be undefined, and don't update the value.
+		if (value === '') {
+			this._value = undefined;
+			this._fireChangeEvent();
+		}
+
 		// Clone the DOM, to remove the classes and attributes on the original:
 		const div = document.createElement('div');
 		div.innerHTML = value;

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -67,6 +67,14 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 		await Promise.all([await this.#loadExtensions(), await this.#loadEditor()]);
 	}
 
+	/**
+	 * Checks if the editor is empty.
+	 * @returns {boolean}
+	 */
+	public isEmpty(): boolean {
+		return this._editor.isEmpty;
+	}
+
 	async #loadExtensions() {
 		await new Promise<void>((resolve) => {
 			this.observe(umbExtensionsRegistry.byType('tiptapExtension'), async (manifests) => {

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap/property-editor-ui-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap/property-editor-ui-tiptap.element.ts
@@ -14,6 +14,13 @@ export class UmbPropertyEditorUiTiptapElement extends UmbPropertyEditorUiRteElem
 	#onChange(event: CustomEvent & { target: UmbInputTiptapElement }) {
 		const value = event.target.value;
 
+		// If we don't get any markup clear the property editor value.
+		if (value === '') {
+			this.value = undefined;
+			this._fireChangeEvent();
+			return;
+		}
+
 		// Remove unused Blocks of Blocks Layout. Leaving only the Blocks that are present in Markup.
 		const usedContentKeys: string[] = [];
 
@@ -32,10 +39,12 @@ export class UmbPropertyEditorUiTiptapElement extends UmbPropertyEditorUiRteElem
 
 		this._latestMarkup = value;
 
-		this._value = {
-			...this._value,
-			markup: this._latestMarkup,
-		};
+		this._value = this._value
+			? {
+					...this._value,
+					markup: this._latestMarkup,
+				}
+			: undefined;
 
 		this._fireChangeEvent();
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap/property-editor-ui-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap/property-editor-ui-tiptap.element.ts
@@ -12,10 +12,11 @@ const elementName = 'umb-property-editor-ui-tiptap';
 @customElement(elementName)
 export class UmbPropertyEditorUiTiptapElement extends UmbPropertyEditorUiRteElementBase {
 	#onChange(event: CustomEvent & { target: UmbInputTiptapElement }) {
-		const value = event.target.value;
+		const tipTapElement = event.target;
+		const value = tipTapElement.value;
 
 		// If we don't get any markup clear the property editor value.
-		if (value === '') {
+		if (tipTapElement.isEmpty()) {
 			this.value = undefined;
 			this._fireChangeEvent();
 			return;


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/17670

The PR aims to clean up how we set/update the RTE property value so we don't get the "Discard Changes" dialog unless there has been user updates to the value.

How I went about this:

**Allow the internal property _value to be undefined.**
The property value can be undefined but the internal _value could only be the full value object with blocks. By aligning these it is easier to keep them in sync. The new code clears all internal the values and only sets the block data if we get a markup value.

**Handles the Tip Tap empty `<p></p>` tag (https://github.com/ueberdosis/tiptap/issues/154)**
This issue wasn't directly linked to this issue but for us to be able to check for an empty tip tap editor I encountered this issue. Tip Tap has a property on their element to check if it's empty. It ignores the <p></p> and returns the value you would expect. I have added a public method on our element to proxy their value.

What to test:
* Please ensure that you only get the "Discard Changes"-dialog if you have done any changes to an RTE.
* Test both Tiny MCE and Tip Tap