### PR TITLE
Change Slider DataEditor to accept decimal values, fixes #17189

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/SliderPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/SliderPropertyEditor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System.Globalization;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Editors;
@@ -61,7 +62,7 @@ public class SliderPropertyEditor : DataEditor
 
             var parts = stringValue.Split(Constants.CharArrays.Comma);
             var parsed = parts
-                .Select(s => int.TryParse(s, out var i) ? i : (int?)null)
+                .Select(s => decimal.TryParse(s, CultureInfo.InvariantCulture, out var i) ? i : (decimal?)null)
                 .Where(i => i != null)
                 .Select(i => i!.Value)
                 .ToArray();
@@ -78,11 +79,11 @@ public class SliderPropertyEditor : DataEditor
 
         internal class SliderRange
         {
-            public int From { get; set; }
+            public decimal From { get; set; }
 
-            public int To { get; set; }
+            public decimal To { get; set; }
 
-            public override string ToString() => From == To ? $"{From}" : $"{From},{To}";
+            public override string ToString() => From == To ? string.Create(CultureInfo.InvariantCulture, $"{From}") : string.Create(CultureInfo.InvariantCulture, $"{From},{To}");
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [ x ] I have added steps to test this contribution in the description below

This fixes #17189 

### Description
This changes the DataEditor for the Slider Property editor to use decimal instead of int for representing the JSON from and to values. Since the slider is able to be configured to use decimal values, the code should support this.

To test, create a slider that has a step value of 0.1, and minimum of 0 and a maximum of 1 (or any other configuration that stores a decimal value) and test that values are persisted as they should.

The existing PropertyValueConverter already handles this case, so no changes are needed there.
