### PR TITLE
Fix `PanicException: failed to get child with id=` after updating content types

### DIFF
--- a/src/Umbraco.PublishedCache.NuCache/ContentStore.cs
+++ b/src/Umbraco.PublishedCache.NuCache/ContentStore.cs
@@ -1306,7 +1306,11 @@ public class ContentStore
             return;
         }
 
+        // clear the entire branch
         ClearBranchLocked(link.Value);
+
+        // manage the tree
+        RemoveTreeNodeLocked(link.Value);
     }
 
     private void ClearBranchLocked(ContentNode? content)

--- a/src/Umbraco.PublishedCache.NuCache/ContentStore.cs
+++ b/src/Umbraco.PublishedCache.NuCache/ContentStore.cs
@@ -1276,52 +1276,42 @@ public class ContentStore
 
         // try to find the content
         // if it is not there, nothing to do
-        _contentNodes.TryGetValue(id, out LinkedNode<ContentNode?>? link); // else null
-        if (link?.Value == null)
+        if (_contentNodes.TryGetValue(id, out LinkedNode<ContentNode?>? link) &&
+            link.Value is ContentNode content)
         {
-            return false;
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("Clear content ID: {ContentId}", content.Id);
+            }
+
+            // clear the entire branch
+            ClearBranchLocked(content);
+
+            // manage the tree
+            RemoveTreeNodeLocked(content);
+
+            return true;
         }
 
-        ContentNode? content = link.Value;
-
-        if (_logger.IsEnabled(LogLevel.Debug))
-        {
-            _logger.LogDebug("Clear content ID: {ContentId}", content.Id);
-        }
-
-        // clear the entire branch
-        ClearBranchLocked(content);
-
-        // manage the tree
-        RemoveTreeNodeLocked(content);
-
-        return true;
+        return false;
     }
 
     private void ClearBranchLocked(int id)
     {
-        _contentNodes.TryGetValue(id, out LinkedNode<ContentNode?>? link);
-        if (link?.Value == null)
+        if (_contentNodes.TryGetValue(id, out LinkedNode<ContentNode?>? link) &&
+            link.Value is ContentNode content)
         {
-            return;
+            // clear the entire branch
+            ClearBranchLocked(content);
+
+            // manage the tree
+            RemoveTreeNodeLocked(content);
         }
-
-        // clear the entire branch
-        ClearBranchLocked(link.Value);
-
-        // manage the tree
-        RemoveTreeNodeLocked(link.Value);
     }
 
-    private void ClearBranchLocked(ContentNode? content)
+    private void ClearBranchLocked(ContentNode content)
     {
-        // This should never be null, all code that calls this method is null checking but we've seen
-        // issues of null ref exceptions in issue reports so we'll double check here
-        if (content == null)
-        {
-            throw new ArgumentNullException(nameof(content));
-        }
-
+        // Clear content node
         SetValueLocked(_contentNodes, content.Id, null);
         if (_localDb != null)
         {
@@ -1330,14 +1320,21 @@ public class ContentStore
 
         _contentKeyToIdMap.TryRemove(content.Uid, out _);
 
-        var id = content.FirstChildContentId;
-        while (id > 0)
+        // Clear children
+        int childId = content.FirstChildContentId;
+        if (childId > 0)
         {
-            // get the required link node, this ensures that both `link` and `link.Value` are not null
-            LinkedNode<ContentNode> link = GetRequiredLinkedNode(id, "child", null);
-            ContentNode? linkValue = link.Value; // capture local since clearing in recurse can clear it
-            ClearBranchLocked(linkValue); // recurse
-            id = linkValue?.NextSiblingContentId ?? 0;
+            ContentNode childContent = GetRequiredLinkedNode(childId, "first child", null).Value!;
+            ClearBranchLocked(childContent); // recurse
+
+            // Clear all siblings of child
+            int siblingId = childContent.NextSiblingContentId;
+            while (siblingId > 0)
+            {
+                ContentNode siblingContent = GetRequiredLinkedNode(siblingId, "next sibling", null).Value!;
+                ClearBranchLocked(siblingContent); // recurse
+                siblingId = siblingContent.NextSiblingContentId;
+            }
         }
     }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/15569 and https://github.com/umbraco/Umbraco.Deploy.Issues/issues/145.

### Description
When content types (document or media types) are saved/changed, the content cache (NuCache) is updated via cache refreshers to ensure all content items are stored using the updated schema. However, sometimes a `PanicException` was thrown in `ContentStore`. This was especially noticeable when doing a large amount of changes in a single scope (Unit of Work), like Deploy does when deploying schema changes or importing content and/or schema. So much so, that we decided to add a special error message if a Deploy import failed due to an unhandled exception 🙃

However, with the recent Deploy feature that imports a ZIP archive on startup, this exception results in the site completely failing to boot. Since this was consistently and really easy to replicate with an export I created, I've decided to install Deploy on the `v13/dev` branch and debug the issue to find the root cause of this exception. Testing can be done by adding the following package references to the Umbraco.Web.UI project:

```csproj
  <ItemGroup>
    <PackageReference Include="Umbraco.Deploy.OnPrem" VersionOverride="13.3.1" />
    <PackageReference Include="Bergmania.OpenStreetMap" VersionOverride="5.3.2" />
  </ItemGroup>
```

And putting [this `import-on-startup.zip`](https://github.com/user-attachments/files/17980177/import-on-startup.zip) in the `umbraco\Deploy` folder...

When you start the site using the `v13/dev` branch, you'll get the `PanicException`:

```
System.AggregateException: One or more errors occurred. (failed to get child with id=1110)
 ---> Umbraco.Cms.Core.Exceptions.PanicException: failed to get child with id=1110
   at Umbraco.Cms.Infrastructure.PublishedCache.ContentStore.GetRequiredLinkedNode(Int32 id, String description, Nullable`1 gen) in src\Umbraco.PublishedCache.NuCache\ContentStore.cs:line 1358
   at Umbraco.Cms.Infrastructure.PublishedCache.ContentStore.ClearBranchLocked(ContentNode content) in src\Umbraco.PublishedCache.NuCache\ContentStore.cs:line 1333
   at Umbraco.Cms.Infrastructure.PublishedCache.ContentStore.ClearBranchLocked(Int32 id) in src\Umbraco.PublishedCache.NuCache\ContentStore.cs:line 1309
   at Umbraco.Cms.Infrastructure.PublishedCache.ContentStore.UpdateContentTypesLocked(IReadOnlyCollection`1 removedIds, IReadOnlyCollection`1 refreshedTypes, IReadOnlyCollection`1 kits) in src\Umbraco.PublishedCache.NuCache\ContentStore.cs:line 730
   at Umbraco.Cms.Infrastructure.PublishedCache.PublishedSnapshotService.RefreshMediaTypesLocked(List`1 removedIds, List`1 refreshedIds, List`1 otherIds, List`1 newIds) in src\Umbraco.PublishedCache.NuCache\PublishedSnapshotService.cs:line 1217
   at Umbraco.Cms.Infrastructure.PublishedCache.PublishedSnapshotService.Notify[T](ContentStore store, JsonPayload[] payloads, Action`4 action) in src\Umbraco.PublishedCache.NuCache\PublishedSnapshotService.cs:line 1089
   at Umbraco.Cms.Infrastructure.PublishedCache.PublishedSnapshotService.Notify(JsonPayload[] payloads) in src\Umbraco.PublishedCache.NuCache\PublishedSnapshotService.cs:line 198
   at Umbraco.Cms.Core.Cache.ContentTypeCacheRefresher.<>c__DisplayClass11_0.<Refresh>b__0() in src\Umbraco.Core\Cache\Refreshers\Implement\ContentTypeCacheRefresher.cs:line 120
   at Umbraco.Extensions.PublishedModelFactoryExtensions.WithSafeLiveFactoryReset(IPublishedModelFactory factory, Action action) in src\Umbraco.Core\Extensions\PublishedModelFactoryExtensions.cs:line 44
   at Umbraco.Cms.Core.Cache.ContentTypeCacheRefresher.Refresh(JsonPayload[] payloads) in src\Umbraco.Core\Cache\Refreshers\Implement\ContentTypeCacheRefresher.cs:line 119
   at Umbraco.Cms.Infrastructure.Sync.ServerMessengerBase.DeliverLocal[TPayload](ICacheRefresher refresher, TPayload[] payload) in src\Umbraco.Infrastructure\Sync\ServerMessengerBase.cs:line 212
   at Umbraco.Cms.Infrastructure.Sync.ServerMessengerBase.Deliver[TPayload](ICacheRefresher refresher, TPayload[] payload) in src\Umbraco.Infrastructure\Sync\ServerMessengerBase.cs:line 371
   at Umbraco.Cms.Infrastructure.Sync.ServerMessengerBase.QueueRefresh[TPayload](ICacheRefresher refresher, TPayload[] payload) in src\Umbraco.Infrastructure\Sync\ServerMessengerBase.cs:line 91
   at Umbraco.Cms.Core.Cache.DistributedCache.RefreshByPayload[TPayload](Guid refresherGuid, TPayload[] payload) in src\Umbraco.Core\Cache\DistributedCache.cs:line 115
   at Umbraco.Cms.Core.Cache.DistributedCache.RefreshByPayload[TPayload](Guid refresherGuid, IEnumerable`1 payloads) in src\Umbraco.Core\Cache\DistributedCache.cs:line 126
   at Umbraco.Extensions.DistributedCacheExtensions.RefreshContentTypeCache(DistributedCache dc, IEnumerable`1 changes) in src\Umbraco.Core\Cache\DistributedCacheExtensions.cs:line 247
   at Umbraco.Cms.Core.Cache.MediaTypeChangedDistributedCacheNotificationHandler.Handle(IEnumerable`1 entities) in src\Umbraco.Core\Cache\NotificationHandlers\Implement\MediaTypeChangedDistributedCacheNotificationHandler.cs:line 22
   at Umbraco.Cms.Core.Cache.DistributedCacheNotificationHandlerBase`2.Handle(IEnumerable`1 notifications) in src\Umbraco.Core\Cache\NotificationHandlers\DistributedCacheNotificationHandlerBase.cs:line 17
   at Umbraco.Cms.Core.Events.NotificationHandlerWrapperImpl`1.<>c__DisplayClass0_0`2.<Handle>b__2(IEnumerable`1 handlerNotifications) in src\Umbraco.Core\Events\EventAggregator.Notifications.cs:line 284
   at Umbraco.Cms.Core.Events.EventAggregator.PublishCore[TNotification](IEnumerable`1 allHandlers, IEnumerable`1 notifications) in src\Umbraco.Core\Events\EventAggregator.Notifications.cs:line 109
   at Umbraco.Cms.Core.Events.NotificationHandlerWrapperImpl`1.Handle[TNotification,TNotificationHandler](IEnumerable`1 notifications, ServiceFactory serviceFactory, Action`2 publish) in src\Umbraco.Core\Events\EventAggregator.Notifications.cs:line 286
   at Umbraco.Cms.Core.Events.EventAggregator.PublishNotifications[TNotification,TNotificationHandler](IEnumerable`1 notifications) in src\Umbraco.Core\Events\EventAggregator.Notifications.cs:line 77
   at Umbraco.Cms.Core.Events.EventAggregator.Publish[TNotification,TNotificationHandler](IEnumerable`1 notifications) in src\Umbraco.Core\Events\EventAggregator.cs:line 26
   at Umbraco.Deploy.Infrastructure.DeployScopedNotificationPublisher.PublishScopedNotifications(IList`1 notifications)
   at Umbraco.Cms.Core.Events.ScopedNotificationPublisher`1.ScopeExit(Boolean completed) in src\Umbraco.Core\Events\ScopedNotificationPublisher.cs:line 94
   at Umbraco.Cms.Core.Scoping.CoreScope.HandleScopedNotifications() in src\Umbraco.Core\Scoping\CoreScope.cs:line 253
   at Umbraco.Cms.Infrastructure.Scoping.Scope.TryFinally(Action[] actions) in src\Umbraco.Infrastructure\Scoping\Scope.cs:line 581
   --- End of inner exception stack trace ---
   at Umbraco.Cms.Infrastructure.Scoping.Scope.TryFinally(Action[] actions) in src\Umbraco.Infrastructure\Scoping\Scope.cs:line 591
   at Umbraco.Cms.Infrastructure.Scoping.Scope.RobustExit(Boolean completed, Boolean onException) in src\Umbraco.Infrastructure\Scoping\Scope.cs:line 566
   at Umbraco.Cms.Infrastructure.Scoping.Scope.DisposeLastScope() in src\Umbraco.Infrastructure\Scoping\Scope.cs:line 502
   at Umbraco.Cms.Infrastructure.Scoping.Scope.Dispose() in src\Umbraco.Infrastructure\Scoping\Scope.cs:line 414
   at Umbraco.Deploy.Infrastructure.ArtifactImportExportService.ImportArtifactsAsync(IArtifactImportProvider artifactImportProvider, ImportArtifactOptions options, IProgress`1 progress, CancellationToken cancellationToken, String[] entityTypes)
   at Umbraco.Deploy.Infrastructure.ArtifactImportOnStartupProviderZipArchiveBase.ImportAsync(CancellationToken cancellationToken)
   at Umbraco.Deploy.Infrastructure.NotificationHandlers.UmbracoDeployStartingHandler.ImportAsync(CancellationToken cancellationToken)
   at Umbraco.Deploy.Infrastructure.NotificationHandlers.UmbracoDeployStartingHandler.HandleAsync(UmbracoApplicationStartingNotification notification, CancellationToken cancellationToken)
   at Umbraco.Cms.Core.Events.INotificationAsyncHandler`1.HandleAsync(IEnumerable`1 notifications, CancellationToken cancellationToken) in src\Umbraco.Core\Events\INotificationAsyncHandler.cs:line 37
   at Umbraco.Cms.Core.Events.EventAggregator.PublishCoreAsync[TNotification](IEnumerable`1 allHandlers, IEnumerable`1 notifications, CancellationToken cancellationToken) in src\Umbraco.Core\Events\EventAggregator.Notifications.cs:line 122
   at Umbraco.Cms.Core.Events.NotificationAsyncHandlerWrapperImpl`1.HandleAsync[TNotification,TNotificationHandler](IEnumerable`1 notifications, CancellationToken cancellationToken, ServiceFactory serviceFactory, Func`4 publish) in src\Umbraco.Core\Events\EventAggregator.Notifications.cs:line 259
   at Umbraco.Cms.Core.Events.EventAggregator.PublishNotificationsAsync[TNotification,TNotificationHandler](IEnumerable`1 notifications, CancellationToken cancellationToken) in src\Umbraco.Core\Events\EventAggregator.Notifications.cs:line 101
   at Umbraco.Cms.Core.Events.EventAggregator.PublishAsync[TNotification,TNotificationHandler](IEnumerable`1 notifications, CancellationToken cancellationToken) in src\Umbraco.Core\Events\EventAggregator.cs:line 51
   at Umbraco.Cms.Core.Events.EventAggregator.PublishAsync[TNotification](TNotification notification, CancellationToken cancellationToken) in src\Umbraco.Core\Events\EventAggregator.cs:line 41
   at Umbraco.Cms.Infrastructure.Runtime.CoreRuntime.StartAsync(CancellationToken cancellationToken, Boolean isRestarting) in src\Umbraco.Infrastructure\Runtime\CoreRuntime.cs:line 207
   at Umbraco.Cms.Infrastructure.Runtime.CoreRuntime.StartAsync(CancellationToken cancellationToken) in src\Umbraco.Infrastructure\Runtime\CoreRuntime.cs:line 136
   at Umbraco.Extensions.WebApplicationExtensions.BootUmbracoAsync(WebApplication app) in src\Umbraco.Web.Common\Extensions\WebApplicationExtensions.cs:line 29
   at Program.<Main>$(String[] args) in src\Umbraco.Web.UI\Program.cs:line 12
   at Program.<Main>(String[] args)
```

While debugging this, I noticed the `UpdateContentTypesLocked()` calls `ClearBranchLocked()` multiple times, but without calling `RemoveTreeNodeLocked()`. This can result in clearing content nodes from the cache without updating the `FirstChildContentId` and `NextSiblingContentId` and consecutive calls trying to use the outdated IDs to get 'required linked nodes'.

The fix ended up being really simple and just ensures `RemoveTreeNodeLocked()` is called after each `ClearBranchLocked()` 🤡 Switching to this PR branch fixes the issue, so starting the site again will successfully import the ZIP archive (and probably show another exception due to missing partial views used in the imported templates).

However, the `while` loop that cleared all children and siblings of the specified content ID was always using `child` in the exception description, which was a bit misleading (and the code overall was quite hard to decipher). I've therefore refactored this method to split clearing the children and siblings, making the intention more clear and use the correct exception message _if_ something still ends up in an inconsistent state.