### PR TITLE
Hotfix: Don't request urls every time the document name updates

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/views/info/document-workspace-view-info-links.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/views/info/document-workspace-view-info-links.element.ts
@@ -26,6 +26,9 @@ export class UmbDocumentWorkspaceViewInfoLinksElement extends UmbLitElement {
 	@state()
 	private _lookup: Record<string, string[]> = {};
 
+	@state()
+	private _loading = false;
+
 	#documentWorkspaceContext?: typeof UMB_DOCUMENT_WORKSPACE_CONTEXT.TYPE;
 	#eventContext?: typeof UMB_ACTION_EVENT_CONTEXT.TYPE;
 
@@ -66,6 +69,8 @@ export class UmbDocumentWorkspaceViewInfoLinksElement extends UmbLitElement {
 		if (this._isNew) return;
 		if (!this._unique) return;
 
+		this._loading = true;
+
 		const { data } = await this.#documentUrlRepository.requestItems([this._unique]);
 
 		if (data?.length) {
@@ -79,6 +84,8 @@ export class UmbDocumentWorkspaceViewInfoLinksElement extends UmbLitElement {
 			});
 			this.requestUpdate('_lookup');
 		}
+
+		this._loading = false;
 	}
 
 	#getStateLocalizationKey(variantOption: UmbDocumentVariantOptionModel) {
@@ -109,11 +116,25 @@ export class UmbDocumentWorkspaceViewInfoLinksElement extends UmbLitElement {
 		return html`
 			<uui-box headline=${this.localize.term('general_links')}>
 				${when(
-					this._isNew,
-					() => this.#renderNotCreated(),
-					() => this.#renderUrls(),
+					this._loading,
+					() => this.#renderLoading(),
+					() => this.#renderContent(),
 				)}
 			</uui-box>
+		`;
+	}
+
+	#renderLoading() {
+		return html`<div id="loader-container"><uui-loader></uui-loader></div>`;
+	}
+
+	#renderContent() {
+		return html`
+			${when(
+				this._isNew,
+				() => this.#renderNotCreated(),
+				() => this.#renderUrls(),
+			)}
 		`;
 	}
 
@@ -173,6 +194,13 @@ export class UmbDocumentWorkspaceViewInfoLinksElement extends UmbLitElement {
 		css`
 			uui-box {
 				--uui-box-default-padding: 0;
+			}
+
+			#loader-container {
+				display: flex;
+				justify-content: center;
+				align-items: center;
+				padding: var(--uui-size-space-2);
 			}
 
 			.link-item {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/views/info/document-workspace-view-info-links.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/views/info/document-workspace-view-info-links.element.ts
@@ -70,11 +70,14 @@ export class UmbDocumentWorkspaceViewInfoLinksElement extends UmbLitElement {
 		if (!this._unique) return;
 
 		this._loading = true;
+		this._lookup = {};
 
 		const { data } = await this.#documentUrlRepository.requestItems([this._unique]);
 
 		if (data?.length) {
-			data[0].urls.forEach((item) => {
+			const item = data[0];
+
+			item.urls.forEach((item) => {
 				if (item.culture && item.url) {
 					if (this._lookup[item.culture] == null) {
 						this._lookup[item.culture] = [];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/views/info/document-workspace-view-info-links.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/views/info/document-workspace-view-info-links.element.ts
@@ -34,16 +34,17 @@ export class UmbDocumentWorkspaceViewInfoLinksElement extends UmbLitElement {
 		});
 
 		this.consumeContext(UMB_DOCUMENT_WORKSPACE_CONTEXT, (context) => {
-			this.observe(
-				observeMultiple([context.isNew, context.unique, context.variantOptions]),
-				([isNew, unique, variantOptions]) => {
-					if (!unique) return;
-					this._isNew = isNew === true;
+			this.observe(observeMultiple([context.isNew, context.unique]), ([isNew, unique]) => {
+				if (!unique) return;
+				this._isNew = isNew === true;
+
+				if (unique !== this._unique) {
 					this._unique = unique;
-					this._variantOptions = variantOptions;
 					this.#requestUrls();
-				},
-			);
+				}
+			});
+
+			this.observe(context.variantOptions, (variantOptions) => (this._variantOptions = variantOptions));
 		});
 	}
 
@@ -56,7 +57,7 @@ export class UmbDocumentWorkspaceViewInfoLinksElement extends UmbLitElement {
 		if (data?.length) {
 			data[0].urls.forEach((item) => {
 				if (item.culture && item.url) {
-					if(this._lookup[item.culture] == null){
+					if (this._lookup[item.culture] == null) {
 						this._lookup[item.culture] = [];
 					}
 					this._lookup[item.culture].push(item.url);
@@ -114,16 +115,16 @@ export class UmbDocumentWorkspaceViewInfoLinksElement extends UmbLitElement {
 		const urls = this._lookup[culture];
 		return when(
 			urls && urls.length >= 1,
-			() => html`
-				${urls.map((url) =>
-					html`
-						<a class="link-item" href=${url} target="_blank">
+			() =>
+				html` ${urls.map(
+					(url) =>
+						html` <a class="link-item" href=${url} target="_blank">
 							<span>
 								<span class="culture">${varies ? culture : nothing}</span>
 								<span>${url}</span>
 							</span>
 							<uui-icon name="icon-out"></uui-icon>
-						</a>`
+						</a>`,
 				)}`,
 			() => html`
 				<div class="link-item">


### PR DESCRIPTION
The issue:

https://github.com/user-attachments/assets/1a12c39a-382a-4e85-adf4-ee667dab80e6


This PR fixes an issue with the document URL UI updating every time the document name is changed. The main problem was that the observer responsible for requesting the URLs also included the document variant names. This resulted in a server request being made every time the name was changed.

I have split the observer into two: one for loading the document URLs and one for observing the variants.

The PR also includes general event cleanup and adds a loader state.

##what to test
* Please ensure that the URLs are loaded and updated correctly
* Make sure that it works for variant and invariant documents


