### PR TITLE
V15 QA added parallelization for the integration tests

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -351,35 +351,35 @@ stages:
               vmImage: "windows-latest"
               Tests__Database__DatabaseType: LocalDb
               Tests__Database__SQLServerMasterConnectionString: N/A
-              testFilter: "(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)"
+              testFilter: '(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
             WindowsPart2Of3:
               vmImage: "windows-latest"
               Tests__Database__DatabaseType: LocalDb
               Tests__Database__SQLServerMasterConnectionString: N/A
-              testFilter: "(FullyQualifiedName~Umbraco.Infrastructure.Service)"
+              testFilter: '(FullyQualifiedName~Umbraco.Infrastructure.Service)'
             WindowsPart3Of3:
               vmImage: "windows-latest"
               Tests__Database__DatabaseType: LocalDb
               Tests__Database__SQLServerMasterConnectionString: N/A
-              testFilter: "(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)"
+              testFilter: '(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
             LinuxPart1Of3:
               vmImage: "ubuntu-latest"
               SA_PASSWORD: UmbracoIntegration123!
               Tests__Database__DatabaseType: SqlServer
               Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
-              testFilter: "(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)"
+              testFilter: '(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
             LinuxPart2Of3:
                 vmImage: "ubuntu-latest"
                 SA_PASSWORD: UmbracoIntegration123!
                 Tests__Database__DatabaseType: SqlServer
                 Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
-                testFilter: "(FullyQualifiedName~Umbraco.Infrastructure.Service)"
+                testFilter: '(FullyQualifiedName~Umbraco.Infrastructure.Service)'
             LinuxPart3Of3:
                 vmImage: "ubuntu-latest"
                 SA_PASSWORD: UmbracoIntegration123!
                 Tests__Database__DatabaseType: SqlServer
                 Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
-                testFilter: "(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)"
+                testFilter: '(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
         pool:
           vmImage: $(vmImage)
         steps:

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -305,7 +305,7 @@ stages:
               testFilter: '(FullyQualifiedName~Umbraco.Infrastructure.Service)'
             LinuxPart3Of3:
               vmImage: "ubuntu-24.04"
-              testFilter: '(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
+              testFilter: '(FullyQualifiedName!~Umbraco.Infrastructure)'
             macOSPart1Of3:
               vmImage: "macOS-latest"
               testFilter: '(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
@@ -314,7 +314,7 @@ stages:
               testFilter: '(FullyQualifiedName~Umbraco.Infrastructure.Service)'
             macOSPart3Of3:
               vmImage: "macOS-latest"
-              testFilter: '(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
+              testFilter: '(FullyQualifiedName!~Umbraco.Infrastructure)'
         pool:
           vmImage: $(vmImage)
         variables:
@@ -374,7 +374,7 @@ stages:
               vmImage: "windows-latest"
               Tests__Database__DatabaseType: LocalDb
               Tests__Database__SQLServerMasterConnectionString: N/A
-              testFilter: '(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
+              testFilter: '(FullyQualifiedName!~Umbraco.Infrastructure)'
             LinuxPart1Of3:
               vmImage: "ubuntu-latest"
               SA_PASSWORD: UmbracoIntegration123!
@@ -392,7 +392,7 @@ stages:
                 SA_PASSWORD: UmbracoIntegration123!
                 Tests__Database__DatabaseType: SqlServer
                 Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
-                testFilter: '(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
+                testFilter: '(FullyQualifiedName!~Umbraco.Infrastructure)'
         pool:
           vmImage: $(vmImage)
         steps:

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -351,7 +351,7 @@ stages:
               vmImage: "windows-latest"
               Tests__Database__DatabaseType: LocalDb
               Tests__Database__SQLServerMasterConnectionString: N/A
-              testFilter: '--filter \"(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)\"'
+              testFilter: '(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
             WindowsPart2Of3:
               vmImage: "windows-latest"
               Tests__Database__DatabaseType: LocalDb
@@ -361,25 +361,25 @@ stages:
               vmImage: "windows-latest"
               Tests__Database__DatabaseType: LocalDb
               Tests__Database__SQLServerMasterConnectionString: N/A
-              testFilter: '--filter \"(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)\"'
+              testFilter: '(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
             LinuxPart1Of3:
               vmImage: "ubuntu-latest"
               SA_PASSWORD: UmbracoIntegration123!
               Tests__Database__DatabaseType: SqlServer
               Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
-              testFilter: '--filter \"(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)\"'
+              testFilter: '(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
             LinuxPart2Of3:
                 vmImage: "ubuntu-latest"
                 SA_PASSWORD: UmbracoIntegration123!
                 Tests__Database__DatabaseType: SqlServer
                 Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
-                testFilter: '--filter \"(FullyQualifiedName~Umbraco.Infrastructure.Service)\"'
+                testFilter: '(FullyQualifiedName~Umbraco.Infrastructure.Service)'
             LinuxPart3Of3:
                 vmImage: "ubuntu-latest"
                 SA_PASSWORD: UmbracoIntegration123!
                 Tests__Database__DatabaseType: SqlServer
                 Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
-                testFilter: '--filter \"(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)\"'
+                testFilter: '(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
         pool:
           vmImage: $(vmImage)
         steps:
@@ -412,13 +412,13 @@ stages:
               projects: "tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj"
               testRunTitle: Integration Tests SQL Server - $(Agent.OS)
               ${{ if and(eq(variables['Agent.OS'],'Windows_NT'), or(variables.releaseTestFilter, parameters.forceReleaseTestFilter)) }}:
-                arguments: "$(testFilter) --configuration $(buildConfiguration) --no-build ${{parameters.integrationReleaseTestFilter}}"
+                arguments: '--filter "$(testFilter)" --configuration $(buildConfiguration) --no-build ${{parameters.integrationReleaseTestFilter}}'
               ${{ elseif eq(variables['Agent.OS'],'Windows_NT') }}:
-                arguments: "$(testFilter) --configuration $(buildConfiguration) --no-build ${{parameters.integrationNonReleaseTestFilter}}"
+                arguments: '--filter "$(testFilter)" --configuration $(buildConfiguration) --no-build ${{parameters.integrationNonReleaseTestFilter}}'
               ${{ elseif or(variables.releaseTestFilter, parameters.forceReleaseTestFilter) }}:
-                arguments: "$(testFilter) --configuration $(buildConfiguration) --no-build ${{parameters.nonWindowsIntegrationReleaseTestFilter}}"
+                arguments: '--filter "$(testFilter)" --configuration $(buildConfiguration) --no-build ${{parameters.nonWindowsIntegrationReleaseTestFilter}}'
               ${{ else }}:
-                arguments: "$(testFilter) --configuration $(buildConfiguration) --no-build ${{parameters.nonWindowsIntegrationNonReleaseTestFilter}}"
+                arguments: '--filter "$(testFilter)" --configuration $(buildConfiguration) --no-build ${{parameters.nonWindowsIntegrationNonReleaseTestFilter}}'
 
           # Stop SQL Server
           - pwsh: docker stop mssql

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -297,10 +297,24 @@ stages:
           matrix:
             #            Windows:
             #              vmImage: 'windows-latest'
-            Linux:
+            LinuxPart1Of3:
               vmImage: "ubuntu-24.04"
-            macOS:
+              testFilter: '(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
+            LinuxPart2Of3:
+              vmImage: "ubuntu-24.04"
+              testFilter: '(FullyQualifiedName~Umbraco.Infrastructure.Service)'
+            LinuxPart3Of3:
+              vmImage: "ubuntu-24.04"
+              testFilter: '(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
+            macOSPart1Of3:
               vmImage: "macOS-latest"
+              testFilter: '(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
+            macOSPart2Of3:
+              vmImage: "macOS-latest"
+              testFilter: '(FullyQualifiedName~Umbraco.Infrastructure.Service)'
+            macOSPart3Of3:
+              vmImage: "macOS-latest"
+              testFilter: '(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
         pool:
           vmImage: $(vmImage)
         variables:
@@ -331,14 +345,13 @@ stages:
               projects: "tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj"
               testRunTitle: Integration Tests SQLite - $(Agent.OS)
               ${{ if and(eq(variables['Agent.OS'],'Windows_NT'), or(variables.releaseTestFilter, parameters.forceReleaseTestFilter)) }}:
-                arguments: "--configuration $(buildConfiguration) --no-build ${{parameters.integrationReleaseTestFilter}}"
+                arguments: '--filter "$(testFilter)" --configuration $(buildConfiguration) --no-build ${{parameters.integrationReleaseTestFilter}}'
               ${{ elseif eq(variables['Agent.OS'],'Windows_NT') }}:
-                arguments: "--configuration $(buildConfiguration) --no-build ${{parameters.integrationNonReleaseTestFilter}}"
+                arguments: '--filter "$(testFilter)" --configuration $(buildConfiguration) --no-build ${{parameters.integrationNonReleaseTestFilter}}'
               ${{ elseif or(variables.releaseTestFilter, parameters.forceReleaseTestFilter) }}:
-                arguments: "--configuration $(buildConfiguration) --no-build ${{parameters.nonWindowsIntegrationReleaseTestFilter}}"
+                arguments: '--filter "$(testFilter)" --configuration $(buildConfiguration) --no-build ${{parameters.nonWindowsIntegrationReleaseTestFilter}}'
               ${{ else }}:
-                arguments: "--configuration $(buildConfiguration) --no-build ${{parameters.nonWindowsIntegrationNonReleaseTestFilter}}"
-
+                arguments: '--filter "$(testFilter)" --configuration $(buildConfiguration) --no-build ${{parameters.nonWindowsIntegrationNonReleaseTestFilter}}'
       # Integration Tests (SQL Server)
       - job:
         timeoutInMinutes: 180

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -347,15 +347,39 @@ stages:
         displayName: Integration Tests (SQL Server)
         strategy:
           matrix:
-            Windows:
+            WindowsPart1Of3:
               vmImage: "windows-latest"
               Tests__Database__DatabaseType: LocalDb
               Tests__Database__SQLServerMasterConnectionString: N/A
-            Linux:
+              testFilter: "(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)"
+            WindowsPart2Of3:
+              vmImage: "windows-latest"
+              Tests__Database__DatabaseType: LocalDb
+              Tests__Database__SQLServerMasterConnectionString: N/A
+              testFilter: "(FullyQualifiedName~Umbraco.Infrastructure.Service)"
+            WindowsPart3Of3:
+              vmImage: "windows-latest"
+              Tests__Database__DatabaseType: LocalDb
+              Tests__Database__SQLServerMasterConnectionString: N/A
+              testFilter: "(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)"
+            LinuxPart1Of3:
               vmImage: "ubuntu-latest"
               SA_PASSWORD: UmbracoIntegration123!
               Tests__Database__DatabaseType: SqlServer
               Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
+              testFilter: "(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)"
+            LinuxPart2Of3:
+                vmImage: "ubuntu-latest"
+                SA_PASSWORD: UmbracoIntegration123!
+                Tests__Database__DatabaseType: SqlServer
+                Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
+                testFilter: "(FullyQualifiedName~Umbraco.Infrastructure.Service)"
+            LinuxPart3Of3:
+                vmImage: "ubuntu-latest"
+                SA_PASSWORD: UmbracoIntegration123!
+                Tests__Database__DatabaseType: SqlServer
+                Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
+                testFilter: "(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)"
         pool:
           vmImage: $(vmImage)
         steps:
@@ -388,13 +412,13 @@ stages:
               projects: "tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj"
               testRunTitle: Integration Tests SQL Server - $(Agent.OS)
               ${{ if and(eq(variables['Agent.OS'],'Windows_NT'), or(variables.releaseTestFilter, parameters.forceReleaseTestFilter)) }}:
-                arguments: "--configuration $(buildConfiguration) --no-build ${{parameters.integrationReleaseTestFilter}}"
+                arguments: "--filter $(testFilter) --configuration $(buildConfiguration) --no-build ${{parameters.integrationReleaseTestFilter}}"
               ${{ elseif eq(variables['Agent.OS'],'Windows_NT') }}:
-                arguments: "--configuration $(buildConfiguration) --no-build ${{parameters.integrationNonReleaseTestFilter}}"
+                arguments: "--filter $(testFilter) --configuration $(buildConfiguration) --no-build ${{parameters.integrationNonReleaseTestFilter}}"
               ${{ elseif or(variables.releaseTestFilter, parameters.forceReleaseTestFilter) }}:
-                arguments: "--configuration $(buildConfiguration) --no-build ${{parameters.nonWindowsIntegrationReleaseTestFilter}}"
+                arguments: "--filter $(testFilter) --configuration $(buildConfiguration) --no-build ${{parameters.nonWindowsIntegrationReleaseTestFilter}}"
               ${{ else }}:
-                arguments: "--configuration $(buildConfiguration) --no-build ${{parameters.nonWindowsIntegrationNonReleaseTestFilter}}"
+                arguments: "--filter $(testFilter) --configuration $(buildConfiguration) --no-build ${{parameters.nonWindowsIntegrationNonReleaseTestFilter}}"
 
           # Stop SQL Server
           - pwsh: docker stop mssql

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -351,7 +351,7 @@ stages:
               vmImage: "windows-latest"
               Tests__Database__DatabaseType: LocalDb
               Tests__Database__SQLServerMasterConnectionString: N/A
-              testFilter: '(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
+              testFilter: '--filter "(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)"'
             WindowsPart2Of3:
               vmImage: "windows-latest"
               Tests__Database__DatabaseType: LocalDb
@@ -361,25 +361,25 @@ stages:
               vmImage: "windows-latest"
               Tests__Database__DatabaseType: LocalDb
               Tests__Database__SQLServerMasterConnectionString: N/A
-              testFilter: '(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
+              testFilter: '--filter "(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)"'
             LinuxPart1Of3:
               vmImage: "ubuntu-latest"
               SA_PASSWORD: UmbracoIntegration123!
               Tests__Database__DatabaseType: SqlServer
               Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
-              testFilter: '(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
+              testFilter: '--filter "(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)"'
             LinuxPart2Of3:
                 vmImage: "ubuntu-latest"
                 SA_PASSWORD: UmbracoIntegration123!
                 Tests__Database__DatabaseType: SqlServer
                 Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
-                testFilter: '(FullyQualifiedName~Umbraco.Infrastructure.Service)'
+                testFilter: '--filter "(FullyQualifiedName~Umbraco.Infrastructure.Service)"'
             LinuxPart3Of3:
                 vmImage: "ubuntu-latest"
                 SA_PASSWORD: UmbracoIntegration123!
                 Tests__Database__DatabaseType: SqlServer
                 Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
-                testFilter: '(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
+                testFilter: '--filter "(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)"'
         pool:
           vmImage: $(vmImage)
         steps:
@@ -412,13 +412,13 @@ stages:
               projects: "tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj"
               testRunTitle: Integration Tests SQL Server - $(Agent.OS)
               ${{ if and(eq(variables['Agent.OS'],'Windows_NT'), or(variables.releaseTestFilter, parameters.forceReleaseTestFilter)) }}:
-                arguments: "--filter $(testFilter) --configuration $(buildConfiguration) --no-build ${{parameters.integrationReleaseTestFilter}}"
+                arguments: "$(testFilter) --configuration $(buildConfiguration) --no-build ${{parameters.integrationReleaseTestFilter}}"
               ${{ elseif eq(variables['Agent.OS'],'Windows_NT') }}:
-                arguments: "--filter $(testFilter) --configuration $(buildConfiguration) --no-build ${{parameters.integrationNonReleaseTestFilter}}"
+                arguments: "$(testFilter) --configuration $(buildConfiguration) --no-build ${{parameters.integrationNonReleaseTestFilter}}"
               ${{ elseif or(variables.releaseTestFilter, parameters.forceReleaseTestFilter) }}:
-                arguments: "--filter $(testFilter) --configuration $(buildConfiguration) --no-build ${{parameters.nonWindowsIntegrationReleaseTestFilter}}"
+                arguments: "$(testFilter) --configuration $(buildConfiguration) --no-build ${{parameters.nonWindowsIntegrationReleaseTestFilter}}"
               ${{ else }}:
-                arguments: "--filter $(testFilter) --configuration $(buildConfiguration) --no-build ${{parameters.nonWindowsIntegrationNonReleaseTestFilter}}"
+                arguments: "$(testFilter) --configuration $(buildConfiguration) --no-build ${{parameters.nonWindowsIntegrationNonReleaseTestFilter}}"
 
           # Stop SQL Server
           - pwsh: docker stop mssql

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -297,23 +297,30 @@ stages:
           matrix:
             #            Windows:
             #              vmImage: 'windows-latest'
+            # We split the tests into 3 parts for each OS to reduce the time it takes to run them on the pipeline
             LinuxPart1Of3:
               vmImage: "ubuntu-24.04"
+              # Filter tests that are part of the Umbraco.Infrastructure namespace but not part of the Umbraco.Infrastructure.Service namespace
               testFilter: '(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
             LinuxPart2Of3:
               vmImage: "ubuntu-24.04"
+              # Filter tests that are part of the Umbraco.Infrastructure.Service namespace
               testFilter: '(FullyQualifiedName~Umbraco.Infrastructure.Service)'
             LinuxPart3Of3:
               vmImage: "ubuntu-24.04"
+              # Filter tests that are not part of the Umbraco.Infrastructure namespace. So this will run all tests that are not part of the Umbraco.Infrastructure namespace
               testFilter: '(FullyQualifiedName!~Umbraco.Infrastructure)'
             macOSPart1Of3:
               vmImage: "macOS-latest"
+              # Filter tests that are part of the Umbraco.Infrastructure namespace but not part of the Umbraco.Infrastructure.Service namespace
               testFilter: '(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
             macOSPart2Of3:
               vmImage: "macOS-latest"
+              # Filter tests that are part of the Umbraco.Infrastructure.Service namespace
               testFilter: '(FullyQualifiedName~Umbraco.Infrastructure.Service)'
             macOSPart3Of3:
               vmImage: "macOS-latest"
+              # Filter tests that are not part of the Umbraco.Infrastructure namespace.
               testFilter: '(FullyQualifiedName!~Umbraco.Infrastructure)'
         pool:
           vmImage: $(vmImage)
@@ -360,39 +367,46 @@ stages:
         displayName: Integration Tests (SQL Server)
         strategy:
           matrix:
+            # We split the tests into 3 parts for each OS to reduce the time it takes to run them on the pipeline
             WindowsPart1Of3:
               vmImage: "windows-latest"
               Tests__Database__DatabaseType: LocalDb
               Tests__Database__SQLServerMasterConnectionString: N/A
+              # Filter tests that are part of the Umbraco.Infrastructure namespace but not part of the Umbraco.Infrastructure.Service namespace
               testFilter: '(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
             WindowsPart2Of3:
               vmImage: "windows-latest"
               Tests__Database__DatabaseType: LocalDb
               Tests__Database__SQLServerMasterConnectionString: N/A
+              # Filter tests that are part of the Umbraco.Infrastructure.Service namespace
               testFilter: '(FullyQualifiedName~Umbraco.Infrastructure.Service)'
             WindowsPart3Of3:
               vmImage: "windows-latest"
               Tests__Database__DatabaseType: LocalDb
               Tests__Database__SQLServerMasterConnectionString: N/A
+              # Filter tests that are not part of the Umbraco.Infrastructure namespace. So this will run all tests that are not part of the Umbraco.Infrastructure namespace
               testFilter: '(FullyQualifiedName!~Umbraco.Infrastructure)'
             LinuxPart1Of3:
               vmImage: "ubuntu-latest"
               SA_PASSWORD: UmbracoIntegration123!
               Tests__Database__DatabaseType: SqlServer
               Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
+              # Filter tests that are part of the Umbraco.Infrastructure namespace but not part of the Umbraco.Infrastructure.Service namespace
               testFilter: '(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)'
             LinuxPart2Of3:
-                vmImage: "ubuntu-latest"
-                SA_PASSWORD: UmbracoIntegration123!
-                Tests__Database__DatabaseType: SqlServer
-                Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
-                testFilter: '(FullyQualifiedName~Umbraco.Infrastructure.Service)'
+              vmImage: "ubuntu-latest"
+              SA_PASSWORD: UmbracoIntegration123!
+              Tests__Database__DatabaseType: SqlServer
+              Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
+              # Filter tests that are part of the Umbraco.Infrastructure.Service namespace
+              testFilter: '(FullyQualifiedName~Umbraco.Infrastructure.Service)'
             LinuxPart3Of3:
-                vmImage: "ubuntu-latest"
-                SA_PASSWORD: UmbracoIntegration123!
-                Tests__Database__DatabaseType: SqlServer
-                Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
-                testFilter: '(FullyQualifiedName!~Umbraco.Infrastructure)'
+              vmImage: "ubuntu-latest"
+              SA_PASSWORD: UmbracoIntegration123!
+              Tests__Database__DatabaseType: SqlServer
+              Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
+              # Filter tests that are not part of the Umbraco.Infrastructure namespace. So this will run all tests that are not part of the Umbraco.Infrastructure namespace
+              testFilter: '(FullyQualifiedName!~Umbraco.Infrastructure)'
         pool:
           vmImage: $(vmImage)
         steps:

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -351,7 +351,7 @@ stages:
               vmImage: "windows-latest"
               Tests__Database__DatabaseType: LocalDb
               Tests__Database__SQLServerMasterConnectionString: N/A
-              testFilter: '--filter "(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)"'
+              testFilter: '--filter \"(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)\"'
             WindowsPart2Of3:
               vmImage: "windows-latest"
               Tests__Database__DatabaseType: LocalDb
@@ -361,25 +361,25 @@ stages:
               vmImage: "windows-latest"
               Tests__Database__DatabaseType: LocalDb
               Tests__Database__SQLServerMasterConnectionString: N/A
-              testFilter: '--filter "(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)"'
+              testFilter: '--filter \"(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)\"'
             LinuxPart1Of3:
               vmImage: "ubuntu-latest"
               SA_PASSWORD: UmbracoIntegration123!
               Tests__Database__DatabaseType: SqlServer
               Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
-              testFilter: '--filter "(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)"'
+              testFilter: '--filter \"(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)\"'
             LinuxPart2Of3:
                 vmImage: "ubuntu-latest"
                 SA_PASSWORD: UmbracoIntegration123!
                 Tests__Database__DatabaseType: SqlServer
                 Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
-                testFilter: '--filter "(FullyQualifiedName~Umbraco.Infrastructure.Service)"'
+                testFilter: '--filter \"(FullyQualifiedName~Umbraco.Infrastructure.Service)\"'
             LinuxPart3Of3:
                 vmImage: "ubuntu-latest"
                 SA_PASSWORD: UmbracoIntegration123!
                 Tests__Database__DatabaseType: SqlServer
                 Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
-                testFilter: '--filter "(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)"'
+                testFilter: '--filter \"(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)\"'
         pool:
           vmImage: $(vmImage)
         steps:


### PR DESCRIPTION
This PR divides each integration test run by OS into three parts, with each part filtered to cover specific sections of the integration tests. This approach ensures all tests are covered while reducing the time it takes for each PR