### PR TITLE
Add "user info" endpoint for the Delivery API

### DIFF
--- a/src/Umbraco.Cms.Api.Common/DependencyInjection/UmbracoBuilderAuthExtensions.cs
+++ b/src/Umbraco.Cms.Api.Common/DependencyInjection/UmbracoBuilderAuthExtensions.cs
@@ -40,7 +40,9 @@ public static class UmbracoBuilderAuthExtensions
                     .SetLogoutEndpointUris(
                         Paths.MemberApi.LogoutEndpoint.TrimStart(Constants.CharArrays.ForwardSlash))
                     .SetRevocationEndpointUris(
-                        Paths.MemberApi.RevokeEndpoint.TrimStart(Constants.CharArrays.ForwardSlash));
+                        Paths.MemberApi.RevokeEndpoint.TrimStart(Constants.CharArrays.ForwardSlash))
+                    .SetUserinfoEndpointUris(
+                        Paths.MemberApi.UserinfoEndpoint.TrimStart(Constants.CharArrays.ForwardSlash));
 
                 // Enable authorization code flow with PKCE
                 options
@@ -52,7 +54,8 @@ public static class UmbracoBuilderAuthExtensions
                 options
                     .UseAspNetCore()
                     .EnableAuthorizationEndpointPassthrough()
-                    .EnableLogoutEndpointPassthrough();
+                    .EnableLogoutEndpointPassthrough()
+                    .EnableUserinfoEndpointPassthrough();
 
                 // Enable reference tokens
                 // - see https://documentation.openiddict.com/configuration/token-storage.html

--- a/src/Umbraco.Cms.Api.Common/Security/Paths.cs
+++ b/src/Umbraco.Cms.Api.Common/Security/Paths.cs
@@ -14,6 +14,8 @@ public static class Paths
 
         public static readonly string RevokeEndpoint = EndpointPath($"{EndpointTemplate}/revoke");
 
+        public static readonly string UserinfoEndpoint = EndpointPath($"{EndpointTemplate}/userinfo");
+
         // NOTE: we're NOT using /api/v1.0/ here because it will clash with the Delivery API docs
         private static string EndpointPath(string relativePath) => $"/umbraco/delivery/api/v1/{relativePath}";
     }

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/Security/CurrentMemberController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/Security/CurrentMemberController.cs
@@ -1,0 +1,28 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using OpenIddict.Server.AspNetCore;
+using Umbraco.Cms.Api.Delivery.Routing;
+using Umbraco.Cms.Api.Delivery.Services;
+
+namespace Umbraco.Cms.Api.Delivery.Controllers.Security;
+
+[ApiVersion("1.0")]
+[ApiController]
+[VersionedDeliveryApiRoute(Common.Security.Paths.MemberApi.EndpointTemplate)]
+[ApiExplorerSettings(IgnoreApi = true)]
+[Authorize(AuthenticationSchemes = OpenIddictServerAspNetCoreDefaults.AuthenticationScheme)]
+public class CurrentMemberController : DeliveryApiControllerBase
+{
+    private readonly ICurrentMemberClaimsProvider _currentMemberClaimsProvider;
+
+    public CurrentMemberController(ICurrentMemberClaimsProvider currentMemberClaimsProvider)
+        => _currentMemberClaimsProvider = currentMemberClaimsProvider;
+
+    [HttpGet("userinfo")]
+    public async Task<IActionResult> Userinfo()
+    {
+        Dictionary<string, object> claims = await _currentMemberClaimsProvider.GetClaimsAsync();
+        return Ok(claims);
+    }
+}

--- a/src/Umbraco.Cms.Api.Delivery/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Delivery/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -60,6 +60,7 @@ public static class UmbracoBuilderExtensions
         builder.Services.AddSingleton<IApiMediaQueryService, ApiMediaQueryService>();
         builder.Services.AddTransient<IMemberApplicationManager, MemberApplicationManager>();
         builder.Services.AddTransient<IRequestMemberAccessService, RequestMemberAccessService>();
+        builder.Services.AddTransient<ICurrentMemberClaimsProvider, CurrentMemberClaimsProvider>();
 
         builder.Services.ConfigureOptions<ConfigureUmbracoDeliveryApiSwaggerGenOptions>();
         builder.AddUmbracoApiOpenApiUI();

--- a/src/Umbraco.Cms.Api.Delivery/Services/CurrentMemberClaimsProvider.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/CurrentMemberClaimsProvider.cs
@@ -1,0 +1,42 @@
+﻿using OpenIddict.Abstractions;
+using Umbraco.Cms.Core.Security;
+
+namespace Umbraco.Cms.Api.Delivery.Services;
+
+public class CurrentMemberClaimsProvider : ICurrentMemberClaimsProvider
+{
+    private readonly IMemberManager _memberManager;
+
+    public CurrentMemberClaimsProvider(IMemberManager memberManager)
+        => _memberManager = memberManager;
+
+    public virtual async Task<Dictionary<string, object>> GetClaimsAsync()
+    {
+        MemberIdentityUser? memberIdentityUser = await _memberManager.GetCurrentMemberAsync();
+        return memberIdentityUser is not null
+            ? await GetClaimsForMemberIdentityAsync(memberIdentityUser)
+            : throw new InvalidOperationException("Could not retrieve the current member. This method should only ever be invoked when a member has been authorized.");
+    }
+
+    protected virtual async Task<Dictionary<string, object>> GetClaimsForMemberIdentityAsync(MemberIdentityUser memberIdentityUser)
+    {
+        var claims = new Dictionary<string, object>
+        {
+            [OpenIddictConstants.Claims.Subject] = memberIdentityUser.Key
+        };
+
+        if (memberIdentityUser.Name is not null)
+        {
+            claims[OpenIddictConstants.Claims.Name] = memberIdentityUser.Name;
+        }
+
+        if (memberIdentityUser.Email is not null)
+        {
+            claims[OpenIddictConstants.Claims.Email] = memberIdentityUser.Email;
+        }
+
+        claims[OpenIddictConstants.Claims.Role] = await _memberManager.GetRolesAsync(memberIdentityUser);
+
+        return claims;
+    }
+}

--- a/src/Umbraco.Cms.Api.Delivery/Services/CurrentMemberClaimsProvider.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/CurrentMemberClaimsProvider.cs
@@ -3,6 +3,7 @@ using Umbraco.Cms.Core.Security;
 
 namespace Umbraco.Cms.Api.Delivery.Services;
 
+// NOTE: this is public and unsealed to allow overriding the default claims with minimal effort.
 public class CurrentMemberClaimsProvider : ICurrentMemberClaimsProvider
 {
     private readonly IMemberManager _memberManager;

--- a/src/Umbraco.Cms.Api.Delivery/Services/ICurrentMemberClaimsProvider.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/ICurrentMemberClaimsProvider.cs
@@ -1,0 +1,12 @@
+﻿namespace Umbraco.Cms.Api.Delivery.Services;
+
+public interface ICurrentMemberClaimsProvider
+{
+    /// <summary>
+    /// Retrieves the claims for the currently logged in member.
+    /// </summary>
+    /// <remarks>
+    /// This is used by the OIDC user info endpoint to supply "current user" info.
+    /// </remarks>
+    Task<Dictionary<string, object>> GetClaimsAsync();
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/discussions/17508

### Description

This PR adds a "user info" endpoint to the Delivery API, to access basic information about authorized members. See the linked discussion for details on the motivation for adding this endpoint.

The "user info" endpoint is part of the [OpenId Connect core spec](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo).

This implementation returns a few of the [standard claims](https://openid.net/specs/openid-connect-basic-1_0.html#StandardClaims), all of which are subject of availability:

- `sub` (required claim)
- `name` (if available)
- `email` (if available)

On top of this, the member groups (if any) are returned in the `role` claim.

The implementation is build to be extendable, so custom claims can be added to these claims - and the core claims can be removed, too.

## Testing this PR

_To test this PR, authorized member access must be enabled and setup for the Delivery API - see [the docs](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api)._

Verify that:

1. The standard claims can be retrieved from the user info endpoint given a valid access token.
2. The user info endpoint is _not_ available without a valid access token.
3. It is possible to extend the returned claims with a custom implementation of `ICurrentMemberClaimsProvider` (or a specialization of `CurrentMemberClaimsProvider`).
4. The user info endpoint is listed under `/.well-known/openid-configuration`.
![image](https://github.com/user-attachments/assets/e15e10b9-556a-40ac-a97c-cb0e7766dbf3)
