### PR TITLE
Feat: auto expose blocks on current variant

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entry.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entry.context.ts
@@ -499,15 +499,7 @@ export abstract class UmbBlockEntryContext<
 			]),
 			([variantId, variesByCulture, variesBySegment]) => {
 				if (!variantId || variesByCulture === undefined || variesBySegment === undefined) return;
-				if (!variesBySegment && !variesByCulture) {
-					variantId = UmbVariantId.CreateInvariant();
-				} else if (!variesBySegment) {
-					variantId = variantId.toSegmentInvariant();
-				} else if (!variesByCulture) {
-					variantId = variantId.toCultureInvariant();
-				}
-
-				this.#variantId.setValue(variantId);
+				this.#variantId.setValue(variantId.toVariant(variesByCulture, variesBySegment));
 				this.#gotVariantId();
 			},
 			'observeBlockType',

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content-type/structure/content-type-structure-manager.class.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content-type/structure/content-type-structure-manager.class.ts
@@ -268,6 +268,15 @@ export class UmbContentTypeStructureManager<
 		return this.#ownerContentTypeUnique;
 	}
 
+	getVariesByCulture() {
+		const ownerContentType = this.getOwnerContentType();
+		return ownerContentType?.variesByCulture;
+	}
+	getVariesBySegment() {
+		const ownerContentType = this.getOwnerContentType();
+		return ownerContentType?.variesBySegment;
+	}
+
 	/**
 	 * Figure out if any of the Content Types has a Property.
 	 * @returns {boolean} - true if any of the Content Type in this composition has a Property.

--- a/src/Umbraco.Web.UI.Client/src/packages/core/variant/variant-id.class.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/variant/variant-id.class.ts
@@ -87,7 +87,10 @@ export class UmbVariantId {
 		return Object.freeze(new UmbVariantId(this.culture, null));
 	}
 	public toCultureInvariant(): UmbVariantId {
-		return Object.freeze(new UmbVariantId(null, this.culture));
+		return Object.freeze(new UmbVariantId(null, this.segment));
+	}
+	public toVariant(varyByCulture?: boolean, varyBySegment?: boolean): UmbVariantId {
+		return Object.freeze(new UmbVariantId(varyByCulture ? this.culture : null, varyBySegment ? this.segment : null));
 	}
 
 	// TODO: needs localization option:


### PR DESCRIPTION
Makes a Block automatically expose, this is mainly relevant in Inline Editing Mode where the user does not actively press 'create' of the Block, but it gets inserted directly from the catalogue.

Test that is works across variants, it should only auto expose on the variant that the Blocks is created for. — Notice that invariant blocks is shared across variants, so this only counts for Variant Blocks(Where its Content Element Type is set to vary by culture)
