### PR TITLE
V15: Fix docker

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -46,6 +46,7 @@
 *.xml text=auto
 *.resx text=auto
 *.yml text eol=lf core.whitespace whitespace=tab-in-indent,trailing-space,tabwidth=2
+*.sh eol=lf
 
 *.csproj text=auto merge=union
 *.vbproj text=auto merge=union

--- a/templates/UmbracoProject/Dockerfile
+++ b/templates/UmbracoProject/Dockerfile
@@ -1,10 +1,10 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+﻿FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
 USER $APP_UID
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["UmbracoProject/UmbracoProject.csproj", "UmbracoProject/"]


### PR DESCRIPTION
Fixes issues with Docker in v15, fixes #17648. There is 2 issues

1. The image currently tries to build using dotnet 9
2. We changed the build server to windows, resulting in files having `CRLF` line endings, however the Docker images are running on Linux containers which expects `LF` 


## Testing

Download the artifacts and follow #16815