### PR TITLE
Feat: Content Property Datatset Context Token

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/context/block-grid-entries.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/context/block-grid-entries.context.ts
@@ -19,7 +19,7 @@ import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/router';
 import { pathFolderName } from '@umbraco-cms/backoffice/utils';
 import type { UmbNumberRangeValueType } from '@umbraco-cms/backoffice/models';
-import { UMB_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
+import { UMB_CONTENT_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/content';
 
 interface UmbBlockGridAreaTypeInvalidRuleType {
 	groupKey?: string;
@@ -222,7 +222,7 @@ export class UmbBlockGridEntriesContext
 				this._workspacePath.setValue(newPath);
 			});
 
-		this.consumeContext(UMB_PROPERTY_DATASET_CONTEXT, (dataset) => {
+		this.consumeContext(UMB_CONTENT_PROPERTY_DATASET_CONTEXT, (dataset) => {
 			const variantId = dataset.getVariantId();
 			this.#catalogueModal.setUniquePathValue('variantId', variantId?.toString());
 			this.#workspaceModal.setUniquePathValue('variantId', variantId?.toString());

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/context/block-list-entries.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/context/block-list-entries.context.ts
@@ -7,7 +7,7 @@ import { UMB_BLOCK_LIST_MANAGER_CONTEXT } from './block-list-manager.context-tok
 import { UmbBooleanState } from '@umbraco-cms/backoffice/observable-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/router';
-import { UMB_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
+import { UMB_CONTENT_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/content';
 
 export class UmbBlockListEntriesContext extends UmbBlockEntriesContext<
 	typeof UMB_BLOCK_LIST_MANAGER_CONTEXT,
@@ -83,7 +83,8 @@ export class UmbBlockListEntriesContext extends UmbBlockEntriesContext<
 				this._workspacePath.setValue(newPath);
 			});
 
-		this.consumeContext(UMB_PROPERTY_DATASET_CONTEXT, (dataset) => {
+		// TODO: This must later be switched out with a smarter Modal Registration System, cause here is a issue with Block Editors in inline mode in Block Editors, cause the hosting Block is also of type Content. [NL]
+		this.consumeContext(UMB_CONTENT_PROPERTY_DATASET_CONTEXT, (dataset) => {
 			const variantId = dataset.getVariantId();
 			this.#catalogueModal.setUniquePathValue('variantId', variantId?.toString());
 			this.#workspaceModal.setUniquePathValue('variantId', variantId?.toString());

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/context/block-rte-entries.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/context/block-rte-entries.context.ts
@@ -9,7 +9,7 @@ import { UMB_BLOCK_RTE_MANAGER_CONTEXT } from './block-rte-manager.context-token
 import { UmbBooleanState } from '@umbraco-cms/backoffice/observable-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/router';
-import { UMB_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
+import { UMB_CONTENT_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/content';
 
 export class UmbBlockRteEntriesContext extends UmbBlockEntriesContext<
 	typeof UMB_BLOCK_RTE_MANAGER_CONTEXT,
@@ -79,7 +79,7 @@ export class UmbBlockRteEntriesContext extends UmbBlockEntriesContext<
 				this._workspacePath.setValue(newPath);
 			});
 
-		this.consumeContext(UMB_PROPERTY_DATASET_CONTEXT, (dataset) => {
+		this.consumeContext(UMB_CONTENT_PROPERTY_DATASET_CONTEXT, (dataset) => {
 			const variantId = dataset.getVariantId();
 			this.#catalogueModal.setUniquePathValue('variantId', variantId?.toString());
 			this.#workspaceModal.setUniquePathValue('variantId', variantId?.toString());

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content/property-dataset-context/content-property-dataset.context-token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content/property-dataset-context/content-property-dataset.context-token.ts
@@ -1,0 +1,12 @@
+import type { UmbContentPropertyDatasetContext } from './content-property-dataset.context.js';
+import type { UmbPropertyDatasetContext } from '@umbraco-cms/backoffice/property';
+import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
+
+export const IsContentPropertyDatasetContext = (
+	context: UmbPropertyDatasetContext,
+): context is UmbContentPropertyDatasetContext => (context as any).IS_CONTENT === true;
+
+export const UMB_CONTENT_PROPERTY_DATASET_CONTEXT = new UmbContextToken<
+	UmbPropertyDatasetContext,
+	UmbContentPropertyDatasetContext
+>('UmbPropertyDatasetContext', undefined, IsContentPropertyDatasetContext);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content/property-dataset-context/content-property-dataset.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content/property-dataset-context/content-property-dataset.context.ts
@@ -23,6 +23,8 @@ export class UmbContentPropertyDatasetContext<
 	culture = this.#currentVariant.asObservablePart((x) => x?.culture);
 	segment = this.#currentVariant.asObservablePart((x) => x?.segment);
 
+	readonly IS_CONTENT = true;
+
 	getName(): string | undefined {
 		return this._dataOwner.getName(this.getVariantId());
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content/property-dataset-context/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content/property-dataset-context/index.ts
@@ -1,3 +1,4 @@
+export * from './content-property-dataset.context-token.js';
 export * from './content-property-dataset.context.js';
 export type * from './element-property-data-owner.interface.js';
 export * from './element-property-dataset.context.js';


### PR DESCRIPTION
This improves the modal path specification of Block Editors. But there is still a case to be handled — So I have created a task for such. But introducing this solve most cases for now.

Test by following:
Have a document that varies by culture.
Open split view.
Have a Block Editor that does not vary.
Verifying that opening a modal from a Block only opens a single modal — before this fix it would open two.