### PR TITLE
V15: Add custom serializer for hybrid cache

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -104,6 +104,6 @@ public class UmbracoPlan : MigrationPlan
         To<V_15_0_0.ConvertBlockGridEditorProperties>("{9D3CE7D4-4884-41D4-98E8-302EB6CB0CF6}");
         To<V_15_0_0.ConvertRichTextEditorProperties>("{37875E80-5CDD-42FF-A21A-7D4E3E23E0ED}");
         To<V_15_0_0.ConvertLocalLinks>("{42E44F9E-7262-4269-922D-7310CB48E724}");
-        To<V_15_2_0.RebuildCacheMigration>("7B51B4DE-5574-4484-993E-05D12D9ED703");
+        To<V_15_1_0.RebuildCacheMigration>("7B51B4DE-5574-4484-993E-05D12D9ED703");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -104,6 +104,6 @@ public class UmbracoPlan : MigrationPlan
         To<V_15_0_0.ConvertBlockGridEditorProperties>("{9D3CE7D4-4884-41D4-98E8-302EB6CB0CF6}");
         To<V_15_0_0.ConvertRichTextEditorProperties>("{37875E80-5CDD-42FF-A21A-7D4E3E23E0ED}");
         To<V_15_0_0.ConvertLocalLinks>("{42E44F9E-7262-4269-922D-7310CB48E724}");
-        To<V_15_1_0.RebuildCacheMigration>("7B51B4DE-5574-4484-993E-05D12D9ED703");
+        To<V_15_1_0.RebuildCacheMigration>("{7B51B4DE-5574-4484-993E-05D12D9ED703}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -104,5 +104,6 @@ public class UmbracoPlan : MigrationPlan
         To<V_15_0_0.ConvertBlockGridEditorProperties>("{9D3CE7D4-4884-41D4-98E8-302EB6CB0CF6}");
         To<V_15_0_0.ConvertRichTextEditorProperties>("{37875E80-5CDD-42FF-A21A-7D4E3E23E0ED}");
         To<V_15_0_0.ConvertLocalLinks>("{42E44F9E-7262-4269-922D-7310CB48E724}");
+        To<V_15_2_0.RebuildCacheMigration>("7B51B4DE-5574-4484-993E-05D12D9ED703");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_1_0/RebuildCacheMigration.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_1_0/RebuildCacheMigration.cs
@@ -6,10 +6,18 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_15_1_0;
 public class RebuildCacheMigration : MigrationBase
 {
     private readonly IDocumentCacheService _documentCacheService;
+    private readonly IMediaCacheService _mediaCacheService;
 
-    public RebuildCacheMigration(IMigrationContext context, IDocumentCacheService documentCacheService) : base(context) =>
+    public RebuildCacheMigration(IMigrationContext context, IDocumentCacheService documentCacheService, IMediaCacheService mediaCacheService) : base(context)
+    {
         _documentCacheService = documentCacheService;
+        _mediaCacheService = mediaCacheService;
+    }
 
-    protected override void Migrate() =>
+    protected override void Migrate()
+    {
         _documentCacheService.ClearMemoryCacheAsync(CancellationToken.None).GetAwaiter().GetResult();
+        _mediaCacheService.ClearMemoryCacheAsync(CancellationToken.None).GetAwaiter().GetResult();
+    }
+
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_1_0/RebuildCacheMigration.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_1_0/RebuildCacheMigration.cs
@@ -1,6 +1,6 @@
 ﻿using Umbraco.Cms.Core.PublishedCache;
 
-namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_15_2_0;
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_15_1_0;
 
 [Obsolete("Will be removed in V18")]
 public class RebuildCacheMigration : MigrationBase

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_2_0/RebuildCacheMigration.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_2_0/RebuildCacheMigration.cs
@@ -1,0 +1,15 @@
+﻿using Umbraco.Cms.Core.PublishedCache;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_15_2_0;
+
+[Obsolete("Will be removed in V18")]
+public class RebuildCacheMigration : MigrationBase
+{
+    private readonly IDocumentCacheService _documentCacheService;
+
+    public RebuildCacheMigration(IMigrationContext context, IDocumentCacheService documentCacheService) : base(context) =>
+        _documentCacheService = documentCacheService;
+
+    protected override void Migrate() =>
+        _documentCacheService.ClearMemoryCacheAsync(CancellationToken.None).GetAwaiter().GetResult();
+}

--- a/src/Umbraco.PublishedCache.HybridCache/ContentCacheNode.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/ContentCacheNode.cs
@@ -4,7 +4,7 @@ namespace Umbraco.Cms.Infrastructure.HybridCache;
 
 // This is for cache performance reasons, see https://learn.microsoft.com/en-us/aspnet/core/performance/caching/hybrid?view=aspnetcore-9.0#reuse-objects
 [ImmutableObject(true)]
-internal sealed class ContentCacheNode
+public sealed class ContentCacheNode
 {
     public int Id { get; set; }
 

--- a/src/Umbraco.PublishedCache.HybridCache/ContentData.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/ContentData.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.HybridCache;
 /// </summary>
 // This is for cache performance reasons, see https://learn.microsoft.com/en-us/aspnet/core/performance/caching/hybrid?view=aspnetcore-9.0#reuse-objects
 [ImmutableObject(true)]
-internal sealed class ContentData
+public sealed class ContentData
 {
     public ContentData(string? name, string? urlSegment, int versionId, DateTime versionDate, int writerId, int? templateId, bool published, Dictionary<string, PropertyData[]>? properties, IReadOnlyDictionary<string, CultureVariation>? cultureInfos)
     {

--- a/src/Umbraco.PublishedCache.HybridCache/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -1,7 +1,6 @@
 ﻿
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Notifications;
@@ -35,7 +34,7 @@ public static class UmbracoBuilderExtensions
             // We'll be a bit friendlier and default this to a higher value, you quickly hit the 1MB limit with a few languages and especially blocks.
             // This can be overwritten later if needed.
             options.MaximumPayloadBytes = 1024 * 1024 * 100; // 100MB
-        });
+        }).AddSerializer<ContentCacheNode, HybridCacheSerializer>();
 #pragma warning restore EXTEXP0018
         builder.Services.AddSingleton<IDatabaseCacheRepository, DatabaseCacheRepository>();
         builder.Services.AddSingleton<IPublishedContentCache, DocumentCache>();

--- a/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
@@ -189,30 +189,6 @@ AND cmsContentNu.nodeId IS NULL
         return count == 0;
     }
 
-    public async Task<ContentCacheNode?> GetContentSourceAsync(int id, bool preview = false)
-    {
-        Sql<ISqlContext>? sql = SqlContentSourcesSelect()
-            .Append(SqlObjectTypeNotTrashed(SqlContext, Constants.ObjectTypes.Document))
-            .Append(SqlWhereNodeId(SqlContext, id))
-            .Append(SqlOrderByLevelIdSortOrder(SqlContext));
-
-        ContentSourceDto? dto = await Database.FirstOrDefaultAsync<ContentSourceDto>(sql);
-
-        if (dto == null)
-        {
-            return null;
-        }
-
-        if (preview is false && dto.PubDataRaw is null && dto.PubData is null)
-        {
-            return null;
-        }
-
-        IContentCacheDataSerializer serializer =
-            _contentCacheDataSerializerFactory.Create(ContentCacheDataSerializerEntityType.Document);
-        return CreateContentNodeKit(dto, serializer, preview);
-    }
-
     public async Task<ContentCacheNode?> GetContentSourceAsync(Guid key, bool preview = false)
     {
         Sql<ISqlContext>? sql = SqlContentSourcesSelect()
@@ -291,25 +267,6 @@ AND cmsContentNu.nodeId IS NULL
     /// <inheritdoc />
     public IEnumerable<Guid> GetDocumentKeysByContentTypeKeys(IEnumerable<Guid> keys, bool published = false)
         => GetContentSourceByDocumentTypeKey(keys, Constants.ObjectTypes.Document).Where(x => x.Published == published).Select(x => x.Key);
-
-    public async Task<ContentCacheNode?> GetMediaSourceAsync(int id)
-    {
-        Sql<ISqlContext>? sql = SqlMediaSourcesSelect()
-            .Append(SqlObjectTypeNotTrashed(SqlContext, Constants.ObjectTypes.Media))
-            .Append(SqlWhereNodeId(SqlContext, id))
-            .Append(SqlOrderByLevelIdSortOrder(SqlContext));
-
-        ContentSourceDto? dto = await Database.FirstOrDefaultAsync<ContentSourceDto>(sql);
-
-        if (dto is null)
-        {
-            return null;
-        }
-
-        IContentCacheDataSerializer serializer =
-            _contentCacheDataSerializerFactory.Create(ContentCacheDataSerializerEntityType.Media);
-        return CreateMediaNodeKit(dto, serializer);
-    }
 
     public async Task<ContentCacheNode?> GetMediaSourceAsync(Guid key)
     {

--- a/src/Umbraco.PublishedCache.HybridCache/Persistence/IDatabaseCacheRepository.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Persistence/IDatabaseCacheRepository.cs
@@ -7,11 +7,7 @@ internal interface IDatabaseCacheRepository
 {
     Task DeleteContentItemAsync(int id);
 
-    Task<ContentCacheNode?> GetContentSourceAsync(int id, bool preview = false);
-
     Task<ContentCacheNode?> GetContentSourceAsync(Guid key, bool preview = false);
-
-    Task<ContentCacheNode?> GetMediaSourceAsync(int id);
 
     Task<ContentCacheNode?> GetMediaSourceAsync(Guid key);
 

--- a/src/Umbraco.PublishedCache.HybridCache/Serialization/HybridCacheSerializer.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Serialization/HybridCacheSerializer.cs
@@ -1,0 +1,26 @@
+﻿using System.Buffers;
+using MessagePack;
+using MessagePack.Resolvers;
+using Microsoft.Extensions.Caching.Hybrid;
+
+namespace Umbraco.Cms.Infrastructure.HybridCache.Serialization;
+
+internal class HybridCacheSerializer : IHybridCacheSerializer<ContentCacheNode>
+{
+    private readonly MessagePackSerializerOptions _options;
+
+    public HybridCacheSerializer()
+    {
+        MessagePackSerializerOptions defaultOptions = ContractlessStandardResolver.Options;
+        IFormatterResolver resolver = CompositeResolver.Create(defaultOptions.Resolver);
+
+        _options = defaultOptions
+            .WithResolver(resolver)
+            .WithCompression(MessagePackCompression.Lz4BlockArray)
+            .WithSecurity(MessagePackSecurity.UntrustedData);
+    }
+
+    public ContentCacheNode Deserialize(ReadOnlySequence<byte> source) => MessagePackSerializer.Deserialize<ContentCacheNode>(source, _options);
+
+    public void Serialize(ContentCacheNode value, IBufferWriter<byte> target) => target.Write(MessagePackSerializer.Serialize(value, _options));
+}

--- a/src/Umbraco.PublishedCache.HybridCache/Serialization/HybridCacheSerializer.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Serialization/HybridCacheSerializer.cs
@@ -2,15 +2,18 @@
 using MessagePack;
 using MessagePack.Resolvers;
 using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.Logging;
 
 namespace Umbraco.Cms.Infrastructure.HybridCache.Serialization;
 
 internal class HybridCacheSerializer : IHybridCacheSerializer<ContentCacheNode>
 {
+    private readonly ILogger<HybridCacheSerializer> _logger;
     private readonly MessagePackSerializerOptions _options;
 
-    public HybridCacheSerializer()
+    public HybridCacheSerializer(ILogger<HybridCacheSerializer> logger)
     {
+        _logger = logger;
         MessagePackSerializerOptions defaultOptions = ContractlessStandardResolver.Options;
         IFormatterResolver resolver = CompositeResolver.Create(defaultOptions.Resolver);
 
@@ -20,7 +23,18 @@ internal class HybridCacheSerializer : IHybridCacheSerializer<ContentCacheNode>
             .WithSecurity(MessagePackSecurity.UntrustedData);
     }
 
-    public ContentCacheNode Deserialize(ReadOnlySequence<byte> source) => MessagePackSerializer.Deserialize<ContentCacheNode>(source, _options);
+    public ContentCacheNode Deserialize(ReadOnlySequence<byte> source)
+    {
+        try
+        {
+            return MessagePackSerializer.Deserialize<ContentCacheNode>(source, _options);
+        }
+        catch (MessagePackSerializationException ex)
+        {
+            _logger.LogError(ex, "Error deserializing ContentCacheNode");
+            return null!;
+        }
+    }
 
     public void Serialize(ContentCacheNode value, IBufferWriter<byte> target) => target.Write(MessagePackSerializer.Serialize(value, _options));
 }

--- a/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
@@ -76,9 +76,7 @@ internal class MediaCacheService : IMediaCacheService
             return null;
         }
 
-        var id = idAttempt.Result;
-
-        return await GetNodeAsync(id, key);
+        return await GetNodeAsync(key);
     }
 
     public async Task<IPublishedContent?> GetByIdAsync(int id)
@@ -91,10 +89,10 @@ internal class MediaCacheService : IMediaCacheService
 
         Guid key = keyAttempt.Result;
 
-        return await GetNodeAsync(id, key);
+        return await GetNodeAsync(key);
     }
 
-    private async Task<IPublishedContent?> GetNodeAsync(int id, Guid key)
+    private async Task<IPublishedContent?> GetNodeAsync(Guid key)
     {
         var cacheKey = $"{key}";
         ContentCacheNode? contentCacheNode = await _hybridCache.GetOrCreateAsync(
@@ -102,7 +100,7 @@ internal class MediaCacheService : IMediaCacheService
             async cancel =>
             {
                 using ICoreScope scope = _scopeProvider.CreateCoreScope();
-                ContentCacheNode? mediaCacheNode = await _databaseCacheRepository.GetMediaSourceAsync(id);
+                ContentCacheNode? mediaCacheNode = await _databaseCacheRepository.GetMediaSourceAsync(key);
                 scope.Complete();
                 return mediaCacheNode;
             }, GetEntryOptions(key));

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheMockTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheMockTests.cs
@@ -76,12 +76,6 @@ public class DocumentHybridCacheMockTests : UmbracoIntegrationTestWithContent
             IsDraft = false,
         };
 
-        _mockedNucacheRepository.Setup(r => r.GetContentSourceAsync(It.IsAny<int>(), true))
-            .ReturnsAsync(draftTestCacheNode);
-
-        _mockedNucacheRepository.Setup(r => r.GetContentSourceAsync(It.IsAny<int>(), false))
-            .ReturnsAsync(publishedTestCacheNode);
-
         _mockedNucacheRepository.Setup(r => r.GetContentSourceAsync(It.IsAny<Guid>(), true))
             .ReturnsAsync(draftTestCacheNode);
 
@@ -153,7 +147,7 @@ public class DocumentHybridCacheMockTests : UmbracoIntegrationTestWithContent
         var textPage2 = await _mockedCache.GetByIdAsync(Textpage.Id, true);
         AssertTextPage(textPage);
         AssertTextPage(textPage2);
-        _mockedNucacheRepository.Verify(x => x.GetContentSourceAsync(It.IsAny<int>(), It.IsAny<bool>()), Times.Exactly(1));
+        _mockedNucacheRepository.Verify(x => x.GetContentSourceAsync(It.IsAny<Guid>(), It.IsAny<bool>()), Times.Exactly(1));
     }
 
     [Test]
@@ -171,10 +165,12 @@ public class DocumentHybridCacheMockTests : UmbracoIntegrationTestWithContent
 
         _cacheSettings.ContentTypeKeys = [ Textpage.ContentType.Key ];
         await _mockDocumentCacheService.SeedAsync(CancellationToken.None);
+        _mockedNucacheRepository.Verify(x => x.GetContentSourceAsync(It.IsAny<Guid>(), It.IsAny<bool>()), Times.Exactly(1));
+
         var textPage = await _mockedCache.GetByIdAsync(Textpage.Id);
         AssertTextPage(textPage);
 
-        _mockedNucacheRepository.Verify(x => x.GetContentSourceAsync(It.IsAny<int>(), It.IsAny<bool>()), Times.Exactly(0));
+        _mockedNucacheRepository.Verify(x => x.GetContentSourceAsync(It.IsAny<Guid>(), It.IsAny<bool>()), Times.Exactly(1));
     }
 
     [Test]
@@ -192,10 +188,11 @@ public class DocumentHybridCacheMockTests : UmbracoIntegrationTestWithContent
 
         _cacheSettings.ContentTypeKeys = [ Textpage.ContentType.Key ];
         await _mockDocumentCacheService.SeedAsync(CancellationToken.None);
+        _mockedNucacheRepository.Verify(x => x.GetContentSourceAsync(It.IsAny<Guid>(), It.IsAny<bool>()), Times.Exactly(1));
         var textPage = await _mockedCache.GetByIdAsync(Textpage.Key);
         AssertTextPage(textPage);
 
-        _mockedNucacheRepository.Verify(x => x.GetContentSourceAsync(It.IsAny<int>(), It.IsAny<bool>()), Times.Exactly(0));
+        _mockedNucacheRepository.Verify(x => x.GetContentSourceAsync(It.IsAny<Guid>(), It.IsAny<bool>()), Times.Exactly(1));
     }
 
     [Test]
@@ -209,7 +206,7 @@ public class DocumentHybridCacheMockTests : UmbracoIntegrationTestWithContent
         var textPage = await _mockedCache.GetByIdAsync(Textpage.Id, true);
         AssertTextPage(textPage);
 
-        _mockedNucacheRepository.Verify(x => x.GetContentSourceAsync(It.IsAny<int>(), It.IsAny<bool>()), Times.Exactly(1));
+        _mockedNucacheRepository.Verify(x => x.GetContentSourceAsync(It.IsAny<Guid>(), It.IsAny<bool>()), Times.Exactly(1));
     }
 
     [Test]


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/17649

# Notes
- The root cause of the issue, was that Redis was serializing `object` properties differently than the memory cache, resulting in value converters nok being able to convert the value.

A `string` value on a `object` property serializes to a `JsonElement` with Redis: 
![image](https://github.com/user-attachments/assets/b82ee4ee-6692-4616-af1a-f01e88522627)
And to a string with memory cache: 
![image](https://github.com/user-attachments/assets/99acc8d5-0604-498a-9c81-1bd7390f3a55)

This PR remedies this issue, by implementing a custom serializer.

# How to test
- Setup redis, i used docker and the `redis/redis-stack:latest` image
- It can be done with this command in your terminal`docker run -d --name redis-stack-server -p 6379:6379 redis/redis-stack-server:latest`
- Add this snippet to your program.cs, to enable redis caching 
```
builder.Services.AddStackExchangeRedisCache(options =>
{
    options.Configuration = "localhost:6379";
});
```

- Run umbraco, create a content type with a content picker, a text string property, and allow as root set to true
- Create some content with that content type (remember to pick another content node, create one if you don't have one)
- Write down the content id (Guid)
- Stop your site
- Enable delivery API (put these in `appsettings:Umbraco:Cms`)
```
"DeliveryApi": {
        "Enabled": true,
        "PublicAccess": true,
        "RichTextOutputAsJson": true
      },
```
- Run your site again
- Get the content via the delivery API, use the id you wrote down earlier. Here is the URL to call: 
`https://localhost:44339/umbraco/delivery/api/v2/content/item/{YOUR GUID HERE}?fields=properties[$all]&expand=properties[$all[properties[$all]]]`