### PR TITLE
Fix: is-current user text

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/current-user.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/current-user.context.ts
@@ -58,10 +58,10 @@ export class UmbCurrentUserContext extends UmbContextBase<UmbCurrentUserContext>
 		const { asObservable } = await this.#currentUserRepository.requestCurrentUser();
 
 		if (asObservable) {
-			this.observe(asObservable(), (currentUser) => {
+			await this.observe(asObservable(), (currentUser) => {
 				this.#currentUser?.setValue(currentUser);
 				this.#redirectToFirstAllowedSectionIfNeeded();
-			});
+			}).asPromise();
 		}
 	}
 


### PR DESCRIPTION
Make the is-current user context load method wait until value is set — this should fix the flaky tests