### PR TITLE
v15: Use init instead of rebuild for urls when refreshing cache

### DIFF
--- a/src/Umbraco.Core/Cache/Refreshers/Implement/ContentCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/ContentCacheRefresher.cs
@@ -338,7 +338,7 @@ public sealed class ContentCacheRefresher : PayloadCacheRefresherBase<ContentCac
         }
         if(payload.ChangeTypes.HasType(TreeChangeTypes.RefreshAll))
         {
-            _documentUrlService.RebuildAllUrlsAsync().GetAwaiter().GetResult(); //TODO make async
+            _documentUrlService.InitAsync(false, CancellationToken.None).GetAwaiter().GetResult(); //TODO make async
         }
 
         if(payload.ChangeTypes.HasType(TreeChangeTypes.RefreshNode))


### PR DESCRIPTION
# Notes
- Clicking the "Reload memory cache" button in the PublishStatus button was extremely slow, turns out we where getting all the document URLs from the database.
- Switched to InitAsync to mimic behavior from when we start the site.

# How to test
- Have a site with lots of nodes
- Click the "Rebuild memory cache" button in the PublishedStatus dashboard
- It should no longer be extremely slow