### PR TITLE
Add (un)publishing details to TreeChange notifications

### DIFF
--- a/src/Umbraco.Core/Cache/DistributedCacheExtensions.cs
+++ b/src/Umbraco.Core/Cache/DistributedCacheExtensions.cs
@@ -142,7 +142,9 @@ public static class DistributedCacheExtensions
             Id = x.Item.Id,
             Key = x.Item.Key,
             ChangeTypes = x.ChangeTypes,
-            Blueprint = x.Item.Blueprint
+            Blueprint = x.Item.Blueprint,
+            PublishedCultures = x.PublishedCultures?.ToArray(),
+            UnpublishedCultures = x.UnpublishedCultures?.ToArray()
         });
 
         dc.RefreshByPayload(ContentCacheRefresher.UniqueId, payloads);

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/ContentCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/ContentCacheRefresher.cs
@@ -182,6 +182,10 @@ public sealed class ContentCacheRefresher : PayloadCacheRefresherBase<ContentCac
         public TreeChangeTypes ChangeTypes { get; init; }
 
         public bool Blueprint { get; init; }
+
+        public string[]? PublishedCultures { get; init; }
+
+        public string[]? UnpublishedCultures { get; init; }
     }
 
     #endregion

--- a/src/Umbraco.Core/Notifications/ContentTreeChangeNotification.cs
+++ b/src/Umbraco.Core/Notifications/ContentTreeChangeNotification.cs
@@ -32,4 +32,14 @@ public class ContentTreeChangeNotification : TreeChangeNotification<IContent>
         : base(new TreeChange<IContent>(target, changeTypes), messages)
     {
     }
+
+    public ContentTreeChangeNotification(
+        IContent target,
+        TreeChangeTypes changeTypes,
+        IEnumerable<string>? publishedCultures,
+        IEnumerable<string>? unpublishedCultures,
+        EventMessages messages)
+        : base(new TreeChange<IContent>(target, changeTypes, publishedCultures, unpublishedCultures), messages)
+    {
+    }
 }

--- a/src/Umbraco.Core/Services/Changes/TreeChange.cs
+++ b/src/Umbraco.Core/Services/Changes/TreeChange.cs
@@ -8,9 +8,21 @@ public class TreeChange<TItem>
         ChangeTypes = changeTypes;
     }
 
+    public TreeChange(TItem changedItem, TreeChangeTypes changeTypes, IEnumerable<string>? publishedCultures, IEnumerable<string>? unpublishedCultures)
+    {
+        Item = changedItem;
+        ChangeTypes = changeTypes;
+        PublishedCultures = publishedCultures;
+        UnpublishedCultures = unpublishedCultures;
+    }
+
     public TItem Item { get; }
 
     public TreeChangeTypes ChangeTypes { get; }
+
+    public IEnumerable<string>? PublishedCultures { get; }
+
+    public IEnumerable<string>? UnpublishedCultures { get; }
 
     public EventArgs ToEventArgs() => new EventArgs(this);
 

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1595,7 +1595,12 @@ public class ContentService : RepositoryService, IContentService
                 // events and audit
                 scope.Notifications.Publish(
                     new ContentUnpublishedNotification(content, eventMessages).WithState(notificationState));
-                scope.Notifications.Publish(new ContentTreeChangeNotification(content, TreeChangeTypes.RefreshBranch, eventMessages));
+                scope.Notifications.Publish(new ContentTreeChangeNotification(
+                    content,
+                    TreeChangeTypes.RefreshBranch,
+                    variesByCulture ? culturesPublishing.IsCollectionEmpty() ? null : culturesPublishing : null,
+                    variesByCulture ? culturesUnpublishing.IsCollectionEmpty() ? null : culturesUnpublishing : ["*"],
+                    eventMessages));
 
                 if (culturesUnpublishing != null)
                 {
@@ -1654,7 +1659,12 @@ public class ContentService : RepositoryService, IContentService
                 if (!branchOne)
                 {
                     scope.Notifications.Publish(
-                        new ContentTreeChangeNotification(content, changeType, eventMessages));
+                        new ContentTreeChangeNotification(
+                            content,
+                            changeType,
+                            variesByCulture ? culturesPublishing.IsCollectionEmpty() ? null : culturesPublishing : ["*"],
+                            variesByCulture ? culturesUnpublishing.IsCollectionEmpty() ? null : culturesUnpublishing : null,
+                            eventMessages));
                     scope.Notifications.Publish(
                         new ContentPublishedNotification(content, eventMessages).WithState(notificationState));
                 }
@@ -2118,7 +2128,8 @@ public class ContentService : RepositoryService, IContentService
             }
 
             // deal with the branch root - if it fails, abort
-            PublishResult? result = SaveAndPublishBranchItem(scope, document, shouldPublish, publishCultures, true, publishedDocuments, eventMessages, userId, allLangs, out IDictionary<string, object?> notificationState);
+            HashSet<string>? culturesToPublish = shouldPublish(document);
+            PublishResult? result = SaveAndPublishBranchItem(scope, document, culturesToPublish, publishCultures, true, publishedDocuments, eventMessages, userId, allLangs, out IDictionary<string, object?> notificationState);
             if (result != null)
             {
                 results.Add(result);
@@ -2127,6 +2138,8 @@ public class ContentService : RepositoryService, IContentService
                     return results;
                 }
             }
+
+            HashSet<string> culturesPublished = culturesToPublish ?? [];
 
             // deal with descendants
             // if one fails, abort its branch
@@ -2153,12 +2166,14 @@ public class ContentService : RepositoryService, IContentService
                     }
 
                     // no need to check path here, parent has to be published here
-                    result = SaveAndPublishBranchItem(scope, d, shouldPublish, publishCultures, false, publishedDocuments, eventMessages, userId, allLangs, out _);
+                    culturesToPublish = shouldPublish(d);
+                    result = SaveAndPublishBranchItem(scope, d, culturesToPublish, publishCultures, false, publishedDocuments, eventMessages, userId, allLangs, out _);
                     if (result != null)
                     {
                         results.Add(result);
                         if (result.Success)
                         {
+                            culturesPublished.UnionWith(culturesToPublish ?? []);
                             continue;
                         }
                     }
@@ -2175,8 +2190,14 @@ public class ContentService : RepositoryService, IContentService
 
             // trigger events for the entire branch
             // (SaveAndPublishBranchOne does *not* do it)
+            var variesByCulture = document.ContentType.VariesByCulture();
             scope.Notifications.Publish(
-                new ContentTreeChangeNotification(document, TreeChangeTypes.RefreshBranch, eventMessages));
+                new ContentTreeChangeNotification(
+                    document,
+                    TreeChangeTypes.RefreshBranch,
+                    variesByCulture ? culturesPublished.IsCollectionEmpty() ? null : culturesPublished : ["*"],
+                    null,
+                    eventMessages));
             scope.Notifications.Publish(new ContentPublishedNotification(publishedDocuments, eventMessages).WithState(notificationState));
 
             scope.Complete();
@@ -2191,7 +2212,7 @@ public class ContentService : RepositoryService, IContentService
     private PublishResult? SaveAndPublishBranchItem(
         ICoreScope scope,
         IContent document,
-        Func<IContent, HashSet<string>?> shouldPublish,
+        HashSet<string>? culturesToPublish,
         Func<IContent, HashSet<string>, IReadOnlyCollection<ILanguage>,
             bool> publishCultures,
         bool isRoot,
@@ -2202,7 +2223,6 @@ public class ContentService : RepositoryService, IContentService
         out IDictionary<string, object?> notificationState)
     {
         notificationState = new Dictionary<string, object?>();
-        HashSet<string>? culturesToPublish = shouldPublish(document);
 
         // null = do not include
         if (culturesToPublish == null)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/RefresherTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/RefresherTests.cs
@@ -27,26 +27,68 @@ public class RefresherTests
         Assert.AreEqual(source[0].ChangeTypes, payload[0].ChangeTypes);
     }
 
-    [Test]
-    public void ContentCacheRefresherCanDeserializeJsonPayload()
+    [TestCase(TreeChangeTypes.None, false)]
+    [TestCase(TreeChangeTypes.RefreshAll, true)]
+    [TestCase(TreeChangeTypes.RefreshBranch, false)]
+    [TestCase(TreeChangeTypes.Remove, true)]
+    [TestCase(TreeChangeTypes.RefreshNode, false)]
+    public void ContentCacheRefresherCanDeserializeJsonPayload(TreeChangeTypes changeTypes, bool blueprint)
     {
+        var key = Guid.NewGuid();
         ContentCacheRefresher.JsonPayload[] source =
         {
             new ContentCacheRefresher.JsonPayload()
             {
                 Id = 1234,
-                Key = Guid.NewGuid(),
-                ChangeTypes = TreeChangeTypes.None
+                Key = key,
+                ChangeTypes = changeTypes,
+                Blueprint = blueprint
             }
         };
 
         var json = JsonConvert.SerializeObject(source);
         var payload = JsonConvert.DeserializeObject<ContentCacheRefresher.JsonPayload[]>(json);
 
-        Assert.AreEqual(source[0].Id, payload[0].Id);
-        Assert.AreEqual(source[0].Key, payload[0].Key);
-        Assert.AreEqual(source[0].ChangeTypes, payload[0].ChangeTypes);
-        Assert.AreEqual(source[0].Blueprint, payload[0].Blueprint);
+        Assert.AreEqual(1234, payload[0].Id);
+        Assert.AreEqual(key, payload[0].Key);
+        Assert.AreEqual(changeTypes, payload[0].ChangeTypes);
+        Assert.AreEqual(blueprint, payload[0].Blueprint);
+        Assert.IsNull(payload[0].PublishedCultures);
+        Assert.IsNull(payload[0].UnpublishedCultures);
+    }
+
+    [Test]
+    public void ContentCacheRefresherCanDeserializeJsonPayloadWithCultures()
+    {
+        var key = Guid.NewGuid();
+        ContentCacheRefresher.JsonPayload[] source =
+        {
+            new ContentCacheRefresher.JsonPayload()
+            {
+                Id = 1234,
+                Key = key,
+                PublishedCultures = ["en-US", "da-DK"],
+                UnpublishedCultures = ["de-DE"]
+            }
+        };
+
+        var json = JsonConvert.SerializeObject(source);
+        var payload = JsonConvert.DeserializeObject<ContentCacheRefresher.JsonPayload[]>(json);
+
+        Assert.IsNotNull(payload[0].PublishedCultures);
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(2, payload[0].PublishedCultures.Length);
+            Assert.AreEqual("en-US", payload[0].PublishedCultures.First());
+            Assert.AreEqual("da-DK", payload[0].PublishedCultures.Last());
+        });
+
+        Assert.IsNotNull(payload[0].UnpublishedCultures);
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(1, payload[0].UnpublishedCultures.Length);
+            Assert.AreEqual("de-DE", payload[0].UnpublishedCultures.First());
+        });
     }
 
     [Test]


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR adds additional (un)publishing info to `TreeChange` (specifically which cultures were affected by the operation), to be consumed by `ContentTreeChangeNotification` handlers.

This additional info is also added to the `ContentCacheRefresherNotification`, to make it available in a load balanced scenario. 

For invariant content, the wildcard (`*`) is used to communicate the affected cultures.

### Testing this PR

Add a notification handler to `ContentTreeChangeNotification` and `ContentCacheRefresherNotification`, and verify that the `PublishedCultures ` and `UnpublishedCultures` properties match any (un)publishing operations performed in the backoffice.

Here's a notification handler 😄 

```cs
using Umbraco.Cms.Core.Cache;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Notifications;
using Umbraco.Cms.Core.Services.Changes;

namespace Umbraco.Cms.Web.UI.Custom;

public class ContentCacheRefresherNotificationHandler :
    INotificationHandler<ContentCacheRefresherNotification>,
    INotificationHandler<ContentTreeChangeNotification>
{
    public void Handle(ContentCacheRefresherNotification notification)
    {
        if (notification.MessageObject is not ContentCacheRefresher.JsonPayload[] payloads)
        {
            return;
        }

        foreach (ContentCacheRefresher.JsonPayload payload in payloads)
        {
            Console.WriteLine(
                "## Content cache refresher - published = {0}, unpublished = {1}",
                string.Join(", ", payload.PublishedCultures ?? []),
                string.Join(", ", payload.UnpublishedCultures ?? []));
        }
    }

    public void Handle(ContentTreeChangeNotification notification)
    {
        foreach (TreeChange<IContent> change in notification.Changes)
        {
            Console.WriteLine(
                "## Content tree change - published = {0}, unpublished = {1}",
                string.Join(", ", change.PublishedCultures ?? []),
                string.Join(", ", change.UnpublishedCultures ?? []));
        }
    }
}

public class ContentCacheRefresherNotificationHandlerComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
        => builder.AddNotificationHandler<ContentCacheRefresherNotification, ContentCacheRefresherNotificationHandler>();
}
```