### PR TITLE
Update dotnet to version 9

### DIFF
--- a/templates/UmbracoProject/Dockerfile
+++ b/templates/UmbracoProject/Dockerfile
@@ -1,10 +1,10 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+﻿FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
 USER $APP_UID
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["UmbracoProject/UmbracoProject.csproj", "UmbracoProject/"]


### PR DESCRIPTION
### Prerequisites

- I ran into this while trying out umbraco 15 running from docker, the dotnet version should be 9

Not seen this issue mentioned 

### Description
This is just as simple of a change as they get.