### PR TITLE
15.1/hotfix/block editors discard changes on document load

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-areas-config/property-editor-ui-block-grid-areas-config.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-areas-config/property-editor-ui-block-grid-areas-config.element.ts
@@ -11,6 +11,7 @@ import { UMB_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
 import { UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/router';
 import { incrementString } from '@umbraco-cms/backoffice/utils';
 
+import '../../components/block-grid-area-config-entry/index.js';
 @customElement('umb-property-editor-ui-block-grid-areas-config')
 export class UmbPropertyEditorUIBlockGridAreasConfigElement
 	extends UmbLitElement

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/property-editors/block-list-editor/property-editor-ui-block-list.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/property-editors/block-list-editor/property-editor-ui-block-list.element.ts
@@ -56,15 +56,19 @@ export class UmbPropertyEditorUIBlockListElement
 
 	//#catalogueModal: UmbModalRouteRegistrationController<typeof UMB_BLOCK_CATALOGUE_MODAL.DATA, undefined>;
 
-	private _value: UmbBlockListValueModel = {
-		layout: {},
-		contentData: [],
-		settingsData: [],
-		expose: [],
-	};
+	private _value: UmbBlockListValueModel | undefined = undefined;
+
+	#lastValue: UmbBlockListValueModel | undefined = undefined;
 
 	@property({ attribute: false })
 	public override set value(value: UmbBlockListValueModel | undefined) {
+		this.#lastValue = value;
+
+		if (!value) {
+			this._value = undefined;
+			return;
+		}
+
 		const buildUpValue: Partial<UmbBlockListValueModel> = value ? { ...value } : {};
 		buildUpValue.layout ??= {};
 		buildUpValue.contentData ??= [];
@@ -188,13 +192,24 @@ export class UmbPropertyEditorUIBlockListElement
 					this.#managerContext.exposes,
 				]).pipe(debounceTime(20)),
 				([layouts, contents, settings, exposes]) => {
-					this._value = {
-						...this._value,
-						layout: { [UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS]: layouts },
-						contentData: contents,
-						settingsData: settings,
-						expose: exposes,
-					};
+					if (layouts.length === 0) {
+						this._value = undefined;
+					} else {
+						this._value = {
+							...this._value,
+							layout: { [UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS]: layouts },
+							contentData: contents,
+							settingsData: settings,
+							expose: exposes,
+						};
+					}
+
+					// If we don't have a value set from the outside or an internal value, we don't want to set the value.
+					// This is added to prevent the block list from setting an empty value on startup.
+					if (this.#lastValue === undefined && this._value === undefined) {
+						return;
+					}
+
 					context.setValue(this._value);
 				},
 				'motherObserver',


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/17650

Block List and Block Grid editors both set an empty block object property value when they are loaded. This results in a "discard changes" dialog because the stored data isn't the same as the new one.

The PR prevents the editors from setting the initial empty value.