### PR TITLE
V15: Fix friendly content extension performance

### DIFF
--- a/src/Umbraco.Core/DeliveryApi/ApiContentRouteBuilder.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiContentRouteBuilder.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.Extensions.Options;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
@@ -16,6 +18,7 @@ public sealed class ApiContentRouteBuilder : IApiContentRouteBuilder
     private readonly IRequestPreviewService _requestPreviewService;
     private readonly IPublishedContentCache _contentCache;
     private readonly IDocumentNavigationQueryService _navigationQueryService;
+    private readonly IPublishStatusQueryService _publishStatusQueryService;
     private RequestHandlerSettings _requestSettings;
 
     public ApiContentRouteBuilder(
@@ -25,16 +28,39 @@ public sealed class ApiContentRouteBuilder : IApiContentRouteBuilder
         IRequestPreviewService requestPreviewService,
         IOptionsMonitor<RequestHandlerSettings> requestSettings,
         IPublishedContentCache contentCache,
-        IDocumentNavigationQueryService navigationQueryService)
+        IDocumentNavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService)
     {
         _apiContentPathProvider = apiContentPathProvider;
         _variationContextAccessor = variationContextAccessor;
         _requestPreviewService = requestPreviewService;
         _contentCache = contentCache;
         _navigationQueryService = navigationQueryService;
+        _publishStatusQueryService = publishStatusQueryService;
         _globalSettings = globalSettings.Value;
         _requestSettings = requestSettings.CurrentValue;
         requestSettings.OnChange(settings => _requestSettings = settings);
+    }
+
+    [Obsolete("Use constructor that takes an IPublishStatusQueryService instead, scheduled for removal in v17")]
+    public ApiContentRouteBuilder(
+        IApiContentPathProvider apiContentPathProvider,
+        IOptions<GlobalSettings> globalSettings,
+        IVariationContextAccessor variationContextAccessor,
+        IRequestPreviewService requestPreviewService,
+        IOptionsMonitor<RequestHandlerSettings> requestSettings,
+        IPublishedContentCache contentCache,
+        IDocumentNavigationQueryService navigationQueryService)
+        : this(
+        apiContentPathProvider,
+        globalSettings,
+        variationContextAccessor,
+        requestPreviewService,
+        requestSettings,
+        contentCache,
+        navigationQueryService,
+        StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>())
+    {
     }
 
     public IApiContentRoute? Build(IPublishedContent content, string? culture = null)
@@ -105,7 +131,7 @@ public sealed class ApiContentRouteBuilder : IApiContentRouteBuilder
     {
         if (isPreview is false)
         {
-            return content.Root(_contentCache, _navigationQueryService);
+            return content.Root(_variationContextAccessor, _contentCache, _navigationQueryService, _publishStatusQueryService);
         }
 
         _navigationQueryService.TryGetRootKeys(out IEnumerable<Guid> rootKeys);
@@ -114,6 +140,6 @@ public sealed class ApiContentRouteBuilder : IApiContentRouteBuilder
         // in very edge case scenarios during preview, content.Root() does not map to the root.
         // we'll code our way around it for the time being.
         return rootContent.FirstOrDefault(root => root.IsAncestorOrSelf(content))
-               ?? content.Root(_contentCache, _navigationQueryService);
+               ?? content.Root(_variationContextAccessor, _contentCache, _navigationQueryService, _publishStatusQueryService);
     }
 }

--- a/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
@@ -2759,6 +2759,7 @@ public static class PublishedContentExtensions
     /// <param name="content">The content.</param>
     /// <param name="navigationQueryService">The navigation service</param>
     /// <param name="variationContextAccessor">Variation context accessor.</param>
+    /// <param name="publishStatusQueryService"></param>
     /// <param name="culture">
     ///     The specific culture to filter for. If null is used the current culture is used. (Default is
     ///     null)
@@ -2773,9 +2774,68 @@ public static class PublishedContentExtensions
         IPublishedCache publishedCache,
         INavigationQueryService navigationQueryService,
         IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
         string? culture = null) =>
-        SiblingsAndSelf(content, publishedCache, navigationQueryService, variationContextAccessor, culture)
+        SiblingsAndSelf(content, publishedCache, navigationQueryService, variationContextAccessor, publishStatusQueryService, culture)
             ?.Where(x => x.Id != content.Id) ?? Enumerable.Empty<IPublishedContent>();
+
+    /// <summary>
+    ///     Gets the siblings of the content.
+    /// </summary>
+    /// <param name="content">The content.</param>
+    /// <param name="navigationQueryService">The navigation service</param>
+    /// <param name="variationContextAccessor">Variation context accessor.</param>
+    /// <param name="culture">
+    ///     The specific culture to filter for. If null is used the current culture is used. (Default is
+    ///     null)
+    /// </param>
+    /// <param name="publishedCache">The content cache instance.</param>
+    /// <returns>The siblings of the content.</returns>
+    /// <remarks>
+    ///     <para>Note that in V7 this method also return the content node self.</para>
+    /// </remarks>
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
+    public static IEnumerable<IPublishedContent> Siblings(
+        this IPublishedContent content,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        IVariationContextAccessor variationContextAccessor,
+        string? culture = null) =>
+        Siblings(
+            content,
+            publishedCache,
+            navigationQueryService,
+            variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            culture);
+
+    /// <summary>
+    ///     Gets the siblings of the content, of a given content type.
+    /// </summary>
+    /// <param name="content">The content.</param>
+    /// <param name="variationContextAccessor">Variation context accessor.</param>
+    /// <param name="culture">
+    ///     The specific culture to filter for. If null is used the current culture is used. (Default is
+    ///     null)
+    /// </param>
+    /// <param name="publishedCache"></param>
+    /// <param name="navigationQueryService"></param>
+    /// <param name="publishStatusQueryService"></param>
+    /// <param name="contentTypeAlias">The content type alias.</param>
+    /// <returns>The siblings of the content, of the given content type.</returns>
+    /// <remarks>
+    ///     <para>Note that in V7 this method also return the content node self.</para>
+    /// </remarks>
+    public static IEnumerable<IPublishedContent> SiblingsOfType(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
+        string contentTypeAlias,
+        string? culture = null) =>
+        SiblingsAndSelfOfType(content, variationContextAccessor, publishedCache, navigationQueryService, publishStatusQueryService, contentTypeAlias, culture)
+            .Where(x => x.Id != content.Id);
 
     /// <summary>
     ///     Gets the siblings of the content, of a given content type.
@@ -2793,6 +2853,7 @@ public static class PublishedContentExtensions
     /// <remarks>
     ///     <para>Note that in V7 this method also return the content node self.</para>
     /// </remarks>
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
     public static IEnumerable<IPublishedContent> SiblingsOfType(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2800,8 +2861,42 @@ public static class PublishedContentExtensions
         INavigationQueryService navigationQueryService,
         string contentTypeAlias,
         string? culture = null) =>
-        SiblingsAndSelfOfType(content, variationContextAccessor, publishedCache, navigationQueryService, contentTypeAlias, culture)
-            .Where(x => x.Id != content.Id);
+        SiblingsOfType(
+            content,
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            contentTypeAlias,
+            culture);
+
+    /// <summary>
+    ///     Gets the siblings of the content, of a given content type.
+    /// </summary>
+    /// <typeparam name="T">The content type.</typeparam>
+    /// <param name="content">The content.</param>
+    /// <param name="variationContextAccessor">Variation context accessor.</param>
+    /// <param name="publishedCache"></param>
+    /// <param name="navigationQueryService"></param>
+    /// <param name="publishStatusQueryService"></param>
+    /// <param name="culture">
+    ///     The specific culture to filter for. If null is used the current culture is used. (Default is
+    ///     null)
+    /// </param>
+    /// <returns>The siblings of the content, of the given content type.</returns>
+    /// <remarks>
+    ///     <para>Note that in V7 this method also return the content node self.</para>
+    /// </remarks>
+    public static IEnumerable<T> Siblings<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        SiblingsAndSelf<T>(content, variationContextAccessor, publishedCache, navigationQueryService, publishStatusQueryService, culture)
+            ?.Where(x => x.Id != content.Id) ?? Enumerable.Empty<T>();
 
     /// <summary>
     ///     Gets the siblings of the content, of a given content type.
@@ -2819,6 +2914,7 @@ public static class PublishedContentExtensions
     /// <remarks>
     ///     <para>Note that in V7 this method also return the content node self.</para>
     /// </remarks>
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
     public static IEnumerable<T> Siblings<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -2826,8 +2922,56 @@ public static class PublishedContentExtensions
         INavigationQueryService navigationQueryService,
         string? culture = null)
         where T : class, IPublishedContent =>
-        SiblingsAndSelf<T>(content, variationContextAccessor, publishedCache, navigationQueryService, culture)
-            ?.Where(x => x.Id != content.Id) ?? Enumerable.Empty<T>();
+        Siblings<T>(
+            content,
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            culture);
+
+    /// <summary>
+    ///     Gets the siblings of the content including the node itself to indicate the position.
+    /// </summary>
+    /// <param name="content">The content.</param>
+    /// <param name="publishedCache">Cache instance.</param>
+    /// <param name="navigationQueryService">The navigation service.</param>
+    /// <param name="variationContextAccessor">Variation context accessor.</param>
+    /// <param name="publishStatusQueryService"></param>
+    /// <param name="culture">
+    ///     The specific culture to filter for. If null is used the current culture is used. (Default is
+    ///     null)
+    /// </param>
+    /// <returns>The siblings of the content including the node itself.</returns>
+    public static IEnumerable<IPublishedContent>? SiblingsAndSelf(
+        this IPublishedContent content,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
+        string? culture = null)
+    {
+        var success = navigationQueryService.TryGetParentKey(content.Key, out Guid? parentKey);
+
+        if (success is false || parentKey is null)
+        {
+            if (navigationQueryService.TryGetRootKeys(out IEnumerable<Guid> childrenKeys) is false)
+            {
+                return null;
+            }
+
+            culture ??= variationContextAccessor.VariationContext?.Culture ?? string.Empty;
+            return childrenKeys
+                .Where(x => publishStatusQueryService.IsDocumentPublished(x , culture))
+                .Select(publishedCache.GetById)
+                .WhereNotNull()
+                .WhereIsInvariantOrHasCulture(variationContextAccessor, culture);
+        }
+
+        return navigationQueryService.TryGetChildrenKeys(parentKey.Value, out IEnumerable<Guid> siblingKeys) is false
+            ? null
+            : siblingKeys.Select(publishedCache.GetById).WhereNotNull();
+    }
 
     /// <summary>
     ///     Gets the siblings of the content including the node itself to indicate the position.
@@ -2841,31 +2985,66 @@ public static class PublishedContentExtensions
     ///     null)
     /// </param>
     /// <returns>The siblings of the content including the node itself.</returns>
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
     public static IEnumerable<IPublishedContent>? SiblingsAndSelf(
         this IPublishedContent content,
         IPublishedCache publishedCache,
         INavigationQueryService navigationQueryService,
         IVariationContextAccessor variationContextAccessor,
+        string? culture = null) =>
+        SiblingsAndSelf(
+            content,
+            publishedCache,
+            navigationQueryService,
+            variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            culture);
+
+    /// <summary>
+    ///     Gets the siblings of the content including the node itself to indicate the position, of a given content type.
+    /// </summary>
+    /// <param name="content">The content.</param>
+    /// <param name="variationContextAccessor">Variation context accessor.</param>
+    /// <param name="culture">
+    ///     The specific culture to filter for. If null is used the current culture is used. (Default is
+    ///     null)
+    /// </param>
+    /// <param name="navigationQueryService"></param>
+    /// <param name="publishStatusQueryService"></param>
+    /// <param name="contentTypeAlias">The content type alias.</param>
+    /// <param name="publishedCache"></param>
+    /// <returns>The siblings of the content including the node itself, of the given content type.</returns>
+    public static IEnumerable<IPublishedContent> SiblingsAndSelfOfType(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
+        string contentTypeAlias,
         string? culture = null)
     {
-        var success = navigationQueryService.TryGetParentKey(content.Key, out Guid? parentKey);
+        var parentExists = navigationQueryService.TryGetParentKey(content.Key, out Guid? parentKey);
 
-        if (success is false || parentKey is null)
+        IPublishedContent? parent = parentKey is null
+            ? null
+            : publishedCache.GetById(parentKey.Value);
+
+        if (parentExists && parent is not null)
         {
-            if (navigationQueryService.TryGetRootKeys(out IEnumerable<Guid> childrenKeys) is false)
-            {
-                return null;
-            }
-
-            return childrenKeys
-                .Select(publishedCache.GetById)
-                .WhereNotNull()
-                .WhereIsInvariantOrHasCulture(variationContextAccessor, culture);
+            return parent.ChildrenOfType(variationContextAccessor, publishedCache, navigationQueryService, publishStatusQueryService, contentTypeAlias, culture);
         }
 
-        return navigationQueryService.TryGetChildrenKeys(parentKey.Value, out IEnumerable<Guid> siblingKeys) is false
-            ? null
-            : siblingKeys.Select(publishedCache.GetById).WhereNotNull();
+        if (navigationQueryService.TryGetRootKeysOfType(contentTypeAlias, out IEnumerable<Guid> rootKeysOfType) is false)
+        {
+            return [];
+        }
+
+        culture ??= variationContextAccessor.VariationContext?.Culture ?? string.Empty;
+        return rootKeysOfType
+            .Where(x => publishStatusQueryService.IsDocumentPublished(x, culture))
+            .Select(publishedCache.GetById)
+            .WhereNotNull()
+            .WhereIsInvariantOrHasCulture(variationContextAccessor, culture);
     }
 
     /// <summary>
@@ -2881,35 +3060,22 @@ public static class PublishedContentExtensions
     /// <param name="contentTypeAlias">The content type alias.</param>
     /// <param name="publishedCache"></param>
     /// <returns>The siblings of the content including the node itself, of the given content type.</returns>
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
     public static IEnumerable<IPublishedContent> SiblingsAndSelfOfType(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         IPublishedCache publishedCache,
         INavigationQueryService navigationQueryService,
         string contentTypeAlias,
-        string? culture = null)
-    {
-        var parentExists = navigationQueryService.TryGetParentKey(content.Key, out Guid? parentKey);
-
-        IPublishedContent? parent = parentKey is null
-            ? null
-            : publishedCache.GetById(parentKey.Value);
-
-        if (parentExists && parent is not null)
-        {
-            return parent.ChildrenOfType(variationContextAccessor, publishedCache, navigationQueryService, contentTypeAlias, culture);
-        }
-
-        if (navigationQueryService.TryGetRootKeysOfType(contentTypeAlias, out IEnumerable<Guid> rootKeysOfType) is false)
-        {
-            return [];
-        }
-
-        return rootKeysOfType
-            .Select(publishedCache.GetById)
-            .WhereNotNull()
-            .WhereIsInvariantOrHasCulture(variationContextAccessor, culture);
-    }
+        string? culture = null) =>
+        SiblingsAndSelfOfType(
+            content,
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            contentTypeAlias,
+            culture);
 
     /// <summary>
     ///     Gets the siblings of the content including the node itself to indicate the position, of a given content type.
@@ -2945,7 +3111,9 @@ public static class PublishedContentExtensions
                 return [];
             }
 
+            culture ??= variationContextAccessor.VariationContext?.Culture ?? string.Empty;
             return rootKeys
+                .Where(x => publishStatusQueryService.IsDocumentPublished(x, culture))
                 .Select(publishedCache.GetById)
                 .WhereNotNull()
                 .WhereIsInvariantOrHasCulture(variationContextAccessor, culture)
@@ -2975,14 +3143,13 @@ public static class PublishedContentExtensions
         IPublishedCache publishedCache,
         INavigationQueryService navigationQueryService,
         string? culture = null)
-        where T : class, IPublishedContent =>
-    SiblingsAndSelf<T>(
-        content,
-        variationContextAccessor,
-        publishedCache,
-        navigationQueryService,
-        StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
-        culture);
+        where T : class, IPublishedContent => SiblingsAndSelf<T>(
+            content,
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            culture);
 
     #endregion
 
@@ -4147,9 +4314,27 @@ public static class PublishedContentExtensions
     public static IEnumerable<T> SiblingsAndSelf<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
         string? culture = null)
-        where T : class, IPublishedContent => SiblingsAndSelf<T>(content, variationContextAccessor, GetPublishedCache(content),
-        GetNavigationQueryService(content), culture);
+        where T : class, IPublishedContent =>
+        SiblingsAndSelf<T>(
+            content,
+            variationContextAccessor,
+            GetPublishedCache(content),
+            GetNavigationQueryService(content),
+            publishStatusQueryService,
+            culture);
+
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
+    public static IEnumerable<T> SiblingsAndSelf<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string? culture = null)
+        where T : class, IPublishedContent => SiblingsAndSelf<T>(
+            content,
+            variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            culture);
 
 
     private static INavigationQueryService GetNavigationQueryService(IPublishedContent content)

--- a/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
@@ -987,6 +987,7 @@ public static class PublishedContentExtensions
     /// <param name="parentNodes"></param>
     /// <param name="variationContextAccessor">Variation context accessor.</param>
     /// <param name="navigationQueryService"></param>
+    /// <param name="publishStatusQueryService"></param>
     /// <param name="docTypeAlias"></param>
     /// <param name="culture">
     ///     The specific culture to filter for. If null is used the current culture is used. (Default is
@@ -1002,9 +1003,69 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         IPublishedCache publishedCache,
         INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
         string docTypeAlias,
         string? culture = null) => parentNodes.SelectMany(x =>
-        x.DescendantsOrSelfOfType(variationContextAccessor, publishedCache, navigationQueryService, docTypeAlias, culture));
+        x.DescendantsOrSelfOfType(variationContextAccessor, publishedCache, navigationQueryService, publishStatusQueryService, docTypeAlias, culture));
+
+    /// <summary>
+    ///     Returns all DescendantsOrSelf of all content referenced
+    /// </summary>
+    /// <param name="parentNodes"></param>
+    /// <param name="variationContextAccessor">Variation context accessor.</param>
+    /// <param name="navigationQueryService"></param>
+    /// <param name="docTypeAlias"></param>
+    /// <param name="culture">
+    ///     The specific culture to filter for. If null is used the current culture is used. (Default is
+    ///     null)
+    /// </param>
+    /// <param name="publishedCache"></param>
+    /// <returns></returns>
+    /// <remarks>
+    ///     This can be useful in order to return all nodes in an entire site by a type when combined with TypedContentAtRoot
+    /// </remarks>
+    [Obsolete("Use the overload with IPublishStatusQueryService instead, scheduled for removal in v17")]
+    public static IEnumerable<IPublishedContent> DescendantsOrSelfOfType(
+        this IEnumerable<IPublishedContent> parentNodes,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        string docTypeAlias,
+        string? culture = null) =>
+        DescendantsOrSelfOfType(
+            parentNodes,
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            docTypeAlias,
+            culture);
+
+    /// <summary>
+    ///     Returns all DescendantsOrSelf of all content referenced
+    /// </summary>
+    /// <param name="parentNodes"></param>
+    /// <param name="variationContextAccessor">Variation context accessor.</param>
+    /// <param name="navigationQueryService"></param>
+    /// <param name="publishStatusQueryService"></param>
+    /// <param name="culture">
+    ///     The specific culture to filter for. If null is used the current culture is used. (Default is
+    ///     null)
+    /// </param>
+    /// <param name="publishedCache"></param>
+    /// <returns></returns>
+    /// <remarks>
+    ///     This can be useful in order to return all nodes in an entire site by a type when combined with TypedContentAtRoot
+    /// </remarks>
+    public static IEnumerable<T> DescendantsOrSelf<T>(
+        this IEnumerable<IPublishedContent> parentNodes,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        parentNodes.SelectMany(x => x.DescendantsOrSelf<T>(variationContextAccessor, publishedCache, navigationQueryService, publishStatusQueryService, culture));
 
     /// <summary>
     ///     Returns all DescendantsOrSelf of all content referenced
@@ -1021,6 +1082,7 @@ public static class PublishedContentExtensions
     /// <remarks>
     ///     This can be useful in order to return all nodes in an entire site by a type when combined with TypedContentAtRoot
     /// </remarks>
+    [Obsolete("Use the overload with IPublishStatusQueryService instead, scheduled for removal in v17")]
     public static IEnumerable<T> DescendantsOrSelf<T>(
         this IEnumerable<IPublishedContent> parentNodes,
         IVariationContextAccessor variationContextAccessor,
@@ -1028,7 +1090,13 @@ public static class PublishedContentExtensions
         INavigationQueryService navigationQueryService,
         string? culture = null)
         where T : class, IPublishedContent =>
-        parentNodes.SelectMany(x => x.DescendantsOrSelf<T>(variationContextAccessor, publishedCache, navigationQueryService, culture));
+        DescendantsOrSelf<T>(
+            parentNodes,
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            culture);
 
     // as per XPath 1.0 specs �2.2,
     // - the descendant axis contains the descendants of the context node; a descendant is a child or a child of a child and so on; thus
@@ -1053,9 +1121,43 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         IPublishedCache publishedCache,
         INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
         string? culture = null) =>
-        content.DescendantsOrSelf(variationContextAccessor, publishedCache, navigationQueryService, false, null, culture);
+        content.DescendantsOrSelf(variationContextAccessor, publishedCache, navigationQueryService, publishStatusQueryService, false, null, culture);
 
+    [Obsolete("Use the overload with IPublishStatusQuery instead, scheduled for removal in v17")]
+    public static IEnumerable<IPublishedContent> Descendants(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        string? culture = null) =>
+        Descendants(
+            content,
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            culture);
+
+    public static IEnumerable<IPublishedContent> Descendants(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
+        int level,
+        string? culture = null) =>
+        content.DescendantsOrSelf(
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            publishStatusQueryService,
+            false,
+            p => p.Level >= level,
+            culture);
+
+    [Obsolete("Use the overload with IPublishStatusQuery instead, scheduled for removal in v17")]
     public static IEnumerable<IPublishedContent> Descendants(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -1063,8 +1165,33 @@ public static class PublishedContentExtensions
         INavigationQueryService navigationQueryService,
         int level,
         string? culture = null) =>
-        content.DescendantsOrSelf(variationContextAccessor, publishedCache, navigationQueryService, false, p => p.Level >= level, culture);
+        Descendants(
+            content,
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            level,
+            culture);
 
+    public static IEnumerable<IPublishedContent> DescendantsOfType(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
+        string contentTypeAlias,
+        string? culture = null) =>
+        content.EnumerateDescendantsOrSelfInternal(
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            publishStatusQueryService,
+            culture,
+            false,
+            contentTypeAlias);
+
+    [Obsolete("Use the overload with IPublishStatusQuery instead, scheduled for removal in v17")]
     public static IEnumerable<IPublishedContent> DescendantsOfType(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -1072,14 +1199,26 @@ public static class PublishedContentExtensions
         INavigationQueryService navigationQueryService,
         string contentTypeAlias,
         string? culture = null) =>
-        content.EnumerateDescendantsOrSelfInternal(
+        DescendantsOfType(
+            content,
             variationContextAccessor,
             publishedCache,
             navigationQueryService,
-            culture,
-            false,
-            contentTypeAlias);
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            contentTypeAlias,
+            culture);
 
+    public static IEnumerable<T> Descendants<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.Descendants(variationContextAccessor, publishedCache, navigationQueryService, publishStatusQueryService, culture).OfType<T>();
+
+    [Obsolete("Use the overload with IPublishStatusQuery instead, scheduled for removal in v17")]
     public static IEnumerable<T> Descendants<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -1094,19 +1233,65 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         IPublishedCache publishedCache,
         INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
         int level,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.Descendants(variationContextAccessor, publishedCache, navigationQueryService, level, culture).OfType<T>();
+        content.Descendants(variationContextAccessor, publishedCache, navigationQueryService, publishStatusQueryService, level, culture).OfType<T>();
+
+    [Obsolete("Use the overload with IPublishStatusQuery instead, scheduled for removal in v17")]
+    public static IEnumerable<T> Descendants<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        int level,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        Descendants<T>(
+            content,
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            level,
+            culture);
 
     public static IEnumerable<IPublishedContent> DescendantsOrSelf(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         IPublishedCache publishedCache,
         INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
         string? culture = null) =>
-        content.DescendantsOrSelf(variationContextAccessor, publishedCache, navigationQueryService, true, null, culture);
+        content.DescendantsOrSelf(variationContextAccessor, publishedCache, navigationQueryService, publishStatusQueryService, true, null, culture);
 
+    [Obsolete("Use the overload with IPublishStatusQuery instead, scheduled for removal in v17")]
+    public static IEnumerable<IPublishedContent> DescendantsOrSelf(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        string? culture = null) =>
+       DescendantsOrSelf(
+           content,
+           variationContextAccessor,
+           publishedCache,
+           navigationQueryService,
+           StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+           culture);
+
+    public static IEnumerable<IPublishedContent> DescendantsOrSelf(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
+        int level,
+        string? culture = null) =>
+        content.DescendantsOrSelf(variationContextAccessor, publishedCache, navigationQueryService, publishStatusQueryService, true, p => p.Level >= level, culture);
+
+    [Obsolete("Use the overload with IPublishStatusQuery instead, scheduled for removal in v17")]
     public static IEnumerable<IPublishedContent> DescendantsOrSelf(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -1114,8 +1299,33 @@ public static class PublishedContentExtensions
         INavigationQueryService navigationQueryService,
         int level,
         string? culture = null) =>
-        content.DescendantsOrSelf(variationContextAccessor, publishedCache, navigationQueryService, true, p => p.Level >= level, culture);
+        DescendantsOrSelf(
+            content,
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            level,
+            culture);
 
+    public static IEnumerable<IPublishedContent> DescendantsOrSelfOfType(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
+        string contentTypeAlias,
+        string? culture = null) =>
+        content.EnumerateDescendantsOrSelfInternal(
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            publishStatusQueryService,
+            culture,
+            true,
+            contentTypeAlias);
+
+    [Obsolete("Use the overload with IPublishStatusQuery instead, scheduled for removal in v17")]
     public static IEnumerable<IPublishedContent> DescendantsOrSelfOfType(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -1123,14 +1333,26 @@ public static class PublishedContentExtensions
         INavigationQueryService navigationQueryService,
         string contentTypeAlias,
         string? culture = null) =>
-        content.EnumerateDescendantsOrSelfInternal(
+        DescendantsOrSelfOfType(
+            content,
             variationContextAccessor,
             publishedCache,
             navigationQueryService,
-            culture,
-            true,
-            contentTypeAlias);
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            contentTypeAlias,
+            culture);
 
+    public static IEnumerable<T> DescendantsOrSelf<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.DescendantsOrSelf(variationContextAccessor, publishedCache, navigationQueryService, publishStatusQueryService, culture).OfType<T>();
+
+    [Obsolete("Use the overload with IPublishStatusQuery instead, scheduled for removal in v17")]
     public static IEnumerable<T> DescendantsOrSelf<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -1138,8 +1360,25 @@ public static class PublishedContentExtensions
         INavigationQueryService navigationQueryService,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.DescendantsOrSelf(variationContextAccessor, publishedCache, navigationQueryService, culture).OfType<T>();
+        content.DescendantsOrSelf<T>(
+                variationContextAccessor,
+                publishedCache,
+                navigationQueryService,
+                StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+                culture);
 
+    public static IEnumerable<T> DescendantsOrSelf<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
+        int level,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.DescendantsOrSelf(variationContextAccessor, publishedCache, navigationQueryService, publishStatusQueryService, level, culture).OfType<T>();
+
+    [Obsolete("Use the overload with IPublishStatusQuery instead, scheduled for removal in v17")]
     public static IEnumerable<T> DescendantsOrSelf<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -1148,41 +1387,118 @@ public static class PublishedContentExtensions
         int level,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.DescendantsOrSelf(variationContextAccessor, publishedCache, navigationQueryService, level, culture).OfType<T>();
+        DescendantsOrSelf<T>(
+            content,
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            level,
+            culture);
 
+    public static IPublishedContent? Descendant(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
+        string? culture = null) =>
+        content.Children(
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            publishStatusQueryService,
+            culture)?.FirstOrDefault();
+
+    [Obsolete("Use the overload with IPublishStatusQuery instead, scheduled for removal in v17")]
     public static IPublishedContent? Descendant(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         IPublishedCache publishedCache,
         INavigationQueryService navigationQueryService,
         string? culture = null) =>
-        content.Children(variationContextAccessor, publishedCache, navigationQueryService, culture)?.FirstOrDefault();
+        Descendant(
+            content,
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            culture);
 
     public static IPublishedContent? Descendant(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         IPublishedCache publishedCache,
         INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
         int level,
         string? culture = null) => content
-        .EnumerateDescendants(variationContextAccessor, publishedCache, navigationQueryService, false, culture).FirstOrDefault(x => x.Level == level);
+        .EnumerateDescendants(variationContextAccessor, publishedCache, navigationQueryService, publishStatusQueryService, false, culture).FirstOrDefault(x => x.Level == level);
+
+    [Obsolete("Use the overload with IPublishStatusQuery instead, scheduled for removal in v17")]
+    public static IPublishedContent? Descendant(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        int level,
+        string? culture = null) =>
+        content
+        .EnumerateDescendants(
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            false,
+            culture)
+        .FirstOrDefault(x => x.Level == level);
 
     public static IPublishedContent? DescendantOfType(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         IPublishedCache publishedCache,
         INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
         string contentTypeAlias,
         string? culture = null) => content
             .EnumerateDescendantsOrSelfInternal(
                 variationContextAccessor,
                 publishedCache,
                 navigationQueryService,
+                publishStatusQueryService,
                 culture,
                 false,
                 contentTypeAlias)
             .FirstOrDefault();
 
+    [Obsolete("Use the overload with IPublishStatusQuery instead, scheduled for removal in v17")]
+    public static IPublishedContent? DescendantOfType(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        string contentTypeAlias,
+        string? culture = null) =>
+        DescendantOfType(
+            content,
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            contentTypeAlias,
+            culture);
+
+    public static T? Descendant<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.EnumerateDescendants(variationContextAccessor, publishedCache, navigationQueryService, publishStatusQueryService, false, culture).FirstOrDefault(x => x is T) as T;
+
+    [Obsolete("Use the overload with IPublishStatusQuery instead, scheduled for removal in v17")]
     public static T? Descendant<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -1190,8 +1506,26 @@ public static class PublishedContentExtensions
         INavigationQueryService navigationQueryService,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.EnumerateDescendants(variationContextAccessor, publishedCache, navigationQueryService, false, culture).FirstOrDefault(x => x is T) as T;
+        Descendant<T>(
+            content,
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            culture);
 
+    public static T? Descendant<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
+        int level,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.Descendant(variationContextAccessor, publishedCache, navigationQueryService, publishStatusQueryService, level, culture) as T;
+
+    [Obsolete("Use the overload with IPublishStatusQuery instead, scheduled for removal in v17")]
     public static T? Descendant<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -1200,35 +1534,121 @@ public static class PublishedContentExtensions
         int level,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.Descendant(variationContextAccessor, publishedCache, navigationQueryService, level, culture) as T;
+        Descendant<T>(
+            content,
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            level,
+            culture);
 
-    public static IPublishedContent DescendantOrSelf(this IPublishedContent content, IVariationContextAccessor variationContextAccessor, string? culture = null) => content;
+    public static IPublishedContent DescendantOrSelf(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
+        string? culture = null) =>
+        content.EnumerateDescendants(
+                variationContextAccessor,
+                GetPublishedCache(content),
+                GetNavigationQueryService(content),
+                publishStatusQueryService,
+                true,
+                culture)
+            .FirstOrDefault() ??
+        content;
+
+    [Obsolete("Use the overload with IPublishStatusQuery instead, scheduled for removal in v17")]
+    public static IPublishedContent DescendantOrSelf(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string? culture = null) =>
+        DescendantOrSelf(
+            content,
+            variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            culture);
 
     public static IPublishedContent? DescendantOrSelf(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         IPublishedCache publishedCache,
         INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
         int level,
         string? culture = null) => content
-        .EnumerateDescendants(variationContextAccessor, publishedCache, navigationQueryService, true, culture).FirstOrDefault(x => x.Level == level);
+        .EnumerateDescendants(
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            publishStatusQueryService,
+            true,
+            culture)
+        .FirstOrDefault(x => x.Level == level);
+
+    [Obsolete("Use the overload with IPublishStatusQuery instead, scheduled for removal in v17")]
+    public static IPublishedContent? DescendantOrSelf(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        int level,
+        string? culture = null) =>
+        DescendantOrSelf(
+            content,
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            level,
+            culture);
 
     public static IPublishedContent? DescendantOrSelfOfType(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         IPublishedCache publishedCache,
         INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
         string contentTypeAlias,
         string? culture = null) => content
         .EnumerateDescendantsOrSelfInternal(
             variationContextAccessor,
             publishedCache,
             navigationQueryService,
+            publishStatusQueryService,
             culture,
             true,
             contentTypeAlias)
         .FirstOrDefault();
 
+    [Obsolete("Use the overload with IPublishStatusQuery instead, scheduled for removal in v17")]
+    public static IPublishedContent? DescendantOrSelfOfType(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        string contentTypeAlias,
+        string? culture = null) =>
+        DescendantOrSelfOfType(
+            content,
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            contentTypeAlias,
+            culture);
+
+    public static T? DescendantOrSelf<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.EnumerateDescendants(variationContextAccessor, publishedCache, navigationQueryService, publishStatusQueryService, true, culture).FirstOrDefault(x => x is T) as T;
+
+    [Obsolete("Use the overload with IPublishStatusQuery instead, scheduled for removal in v17")]
     public static T? DescendantOrSelf<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -1236,8 +1656,26 @@ public static class PublishedContentExtensions
         INavigationQueryService navigationQueryService,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.EnumerateDescendants(variationContextAccessor, publishedCache, navigationQueryService, true, culture).FirstOrDefault(x => x is T) as T;
+        DescendantOrSelf<T>(
+            content,
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            culture);
 
+    public static T? DescendantOrSelf<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
+        int level,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.DescendantOrSelf(variationContextAccessor, publishedCache, navigationQueryService, publishStatusQueryService, level, culture) as T;
+
+    [Obsolete("Use the overload with IPublishStatusQuery instead, scheduled for removal in v17")]
     public static T? DescendantOrSelf<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
@@ -1246,17 +1684,25 @@ public static class PublishedContentExtensions
         int level,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.DescendantOrSelf(variationContextAccessor, publishedCache, navigationQueryService, level, culture) as T;
+        DescendantOrSelf<T>(
+            content,
+            variationContextAccessor,
+            publishedCache,
+            navigationQueryService,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            level,
+            culture);
 
     internal static IEnumerable<IPublishedContent> DescendantsOrSelf(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         IPublishedCache publishedCache,
         INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
         bool orSelf,
         Func<IPublishedContent, bool>? func,
         string? culture = null) =>
-        content.EnumerateDescendants(variationContextAccessor, publishedCache, navigationQueryService, orSelf, culture)
+        content.EnumerateDescendants(variationContextAccessor, publishedCache, navigationQueryService, publishStatusQueryService, orSelf, culture)
         .Where(x => func == null || func(x));
 
     internal static IEnumerable<IPublishedContent> EnumerateDescendants(
@@ -1264,6 +1710,7 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         IPublishedCache publishedCache,
         INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
         bool orSelf,
         string? culture = null)
     {
@@ -1273,6 +1720,7 @@ public static class PublishedContentExtensions
                      variationContextAccessor,
                      publishedCache,
                      navigationQueryService,
+                     publishStatusQueryService,
                      culture,
                      orSelf))
         {
@@ -1285,6 +1733,7 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         IPublishedCache publishedCache,
         INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
         string? culture = null)
     {
         yield return content;
@@ -1293,6 +1742,7 @@ public static class PublishedContentExtensions
                      variationContextAccessor,
                      publishedCache,
                      navigationQueryService,
+                     publishStatusQueryService,
                      culture,
                      false))
         {
@@ -2291,26 +2741,37 @@ public static class PublishedContentExtensions
     public static IEnumerable<IPublishedContent> Children(
         this IPublishedContent content,
         IVariationContextAccessor? variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
         string? culture = null)
-        => Children(content, variationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
+        => Children(content, variationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), publishStatusQueryService, culture);
 
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
+    public static IEnumerable<IPublishedContent> Children(
+        this IPublishedContent content,
+        IVariationContextAccessor? variationContextAccessor,
+        string? culture = null)
+        => Children(content, variationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(), culture);
+
+    public static IEnumerable<IPublishedContent> Children(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
+        Func<IPublishedContent, bool> predicate,
+        string? culture = null) =>
+        content.Children(variationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), publishStatusQueryService, culture).Where(predicate);
+
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
     public static IEnumerable<IPublishedContent> Children(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         Func<IPublishedContent, bool> predicate,
         string? culture = null) =>
-        content.Children(variationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture).Where(predicate);
-
-    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
-    public static IEnumerable<IPublishedContent> ChildrenOfType(
-        this IPublishedContent content,
-        IVariationContextAccessor variationContextAccessor,
-        string? contentTypeAlias,
-        string? culture = null)
-    {
-        IPublishStatusQueryService publishStatusQueryService = StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>();
-        return ChildrenOfType(content, variationContextAccessor, publishStatusQueryService, contentTypeAlias, culture);
-    }
+        Children(
+            content,
+            variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            predicate,
+            culture);
 
     public static IEnumerable<IPublishedContent> ChildrenOfType(
         this IPublishedContent content,
@@ -2326,13 +2787,32 @@ public static class PublishedContentExtensions
         return children.FilterByCulture(culture, variationContextAccessor);
     }
 
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
+    public static IEnumerable<IPublishedContent> ChildrenOfType(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string? contentTypeAlias,
+        string? culture = null)
+    {
+        IPublishStatusQueryService publishStatusQueryService = StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>();
+        return ChildrenOfType(content, variationContextAccessor, publishStatusQueryService, contentTypeAlias, culture);
+    }
+
+    public static IEnumerable<T> Children<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.Children(variationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), publishStatusQueryService, culture).OfType<T>();
+
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
     public static IEnumerable<T> Children<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.Children(variationContextAccessor, GetPublishedCache(content),
-            GetNavigationQueryService(content), culture).OfType<T>();
+        Children<T>(content, variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(), culture);
 
     public static DataTable ChildrenAsTable(
         this IPublishedContent content,
@@ -2349,213 +2829,525 @@ public static class PublishedContentExtensions
     public static IEnumerable<IPublishedContent> DescendantsOrSelfOfType(
         this IEnumerable<IPublishedContent> parentNodes,
         IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
         string docTypeAlias,
-        string? culture = null) => parentNodes.SelectMany(x =>
-        x.DescendantsOrSelfOfType(variationContextAccessor, GetPublishedCache(parentNodes.First()),
-            GetNavigationQueryService(parentNodes.First()), docTypeAlias, culture));
+        string? culture = null) =>
+        parentNodes.SelectMany(x => x.DescendantsOrSelfOfType(
+            variationContextAccessor,
+            GetPublishedCache(parentNodes.First()),
+            GetNavigationQueryService(parentNodes.First()),
+            publishStatusQueryService,
+            docTypeAlias,
+            culture));
 
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
+    public static IEnumerable<IPublishedContent> DescendantsOrSelfOfType(
+        this IEnumerable<IPublishedContent> parentNodes,
+        IVariationContextAccessor variationContextAccessor,
+        string docTypeAlias,
+        string? culture = null) =>
+        DescendantsOrSelfOfType(
+            parentNodes,
+            variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            docTypeAlias,
+            culture);
 
+    public static IEnumerable<T> DescendantsOrSelf<T>(
+        this IEnumerable<IPublishedContent> parentNodes,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        parentNodes.SelectMany(
+            x => x.DescendantsOrSelf<T>(
+                variationContextAccessor,
+                GetPublishedCache(parentNodes.First()),
+                GetNavigationQueryService(parentNodes.First()),
+                publishStatusQueryService,
+                culture));
+
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
     public static IEnumerable<T> DescendantsOrSelf<T>(
         this IEnumerable<IPublishedContent> parentNodes,
         IVariationContextAccessor variationContextAccessor,
         string? culture = null)
         where T : class, IPublishedContent =>
-        parentNodes.SelectMany(x => x.DescendantsOrSelf<T>(variationContextAccessor, GetPublishedCache(parentNodes.First()),
-            GetNavigationQueryService(parentNodes.First()), culture));
+        DescendantsOrSelf<T>(parentNodes, variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(), culture);
 
+    public static IEnumerable<IPublishedContent> Descendants(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
+        string? culture = null) =>
+        content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), publishStatusQueryService, false, null, culture);
+
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
+    public static IEnumerable<IPublishedContent> Descendants(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string? culture = null) =>
+        Descendants(content, variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(), culture);
 
 
     public static IEnumerable<IPublishedContent> Descendants(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
+        int level,
         string? culture = null) =>
-        content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content),
-            GetNavigationQueryService(content), false, null, culture);
+        content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), publishStatusQueryService, false, p => p.Level >= level, culture);
 
-
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
     public static IEnumerable<IPublishedContent> Descendants(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         int level,
         string? culture = null) =>
-        content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content),
-            GetNavigationQueryService(content), false, p => p.Level >= level, culture);
+        Descendants(
+            content,
+            variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            level,
+            culture);
 
 
     public static IEnumerable<IPublishedContent> DescendantsOfType(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
         string contentTypeAlias, string? culture = null) =>
         content.EnumerateDescendantsOrSelfInternal(
             variationContextAccessor,
             GetPublishedCache(content),
             GetNavigationQueryService(content),
+            publishStatusQueryService,
             culture,
             false,
             contentTypeAlias);
 
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
+    public static IEnumerable<IPublishedContent> DescendantsOfType(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string contentTypeAlias,
+        string? culture = null) =>
+        DescendantsOfType(
+            content,
+            variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            contentTypeAlias,
+            culture);
 
+
+    public static IEnumerable<T> Descendants<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.Descendants(variationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), publishStatusQueryService, culture).OfType<T>();
+
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
     public static IEnumerable<T> Descendants<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.Descendants(variationContextAccessor, GetPublishedCache(content),
-            GetNavigationQueryService(content), culture).OfType<T>();
+        Descendants<T>(content, variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(), culture);
 
 
+    public static IEnumerable<T> Descendants<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
+        int level,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.Descendants(variationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), publishStatusQueryService, level, culture).OfType<T>();
+
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
     public static IEnumerable<T> Descendants<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         int level,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.Descendants(variationContextAccessor, GetPublishedCache(content),
-            GetNavigationQueryService(content), level, culture).OfType<T>();
+        Descendants<T>(
+            content,
+            variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            level,
+            culture);
 
 
     public static IEnumerable<IPublishedContent> DescendantsOrSelf(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
         string? culture = null) =>
-        content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content),
-            GetNavigationQueryService(content), true, null, culture);
+        content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), publishStatusQueryService, true, null, culture);
+
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
+    public static IEnumerable<IPublishedContent> DescendantsOrSelf(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string? culture = null) =>
+        DescendantsOrSelf(
+            content,
+            variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            culture);
 
 
+    public static IEnumerable<IPublishedContent> DescendantsOrSelf(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
+        int level,
+        string? culture = null) =>
+        content.DescendantsOrSelf(
+            variationContextAccessor,
+            GetPublishedCache(content),
+            GetNavigationQueryService(content),
+            publishStatusQueryService,
+            true,
+            p => p.Level >= level,
+            culture);
+
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
     public static IEnumerable<IPublishedContent> DescendantsOrSelf(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         int level,
         string? culture = null) =>
-        content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content),
-            GetNavigationQueryService(content), true, p => p.Level >= level, culture);
-
+        DescendantsOrSelf(
+            content,
+            variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            level,
+            culture);
 
     public static IEnumerable<IPublishedContent> DescendantsOrSelfOfType(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
         string contentTypeAlias,
         string? culture = null) =>
         content.EnumerateDescendantsOrSelfInternal(
             variationContextAccessor,
             GetPublishedCache(content),
             GetNavigationQueryService(content),
+            publishStatusQueryService,
             culture,
             true,
             contentTypeAlias);
 
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
+    public static IEnumerable<IPublishedContent> DescendantsOrSelfOfType(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string contentTypeAlias,
+        string? culture = null) =>
+        DescendantsOrSelfOfType(
+            content,
+            variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            contentTypeAlias,
+            culture);
 
+
+    public static IEnumerable<T> DescendantsOrSelf<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.DescendantsOrSelf(
+                variationContextAccessor,
+                GetPublishedCache(content),
+                GetNavigationQueryService(content),
+                publishStatusQueryService,
+                culture).OfType<T>();
+
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
     public static IEnumerable<T> DescendantsOrSelf<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content),
-            GetNavigationQueryService(content), culture).OfType<T>();
+        DescendantsOrSelf<T>(
+            content,
+            variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            culture);
 
 
+    public static IEnumerable<T> DescendantsOrSelf<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
+        int level,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.DescendantsOrSelf(
+                variationContextAccessor,
+                GetPublishedCache(content),
+                GetNavigationQueryService(content),
+                publishStatusQueryService,
+                level,
+                culture).OfType<T>();
+
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
     public static IEnumerable<T> DescendantsOrSelf<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         int level,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.DescendantsOrSelf(variationContextAccessor, GetPublishedCache(content),
-            GetNavigationQueryService(content), level, culture).OfType<T>();
+        DescendantsOrSelf<T>(
+            content,
+            variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            level,
+            culture);
 
 
+    public static IPublishedContent? Descendant(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
+        string? culture = null) =>
+        content.Children(variationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), publishStatusQueryService, culture)?.FirstOrDefault();
+
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
     public static IPublishedContent? Descendant(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         string? culture = null) =>
-        content.Children(variationContextAccessor, GetPublishedCache(content),
-            GetNavigationQueryService(content), culture)?.FirstOrDefault();
+        Descendant(
+            content,
+            variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            culture);
 
 
     public static IPublishedContent? Descendant(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
         int level,
         string? culture = null) => content
-        .EnumerateDescendants(variationContextAccessor, GetPublishedCache(content),
-            GetNavigationQueryService(content), false, culture).FirstOrDefault(x => x.Level == level);
+        .EnumerateDescendants(
+            variationContextAccessor,
+            GetPublishedCache(content),
+            GetNavigationQueryService(content),
+            publishStatusQueryService,
+            false,
+            culture).FirstOrDefault(x => x.Level == level);
+
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
+    public static IPublishedContent? Descendant(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        int level,
+        string? culture = null) =>
+        Descendant(
+            content,
+            variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            level,
+            culture);
 
 
     public static IPublishedContent? DescendantOfType(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
         string contentTypeAlias,
         string? culture = null) => content
             .EnumerateDescendantsOrSelfInternal(
                 variationContextAccessor,
                 GetPublishedCache(content),
                 GetNavigationQueryService(content),
+                publishStatusQueryService,
                 culture,
                 false,
                 contentTypeAlias)
             .FirstOrDefault();
 
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
+    public static IPublishedContent? DescendantOfType(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string contentTypeAlias,
+        string? culture = null) =>
+        DescendantOfType(
+            content,
+            variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            contentTypeAlias,
+            culture);
 
+
+    public static T? Descendant<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.EnumerateDescendants(
+                variationContextAccessor,
+                GetPublishedCache(content),
+                GetNavigationQueryService(content),
+                publishStatusQueryService,
+                false,
+                culture)
+            .FirstOrDefault(x => x is T) as T;
+
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
     public static T? Descendant<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.EnumerateDescendants(variationContextAccessor, GetPublishedCache(content),
-            GetNavigationQueryService(content), false, culture).FirstOrDefault(x => x is T) as T;
+        Descendant<T>(
+            content,
+            variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            culture);
 
 
+    public static T? Descendant<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
+        int level,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.Descendant(
+            variationContextAccessor,
+            GetPublishedCache(content),
+            GetNavigationQueryService(content),
+            publishStatusQueryService,
+            level,
+            culture) as T;
+
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
     public static T? Descendant<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         int level,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.Descendant(variationContextAccessor, GetPublishedCache(content),
-            GetNavigationQueryService(content), level, culture) as T;
+        Descendant<T>(
+            content,
+            variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            level,
+            culture);
 
 
     public static IPublishedContent? DescendantOrSelf(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
         int level,
         string? culture = null) => content
-        .EnumerateDescendants(variationContextAccessor, GetPublishedCache(content),
-            GetNavigationQueryService(content), true, culture).FirstOrDefault(x => x.Level == level);
+        .EnumerateDescendants(
+            variationContextAccessor,
+            GetPublishedCache(content),
+            GetNavigationQueryService(content),
+            publishStatusQueryService,
+            true,
+            culture).FirstOrDefault(x => x.Level == level);
+
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
+    public static IPublishedContent? DescendantOrSelf(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        int level,
+        string? culture = null) => DescendantOrSelf(content, variationContextAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(), level, culture);
 
 
     public static IPublishedContent? DescendantOrSelfOfType(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
         string contentTypeAlias,
         string? culture = null) => content
             .EnumerateDescendantsOrSelfInternal(
                 variationContextAccessor,
                 GetPublishedCache(content),
                 GetNavigationQueryService(content),
+                publishStatusQueryService,
                 culture,
                 true,
                 contentTypeAlias)
             .FirstOrDefault();
 
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
+    public static IPublishedContent? DescendantOrSelfOfType(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        string contentTypeAlias,
+        string? culture = null) =>
+        DescendantOrSelfOfType(
+            content,
+            variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            contentTypeAlias,
+            culture);
 
+
+    public static T? DescendantOrSelf<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.EnumerateDescendants(
+                variationContextAccessor,
+                GetPublishedCache(content),
+                GetNavigationQueryService(content),
+                publishStatusQueryService,
+                true,
+                culture).FirstOrDefault(x => x is T) as T;
+
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
     public static T? DescendantOrSelf<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.EnumerateDescendants(variationContextAccessor, GetPublishedCache(content),
-            GetNavigationQueryService(content), true, culture).FirstOrDefault(x => x is T) as T;
+        DescendantOrSelf<T>(
+            content,
+            variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            culture);
 
+    public static T? DescendantOrSelf<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishStatusQueryService publishStatusQueryService,
+        int level,
+        string? culture = null)
+        where T : class, IPublishedContent =>
+        content.DescendantOrSelf(variationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), publishStatusQueryService, level, culture) as T;
 
+    [Obsolete("Use the overload with IPublishStatusQueryService, scheduled for removal in v17")]
     public static T? DescendantOrSelf<T>(
         this IPublishedContent content,
         IVariationContextAccessor variationContextAccessor,
         int level,
         string? culture = null)
         where T : class, IPublishedContent =>
-        content.DescendantOrSelf(variationContextAccessor, GetPublishedCache(content),
-            GetNavigationQueryService(content), level, culture) as T;
+        DescendantOrSelf<T>(
+            content,
+            variationContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>(),
+            level,
+            culture);
 
 
 
@@ -2838,6 +3630,7 @@ public static class PublishedContentExtensions
         IVariationContextAccessor variationContextAccessor,
         IPublishedCache publishedCache,
         INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
         string? culture,
         bool orSelf,
         string? contentTypeAlias = null)
@@ -2859,7 +3652,9 @@ public static class PublishedContentExtensions
             yield break;
         }
 
+        culture ??= variationContextAccessor?.VariationContext?.Culture ?? string.Empty;
         IEnumerable<IPublishedContent> descendants = descendantsKeys
+            .Where(x => publishStatusQueryService.IsDocumentPublished(x, culture))
             .Select(publishedCache.GetById)
             .WhereNotNull()
             .FilterByCulture(culture, variationContextAccessor);

--- a/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
@@ -3159,8 +3159,10 @@ public static class PublishedContentExtensions
     ///     Gets the root content (ancestor or self at level 1) for the specified <paramref name="content" />.
     /// </summary>
     /// <param name="content">The content.</param>
+    /// <param name="variationContextAccessor"></param>
     /// <param name="publishedCache">The content cache.</param>
     /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
+    /// <param name="publishStatusQueryService"></param>
     /// <returns>
     ///     The root content (ancestor or self at level 1) for the specified <paramref name="content" />.
     /// </returns>
@@ -3171,8 +3173,63 @@ public static class PublishedContentExtensions
     /// </remarks>
     public static IPublishedContent Root(
         this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
         IPublishedCache publishedCache,
-        INavigationQueryService navigationQueryService) => content.AncestorOrSelf(publishedCache, navigationQueryService, 1);
+        INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService) => content.AncestorOrSelf(variationContextAccessor, publishedCache, navigationQueryService, publishStatusQueryService, 1);
+
+    /// <summary>
+    ///     Gets the root content (ancestor or self at level 1) for the specified <paramref name="content" />.
+    /// </summary>
+    /// <param name="content">The content.</param>
+    /// <param name="publishedCache">The content cache.</param>
+    /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
+    /// <returns>
+    ///     The root content (ancestor or self at level 1) for the specified <paramref name="content" />.
+    /// </returns>
+    /// <remarks>
+    ///     This is the same as calling
+    ///     <see cref="AncestorOrSelf(IPublishedContent, int)" /> with <c>maxLevel</c>
+    ///     set to 1.
+    /// </remarks>
+    [Obsolete("Use the overload with IVariationContextAccessor & IPublishStatusQueryService, scheduled for removal in v17")]
+    public static IPublishedContent Root(
+        this IPublishedContent content,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService) => Root(
+            content,
+            StaticServiceProvider.Instance.GetRequiredService<IVariationContextAccessor>(),
+            publishedCache,
+            navigationQueryService,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>());
+
+    /// <summary>
+    ///     Gets the root content (ancestor or self at level 1) for the specified <paramref name="content" /> if it's of the
+    ///     specified content type <typeparamref name="T" />.
+    /// </summary>
+    /// <typeparam name="T">The content type.</typeparam>
+    /// <param name="content">The content.</param>
+    /// <param name="variationContextAccessor"></param>
+    /// <param name="publishedCache">The content cache.</param>
+    /// <param name="navigationQueryService">The query service for the in-memory navigation structure.</param>
+    /// <param name="publishStatusQueryService"></param>
+    /// <returns>
+    ///     The root content (ancestor or self at level 1) for the specified <paramref name="content" /> of content type
+    ///     <typeparamref name="T" />.
+    /// </returns>
+    /// <remarks>
+    ///     This is the same as calling
+    ///     <see cref="AncestorOrSelf{T}(IPublishedContent, int)" /> with
+    ///     <c>maxLevel</c> set to 1.
+    /// </remarks>
+    public static T? Root<T>(
+        this IPublishedContent content,
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService)
+        where T : class, IPublishedContent =>
+        content.AncestorOrSelf<T>(variationContextAccessor, publishedCache, navigationQueryService, publishStatusQueryService, 1);
 
     /// <summary>
     ///     Gets the root content (ancestor or self at level 1) for the specified <paramref name="content" /> if it's of the
@@ -3191,12 +3248,18 @@ public static class PublishedContentExtensions
     ///     <see cref="AncestorOrSelf{T}(IPublishedContent, int)" /> with
     ///     <c>maxLevel</c> set to 1.
     /// </remarks>
+    [Obsolete("Use the overload with IVariationContextAccessor & PublishStatusQueryService, scheduled for removal in v17")]
     public static T? Root<T>(
         this IPublishedContent content,
         IPublishedCache publishedCache,
         INavigationQueryService navigationQueryService)
         where T : class, IPublishedContent =>
-        content.AncestorOrSelf<T>(publishedCache, navigationQueryService, 1);
+        Root<T>(
+            content,
+            StaticServiceProvider.Instance.GetRequiredService<IVariationContextAccessor>(),
+            publishedCache,
+            navigationQueryService,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>());
 
     #endregion
 

--- a/src/Umbraco.Core/Services/PublishStatus/PublishStatusService.cs
+++ b/src/Umbraco.Core/Services/PublishStatus/PublishStatusService.cs
@@ -1,5 +1,7 @@
 using System.Collections.Concurrent;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Scoping;
 
@@ -10,15 +12,31 @@ public class PublishStatusService : IPublishStatusManagementService, IPublishSta
     private readonly ILogger<PublishStatusService> _logger;
     private readonly IPublishStatusRepository _publishStatusRepository;
     private readonly ICoreScopeProvider _coreScopeProvider;
+    private readonly ILanguageService _languageService;
     private readonly IDictionary<Guid, ISet<string>> _publishedCultures = new Dictionary<Guid, ISet<string>>();
+
+    private string? DefaultCulture { get; set; }
+
+    [Obsolete("Use non-obsolete constructor. This will be removed in Umbraco 17.")]
     public PublishStatusService(
         ILogger<PublishStatusService> logger,
         IPublishStatusRepository publishStatusRepository,
         ICoreScopeProvider coreScopeProvider)
+        : this(logger, publishStatusRepository, coreScopeProvider, StaticServiceProvider.Instance.GetRequiredService<LanguageService>())
+    {
+
+    }
+
+    public PublishStatusService(
+        ILogger<PublishStatusService> logger,
+        IPublishStatusRepository publishStatusRepository,
+        ICoreScopeProvider coreScopeProvider,
+        ILanguageService languageService)
     {
         _logger = logger;
         _publishStatusRepository = publishStatusRepository;
         _coreScopeProvider = coreScopeProvider;
+        _languageService = languageService;
     }
 
     public async Task InitializeAsync(CancellationToken cancellationToken)
@@ -39,11 +57,16 @@ public class PublishStatusService : IPublishStatusManagementService, IPublishSta
             }
         }
 
-
+        DefaultCulture = await _languageService.GetDefaultIsoCodeAsync();
     }
 
     public bool IsDocumentPublished(Guid documentKey, string culture)
     {
+        if (string.IsNullOrEmpty(culture) && DefaultCulture is not null)
+        {
+            culture = DefaultCulture;
+        }
+
         if (_publishedCultures.TryGetValue(documentKey, out ISet<string>? publishedCultures))
         {
             return publishedCultures.Contains(culture, StringComparer.InvariantCultureIgnoreCase);

--- a/src/Umbraco.Core/Services/PublishStatus/PublishStatusService.cs
+++ b/src/Umbraco.Core/Services/PublishStatus/PublishStatusService.cs
@@ -22,7 +22,7 @@ public class PublishStatusService : IPublishStatusManagementService, IPublishSta
         ILogger<PublishStatusService> logger,
         IPublishStatusRepository publishStatusRepository,
         ICoreScopeProvider coreScopeProvider)
-        : this(logger, publishStatusRepository, coreScopeProvider, StaticServiceProvider.Instance.GetRequiredService<LanguageService>())
+        : this(logger, publishStatusRepository, coreScopeProvider, StaticServiceProvider.Instance.GetRequiredService<ILanguageService>())
     {
 
     }

--- a/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs
@@ -67,6 +67,9 @@ public static class FriendlyPublishedContentExtensions
     private static IMemberTypeService MemberTypeService { get; } =
         StaticServiceProvider.Instance.GetRequiredService<IMemberTypeService>();
 
+    private static IPublishStatusQueryService PublishStatusQueryService { get; } =
+        StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>();
+
     private static INavigationQueryService GetNavigationQueryService(IPublishedContent content)
     {
         switch (content.ContentType.ItemType)
@@ -468,7 +471,7 @@ public static class FriendlyPublishedContentExtensions
     ///     </para>
     /// </remarks>
     public static IEnumerable<IPublishedContent> Children(this IPublishedContent content, string? culture = null)
-        => content.Children(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
+        => content.Children(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, culture);
 
     /// <summary>
     ///     Gets the children of the content, filtered by a predicate.
@@ -487,7 +490,7 @@ public static class FriendlyPublishedContentExtensions
         this IPublishedContent content,
         Func<IPublishedContent, bool> predicate,
         string? culture = null)
-        => content.Children(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), predicate, culture);
+        => content.Children(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, predicate, culture);
 
     /// <summary>
     ///     Gets the children of the content, of any of the specified types.
@@ -500,7 +503,7 @@ public static class FriendlyPublishedContentExtensions
     /// <param name="contentTypeAlias">The content type alias.</param>
     /// <returns>The children of the content, of any of the specified types.</returns>
     public static IEnumerable<IPublishedContent>? ChildrenOfType(this IPublishedContent content, string contentTypeAlias, string? culture = null)
-        => content.ChildrenOfType(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias, culture);
+        => content.ChildrenOfType(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, contentTypeAlias, culture);
 
     /// <summary>
     ///     Gets the children of the content, of a given content type.
@@ -517,30 +520,30 @@ public static class FriendlyPublishedContentExtensions
     /// </remarks>
     public static IEnumerable<T>? Children<T>(this IPublishedContent content, string? culture = null)
         where T : class, IPublishedContent
-        => content.Children<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
+        => content.Children<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, culture);
 
     public static IPublishedContent? FirstChild(this IPublishedContent content, string? culture = null)
-        => content.FirstChild(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
+        => content.FirstChild(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, culture);
 
     /// <summary>
     ///     Gets the first child of the content, of a given content type.
     /// </summary>
     public static IPublishedContent? FirstChildOfType(this IPublishedContent content, string contentTypeAlias, string? culture = null)
-        => content.FirstChildOfType(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias, culture);
+        => content.FirstChildOfType(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, contentTypeAlias, culture);
 
     public static IPublishedContent? FirstChild(this IPublishedContent content, Func<IPublishedContent, bool> predicate, string? culture = null)
-        => content.FirstChild(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), predicate, culture);
+        => content.FirstChild(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, predicate, culture);
 
     public static IPublishedContent? FirstChild(this IPublishedContent content, Guid uniqueId, string? culture = null)
-        => content.FirstChild(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), uniqueId, culture);
+        => content.FirstChild(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, uniqueId, culture);
 
     public static T? FirstChild<T>(this IPublishedContent content, string? culture = null)
         where T : class, IPublishedContent
-        => content.FirstChild<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
+        => content.FirstChild<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, culture);
 
     public static T? FirstChild<T>(this IPublishedContent content, Func<T, bool> predicate, string? culture = null)
         where T : class, IPublishedContent
-        => content.FirstChild(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), predicate, culture);
+        => content.FirstChild(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, predicate, culture);
 
     /// <summary>
     ///     Gets the siblings of the content.

--- a/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs
@@ -289,7 +289,7 @@ public static class FriendlyPublishedContentExtensions
     /// <returns>The ancestors of the content, in down-top order.</returns>
     /// <remarks>Does not consider the content itself.</remarks>
     public static IEnumerable<IPublishedContent> Ancestors(this IPublishedContent content)
-        => content.Ancestors(GetPublishedCache(content), GetNavigationQueryService(content));
+        => content.Ancestors(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService);
 
     /// <summary>
     ///     Gets the content and its ancestors.
@@ -297,7 +297,7 @@ public static class FriendlyPublishedContentExtensions
     /// <param name="content">The content.</param>
     /// <returns>The content and its ancestors, in down-top order.</returns>
     public static IEnumerable<IPublishedContent> AncestorsOrSelf(this IPublishedContent content)
-        => content.AncestorsOrSelf(GetPublishedCache(content), GetNavigationQueryService(content));
+        => content.AncestorsOrSelf(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService);
 
     /// <summary>
     ///     Gets the content and its ancestors, of a specified content type.
@@ -308,7 +308,7 @@ public static class FriendlyPublishedContentExtensions
     /// <remarks>May or may not begin with the content itself, depending on its content type.</remarks>
     public static IEnumerable<T> AncestorsOrSelf<T>(this IPublishedContent content)
         where T : class, IPublishedContent
-        => content.AncestorsOrSelf<T>(GetPublishedCache(content), GetNavigationQueryService(content));
+        => content.AncestorsOrSelf<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService);
 
     /// <summary>
     ///     Gets the ancestor of the content, i.e. its parent.
@@ -327,7 +327,7 @@ public static class FriendlyPublishedContentExtensions
     /// <remarks>Does not consider the content itself. May return <c>null</c>.</remarks>
     public static T? Ancestor<T>(this IPublishedContent content)
         where T : class, IPublishedContent
-        => content.Ancestor<T>(GetPublishedCache(content), GetNavigationQueryService(content));
+        => content.Ancestor<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService);
 
     /// <summary>
     ///     Gets the content or its nearest ancestor, of a specified content type.
@@ -338,7 +338,7 @@ public static class FriendlyPublishedContentExtensions
     /// <remarks>May or may not return the content itself depending on its content type. May return <c>null</c>.</remarks>
     public static T? AncestorOrSelf<T>(this IPublishedContent content)
         where T : class, IPublishedContent
-        => content.AncestorOrSelf<T>(GetPublishedCache(content), GetNavigationQueryService(content));
+        => content.AncestorOrSelf<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService);
 
     /// <summary>
     ///     Returns all DescendantsOrSelf of all content referenced

--- a/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs
@@ -558,7 +558,7 @@ public static class FriendlyPublishedContentExtensions
     ///     <para>Note that in V7 this method also return the content node self.</para>
     /// </remarks>
     public static IEnumerable<IPublishedContent>? Siblings(this IPublishedContent content, string? culture = null)
-        => content.Siblings(GetPublishedCache(content), GetNavigationQueryService(content), VariationContextAccessor, culture);
+        => content.Siblings(GetPublishedCache(content), GetNavigationQueryService(content), VariationContextAccessor, PublishStatusQueryService, culture);
 
     /// <summary>
     ///     Gets the siblings of the content, of a given content type.
@@ -574,7 +574,7 @@ public static class FriendlyPublishedContentExtensions
     ///     <para>Note that in V7 this method also return the content node self.</para>
     /// </remarks>
     public static IEnumerable<IPublishedContent>? SiblingsOfType(this IPublishedContent content, string contentTypeAlias, string? culture = null)
-        => content.SiblingsOfType(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias, culture);
+        => content.SiblingsOfType(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, contentTypeAlias, culture);
 
     /// <summary>
     ///     Gets the siblings of the content, of a given content type.
@@ -591,7 +591,7 @@ public static class FriendlyPublishedContentExtensions
     /// </remarks>
     public static IEnumerable<T>? Siblings<T>(this IPublishedContent content, string? culture = null)
         where T : class, IPublishedContent
-        => content.Siblings<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
+        => content.Siblings<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, culture);
 
     /// <summary>
     ///     Gets the siblings of the content including the node itself to indicate the position.
@@ -605,7 +605,7 @@ public static class FriendlyPublishedContentExtensions
     public static IEnumerable<IPublishedContent>? SiblingsAndSelf(
         this IPublishedContent content,
         string? culture = null)
-        => content.SiblingsAndSelf(GetPublishedCache(content), GetNavigationQueryService(content), VariationContextAccessor, culture);
+        => content.SiblingsAndSelf(GetPublishedCache(content), GetNavigationQueryService(content), VariationContextAccessor, PublishStatusQueryService, culture);
 
     /// <summary>
     ///     Gets the siblings of the content including the node itself to indicate the position, of a given content type.
@@ -621,7 +621,7 @@ public static class FriendlyPublishedContentExtensions
         this IPublishedContent content,
         string contentTypeAlias,
         string? culture = null)
-        => content.SiblingsAndSelfOfType(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias, culture);
+        => content.SiblingsAndSelfOfType(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, contentTypeAlias, culture);
 
     /// <summary>
     ///     Gets the siblings of the content including the node itself to indicate the position, of a given content type.
@@ -635,7 +635,7 @@ public static class FriendlyPublishedContentExtensions
     /// <returns>The siblings of the content including the node itself, of the given content type.</returns>
     public static IEnumerable<T>? SiblingsAndSelf<T>(this IPublishedContent content, string? culture = null)
         where T : class, IPublishedContent
-        => content.SiblingsAndSelf<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
+        => content.SiblingsAndSelf<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, culture);
 
     /// <summary>
     ///     Gets the url of the content item.

--- a/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs
@@ -355,7 +355,7 @@ public static class FriendlyPublishedContentExtensions
     /// </remarks>
     public static IEnumerable<IPublishedContent> DescendantsOrSelfOfType(
         this IEnumerable<IPublishedContent> parentNodes, string docTypeAlias, string? culture = null)
-        => parentNodes.DescendantsOrSelfOfType(VariationContextAccessor, GetPublishedCache(parentNodes.First()), GetNavigationQueryService(parentNodes.First()), docTypeAlias, culture);
+        => parentNodes.DescendantsOrSelfOfType(VariationContextAccessor, GetPublishedCache(parentNodes.First()), GetNavigationQueryService(parentNodes.First()), PublishStatusQueryService, docTypeAlias, culture);
 
     /// <summary>
     ///     Returns all DescendantsOrSelf of all content referenced
@@ -373,77 +373,77 @@ public static class FriendlyPublishedContentExtensions
         this IEnumerable<IPublishedContent> parentNodes,
         string? culture = null)
         where T : class, IPublishedContent
-        => parentNodes.DescendantsOrSelf<T>(VariationContextAccessor, GetPublishedCache(parentNodes.First()), GetNavigationQueryService(parentNodes.First()), culture);
+        => parentNodes.DescendantsOrSelf<T>(VariationContextAccessor, GetPublishedCache(parentNodes.First()), GetNavigationQueryService(parentNodes.First()), PublishStatusQueryService, culture);
 
     public static IEnumerable<IPublishedContent> Descendants(this IPublishedContent content, string? culture = null)
-        => content.Descendants(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
+        => content.Descendants(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, culture);
 
     public static IEnumerable<IPublishedContent> Descendants(this IPublishedContent content, int level, string? culture = null)
-        => content.Descendants(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), level, culture);
+        => content.Descendants(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, level, culture);
 
     public static IEnumerable<IPublishedContent> DescendantsOfType(this IPublishedContent content, string contentTypeAlias, string? culture = null)
-        => content.DescendantsOfType(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias, culture);
+        => content.DescendantsOfType(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, contentTypeAlias, culture);
 
     public static IEnumerable<T> Descendants<T>(this IPublishedContent content, string? culture = null)
         where T : class, IPublishedContent
-        => content.Descendants<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
+        => content.Descendants<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, culture);
 
     public static IEnumerable<T> Descendants<T>(this IPublishedContent content, int level, string? culture = null)
         where T : class, IPublishedContent
-        => content.Descendants<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), level, culture);
+        => content.Descendants<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, level, culture);
 
     public static IEnumerable<IPublishedContent> DescendantsOrSelf(
         this IPublishedContent content,
         string? culture = null)
-        => content.DescendantsOrSelf(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
+        => content.DescendantsOrSelf(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, culture);
 
     public static IEnumerable<IPublishedContent> DescendantsOrSelf(this IPublishedContent content, int level, string? culture = null)
-        => content.DescendantsOrSelf(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), level, culture);
+        => content.DescendantsOrSelf(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, level, culture);
 
     public static IEnumerable<IPublishedContent> DescendantsOrSelfOfType(this IPublishedContent content, string contentTypeAlias, string? culture = null)
-        => content.DescendantsOrSelfOfType(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias, culture);
+        => content.DescendantsOrSelfOfType(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, contentTypeAlias, culture);
 
     public static IEnumerable<T> DescendantsOrSelf<T>(this IPublishedContent content, string? culture = null)
         where T : class, IPublishedContent
-        => content.DescendantsOrSelf<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
+        => content.DescendantsOrSelf<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, culture);
 
     public static IEnumerable<T> DescendantsOrSelf<T>(this IPublishedContent content, int level, string? culture = null)
         where T : class, IPublishedContent
-        => content.DescendantsOrSelf<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), level, culture);
+        => content.DescendantsOrSelf<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, level, culture);
 
     public static IPublishedContent? Descendant(this IPublishedContent content, string? culture = null)
-        => content.Descendant(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
+        => content.Descendant(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, culture);
 
     public static IPublishedContent? Descendant(this IPublishedContent content, int level, string? culture = null)
-        => content.Descendant(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), level, culture);
+        => content.Descendant(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, level, culture);
 
     public static IPublishedContent? DescendantOfType(this IPublishedContent content, string contentTypeAlias, string? culture = null)
-        => content.DescendantOfType(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias, culture);
+        => content.DescendantOfType(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, contentTypeAlias, culture);
 
     public static T? Descendant<T>(this IPublishedContent content, string? culture = null)
         where T : class, IPublishedContent
-        => content.Descendant<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
+        => content.Descendant<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, culture);
 
     public static T? Descendant<T>(this IPublishedContent content, int level, string? culture = null)
         where T : class, IPublishedContent
-        => content.Descendant<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), level, culture);
+        => content.Descendant<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, level, culture);
 
     public static IPublishedContent DescendantOrSelf(this IPublishedContent content, string? culture = null)
-        => content.DescendantOrSelf(VariationContextAccessor, culture);
+        => content.DescendantOrSelf(VariationContextAccessor, PublishStatusQueryService, culture);
 
     public static IPublishedContent? DescendantOrSelf(this IPublishedContent content, int level, string? culture = null)
-        => content.DescendantOrSelf(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), level, culture);
+        => content.DescendantOrSelf(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, level, culture);
 
     public static IPublishedContent? DescendantOrSelfOfType(this IPublishedContent content, string contentTypeAlias, string? culture = null)
-        => content.DescendantOrSelfOfType(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), contentTypeAlias, culture);
+        => content.DescendantOrSelfOfType(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, contentTypeAlias, culture);
 
     public static T? DescendantOrSelf<T>(this IPublishedContent content, string? culture = null)
         where T : class, IPublishedContent
-        => content.DescendantOrSelf<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), culture);
+        => content.DescendantOrSelf<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, culture);
 
     public static T? DescendantOrSelf<T>(this IPublishedContent content, int level, string? culture = null)
         where T : class, IPublishedContent
-        => content.DescendantOrSelf<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), level, culture);
+        => content.DescendantOrSelf<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService, level, culture);
 
     /// <summary>
     ///     Gets the children of the content item.

--- a/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs
@@ -243,7 +243,7 @@ public static class FriendlyPublishedContentExtensions
     ///     set to 1.
     /// </remarks>
     public static IPublishedContent Root(this IPublishedContent content)
-        => content.Root(GetPublishedCache(content), GetNavigationQueryService(content));
+        => content.Root(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService);
 
     /// <summary>
     ///     Gets the root content (ancestor or self at level 1) for the specified <paramref name="content" /> if it's of the
@@ -262,7 +262,7 @@ public static class FriendlyPublishedContentExtensions
     /// </remarks>
     public static T? Root<T>(this IPublishedContent content)
         where T : class, IPublishedContent
-        => content.Root<T>(GetPublishedCache(content), GetNavigationQueryService(content));
+        => content.Root<T>(VariationContextAccessor, GetPublishedCache(content), GetNavigationQueryService(content), PublishStatusQueryService);
 
     /// <summary>
     ///     Gets the parent of the content item.

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/PublishStatusServiceTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/PublishStatusServiceTest.cs
@@ -98,7 +98,9 @@ public class PublishStatusServiceTest : UmbracoIntegrationTestWithContent
         var sut = new PublishStatusService(
             GetRequiredService<ILogger<PublishStatusService>>(),
             GetRequiredService<IPublishStatusRepository>(),
-            GetRequiredService<ICoreScopeProvider>());
+            GetRequiredService<ICoreScopeProvider>(),
+            GetRequiredService<ILanguageService>()
+            );
 
         Assert.IsFalse(sut.IsDocumentPublished(Textpage.Key, DefaultCulture));
 
@@ -118,7 +120,8 @@ public class PublishStatusServiceTest : UmbracoIntegrationTestWithContent
         var sut = new PublishStatusService(
             GetRequiredService<ILogger<PublishStatusService>>(),
             GetRequiredService<IPublishStatusRepository>(),
-            GetRequiredService<ICoreScopeProvider>());
+            GetRequiredService<ICoreScopeProvider>(),
+            GetRequiredService<ILanguageService>());
 
         Assert.IsFalse(sut.IsDocumentPublished(Textpage.Key, DefaultCulture));
 

--- a/tests/Umbraco.Tests.UnitTests/AutoFixture/Customizations/UmbracoCustomizations.cs
+++ b/tests/Umbraco.Tests.UnitTests/AutoFixture/Customizations/UmbracoCustomizations.cs
@@ -11,6 +11,7 @@ using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Install;
@@ -34,7 +35,8 @@ internal class UmbracoCustomizations : ICustomization
             .Customize(new ConstructorCustomization(typeof(DatabaseSchemaCreatorFactory), new GreedyConstructorQuery()))
             .Customize(new ConstructorCustomization(typeof(InstallHelper), new GreedyConstructorQuery()))
             .Customize(new ConstructorCustomization(typeof(DatabaseBuilder), new GreedyConstructorQuery()))
-            .Customize(new ConstructorCustomization(typeof(ContentVersionService), new GreedyConstructorQuery()));
+            .Customize(new ConstructorCustomization(typeof(ContentVersionService), new GreedyConstructorQuery()))
+            .Customize(new ConstructorCustomization(typeof(ContentFinderByUrlAlias), new GreedyConstructorQuery()));
 
         // When requesting an IUserStore ensure we actually uses a IUserLockoutStore
         fixture.Customize<IUserStore<BackOfficeIdentityUser>>(cc =>

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ContentRouteBuilderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ContentRouteBuilderTests.cs
@@ -429,9 +429,10 @@ public class ContentRouteBuilderTests : DeliveryApiTests
     {
         var variantContextAccessor = Mock.Of<IVariationContextAccessor>();
 
+
         string Url(IPublishedContent content, string? culture)
         {
-            var ancestorsOrSelf = content.AncestorsOrSelf(contentCache, navigationQueryService).ToArray();
+            var ancestorsOrSelf = content.AncestorsOrSelf(variantContextAccessor, contentCache, navigationQueryService, PublishStatusQueryService).ToArray();
             return ancestorsOrSelf.All(c => c.IsPublished(culture))
                 ? string.Join("/", ancestorsOrSelf.Reverse().Skip(hideTopLevelNodeFromPath ? 1 : 0).Select(c => c.UrlSegment(variantContextAccessor, culture))).EnsureStartsWith("/")
                 : "#";

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/DeliveryApiTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/DeliveryApiTests.cs
@@ -20,6 +20,8 @@ public class DeliveryApiTests
 
     protected IPublishedPropertyType DefaultPropertyType { get; private set; }
 
+    protected IPublishStatusQueryService PublishStatusQueryService { get; private set; }
+
     [SetUp]
     public virtual void Setup()
     {
@@ -57,6 +59,13 @@ public class DeliveryApiTests
         defaultPropertyValueConverter.Setup(p => p.GetPropertyCacheLevel(It.IsAny<IPublishedPropertyType>())).Returns(PropertyCacheLevel.None);
 
         DefaultPropertyType = SetupPublishedPropertyType(defaultPropertyValueConverter.Object, "default", "Default.Editor");
+
+        var publishStatusQueryService = new Mock<IPublishStatusQueryService>();
+        publishStatusQueryService
+            .Setup(x => x.IsDocumentPublished(It.IsAny<Guid>(), It.IsAny<string>()))
+            .Returns(true);
+
+        PublishStatusQueryService = publishStatusQueryService.Object;
     }
 
     protected IPublishedPropertyType SetupPublishedPropertyType(IPropertyValueConverter valueConverter, string propertyTypeAlias, string editorAlias, object? dataTypeConfiguration = null)
@@ -117,7 +126,8 @@ public class DeliveryApiTests
         IRequestPreviewService? requestPreviewService = null,
         IOptionsMonitor<RequestHandlerSettings>? requestHandlerSettingsMonitor = null,
         IPublishedContentCache? contentCache = null,
-        IDocumentNavigationQueryService? navigationQueryService = null)
+        IDocumentNavigationQueryService? navigationQueryService = null,
+        IPublishStatusQueryService? publishStatusQueryService = null)
     {
         if (requestHandlerSettingsMonitor == null)
         {
@@ -133,6 +143,7 @@ public class DeliveryApiTests
             requestPreviewService ?? Mock.Of<IRequestPreviewService>(),
             requestHandlerSettingsMonitor,
             contentCache ?? Mock.Of<IPublishedContentCache>(),
-            navigationQueryService ?? Mock.Of<IDocumentNavigationQueryService>());
+            navigationQueryService ?? Mock.Of<IDocumentNavigationQueryService>(),
+            publishStatusQueryService ?? PublishStatusQueryService);
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByUrlAliasTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByUrlAliasTests.cs
@@ -7,6 +7,7 @@ using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.Navigation;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Tests.UnitTests.AutoFixture;
 
@@ -30,6 +31,7 @@ public class ContentFinderByUrlAliasTests
         [Frozen] IUmbracoContextAccessor umbracoContextAccessor,
         [Frozen] IUmbracoContext umbracoContext,
         [Frozen] IVariationContextAccessor variationContextAccessor,
+        [Frozen] IPublishStatusQueryService publishStatusQueryService,
         IFileService fileService,
         ContentFinderByUrlAlias sut,
         IPublishedContent[] rootContents,
@@ -48,6 +50,7 @@ public class ContentFinderByUrlAliasTests
         Mock.Get(urlProperty).Setup(x => x.GetValue(null, null)).Returns(relativeUrl);
 
         Mock.Get(variationContextAccessor).Setup(x => x.VariationContext).Returns(variationContext);
+        Mock.Get(publishStatusQueryService).Setup(x => x.IsDocumentPublished(It.IsAny<Guid>(), It.IsAny<string>())).Returns(true);
         var publishedRequestBuilder = new PublishedRequestBuilder(new Uri(absoluteUrl, UriKind.Absolute), fileService);
 
         // Act

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlImageSourceParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlImageSourceParserTests.cs
@@ -99,7 +99,8 @@ public class HtmlImageSourceParserTests
             new MediaUrlProviderCollection(() => new[] { mediaUrlProvider.Object }),
             Mock.Of<IVariationContextAccessor>(),
             Mock.Of<IPublishedContentCache>(),
-            Mock.Of<IDocumentNavigationQueryService>());
+            Mock.Of<IDocumentNavigationQueryService>(),
+            Mock.Of<IPublishStatusQueryService>());
 
         using (var reference = umbracoContextFactory.EnsureUmbracoContext())
         {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
@@ -235,6 +235,11 @@ public class HtmlLocalLinkParserTests
             mediaCache.Setup(x => x.GetById(It.IsAny<int>())).Returns(media.Object);
             mediaCache.Setup(x => x.GetById(It.IsAny<Guid>())).Returns(media.Object);
 
+            var publishStatusQueryService = new Mock<IPublishStatusQueryService>();
+            publishStatusQueryService
+                .Setup(x => x.IsDocumentPublished(It.IsAny<Guid>(), It.IsAny<string>()))
+                .Returns(true);
+
             var publishedUrlProvider = new UrlProvider(
                 umbracoContextAccessor,
                 Options.Create(webRoutingSettings),
@@ -242,7 +247,8 @@ public class HtmlLocalLinkParserTests
                 new MediaUrlProviderCollection(() => new[] { mediaUrlProvider.Object }),
                 Mock.Of<IVariationContextAccessor>(),
                 contentCache.Object,
-                navigationQueryService.Object);
+                navigationQueryService.Object,
+                publishStatusQueryService.Object);
 
             var linkParser = new HtmlLocalLinkParser(publishedUrlProvider);
 


### PR DESCRIPTION
FIxes https://github.com/umbraco/Umbraco-CMS/issues/17768

# Notes 
- We stopped caching null values with https://github.com/umbraco/Umbraco-CMS/pull/17727, this uncovered a bug with all our FriendlyPublishedContentExtensions, as it would not filter by only published content
- This PR refactors every single one of those (and obsoleted the old ones), to use the `IPublishStatusQuery` service, to check if a given key is published or not, this turns a 30s operation into 0.5s (and this is cached), and after caching, down to 1-10ms depending on size 😁 

# How to test
- Create a doc type with allow as root set to true
- Create a doc type named "Child"
- Allow "Child" as child on the first doc type
- Create a parent node
- Create 500 child nodes
- Try using the methods, like `Children` or `Descendants` it should no longer take multiple seconds
- Here is some sample code to help with creation of child nodes, and quering of `.Children`
```
using Microsoft.AspNetCore.Mvc;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.PublishedCache;
using Umbraco.Cms.Core.Services;

namespace Umbraco.Cms.Web.UI;

[ApiController]
[Route("[controller]/[action]")]
public class TestController : Controller
{
    private readonly IPublishedContentCache _publishedContentCache;
    private readonly IContentService _contentService;

    public TestController(IPublishedContentCache publishedContentCache, IContentService contentService)
    {
        _publishedContentCache = publishedContentCache;
        _contentService = contentService;
    }

    [HttpGet]
    public IActionResult Index(Guid? parentKey)
    {
        var content = _publishedContentCache.GetByIdAsync(parentKey ?? new Guid("119b7b3d-f24e-4d27-af98-7b8d14d62f9c")).GetAwaiter().GetResult();

        var children = content?.Descendants();

        var count = children?.Count();
        return Ok(count);
    }

    [HttpGet]
    public IActionResult CreateTestContent(Guid? parentKey)
    {
        // Create a variable for the GUID of the parent page - Catalogue, where you want to add a child item.
        var parentId = parentKey ?? Guid.Parse("119b7b3d-f24e-4d27-af98-7b8d14d62f9c");

        for (int i = 1; i < 5000; i++)
        {
            // Create a new child item of type 'Product'
            IContent demoproduct = _contentService.Create($"Child {i}", parentId, "child");

            // Set the value of the property with alias 'category'
            demoproduct.SetValue("title" , "Title of child " + i);

            // Save and publish the child item
            _contentService.Save(demoproduct);
        }

        return Ok();
    }
}

```