### PR TITLE
hotfix: no need to redirect when removing tab. router handles this fine

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/content-type/workspace/views/design/content-type-design-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content-type/workspace/views/design/content-type-design-editor.element.ts
@@ -269,9 +269,8 @@ export class UmbContentTypeDesignEditorElement extends UmbLitElement implements 
 	#deleteTab(tabId?: string) {
 		if (!tabId) return;
 		this.#workspaceContext?.structure.removeContainer(null, tabId);
-		// TODO: We should only navigate away if it was the last tab and if it was the active one... [NL]
-		if (this.#tabsStructureHelper?.isOwnerChildContainer(tabId)) {
-			window.history.replaceState(null, '', this._routerPath + (this._routes[0]?.path ?? '/root'));
+		if (this._activeTabId === tabId) {
+			this._activeTabId = undefined;
 		}
 	}
 	async #addTab() {


### PR DESCRIPTION
Fixes issue when removing tab from a document type, but it was only a problem when user was on another tab than the one to be deleted.

Fixes #17771

see
https://umbraco.slack.com/archives/C027U315T54/p1733894530378609?thread_ts=1733894482.267889&cid=C027U315T54

Notice, the problem seemed to be a re-direct and this was not needed anymore, the router seems to handle this fine by its own redirects.

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
