### PR TITLE
V15: Check if language has changed when updating domains

### DIFF
--- a/src/Umbraco.Core/Services/DomainService.cs
+++ b/src/Umbraco.Core/Services/DomainService.cs
@@ -311,12 +311,17 @@ public class DomainService : RepositoryService, IDomainService
         var sortOrder = 0;
         foreach (DomainModel domainModel in updateModel.Domains)
         {
-            IDomain assignedDomain = currentlyAssignedDomains.FirstOrDefault(domain => domainModel.DomainName.InvariantEquals(domain.DomainName))
-                                     ?? new UmbracoDomain(domainModel.DomainName)
-                                     {
-                                         LanguageId = languageIdByIsoCode[domainModel.IsoCode],
-                                         RootContentId = contentId
-                                     };
+            IDomain? assignedDomain = currentlyAssignedDomains.FirstOrDefault(domain => domainModel.DomainName.InvariantEquals(domain.DomainName));
+
+            // If we do not have an assigned domain, or the domain-language has been changed, create new domain.
+            if (assignedDomain is null || assignedDomain.LanguageId != languageIdByIsoCode[domainModel.IsoCode])
+            {
+                assignedDomain = new UmbracoDomain(domainModel.DomainName)
+                {
+                    LanguageId = languageIdByIsoCode[domainModel.IsoCode],
+                    RootContentId = contentId
+                };
+            }
 
             assignedDomain.SortOrder = sortOrder++;
             newAssignedDomains.Add(assignedDomain);


### PR DESCRIPTION
# Notes
- Fixes issue found by @nhudinh0309, where you could not change the language on a domain.
- This happen because we did not change if the language changed, only if the domain name changed, this PR remedies that.


# How to test
- Create another language, so that you have at least 2
- Create a content type with allow as root set to true
- Create some content with that type
- On the document, go to culture and hostnames, and create 2 of the English language, for example `/en/test` & `/en/testtwo`
-  Now try switching on of them to another language, this should now work 🙌 