### PR TITLE
Don't overwrite ancestor configurations for public access

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/GetPublicAccessDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/GetPublicAccessDocumentController.cs
@@ -49,7 +49,7 @@ public class GetPublicAccessDocumentController : DocumentControllerBase
         }
 
         Attempt<PublicAccessEntry?, PublicAccessOperationStatus> accessAttempt =
-            await _publicAccessService.GetEntryByContentKeyAsync(id);
+            await _publicAccessService.GetEntryByContentKeyWithoutAncestorsAsync(id);
 
         if (accessAttempt.Success is false || accessAttempt.Result is null)
         {

--- a/src/Umbraco.Core/Services/IPublicAccessService.cs
+++ b/src/Umbraco.Core/Services/IPublicAccessService.cs
@@ -85,7 +85,22 @@ public interface IPublicAccessService : IService
     /// </summary>
     /// <param name="key"></param>
     /// <returns>Returns null if no entry is found</returns>
+    /// <remarks>
+    /// This method supports inheritance by considering ancestor entries (if any),
+    /// if no entry is found for the specified content key.
+    /// </remarks>
     Task<Attempt<PublicAccessEntry?, PublicAccessOperationStatus>> GetEntryByContentKeyAsync(Guid key);
+
+    /// <summary>
+    ///     Gets the entry defined for the content item based on a content key, without taking ancestor entries into account.
+    /// </summary>
+    /// <param name="key"></param>
+    /// <returns>Returns null if no entry is found</returns>
+    /// <remarks>
+    /// This method does not support inheritance. Use <see cref="GetEntryByContentKeyAsync"/> to include ancestor entries (if any).
+    /// </remarks>
+    Task<Attempt<PublicAccessEntry?, PublicAccessOperationStatus>> GetEntryByContentKeyWithoutAncestorsAsync(Guid key)
+        => Task.FromResult(Attempt.SucceedWithStatus<PublicAccessEntry?, PublicAccessOperationStatus>(PublicAccessOperationStatus.EntryNotFound, null));
 
     /// <summary>
     ///     Deletes the entry and all associated rules for a given key.

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/public-access/repository/public-access.server.data.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/public-access/repository/public-access.server.data.ts
@@ -1,7 +1,7 @@
 import { DocumentService } from '@umbraco-cms/backoffice/external/backend-api';
 import type { PublicAccessRequestModel } from '@umbraco-cms/backoffice/external/backend-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import {tryExecute, tryExecuteAndNotify} from '@umbraco-cms/backoffice/resources';
+import { tryExecute, tryExecuteAndNotify } from '@umbraco-cms/backoffice/resources';
 
 /**
  * A data source for the Document Public Access that fetches data from the server

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/public-access/repository/public-access.server.data.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/public-access/repository/public-access.server.data.ts
@@ -1,7 +1,7 @@
 import { DocumentService } from '@umbraco-cms/backoffice/external/backend-api';
 import type { PublicAccessRequestModel } from '@umbraco-cms/backoffice/external/backend-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import { tryExecuteAndNotify } from '@umbraco-cms/backoffice/resources';
+import {tryExecute, tryExecuteAndNotify} from '@umbraco-cms/backoffice/resources';
 
 /**
  * A data source for the Document Public Access that fetches data from the server
@@ -41,7 +41,9 @@ export class UmbDocumentPublicAccessServerDataSource {
 	 */
 	async read(unique: string) {
 		if (!unique) throw new Error('unique is missing');
-		return tryExecuteAndNotify(this.#host, DocumentService.getDocumentByIdPublicAccess({ id: unique }));
+		// NOTE: The entity will not be present, when fetching Public Access for a descendant of a protected Document.
+		//       This is a perfectly valid scenario, which is handled in the view. In other words, just use tryExecute here.
+		return tryExecute(DocumentService.getDocumentByIdPublicAccess({ id: unique }));
 	}
 
 	/**


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #17709

### Description

See the linked issue for a description and steps to reproduce 😃 

### Testing this PR

Verify that:

1. Public access can be _added_ and _updated_ in the structure below a protected document, without affecting the ancestor protection.
2. Public access can be _removed_ from the structure below a protected document, without affecting the ancestor protection.
3. Public access can be _removed_ from an ancestor document, without affecting any descendants with explicit public access configuration.