### PR TITLE
Make sure Examine dashboard still functions when an index is corrupt

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/ExamineManagementController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ExamineManagementController.cs
@@ -205,7 +205,7 @@ public class ExamineManagementController : UmbracoAuthorizedJsonController
             documentCount = indexDiag.GetDocumentCount();
             fieldCount = indexDiag.GetFieldNames().Count();
         }
-        catch (FileNotFoundException ex)
+        catch (Exception ex)
         {
             // Safe catch that will allow to rebuild a corrupted index
             documentCount = 0;


### PR DESCRIPTION
### Description
Improves the dashboard resilience reported in https://github.com/umbraco/Umbraco-CMS/issues/17114 for v13 and the logs hold better information when things go wrong with rebuilding