### PR TITLE
V13 Fixes #17646 where bold markdown does not work in a property description 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/filters/simpleMarkdown.filter.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/simpleMarkdown.filter.js
@@ -11,8 +11,8 @@ angular.module("umbraco.filters").filter('simpleMarkdown', function () {
     }
 
     return text
-      .replace(/\*\*(.*)\*\*/gim, '<b>$1</b>')
-      .replace(/\*(.*)\*/gim, '<i>$1</i>')
+      .replace(/\*\*(.+?)\*\*/gim, '<b>$1</b>')
+      .replace(/\*(.+?)\*/gim, '<i>$1</i>')
       .replace(/!\[(.*?)\]\((.*?)\)/gim, "<img alt='$1' src='$2' />")
       .replace(/\[(.*?)\]\((.*?)\)/gim, "<a href='$2' target='_blank' rel='noopener' class='underline'>$1</a>")
       .replace(/\n/g, '<br />').trim();

--- a/src/Umbraco.Web.UI.Client/src/common/filters/simpleMarkdown.filter.js.js
+++ b/src/Umbraco.Web.UI.Client/src/common/filters/simpleMarkdown.filter.js.js
@@ -11,8 +11,8 @@ angular.module("umbraco.filters").filter('simpleMarkdown', function () {
     }
 
     return text
-      .replace(/\*\*(.*)\*\*/gim, '<b>$1</b>')
-      .replace(/\*(.*)\*/gim, '<i>$1</i>')
+      .replace(/\*\*(.+?)\*\*/gim, '<b>$1</b>')
+      .replace(/\*(.+?)\*/gim, '<i>$1</i>')
       .replace(/!\[(.*?)\]\((.*?)\)/gim, "<img alt='$1' src='$2' />")
       .replace(/\[(.*?)\]\((.*?)\)/gim, "<a href='$2' target='_blank' class='underline'>$1</a>")
       .replace(/\n/g, '<br />').trim();


### PR DESCRIPTION
Fixed an issue where bold markdown would not work inside a property description #17646 

### Prerequisites

- [x] I have added steps to test this contribution in the description below



### Description

- Add a property description to a new or existing property which contains `**` around a couple of different words. 
- Save the document type.
- Go to Content and view an instance of that Document Type
- View the lovely formatted property description. Previously the style would break. This fix now renders the wrapped markdown words using `**` in bold.

![Screenshot 2024-12-12 at 13 48 39](https://github.com/user-attachments/assets/05bba6fb-c087-4bed-b0a2-e576454e4c4e)
