### PR TITLE
V13: Allow anonymous calls for `UmbLoginStatusController.HandleLogout` action

### DIFF
--- a/src/Umbraco.Web.Website/Controllers/UmbLoginStatusController.cs
+++ b/src/Umbraco.Web.Website/Controllers/UmbLoginStatusController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Logging;
@@ -29,6 +30,7 @@ public class UmbLoginStatusController : SurfaceController
         => _signInManager = signInManager;
 
     [HttpPost]
+    [AllowAnonymous]
     [ValidateAntiForgeryToken]
     [ValidateUmbracoFormRouteString]
     public async Task<IActionResult> HandleLogout([Bind(Prefix = "logoutModel")] PostRedirectModel model)


### PR DESCRIPTION
## Details
- Fixes: https://github.com/umbraco/Umbraco-CMS/issues/17013
- You can log out after the member you are logged in as has been deleted.

## Test
- Create `RegisterMember.cshtml` partial view from snippet;
- Create `Login.cshtml` partial view from snippet;
- Create `LoginStatus.cshtml` partial view from snippet;
- Create a doc type `contentPage` and in its template add:
```cshtml
@using Umbraco.Cms.Web.Common.PublishedModels;
@using Umbraco.Cms.Core.Services;
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<ContentModels.ContentPage>
@inject IMemberService MemberService
@using ContentModels = Umbraco.Cms.Web.Common.PublishedModels;
@{
	Layout = null;
	var isLoggedIn = Context.User?.Identity?.IsAuthenticated ?? false;
}

@if (!isLoggedIn)
{
    @await Html.PartialAsync("RegisterMember")
    <hr/>
    <br/>
    @await Html.PartialAsync("Login")
}
else
{
    @await Html.PartialAsync("LoginStatus")
}
```
- Register a member - you will be logged in;
- Verify that you can logout when the member still exists;
- Login again;
- Delete the member from the backoffice;
- Verify that you are able to logout with the member after deletion.