### PR TITLE
Fix mistakes in 15.0.0 migrations

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -105,5 +105,6 @@ public class UmbracoPlan : MigrationPlan
         To<V_15_0_0.ConvertRichTextEditorProperties>("{37875E80-5CDD-42FF-A21A-7D4E3E23E0ED}");
         To<V_15_0_0.ConvertLocalLinks>("{42E44F9E-7262-4269-922D-7310CB48E724}");
         To<V_15_1_0.RebuildCacheMigration>("{7B51B4DE-5574-4484-993E-05D12D9ED703}");
+        To<V_15_1_0.FixConvertLocalLinks>("{F3D3EF46-1B1F-47DB-B437-7D573EEDEB98}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertLocalLinks.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertLocalLinks.cs
@@ -131,6 +131,7 @@ public class ConvertLocalLinks : MigrationBase
         }
 
         _linkMigrationTracker.MarkFixedMigrationRan();
+        RebuildCache = true;
     }
 
     private bool ProcessPropertyTypes(IPropertyType[] propertyTypes, IDictionary<int, ILanguage> languagesById)

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/LocalLinks/ConvertLocalLinkComposer.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/LocalLinks/ConvertLocalLinkComposer.cs
@@ -13,5 +13,7 @@ public class ConvertLocalLinkComposer : IComposer
         builder.Services.AddSingleton<ITypedLocalLinkProcessor, LocalLinkBlockGridProcessor>();
         builder.Services.AddSingleton<ITypedLocalLinkProcessor, LocalLinkRteProcessor>();
         builder.Services.AddSingleton<LocalLinkProcessor>();
+        builder.Services.AddSingleton<LocalLinkProcessorForFaultyLinks>();
+        builder.Services.AddSingleton<LocalLinkMigrationTracker>();
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/LocalLinks/LocalLinkMigrationTracker.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/LocalLinks/LocalLinkMigrationTracker.cs
@@ -1,0 +1,8 @@
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_15_0_0.LocalLinks;
+
+public class LocalLinkMigrationTracker
+{
+    public bool HasFixedMigrationRun { get; private set; }
+
+    public void MarkFixedMigrationRan() => HasFixedMigrationRun = true;
+}

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_1_0/FixConvertLocalLinks.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_1_0/FixConvertLocalLinks.cs
@@ -108,6 +108,8 @@ public class FixConvertLocalLinks : MigrationBase
                     propertyEditorAlias);
             }
         }
+
+        RebuildCache = true;
     }
 
     private bool ProcessPropertyTypes(IPropertyType[] propertyTypes, IDictionary<int, ILanguage> languagesById)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/MigrationPlanTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/MigrationPlanTests.cs
@@ -71,13 +71,17 @@ public class MigrationPlanTests
             Mock.Of<IServerMessenger>(),
             new CacheRefresherCollection(() => Enumerable.Empty<ICacheRefresher>()));
 
+        var isolatedCaches = new IsolatedCaches(type => NoAppCache.Instance);
+
+        var appCaches = new AppCaches(Mock.Of<IAppPolicyCache>(), Mock.Of<IRequestCache>(), isolatedCaches);
+
         var executor = new MigrationPlanExecutor(
             scopeProvider,
             scopeProvider,
             loggerFactory,
             migrationBuilder,
             databaseFactory,
-            Mock.Of<IDatabaseCacheRebuilder>(), distributedCache, Mock.Of<IKeyValueService>(), Mock.Of<IServiceScopeFactory>());
+            Mock.Of<IDatabaseCacheRebuilder>(), distributedCache, Mock.Of<IKeyValueService>(), Mock.Of<IServiceScopeFactory>(), appCaches);
 
         var plan = new MigrationPlan("default")
             .From(string.Empty)


### PR DESCRIPTION
In v15.0.0, 2 migrations were introduced that dealt with RTE and Blocks. 
ConvertLocalLinks, which has an error regarding the string manipulation of locallinks that results in broken links.
ConvertRichTextEditorProperties, which has RTE markup transformation logic that is not executed on RTE's inside a nested structure (like blocks)

To fix this, this PR
- Updates the (original) LocalLinkRteProcessor that is ran recursively by the ConvertLocalLinks migration to execute the same markup transformation as ConvertRichTextEditorProperties
- Fixes LocalLinkProcessor to correctly transform the links
- Introduces LocalLinkProcessorForFaultyLinks that has a detector and fix for the very specifically identifiable incorrect locallink <a/> tags
- A secondary Migration that runs (a copy) of the locallinks migration (with the 2 fixes incorperated) if the previous migrations have not run yet in the same migration sessions.