### PR TITLE
V13: Clear username cache

### DIFF
--- a/src/Umbraco.Infrastructure/Cache/MemberRepositoryUsernameCachePolicy.cs
+++ b/src/Umbraco.Infrastructure/Cache/MemberRepositoryUsernameCachePolicy.cs
@@ -30,4 +30,10 @@ public class MemberRepositoryUsernameCachePolicy : DefaultRepositoryCachePolicy<
 
         return entity;
     }
+
+    public void DeleteByUserName(string key, string? username)
+    {
+        var cacheKey = GetEntityCacheKey(key + username);
+        Cache.ClearByKey(cacheKey);
+    }
 }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
@@ -38,6 +38,7 @@ public class MemberRepository : ContentRepositoryBase<int, IMember, MemberReposi
     private readonly ITagRepository _tagRepository;
     private bool _passwordConfigInitialized;
     private string? _passwordConfigJson;
+    private const string UsernameCacheKey = "uRepo_userNameKey+";
 
     public MemberRepository(
         IScopeAccessor scopeAccessor,
@@ -228,7 +229,7 @@ public class MemberRepository : ContentRepositoryBase<int, IMember, MemberReposi
     }
 
     public IMember? GetByUsername(string? username) =>
-        _memberByUsernameCachePolicy.GetByUserName("uRepo_userNameKey+", username, PerformGetByUsername, PerformGetAllByUsername);
+        _memberByUsernameCachePolicy.GetByUserName(UsernameCacheKey, username, PerformGetByUsername, PerformGetAllByUsername);
 
     public int[] GetMemberIds(string[] usernames)
     {
@@ -506,6 +507,12 @@ public class MemberRepository : ContentRepositoryBase<int, IMember, MemberReposi
         }
 
         return sql;
+    }
+
+    protected override void PersistDeletedItem(IMember entity)
+    {
+        _memberByUsernameCachePolicy.DeleteByUserName(UsernameCacheKey, entity.Username);
+        base.PersistDeletedItem(entity);
     }
 
     // TODO: move that one up to Versionable! or better: kill it!

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
@@ -844,6 +844,8 @@ public class MemberRepository : ContentRepositoryBase<int, IMember, MemberReposi
 
         OnUowRefreshedEntity(new MemberRefreshNotification(entity, new EventMessages()));
 
+        _memberByUsernameCachePolicy.DeleteByUserName(UsernameCacheKey, entity.Username);
+
         entity.ResetDirtyProperties();
     }
 


### PR DESCRIPTION
# Notes
- There was a bug where you could still login as a member for a little while, after you've deleted the member.
This was caused by the userNameCache not being cleared in the member repository.
- Clears the user name cache in the `MemberRepository` when members are updated/deleted

# How to test

- Create RegisterMember.cshtml partial view from snippet
- Create Login.cshtml partial view from snippet
- Create LoginStatus.cshtml partial view from snippet
- Create a doc type `ContentPage` and in its template add:
```
@using Umbraco.Cms.Web.Common.PublishedModels;
@using Umbraco.Cms.Core.Services;
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<ContentModels.ContentPage>
@inject IMemberService MemberService
@using ContentModels = Umbraco.Cms.Web.Common.PublishedModels;
@{
	Layout = null;
	var isLoggedIn = Context.User?.Identity?.IsAuthenticated ?? false;
}

@if (!isLoggedIn)
{
    @await Html.PartialAsync("RegisterMember")
    <hr/>
    <br/>
    @await Html.PartialAsync("Login")
}
else
{
    @await Html.PartialAsync("LoginStatus")
}
```
- Register a member
- Logout
- Delete the member
- Try to login ---> This should fail