### PR TITLE
Allow skipSelect blueprints only when one blueprint exists

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/content.create.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/content.create.controller.js
@@ -86,7 +86,7 @@ function contentCreateController($scope,
         });
         $scope.docType = docType;
         if (blueprints.length) {
-            if (blueprintConfig.skipSelect) {
+            if (blueprintConfig.skipSelect && blueprints.length === 1) {
                 createFromBlueprint(blueprints[0].id);
             } else {
                 $scope.selectContentType = false;


### PR DESCRIPTION
Since Umbraco 7.7 it has been possible to configure the behaviour when creating new content via AngularJS – to require the user to select a blueprint / content template, or auto-select one.

If `skipSelect` is enabled, the first available blueprint is selected. The issue has been if multiple blueprints exist for a specific type the user has no way to select which blueprint to use.

This PR includes an additional check to only skip the content template select dialog if just one option exists – otherwise the user is presented a dialog to select.