### PR TITLE
v14: DictionaryRepository - override PerformGetAll

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DictionaryRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DictionaryRepository.cs
@@ -223,6 +223,19 @@ internal class DictionaryRepository : EntityRepositoryBase<int, IDictionaryItem>
             return new SingleItemsOnlyRepositoryCachePolicy<IDictionaryItem, Guid>(GlobalIsolatedCache, ScopeAccessor,
                 options);
         }
+
+        protected override IEnumerable<IDictionaryItem> PerformGetAll(params Guid[]? ids)
+        {
+            Sql<ISqlContext> sql = GetBaseQuery(false).Where<DictionaryDto>(x => x.PrimaryKey > 0);
+            if (ids?.Any() ?? false)
+            {
+                sql.WhereIn<DictionaryDto>(x => x.UniqueId, ids);
+            }
+
+            return Database
+                .FetchOneToMany<DictionaryDto>(x => x.LanguageTextDtos, sql)
+                .Select(ConvertToEntity);
+        }
     }
 
     private class DictionaryByKeyRepository : SimpleGetRepository<string, IDictionaryItem, DictionaryDto>
@@ -265,6 +278,19 @@ internal class DictionaryRepository : EntityRepositoryBase<int, IDictionaryItem>
 
             return new SingleItemsOnlyRepositoryCachePolicy<IDictionaryItem, string>(GlobalIsolatedCache, ScopeAccessor,
                 options);
+        }
+
+        protected override IEnumerable<IDictionaryItem> PerformGetAll(params string[]? ids)
+        {
+            Sql<ISqlContext> sql = GetBaseQuery(false).Where<DictionaryDto>(x => x.PrimaryKey > 0);
+            if (ids?.Any() ?? false)
+            {
+                sql.WhereIn<DictionaryDto>(x => x.Key, ids);
+            }
+
+            return Database
+                .FetchOneToMany<DictionaryDto>(x => x.LanguageTextDtos, sql)
+                .Select(ConvertToEntity);
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/17431

# Notes
- DictionaryRepository is a little weird, as you can get dictionary items by int id, GUID & string, this means we have private classes like `DictionaryByKeyRepository` in there, wich derives from `SimpleGetRepository`
This bug was caused by not having the `.FetchOneToMany<DictionaryDto>(x => x.LanguageTextDtos, sql)`, as there is no way to put this in, in the default overrides of `SimpleGetRepository` (as this makes it no longer simple 😛)
- Long story short, this is solved by simply overriding the `PerformGetAll`, mirroring the implementation of the original <int> DictionaryRepository 👍 

# How to test
- Follow steps in original issue. Here is a test controller i used to make calling the service easy (put your own keys in there instead of my guids):
This is the endpoint i called from postman `https://localhost:44339/test/index`
```
using Microsoft.AspNetCore.Mvc;
using Umbraco.Cms.Core.Services;

namespace Umbraco.Cms.Web.UI;

[ApiController]
[Route("[controller]/[action]")]
public class TestController : Controller
{
    private readonly IDictionaryItemService _dictionaryItemService;

    public TestController(IDictionaryItemService dictionaryItemService)
    {
        _dictionaryItemService = dictionaryItemService;
    }

    [HttpGet]
    public async Task<IActionResult> Index()
    {
        var firstItem = await _dictionaryItemService.GetAsync(new Guid("5f07e57d-9146-4666-8414-7dab656b0f7f"));
        var items = await _dictionaryItemService.GetManyAsync(new Guid("5f07e57d-9146-4666-8414-7dab656b0f7f"), new Guid("ea89f199-bc49-42e8-b218-20de753aff31"), new Guid("448527bc-3f59-4843-a125-679ad492aa92"));
        return Ok(items.Count());
    }
}

```