### PR TITLE
Make parallel block editor migration optional

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertBlockEditorPropertiesBase.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertBlockEditorPropertiesBase.cs
@@ -32,6 +32,8 @@ public abstract class ConvertBlockEditorPropertiesBase : MigrationBase
 
     protected bool SkipMigration { get; init; }
 
+    protected bool ParallelizeMigration { get; init; }
+
     protected enum EditorValueHandling
     {
         IgnoreConversion,
@@ -258,7 +260,7 @@ public abstract class ConvertBlockEditorPropertiesBase : MigrationBase
                             propertyDataDto.TextValue = stringValue;
                 }
 
-                if (DatabaseType == DatabaseType.SQLite)
+                if (ParallelizeMigration is false || DatabaseType == DatabaseType.SQLite)
                 {
                     // SQLite locks up if we run the migration in parallel, so... let's not.
                     foreach (UpdateBatch<PropertyDataDto> update in updateBatch)

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertBlockEditorPropertiesOptions.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertBlockEditorPropertiesOptions.cs
@@ -26,4 +26,12 @@ public class ConvertBlockEditorPropertiesOptions
     /// If you choose to skip the migration, you're responsible for performing the content migration for Rich Texts after the V15 upgrade has completed.
     /// </remarks>
     public bool SkipRichTextEditors { get; set; } = false;
+
+    /// <summary>
+    /// Setting this property to true will cause all block editor migrations to run as parallel operations.
+    /// </summary>
+    /// <remarks>
+    /// While this greatly improves the speed of the migration, some content setups may experience issues and failing migrations as a result.
+    /// </remarks>
+    public bool ParallelizeMigration { get; set; } = false;
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertBlockGridEditorProperties.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertBlockGridEditorProperties.cs
@@ -23,7 +23,10 @@ public class ConvertBlockGridEditorProperties : ConvertBlockEditorPropertiesBase
         IOptions<ConvertBlockEditorPropertiesOptions> options,
         ICoreScopeProvider coreScopeProvider)
         : base(context, logger, contentTypeService, dataTypeService, jsonSerializer, umbracoContextFactory, languageService, coreScopeProvider)
-        => SkipMigration = options.Value.SkipBlockGridEditors;
+    {
+        SkipMigration = options.Value.SkipBlockGridEditors;
+        ParallelizeMigration = options.Value.ParallelizeMigration;
+    }
 
     protected override IEnumerable<string> PropertyEditorAliases
         => new[] { Constants.PropertyEditors.Aliases.BlockGrid };

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertBlockListEditorProperties.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertBlockListEditorProperties.cs
@@ -23,7 +23,10 @@ public class ConvertBlockListEditorProperties : ConvertBlockEditorPropertiesBase
         IOptions<ConvertBlockEditorPropertiesOptions> options,
         ICoreScopeProvider coreScopeProvider)
         : base(context, logger, contentTypeService, dataTypeService, jsonSerializer, umbracoContextFactory, languageService, coreScopeProvider)
-        => SkipMigration = options.Value.SkipBlockListEditors;
+    {
+        SkipMigration = options.Value.SkipBlockListEditors;
+        ParallelizeMigration = options.Value.ParallelizeMigration;
+    }
 
     protected override IEnumerable<string> PropertyEditorAliases
         => new[] { Constants.PropertyEditors.Aliases.BlockList };

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertRichTextEditorProperties.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertRichTextEditorProperties.cs
@@ -25,7 +25,10 @@ public partial class ConvertRichTextEditorProperties : ConvertBlockEditorPropert
         IOptions<ConvertBlockEditorPropertiesOptions> options,
         ICoreScopeProvider coreScopeProvider)
         : base(context, logger, contentTypeService, dataTypeService, jsonSerializer, umbracoContextFactory, languageService, coreScopeProvider)
-        => SkipMigration = options.Value.SkipRichTextEditors;
+    {
+        SkipMigration = options.Value.SkipRichTextEditors;
+        ParallelizeMigration = options.Value.ParallelizeMigration;
+    }
 
     protected override IEnumerable<string> PropertyEditorAliases
         => new[] { Constants.PropertyEditors.Aliases.TinyMce, Constants.PropertyEditors.Aliases.RichText };


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #17810

### Description

we're migrating all block editor data for V15 to a new data format that supports block level variance. For SQL Server, we run this migration in parallel to speed things up. Unfortunately, it turns out that certain content architectures won't support that - #17810 is an example of this.

This PR makes the parallel migration an opt-in thing, meaning one must explicitly choose to use parallel migration. It utilises the migration options that have already been put in place for opting out of the migration entirely (see [this docs article](https://docs.umbraco.com/umbraco-cms/fundamentals/setup/upgrading/version-specific/migrate-content-to-umbraco-15)).

### Testing this PR

Setup a V13 or V14 site using SQL Server. Make sure you have a backup of the database 😄 

Now run the V15 migration from this branch. It _should_ run both with and without parallel execution of the migration.

To enable parallel migration, add the following composer:

```cs
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_15_0_0;

namespace UmbracoDocs.Samples;

public class DisableBlockEditorMigrationComposer : IComposer
{
    [Obsolete]
    public void Compose(IUmbracoBuilder builder)
        => builder.Services.Configure<ConvertBlockEditorPropertiesOptions>(options =>
        {
            // setting this to true will parallelize the migration of all Block Editors
            options.ParallelizeMigration = true;
        });
}
```

### Docs update

I have queued a task to update the article above to include this configuration, after this is merged in 👍 