### PR TITLE
Fix null exceptions when requesting specific content trough the backoffice APIs

### DIFF
--- a/src/Umbraco.Web.BackOffice/Authorization/ContentPermissionsQueryStringHandler.cs
+++ b/src/Umbraco.Web.BackOffice/Authorization/ContentPermissionsQueryStringHandler.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 
@@ -60,9 +61,15 @@ public class
             nodeId = requirement.NodeId.Value;
         }
 
+        IUser? currentUser = BackOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser;
+        if (currentUser is null)
+        {
+            return Task.FromResult(false);
+        }
+
         ContentPermissions.ContentAccess permissionResult = _contentPermissions.CheckPermissions(
             nodeId,
-            BackOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser,
+            currentUser,
             out IContent? contentItem,
             new[] { requirement.PermissionToCheck });
 

--- a/src/Umbraco.Web.BackOffice/Authorization/ContentPermissionsResourceHandler.cs
+++ b/src/Umbraco.Web.BackOffice/Authorization/ContentPermissionsResourceHandler.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Authorization;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Security;
 
 namespace Umbraco.Cms.Web.BackOffice.Authorization;
@@ -34,15 +35,21 @@ public class ContentPermissionsResourceHandler : MustSatisfyRequirementAuthoriza
     protected override Task<bool> IsAuthorized(AuthorizationHandlerContext context,
         ContentPermissionsResourceRequirement requirement, ContentPermissionsResource resource)
     {
+        IUser? currentUser = _backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser;
+        if (currentUser is null)
+        {
+            return Task.FromResult(false);
+        }
+
         ContentPermissions.ContentAccess permissionResult = resource.NodeId.HasValue
             ? _contentPermissions.CheckPermissions(
                 resource.NodeId.Value,
-                _backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser,
+                currentUser,
                 out IContent? _,
                 resource.PermissionsToCheck)
             : _contentPermissions.CheckPermissions(
                 resource.Content,
-                _backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser,
+                currentUser,
                 resource.PermissionsToCheck);
 
         return Task.FromResult(permissionResult != ContentPermissions.ContentAccess.Denied);


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/17701

### Description
As the ContentPermissions.CheckPermissions() implicetly throws an error, I chose to fix the null ref in the consuming handlers as from a AuthorizationHandler it makes sense that we have a logged in user before checking it's permissions.

### Testing
Check the steps in the linked issue and keep in mind that this fix delivers a result that is in line with other Authorization Handlers failing in any way.