### PR TITLE
Fix: select app language

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/language/app-language-select/app-language-select.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/language/app-language-select/app-language-select.element.ts
@@ -112,16 +112,9 @@ export class UmbAppLanguageSelectElement extends UmbLitElement {
 		}
 	}
 
-	#onLabelClick(event: UUIMenuItemEvent) {
-		const menuItem = event.target;
-		const unique = menuItem.dataset.unique;
-		if (!unique) throw new Error('Missing unique on menu item');
-
+	#chooseLanguage(unique: string) {
 		this.#appLanguageContext?.setLanguage(unique);
 		this._isOpen = false;
-
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
 		this._popoverElement?.hidePopover();
 	}
 
@@ -153,7 +146,7 @@ export class UmbAppLanguageSelectElement extends UmbLitElement {
 							label=${ifDefined(language.name)}
 							data-mark="${language.entityType}:${language.unique}"
 							?active=${language.unique === this._appLanguage?.unique}
-							@click-label=${this.#onLabelClick}>
+							@click-label=${() => this.#chooseLanguage(language.unique)}>
 							${this.#isLanguageReadOnly(language.unique) ? this.#renderReadOnlyTag(language.unique) : nothing}
 						</uui-menu-item>
 					`,


### PR DESCRIPTION
App language selection was broken because we removed the unique attribute as part of adding data-marks — but I think that is okay, so just needed to solve the data needed for the click event in a different way.

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
