### PR TITLE
Use data type configuration to determine default value for empty toggle and slider property values

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/SliderConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/SliderConfiguration.cs
@@ -11,18 +11,14 @@ public class SliderConfiguration
     public bool EnableRange { get; set; }
 
     [ConfigurationField("minVal")]
-    [JsonPropertyName("minVal")]
     public decimal MinimumValue { get; set; }
 
     [ConfigurationField("maxVal")]
-    [JsonPropertyName("maxVal")]
     public decimal MaximumValue { get; set; }
 
     [ConfigurationField("initVal1")]
-    [JsonPropertyName("initVal1")]
     public decimal InitialValue1 { get; set; }
 
     [ConfigurationField("initVal2")]
-    [JsonPropertyName("initVal2")]
     public decimal InitialValue2 { get; set; }
 }

--- a/src/Umbraco.Core/PropertyEditors/SliderConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/SliderConfiguration.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Umbraco.Cms.Core.PropertyEditors;
 
 /// <summary>
@@ -9,8 +11,18 @@ public class SliderConfiguration
     public bool EnableRange { get; set; }
 
     [ConfigurationField("minVal")]
+    [JsonPropertyName("minVal")]
     public decimal MinimumValue { get; set; }
 
     [ConfigurationField("maxVal")]
+    [JsonPropertyName("maxVal")]
     public decimal MaximumValue { get; set; }
+
+    [ConfigurationField("initVal1")]
+    [JsonPropertyName("initVal1")]
+    public decimal InitialValue1 { get; set; }
+
+    [ConfigurationField("initVal2")]
+    [JsonPropertyName("initVal2")]
+    public decimal InitialValue2 { get; set; }
 }

--- a/src/Umbraco.Core/PropertyEditors/TrueFalseConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/TrueFalseConfiguration.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace Umbraco.Cms.Core.PropertyEditors;
+
+/// <summary>
+///     Represents the configuration for the true/false (toggle) value editor.
+/// </summary>
+public class TrueFalseConfiguration
+{
+    [ConfigurationField("default")]
+    [JsonPropertyName("default")]
+    public bool InitialState { get; set; }
+}

--- a/src/Umbraco.Core/PropertyEditors/TrueFalseConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/TrueFalseConfiguration.cs
@@ -8,6 +8,5 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 public class TrueFalseConfiguration
 {
     [ConfigurationField("default")]
-    [JsonPropertyName("default")]
     public bool InitialState { get; set; }
 }

--- a/src/Umbraco.Core/PropertyEditors/TrueFalseConfigurationEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/TrueFalseConfigurationEditor.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Umbraco.Cms.Core.IO;
+
+namespace Umbraco.Cms.Core.PropertyEditors;
+
+/// <summary>
+///     Represents the configuration editor for the true/false (toggle) value editor.
+/// </summary>
+public class TrueFalseConfigurationEditor : ConfigurationEditor<TrueFalseConfiguration>
+{
+    public TrueFalseConfigurationEditor(IIOHelper ioHelper)
+        : base(ioHelper)
+    {
+    }
+}

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/SliderValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/SliderValueConverter.cs
@@ -49,16 +49,29 @@ public class SliderValueConverter : PropertyValueConverterBase
     /// <inheritdoc />
     public override object? ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel cacheLevel, object? source, bool preview)
     {
-        bool isRange = IsRange(propertyType);
+        SliderConfiguration? configuration = propertyType.DataType.ConfigurationAs<SliderConfiguration>();
+        bool isRange = IsRange(configuration);
 
         var sourceString = source?.ToString();
+
+        // If source is null, the returned value depends on the configured initial values.
+        if (string.IsNullOrEmpty(sourceString))
+        {
+            return isRange
+                ? new Range<decimal>
+                {
+                    Minimum = configuration?.InitialValue1 ?? 0M,
+                    Maximum = configuration?.InitialValue2 ?? 0M
+                }
+                : configuration?.InitialValue1 ?? 0M;
+        }
 
         return isRange
             ? HandleRange(sourceString)
             : HandleDecimal(sourceString);
     }
 
-    private static Range<decimal> HandleRange(string? sourceString)
+    private static Range<decimal> HandleRange(string sourceString)
     {
         if (sourceString is null)
         {
@@ -92,13 +105,8 @@ public class SliderValueConverter : PropertyValueConverterBase
         return new Range<decimal>();
     }
 
-    private static decimal HandleDecimal(string? sourceString)
+    private static decimal HandleDecimal(string sourceString)
     {
-        if (string.IsNullOrEmpty(sourceString))
-        {
-            return default;
-        }
-
         // This used to be a range slider, so we'll assign the minimum value as the new value
         if (sourceString.Contains(','))
         {
@@ -124,5 +132,8 @@ public class SliderValueConverter : PropertyValueConverterBase
         => decimal.TryParse(representation, NumberStyles.Number, CultureInfo.InvariantCulture, out value);
 
     private static bool IsRange(IPublishedPropertyType propertyType)
-        => propertyType.DataType.ConfigurationAs<SliderConfiguration>()?.EnableRange == true;
+        => IsRange(propertyType.DataType.ConfigurationAs<SliderConfiguration>());
+
+    private static bool IsRange(SliderConfiguration? configuration)
+        => configuration?.EnableRange == true;
 }

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/YesNoValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/YesNoValueConverter.cs
@@ -16,6 +16,21 @@ public class YesNoValueConverter : PropertyValueConverterBase
 
     public override object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object? source, bool preview)
     {
+        // If source is null, whether we return true or false depends on the configured default value (initial state).
+        if (source is null)
+        {
+            const string DefaultValueKey = "default"; // Aligns with key defined client-side in Umb.PropertyEditorUi.Toggle
+
+            var dataTypeConfiguration = propertyType.DataType.ConfigurationObject as Dictionary<string, object>;
+            if (dataTypeConfiguration?.TryGetValue(DefaultValueKey, out object? defaultValue) ?? false)
+            {
+                return defaultValue is bool boolValue && boolValue;
+            }
+
+            // Default if no default value is set is false.
+            return false;
+        }
+
         // in xml a boolean is: string
         // in the database a boolean is: string "1" or "0" or empty
         // typically the converter does not need to handle anything else ("true"...)
@@ -35,23 +50,23 @@ public class YesNoValueConverter : PropertyValueConverterBase
             return bool.TryParse(s, out var result) && result;
         }
 
-        if (source is int)
+        if (source is int sourceAsInt)
         {
-            return (int)source == 1;
+            return sourceAsInt == 1;
         }
 
         // this is required for correct true/false handling in nested content elements
-        if (source is long)
+        if (source is long sourceAsLong)
         {
-            return (long)source == 1;
+            return sourceAsLong == 1;
         }
 
-        if (source is bool)
+        if (source is bool sourceAsBoolean)
         {
-            return (bool)source;
+            return sourceAsBoolean;
         }
 
-        // default value is: false
+        // false for any other value
         return false;
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/YesNoValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/YesNoValueConverter.cs
@@ -14,21 +14,11 @@ public class YesNoValueConverter : PropertyValueConverterBase
     public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType)
         => PropertyCacheLevel.Element;
 
-    public override object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object? source, bool preview)
+    public override object? ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object? source, bool preview)
     {
-        // If source is null, whether we return true or false depends on the configured default value (initial state).
         if (source is null)
         {
-            const string DefaultValueKey = "default"; // Aligns with key defined client-side in Umb.PropertyEditorUi.Toggle
-
-            var dataTypeConfiguration = propertyType.DataType.ConfigurationObject as Dictionary<string, object>;
-            if (dataTypeConfiguration?.TryGetValue(DefaultValueKey, out object? defaultValue) ?? false)
-            {
-                return defaultValue is bool boolValue && boolValue;
-            }
-
-            // Default if no default value is set is false.
-            return false;
+            return null;
         }
 
         // in xml a boolean is: string
@@ -68,5 +58,18 @@ public class YesNoValueConverter : PropertyValueConverterBase
 
         // false for any other value
         return false;
+    }
+
+    /// <inheritdoc />
+    public override object? ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel cacheLevel, object? source, bool preview)
+    {
+        // If source is null, whether we return true or false depends on the configured default value (initial state).
+        if (source is null)
+        {
+            TrueFalseConfiguration? configuration = propertyType.DataType.ConfigurationAs<TrueFalseConfiguration>();
+            return configuration?.InitialState ?? false;
+        }
+
+        return (bool)source;
     }
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/TrueFalsePropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/TrueFalsePropertyEditor.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Editors;
@@ -18,16 +20,36 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     ValueEditorIsReusable = true)]
 public class TrueFalsePropertyEditor : DataEditor
 {
+    private readonly IIOHelper _ioHelper;
+
     /// <summary>
     ///     Initializes a new instance of the <see cref="TrueFalsePropertyEditor" /> class.
     /// </summary>
+    [Obsolete("Please use the constructor taking all parameters. This constructor will be removed in V17.")]
     public TrueFalsePropertyEditor(IDataValueEditorFactory dataValueEditorFactory)
+        : this(
+              dataValueEditorFactory,
+              StaticServiceProvider.Instance.GetRequiredService<IIOHelper>())
+    {
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="TrueFalsePropertyEditor" /> class.
+    /// </summary>
+    public TrueFalsePropertyEditor(IDataValueEditorFactory dataValueEditorFactory, IIOHelper ioHelper)
         : base(dataValueEditorFactory)
-        => SupportsReadOnly = true;
+    {
+        _ioHelper = ioHelper;
+        SupportsReadOnly = true;
+    }
 
     /// <inheritdoc />
     protected override IDataValueEditor CreateValueEditor()
         => DataValueEditorFactory.Create<TrueFalsePropertyValueEditor>(Attribute!);
+
+    /// <inheritdoc />
+    protected override IConfigurationEditor CreateConfigurationEditor() =>
+        new TrueFalseConfigurationEditor(_ioHelper);
 
     internal class TrueFalsePropertyValueEditor : DataValueEditor
     {

--- a/src/Umbraco.Infrastructure/Serialization/SystemTextConfigurationEditorJsonSerializer.cs
+++ b/src/Umbraco.Infrastructure/Serialization/SystemTextConfigurationEditorJsonSerializer.cs
@@ -51,7 +51,7 @@ public sealed class SystemTextConfigurationEditorJsonSerializer : SystemTextJson
     /// </remarks>
     private static Action<JsonTypeInfo> UseAttributeConfiguredPropertyNames() => typeInfo =>
     {
-        if (typeInfo.Kind != JsonTypeInfoKind.Object)
+        if (typeInfo.Kind is not JsonTypeInfoKind.Object)
         {
             return;
         }
@@ -60,9 +60,9 @@ public sealed class SystemTextConfigurationEditorJsonSerializer : SystemTextJson
         {
             if (property.AttributeProvider?.GetCustomAttributes(typeof(ConfigurationFieldAttribute), true) is { } attributes)
             {
-                foreach (ConfigurationFieldAttribute attr in attributes)
+                foreach (ConfigurationFieldAttribute attribute in attributes)
                 {
-                    property.Name = attr.Key;
+                    property.Name = attribute.Key;
                 }
             }
         }

--- a/src/Umbraco.Infrastructure/Serialization/SystemTextConfigurationEditorJsonSerializer.cs
+++ b/src/Umbraco.Infrastructure/Serialization/SystemTextConfigurationEditorJsonSerializer.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Serialization;
 
 namespace Umbraco.Cms.Infrastructure.Serialization;
@@ -16,8 +18,9 @@ public sealed class SystemTextConfigurationEditorJsonSerializer : SystemTextJson
         => _jsonSerializerOptions = new JsonSerializerOptions()
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            // in some cases, configs aren't camel cased in the DB, so we have to resort to case insensitive
-            // property name resolving when creating configuration objects (deserializing DB configs)
+
+            // In some cases, configs aren't camel cased in the DB, so we have to resort to case insensitive
+            // property name resolving when creating configuration objects (deserializing DB configs).
             PropertyNameCaseInsensitive = true,
             NumberHandling = JsonNumberHandling.AllowReadingFromString,
             Converters =
@@ -26,9 +29,42 @@ public sealed class SystemTextConfigurationEditorJsonSerializer : SystemTextJson
                 new JsonObjectConverter(),
                 new JsonUdiConverter(),
                 new JsonUdiRangeConverter(),
-                new JsonBooleanConverter()
-            }
+                new JsonBooleanConverter(),
+            },
+
+            // Properties of data type configuration objects are annotated with [ConfigurationField] attributes
+            // that provide the serialized name. Rather than decorating them as well with [JsonPropertyName] attributes
+            // when they differ from the property name, we'll define a custom type info resolver to use the
+            // existing attribute.
+            TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+                .WithAddedModifier(UseAttributeConfiguredPropertyNames()),
         };
 
     protected override JsonSerializerOptions JsonSerializerOptions => _jsonSerializerOptions;
+
+    /// <summary>
+    /// A custom action used to provide property names when they are overridden by
+    /// <see cref="ConfigurationField"/> attributes.
+    /// </summary>
+    /// <remarks>
+    /// Hat-tip: https://stackoverflow.com/a/78063664
+    /// </remarks>
+    private static Action<JsonTypeInfo> UseAttributeConfiguredPropertyNames() => typeInfo =>
+    {
+        if (typeInfo.Kind != JsonTypeInfoKind.Object)
+        {
+            return;
+        }
+
+        foreach (JsonPropertyInfo property in typeInfo.Properties)
+        {
+            if (property.AttributeProvider?.GetCustomAttributes(typeof(ConfigurationFieldAttribute), true) is { } attributes)
+            {
+                foreach (ConfigurationFieldAttribute attr in attributes)
+                {
+                    property.Name = attr.Key;
+                }
+            }
+        }
+    };
 }

--- a/tests/Umbraco.Tests.Common/Builders/DataTypeBuilder.cs
+++ b/tests/Umbraco.Tests.Common/Builders/DataTypeBuilder.cs
@@ -119,9 +119,9 @@ public class DataTypeBuilder
         return this;
     }
 
-    public DataTypeBuilder WithConfigurationData(Dictionary<string, object> configurationData)
+    public DataTypeBuilder AddOrUpdateConfigurationDataValue(string key, object value)
     {
-        _configurationData = configurationData;
+        _configurationData[key] = value;
         return this;
     }
 
@@ -143,9 +143,8 @@ public class DataTypeBuilder
         var databaseType = _databaseType ?? ValueStorageType.Ntext;
         var sortOrder = _sortOrder ?? 0;
         var serializer = new SystemTextConfigurationEditorJsonSerializer();
-        var configurationData = _configurationData;
 
-        return new DataType(editor, serializer, parentId)
+        var dataType = new DataType(editor, serializer, parentId)
         {
             Id = id,
             Key = key,
@@ -158,8 +157,14 @@ public class DataTypeBuilder
             Path = path,
             CreatorId = creatorId,
             DatabaseType = databaseType,
-            SortOrder = sortOrder,
-            ConfigurationData = configurationData,
+            SortOrder = sortOrder
         };
+
+        foreach (var item in _configurationData)
+        {
+            dataType.ConfigurationData[item.Key] = item.Value;
+        }
+
+        return dataType;
     }
 }

--- a/tests/Umbraco.Tests.Common/Builders/DataTypeBuilder.cs
+++ b/tests/Umbraco.Tests.Common/Builders/DataTypeBuilder.cs
@@ -37,6 +37,7 @@ public class DataTypeBuilder
     private int? _sortOrder;
     private bool? _trashed;
     private DateTime? _updateDate;
+    private Dictionary<string, object> _configurationData = [];
 
     public DataTypeBuilder() => _dataEditorBuilder = new DataEditorBuilder<DataTypeBuilder>(this);
 
@@ -118,6 +119,12 @@ public class DataTypeBuilder
         return this;
     }
 
+    public DataTypeBuilder WithConfigurationData(Dictionary<string, object> configurationData)
+    {
+        _configurationData = configurationData;
+        return this;
+    }
+
     public DataEditorBuilder<DataTypeBuilder> AddEditor() => _dataEditorBuilder;
 
     public override DataType Build()
@@ -136,6 +143,7 @@ public class DataTypeBuilder
         var databaseType = _databaseType ?? ValueStorageType.Ntext;
         var sortOrder = _sortOrder ?? 0;
         var serializer = new SystemTextConfigurationEditorJsonSerializer();
+        var configurationData = _configurationData;
 
         return new DataType(editor, serializer, parentId)
         {
@@ -150,7 +158,8 @@ public class DataTypeBuilder
             Path = path,
             CreatorId = creatorId,
             DatabaseType = databaseType,
-            SortOrder = sortOrder
+            SortOrder = sortOrder,
+            ConfigurationData = configurationData,
         };
     }
 }

--- a/tests/Umbraco.Tests.Common/Builders/DataTypeBuilder.cs
+++ b/tests/Umbraco.Tests.Common/Builders/DataTypeBuilder.cs
@@ -37,7 +37,6 @@ public class DataTypeBuilder
     private int? _sortOrder;
     private bool? _trashed;
     private DateTime? _updateDate;
-    private Dictionary<string, object> _configurationData = [];
 
     public DataTypeBuilder() => _dataEditorBuilder = new DataEditorBuilder<DataTypeBuilder>(this);
 
@@ -119,12 +118,6 @@ public class DataTypeBuilder
         return this;
     }
 
-    public DataTypeBuilder AddOrUpdateConfigurationDataValue(string key, object value)
-    {
-        _configurationData[key] = value;
-        return this;
-    }
-
     public DataEditorBuilder<DataTypeBuilder> AddEditor() => _dataEditorBuilder;
 
     public override DataType Build()
@@ -159,11 +152,6 @@ public class DataTypeBuilder
             DatabaseType = databaseType,
             SortOrder = sortOrder
         };
-
-        foreach (var item in _configurationData)
-        {
-            dataType.ConfigurationData[item.Key] = item.Value;
-        }
 
         return dataType;
     }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/PropertyEditorValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/PropertyEditorValueConverterTests.cs
@@ -66,17 +66,7 @@ public class PropertyEditorValueConverterTests
     [TestCase(null, true, true)]
     public void CanConvertYesNoPropertyEditor(object value, bool? initialStateConfigurationValue, bool expected)
     {
-        var dataTypeConfiguration = new Dictionary<string, object>();
-        if (initialStateConfigurationValue.HasValue)
-        {
-            dataTypeConfiguration.Add("default", initialStateConfigurationValue.Value);
-        }
-
-        var dataType = new DataTypeBuilder()
-            .WithConfigurationData(dataTypeConfiguration)
-            .Build();
-
-        var publishedDataType = new PublishedDataType(dataType.Id, dataType.EditorAlias, dataType.EditorUiAlias, new Lazy<object>(() => dataTypeConfiguration));
+        var publishedDataType = CreatePublishedDataType(initialStateConfigurationValue);
 
         var publishedPropertyTypeMock = new Mock<IPublishedPropertyType>();
         publishedPropertyTypeMock
@@ -88,6 +78,26 @@ public class PropertyEditorValueConverterTests
             converter.ConvertSourceToIntermediate(null, publishedPropertyTypeMock.Object, value, false); // does not use type for conversion
 
         Assert.AreEqual(expected, result);
+    }
+
+    private static PublishedDataType CreatePublishedDataType(bool? initialStateConfigurationValue)
+    {
+        var dataTypeConfiguration = new Dictionary<string, object>();
+        if (initialStateConfigurationValue.HasValue)
+        {
+            dataTypeConfiguration.Add("default", initialStateConfigurationValue.Value);
+        }
+
+        var dataTypeBuilder = new DataTypeBuilder();
+
+        if (initialStateConfigurationValue.HasValue)
+        {
+            dataTypeBuilder = dataTypeBuilder.AddOrUpdateConfigurationDataValue("default", initialStateConfigurationValue.Value);
+        }
+
+        var dataType = dataTypeBuilder.Build();
+
+        return new PublishedDataType(dataType.Id, dataType.EditorAlias, dataType.EditorUiAlias, new Lazy<object>(() => dataTypeConfiguration));
     }
 
     [TestCase("[\"apples\"]", new[] { "apples" })]


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes https://github.com/umbraco/Umbraco-CMS/issues/17833, tracked under [AB 45702](https://dev.azure.com/umbraco/D-Team%20Tracker/_workitems/edit/45702) (internal HQ tracker)

Also Fixes https://github.com/umbraco/Umbraco-CMS/issues/17099, tracked under [AB 47510](https://dev.azure.com/umbraco/D-Team%20Tracker/_workitems/edit/47510)

### Description

**Reported issue:** For toggle properties set to the initial value of true, this is not working. The value is stored as false even though it is displayed as “on” in the UI.

**Background:**  If the user does not interact with a Property Editor, we do not store anything.
This is how the Client works as of v.14, and this plays well with the fact that we do not render Property Editors that the user haven't navigated to, meaning we do not guarantee that the Property Editor UI would be available to set an initial(default) value.
In other words, Default Values should be set by the server.

**Reproduction:**

- Create two data types based on the "Toggle" property editor named "Toggle 1" and "Toggle 2".
- For one set the "Initial state" value to "on", for the other leave it "off".
- Add the two data types to a document type and render in a template like the following:

```
@using Umbraco.Cms.Web.Common.PublishedModels;
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<ContentModels.HomePage>
@using ContentModels = Umbraco.Cms.Web.Common.PublishedModels;
@{
  Layout = null;
}

<ul>
  <li>Setting 1: @Model.Toggle1</li>
  <li>Setting 2: @Model.Toggle2</li>
</ul>
```

- Create a content item based on the document type, note that one toggle will be on and one off as expected.
- Save and publish the document type without touching the toggles.
- Render the page and note that both toggle values are false.

With this PR I've added a check for null values in the property value converter, when, if found, the default value from the data type configuration will be used.

**To Test:**

- Follow the reproduction steps described and note that with the PR applied that the expected values are displayed.
- Edit the content, setting the toggle values explicitly, and confirm you again see the expected values.
- Repeat for the slider.
