### PR TITLE
Fix #17758: V15 - Race condition breaks navigation between documents

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/content-type/structure/content-type-structure-manager.class.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content-type/structure/content-type-structure-manager.class.ts
@@ -192,8 +192,9 @@ export class UmbContentTypeStructureManager<
 
 	async #loadContentTypeCompositions(ownerContentTypeCompositions: T['compositions'] | undefined) {
 		if (!ownerContentTypeCompositions) {
-			// Owner content type was undefined, so we can not load compositions. But at this point we neither offload existing compositions, this is most likely not a case that needs to be handled.
-			return;
+			// Owner content type was undefined, so we cannot load compositions.
+			// But to clean up existing compositions, we set the array to empty to still be able to execute the clean-up code.
+			ownerContentTypeCompositions = [];
 		}
 
 		const ownerUnique = this.getOwnerContentTypeUnique();

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content/workspace/content-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content/workspace/content-detail-workspace-base.ts
@@ -112,6 +112,9 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 	abstract readonly contentTypeUnique: Observable<string | undefined>;
 
 	/* Data Type */
+	// This dataTypeItemManager is used to load the data type items for this content type, so we have all data-types for this content type up front. [NL]
+	// But once we have a propert application cache this could be solved in a way where we ask the cache for the data type items. [NL]
+	// And then we do not need to store them here in a local manager, but instead just request them here up-front and then again needed(which would get them from the cache, which as well could be update while this runs) [NL]
 	readonly #dataTypeItemManager = new UmbDataTypeItemRepositoryManager(this);
 
 	#varies?: boolean;
@@ -410,8 +413,10 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 			throw new Error(`Property alias "${alias}" not found.`);
 		}
 
+		// the getItemByUnique is a async method that first resolves once the item is loaded.
 		const editorAlias = (await this.#dataTypeItemManager.getItemByUnique(property.dataType.unique))
 			.propertyEditorSchemaAlias;
+		// This means if its not loaded this will never resolve and the error below will never happen.
 		if (!editorAlias) {
 			throw new Error(`Editor Alias of "${property.dataType.unique}" not found.`);
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content/workspace/content-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content/workspace/content-detail-workspace-base.ts
@@ -113,10 +113,6 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 
 	/* Data Type */
 	readonly #dataTypeItemManager = new UmbDataTypeItemRepositoryManager(this);
-	/**
-	 * Data Type Schema Map is used for lookup, this should make coder simpler and give better performance. [NL]
-	 */
-	//#dataTypeSchemaAliasMap = new Map<string, string>();
 
 	#varies?: boolean;
 	#variesByCulture?: boolean;
@@ -237,20 +233,6 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 			},
 			null,
 		);
-		/*
-		this.observe(
-			this.#dataTypeItemManager.items,
-			(dataTypes) => {
-				// Make a map of the data type unique and editorAlias
-				this.#dataTypeSchemaAliasMap = new Map(
-					dataTypes.map((dataType) => {
-						return [dataType.unique, dataType.propertyEditorSchemaAlias];
-					}),
-				);
-			},
-			null,
-		);
-		*/
 
 		this.loadLanguages();
 	}
@@ -430,7 +412,6 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 
 		const editorAlias = (await this.#dataTypeItemManager.getItemByUnique(property.dataType.unique))
 			.propertyEditorSchemaAlias;
-		//const editorAlias = this.#dataTypeSchemaAliasMap.get(property.dataType.unique);
 		if (!editorAlias) {
 			throw new Error(`Editor Alias of "${property.dataType.unique}" not found.`);
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content/workspace/content-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content/workspace/content-detail-workspace-base.ts
@@ -116,7 +116,7 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 	/**
 	 * Data Type Schema Map is used for lookup, this should make coder simpler and give better performance. [NL]
 	 */
-	#dataTypeSchemaAliasMap = new Map<string, string>();
+	//#dataTypeSchemaAliasMap = new Map<string, string>();
 
 	#varies?: boolean;
 	#variesByCulture?: boolean;
@@ -237,6 +237,7 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 			},
 			null,
 		);
+		/*
 		this.observe(
 			this.#dataTypeItemManager.items,
 			(dataTypes) => {
@@ -249,6 +250,7 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 			},
 			null,
 		);
+		*/
 
 		this.loadLanguages();
 	}
@@ -426,7 +428,9 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 			throw new Error(`Property alias "${alias}" not found.`);
 		}
 
-		const editorAlias = this.#dataTypeSchemaAliasMap.get(property.dataType.unique);
+		const editorAlias = (await this.#dataTypeItemManager.getItemByUnique(property.dataType.unique))
+			.propertyEditorSchemaAlias;
+		//const editorAlias = this.#dataTypeSchemaAliasMap.get(property.dataType.unique);
 		if (!editorAlias) {
 			throw new Error(`Editor Alias of "${property.dataType.unique}" not found.`);
 		}


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/17758

The issue is not that present any longer, but this change resolves the underlying issue.

The underlying issue was that when requesting the data-type we did not await its request, which most likely was fine for the main document type, but for data-types only used in the composition document types this was a problem.

This change simplifies things a bit by using a DataType Item Manager instead.