### PR TITLE
Ensure sort order is used when rendering the list of allowed documents that can be created under an item in the content section.

### DIFF
--- a/src/Umbraco.Core/Services/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
+++ b/src/Umbraco.Core/Services/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
@@ -1171,10 +1171,14 @@ public abstract class ContentTypeServiceBase<TRepository, TItem> : ContentTypeSe
         }
         else
         {
-            TItem[] allowedChildren = GetMany(parent.AllowedContentTypes.Select(x => x.Key)).ToArray();
+            // Get the sorted keys. Whilst we can't guarantee the order that comes back from GetMany, we can use
+            // this to sort the resulting list of allowed children.
+            Guid[] sortedKeys = parent.AllowedContentTypes.OrderBy(x => x.SortOrder).Select(x => x.Key).ToArray();
+
+            TItem[] allowedChildren = GetMany(sortedKeys).ToArray();
             result = new PagedModel<TItem>
             {
-                Items = allowedChildren.Take(take).Skip(skip),
+                Items = allowedChildren.OrderBy(x => sortedKeys.IndexOf(x.Key)).Take(take).Skip(skip),
                 Total = allowedChildren.Length,
             };
         }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes https://github.com/umbraco/Umbraco-CMS/issues/17843

### Description

Although it's not very obvious since you can't re-order without removing and reselecting, you can set the order of the list of allowed document types on the "Structure" tab for a document type by selecting the allowed types in the order you want.  That order will be retained and displayed here.

When you create a new content item under an existing one and are presented with the list of items to pick from, the order isn't used.

With this PR in place the order will be retained and the selection displayed in the same order you see in the settings section of the backoffice.

I.e. this dialog:

![image](https://github.com/user-attachments/assets/a9d98ce7-cb7f-41a3-a19b-1818fbc6d443)

Now matches what you see here:

![image](https://github.com/user-attachments/assets/14f1fe8a-a8b6-4e54-85f4-3d4aa83ba0fc)

To Test:

- Create a document type.
- Create further document types to be allowed to be created under the first document type.  When picking the allowed types, do so in the order you want them to be displayed to the editor.
- Create a content item using the first document type.
- Create a second content item under the first document type.  Note that the order of the items you can select from match the order you defined when setting up the document types.