### PR TITLE
Fixed infinite loop triggered when requesting media by ID in a folder via the media delivery API

### DIFF
--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiMediaWithCropsResponseBuilder.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiMediaWithCropsResponseBuilder.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Models.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
@@ -38,7 +38,7 @@ internal sealed class ApiMediaWithCropsResponseBuilder : ApiMediaWithCropsBuilde
         while (current != null)
         {
             yield return current.Name.ToLowerInvariant();
-            current = GetParent(media);
+            current = GetParent(current);
         }
     }
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes https://github.com/umbraco/Umbraco-CMS/issues/17841, tracked under [AB 47486](https://dev.azure.com/umbraco/D-Team%20Tracker/_workitems/edit/47486) (internal HQ tracker).

### Description

When requesting a media item contained within a folder by ID via the media delivery API, an infinite loop would be triggered when calculating the path.  With the PR applied the code is corrected such that this does not occur.

**To Test:**

- Create a media folder
- Create an image inside the folder
- Enable the [media delivery API](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/media-delivery-api)
- Request the media item via the `/umbraco/delivery/api/v2/media/item/{id}` endpoint