### PR TITLE
Timing updates for rendering and preparation of user group granular permissions details to resolve intermittent error on race condition

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/extension-registry/components/extension-slot/extension-slot.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/extension-registry/components/extension-slot/extension-slot.element.ts
@@ -1,5 +1,5 @@
 import { umbExtensionsRegistry } from '../../registry.js';
-import type { TemplateResult } from '@umbraco-cms/backoffice/external/lit';
+import type { TemplateResult, nothing } from '@umbraco-cms/backoffice/external/lit';
 import { css, repeat, customElement, property, state, html } from '@umbraco-cms/backoffice/external/lit';
 import {
 	type UmbExtensionElementInitializer,
@@ -95,7 +95,7 @@ export class UmbExtensionSlotElement extends UmbLitElement {
 	public renderMethod?: (
 		extension: UmbExtensionElementInitializer,
 		index: number,
-	) => TemplateResult | HTMLElement | null | undefined;
+	) => TemplateResult | TemplateResult<1> | HTMLElement | null | undefined | typeof nothing;
 
 	override connectedCallback(): void {
 		super.connectedCallback();

--- a/src/Umbraco.Web.UI.Client/src/packages/core/extension-registry/components/extension-with-api-slot/extension-with-api-slot.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/extension-registry/components/extension-with-api-slot/extension-with-api-slot.element.ts
@@ -1,5 +1,5 @@
 import { umbExtensionsRegistry } from '../../registry.js';
-import type { TemplateResult } from '@umbraco-cms/backoffice/external/lit';
+import type { TemplateResult, nothing } from '@umbraco-cms/backoffice/external/lit';
 import { css, repeat, customElement, property, state, html } from '@umbraco-cms/backoffice/external/lit';
 import {
 	type UmbExtensionElementAndApiInitializer,
@@ -141,7 +141,7 @@ export class UmbExtensionWithApiSlotElement extends UmbLitElement {
 	public renderMethod?: (
 		extension: UmbExtensionElementAndApiInitializer,
 		index: number,
-	) => TemplateResult | HTMLElement | null | undefined;
+	) => TemplateResult | TemplateResult<1> | HTMLElement | null | undefined | typeof nothing;
 
 	override connectedCallback(): void {
 		super.connectedCallback();

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user-group/workspace/user-group/components/user-group-granular-permission-list.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user-group/workspace/user-group/components/user-group-granular-permission-list.element.ts
@@ -1,8 +1,7 @@
 import { UMB_USER_GROUP_WORKSPACE_CONTEXT } from '../user-group-workspace.context-token.js';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
-import { createExtensionElement } from '@umbraco-cms/backoffice/extension-api';
+import type { UmbExtensionElementInitializer } from '@umbraco-cms/backoffice/extension-api';
 import type { ManifestGranularUserPermission } from '@umbraco-cms/backoffice/user-permission';
-import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { html, customElement, state, nothing } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { filterFrozenArray } from '@umbraco-cms/backoffice/observable-api';
@@ -10,7 +9,7 @@ import { filterFrozenArray } from '@umbraco-cms/backoffice/observable-api';
 @customElement('umb-user-group-granular-permission-list')
 export class UmbUserGroupGranularPermissionListElement extends UmbLitElement {
 	@state()
-	_extensionElements: Array<HTMLElement> = [];
+	_userGroupPermissions?: Array<any>;
 
 	#workspaceContext?: typeof UMB_USER_GROUP_WORKSPACE_CONTEXT.TYPE;
 
@@ -19,45 +18,15 @@ export class UmbUserGroupGranularPermissionListElement extends UmbLitElement {
 
 		this.consumeContext(UMB_USER_GROUP_WORKSPACE_CONTEXT, (instance) => {
 			this.#workspaceContext = instance;
+
+			this.observe(
+				this.#workspaceContext.data,
+				(userGroup) => {
+					this._userGroupPermissions = userGroup?.permissions;
+				},
+				'umbUserGroupGranularPermissionObserver',
+			);
 		});
-
-		this.#observeExtensionRegistry();
-	}
-
-	#observeExtensionRegistry() {
-		this.observe(umbExtensionsRegistry.byType('userGranularPermission'), (manifests) => {
-			if (!manifests) {
-				this._extensionElements = [];
-				return;
-			}
-
-			manifests.forEach(async (manifest) => await this.#extensionElementSetup(manifest));
-		});
-	}
-
-	async #extensionElementSetup(manifest: ManifestGranularUserPermission) {
-		const element = (await createExtensionElement(manifest)) as any;
-		if (!element) throw new Error(`Failed to create extension element for manifest ${manifest.alias}`);
-		if (!this.#workspaceContext) throw new Error('User Group Workspace context is not available');
-
-		this._extensionElements.push(element);
-
-		this.observe(
-			this.#workspaceContext.data,
-			(userGroup) => {
-				if (!userGroup) return;
-
-				const schemaType = manifest.meta.schemaType;
-				const permissionsForSchemaType =
-					userGroup.permissions.filter((permission) => permission.$type === schemaType) || [];
-
-				element.permissions = permissionsForSchemaType;
-				element.manifest = manifest;
-				element.addEventListener(UmbChangeEvent.TYPE, this.#onValueChange);
-				this.requestUpdate('_extensionElements');
-			},
-			'umbUserGroupGranularPermissionObserver',
-		);
 	}
 
 	#onValueChange = (e: UmbChangeEvent) => {
@@ -83,31 +52,38 @@ export class UmbUserGroupGranularPermissionListElement extends UmbLitElement {
 	};
 
 	override render() {
-		return html`${this._extensionElements.map((element) => this.#renderProperty(element))}`;
+		if (!this._userGroupPermissions) return;
+		//return html`${this._extensionElements.map((element) => this.#renderProperty(element))}`;
+		return html`<umb-extension-slot
+			type="userGranularPermission"
+			.renderMethod=${this.#renderProperty}></umb-extension-slot>`;
 	}
 
-	#renderProperty(element: any) {
-		const manifest = element.manifest as ManifestGranularUserPermission;
-		if (!manifest) {
-			return nothing;
-		}
+	#renderProperty = (extension: UmbExtensionElementInitializer<ManifestGranularUserPermission>) => {
+		if (!this._userGroupPermissions) return nothing;
+		if (!extension.component) return nothing;
+
+		const manifest = extension.manifest;
+		if (!manifest) throw new Error('Manifest is not available');
 
 		const label = manifest.meta.labelKey ? this.localize.term(manifest.meta.labelKey) : manifest.meta.label;
 		const description = manifest.meta.descriptionKey
 			? this.localize.term(manifest.meta.descriptionKey)
 			: manifest.meta.description;
 
+		const schemaType = manifest.meta.schemaType;
+		const permissionsForSchemaType =
+			this._userGroupPermissions.filter((permission) => permission.$type === schemaType) || [];
+
+		(extension.component as any).permissions = permissionsForSchemaType;
+		extension.component.addEventListener(UmbChangeEvent.TYPE, this.#onValueChange);
+
 		return html`
 			<umb-property-layout .label=${label || ''} .description=${description || ''}>
-				<div slot="editor">${element}</div>
+				<div slot="editor">${extension.component}</div>
 			</umb-property-layout>
 		`;
-	}
-
-	override disconnectedCallback(): void {
-		this._extensionElements.forEach((element) => element.removeEventListener(UmbChangeEvent.TYPE, this.#onValueChange));
-		super.disconnectedCallback();
-	}
+	};
 }
 
 export default UmbUserGroupGranularPermissionListElement;

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user-group/workspace/user-group/components/user-group-granular-permission-list.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user-group/workspace/user-group/components/user-group-granular-permission-list.element.ts
@@ -53,7 +53,6 @@ export class UmbUserGroupGranularPermissionListElement extends UmbLitElement {
 
 	override render() {
 		if (!this._userGroupPermissions) return;
-		//return html`${this._extensionElements.map((element) => this.#renderProperty(element))}`;
 		return html`<umb-extension-slot
 			type="userGranularPermission"
 			.renderMethod=${this.#renderProperty}></umb-extension-slot>`;

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user-group/workspace/user-group/components/user-group-granular-permission-list.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user-group/workspace/user-group/components/user-group-granular-permission-list.element.ts
@@ -89,7 +89,6 @@ export class UmbUserGroupGranularPermissionListElement extends UmbLitElement {
 	#renderProperty(element: any) {
 		const manifest = element.manifest as ManifestGranularUserPermission;
 		if (!manifest) {
-			console.log("no manifest");
 			return nothing;
 		}
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes https://github.com/umbraco/Umbraco-CMS/issues/17860, tracked under [AB 47493](https://dev.azure.com/umbraco/D-Team%20Tracker/_workitems/edit/47493) (internal HQ tracker).

### Description

This was tricky to replicate as it doesn't happen all the time, but I could fairly consistently find that after five or six refreshes of a user group detail page open in the backoffice - i.e. `/umbraco/section/user-management/workspace/user-group/edit/{id}` - you would see what's reported in the linked issue (no granular permission details displayed, and the error in the console).

With the updates in this PR in place I could no longer see the issue.

**To Test:**

- Other than visual code inspection that the updates make sense, refresh and navigate multiple times to the user group detail and ensure the granular permissions component renders correctly and without console errors.
- Verify granular permissions can be set for a user group.