### PR TITLE
Implemented sorting for media picker crops

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/image-crops/property-editor-ui-image-crops.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/image-crops/property-editor-ui-image-crops.element.ts
@@ -4,7 +4,7 @@ import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/propert
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-editor';
 import { generateAlias } from '@umbraco-cms/backoffice/utils';
-import { UmbSorterController, type UmbSorterConfig } from '@umbraco-cms/backoffice/sorter';
+import { UmbSorterController } from '@umbraco-cms/backoffice/sorter';
 
 export type UmbCrop = {
 	label: string;

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/image-crops/property-editor-ui-image-crops.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/image-crops/property-editor-ui-image-crops.element.ts
@@ -4,6 +4,7 @@ import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/propert
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-editor';
 import { generateAlias } from '@umbraco-cms/backoffice/utils';
+import { UmbSorterController, type UmbSorterConfig } from '@umbraco-cms/backoffice/sorter';
 
 export type UmbCrop = {
 	label: string;
@@ -20,13 +21,41 @@ export class UmbPropertyEditorUIImageCropsElement extends UmbLitElement implemen
 	@query('#label')
 	private _labelInput!: HTMLInputElement;
 
-	@property({ attribute: false })
-	value: UmbCrop[] = [];
+	@state()
+	private _value: Array<UmbCrop> = [];
+
+	@property({ type: Array })
+	public set value(value: Array<UmbCrop>) {
+		this._value = value ?? [];
+		this.#sorter.setModel(this.value);
+	}
+	public get value(): Array<UmbCrop> {
+		return this._value;
+	}
 
 	@state()
 	editCropAlias = '';
 
 	#oldInputValue = '';
+
+	#sorter = new UmbSorterController(this, {
+		getUniqueOfElement: (element: HTMLElement) => {
+			const unique = element.dataset["alias"];
+			return unique;
+		},
+		getUniqueOfModel: (modelEntry: UmbCrop) => {
+			return modelEntry.alias;
+		},
+		identifier: 'Umb.SorterIdentifier.ImageCrops',
+		itemSelector: '.crop',
+		containerSelector: '.crops',
+		onChange: ({ model }) => {
+			const oldValue = this._value;
+			this._value = model;
+			this.requestUpdate('_value', oldValue);
+		  this.dispatchEvent(new UmbPropertyValueChangeEvent());
+		},
+	});
 
 	#onRemove(alias: string) {
 		this.value = [...this.value.filter((item) => item.alias !== alias)];
@@ -163,7 +192,7 @@ export class UmbPropertyEditorUIImageCropsElement extends UmbLitElement implemen
 					this.value,
 					(item) => item.alias,
 					(item) => html`
-						<div class="crop">
+						<div class="crop" data-alias="${item.alias}">
 							<span class="crop-drag">+</span>
 							<span><strong>${item.label}</strong> <em>(${item.alias})</em></span>
 							<span class="crop-size">(${item.width} x ${item.height}px)</span>


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes https://github.com/umbraco/Umbraco-CMS/issues/17829, tracked under [AB 47498](https://dev.azure.com/umbraco/D-Team%20Tracker/_workitems/edit/47498) (internal HQ tracker).

### Description

The linked issue raises two points:

1. Sorting is indicated by the presence of a "drag" icon, but it's not actually implemented.
2. No message displays the need for the width and height.

I don't think there's anything to do for point 2.  Whilst no message is displayed, you can't enter a new crop unless you provide all fields, so it's fairly clear the information needs to be provided, and is consistent with the other required fields of name and alias.

It should be possible to sort though, and when merged this PR will provide that functionality.

**To Test:**

- Create a few crops on a media picker data type.
- Verify that you can move the crop within the list by drag and drop.
- Save the data type and verify that the moved items are persisted in the expected order.
