### PR TITLE
Fix to GetCultureFromDomains extensions following changes to routing and published content cache

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs
@@ -19,6 +19,9 @@ public static class FriendlyPublishedContentExtensions
     private static IVariationContextAccessor VariationContextAccessor { get; } =
         StaticServiceProvider.Instance.GetRequiredService<IVariationContextAccessor>();
 
+    private static IDomainCache DomainCache { get; } =
+        StaticServiceProvider.Instance.GetRequiredService<IDomainCache>();
+
     private static IPublishedContentCache PublishedContentCache { get; } =
         StaticServiceProvider.Instance.GetRequiredService<IPublishedContentCache>();
 
@@ -731,7 +734,7 @@ public static class FriendlyPublishedContentExtensions
     public static string? GetCultureFromDomains(
         this IPublishedContent content,
         Uri? current = null)
-        => content.GetCultureFromDomains(UmbracoContextAccessor, SiteDomainHelper, current);
+        => content.GetCultureFromDomains(UmbracoContextAccessor, SiteDomainHelper, DomainCache, PublishedContentCache, DocumentNavigationQueryService, current);
 
     public static IEnumerable<PublishedSearchResult> SearchDescendants(
         this IPublishedContent content,

--- a/src/Umbraco.Web.Common/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/PublishedContentExtensions.cs
@@ -4,8 +4,10 @@ using Examine.Search;
 using Microsoft.AspNetCore.Html;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.Navigation;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Infrastructure.Examine;
 
@@ -20,7 +22,36 @@ public static class PublishedContentExtensions
     /// </summary>
     /// <param name="content">The document.</param>
     /// <param name="umbracoContextAccessor"></param>
-    /// <param name="siteDomainHelper"></param>
+    /// <param name="siteDomainHelper">The site domain helper.</param>
+    /// <param name="current">An optional current Uri.</param>
+    /// <returns>The culture assigned to the document by domains.</returns>
+    /// <remarks>
+    ///     <para>
+    ///         In 1:1 multilingual setup, a document contains several cultures (there is not
+    ///         one document per culture), and domains, withing the context of a current Uri, assign
+    ///         a culture to that document.
+    ///     </para>
+    /// </remarks>
+    [Obsolete("Please use the method taking all parameters. This overload will be removed in V17.")]
+    public static string? GetCultureFromDomains(
+        this IPublishedContent content,
+        IUmbracoContextAccessor umbracoContextAccessor,
+        ISiteDomainMapper siteDomainHelper,
+        Uri? current = null)
+    {
+        IUmbracoContext umbracoContext = umbracoContextAccessor.GetRequiredUmbracoContext();
+        return DomainUtilities.GetCultureFromDomains(content.Id, content.Path, current, umbracoContext, siteDomainHelper);
+    }
+
+    /// <summary>
+    ///     Gets the culture assigned to a document by domains, in the context of a current Uri.
+    /// </summary>
+    /// <param name="content">The document.</param>
+    /// <param name="umbracoContextAccessor"></param>
+    /// <param name="siteDomainHelper">The site domain helper.</param>
+    /// <param name="domainCache">The domain cache.</param>
+    /// <param name="publishedCache">The published content cache.</param>
+    /// <param name="navigationQueryService">The navigation query service.</param>
     /// <param name="current">An optional current Uri.</param>
     /// <returns>The culture assigned to the document by domains.</returns>
     /// <remarks>
@@ -34,10 +65,13 @@ public static class PublishedContentExtensions
         this IPublishedContent content,
         IUmbracoContextAccessor umbracoContextAccessor,
         ISiteDomainMapper siteDomainHelper,
+        IDomainCache domainCache,
+        IPublishedCache publishedCache,
+        INavigationQueryService navigationQueryService,
         Uri? current = null)
     {
         IUmbracoContext umbracoContext = umbracoContextAccessor.GetRequiredUmbracoContext();
-        return DomainUtilities.GetCultureFromDomains(content.Id, content.Path, current, umbracoContext, siteDomainHelper);
+        return DomainUtilities.GetCultureFromDomains(content.Id, content.Path, current, umbracoContext, siteDomainHelper, domainCache, publishedCache, navigationQueryService);
     }
 
     #endregion


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes https://github.com/umbraco/Umbraco-CMS/issues/17605, tracked under [AB 47518](https://dev.azure.com/umbraco/D-Team%20Tracker/_workitems/edit/47518) (internal HQ tracker).

### Description

As reported in the linked issue, the recommended way of implementing a "language switcher" no longer works as of 15, due to changes in the routing and published cache.

Previously it seems we had methods to retrieve the route from a content ID, which are now obsoleted in favour of `IPublishedUrlProvider.GetUrl`.  However the old methods had a variation in that they would prefix the content ID of the node that defines the domains - see [here](https://github.com/umbraco/Umbraco-CMS/blob/v13/dev/src/Umbraco.PublishedCache.NuCache/ContentCache.cs#L208) - which doesn't look to have been carried over.

Rather than re-introducing this (at very least it seems a little obscure) I've amended the `GetCultureFromDomains` itself to take the necessary parameters to find the ancestor node with domains assigned and use that to implement the functionality.

**To Test:**

- Set up a website with two languages, with content varying by culture and content for both languages.
- Implement a language switcher similar to that provided in the linked issue.
- Verify you can switch languages from root and sub pages.