### PR TITLE
Refactor workspace context creation logic

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/libs/extension-api/controller/base-extension-initializer.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/extension-api/controller/base-extension-initializer.controller.ts
@@ -63,11 +63,11 @@ export abstract class UmbBaseExtensionInitializer<
 	constructor(
 		host: UmbControllerHost,
 		extensionRegistry: UmbExtensionRegistry<ManifestCondition>,
-		extensionTypeName: string,
+		controllerTypeName: string,
 		alias: string,
 		onPermissionChanged?: (isPermitted: boolean, controller: SubClassType) => void,
 	) {
-		super(host, extensionTypeName + '_' + alias);
+		super(host, controllerTypeName + '_' + alias);
 		this.#extensionRegistry = extensionRegistry;
 		this.#alias = alias;
 		this.#onPermissionChanged = onPermissionChanged;

--- a/src/Umbraco.Web.UI.Client/src/libs/extension-api/controller/base-extensions-initializer.controller.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/extension-api/controller/base-extensions-initializer.controller.test.ts
@@ -1,7 +1,7 @@
 import { UmbExtensionRegistry } from '../registry/extension.registry.js';
 import type { ManifestCondition, ManifestWithDynamicConditions, UmbConditionConfigBase } from '../types/index.js';
 import type { UmbExtensionCondition } from '../condition/extension-condition.interface.js';
-import type { PermittedControllerType } from './index.js';
+import type { PermittedControllerType, UmbBaseExtensionsInitializerArgs } from './index.js';
 import { UmbBaseExtensionInitializer, UmbBaseExtensionsInitializer } from './index.js';
 import { expect, fixture } from '@open-wc/testing';
 import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
@@ -21,7 +21,7 @@ class UmbTestExtensionController extends UmbBaseExtensionInitializer {
 		alias: string,
 		onPermissionChanged: (isPermitted: boolean, controller: UmbTestExtensionController) => void,
 	) {
-		super(host, extensionRegistry, 'test_', alias, onPermissionChanged);
+		super(host, extensionRegistry, 'test', alias, onPermissionChanged);
 		this._init();
 	}
 
@@ -57,8 +57,9 @@ class UmbTestExtensionsController<
 		type: myTestManifestTypes,
 		filter: null | ((manifest: ManifestWithDynamicConditions) => boolean),
 		onChange: (permittedManifests: Array<MyPermittedControllerType>) => void,
+		args?: UmbBaseExtensionsInitializerArgs,
 	) {
-		super(host, extensionRegistry, type, filter, onChange);
+		super(host, extensionRegistry, type, filter, onChange, 'testController', args);
 		this.#extensionRegistry = extensionRegistry;
 		this._init();
 	}
@@ -128,6 +129,28 @@ describe('UmbBaseExtensionsController', () => {
 						done();
 					}
 				},
+			);
+		});
+
+		it('exposes only one manifests in single mode', (done) => {
+			let count = 0;
+
+			const extensionsInitController = new UmbTestExtensionsController(
+				hostElement,
+				testExtensionRegistry,
+				'extension-type',
+				null,
+				(permitted) => {
+					count++;
+					console.log('permitted', permitted);
+					if (count === 1) {
+						expect(permitted.length).to.eq(1);
+						extensionsInitController.destroy();
+					} else if (count === 2) {
+						done();
+					}
+				},
+				{ single: true },
 			);
 		});
 

--- a/src/Umbraco.Web.UI.Client/src/libs/extension-api/controller/base-extensions-initializer.controller.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/extension-api/controller/base-extensions-initializer.controller.test.ts
@@ -126,6 +126,7 @@ describe('UmbBaseExtensionsController', () => {
 						expect(permitted.length).to.eq(2);
 						extensionsInitController.destroy();
 					} else if (count === 2) {
+						// because we destroy above there is a last callback with no permitted controllers. [NL]
 						done();
 					}
 				},
@@ -142,11 +143,11 @@ describe('UmbBaseExtensionsController', () => {
 				null,
 				(permitted) => {
 					count++;
-					console.log('permitted', permitted);
 					if (count === 1) {
 						expect(permitted.length).to.eq(1);
 						extensionsInitController.destroy();
 					} else if (count === 2) {
+						// because we destroy above there is a last callback with no permitted controllers. [NL]
 						done();
 					}
 				},
@@ -236,6 +237,33 @@ describe('UmbBaseExtensionsController', () => {
 						extensionsInitController.destroy();
 					}
 				},
+			);
+		});
+
+		it('change the exposed manifests even in single mode', (done) => {
+			let count = 0;
+			const extensionsInitController = new UmbTestExtensionsController(
+				hostElement,
+				testExtensionRegistry,
+				'extension-type',
+				null,
+				(permitted) => {
+					count++;
+					if (count === 1) {
+						// Still just equal one, as the second one overwrites the first one. [NL]
+						expect(permitted.length).to.eq(1);
+						expect(permitted[0].alias).to.eq('Umb.Test.Extension.B');
+
+						// lets remove the overwriting extension to see the original coming back. [NL]
+						testExtensionRegistry.unregister('Umb.Test.Extension.B');
+					} else if (count === 2) {
+						expect(permitted.length).to.eq(1);
+						expect(permitted[0].alias).to.eq('Umb.Test.Extension.A');
+						done();
+						extensionsInitController.destroy();
+					}
+				},
+				{ single: true },
 			);
 		});
 	});

--- a/src/Umbraco.Web.UI.Client/src/libs/extension-api/controller/extensions-api-initializer.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/extension-api/controller/extensions-api-initializer.controller.ts
@@ -8,9 +8,13 @@ import type {
 	ManifestApi,
 	ManifestBase,
 	UmbApiConstructorArgumentsMethodType,
+	UmbBaseExtensionsInitializerArgs,
 	UmbExtensionRegistry,
 } from '@umbraco-cms/backoffice/extension-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface UmbExtensionsApiInitializerArgs extends UmbBaseExtensionsInitializerArgs {}
 
 /**
  * This Controller manages a set of Extensions and their Manifest.
@@ -63,8 +67,9 @@ export class UmbExtensionsApiInitializer<
 		filter?: undefined | null | ((manifest: ManifestTypeAsApi) => boolean),
 		onChange?: (permittedManifests: Array<MyPermittedControllerType>) => void,
 		controllerAlias?: string,
+		args?: UmbExtensionsApiInitializerArgs,
 	) {
-		super(host, extensionRegistry, type, filter, onChange, controllerAlias);
+		super(host, extensionRegistry, type, filter, onChange, controllerAlias, args);
 		this.#extensionRegistry = extensionRegistry;
 		this.#constructorArgs = constructorArguments;
 		this._init();

--- a/src/Umbraco.Web.UI.Client/src/libs/extension-api/controller/extensions-element-and-api-initializer.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/extension-api/controller/extensions-element-and-api-initializer.controller.ts
@@ -1,13 +1,16 @@
 import type { ApiLoaderProperty, ManifestBase } from '../types/index.js';
 import type { UmbExtensionRegistry } from '../registry/extension.registry.js';
 import type { SpecificManifestTypeOrManifestBase } from '../types/map.types.js';
-import type { UmbApiConstructorArgumentsMethodType } from '../index.js';
+import type { UmbApiConstructorArgumentsMethodType, UmbBaseExtensionsInitializerArgs } from '../index.js';
 import { UmbExtensionElementAndApiInitializer } from './extension-element-and-api-initializer.controller.js';
 import {
 	type PermittedControllerType,
 	UmbBaseExtensionsInitializer,
 } from './base-extensions-initializer.controller.js';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface UmbExtensionsElementAndApiInitializerArgs extends UmbBaseExtensionsInitializerArgs {}
 
 /**
  */
@@ -63,8 +66,9 @@ export class UmbExtensionsElementAndApiInitializer<
 		controllerAlias?: string,
 		defaultElement?: string,
 		defaultApi?: ApiLoaderProperty,
+		args?: UmbExtensionsElementAndApiInitializerArgs,
 	) {
-		super(host, extensionRegistry, type, filter, onChange, controllerAlias);
+		super(host, extensionRegistry, type, filter, onChange, controllerAlias, args);
 		this.#extensionRegistry = extensionRegistry;
 		this.#constructorArgs = constructorArguments;
 		this.#defaultElement = defaultElement;

--- a/src/Umbraco.Web.UI.Client/src/libs/extension-api/controller/extensions-element-initializer.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/extension-api/controller/extensions-element-initializer.controller.ts
@@ -5,8 +5,12 @@ import { UmbExtensionElementInitializer } from './extension-element-initializer.
 import {
 	type PermittedControllerType,
 	UmbBaseExtensionsInitializer,
+	type UmbBaseExtensionsInitializerArgs,
 } from './base-extensions-initializer.controller.js';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface UmbExtensionsElementInitializerArgs extends UmbBaseExtensionsInitializerArgs {}
 
 /**
  */
@@ -46,8 +50,9 @@ export class UmbExtensionsElementInitializer<
 		onChange: (permittedManifests: Array<MyPermittedControllerType>) => void,
 		controllerAlias?: string,
 		defaultElement?: string,
+		args?: UmbExtensionsElementInitializerArgs,
 	) {
-		super(host, extensionRegistry, type, filter, onChange, controllerAlias);
+		super(host, extensionRegistry, type, filter, onChange, controllerAlias, args);
 		this.#extensionRegistry = extensionRegistry;
 		this.#defaultElement = defaultElement;
 		this._init();

--- a/src/Umbraco.Web.UI.Client/src/libs/extension-api/controller/extensions-manifest-initializer.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/extension-api/controller/extensions-manifest-initializer.controller.ts
@@ -4,8 +4,15 @@ import {
 	type PermittedControllerType,
 	UmbBaseExtensionsInitializer,
 } from './base-extensions-initializer.controller.js';
-import type { ManifestBase, UmbExtensionRegistry } from '@umbraco-cms/backoffice/extension-api';
+import type {
+	ManifestBase,
+	UmbBaseExtensionsInitializerArgs,
+	UmbExtensionRegistry,
+} from '@umbraco-cms/backoffice/extension-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface UmbExtensionsManifestInitializerArgs extends UmbBaseExtensionsInitializerArgs {}
 
 /**
  */
@@ -32,8 +39,9 @@ export class UmbExtensionsManifestInitializer<
 		filter: null | ((manifest: ManifestType) => boolean),
 		onChange: (permittedManifests: Array<MyPermittedControllerType>) => void,
 		controllerAlias?: string,
+		args?: UmbExtensionsManifestInitializerArgs,
 	) {
-		super(host, extensionRegistry, type, filter, onChange, controllerAlias);
+		super(host, extensionRegistry, type, filter, onChange, controllerAlias, args);
 		this.#extensionRegistry = extensionRegistry;
 		this._init();
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-block-inline/block-grid-block-inline.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-block-inline/block-grid-block-inline.element.ts
@@ -131,10 +131,7 @@ export class UmbBlockGridBlockInlineElement extends UmbLitElement {
 						'observeVariant',
 					);
 
-					new UmbExtensionsApiInitializer(this, umbExtensionsRegistry, 'workspaceContext', [
-						this,
-						this.#workspaceContext,
-					]);
+					new UmbExtensionsApiInitializer(this, umbExtensionsRegistry, 'workspaceContext', [this.#workspaceContext]);
 				}
 			},
 		);

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/components/inline-list-block/inline-list-block.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/components/inline-list-block/inline-list-block.element.ts
@@ -115,10 +115,7 @@ export class UmbInlineListBlockElement extends UmbLitElement {
 						'observeVariant',
 					);
 
-					new UmbExtensionsApiInitializer(this, umbExtensionsRegistry, 'workspaceContext', [
-						this,
-						this.#workspaceContext,
-					]);
+					new UmbExtensionsApiInitializer(this, umbExtensionsRegistry, 'workspaceContext', [this.#workspaceContext]);
 				}
 			},
 		);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/extension-registry/components/extension-slot/extension-slot.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/extension-registry/components/extension-slot/extension-slot.element.ts
@@ -124,6 +124,9 @@ export class UmbExtensionSlotElement extends UmbLitElement {
 				},
 				undefined, // We can leave the alias undefined as we destroy this our selfs.
 				this.defaultElement,
+				{
+					single: this.single,
+				},
 			);
 			this.#extensionsController.properties = this.#props;
 		}
@@ -132,9 +135,7 @@ export class UmbExtensionSlotElement extends UmbLitElement {
 	override render() {
 		return this._permitted
 			? this._permitted.length > 0
-				? this.single
-					? this.#renderExtension(this._permitted[0], 0)
-					: repeat(this._permitted, (ext) => ext.alias, this.#renderExtension)
+				? repeat(this._permitted, (ext) => ext.alias, this.#renderExtension)
 				: html`<slot></slot>`
 			: nothing;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/extension-registry/components/extension-slot/extension-slot.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/extension-registry/components/extension-slot/extension-slot.element.ts
@@ -1,6 +1,6 @@
 import { umbExtensionsRegistry } from '../../registry.js';
 import type { TemplateResult } from '@umbraco-cms/backoffice/external/lit';
-import { css, repeat, customElement, property, state, html } from '@umbraco-cms/backoffice/external/lit';
+import { css, repeat, customElement, property, state, html, nothing } from '@umbraco-cms/backoffice/external/lit';
 import {
 	type UmbExtensionElementInitializer,
 	UmbExtensionsElementInitializer,
@@ -136,7 +136,7 @@ export class UmbExtensionSlotElement extends UmbLitElement {
 					? this.#renderExtension(this._permitted[0], 0)
 					: repeat(this._permitted, (ext) => ext.alias, this.#renderExtension)
 				: html`<slot></slot>`
-			: '';
+			: nothing;
 	}
 
 	#renderExtension = (ext: UmbExtensionElementInitializer, i: number) => {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/extension-registry/components/extension-with-api-slot/extension-with-api-slot.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/extension-registry/components/extension-with-api-slot/extension-with-api-slot.element.ts
@@ -172,6 +172,9 @@ export class UmbExtensionWithApiSlotElement extends UmbLitElement {
 				undefined, // We can leave the alias to undefined, as we destroy this our selfs.
 				this.defaultElement,
 				this.defaultApi,
+				{
+					single: this.single,
+				},
 			);
 			this.#extensionsController.apiProperties = this.#apiProps;
 			this.#extensionsController.elementProperties = this.#elProps;
@@ -181,9 +184,7 @@ export class UmbExtensionWithApiSlotElement extends UmbLitElement {
 	override render() {
 		return this._permitted
 			? this._permitted.length > 0
-				? this.single
-					? this.#renderExtension(this._permitted[0], 0)
-					: repeat(this._permitted, (ext) => ext.alias, this.#renderExtension)
+				? repeat(this._permitted, (ext) => ext.alias, this.#renderExtension)
 				: html`<slot></slot>`
 			: nothing;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/extension-registry/components/extension-with-api-slot/extension-with-api-slot.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/extension-registry/components/extension-with-api-slot/extension-with-api-slot.element.ts
@@ -1,6 +1,6 @@
 import { umbExtensionsRegistry } from '../../registry.js';
 import type { TemplateResult } from '@umbraco-cms/backoffice/external/lit';
-import { css, repeat, customElement, property, state, html } from '@umbraco-cms/backoffice/external/lit';
+import { css, repeat, customElement, property, state, html, nothing } from '@umbraco-cms/backoffice/external/lit';
 import {
 	type UmbExtensionElementAndApiInitializer,
 	UmbExtensionsElementAndApiInitializer,
@@ -185,7 +185,7 @@ export class UmbExtensionWithApiSlotElement extends UmbLitElement {
 					? this.#renderExtension(this._permitted[0], 0)
 					: repeat(this._permitted, (ext) => ext.alias, this.#renderExtension)
 				: html`<slot></slot>`
-			: '';
+			: nothing;
 	}
 
 	#renderExtension = (ext: UmbExtensionElementAndApiInitializer, i: number) => {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/kinds/routable/routable-workspace.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/kinds/routable/routable-workspace.element.ts
@@ -1,9 +1,7 @@
 import type { UmbRoutableWorkspaceContext } from '../../contexts/tokens/routable-workspace-context.interface.js';
-import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { UmbRoute } from '@umbraco-cms/backoffice/router';
-import { UmbExtensionsApiInitializer } from '@umbraco-cms/backoffice/extension-api';
 
 @customElement('umb-routable-workspace')
 export class UmbRoutableWorkspaceElement extends UmbLitElement {
@@ -12,8 +10,6 @@ export class UmbRoutableWorkspaceElement extends UmbLitElement {
 
 	public set api(api: UmbRoutableWorkspaceContext) {
 		this.observe(api.routes.routes, (routes) => (this._routes = routes));
-
-		new UmbExtensionsApiInitializer(this, umbExtensionsRegistry, 'workspaceContext', [api]);
 	}
 
 	override render() {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/workspace.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/workspace.element.ts
@@ -2,6 +2,7 @@ import { nothing, customElement, property, type PropertyValueMap, state } from '
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { ManifestWorkspace } from '@umbraco-cms/backoffice/workspace';
 import {
+	UmbExtensionsApiInitializer,
 	UmbExtensionsElementAndApiInitializer,
 	type UmbApiConstructorArgumentsMethodType,
 } from '@umbraco-cms/backoffice/extension-api';
@@ -46,7 +47,12 @@ export class UmbWorkspaceElement extends UmbLitElement {
 			apiArgsCreator,
 			(manifest: ManifestWorkspace) => manifest.meta.entityType === entityType,
 			(extensionControllers) => {
-				this._component = extensionControllers[0].component;
+				this._component = extensionControllers[0]?.component;
+				const api = extensionControllers[0]?.api;
+				if (api) {
+					// We create the additional workspace contexts with the Workspace API as its host, to ensure they can use the same Context-Alias with different API-Aliases and still be reached cause they will then be provided at the same host. [NL]
+					new UmbExtensionsApiInitializer(api, umbExtensionsRegistry, 'workspaceContext', [api]);
+				}
 			},
 			undefined, // We can leave the alias to undefined, as we destroy this our selfs.
 			undefined,

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/workspace.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/workspace.element.ts
@@ -1,8 +1,12 @@
-import { html, nothing, customElement, property, type PropertyValueMap } from '@umbraco-cms/backoffice/external/lit';
+import { nothing, customElement, property, type PropertyValueMap, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { ManifestWorkspace } from '@umbraco-cms/backoffice/workspace';
-import type { UmbApiConstructorArgumentsMethodType } from '@umbraco-cms/backoffice/extension-api';
+import {
+	UmbExtensionsElementAndApiInitializer,
+	type UmbApiConstructorArgumentsMethodType,
+} from '@umbraco-cms/backoffice/extension-api';
 import { UMB_MARK_ATTRIBUTE_NAME } from '@umbraco-cms/backoffice/const';
+import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 
 const apiArgsCreator: UmbApiConstructorArgumentsMethodType<unknown> = (manifest: unknown) => {
 	return [{ manifest }];
@@ -10,22 +14,49 @@ const apiArgsCreator: UmbApiConstructorArgumentsMethodType<unknown> = (manifest:
 
 @customElement('umb-workspace')
 export class UmbWorkspaceElement extends UmbLitElement {
+	#extensionsController?: UmbExtensionsElementAndApiInitializer<any>;
+	#entityType?: string;
+
+	@state()
+	_component?: HTMLElement;
+
 	@property({ type: String, attribute: 'entity-type' })
-	entityType = '';
+	public get entityType(): string | undefined {
+		return this.#entityType;
+	}
+	public set entityType(value: string) {
+		if (value === this.#entityType || !value) return;
+		this.#entityType = value;
+		this.#createController(value);
+	}
 
 	protected override firstUpdated(_changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>): void {
 		super.firstUpdated(_changedProperties);
 		this.setAttribute(UMB_MARK_ATTRIBUTE_NAME, 'workspace');
 	}
 
+	#createController(entityType: string) {
+		if (this.#extensionsController) {
+			this.#extensionsController.destroy();
+		}
+		this.#extensionsController = new UmbExtensionsElementAndApiInitializer(
+			this,
+			umbExtensionsRegistry,
+			'workspace',
+			apiArgsCreator,
+			(manifest: ManifestWorkspace) => manifest.meta.entityType === entityType,
+			(extensionControllers) => {
+				this._component = extensionControllers[0].component;
+			},
+			undefined, // We can leave the alias to undefined, as we destroy this our selfs.
+			undefined,
+			() => import('./kinds/default/default-workspace.context.js'),
+			{ single: true },
+		);
+	}
+
 	override render() {
-		if (!this.entityType) return nothing;
-		return html`<umb-extension-with-api-slot
-			type="workspace"
-			.defaultApi=${() => import('./kinds/default/default-workspace.context.js')}
-			.apiArgs=${apiArgsCreator}
-			.filter=${(manifest: ManifestWorkspace) =>
-				manifest.meta.entityType === this.entityType}></umb-extension-with-api-slot>`;
+		return this._component ?? nothing;
 	}
 }
 


### PR DESCRIPTION
Instead of the specific Main Workspace Context creating extra Workspace Context Extensions, then this PR moves the logic so it happens by the initialization of the Workspace. Enabling Workspace Context Extensions to always be initialized no matter the specific Workspace API(Workspace Context) implementation.

This move the single mode as a feature of extension-slot to a feature of the Extension Initializers. And as part of that work started implementing args object to be parsed for those. This is thought only done for the Single Mode, but could for v.16 be adopted for all args.