### PR TITLE
Don't add a blanket rule to allow synchronous IO, should not be necessary for the new management API

### DIFF
--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -326,7 +326,7 @@ public static partial class UmbracoBuilderExtensions
         return builder;
     }
 
-    // TODO: Does this need to exist and/or be public?
+    [Obsolete("This is not necessary any more. This will be removed in v17")]
     public static IUmbracoBuilder AddWebServer(this IUmbracoBuilder builder)
     {
         return builder;

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -329,17 +329,6 @@ public static partial class UmbracoBuilderExtensions
     // TODO: Does this need to exist and/or be public?
     public static IUmbracoBuilder AddWebServer(this IUmbracoBuilder builder)
     {
-        // TODO: We need to figure out why this is needed and fix those endpoints to not need them, we don't want to change global things
-        // If using Kestrel: https://stackoverflow.com/a/55196057
-        builder.Services.Configure<KestrelServerOptions>(options =>
-        {
-            options.AllowSynchronousIO = true;
-        });
-        builder.Services.Configure<IISServerOptions>(options =>
-        {
-            options.AllowSynchronousIO = true;
-        });
-
         return builder;
     }
 


### PR DESCRIPTION
This is an attempt to fix a problem after multiple reports of v15 not working on Linux machines:

- https://discord-chats.umbraco.com/t/26718591/iis-exception-at-start-up-when-running-umbraco-v15-on-rocky-
- https://discord-chats.umbraco.com/t/26747783/umbraco-15-and-dotnet-9-exception
- https://discord-chats.umbraco.com/t/23442398/umbraco-15-deploy-on-ubuntu-24-missing-microsoft-aspnetcore-
- https://our.umbraco.com/forum/using-umbraco-and-getting-started/115012-cut-by-the-bleeding-edge-has-anyone-managed-to-get-u15-stood-up-on-linux
- https://x.com/DavidBuckell/status/1869520293330670070

The problem is that we're trying to configure IIS options on a machine that doesn't have IIS installed. Curiously, if you install .NET not from the simple packages that Microsoft provides, but manually download it to a folder and updating some global variables then it works. Not sure what is causing it to work in that case.

Anyway, Umbraco should "just" work when using the regular .NET install instructions.

It looks like this code was added at some point (and I can for the life of me not figure out where exactly, looks like 2020):

```csharp
            services.Configure<KestrelServerOptions>(options =>
            {
                options.AllowSynchronousIO = true;
            });

            services.Configure<IISServerOptions>(options =>
            {
                options.AllowSynchronousIO = true;
            });
```

Presumably this was done to make non-async endpoints work. With the introduction of the new management API, everything should be async and this should no longer be needed. 

It looks like @AndyButland tried to remove it in one of his commits for PR #8747 https://github.com/umbraco/Umbraco-CMS/pull/8747/commits/bdfa1fb644e5bdfafb3961bece3ff7189026694a but changed his mind, not sure why. 

I'm just opening this as a draft now to see if any tests fail.
