### PR TITLE
Feature: Minor performance optimization from investigation

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/libs/context-api/provide/context-provider.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/context-api/provide/context-provider.ts
@@ -42,7 +42,20 @@ export class UmbContextProvider<BaseType = unknown, ResultType extends BaseType 
 		this.#instance = instance;
 
 		this.#eventTarget.addEventListener(UMB_CONTEXT_REQUEST_EVENT_TYPE, this.#handleContextRequest);
+		this.#eventTarget.addEventListener(UMB_DEBUG_CONTEXT_EVENT_TYPE, this.#handleDebugContextRequest);
 	}
+
+	/**
+	 * @memberof UmbContextProvider
+	 */
+	public hostConnected(): void {
+		this.#eventTarget.dispatchEvent(new UmbContextProvideEventImplementation(this.#contextAlias));
+	}
+
+	/**
+	 * @memberof UmbContextProvider
+	 */
+	public hostDisconnected(): void {}
 
 	/**
 	 * @private
@@ -65,28 +78,10 @@ export class UmbContextProvider<BaseType = unknown, ResultType extends BaseType 
 	}) as EventListener;
 
 	/**
+	 * @private
+	 * @param {UmbContextRequestEvent} event - the event to append awareness to
 	 * @memberof UmbContextProvider
 	 */
-	public hostConnected(): void {
-		//this.hostElement.addEventListener(UMB_CONTEXT_REQUEST_EVENT_TYPE, this.#handleContextRequest);
-		this.#eventTarget.dispatchEvent(new UmbContextProvideEventImplementation(this.#contextAlias));
-
-		// Listen to our debug event 'umb:debug-contexts'
-		this.#eventTarget.addEventListener(UMB_DEBUG_CONTEXT_EVENT_TYPE, this.#handleDebugContextRequest);
-	}
-
-	/**
-	 * @memberof UmbContextProvider
-	 */
-	public hostDisconnected(): void {
-		//this.hostElement.removeEventListener(UMB_CONTEXT_REQUEST_EVENT_TYPE, this.#handleContextRequest);
-		// Out-commented for now, but kept if we like to reintroduce this:
-		//window.dispatchEvent(new UmbContextUnprovidedEventImplementation(this._contextAlias, this.#instance));
-
-		// Stop listen to our debug event 'umb:debug-contexts'
-		this.#eventTarget?.removeEventListener(UMB_DEBUG_CONTEXT_EVENT_TYPE, this.#handleDebugContextRequest);
-	}
-
 	#handleDebugContextRequest = (event: any): void => {
 		// If the event doesn't have an instances property, create it.
 		if (!event.instances) {
@@ -102,9 +97,9 @@ export class UmbContextProvider<BaseType = unknown, ResultType extends BaseType 
 	};
 
 	destroy(): void {
-		this.hostDisconnected();
 		// Note we are not removing the event listener in the hostDisconnected, therefor we do it here [NL].
 		this.#eventTarget?.removeEventListener(UMB_CONTEXT_REQUEST_EVENT_TYPE, this.#handleContextRequest);
+		this.#eventTarget?.removeEventListener(UMB_DEBUG_CONTEXT_EVENT_TYPE, this.#handleDebugContextRequest);
 		// We want to call a destroy method on the instance, if it has one.
 		(this.#instance as any)?.destroy?.();
 		this.#instance = undefined;

--- a/src/Umbraco.Web.UI.Client/src/libs/context-api/provide/context-provider.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/context-api/provide/context-provider.ts
@@ -55,7 +55,10 @@ export class UmbContextProvider<BaseType = unknown, ResultType extends BaseType 
 	/**
 	 * @memberof UmbContextProvider
 	 */
-	public hostDisconnected(): void {}
+	public hostDisconnected(): void {
+		// Out-commented for now, but kept if we like to reintroduce this:
+		//window.dispatchEvent(new UmbContextUnprovidedEventImplementation(this._contextAlias, this.#instance));
+	}
 
 	/**
 	 * @private


### PR DESCRIPTION
Nothing much, but moving the debug event to constructor similar to the main request event. This will align then and make sure we have less event listeners added and removed, should improve performance tiny bit.

But the real optimization will occur when we have fixed the context-request pickup system, which currently runs for the whole backoffice, but I do think it should be possible to make it more local and thereby win some performance.