### PR TITLE
Update persmission check restored.

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/CreateDocumentControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/CreateDocumentControllerBase.cs
@@ -24,15 +24,16 @@ public abstract class CreateDocumentControllerBase : DocumentControllerBase
         // IEnumerable<string> cultures = requestModel.Variants
         //     .Where(v => v.Culture is not null)
         //     .Select(v => v.Culture!);
-        // AuthorizationResult authorizationResult = await _authorizationService.AuthorizeResourceAsync(
-        //     User,
-        //     ContentPermissionResource.WithKeys(ActionNew.ActionLetter, requestModel.Parent?.Id, cultures),
-        //     AuthorizationPolicies.ContentPermissionByResource);
-        //
-        // if (!authorizationResult.Succeeded)
-        // {
-        //     return Forbidden();
-        // }
+        AuthorizationResult authorizationResult = await _authorizationService.AuthorizeResourceAsync(
+            User,
+            // We set empty cultures to ingore them (ContentEditingService check them), but we still check permission to update
+            ContentPermissionResource.WithKeys(ActionNew.ActionLetter, requestModel.Parent?.Id, Array.Empty<string>()),
+            AuthorizationPolicies.ContentPermissionByResource);
+
+        if (!authorizationResult.Succeeded)
+        {
+            return Forbidden();
+        }
 
         return await authorizedHandler();
     }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/UpdateDocumentControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/UpdateDocumentControllerBase.cs
@@ -20,18 +20,19 @@ public abstract class UpdateDocumentControllerBase : DocumentControllerBase
         // TODO This have temporarily been uncommented, to support the client sends values from all cultures, even when the user do not have access to the languages.
         // The values are ignored in the ContentEditingService
 
-        // IEnumerable<string> cultures = requestModel.Variants
-        //     .Where(v => v.Culture is not null)
-        //     .Select(v => v.Culture!);
-        // AuthorizationResult authorizationResult = await _authorizationService.AuthorizeResourceAsync(
-        //     User,
-        //     ContentPermissionResource.WithKeys(ActionUpdate.ActionLetter, id, cultures),
-        //     AuthorizationPolicies.ContentPermissionByResource);
-        //
-        // if (!authorizationResult.Succeeded)
-        // {
-        //     return Forbidden();
-        // }
+        //IEnumerable<string> cultures = requestModel.Variants
+        //    .Where(v => v.Culture is not null)
+        //    .Select(v => v.Culture!);
+        AuthorizationResult authorizationResult = await _authorizationService.AuthorizeResourceAsync(
+            User,
+            // We set empty cultures to ingore them (ContentEditingService check them), but we still check permission to update
+            ContentPermissionResource.WithKeys(ActionUpdate.ActionLetter, id, Array.Empty<string>()),
+            AuthorizationPolicies.ContentPermissionByResource);
+
+        if (!authorizationResult.Succeeded)
+        {
+            return Forbidden();
+        }
 
         return await authorizedHandler();
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

There is an existed [issue](https://github.com/umbraco/Umbraco-CMS/issues/17890) for this PR

### Description
I have uncommented code to respect "Umb.Document.Update" and "Umb.Document.Create" permissions during creating and saving documents but set empty cultures to check [according this issue](https://github.com/umbraco/Umbraco-CMS/pull/17052)

You can find steps to test in steps to reproduce in the [issue](https://github.com/umbraco/Umbraco-CMS/issues/17890).
