### PR TITLE
v15: Support SVGs in thumbnail endpoint

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Factories/ReziseImageUrlFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/ReziseImageUrlFactory.cs
@@ -52,7 +52,7 @@ public class ReziseImageUrlFactory : IReziseImageUrlFactory
                     yield return new MediaUrlInfo
                     {
                         Culture = null,
-                        Url = url,
+                        Url = _absoluteUrlBuilder.ToAbsoluteUrl(url).ToString(),
                     };
                 }
 

--- a/src/Umbraco.Cms.Api.Management/Factories/ReziseImageUrlFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/ReziseImageUrlFactory.cs
@@ -46,6 +46,16 @@ public class ReziseImageUrlFactory : IReziseImageUrlFactory
             var extension = Path.GetExtension(url).Remove(0, 1);
             if (_imageUrlGenerator.SupportedImageFileTypes.InvariantContains(extension) is false)
             {
+                // It's okay to return just the image URL for SVGs, as they are always scalable.
+                if (extension == "svg")
+                {
+                    yield return new MediaUrlInfo
+                    {
+                        Culture = null,
+                        Url = url,
+                    };
+                }
+
                 continue;
             }
 


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/17597

# Notes
- Svg's weren't support in the thumbnail endpoint, this is now fixed by just returning the SVG URL. as svg's are always scalable anyways.

# how to test
- Follow steps in original issue 