### PR TITLE
V15: Order children by sortorder

### DIFF
--- a/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
@@ -4453,7 +4453,8 @@ public static class PublishedContentExtensions
         return childrenKeys
             .Where(x => publishStatusQueryService.IsDocumentPublished(x, culture))
             .Select(publishedCache.GetById)
-            .WhereNotNull();
+            .WhereNotNull()
+            .OrderBy(x => x.SortOrder);
     }
 
     private static IEnumerable<IPublishedContent> FilterByCulture(


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/17844

# Notes
- Orders children by their sortorder.
- This is only a feature for children, so does not apply to descendants/ancestors etc.

# How to test
- Create a doc type called child, with a property textstring called "Title"
- Create a doc type called root, with allow as root set to true, and the "child" doc type allowed as child.
- Create this structure in your content:

- Root
    - Child One
    - Child Two
    - Child Three
    - Child four

- Now swap the order, by clicking on root and selection the action "sort children"

- You can then use a  controller, or somewhere other, where you call the .Children on your root node,
- I did this by creating a controller, and calling `https://localhost:44339/test/index` via postman

```
using Microsoft.AspNetCore.Mvc;
using Umbraco.Cms.Core.PublishedCache;
using Umbraco.Cms.Core.Services;

namespace Umbraco.Cms.Web.UI;

[ApiController]
[Route("[controller]/[action]")]
public class TestController : Controller
{
    private readonly IPublishedContentCache _publishedContentCache;

    public TestController(IPublishedContentCache publishedContentCache)
    {
        _publishedContentCache = publishedContentCache;
    }

    [HttpGet]
    public async Task<IActionResult> Index()
    {
        var content = await _publishedContentCache.GetByIdAsync(new Guid("´{INSERT YOUR ROOT NODE KEY HERE}"));
        var children = content?.Descendants();
        return Ok(children?.Select(x => x.Name));
    }
}

```