### PR TITLE
Call change event after update of multiple text string order

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/multiple-text-string-input/input-multiple-text-string.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/multiple-text-string-input/input-multiple-text-string.element.ts
@@ -21,13 +21,14 @@ export class UmbInputMultipleTextStringElement extends UmbFormControlMixin<undef
 		getUniqueOfModel: (modelEntry: string) => {
 			return modelEntry;
 		},
-		identifier: 'Umb.SorterIdentifier.ColorEditor',
+		identifier: 'Umb.SorterIdentifier.MultipleTextString',
 		itemSelector: 'umb-input-multiple-text-string-item',
 		containerSelector: '#sorter-wrapper',
 		onChange: ({ model }) => {
 			const oldValue = this._items;
 			this._items = model;
 			this.requestUpdate('_items', oldValue);
+			this.dispatchEvent(new UmbChangeEvent());
 		},
 	});
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16884, tracked under [AB 47563](https://dev.azure.com/umbraco/D-Team%20Tracker/_workitems/edit/47563) (internal HQ tracker).

### Description
This PR adds the missing change event to the re-ordering of multiple text string properties.

**To Test:**

- Create a document type with a multiple text string property.
- Create some content using the property with two or more strings and save.
- Re-order the strings, save again and confirm the re-ordering change has persisted.