### PR TITLE
User invite email fails if visited more than once without completing

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/BackOfficeController.cs
@@ -230,10 +230,12 @@ public class BackOfficeController : UmbracoController
 
         // sign the user in
         DateTime? previousLastLoginDate = identityUser.LastLoginDateUtc;
+        var securityStamp = identityUser.SecurityStamp;
         await _signInManager.SignInAsync(identityUser, false);
 
-        // reset the lastlogindate back to previous as the user hasn't actually logged in, to add a flag or similar to BackOfficeSignInManager would be a breaking change
+        // reset the lastlogindate and securitystamp back to previous as the user hasn't actually logged in, to add a flag or similar to BackOfficeSignInManager would be a breaking change
         identityUser.LastLoginDateUtc = previousLastLoginDate;
+        identityUser.SecurityStamp = securityStamp;
         await _userManager.UpdateAsync(identityUser);
 
         return RedirectToLogin(new { flow = "invite-user", invite = "1" });


### PR DESCRIPTION
#17681

This PR looks to reset the security stamp back to previous when doing the signin behind the scenes in the same way lastlogindate is being reset. This allows the action to happen again until the user completes the process.