### PR TITLE
Fixing problem on Linux where `dotnet run` fails because we try to set an IIS config

### DIFF
--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using System.Data.Common;
 using System.Net.Http.Headers;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection.Infrastructure;
 using Microsoft.AspNetCore.Hosting;
@@ -326,7 +327,7 @@ public static partial class UmbracoBuilderExtensions
         return builder;
     }
 
-    [Obsolete("This is not necessary any more. This will be removed in v17")]
+    [Obsolete("This is not necessary any more. This will be removed in v16")]
     public static IUmbracoBuilder AddWebServer(this IUmbracoBuilder builder)
     {
         builder.Services.Configure<KestrelServerOptions>(options =>
@@ -344,13 +345,15 @@ public static partial class UmbracoBuilderExtensions
             // This workaround came from this comment: https://stackoverflow.com/a/3346975
             AllowSynchronousIOForIIS(builder);
         }
-        catch (Exception)
+        catch (TypeLoadException)
         {
             // Ignoring this exception because it's expected on non-windows machines
         }
         return builder;
     }
 
+    // Prevents the compiler from inlining the method
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static void AllowSynchronousIOForIIS(IUmbracoBuilder builder) =>
         builder.Services.Configure<IISServerOptions>(
             options =>

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -326,7 +326,7 @@ public static partial class UmbracoBuilderExtensions
         return builder;
     }
 
-    // TODO: Does this need to exist and/or be public?
+    [Obsolete("This is not necessary any more. This will be removed in v17")]
     public static IUmbracoBuilder AddWebServer(this IUmbracoBuilder builder)
     {
         return builder;

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -329,17 +329,6 @@ public static partial class UmbracoBuilderExtensions
     // TODO: Does this need to exist and/or be public?
     public static IUmbracoBuilder AddWebServer(this IUmbracoBuilder builder)
     {
-        // TODO: We need to figure out why this is needed and fix those endpoints to not need them, we don't want to change global things
-        // If using Kestrel: https://stackoverflow.com/a/55196057
-        builder.Services.Configure<KestrelServerOptions>(options =>
-        {
-            options.AllowSynchronousIO = true;
-        });
-        builder.Services.Configure<IISServerOptions>(options =>
-        {
-            options.AllowSynchronousIO = true;
-        });
-
         return builder;
     }
 


### PR DESCRIPTION
This is a follow up on #17886 which, after some discussion, seemed like a bad idea as there was a small possibility that we would break behavior that package developers might rely on.

Instead of not setting the global config, this catches errors while adding global rule to allow synchronous IO for IIS only (Kestrel one should run anywhere regardless, so I've kept it as it was before).

This has been tested on a Ubuntu machine with [the apt package manager using these 3 commands](https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-install?tabs=dotnet9&pivots=os-linux-ubuntu-2410):

```bash
sudo apt-get update && \
  sudo apt-get install -y dotnet-sdk-9.0
```
```bash
sudo apt-get update && \
  sudo apt-get install -y aspnetcore-runtime-9.0
```
```bash
sudo apt-get install -y dotnet-runtime-9.0
```

Installing Umbraco as described in the documentation would fail with a `TypeLoaderException` before this change:

![image](https://github.com/user-attachments/assets/f8a790db-e489-46f2-befd-fbab46cc9297)

After this fix it runs like it should:

![image](https://github.com/user-attachments/assets/6938bf04-7961-4547-b540-fc7168d3cc1e)

**Notes**

- I only put the configuration options for IIS in a try/catch - it never failed on Kestrel and I don't see why it would, Kestrel is fully supported on Windows as well
- Had to use a little workaround to get the try/catch to actually work, by deferring the setting of the option to a new method (as found by @AndyButland in this SO post: https://stackoverflow.com/a/3346975) 
- I've left the obsoletion message in there, I think it's a good idea to remove this global override as soon as possible. I've set it to v17 for now, but should it be for v16?