### PR TITLE
Allow sort of children by name and create date

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/DocumentTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/DocumentTreeControllerBase.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Controllers.Tree;
 using Umbraco.Cms.Api.Management.Factories;
@@ -54,6 +54,7 @@ public abstract class DocumentTreeControllerBase : UserStartNodeTreeControllerBa
             responseModel.IsProtected = _publicAccessService.IsProtected(entity.Path);
             responseModel.IsTrashed = entity.Trashed;
             responseModel.Id = entity.Key;
+            responseModel.CreateDate = entity.CreateDate;
 
             responseModel.Variants = _documentPresentationFactory.CreateVariantsItemResponseModels(documentEntitySlim);
             responseModel.DocumentType = _documentPresentationFactory.CreateDocumentTypeReferenceResponseModel(documentEntitySlim);

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Tree/MediaTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Tree/MediaTreeControllerBase.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Controllers.Tree;
 using Umbraco.Cms.Api.Management.Factories;
@@ -50,6 +50,7 @@ public class MediaTreeControllerBase : UserStartNodeTreeControllerBase<MediaTree
         {
             responseModel.IsTrashed = entity.Trashed;
             responseModel.Id = entity.Key;
+            responseModel.CreateDate = entity.CreateDate;
 
             responseModel.Variants = _mediaPresentationFactory.CreateVariantsItemResponseModels(mediaEntitySlim);
             responseModel.MediaType = _mediaPresentationFactory.CreateMediaTypeReferenceResponseModel(mediaEntitySlim);

--- a/src/Umbraco.Cms.Api.Management/Controllers/RecycleBin/RecycleBinControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RecycleBin/RecycleBinControllerBase.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.Controllers.Content;
@@ -54,6 +54,7 @@ public abstract class RecycleBinControllerBase<TItem> : ContentControllerBase
         var viewModel = new TItem
         {
             Id = entity.Key,
+            CreateDate = entity.CreateDate,
             HasChildren = entity.HasChildren,
             Parent = parentKey.HasValue
                 ? new ItemReferenceByIdResponseModel

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -36843,6 +36843,7 @@
       },
       "DocumentRecycleBinItemResponseModel": {
         "required": [
+          "createDate",
           "documentType",
           "hasChildren",
           "id",
@@ -36853,6 +36854,10 @@
           "id": {
             "type": "string",
             "format": "uuid"
+          },
+          "createDate": {
+            "type": "string",
+            "format": "date-time"
           },
           "hasChildren": {
             "type": "boolean"
@@ -38961,6 +38966,7 @@
       },
       "MediaRecycleBinItemResponseModel": {
         "required": [
+          "createDate",
           "hasChildren",
           "id",
           "mediaType",
@@ -38971,6 +38977,10 @@
           "id": {
             "type": "string",
             "format": "uuid"
+          },
+          "createDate": {
+            "type": "string",
+            "format": "date-time"
           },
           "hasChildren": {
             "type": "boolean"

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -36982,6 +36982,7 @@
       },
       "DocumentTreeItemResponseModel": {
         "required": [
+          "createDate",
           "documentType",
           "hasChildren",
           "id",
@@ -37012,6 +37013,10 @@
           "id": {
             "type": "string",
             "format": "uuid"
+          },
+          "createDate": {
+            "type": "string",
+            "format": "date-time"
           },
           "isProtected": {
             "type": "boolean"
@@ -39083,6 +39088,7 @@
       },
       "MediaTreeItemResponseModel": {
         "required": [
+          "createDate",
           "hasChildren",
           "id",
           "isTrashed",
@@ -39112,6 +39118,10 @@
           "id": {
             "type": "string",
             "format": "uuid"
+          },
+          "createDate": {
+            "type": "string",
+            "format": "date-time"
           },
           "mediaType": {
             "oneOf": [

--- a/src/Umbraco.Cms.Api.Management/ViewModels/RecycleBin/RecycleBinItemResponseModelBase.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/RecycleBin/RecycleBinItemResponseModelBase.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using Umbraco.Cms.Api.Management.ViewModels.Item;
 
 namespace Umbraco.Cms.Api.Management.ViewModels.RecycleBin;
@@ -7,6 +7,8 @@ public abstract class RecycleBinItemResponseModelBase
 {
     [Required]
     public Guid Id { get; set; }
+
+    public DateTimeOffset CreateDate { get; set; }
 
     [Required]
     public bool HasChildren { get; set; }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Tree/ContentTreeItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Tree/ContentTreeItemResponseModel.cs
@@ -1,4 +1,4 @@
-﻿namespace Umbraco.Cms.Api.Management.ViewModels.Tree;
+namespace Umbraco.Cms.Api.Management.ViewModels.Tree;
 
 public abstract class ContentTreeItemResponseModel : EntityTreeItemResponseModel
 {
@@ -7,4 +7,6 @@ public abstract class ContentTreeItemResponseModel : EntityTreeItemResponseModel
     public bool IsTrashed { get; set; }
 
     public Guid Id { get; set; }
+
+    public DateTimeOffset CreateDate { get; set; }
 }

--- a/src/Umbraco.Web.UI.Client/src/external/backend-api/src/types.gen.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/backend-api/src/types.gen.ts
@@ -702,6 +702,7 @@ export type DocumentTreeItemResponseModel = {
     noAccess: boolean;
     isTrashed: boolean;
     id: string;
+    createDate: string;
     isProtected: boolean;
     documentType: (DocumentTypeReferenceResponseModel);
     variants: Array<(DocumentVariantItemResponseModel)>;
@@ -1027,8 +1028,8 @@ export type HealthCheckWithResultPresentationModel = {
 export enum HealthStatusModel {
     HEALTHY = 'Healthy',
     UNHEALTHY = 'Unhealthy',
-    CORRUPT = 'Corrupt',
-    REBUILDING = 'Rebuilding'
+    REBUILDING = 'Rebuilding',
+    CORRUPT = 'Corrupt'
 }
 
 export type HealthStatusResponseModel = {
@@ -1223,6 +1224,7 @@ export type MediaTreeItemResponseModel = {
     noAccess: boolean;
     isTrashed: boolean;
     id: string;
+    createDate: string;
     mediaType: (MediaTypeReferenceResponseModel);
     variants: Array<(VariantItemResponseModel)>;
 };

--- a/src/Umbraco.Web.UI.Client/src/external/backend-api/src/types.gen.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/backend-api/src/types.gen.ts
@@ -673,6 +673,7 @@ export type DocumentPermissionPresentationModel = {
 
 export type DocumentRecycleBinItemResponseModel = {
     id: string;
+    createDate: string;
     hasChildren: boolean;
     parent?: ((ItemReferenceByIdResponseModel) | null);
     documentType: (DocumentTypeReferenceResponseModel);
@@ -1197,6 +1198,7 @@ export type MediaItemResponseModel = {
 
 export type MediaRecycleBinItemResponseModel = {
     id: string;
+    createDate: string;
     hasChildren: boolean;
     parent?: ((ItemReferenceByIdResponseModel) | null);
     mediaType: (MediaTypeReferenceResponseModel);

--- a/src/Umbraco.Web.UI.Client/src/mocks/data/document-blueprint/document-blueprint.data.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/data/document-blueprint/document-blueprint.data.ts
@@ -14,6 +14,7 @@ export const data: Array<UmbMockDocumentBlueprintModel> = [
 		],
 		template: null,
 		id: 'the-simplest-document-id',
+		createDate: '2023-02-06T15:32:05.350038',
 		parent: null,
 		documentType: {
 			id: 'the-simplest-document-type-id',

--- a/src/Umbraco.Web.UI.Client/src/mocks/data/document-blueprint/document-blueprint.db.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/data/document-blueprint/document-blueprint.db.ts
@@ -45,6 +45,7 @@ const treeItemMapper = (model: UmbMockDocumentBlueprintModel): Omit<DocumentTree
 		noAccess: model.noAccess,
 		parent: model.parent,
 		variants: model.variants,
+		createDate: model.createDate,
 	};
 };
 
@@ -62,6 +63,7 @@ const createMockDocumentBlueprintMapper = (request: CreateDocumentRequestModel):
 		},
 		hasChildren: false,
 		id: request.id ? request.id : UmbId.new(),
+		createDate: now,
 		isProtected: false,
 		isTrashed: false,
 		noAccess: false,

--- a/src/Umbraco.Web.UI.Client/src/mocks/data/document/document.data.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/data/document/document.data.ts
@@ -17,6 +17,7 @@ export const data: Array<UmbMockDocumentModel> = [
 		],
 		template: null,
 		id: 'the-simplest-document-id',
+		createDate: '2023-02-06T15:32:05.350038',
 		parent: null,
 		documentType: {
 			id: 'the-simplest-document-type-id',
@@ -56,6 +57,7 @@ export const data: Array<UmbMockDocumentModel> = [
 		],
 		template: null,
 		id: 'all-property-editors-document-id',
+		createDate: '2023-02-06T15:32:05.350038',
 		parent: null,
 		documentType: {
 			id: 'all-property-editors-document-type-id',
@@ -601,6 +603,7 @@ export const data: Array<UmbMockDocumentModel> = [
 		],
 		template: null,
 		id: 'c05da24d-7740-447b-9cdc-bd8ce2172e38',
+		createDate: '2023-02-06T15:32:05.350038',
 		parent: null,
 		documentType: {
 			id: '29643452-cff9-47f2-98cd-7de4b6807681',
@@ -734,6 +737,7 @@ export const data: Array<UmbMockDocumentModel> = [
 		urls: [],
 		template: null,
 		id: 'fd56a0b5-01a0-4da2-b428-52773bfa9cc4',
+		createDate: '2023-02-06T15:32:05.350038',
 		parent: null,
 		documentType: {
 			id: '29643452-cff9-47f2-98cd-7de4b6807681',
@@ -822,6 +826,7 @@ export const data: Array<UmbMockDocumentModel> = [
 		],
 		template: null,
 		id: 'simple-document-id',
+		createDate: '2023-02-06T15:32:05.350038',
 		parent: null,
 		documentType: {
 			id: 'simple-document-type-id',
@@ -869,6 +874,7 @@ export const data: Array<UmbMockDocumentModel> = [
 		],
 		template: null,
 		id: 'all-rtes-id',
+		createDate: '2023-02-06T15:32:05.350038',
 		parent: null,
 		documentType: {
 			id: 'all-rtes-document-type-id',
@@ -938,6 +944,7 @@ export const data: Array<UmbMockDocumentModel> = [
 		],
 		template: null,
 		id: 'block-editors-document-id',
+		createDate: '2023-02-06T15:32:05.350038',
 		parent: null,
 		documentType: {
 			id: 'block-editors-document-type-id',

--- a/src/Umbraco.Web.UI.Client/src/mocks/data/document/document.db.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/data/document/document.db.ts
@@ -69,6 +69,7 @@ const treeItemMapper = (model: UmbMockDocumentModel): DocumentTreeItemResponseMo
 		noAccess: model.noAccess,
 		parent: model.parent,
 		variants: model.variants,
+		createDate: model.createDate
 	};
 };
 
@@ -86,6 +87,7 @@ const createMockDocumentMapper = (request: CreateDocumentRequestModel): UmbMockD
 		},
 		hasChildren: false,
 		id: request.id ? request.id : UmbId.new(),
+		createDate: now,
 		isProtected: false,
 		isTrashed: false,
 		noAccess: false,

--- a/src/Umbraco.Web.UI.Client/src/mocks/data/media/media.data.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/data/media/media.data.ts
@@ -10,6 +10,7 @@ export const data: Array<UmbMockMediaModel> = [
 	{
 		hasChildren: false,
 		id: 'f2f81a40-c989-4b6b-84e2-057cecd3adc1',
+		createDate: '2023-02-06T15:32:05.350038',
 		parent: null,
 		noAccess: false,
 		isTrashed: false,
@@ -39,6 +40,7 @@ export const data: Array<UmbMockMediaModel> = [
 	{
 		hasChildren: false,
 		id: '69431027-8867-45bf-a93b-72bbdabfb177',
+		createDate: '2023-02-06T15:32:05.350038',
 		parent: null,
 		noAccess: false,
 		isTrashed: false,
@@ -68,6 +70,7 @@ export const data: Array<UmbMockMediaModel> = [
 	{
 		hasChildren: true,
 		id: '69461027-8867-45bf-a93b-72bbdabfb177',
+		createDate: '2023-02-06T15:32:05.350038',
 		parent: null,
 		noAccess: false,
 		isTrashed: false,
@@ -92,6 +95,7 @@ export const data: Array<UmbMockMediaModel> = [
 	{
 		hasChildren: true,
 		id: '69461027-8867-45bf-a93b-5224dabfb177',
+		createDate: '2023-02-06T15:32:05.350038',
 		parent: null,
 		noAccess: false,
 		isTrashed: false,
@@ -116,6 +120,7 @@ export const data: Array<UmbMockMediaModel> = [
 	{
 		hasChildren: false,
 		id: '69431027-8867-45s7-a93b-7uibdabfb177',
+		createDate: '2023-02-06T15:32:05.350038',
 		parent: { id: '69461027-8867-45bf-a93b-72bbdabfb177' },
 		noAccess: false,
 		isTrashed: false,
@@ -145,6 +150,7 @@ export const data: Array<UmbMockMediaModel> = [
 	{
 		hasChildren: false,
 		id: '69431027-8867-45s7-a93b-7uibdabf2147',
+		createDate: '2023-02-06T15:32:05.350038',
 		parent: { id: '69461027-8867-45bf-a93b-72bbdabfb177' },
 		noAccess: false,
 		isTrashed: false,
@@ -174,6 +180,7 @@ export const data: Array<UmbMockMediaModel> = [
 	{
 		hasChildren: false,
 		id: '694hdj27-8867-45s7-a93b-7uibdabf2147',
+		createDate: '2023-02-06T15:32:05.350038',
 		parent: { id: '69461027-8867-45bf-a93b-5224dabfb177' },
 		noAccess: false,
 		isTrashed: false,
@@ -203,6 +210,7 @@ export const data: Array<UmbMockMediaModel> = [
 	{
 		hasChildren: false,
 		id: '694hdj27-1237-45s7-a93b-7uibdabfas47',
+		createDate: '2023-02-06T15:32:05.350038',
 		parent: { id: '69461027-8867-45bf-a93b-5224dabfb177' },
 		noAccess: false,
 		isTrashed: false,

--- a/src/Umbraco.Web.UI.Client/src/mocks/data/media/media.db.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/data/media/media.db.ts
@@ -45,6 +45,7 @@ const treeItemMapper = (model: UmbMockMediaModel): MediaTreeItemResponseModel =>
 		noAccess: model.noAccess,
 		parent: model.parent,
 		variants: model.variants,
+		createDate: model.createDate,
 	};
 };
 
@@ -62,6 +63,7 @@ const createMockMediaMapper = (request: CreateMediaRequestModel): UmbMockMediaMo
 		},
 		hasChildren: false,
 		id: request.id ? request.id : UmbId.new(),
+		createDate: now,
 		isTrashed: false,
 		noAccess: false,
 		parent: request.parent,

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/modal/sort-children-of-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/modal/sort-children-of-modal.element.ts
@@ -68,6 +68,8 @@ export class UmbSortChildrenOfModalElement extends UmbModalBaseElement<
 			take: this.#pagination.getPageSize(),
 		});
 
+		console.log(data);
+
 		if (data) {
 			this._children = [...this._children, ...data.items];
 			this.#pagination.setTotalItems(data.total);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/modal/sort-children-of-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/modal/sort-children-of-modal.element.ts
@@ -27,6 +27,10 @@ export class UmbSortChildrenOfModalElement extends UmbModalBaseElement<
 	@state()
 	_totalPages = 1;
 
+	#hasMorePages() {
+		return this._currentPage < this._totalPages;;
+	}
+
 	#pagination = new UmbPaginationManager();
 	#sortedUniques = new Set<string>();
 	#sorter?: UmbSorterController<UmbTreeItemModel>;
@@ -237,7 +241,7 @@ export class UmbSortChildrenOfModalElement extends UmbModalBaseElement<
 				)}
 			</uui-table>
 
-			${this._currentPage < this._totalPages
+			${this.#hasMorePages()
 				? html`
 						<uui-button id="loadMoreButton" look="secondary" @click=${this.#onLoadMore}
 							>Load More (${this._currentPage}/${this._totalPages})</uui-button
@@ -248,15 +252,22 @@ export class UmbSortChildrenOfModalElement extends UmbModalBaseElement<
 	}
 
 	#renderHeaderCell(key: string, labelKey: string) {
+		// Only provide buttons for sorting via the column headers if all pages have been loaded.
 		return html`
 			<uui-table-head-cell>
-				<button @click=${() => this.#sortChildrenBy(key)}>
-					${this.localize.term(labelKey)}
-					<uui-symbol-sort
-						?active=${this.#sortBy === key}
-						?descending=${this.#sortDirection === "desc"}
-					></uui-symbol-sort>
-				</button>
+				${this.#hasMorePages()
+					? html`
+						<span>${this.localize.term(labelKey)}</span>
+					`
+					: html`
+						<button @click=${() => this.#sortChildrenBy(key)}>
+							${this.localize.term(labelKey)}
+							<uui-symbol-sort
+								?active=${this.#sortBy === key}
+								?descending=${this.#sortDirection === "desc"}
+							></uui-symbol-sort>
+						</button>
+					`}
 
 			</uui-table-head-cell>`;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/sort-children-of.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/sort-children-of.action.ts
@@ -16,7 +16,7 @@ export class UmbSortChildrenOfEntityAction extends UmbEntityActionBase<MetaEntit
 			},
 		});
 
-		await modal.onSubmit();
+		await modal.onSubmit().catch(() => undefined);
 
 		const eventContext = await this.getContext(UMB_ACTION_EVENT_CONTEXT);
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/recycle-bin/tree/document-recycle-bin-tree.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/recycle-bin/tree/document-recycle-bin-tree.server.data-source.ts
@@ -85,5 +85,6 @@ const mapper = (item: DocumentRecycleBinItemResponseModel): UmbDocumentRecycleBi
 		}),
 		name: item.variants[0]?.name, // TODO: this is not correct. We need to get it from the variants. This is a temp solution.
 		isFolder: false,
+		createDate: item.createDate
 	};
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/tree/document-tree.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/tree/document-tree.server.data-source.ts
@@ -91,5 +91,6 @@ const mapper = (item: DocumentTreeItemResponseModel): UmbDocumentTreeItemModel =
 		}),
 		name: item.variants[0]?.name, // TODO: this is not correct. We need to get it from the variants. This is a temp solution.
 		isFolder: false,
+		createDate: item.createDate,
 	};
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/tree/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/tree/types.ts
@@ -18,6 +18,7 @@ export interface UmbDocumentTreeItemModel extends UmbTreeItemModel {
 		icon: string;
 		collection: UmbReferenceByUnique | null;
 	};
+	createDate: string;
 	variants: Array<UmbDocumentTreeItemVariantModel>;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/recycle-bin/tree/media-recycle-bin-tree.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/recycle-bin/tree/media-recycle-bin-tree.server.data-source.ts
@@ -82,6 +82,6 @@ const mapper = (item: MediaRecycleBinItemResponseModel): UmbMediaRecycleBinTreeI
 		}),
 		name: item.variants[0]?.name, // TODO: this is not correct. We need to get it from the variants. This is a temp solution.
 		isFolder: false,
-		createDate: ""//item.createDate
+		createDate: item.createDate
 	};
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/recycle-bin/tree/media-recycle-bin-tree.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/recycle-bin/tree/media-recycle-bin-tree.server.data-source.ts
@@ -82,5 +82,6 @@ const mapper = (item: MediaRecycleBinItemResponseModel): UmbMediaRecycleBinTreeI
 		}),
 		name: item.variants[0]?.name, // TODO: this is not correct. We need to get it from the variants. This is a temp solution.
 		isFolder: false,
+		createDate: ""//item.createDate
 	};
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/tree/media-tree.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/tree/media-tree.server.data-source.ts
@@ -83,5 +83,6 @@ const mapper = (item: MediaTreeItemResponseModel): UmbMediaTreeItemModel => {
 				culture: variant.culture || null,
 			};
 		}),
+		createDate: item.createDate,
 	};
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/tree/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/tree/types.ts
@@ -17,6 +17,7 @@ export interface UmbMediaTreeItemModel extends UmbTreeItemModel {
 		collection: UmbReferenceByUnique | null;
 	};
 	variants: Array<UmbMediaTreeItemVariantModel>;
+	createDate: string;
 }
 
 export interface UmbMediaTreeRootModel extends UmbTreeRootModel {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16850, tracked under [AB 47578](https://dev.azure.com/umbraco/D-Team%20Tracker/_workitems/edit/47578).

### Description

The raised issue notes that we are missing the option to sort children by name or create date, only allowing the movement of each item one at a time.

This PR restores that behaviour available in Umbraco 13.

I've made an amend to the management API, introducing the create date field for document and media trees, in order to have that information available in the UI for sorting.

**To Test:**

- Create a content item and/or media folder with a few child items.
- Access the "Sort children..." tree entity action and experiment with moving items via the table headers and individually.  Confirm when the modal is submitted that the new order is persisted.
