### PR TITLE
Block list amount valivation message

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/property-editors/block-list-editor/property-editor-ui-block-list.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/property-editors/block-list-editor/property-editor-ui-block-list.element.ts
@@ -244,14 +244,26 @@ export class UmbPropertyEditorUIBlockListElement
 
 		this.addValidator(
 			'rangeUnderflow',
-			() => '#validation_entriesShort',
+			() => {
+					return this.localize.term(
+					'validation_entriesShort',
+					this._limitMin,
+					(this._limitMin?? 0) - this.#entriesContext.getLength()
+				);
+			},
 			() => !!this._limitMin && this.#entriesContext.getLength() < this._limitMin,
 		);
-
+	
 		this.addValidator(
-			'rangeOverflow',
-			() => '#validation_entriesExceed',
-			() => !!this._limitMax && this.#entriesContext.getLength() > this._limitMax,
+				'rangeOverflow',
+				() => {
+					return this.localize.term(
+						'validation_entriesExceed',
+						this._limitMax,
+						this.#entriesContext.getLength()
+					);
+				},
+				() => !!this._limitMax && this.#entriesContext.getLength() > this._limitMax,
 		);
 
 		this.observe(this.#entriesContext.layoutEntries, (layouts) => {

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/property-editors/block-list-editor/property-editor-ui-block-list.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/property-editors/block-list-editor/property-editor-ui-block-list.element.ts
@@ -244,26 +244,19 @@ export class UmbPropertyEditorUIBlockListElement
 
 		this.addValidator(
 			'rangeUnderflow',
-			() => {
-					return this.localize.term(
+			() =>
+				this.localize.term(
 					'validation_entriesShort',
 					this._limitMin,
-					(this._limitMin?? 0) - this.#entriesContext.getLength()
-				);
-			},
+					(this._limitMin ?? 0) - this.#entriesContext.getLength(),
+				),
 			() => !!this._limitMin && this.#entriesContext.getLength() < this._limitMin,
 		);
-	
+
 		this.addValidator(
-				'rangeOverflow',
-				() => {
-					return this.localize.term(
-						'validation_entriesExceed',
-						this._limitMax,
-						this.#entriesContext.getLength()
-					);
-				},
-				() => !!this._limitMax && this.#entriesContext.getLength() > this._limitMax,
+			'rangeOverflow',
+			() => this.localize.term('validation_entriesExceed', this._limitMax, this.#entriesContext.getLength()),
+			() => !!this._limitMax && this.#entriesContext.getLength() > this._limitMax,
 		);
 
 		this.observe(this.#entriesContext.layoutEntries, (layouts) => {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #17895 

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
The raised issue notes that we have the wrong validation message for the maximum and minimum amount Block List items.

**To Test:**

- Create a Block List that has configuration **Amount**  minimum = 1 and maximum = 2
- Go to Content that has the Block List, the first validation will be "Minimum 1 entries, requires <strong>2</strong> more"
- After creating 3 items in the  Block list, the validation message will be "Maximum 2 entries, <strong>3</strong> too many"

<!-- Thanks for contributing to Umbraco CMS! -->
