### PR TITLE
Do not allow editing read-only properties

### DIFF
--- a/src/Umbraco.Core/Services/ContentEditingServiceBase.cs
+++ b/src/Umbraco.Core/Services/ContentEditingServiceBase.cs
@@ -458,7 +458,8 @@ internal abstract class ContentEditingServiceBase<TContent, TContentType, TConte
         IDataValueEditor dataValueEditor = dataEditor.GetValueEditor();
         if (dataValueEditor.IsReadOnly)
         {
-            return null;
+            // read-only property editor - get and return the current value
+            return content.GetValue(propertyType.Alias, culture, segment);
         }
 
         IDataType? dataType = await _dataTypeService.GetAsync(propertyType.DataTypeKey);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Update.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Update.cs
@@ -333,4 +333,95 @@ public partial class ContentEditingServiceTests
         Assert.IsFalse(result.Success);
         Assert.AreEqual(ContentEditingOperationStatus.InvalidCulture, result.Status);
     }
+
+    [Test]
+    public async Task Cannot_Update_Invariant_Readonly_Property_Value()
+    {
+        var content = await CreateInvariantContent();
+        content.SetValue("label", "The initial label value");
+        ContentService.Save(content);
+
+        var updateModel = new ContentUpdateModel
+        {
+            InvariantName = "Updated Name",
+            InvariantProperties = new[]
+            {
+                new PropertyValueModel { Alias = "label", Value = "The updated label value" }
+            }
+        };
+
+        var result = await ContentEditingService.UpdateAsync(content.Key, updateModel, Constants.Security.SuperUserKey);
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(ContentEditingOperationStatus.Success, result.Status);
+            Assert.IsNotNull(result.Result.Content);
+        });
+
+        // re-get and validate
+        content = await ContentEditingService.GetAsync(content.Key);
+        Assert.IsNotNull(content);
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual("Updated Name", content.Name);
+            Assert.AreEqual("The initial label value", content.GetValue<string>("label"));
+        });
+    }
+
+    [Test]
+    public async Task Cannot_Update_Variant_Readonly_Property_Value()
+    {
+        var content = await CreateVariantContent();
+        content.SetValue("variantLabel", "The initial English label value", "en-US");
+        content.SetValue("variantLabel", "The initial Danish label value", "da-DK");
+        ContentService.Save(content);
+
+        var updateModel = new ContentUpdateModel
+        {
+            InvariantProperties = new[]
+            {
+                new PropertyValueModel { Alias = "invariantTitle", Value = "The updated invariant title" }
+            },
+            Variants = new []
+            {
+                new VariantModel
+                {
+                    Culture = "en-US",
+                    Name = "Updated English Name",
+                    Properties = new []
+                    {
+                        new PropertyValueModel { Alias = "variantLabel", Value = "The updated English label value" }
+                    }
+                },
+                new VariantModel
+                {
+                    Culture = "da-DK",
+                    Name = "Updated Danish Name",
+                    Properties = new []
+                    {
+                        new PropertyValueModel { Alias = "variantLabel", Value = "The updated Danish  label value" }
+                    }
+                }
+            }
+        };
+
+        var result = await ContentEditingService.UpdateAsync(content.Key, updateModel, Constants.Security.SuperUserKey);
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(ContentEditingOperationStatus.Success, result.Status);
+            Assert.IsNotNull(result.Result.Content);
+        });
+
+        // re-get and validate
+        content = await ContentEditingService.GetAsync(content.Key);
+        Assert.IsNotNull(content);
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual("Updated English Name", content.GetCultureName("en-US"));
+            Assert.AreEqual("Updated Danish Name", content.GetCultureName("da-DK"));
+            Assert.AreEqual("The initial English label value", content.GetValue<string>("variantLabel", "en-US"));
+            Assert.AreEqual("The initial Danish label value", content.GetValue<string>("variantLabel", "da-DK"));
+        });
+    }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTestsBase.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTestsBase.cs
@@ -38,6 +38,13 @@ public abstract class ContentEditingServiceTestsBase : UmbracoIntegrationTestWit
             .WithAlias("text")
             .WithName("Text")
             .WithVariations(ContentVariation.Nothing)
+            .Done()
+            .AddPropertyType()
+            .WithAlias("label")
+            .WithName("Label")
+            .WithDataTypeId(Constants.DataTypes.LabelString)
+            .WithPropertyEditorAlias(Constants.PropertyEditors.Aliases.Label)
+            .WithVariations(ContentVariation.Nothing)
             .Done();
 
         foreach (var template in templates)
@@ -82,6 +89,13 @@ public abstract class ContentEditingServiceTestsBase : UmbracoIntegrationTestWit
             .WithAlias("invariantTitle")
             .WithName("Invariant Title")
             .WithVariations(ContentVariation.Nothing)
+            .Done()
+            .AddPropertyType()
+            .WithAlias("variantLabel")
+            .WithName("Variant Label")
+            .WithDataTypeId(Constants.DataTypes.LabelString)
+            .WithPropertyEditorAlias(Constants.PropertyEditors.Aliases.Label)
+            .WithVariations(ContentVariation.Culture)
             .Done()
             .Build();
         contentType.AllowedAsRoot = true;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #16615 (and #17889 and #17906)

### Description

As described in the linked issues, read-only properties (e.g. labels) are reset upon save.

It should not be possible to edit read-only properties, so that's what this PR ensures 😄 

### Testing this PR

Create some content with a label property, and add a value to that label property .... for example, use this controller to update exiting content:

```cs
using Microsoft.AspNetCore.Mvc;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Services;

namespace Umbraco.Cms.Web.UI.Custom;

[ApiController]
[Route("api/[controller]")]
public class Issue16615Controller : ControllerBase
{
    private readonly IContentService _contentService;

    public Issue16615Controller(IContentService contentService)
        => _contentService = contentService;

    [HttpPost]
    public IActionResult Post(UpdateRequest updateRequest)
    {
        IContent? content = _contentService.GetById(updateRequest.Id);
        if (content is null)
        {
            return NotFound();
        }

        content.SetValue("myLabel", 123);
        _contentService.Save(content);
        return Ok();
    }

    public class UpdateRequest
    {
        public Guid Id { get; init; }
    }
}
```

![image](https://github.com/user-attachments/assets/ab0da702-850b-4dcf-be16-fb6ef82dbc38)

Edit the content and save it. Verify that the label property value is retained after the save 👍 