### PR TITLE
Fix: ensure controllers are destroyed

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/libs/controller-api/controller-host-element.mixin.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/controller-api/controller-host-element.mixin.ts
@@ -26,8 +26,6 @@ export const UmbControllerHostElementMixin = <T extends HTMLElementConstructor>(
 			super.disconnectedCallback?.();
 			this.hostDisconnected();
 		}
-
-		override destroy(): void {}
 	}
 
 	return UmbControllerHostElementClass as unknown as HTMLElementConstructor<UmbControllerHostElement> & T;


### PR DESCRIPTION
For some reason the destroy method was overwritten here. Its not suppose to do that, cause that prevents Umb Elements from destroying their Controllers when the element is asked to be destroyed.