### PR TITLE
Build: Detect circular dependencies with Madge

### DIFF
--- a/.github/workflows/test-backoffice.yml
+++ b/.github/workflows/test-backoffice.yml
@@ -49,8 +49,9 @@ jobs:
       - name: Check for circular dependencies
         run: node devops/circular/index.js src
       - name: Upload report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
+          name: circular-dependencies
           path: circular-dependencies.svg
         if: failure()
 

--- a/.github/workflows/test-backoffice.yml
+++ b/.github/workflows/test-backoffice.yml
@@ -40,10 +40,6 @@ jobs:
           cache: npm
           cache-dependency-path: ./src/Umbraco.Web.UI.Client/package-lock.json
       - run: npm ci --no-audit --no-fund --prefer-offline
-      - run: npm run lint:errors
-      - run: npm run build:for:cms
-      - run: npm run check:paths
-      - run: npm run generate:jsonschema:dist
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v2.0.2
       - name: Check for circular dependencies
@@ -54,6 +50,10 @@ jobs:
           name: circular-dependencies
           path: circular-dependencies.svg
         if: failure()
+      - run: npm run lint:errors
+      - run: npm run build:for:cms
+      - run: npm run check:paths
+      - run: npm run generate:jsonschema:dist
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-backoffice.yml
+++ b/.github/workflows/test-backoffice.yml
@@ -43,12 +43,12 @@ jobs:
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v2.0.2
       - name: Check for circular dependencies
-        run: node devops/circular/index.js src
+        run: node devops/circular/index.js src/Umbraco.Web.UI.Client/src
       - name: Upload report
         uses: actions/upload-artifact@v4
         with:
           name: circular-dependencies
-          path: madge
+          path: src/Umbraco.Web.UI.Client/madge
         if: failure()
       - run: npm run lint:errors
       - run: npm run build:for:cms

--- a/.github/workflows/test-backoffice.yml
+++ b/.github/workflows/test-backoffice.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Upload report
         uses: actions/upload-artifact@v4
         with:
-          name: circular-dependencies
-          path: madge
+          name: madge-report
+          path: src/Umbraco.Web.UI.Client/madge
         if: failure()
       - run: npm run lint:errors
       - run: npm run build:for:cms

--- a/.github/workflows/test-backoffice.yml
+++ b/.github/workflows/test-backoffice.yml
@@ -40,16 +40,8 @@ jobs:
           cache: npm
           cache-dependency-path: ./src/Umbraco.Web.UI.Client/package-lock.json
       - run: npm ci --no-audit --no-fund --prefer-offline
-      - name: Setup Graphviz
-        uses: ts-graphviz/setup-graphviz@v2.0.2
       - name: Check for circular dependencies
         run: node devops/circular/index.js src
-      - name: Upload report
-        uses: actions/upload-artifact@v4
-        with:
-          name: madge-report
-          path: src/Umbraco.Web.UI.Client/madge
-        if: failure()
       - run: npm run lint:errors
       - run: npm run build:for:cms
       - run: npm run check:paths

--- a/.github/workflows/test-backoffice.yml
+++ b/.github/workflows/test-backoffice.yml
@@ -44,6 +44,10 @@ jobs:
       - run: npm run build:for:cms
       - run: npm run check:paths
       - run: npm run generate:jsonschema:dist
+      - name: Setup Graphviz
+        uses: ts-graphviz/setup-graphviz@v2.0.2
+      - name: Check for circular dependencies
+        run: node devops/circular/index.js src
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-backoffice.yml
+++ b/.github/workflows/test-backoffice.yml
@@ -48,6 +48,11 @@ jobs:
         uses: ts-graphviz/setup-graphviz@v2.0.2
       - name: Check for circular dependencies
         run: node devops/circular/index.js src
+      - name: Upload report
+        uses: actions/upload-artifact@v2
+        with:
+          path: circular-dependencies.svg
+        if: failure()
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-backoffice.yml
+++ b/.github/workflows/test-backoffice.yml
@@ -43,12 +43,12 @@ jobs:
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v2.0.2
       - name: Check for circular dependencies
-        run: node devops/circular/index.js src/Umbraco.Web.UI.Client/src
+        run: node devops/circular/index.js src
       - name: Upload report
         uses: actions/upload-artifact@v4
         with:
           name: circular-dependencies
-          path: src/Umbraco.Web.UI.Client/madge
+          path: madge
         if: failure()
       - run: npm run lint:errors
       - run: npm run build:for:cms

--- a/.github/workflows/test-backoffice.yml
+++ b/.github/workflows/test-backoffice.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: circular-dependencies
-          path: circular-dependencies.svg
+          path: madge
         if: failure()
       - run: npm run lint:errors
       - run: npm run build:for:cms

--- a/src/Umbraco.Web.UI.Client/devops/circular/index.js
+++ b/src/Umbraco.Web.UI.Client/devops/circular/index.js
@@ -47,7 +47,8 @@ if (circular.length) {
 		console.log('Circular dependencies graph generated:', image);
 	} catch { console.warn('No image generated. Make sure Graphviz is in your $PATH if you want a visualization'); }
 
-	process.exit(1);
+	// TODO: Set this to 1 when we have fixed all circular dependencies
+	process.exit(0);
 }
 
 console.log('\nNo circular dependencies detected.\n');

--- a/src/Umbraco.Web.UI.Client/devops/circular/index.js
+++ b/src/Umbraco.Web.UI.Client/devops/circular/index.js
@@ -41,7 +41,7 @@ if (circular.length) {
 	console.error('\nPlease fix the circular dependencies before proceeding.\n');
 
 	try {
-		const image = await madgeSetup.image(join(__dirname, '../../madge/circular.jpg'), true);
+		const image = await madgeSetup.image(join(__dirname, '../../madge/circular.svg'), true);
 		console.log('Circular dependencies graph generated:', image);
 	} catch { console.warn('No image generated. Make sure Graphviz is in your $PATH if you want a visualization'); }
 

--- a/src/Umbraco.Web.UI.Client/devops/circular/index.js
+++ b/src/Umbraco.Web.UI.Client/devops/circular/index.js
@@ -33,7 +33,7 @@ console.log('-'.repeat(80));
 
 const circular = madgeSetup.circular();
 
-if (circular.length > 0) {
+if (circular.length) {
 	console.error(circular.length, 'circular dependencies detected:\n');
 	for (let i = 0; i < circular.length; i++) {
 		printCircularDependency(circular[i], i + 1);
@@ -41,10 +41,9 @@ if (circular.length > 0) {
 	console.error('\nPlease fix the circular dependencies before proceeding.\n');
 
 	try {
-		const svg = await madgeSetup.svg();
-		const svgString = svg.toString();
-		writeFileSync(join(__dirname, '../..', 'circular-dependencies.svg'), svgString);
-	} catch { }
+		const image = await madgeSetup.image(join(__dirname, '../../madge'), true);
+		console.log('Circular dependencies graph generated:', image);
+	} catch { console.warn('No image generated. Make sure Graphviz is in your $PATH if you want a visualization'); }
 
 	process.exit(1);
 }

--- a/src/Umbraco.Web.UI.Client/devops/circular/index.js
+++ b/src/Umbraco.Web.UI.Client/devops/circular/index.js
@@ -1,0 +1,72 @@
+/**
+ * This module is used to detect circular dependencies in the Umbraco backoffice.
+ * It is used in the build process to ensure that we don't have circular dependencies.
+ * @example node devops/circular/index.js
+ * @author Umbraco HQ
+ */
+
+import madge from 'madge';
+import { join } from 'path';
+import { writeFileSync } from 'fs';
+
+const __dirname = import.meta.dirname;
+const IS_GITHUB_ACTIONS = process.env.GITHUB_ACTIONS === 'true';
+const IS_AZURE_PIPELINES = process.env.TF_BUILD === 'true';
+const baseDir = process.argv[2] || 'src';
+const specificPaths = (process.argv[3] || '').split(',');
+
+console.log('Scanning for circular dependencies in:', baseDir);
+
+const madgeSetup = await madge(specificPaths, {
+	baseDir,
+	fileExtensions: ['ts'],
+	tsConfig: join(baseDir, 'tsconfig.build.json'),
+	detectiveOptions: {
+		ts: {
+			skipTypeImports: true,
+			skipAsyncImports: true
+		}
+	}
+});
+
+console.log('-'.repeat(80));
+
+const circular = madgeSetup.circular();
+
+if (circular.length > 0) {
+	console.error(circular.length, 'circular dependencies detected:\n');
+	for (let i = 0; i < circular.length; i++) {
+		printCircularDependency(circular[i], i + 1);
+	}
+	console.error('\nPlease fix the circular dependencies before proceeding.\n');
+
+	try {
+		const svg = await madgeSetup.svg();
+		const svgString = svg.toString();
+		writeFileSync(join(__dirname, '../..', 'circular-dependencies.svg'), svgString);
+	} catch { }
+
+	process.exit(1);
+}
+
+console.log('\nNo circular dependencies detected.\n');
+process.exit(0);
+
+/**
+ *
+ * @param {string[]} circular The circular dependencies.
+ * @param {number} idx The index of the circular dependency.
+ */
+function printCircularDependency(circular, idx) {
+	circular = circular.map(file => `${baseDir}/${file}`);
+	const circularPath = circular.join(' -> ');
+	console.error(idx, '=', circularPath, '\n');
+
+	if (IS_GITHUB_ACTIONS) {
+		console.error(`::error file=${circular[0]},title=Circular dependency::Circular dependencies detected: ${circularPath}`);
+	}
+	else if (IS_AZURE_PIPELINES) {
+		console.error(`##vso[task.logissue type=error;sourcepath=${circular[0]};]Circular dependencies detected: ${circularPath}`);
+	}
+
+}

--- a/src/Umbraco.Web.UI.Client/devops/circular/index.js
+++ b/src/Umbraco.Web.UI.Client/devops/circular/index.js
@@ -41,7 +41,7 @@ if (circular.length) {
 	console.error('\nPlease fix the circular dependencies before proceeding.\n');
 
 	try {
-		const image = await madgeSetup.image(join(__dirname, '../../madge'), true);
+		const image = await madgeSetup.image(join(__dirname, '../../madge/circular.jpg'), true);
 		console.log('Circular dependencies graph generated:', image);
 	} catch { console.warn('No image generated. Make sure Graphviz is in your $PATH if you want a visualization'); }
 

--- a/src/Umbraco.Web.UI.Client/devops/circular/index.js
+++ b/src/Umbraco.Web.UI.Client/devops/circular/index.js
@@ -7,6 +7,7 @@
 
 import madge from 'madge';
 import { join } from 'path';
+import { mkdirSync } from 'fs';
 
 const __dirname = import.meta.dirname;
 const IS_GITHUB_ACTIONS = process.env.GITHUB_ACTIONS === 'true';
@@ -40,7 +41,9 @@ if (circular.length) {
 	console.error('\nPlease fix the circular dependencies before proceeding.\n');
 
 	try {
-		const image = await madgeSetup.image(join(__dirname, '../../madge/circular.svg'), true);
+		const imagePath = join(__dirname, '../../madge');
+		mkdirSync(imagePath, { recursive: true });
+		const image = await madgeSetup.image(join(imagePath, 'circular.svg'), true);
 		console.log('Circular dependencies graph generated:', image);
 	} catch (e) { console.warn('No image generated. Make sure Graphviz is in your $PATH if you want a visualization', e); }
 

--- a/src/Umbraco.Web.UI.Client/devops/circular/index.js
+++ b/src/Umbraco.Web.UI.Client/devops/circular/index.js
@@ -45,7 +45,7 @@ if (circular.length) {
 		mkdirSync(imagePath, { recursive: true });
 		const image = await madgeSetup.image(join(imagePath, 'circular.svg'), true);
 		console.log('Circular dependencies graph generated:', image);
-	} catch (e) { console.warn('No image generated. Make sure Graphviz is in your $PATH if you want a visualization', e); }
+	} catch { console.warn('No image generated. Make sure Graphviz is in your $PATH if you want a visualization'); }
 
 	process.exit(1);
 }

--- a/src/Umbraco.Web.UI.Client/devops/circular/index.js
+++ b/src/Umbraco.Web.UI.Client/devops/circular/index.js
@@ -1,13 +1,12 @@
 /**
  * This module is used to detect circular dependencies in the Umbraco backoffice.
  * It is used in the build process to ensure that we don't have circular dependencies.
- * @example node devops/circular/index.js
+ * @example node devops/circular/index.js src
  * @author Umbraco HQ
  */
 
 import madge from 'madge';
 import { join } from 'path';
-import { writeFileSync } from 'fs';
 
 const __dirname = import.meta.dirname;
 const IS_GITHUB_ACTIONS = process.env.GITHUB_ACTIONS === 'true';
@@ -59,13 +58,14 @@ process.exit(0);
 function printCircularDependency(circular, idx) {
 	circular = circular.map(file => `${baseDir}/${file}`);
 	const circularPath = circular.join(' -> ');
-	console.error(idx, '=', circularPath, '\n');
 
 	if (IS_GITHUB_ACTIONS) {
 		console.error(`::error file=${circular[0]},title=Circular dependency::Circular dependencies detected: ${circularPath}`);
 	}
 	else if (IS_AZURE_PIPELINES) {
 		console.error(`##vso[task.logissue type=error;sourcepath=${circular[0]};]Circular dependencies detected: ${circularPath}`);
+	} else {
+		console.error(idx, '=', circularPath, '\n');
 	}
 
 }

--- a/src/Umbraco.Web.UI.Client/devops/circular/index.js
+++ b/src/Umbraco.Web.UI.Client/devops/circular/index.js
@@ -42,7 +42,7 @@ if (circular.length) {
 	try {
 		const image = await madgeSetup.image(join(__dirname, '../../madge/circular.svg'), true);
 		console.log('Circular dependencies graph generated:', image);
-	} catch { console.warn('No image generated. Make sure Graphviz is in your $PATH if you want a visualization'); }
+	} catch (e) { console.warn('No image generated. Make sure Graphviz is in your $PATH if you want a visualization', e); }
 
 	process.exit(1);
 }

--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -158,7 +158,7 @@
 		"postbuild": "rollup -c ./src/rollup.config.js && node ./devops/build/global-types.js",
 		"check": "npm run lint:errors && npm run compile && npm run build-storybook && npm run generate:jsonschema:dist",
 		"check:paths": "node ./devops/build/check-path-length.js dist-cms 120",
-		"check:circular": "madge --circular --warning --extensions ts ./src",
+		"check:circular": "node ./devops/circular/index.js src",
 		"compile": "tsc",
 		"dev": "vite",
 		"dev:server": "cross-env VITE_UMBRACO_USE_MSW=off vite",


### PR DESCRIPTION
## Description

This is setting up a script to run Madge (effectively `npm run check:circular` but with Node.js) so the build can either fail or warn if circular dependencies are detected.

There are 11 circular dependencies, so we might want to set this to **warn** until they are fixed.

Check this previous run to see what it looks like in **error** mode: https://github.com/umbraco/Umbraco-CMS/actions/runs/12689060972/job/35366940767

If you have changed one of the files that has a circular dependency, the error will also pop up as an annotation on that file in the "**Files changed**" view.

## How to test

Run the script locally:

```bash
cd src/Umbraco.Web.UI.Client
node devops/circular/index.js src
```

Check that it shows the currently known circular dependencies.