### PR TITLE
Render all URLs in document workspace info tab and ensure protocol-less links can be used to access the intended URL.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/views/info/document-workspace-view-info-links.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/views/info/document-workspace-view-info-links.element.ts
@@ -10,7 +10,7 @@ import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 import { observeMultiple } from '@umbraco-cms/backoffice/observable-api';
 import { DocumentVariantStateModel } from '@umbraco-cms/backoffice/external/backend-api';
 import { debounce } from '@umbraco-cms/backoffice/utils';
-import { UMB_APP_LANGUAGE_CONTEXT, UmbAppLanguageContext } from '@umbraco-cms/backoffice/language';
+import { UMB_APP_LANGUAGE_CONTEXT } from '@umbraco-cms/backoffice/language';
 
 interface UmbDocumentInfoViewLink {
 	culture: string;

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/views/info/document-workspace-view-info-links.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/views/info/document-workspace-view-info-links.element.ts
@@ -105,7 +105,7 @@ export class UmbDocumentWorkspaceViewInfoLinksElement extends UmbLitElement {
 		}
 
 		if (url.includes(".") && !url.includes("//")) {
-			return "https://" + url;
+			return "//" + url;
 		}
 
 		return url;

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/views/info/document-workspace-view-info-links.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/views/info/document-workspace-view-info-links.element.ts
@@ -10,6 +10,7 @@ import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 import { observeMultiple } from '@umbraco-cms/backoffice/observable-api';
 import { DocumentVariantStateModel } from '@umbraco-cms/backoffice/external/backend-api';
 import { debounce } from '@umbraco-cms/backoffice/utils';
+import { UMB_APP_LANGUAGE_CONTEXT, UmbAppLanguageContext } from '@umbraco-cms/backoffice/language';
 
 interface UmbDocumentInfoViewLink {
 	culture: string;
@@ -35,6 +36,9 @@ export class UmbDocumentWorkspaceViewInfoLinksElement extends UmbLitElement {
 
 	@state()
 	private _links: Array<UmbDocumentInfoViewLink> = [];
+
+	@state()
+	private _defaultCulture?: string;
 
 	#urls: Array<UmbDocumentUrlModel> = [];
 
@@ -75,22 +79,36 @@ export class UmbDocumentWorkspaceViewInfoLinksElement extends UmbLitElement {
 				this.#setLinks();
 			});
 		});
+
+		this.consumeContext(UMB_APP_LANGUAGE_CONTEXT, (instance) => {
+			this.observe(instance.appDefaultLanguage, (value) => {
+				this._defaultCulture = value?.unique;
+				this.#setLinks();
+			});
+		});
 	}
 
 	#setLinks() {
-		const possibleVariantCultures = this._variantOptions?.map((variantOption) => variantOption.culture) ?? [];
-		const possibleUrlCultures = this.#urls.map((link) => link.culture);
-		const possibleCultures = [...new Set([...possibleVariantCultures, ...possibleUrlCultures])].filter(
-			Boolean,
-		) as string[];
-
-		const links: Array<UmbDocumentInfoViewLink> = possibleCultures.map((culture) => {
-			const url = this.#urls.find((link) => link.culture === culture)?.url;
+		const links: Array<UmbDocumentInfoViewLink> = this.#urls.map((u) => {
+			const culture = u.culture ?? this._defaultCulture ?? "";
+			const url = u.url;
 			const state = this._variantOptions?.find((variantOption) => variantOption.culture === culture)?.variant?.state;
 			return { culture, url, state };
 		});
 
 		this._links = links;
+	}
+
+	#getTargetUrl (url: string | undefined) {
+		if (!url || url.length === 0) {
+			return url;
+		}
+
+		if (url.includes(".") && !url.includes("//")) {
+			return "https://" + url;
+		}
+
+		return url;
 	}
 
 	async #requestUrls() {
@@ -181,7 +199,7 @@ export class UmbDocumentWorkspaceViewInfoLinksElement extends UmbLitElement {
 		}
 
 		return html`
-			<a class="link-item" href=${link.url} target="_blank">
+			<a class="link-item" href=${this.#getTargetUrl(link.url)} target="_blank">
 				<span>
 					${this.#renderLinkCulture(link.culture)}
 					<span>${link.url}</span>


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Addresses issues https://github.com/umbraco/Umbraco-CMS/issues/17925 and https://github.com/umbraco/Umbraco-CMS/issues/17791

### Description

This PR addresses the issue that not all URLs as configured under "Culture and Hostnames" are displayed in the document info workspace view, and that if protocol less URLs (like "www,example.com" the link rendered doesn't work correctly).

For the first issue I've switched the logic around so that rather than rendering the first URL found per culture, we render all URLs along with their culture.

And for the second I've added a function to prepend "https://" to protocol-less URLs.

**To Test:**

- Set up a variant and an invariant page with culture and host names.
    - Make sure to add more than one host name per language.
    - Create at least one host name as a root folder - e.g. "en/"
    - Create at least one as a protocol-less URLs - e.g. "www.example.com"
- Browse to the document's "Info" workspace view:
    - Verify that all links are displayed.
    - Verify that all links can be clicked and take you to the expected destination.