### PR TITLE
Fix omitted callback

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/libs/class-api/class.mixin.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/class-api/class.mixin.ts
@@ -53,21 +53,25 @@ export const UmbClassMixin = <T extends ClassConstructor<EventTarget>>(superClas
 		>(
 			// This type dance checks if the Observable given could be undefined, if it potentially could be undefined it means that this potentially could return undefined and then call the callback with undefined. [NL]
 			source: ObservableType,
-			callback: ObserverCallback<SpecificT>,
+			callback?: ObserverCallback<SpecificT>,
 			controllerAlias?: UmbControllerAlias | null,
 		): SpecificR {
-			// Fallback to use a hash of the provided method, but only if the alias is undefined.
-			controllerAlias ??= controllerAlias === undefined ? simpleHashCode(callback.toString()) : undefined;
+			// Fallback to use a hash of the provided method, but only if the alias is undefined and there is a callback.
+			if (controllerAlias === undefined && callback) {
+				controllerAlias = simpleHashCode(callback.toString());
+			} else {
+				controllerAlias = undefined;
+			}
 
 			if (source) {
 				return new UmbObserverController<T>(
 					this,
 					source,
-					callback as unknown as ObserverCallback<T>,
+					callback as unknown as ObserverCallback<T> | undefined,
 					controllerAlias,
 				) as unknown as SpecificR;
 			} else {
-				callback(undefined as SpecificT);
+				callback?.(undefined as SpecificT);
 				this.removeUmbControllerByAlias(controllerAlias);
 				return undefined as SpecificR;
 			}

--- a/src/Umbraco.Web.UI.Client/src/libs/class-api/class.mixin.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/class-api/class.mixin.ts
@@ -59,7 +59,8 @@ export const UmbClassMixin = <T extends ClassConstructor<EventTarget>>(superClas
 			// Fallback to use a hash of the provided method, but only if the alias is undefined and there is a callback.
 			if (controllerAlias === undefined && callback) {
 				controllerAlias = simpleHashCode(callback.toString());
-			} else {
+			} else if (controllerAlias === null) {
+				// if value is null, then reset it to undefined. Null is used to explicitly tell that we do not want a controller alias. [NL]
 				controllerAlias = undefined;
 			}
 

--- a/src/Umbraco.Web.UI.Client/src/libs/element-api/element.mixin.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/element-api/element.mixin.ts
@@ -35,7 +35,8 @@ export const UmbElementMixin = <T extends HTMLElementConstructor>(superClass: T)
 			// Fallback to use a hash of the provided method, but only if the alias is undefined and there is a callback.
 			if (controllerAlias === undefined && callback) {
 				controllerAlias = simpleHashCode(callback.toString());
-			} else {
+			} else if (controllerAlias === null) {
+				// if value is null, then reset it to undefined. Null is used to explicitly tell that we do not want a controller alias. [NL]
 				controllerAlias = undefined;
 			}
 

--- a/src/Umbraco.Web.UI.Client/src/libs/element-api/element.mixin.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/element-api/element.mixin.ts
@@ -29,21 +29,25 @@ export const UmbElementMixin = <T extends HTMLElementConstructor>(superClass: T)
 		>(
 			// This type dance checks if the Observable given could be undefined, if it potentially could be undefined it means that this potentially could return undefined and then call the callback with undefined. [NL]
 			source: ObservableType,
-			callback: ObserverCallback<SpecificT>,
+			callback?: ObserverCallback<SpecificT>,
 			controllerAlias?: UmbControllerAlias | null,
 		): SpecificR {
-			// Fallback to use a hash of the provided method, but only if the alias is undefined.
-			controllerAlias ??= controllerAlias === undefined ? simpleHashCode(callback.toString()) : undefined;
+			// Fallback to use a hash of the provided method, but only if the alias is undefined and there is a callback.
+			if (controllerAlias === undefined && callback) {
+				controllerAlias = simpleHashCode(callback.toString());
+			} else {
+				controllerAlias = undefined;
+			}
 
 			if (source) {
 				return new UmbObserverController<T>(
 					this,
 					source,
-					callback as unknown as ObserverCallback<T>,
+					callback as unknown as ObserverCallback<T> | undefined,
 					controllerAlias,
 				) as unknown as SpecificR;
 			} else {
-				callback(undefined as SpecificT);
+				callback?.(undefined as SpecificT);
 				this.removeUmbControllerByAlias(controllerAlias);
 				return undefined as SpecificR;
 			}


### PR DESCRIPTION
We had a bit of code not complying with the omitted callback method.
Now that we use the omitted callback method for the sysinfo repository. Then this error has been revealed.

Fixes this error when logged in:

<img width="1230" alt="image" src="https://github.com/user-attachments/assets/5938a731-4313-4eed-b5f6-cb673bb241bf" />
