### PR TITLE
V15: Handle domains in invariant content

### DIFF
--- a/src/Umbraco.Core/Services/DocumentUrlService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlService.cs
@@ -469,7 +469,12 @@ public class DocumentUrlService : IDocumentUrlService
             }
 
             IEnumerable<Domain> domains = _domainCacheService.GetAssigned(idAttempt.Result, false);
-            return domains.FirstOrDefault(x=>x.Culture == cultureOrDefault);
+
+            // If no culture is specified, we assume invariant and return the first domain.
+            // This is also only used to later to specify the node id in the route, so it does not matter what culture it is.
+            return string.IsNullOrEmpty(culture)
+                ? domains.FirstOrDefault()
+                : domains.FirstOrDefault(x => x.Culture?.Equals(culture, StringComparison.InvariantCultureIgnoreCase) ?? false);
         });
 
         var urlSegments = new List<string>();


### PR DESCRIPTION
Fixes an issue where domains was broken for invariant content, given the following setup 

* EN Root - Has domain `/en` with English culture
  * Child
* DA Root - Has domain `/da` with Danish culture
  * Child

You would expect that the URLs return by `Url()` to be `/da/` for the danish root, and `/da/text-da/` for the danish child, however this was not the case, and it would instead return the "default" URL 

The reason for this is that `GetLegacyRouteFormat` would always look for a domain with the passed in culture, however this doesn't make sense in an invariant setup like this, since the culture will always be null, and we'll never find any domains.

We can see that similar logic was applied in `DomainCacheExtensions.GetAssignedWithCulture` in the old routing system 

## Testing

Create a setup like above and check that URLs are generated correctly. 


 This template is a helpful way of doing so: 


```html
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
@{
    Layout = null;
    var descendants = Model.DescendantsOrSelf();
}
<html lang="en">
<body>
<h1>@Model.Name</h1>
<ul>
    @foreach (var desc in descendants)
    {
        <li>@desc.Name - @desc.Url()</li>
    }
</ul>
</body>
</html>
```