### PR TITLE
Improve YSOD rendering in the client

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/ysod/ysod.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/ysod/ysod.controller.js
@@ -2,7 +2,6 @@ angular.module("umbraco")
     .controller("Umbraco.Overlays.YsodController", function ($scope, localizationService) {
 
         function onInit() {
-
             if(!$scope.model.title) {
                 localizationService.localize("errors_receivedErrorFromServer").then(function(value){
                     $scope.model.title = value;
@@ -14,7 +13,7 @@ angular.module("umbraco")
                 $scope.model.error.data.StackTrace = $scope.model.error.data.StackTrace.trim();
             }
 
-            if ($scope.model.error && $scope.model.error.data) {
+            if ($scope.model.error && $scope.model.error.data && $scope.model.error.data.InnerException) {
                 $scope.model.error.data.InnerExceptions = [];
                 var ex = $scope.model.error.data.InnerException;
                 while (ex) {
@@ -25,7 +24,13 @@ angular.module("umbraco")
                     ex = ex.InnerException;
                 }
             }
-
+            // in rare occasions, the error.data is not an object but contains a concatenated string of the type and stacktrace
+            // to avoid angular from crashing, we dump the whole thing in the stacktrace so it is at least readable by the user.
+            else if(typeof($scope.model.error.data) === "string"){
+              $scope.model.error.data = {
+                StackTrace: $scope.model.error.data.trim()
+              }
+            }
         }
 
         onInit();

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/ysod/ysod.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/ysod/ysod.html
@@ -1,9 +1,8 @@
 ﻿<div ng-controller="Umbraco.Overlays.YsodController">
-
     <h4 class="heading red">{{model.error.errorMsg}}</h4>
     <p>{{model.error.data.ExceptionMessage || model.error.data.Message}}</p>
 
-    <div class="umb-control-group">
+    <div class="umb-control-group" ng-if="model.error.data.ExceptionType || model.error.data.ExceptionMessage">
         <h5>
             <localize key="defaultdialogs_exceptionDetail">Exception Details:</localize>
         </h5>


### PR DESCRIPTION
Intended to fix https://github.com/umbraco/Umbraco-CMS/issues/17909

### Description
In the linked issue a screenshot was provided with a rather strange Error modal
After forcing the Authorization pipeline to fail by adding `throw new Exception("This is a forced temporary exception");` to the top off `Umbraco.Cms.Web.Common.Security.BackOfficeSecurity.GetUserId()` I was able to get a similar Error modal. After some investigation it seems that Angular simply renders the template when the constructor of the linked controller throws an error.

I have update the controller to catch the edge case where `modal.error.data` is not an object but a string. And also updated the view to render more things conditionally to not clutter the modal with text that does not hold any meaning.

### Testing
- Build the updated client
- Build and run the server
- Create a document so you have something in the tree
- Do not close the browser
- Add the code snippet to the method as described in the description
- Build and run the server
- Right click the node you created previously => an informative modal should pop up.