### PR TITLE
Feature: no callback then destroy

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/libs/observable-api/observer.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/observable-api/observer.ts
@@ -32,6 +32,9 @@ export class UmbObserver<T> {
 						wantedToClose = true;
 					} else {
 						subscription.unsubscribe();
+						if (!this.#callback) {
+							this.destroy();
+						}
 					}
 					resolve(value as Exclude<T, undefined>);
 				}
@@ -39,6 +42,9 @@ export class UmbObserver<T> {
 			initialCallback = false;
 			if (wantedToClose) {
 				subscription.unsubscribe();
+				if (!this.#callback) {
+					this.destroy();
+				}
 			}
 		});
 	}


### PR DESCRIPTION
When an observer has no callback, it has no purpose after resolving the Promise. So then lets clean up and get it destroyed.