### PR TITLE
Corrected property names and structure used in JSON schema generation for configuration of default data to install.

### DIFF
--- a/tools/Umbraco.JsonSchema/UmbracoCmsSchema.cs
+++ b/tools/Umbraco.JsonSchema/UmbracoCmsSchema.cs
@@ -75,12 +75,23 @@ internal class UmbracoCmsSchema
 
         public HelpPageSettings HelpPage { get; set; } = null!;
 
-        public InstallDefaultDataSettings DefaultDataCreation { get; set; } = null!;
+        public InstallDefaultDataNamedOptions InstallDefaultData { get; set; } = null!;
 
         public DataTypesSettings DataTypes { get; set; } = null!;
 
         public MarketplaceSettings Marketplace { get; set; } = null!;
 
         public WebhookSettings Webhook { get; set; } = null!;
+    }
+
+    public class InstallDefaultDataNamedOptions
+    {
+        public InstallDefaultDataSettings Languages { get; set; } = null!;
+
+        public InstallDefaultDataSettings DataTypes { get; set; } = null!;
+
+        public InstallDefaultDataSettings MediaTypes { get; set; } = null!;
+
+        public InstallDefaultDataSettings MemberTypes { get; set; } = null!;
     }
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Addresses the issue raised here: https://github.com/umbraco/Umbraco-CMS/issues/17945

### Description
As reported in the linked issue, the JSON schema generation for the default data you can configure for install isn't correct.

When merged this PR will ensure that the JSON schema generated is correct and matches the paths used in code.  This will correct the intellisense provided when configuring Umbraco.

To Test:

- With the PR merged, rebuild the whole solution.
- Verify the generated schema file found at `src\Umbraco.Web.UI\appsettings-schema.Umbraco.Cms.json`.  You should now see the following elements:

```
  "InstallDefaultData": {
	  "$ref": "#/definitions/InstallDefaultDataNamedOptions"
  },
		
  "InstallDefaultDataNamedOptions": {
    "type": "object",
    "properties": {
      "Languages": {
        "$ref": "#/definitions/InstallDefaultDataSettings"
      },
      "DataTypes": {
        "$ref": "#/definitions/InstallDefaultDataSettings"
      },
      "MediaTypes": {
        "$ref": "#/definitions/InstallDefaultDataSettings"
      },
      "MemberTypes": {
        "$ref": "#/definitions/InstallDefaultDataSettings"
      }
    }
  },		
```

- Edit the `src\Umbraco.Web.UI\appSettings.json` file in an IDE that supports intellisense for configuration, and create an `InstallDefaultData` element under `Umbraco:Cms`.  Verify the options you are presented with via intellisense match the [documented configuration](https://docs.umbraco.com/umbraco-cms/13.latest/reference/configuration/installdefaultdatasettings?fallback=true).