### PR TITLE
Resets send to approval dialog on close such that when re-opening the selection and operation can still be triggered.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/sendtopublish.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/sendtopublish.controller.js
@@ -111,6 +111,7 @@
         $scope.$on('$destroy', function () {
             vm.variants.forEach(variant => {
                 variant.save = false;
+                variant.publish = false;
                 variant.notAllowed = false;
             });
         });


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Addresses issue: https://github.com/umbraco/Umbraco-CMS/issues/17050

### Description

When selecting to send a language variant for approval, there's a glitch if you open the dialog, select a language and close.  When you re-open, the checkbox and enabled button are "out of sync", so you can't complete the operation without reloading the node.

**To Test:**

- For setup, see "steps to reproduce" on the linked issue.
- Click to send the content for approval.
- Check the language checkbox
- Close the dialog.
- Confirm you can select and send the content for approval.
