### PR TITLE
Published Content should handle "is previewing"

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/PublishedContent.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/PublishedContent.cs
@@ -42,6 +42,8 @@ internal class PublishedContent : PublishedContentBase
         _urlSegment = contentData.UrlSegment;
         _published = contentData.Published;
 
+        IsPreviewing = preview;
+
         var properties = new IPublishedProperty[_contentNode.ContentType.PropertyTypes.Count()];
         var i = 0;
         foreach (IPublishedPropertyType propertyType in _contentNode.ContentType.PropertyTypes)
@@ -127,7 +129,7 @@ internal class PublishedContent : PublishedContentBase
 
     public override DateTime UpdateDate { get; }
 
-    public bool IsPreviewing { get; } = false;
+    public bool IsPreviewing { get; }
 
     // Needed for publishedProperty
     internal IVariationContextAccessor VariationContextAccessor { get; }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The `IsPreviewing` property of `PublishedContent` is always `false` - even when previewing.

Besides being somewhat clearly wrong, it also causes problems for property values using `PropertyCacheLevel.Elements`; their cached values are not updated correctly when moving in and out of preview. This causes either preview or the published rendering to be broken:

- If a document is previewed before it's published version is requested for rendering, the draft property value will be rendered for both preview and published rendering.
- If a document is requested for rendering in its published version before it's previewed, the published property value will be rendered for both preview and published rendering.

### Testing this PR

1. Create a document with a content picker.
    - IMPORTANT: the document must have a template that renders out the value of the content picker😄 
2. Pick some content and publish the document.
3. Pick some other content and save the document (don't publish it).

Now verify that:

- The draft version of the document yields the draft value of the content picker (e.g. when previewing).
- The published version of the document contains the published value of the content picker.

### Testing this PR - for the Delivery API

Enable the Delivery API including an API key for previewing. Then:

1. Create a document with an RTE.
2. Enter some text into the RTE and publish the document.
3. Update the RTE and save the document (don't publish it).

Now verify that:

- When requesting the document for previewing via the Delivery API, the draft value of the RTE is returned.
- When requesting the document via the Delivery API _without_ previewing, the published value of the RTE is returned.
