### PR TITLE
Allow filtering for multiple content types

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Querying/Filters/ContentTypeFilter.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Querying/Filters/ContentTypeFilter.cs
@@ -1,6 +1,5 @@
 using Umbraco.Cms.Api.Delivery.Indexing.Filters;
 using Umbraco.Cms.Core.DeliveryApi;
-using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Delivery.Querying.Filters;
 
@@ -15,15 +14,15 @@ public sealed class ContentTypeFilter : IFilterHandler
     /// <inheritdoc/>
     public FilterOption BuildFilterOption(string filter)
     {
-        var alias = filter.Substring(ContentTypeSpecifier.Length);
+        var filterValue = filter.Substring(ContentTypeSpecifier.Length);
+        var negate = filterValue.StartsWith('!');
+        var aliases = filterValue.TrimStart('!').Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
 
         return new FilterOption
         {
             FieldName = ContentTypeFilterIndexer.FieldName,
-            Values = alias.IsNullOrWhiteSpace() == false
-                ? new[] { alias.TrimStart('!') }
-                : Array.Empty<string>(),
-            Operator = alias.StartsWith('!')
+            Values = aliases,
+            Operator = negate
                 ? FilterOperation.IsNot
                 : FilterOperation.Is
         };


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/discussions/17917

### Description

See the linked discussion for details 😄 

### Testing this PR

As described in the linked discussion, the content type filtering syntax now becomes:

- `filter=contentType:article,news` = finds documents of type `article` or `news`
- `filter=contentType:!article,news` = finds all other documents that those of type `article` and `news`

Test that:

1. Multiple content types can be applied to the filter, both with and without negation.
2. The current functionality (filtering for only a single content type) still works.