### PR TITLE
V13: Show validation error, when saving invalid media

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/MediaController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MediaController.cs
@@ -471,7 +471,8 @@ public class MediaController : ContentControllerBase
             null); // media are all invariant
 
         // we will continue to save if model state is invalid, however we cannot save if critical data is missing.
-        // TODO: Allowing media to be saved when it is invalid is odd - media doesn't have a publish phase so suddenly invalid data is allowed to be 'live'
+        // this is a design decision, to continue to be able to save invalid content
+        //  as you can do the same with documents. This will be removed in a future version.
         if (!ModelState.IsValid)
         {
             // check for critical data validation issues, we can't continue saving if this data is invalid
@@ -495,7 +496,7 @@ public class MediaController : ContentControllerBase
         // return the updated model
         MediaItemDisplay? display = _umbracoMapper.Map<MediaItemDisplay>(contentItem.PersistedContent);
 
-        // lastly, if it is not valid, add the model state to the outgoing object and throw a 403
+        // lastly, if it is not valid, add the model state to the outgoing object.
         if (!ModelState.IsValid)
         {
             return ValidationProblem(display, ModelState);

--- a/src/Umbraco.Web.BackOffice/Controllers/MediaController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MediaController.cs
@@ -474,14 +474,8 @@ public class MediaController : ContentControllerBase
         // TODO: Allowing media to be saved when it is invalid is odd - media doesn't have a publish phase so suddenly invalid data is allowed to be 'live'
         if (!ModelState.IsValid)
         {
-            // check for critical data validation issues, we can't continue saving if this data is invalid
-            if (!RequiredForPersistenceAttribute.HasRequiredValuesForPersistence(contentItem))
-            {
-                // ok, so the absolute mandatory data is invalid and it's new, we cannot actually continue!
-                // add the model state to the outgoing object and throw validation response
-                MediaItemDisplay? forDisplay = _umbracoMapper.Map<MediaItemDisplay>(contentItem.PersistedContent);
-                return ValidationProblem(forDisplay, ModelState);
-            }
+            MediaItemDisplay? forDisplay = _umbracoMapper.Map<MediaItemDisplay>(contentItem.PersistedContent);
+            return ValidationProblem(forDisplay, ModelState);
         }
 
         if (contentItem.PersistedContent is null)
@@ -494,12 +488,6 @@ public class MediaController : ContentControllerBase
 
         // return the updated model
         MediaItemDisplay? display = _umbracoMapper.Map<MediaItemDisplay>(contentItem.PersistedContent);
-
-        // lastly, if it is not valid, add the model state to the outgoing object and throw a 403
-        if (!ModelState.IsValid)
-        {
-            return ValidationProblem(display, ModelState, StatusCodes.Status403Forbidden);
-        }
 
         // put the correct msgs in
         switch (contentItem.Action)

--- a/src/Umbraco.Web.BackOffice/Controllers/MediaController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MediaController.cs
@@ -498,7 +498,7 @@ public class MediaController : ContentControllerBase
         // lastly, if it is not valid, add the model state to the outgoing object and throw a 403
         if (!ModelState.IsValid)
         {
-            return ValidationProblem(display, ModelState, StatusCodes.Status403Forbidden);
+            return ValidationProblem(display, ModelState);
         }
 
         // put the correct msgs in


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/17932

# Notes
- returns a validation error, instead of showing a 403 forbidden error, when saving invalid media.
- This means you can still save invalid media as you have always been able to do, but you get a proper validation error like this:
![image](https://github.com/user-attachments/assets/d9a5112b-c961-49ff-8161-2c3ae2b58875)


# How to test
- Follow steps in original issue.