### PR TITLE
Prettier rule for element base

### DIFF
--- a/src/Umbraco.Web.UI.Client/devops/eslint/rules/enforce-element-suffix-on-element-class-name.cjs
+++ b/src/Umbraco.Web.UI.Client/devops/eslint/rules/enforce-element-suffix-on-element-class-name.cjs
@@ -12,11 +12,16 @@ module.exports = {
 	create: function (context) {
 		return {
 			ClassDeclaration(node) {
+				// check if class is abstract
+				const isAbstract = node.abstract;
+
 				// check if the class extends HTMLElement, LitElement, or UmbLitElement
 				const isExtendingElement =
 					node.superClass && ['HTMLElement', 'LitElement', 'UmbLitElement'].includes(node.superClass.name);
-				// check if the class name ends with 'Element'
-				const isClassNameValid = node.id.name.endsWith('Element');
+
+				// check if the class name ends with 'Element' or 'ElementBase'
+				const isClassNameValid = node.id.name.endsWith('Element') || isAbstract && node.id.name.endsWith('ElementBase');
+
 
 				if (isExtendingElement && !isClassNameValid) {
 					context.report({


### PR DESCRIPTION
Updated rule to accept that abstract element class names ends with of 'ElementBase'.