### PR TITLE
V13: Update @microsoft/signalr from 7.0.12 to 8.0.7

### DIFF
--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "ui",
       "dependencies": {
-        "@microsoft/signalr": "7.0.12",
+        "@microsoft/signalr": "8.0.7",
         "@umbraco-ui/uui": "1.11.0",
         "@umbraco-ui/uui-css": "1.11.0",
         "ace-builds": "1.31.1",
@@ -2095,9 +2095,10 @@
       }
     },
     "node_modules/@microsoft/signalr": {
-      "version": "7.0.12",
-      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-7.0.12.tgz",
-      "integrity": "sha512-k1Xu+a73PsWgHwHDm6ctHwHTBnlqCzq7L33cbxdWhj90AGDFpxDSzaGCkZDoJFNHveUetix65zIWiazMvmMg3w==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-8.0.7.tgz",
+      "integrity": "sha512-PHcdMv8v5hJlBkRHAuKG5trGViQEkPYee36LnJQx4xHOQ5LL4X0nEWIxOp5cCtZ7tu+30quz5V3k0b1YNuc6lw==",
+      "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "eventsource": "^2.0.2",

--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -18,7 +18,7 @@
     "npm": ">=10.1"
   },
   "dependencies": {
-    "@microsoft/signalr": "7.0.12",
+    "@microsoft/signalr": "8.0.7",
     "@umbraco-ui/uui": "1.11.0",
     "@umbraco-ui/uui-css": "1.11.0",
     "ace-builds": "1.31.1",


### PR DESCRIPTION
### Description

Update the version of @microsoft/signalr to version 8 to match the .NET version. In general, we should aim to have them match each other.