### PR TITLE
Regression fix: searcher skip 10k not possible

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,7 +45,7 @@
     <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.0" />
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
     <PackageVersion Include="Dazinator.Extensions.FileProviders" Version="2.0.0" />
-    <PackageVersion Include="Examine" Version="3.5.0" />
+    <PackageVersion Include="Examine" Version="3.6.0" />
     <PackageVersion Include="Examine.Core" Version="3.5.0" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.11.71" />
     <PackageVersion Include="JsonPatch.Net" Version="3.1.1" />

--- a/src/Umbraco.Cms.Api.Management/Controllers/Searcher/QuerySearcherController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Searcher/QuerySearcherController.cs
@@ -1,5 +1,6 @@
 ﻿using Asp.Versioning;
 using Examine;
+using Examine.Lucene.Search;
 using Examine.Search;
 using Lucene.Net.QueryParsers.Classic;
 using Microsoft.AspNetCore.Http;
@@ -57,7 +58,7 @@ public class QuerySearcherController : SearcherControllerBase
             results = searcher
                 .CreateQuery()
                 .NativeQuery(term)
-                .Execute(QueryOptions.SkipTake(skip, take));
+                .Execute(new LuceneQueryOptions(skip, take, skipTakeMaxResults: skip + take));
         }
         catch (ParseException)
         {


### PR DESCRIPTION
### Description
Fixes #17920 caused by a breaking change in Examine 3.4

This PR uses the newly added functionality in Examine 3.6 to increase the amount of search results that can be skipped by calculating the max amount needed based on the skip take parameters.

### Testing
See reproduction steps in the linked issue