### PR TITLE
V15: Implement IsLockedOut on base class instead

### DIFF
--- a/src/Umbraco.Infrastructure/Security/UmbracoUserManager.cs
+++ b/src/Umbraco.Infrastructure/Security/UmbracoUserManager.cs
@@ -246,6 +246,31 @@ public abstract class UmbracoUserManager<TUser, TPasswordConfig> : UserManager<T
         return result;
     }
 
+    /// <summary>
+    ///     Override to check the user approval value as well as the user lock out date, by default this only checks the user's
+    ///     locked out date
+    /// </summary>
+    /// <param name="user">The user</param>
+    /// <returns>True if the user is locked out, else false</returns>
+    /// <remarks>
+    ///     In the ASP.NET Identity world, there is only one value for being locked out, in Umbraco we have 2 so when checking
+    ///     this for Umbraco we need to check both values
+    /// </remarks>
+    public override async Task<bool> IsLockedOutAsync(TUser user)
+    {
+        if (user == null)
+        {
+            throw new ArgumentNullException(nameof(user));
+        }
+
+        if (user.IsApproved == false)
+        {
+            return true;
+        }
+
+        return await base.IsLockedOutAsync(user);
+    }
+
     public async Task<bool> ValidateCredentialsAsync(string username, string password)
     {
         TUser? user = await FindByNameAsync(username);

--- a/src/Umbraco.Web.Common/Security/BackOfficeUserManager.cs
+++ b/src/Umbraco.Web.Common/Security/BackOfficeUserManager.cs
@@ -62,31 +62,6 @@ public class BackOfficeUserManager : UmbracoUserManager<BackOfficeIdentityUser, 
         _globalSettings = globalSettings.Value;
     }
 
-    /// <summary>
-    ///     Override to check the user approval value as well as the user lock out date, by default this only checks the user's
-    ///     locked out date
-    /// </summary>
-    /// <param name="user">The user</param>
-    /// <returns>True if the user is locked out, else false</returns>
-    /// <remarks>
-    ///     In the ASP.NET Identity world, there is only one value for being locked out, in Umbraco we have 2 so when checking
-    ///     this for Umbraco we need to check both values
-    /// </remarks>
-    public override async Task<bool> IsLockedOutAsync(BackOfficeIdentityUser user)
-    {
-        if (user == null)
-        {
-            throw new ArgumentNullException(nameof(user));
-        }
-
-        if (user.IsApproved == false)
-        {
-            return true;
-        }
-
-        return await base.IsLockedOutAsync(user);
-    }
-
     public override async Task<IdentityResult> AccessFailedAsync(BackOfficeIdentityUser user)
     {
         IdentityResult result = await base.AccessFailedAsync(user);


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/12232

# Notes
- Implements solution from https://github.com/umbraco/Umbraco-CMS/issues/12232#issuecomment-1371911209
- This implements the IsLockedOut on the ´UmbracoUserManager´ itself instead, so we can align behavior with members & users.

# How to test
- Follow steps in original issue.