### PR TITLE
Added a maxlength setting to the regular expression pattern field

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-group-builder.less
@@ -943,7 +943,7 @@ input.umb-group-builder__group-sort-value {
     .editor-description,
     .editor-validation-pattern {
         min-width: 100%;
-        min-height: 25px;
+        min-height: 60px;
         resize: none;
         box-sizing: border-box;
         border: none;

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/propertysettings/propertysettings.html
@@ -125,6 +125,7 @@
                                       ng-model="model.property.validation.pattern"
                                       ng-change="vm.changeValidationPattern()"
                                       ng-if="vm.showValidationPattern"
+                                      maxlength="255"
                                       umb-auto-resize
                                       focus-when="{{vm.focusOnPatternField}}"
                                       ng-keypress="vm.submitOnEnter($event)">


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/16368

### Description

Currently the regular expression pattern field allows entry of any length of text.  On SQL Server, the limit is 255 characters, so you'll get an exception thrown if you try to enter a longer pattern.  With SQLite, the longer text is accepted, but then errors will occur if you deploy to an environment running SQL Server.

This PR adds a `maxlength` attribute to the field to prevent entry of a value that's too long.

I've also increased the height of the box slightly to better present longer patterns.

<img src="https://github.com/user-attachments/assets/26807bf1-b19e-468d-93d5-9c9b00517399" width="400" />

This resolves the issue for Umbraco 13.  Will check and if necessary create a separate PR for the same on Umbraco 15.
