### PR TITLE
Make the RTE handle inline elements gracefully for JSON

### DIFF
--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs
@@ -101,8 +101,9 @@ internal sealed class ApiRichTextElementParser : ApiRichTextParserBase, IApiRich
         // - non-#comment nodes
         // - non-#text nodes
         // - non-empty #text nodes
+        // - empty #text between inline elements (see #17037)
         HtmlNode[] childNodes = element.ChildNodes
-            .Where(c => c.Name != CommentNodeName && (c.Name != TextNodeName || string.IsNullOrWhiteSpace(c.InnerText) is false))
+            .Where(c => c.Name != CommentNodeName && (c.Name != TextNodeName || c.NextSibling is not null || string.IsNullOrWhiteSpace(c.InnerText) is false))
             .ToArray();
 
         var tag = TagName(element);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/RichTextParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/RichTextParserTests.cs
@@ -358,6 +358,48 @@ public class RichTextParserTests : PropertyValueConverterTests
     }
 
     [Test]
+    public void ParseElement_CanHandleWhitespaceAroundInlineElemements()
+    {
+        var parser = CreateRichTextElementParser();
+
+        var element = parser.Parse("<p>What follows from <strong>here</strong> <em>is</em> <a href=\"#\">just</a> a bunch of text.</p>") as RichTextRootElement;
+        Assert.IsNotNull(element);
+        var paragraphElement = element.Elements.Single() as RichTextGenericElement;
+        Assert.IsNotNull(paragraphElement);
+
+        var childElements = paragraphElement.Elements.ToArray();
+        Assert.AreEqual(7, childElements.Length);
+
+        var childElementCounter = 0;
+
+        void AssertNextChildElementIsText(string expectedText)
+        {
+            var textElement = childElements[childElementCounter++] as RichTextTextElement;
+            Assert.IsNotNull(textElement);
+            Assert.AreEqual(expectedText, textElement.Text);
+        }
+
+        void AssertNextChildElementIsGeneric(string expectedTag, string expectedInnerText)
+        {
+            var genericElement = childElements[childElementCounter++] as RichTextGenericElement;
+            Assert.IsNotNull(genericElement);
+            Assert.AreEqual(expectedTag, genericElement.Tag);
+            Assert.AreEqual(1, genericElement.Elements.Count());
+            var textElement = genericElement.Elements.First() as RichTextTextElement;
+            Assert.IsNotNull(textElement);
+            Assert.AreEqual(expectedInnerText, textElement.Text);
+        }
+
+        AssertNextChildElementIsText("What follows from ");
+        AssertNextChildElementIsGeneric("strong", "here");
+        AssertNextChildElementIsText(" ");
+        AssertNextChildElementIsGeneric("em", "is");
+        AssertNextChildElementIsText(" ");
+        AssertNextChildElementIsGeneric("a", "just");
+        AssertNextChildElementIsText(" a bunch of text.");
+    }
+
+    [Test]
     public void ParseMarkup_CanParseContentLink()
     {
         var parser = CreateRichTextMarkupParser();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #17037

### Description

See the linked issue 👍 

### Testing this PR

Setup the Delivery API to [render RTEs as JSON](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#additional-configuration).

Create and publish a document containing an RTE with this content:

```html
<p>What follows from <strong>here</strong> <em>is</em> <a href="#">just</a> a bunch of text.</p>
```

...you'll likely need to insert it directly into the RTE code editor.

Verify that the Delivery API output for the document has `#text` elements with single whitespaces between the inline elements (`strong`, `em` and `a`):

![image](https://github.com/user-attachments/assets/08091700-b996-4a5c-bfef-3c0591b617e3)
