### PR TITLE
WIP: Added a maxlength setting to the regular expression pattern field (15)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
@@ -2052,6 +2052,7 @@ export default {
 		fieldIsMandatory: 'Field is mandatory',
 		mandatoryMessage: 'Enter a custom validation error message (optional)',
 		validationRegExp: 'Enter a regular expression',
+		validationRegExpTooLong: 'The pattern you have provided is too long. Please limit to 255 characters.',
 		validationRegExpMessage: 'Enter a custom validation error message (optional)',
 		minCount: 'You need to add at least',
 		maxCount: 'You can only have',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -2089,6 +2089,7 @@ export default {
 		fieldIsMandatory: 'Field is mandatory',
 		mandatoryMessage: 'Enter a custom validation error message (optional)',
 		validationRegExp: 'Enter a regular expression',
+		validationRegExpTooLong: 'The pattern you have provided is too long. Please limit to 255 characters.',
 		validationRegExpMessage: 'Enter a custom validation error message (optional)',
 		minCount: 'You need to add at least',
 		maxCount: 'You can only have',

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property-type/workspace/views/settings/property-workspace-view-settings.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property-type/workspace/views/settings/property-workspace-view-settings.element.ts
@@ -386,13 +386,18 @@ export class UmbPropertyTypeWorkspaceViewSettingsElement extends UmbLitElement i
 
 			${this._data?.validation?.regEx !== null
 				? html`
-						<uui-input
-							name="pattern"
-							style="margin-bottom: var(--uui-size-space-1); margin-top: var(--uui-size-space-5);"
-							@change=${this.#onValidationRegExChange}
-							placeholder=${this.localize.term('validation_validationRegExp')}
-							label=${this.localize.term('validation_validationRegExp')}
-							.value=${this._data?.validation?.regEx ?? ''}></uui-input>
+						<umb-form-validation-message>
+							<uui-input
+								name="pattern"
+								style="margin-bottom: var(--uui-size-space-1); margin-top: var(--uui-size-space-5);"
+								@change=${this.#onValidationRegExChange}
+								placeholder=${this.localize.term('validation_validationRegExp')}
+								label=${this.localize.term('validation_validationRegExp')}
+								${umbBindToValidation(this, '$.validation.regex')}
+								maxlength=255
+								maxlengthMessage=${this.localize.term('validation_validationRegExpTooLong')}
+								.value=${this._data?.validation?.regEx ?? ''}></uui-input>
+						</umb-form-validation-message>
 						<uui-textarea
 							name="pattern-message"
 							@change=${this.#onValidationMessageChange}


### PR DESCRIPTION
WIP... this is looking to implement the same fix as for https://github.com/umbraco/Umbraco-CMS/pull/17982

See further (HQ internal) discussion here: https://umbraco.slack.com/archives/C027U315T54/p1736868267763389

Current issues:
- I'm seeing a validation message appear, but not the one I'd ideally like to show which is set on `maxlengthMessage`
    - But that's not so important - the default message is OK if that's what we can use currently.
- I can still submit the modal, but really I shouldn't be able to until the validation issues are fixed.
    - Actually, I see the same with the existing validation for the "Name" field - that also shows a message, but I can submit the modal.