### PR TITLE
Enforce the "Save and preview" button after when switching content app

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -311,10 +311,12 @@
             // create the save button
             if (_.contains($scope.content.allowedActions, "A")) {
                 $scope.page.showSaveButton = true;
+                $scope.page.showPreviewButton = true;
                 // add ellipsis to the save button if it opens the variant overlay
                 $scope.page.saveButtonEllipsis = content.variants && content.variants.length > 1 ? "true" : "false";
             } else {
                 $scope.page.showSaveButton = false;
+                $scope.page.showPreviewButton = false;
             }
 
             // create the pubish combo button


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #16911

### Description

Adding a custom content app introduces a weird behaviour for the "Save and preview" button; if you go to the custom content app and back again to the "Content" or "Info" content apps, the "Save and preview" button has disappeared - the "Save" and the "Publish" buttons are still there, though.

This PR fixes it.

### Testing this PR

⚠️ Remember to rebuild the client before testing ⚠️

Extract [this custom content app](https://github.com/user-attachments/files/18420104/WordCounter.zip) into `/App_Plugins` and restart the site.

Navigate between the content apps and verify that the "Save and preview" button disappears and re-appears along with the rest of the buttons.
