### PR TITLE
Do not show "Save and preview" by default

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -365,8 +365,6 @@
                     handler: () => $scope.preview(content, additionalPreviewUrl.url, '_blank')
                 }
             });
-
-            $scope.page.showPreviewButton = true;
         }
 
         /** Syncs the content item to it's tree node - this occurs on first load and after saving */


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #16854

### Description

Even if a user is not allowed to save or send to publish, they will still see the "Save and preview" button. Fortunately it doesn't work, but it's still wrong.

This PR fixes it.

### Testing this PR

⚠️ Remember to rebuild the client before testing ⚠️

1. Create a user with only "Browse" permissions to content.
2. Login with this user and verify that no buttons are shown for content.
3. Verify that the "Save and publish" button still works for users with content save permission.
