### PR TITLE
Fix: only fire event when instance is available (issue 17847)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.component.js
@@ -348,7 +348,9 @@
           // But I'm not sure it's needed, as this does not trigger the RTE
           if(modelObject) {
             modelObject.update(vm.model.value.blocks, $scope);
-            vm.tinyMceEditor.fire('updateBlocks');
+            if (vm.tinyMceEditor) {
+              vm.tinyMceEditor.fire('updateBlocks');
+            }
             onLoaded();
           }
       }

--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.component.js
@@ -256,7 +256,7 @@
                         toolbar: editorConfig.toolbar,
                         model: vm.model,
                         getValue: function () {
-                          return vm.model.value.markup;
+                          return vm.model.value.markup ?? "";
                         },
                         setValue: function (newVal) {
                           vm.model.value.markup = newVal;


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/17847

Solution is to only fire this event if the instance is available, it seems to me if not available an update is not necessary.