### PR TITLE
Fix: Do not re-map schedule modal on error as it leads to broken bindings

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -926,8 +926,6 @@
                                 formHelper.showNotifications(err.data);
                             }
                             model.submitButtonState = "error";
-                            //re-map the dialog model since we've re-bound the properties
-                            dialog.variants = Utilities.copy($scope.content.variants);
                             handleHttpException(err);
                         });
 


### PR DESCRIPTION
fixes #17406
