### PR TITLE
Fix: Empty groups appear in block grid editor Add content UI

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/modals/block-catalogue/block-catalogue-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/modals/block-catalogue/block-catalogue-modal.element.ts
@@ -157,7 +157,7 @@ export class UmbBlockCatalogueModalElement extends UmbModalBaseElement<
 				: nothing}
 			${this._filtered.map(
 				(group) => html`
-					${group.name && group.name !== '' ? html`<h4>${group.name}</h4>` : nothing}
+					${group.name && group.blocks.length !== 0 && group.name !== '' ? html`<h4>${group.name}</h4>` : nothing}
 					<div class="blockGroup">
 						${repeat(
 							group.blocks,


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/17796

