### PR TITLE
Feature: Create button in Document Type Folder collection

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/tree/tree-item-children/collection/action/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/tree/tree-item-children/collection/action/manifests.ts
@@ -1,0 +1,17 @@
+import { UMB_DOCUMENT_TYPE_TREE_ITEM_CHILDREN_COLLECTION_ALIAS } from '../constants.js';
+import { UMB_COLLECTION_ALIAS_CONDITION } from '@umbraco-cms/backoffice/collection';
+
+export const manifests: Array<UmbExtensionManifest> = [
+	{
+		type: 'collectionAction',
+		kind: 'create',
+		name: 'Document Type Tree Item Children Collection Create Action',
+		alias: 'Umb.CollectionAction.DocumentTypeTreeItemChildren.Create',
+		conditions: [
+			{
+				alias: UMB_COLLECTION_ALIAS_CONDITION,
+				match: UMB_DOCUMENT_TYPE_TREE_ITEM_CHILDREN_COLLECTION_ALIAS,
+			},
+		],
+	},
+];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/tree/tree-item-children/collection/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/tree/tree-item-children/collection/manifests.ts
@@ -1,5 +1,6 @@
-import { manifests as viewManifests } from './views/manifests.js';
+import { manifests as actionManifests } from './action/manifests.js';
 import { manifests as repositoryManifests } from './repository/manifests.js';
+import { manifests as viewManifests } from './views/manifests.js';
 import { UMB_DOCUMENT_TYPE_TREE_ITEM_CHILDREN_COLLECTION_ALIAS } from './constants.js';
 import { UMB_DOCUMENT_TYPE_TREE_ITEM_CHILDREN_COLLECTION_REPOSITORY_ALIAS } from './repository/index.js';
 
@@ -13,6 +14,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			repositoryAlias: UMB_DOCUMENT_TYPE_TREE_ITEM_CHILDREN_COLLECTION_REPOSITORY_ALIAS,
 		},
 	},
-	...viewManifests,
+	...actionManifests,
 	...repositoryManifests,
+	...viewManifests,
 ];


### PR DESCRIPTION
This PR registers a create button in the Document Type Folder Collection workspace. The Create action utilizes the already-registered create options.

<img width="913" alt="Screenshot 2025-01-16 at 21 36 39" src="https://github.com/user-attachments/assets/198ae60b-5f5b-4e7b-9dea-6b2ff9393da3" />