### PR TITLE
First document at root should not have special meaning when routing

### DIFF
--- a/src/Umbraco.Core/Services/DocumentUrlService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlService.cs
@@ -736,8 +736,6 @@ public class DocumentUrlService : IDocumentUrlService
 
         if (considerFirstLevelAsRoot)
         {
-            yield return rootKeys.First();
-
             foreach (Guid rootKey in rootKeys)
             {
                 if (isDraft is false && IsContentPublished(rootKey, culture) is false)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The first root document has been given special meaning when routing content. I can't find any background for this, nor any reasoning why it should have.

#### Specifics

Given this document structure:

![image](https://github.com/user-attachments/assets/8d033db9-1c51-466b-a7d6-e31aafdc7840)

All the blog posts are routable both at their expected path `/[blog post URL segment]/`, but also at `/posts/[blog post URL segment]/`. The latter should not be the case - at least not by default (more on that below).

![image](https://github.com/user-attachments/assets/86181fa8-eade-4d3e-82aa-0e8a43444c6b)


![image](https://github.com/user-attachments/assets/df627357-4eaa-461e-a353-6ceeebb1fdd1)

For comparison, the authors are _not_ routable at `/authors/[author URL segment]/` - only at `/[author URL segment]/`, as expected.

#### `HideTopLevelNodeFromPath`

The `HideTopLevelNodeFromPath` config setting (see [docs](https://docs.umbraco.com/umbraco-cms/reference/configuration/globalsettings)) is by default `true` ... setting it to `false` should include the root document URL segment in the blog post and author paths - and this _does_ work for both blog posts and authors:

![image](https://github.com/user-attachments/assets/aacf0787-a911-49c9-9d5b-74e60c9a4ae7)

![image](https://github.com/user-attachments/assets/837a40d5-9625-48b0-9a10-ec269e9b6966)

### Testing this PR

Verify that V15 routes documents like V13 - with and without `HideTopLevelNodeFromPath` enabled.

**Note:** root documents are always routable by their URL segment even with `HideTopLevelNodeFromPath` - this is consistent with the V13 behaviour.

