### PR TITLE
V15: Main entity name field lacks placeholder and auto-focus

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-split-view/workspace-split-view-variant-selector.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-split-view/workspace-split-view-variant-selector.element.ts
@@ -1,35 +1,18 @@
 import type { ActiveVariant } from '../../controllers/index.js';
 import { UMB_WORKSPACE_SPLIT_VIEW_CONTEXT } from './workspace-split-view.context.js';
-import {
-	type UUIInputElement,
-	UUIInputEvent,
-	type UUIPopoverContainerElement,
-} from '@umbraco-cms/backoffice/external/uui';
-import {
-	css,
-	html,
-	nothing,
-	customElement,
-	state,
-	query,
-	ifDefined,
-	type TemplateResult,
-	ref,
-} from '@umbraco-cms/backoffice/external/lit';
-import {
-	UmbVariantId,
-	type UmbEntityVariantModel,
-	type UmbEntityVariantOptionModel,
-} from '@umbraco-cms/backoffice/variant';
-import { UMB_PROPERTY_DATASET_CONTEXT, isNameablePropertyDatasetContext } from '@umbraco-cms/backoffice/property';
+import { css, customElement, html, ifDefined, nothing, query, ref, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import type { UmbVariantState } from '@umbraco-cms/backoffice/utils';
+import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 import { UmbDataPathVariantQuery, umbBindToValidation } from '@umbraco-cms/backoffice/validation';
+import { UMB_PROPERTY_DATASET_CONTEXT, isNameablePropertyDatasetContext } from '@umbraco-cms/backoffice/property';
+import { UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
 import type { UmbContentWorkspaceContext } from '@umbraco-cms/backoffice/content';
+import type { UmbEntityVariantModel, UmbEntityVariantOptionModel } from '@umbraco-cms/backoffice/variant';
+import type { UmbVariantState } from '@umbraco-cms/backoffice/utils';
+import type { UUIInputElement, UUIPopoverContainerElement } from '@umbraco-cms/backoffice/external/uui';
 
-const elementName = 'umb-workspace-split-view-variant-selector';
-@customElement(elementName)
+@customElement('umb-workspace-split-view-variant-selector')
 export class UmbWorkspaceSplitViewVariantSelectorElement<
 	VariantOptionModelType extends
 		UmbEntityVariantOptionModel<UmbEntityVariantModel> = UmbEntityVariantOptionModel<UmbEntityVariantModel>,
@@ -248,52 +231,47 @@ export class UmbWorkspaceSplitViewVariantSelectorElement<
 				required
 				?readonly=${this.#isReadOnly(this._activeVariant?.culture ?? null)}
 				${umbBindToValidation(this, `$.variants[${UmbDataPathVariantQuery(this._variantId)}].name`, this._name ?? '')}
-				${ref(this.#focusInput)}
-			>
-				${
-					this.#hasVariants()
-						? html`
-								<uui-button
-									id="variant-selector-toggle"
-									compact
-									slot="append"
-									popovertarget="variant-selector-popover"
-									title=${ifDefined(this._activeVariant?.language.name)}
-									label="Select a variant">
-									${this._activeVariant?.language.name} ${this.#renderReadOnlyTag(this._activeVariant?.culture)}
-									<uui-symbol-expand .open=${this._variantSelectorOpen}></uui-symbol-expand>
-								</uui-button>
-								${this._activeVariants.length > 1
-									? html`
-											<uui-button slot="append" compact id="variant-close" @click=${this.#closeSplitView}>
-												<uui-icon name="remove"></uui-icon>
-											</uui-button>
-										`
-									: ''}
-							`
-						: nothing
-				}
+				${ref(this.#focusInput)}>
+				${this.#hasVariants()
+					? html`
+							<uui-button
+								id="variant-selector-toggle"
+								compact
+								slot="append"
+								popovertarget="variant-selector-popover"
+								title=${ifDefined(this._activeVariant?.language.name)}
+								label="Select a variant">
+								${this._activeVariant?.language.name} ${this.#renderReadOnlyTag(this._activeVariant?.culture)}
+								<uui-symbol-expand .open=${this._variantSelectorOpen}></uui-symbol-expand>
+							</uui-button>
+							${this._activeVariants.length > 1
+								? html`
+										<uui-button slot="append" compact id="variant-close" @click=${this.#closeSplitView}>
+											<uui-icon name="remove"></uui-icon>
+										</uui-button>
+									`
+								: ''}
+						`
+					: nothing}
 			</uui-input>
 
-			${
-				this.#hasVariants()
-					? html`
-							<uui-popover-container
-								id="variant-selector-popover"
-								@beforetoggle=${this.#onPopoverToggle}
-								placement="bottom-end">
-								<div id="variant-selector-dropdown">
-									<uui-scroll-container>
-										<ul>
-											${this._variantOptions.map((variant) => this.#renderListItem(variant))}
-										</ul>
-									</uui-scroll-container>
-								</div>
-							</uui-popover-container>
-						`
-					: nothing
-			}
-		</div>`;
+			${this.#hasVariants()
+				? html`
+						<uui-popover-container
+							id="variant-selector-popover"
+							@beforetoggle=${this.#onPopoverToggle}
+							placement="bottom-end">
+							<div id="variant-selector-dropdown">
+								<uui-scroll-container>
+									<ul>
+										${this._variantOptions.map((variant) => this.#renderListItem(variant))}
+									</ul>
+								</uui-scroll-container>
+							</div>
+						</uui-popover-container>
+					`
+				: nothing}
+		`;
 	}
 
 	#renderListItem(variantOption: VariantOptionModelType) {
@@ -327,7 +305,7 @@ export class UmbWorkspaceSplitViewVariantSelectorElement<
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	protected _renderVariantDetails(variantOption: VariantOptionModelType): TemplateResult {
+	protected _renderVariantDetails(variantOption: VariantOptionModelType) {
 		return html``;
 	}
 
@@ -516,6 +494,6 @@ export class UmbWorkspaceSplitViewVariantSelectorElement<
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbWorkspaceSplitViewVariantSelectorElement;
+		'umb-workspace-split-view-variant-selector': UmbWorkspaceSplitViewVariantSelectorElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-split-view/workspace-split-view-variant-selector.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-split-view/workspace-split-view-variant-selector.element.ts
@@ -226,6 +226,7 @@ export class UmbWorkspaceSplitViewVariantSelectorElement<
 			<uui-input
 				id="name-input"
 				data-mark="input:entity-name"
+				placeholder=${this.localize.term('placeholders_entername')}
 				label=${this.localize.term('placeholders_entername')}
 				.value=${this._name ?? ''}
 				@input=${this.#handleInput}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-split-view/workspace-split-view-variant-selector.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-split-view/workspace-split-view-variant-selector.element.ts
@@ -14,6 +14,7 @@ import {
 	query,
 	ifDefined,
 	type TemplateResult,
+	ref,
 } from '@umbraco-cms/backoffice/external/lit';
 import {
 	UmbVariantId,
@@ -21,7 +22,7 @@ import {
 	type UmbEntityVariantOptionModel,
 } from '@umbraco-cms/backoffice/variant';
 import { UMB_PROPERTY_DATASET_CONTEXT, isNameablePropertyDatasetContext } from '@umbraco-cms/backoffice/property';
-import { UmbLitElement, umbFocus } from '@umbraco-cms/backoffice/lit-element';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import type { UmbVariantState } from '@umbraco-cms/backoffice/utils';
 import { UmbDataPathVariantQuery, umbBindToValidation } from '@umbraco-cms/backoffice/validation';
@@ -220,9 +221,23 @@ export class UmbWorkspaceSplitViewVariantSelectorElement<
 		this._popoverElement.style.width = `${host.width}px`;
 	}
 
+	/**
+	 * Focuses the input element after a short delay to ensure it is rendered.
+	 * This works better than the {umbFocus()} directive, which does not work in this context.
+	 */
+	#focusInput(element?: Element) {
+		if (!element) return;
+
+		setTimeout(async () => {
+			await this.updateComplete;
+			(element as UUIInputElement)?.focus();
+		}, 200);
+	}
+
 	override render() {
-		return this._variantId
-			? html`
+		if (!this._variantId) return nothing;
+
+		return html`
 			<uui-input
 				id="name-input"
 				data-mark="input:entity-name"
@@ -233,7 +248,7 @@ export class UmbWorkspaceSplitViewVariantSelectorElement<
 				required
 				?readonly=${this.#isReadOnly(this._activeVariant?.culture ?? null)}
 				${umbBindToValidation(this, `$.variants[${UmbDataPathVariantQuery(this._variantId)}].name`, this._name ?? '')}
-				${umbFocus()}
+				${ref(this.#focusInput)}
 			>
 				${
 					this.#hasVariants()
@@ -278,9 +293,7 @@ export class UmbWorkspaceSplitViewVariantSelectorElement<
 						`
 					: nothing
 			}
-		</div>
-		`
-			: nothing;
+		</div>`;
 	}
 
 	#renderListItem(variantOption: VariantOptionModelType) {


### PR DESCRIPTION
### Description

Fixes #17999

- Adds placeholder to the main entity field
- Adds a `.focus()` call to the main input using a forward ref and a timeout (also tested with **requestAnimationFrame** however it did not work when changing from a different workspace, only within the same workspace)

### Tasks

- [x] fix `umbFocus()` - the directive is attached to the element, but it doesn't seem to work properly as the element is rendered very late

### How to test

1. Test that a placeholder is shown when deleting the value in the name field
2. Verify that the input has focus upon creating a new entity
3. Verify that the input has focus when editing an existing entity
4. Try and switch between workspaces and/or sections, then click "Create" on a document to create a new page