### PR TITLE
Updated the dialog label for User -> Assign Access -> Media Start nodes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
@@ -536,6 +536,7 @@ export default {
 		linkToMedia: 'Link til medie',
 		selectContentStartNode: 'Vælg startnode for indhold',
 		selectMedia: 'Vælg medie',
+		chooseMedia: 'Vælg medie',
 		chooseMediaStartNode: 'Vælg startnode for medie',
 		selectMediaType: 'Vælg medietype',
 		selectIcon: 'Vælg ikon',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
@@ -536,7 +536,7 @@ export default {
 		linkToMedia: 'Link til medie',
 		selectContentStartNode: 'Vælg startnode for indhold',
 		selectMedia: 'Vælg medie',
-		chooseMediaStartNode: 'Vælg medie startnode',
+		chooseMediaStartNode: 'Vælg startnode for medie',
 		selectMediaType: 'Vælg medietype',
 		selectIcon: 'Vælg ikon',
 		selectItem: 'Vælg item',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
@@ -536,7 +536,7 @@ export default {
 		linkToMedia: 'Link til medie',
 		selectContentStartNode: 'Vælg startnode for indhold',
 		selectMedia: 'Vælg medie',
-		chooseMedia: 'Vælg medie start node',
+		chooseMedia: 'Vælg medie startnode',
 		selectMediaType: 'Vælg medietype',
 		selectIcon: 'Vælg ikon',
 		selectItem: 'Vælg item',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
@@ -123,6 +123,7 @@ export default {
 	buttons: {
 		clearSelection: 'Ryd valg',
 		select: 'Vælg',
+		choose: 'Vælg',
 		somethingElse: 'Gør noget andet',
 		bold: 'Fed',
 		deindent: 'Fortryd indryk afsnit',
@@ -535,6 +536,7 @@ export default {
 		linkToMedia: 'Link til medie',
 		selectContentStartNode: 'Vælg startnode for indhold',
 		selectMedia: 'Vælg medie',
+		chooseMedia: 'Vælg medie',
 		selectMediaType: 'Vælg medietype',
 		selectIcon: 'Vælg ikon',
 		selectItem: 'Vælg item',
@@ -1917,6 +1919,9 @@ export default {
 		allowAccessToAllDocuments: 'Tillad adgang til alle dokumenter',
 		allowAccessToAllMedia: 'Tillad adgang til alle medier',
 		selectUserGroup: (multiple: boolean) => {
+			return multiple ? 'Vælg brugergrupper' : 'Vælg brugergruppe';
+		},
+		chooseUserGroup: (multiple: boolean) => {
 			return multiple ? 'Vælg brugergrupper' : 'Vælg brugergruppe';
 		},
 		noStartNode: 'Ingen startnode valgt',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
@@ -536,7 +536,7 @@ export default {
 		linkToMedia: 'Link til medie',
 		selectContentStartNode: 'Vælg startnode for indhold',
 		selectMedia: 'Vælg medie',
-		chooseMedia: 'Vælg medie startnode',
+		chooseMediaStartNode: 'Vælg medie startnode',
 		selectMediaType: 'Vælg medietype',
 		selectIcon: 'Vælg ikon',
 		selectItem: 'Vælg item',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
@@ -536,7 +536,7 @@ export default {
 		linkToMedia: 'Link til medie',
 		selectContentStartNode: 'Vælg startnode for indhold',
 		selectMedia: 'Vælg medie',
-		chooseMedia: 'Vælg medie',
+		chooseMedia: 'Vælg medie start node',
 		selectMediaType: 'Vælg medietype',
 		selectIcon: 'Vælg ikon',
 		selectItem: 'Vælg item',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
@@ -129,6 +129,7 @@ export default {
 	buttons: {
 		clearSelection: 'Clear selection',
 		select: 'Select',
+		choose: 'Choose',
 		somethingElse: 'Do something else',
 		bold: 'Bold',
 		deindent: 'Cancel Paragraph Indent',
@@ -567,6 +568,7 @@ export default {
 		linkToMedia: 'Link to media',
 		selectContentStartNode: 'Select content start node',
 		selectMedia: 'Select media',
+		chooseMedia: 'Choose media',
 		selectMediaType: 'Select media type',
 		selectIcon: 'Select icon',
 		selectItem: 'Select item',
@@ -1970,6 +1972,9 @@ export default {
 		sectionsHelp: 'Add sections to give users access',
 		selectUserGroup: (multiple: boolean) => {
 			return multiple ? 'Select User Groups' : 'Select User Group';
+		},
+		chooseUserGroup: (multiple: boolean) => {
+			return multiple ? 'Choose User Groups' : 'Choose User Group';
 		},
 		noStartNode: 'No start node selected',
 		noStartNodes: 'No start nodes selected',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
@@ -568,7 +568,7 @@ export default {
 		linkToMedia: 'Link to media',
 		selectContentStartNode: 'Select content start node',
 		selectMedia: 'Select media',
-		chooseMedia: 'Choose media',
+		chooseMedia: 'Choose Media Start nodes',
 		selectMediaType: 'Select media type',
 		selectIcon: 'Select icon',
 		selectItem: 'Select item',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
@@ -568,7 +568,7 @@ export default {
 		linkToMedia: 'Link to media',
 		selectContentStartNode: 'Select content start node',
 		selectMedia: 'Select media',
-		chooseMedia: 'Choose Media Start nodes',
+		chooseMediaStartNode: 'Choose Media Start nodes',
 		selectMediaType: 'Select media type',
 		selectIcon: 'Select icon',
 		selectItem: 'Select item',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -129,6 +129,7 @@ export default {
 	buttons: {
 		clearSelection: 'Clear selection',
 		select: 'Select',
+		choose: 'Choose',
 		somethingElse: 'Do something else',
 		bold: 'Bold',
 		deindent: 'Cancel Paragraph Indent',
@@ -558,6 +559,7 @@ export default {
 		selectContentStartNode: 'Select content start node',
 		selectEvent: 'Select event',
 		selectMedia: 'Select media',
+		chooseMedia: 'Choose media',
 		selectMediaType: 'Select media type',
 		selectIcon: 'Select icon',
 		selectItem: 'Select item',
@@ -2009,6 +2011,9 @@ export default {
 		sectionsHelp: 'Add sections to give users access',
 		selectUserGroup: (multiple: boolean) => {
 			return multiple ? 'Select User Groups' : 'Select User Group';
+		},
+		chooseUserGroup: (multiple: boolean) => {
+			return multiple ? 'Choose User Groups' : 'Choose User Group';
 		},
 		noStartNode: 'No start node selected',
 		noStartNodes: 'No start nodes selected',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -559,7 +559,7 @@ export default {
 		selectContentStartNode: 'Select content start node',
 		selectEvent: 'Select event',
 		selectMedia: 'Select media',
-		chooseMedia: 'Choose Media Start nodes',
+		chooseMediaStartNode: 'Choose Media Start nodes',
 		selectMediaType: 'Select media type',
 		selectIcon: 'Select icon',
 		selectItem: 'Select item',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -559,6 +559,7 @@ export default {
 		selectContentStartNode: 'Select content start node',
 		selectEvent: 'Select event',
 		selectMedia: 'Select media',
+		chooseMedia: 'Choose media',
 		chooseMediaStartNode: 'Choose Media Start nodes',
 		selectMediaType: 'Select media type',
 		selectIcon: 'Select icon',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -559,7 +559,7 @@ export default {
 		selectContentStartNode: 'Select content start node',
 		selectEvent: 'Select event',
 		selectMedia: 'Select media',
-		chooseMedia: 'Choose media',
+		chooseMedia: 'Choose Media Start nodes',
 		selectMediaType: 'Select media type',
 		selectIcon: 'Select icon',
 		selectItem: 'Select item',

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
@@ -229,7 +229,7 @@ export class UmbMediaPickerModalElement extends UmbModalBaseElement<
 
 	override render() {
 		return html`
-			<umb-body-layout headline=${this.localize.term('defaultdialogs_chooseMediaStartNode')}>
+			<umb-body-layout headline=${this.localize.term('defaultdialogs_chooseMedia')}>
 				${this.#renderBody()} ${this.#renderBreadcrumb()}
 				<div slot="actions">
 					<uui-button label=${this.localize.term('general_close')} @click=${this._rejectModal}></uui-button>

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
@@ -229,7 +229,7 @@ export class UmbMediaPickerModalElement extends UmbModalBaseElement<
 
 	override render() {
 		return html`
-			<umb-body-layout headline=${this.localize.term('defaultdialogs_chooseMedia')}>
+			<umb-body-layout headline=${this.localize.term('defaultdialogs_chooseMediaStartNode')}>
 				${this.#renderBody()} ${this.#renderBreadcrumb()}
 				<div slot="actions">
 					<uui-button label=${this.localize.term('general_close')} @click=${this._rejectModal}></uui-button>

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
@@ -229,12 +229,12 @@ export class UmbMediaPickerModalElement extends UmbModalBaseElement<
 
 	override render() {
 		return html`
-			<umb-body-layout headline=${this.localize.term('defaultdialogs_selectMedia')}>
+			<umb-body-layout headline=${this.localize.term('defaultdialogs_chooseMedia')}>
 				${this.#renderBody()} ${this.#renderBreadcrumb()}
 				<div slot="actions">
 					<uui-button label=${this.localize.term('general_close')} @click=${this._rejectModal}></uui-button>
 					<uui-button
-						label=${this.localize.term('general_submit')}
+						label=${this.localize.term('general_choose')}
 						look="primary"
 						color="positive"
 						@click=${this._submitModal}></uui-button>


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description

This PR changes the dialog label under User -> Assign Access -> Media Start nodes making the action clearer when clicking the button.

This PR aims to resolve the Media Start nodes label mentioned in the following issue: https://github.com/umbraco/Umbraco-CMS/issues/16668

<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
