### PR TITLE
Add NoopCurrentMemberClaimsProvider so Umbraco can boot without the Delivery API enabled

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Controllers/Security/CurrentMemberController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/Security/CurrentMemberController.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenIddict.Server.AspNetCore;
 using Umbraco.Cms.Api.Delivery.Routing;
-using Umbraco.Cms.Api.Delivery.Services;
+using Umbraco.Cms.Core.DeliveryApi;
 
 namespace Umbraco.Cms.Api.Delivery.Controllers.Security;
 

--- a/src/Umbraco.Cms.Api.Delivery/Services/CurrentMemberClaimsProvider.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/CurrentMemberClaimsProvider.cs
@@ -1,4 +1,5 @@
 ﻿using OpenIddict.Abstractions;
+using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Security;
 
 namespace Umbraco.Cms.Api.Delivery.Services;

--- a/src/Umbraco.Core/DeliveryApi/ICurrentMemberClaimsProvider.cs
+++ b/src/Umbraco.Core/DeliveryApi/ICurrentMemberClaimsProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace Umbraco.Cms.Api.Delivery.Services;
+﻿namespace Umbraco.Cms.Core.DeliveryApi;
 
 public interface ICurrentMemberClaimsProvider
 {

--- a/src/Umbraco.Core/DeliveryApi/NoopCurrentMemberClaimsProvider.cs
+++ b/src/Umbraco.Core/DeliveryApi/NoopCurrentMemberClaimsProvider.cs
@@ -1,0 +1,6 @@
+﻿namespace Umbraco.Cms.Core.DeliveryApi;
+
+public class NoopCurrentMemberClaimsProvider : ICurrentMemberClaimsProvider
+{
+    public Task<Dictionary<string, object>> GetClaimsAsync() => Task.FromResult(new Dictionary<string, object>());
+}

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -454,6 +454,7 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddSingleton<IRequestRedirectService, NoopRequestRedirectService>();
         builder.Services.AddSingleton<IRequestPreviewService, NoopRequestPreviewService>();
         builder.Services.AddSingleton<IRequestMemberAccessService, NoopRequestMemberAccessService>();
+        builder.Services.AddTransient<ICurrentMemberClaimsProvider, NoopCurrentMemberClaimsProvider>();
         builder.Services.AddSingleton<IApiAccessService, NoopApiAccessService>();
         builder.Services.AddSingleton<IApiContentQueryService, NoopApiContentQueryService>();
         builder.Services.AddSingleton<IApiMediaQueryService, NoopApiMediaQueryService>();


### PR DESCRIPTION
### Description

The introduction of the "current member info" endpoint for the Delivery API unfortunately means Umbraco no longer can boot without the Delivery API 😢 

This PR fixes it, by adding a `NoopCurrentMemberClaimsProvider` and moving the `ICurrentMemberClaimsProvider` interface to core. This follows the pattern of all the other Delivery API services required for boot.

### Breaking change?

This _looks_ very breaking, but as it happens, the feature is not yet released (slated for 13.6), so we can break it 👍 