### PR TITLE
Sets `max-height` for Workspace Variant Selector scroll container

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-split-view/workspace-split-view-variant-selector.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-split-view/workspace-split-view-variant-selector.element.ts
@@ -368,6 +368,10 @@ export class UmbWorkspaceSplitViewVariantSelectorElement<
 				white-space: nowrap;
 			}
 
+			uui-scroll-container {
+				max-height: 50dvh;
+			}
+
 			ul {
 				list-style-type: none;
 				padding: 0;


### PR DESCRIPTION
### Description

Fixes #17680.

Adds a `max-height` to the Workspace's Variant Selector scroll container. This has been set to 50% of the browser's current viewport (`50dvh`), so that it can account for dynamic resizing.

To test this, you either need several language/cultures enabled or use the mock API to add them, then open the variant selector and resize the browser window/viewport, notice the scrollbar.


