### PR TITLE
Fixes rendering of the font icons used for buttons in the code editor.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/css/umb-css.css
+++ b/src/Umbraco.Web.UI.Client/src/css/umb-css.css
@@ -3,3 +3,9 @@
 	--umb-header-layout-height: 70px;
 	--umb-section-sidebar-width: 300px;
 }
+
+@font-face{
+	font-display:block;
+	font-family:codicon;
+	src:url('/umbraco/backoffice/assets/fonts/codicon/codicon.ttf') format("truetype")
+}

--- a/src/Umbraco.Web.UI.Client/src/rollup.config.js
+++ b/src/Umbraco.Web.UI.Client/src/rollup.config.js
@@ -54,6 +54,7 @@ console.log('--- Copying TinyMCE i18n done ---');
 console.log('--- Copying monaco-editor ---');
 cpSync('./node_modules/monaco-editor/esm/vs/editor/editor.worker.js', `${DIST_DIRECTORY}/monaco-editor/vs/editor/editor.worker.js`);
 cpSync('./node_modules/monaco-editor/esm/vs/language', `${DIST_DIRECTORY}/monaco-editor/vs/language`, { recursive: true });
+cpSync('./node_modules/monaco-editor/min/vs/base/browser/ui/codicons', `${DIST_DIRECTORY}/assets/fonts`, { recursive: true });
 console.log('--- Copying monaco-editor done ---');
 
 const readFolders = (path) => readdirSync(path).filter((folder) => lstatSync(`${path}/${folder}`).isDirectory());


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/17958

### Description

If you edit a template in the backoffice it uses the code editor component.  Clicking Ctrl + F opens the "Find" window and you can see the buttons on this control don't render correctly.

This PR resolves that by ensuring the font file is copied to the "dist" output and the page rendered for the Umbraco backoffice has the appropriate CSS for the font to be used.  This didn't work when I added the CSS rule to the `<umb-code-editor>` element, and [from what I read](https://github.com/lit/lit-element/issues/793#issuecomment-535536364), needs to be on the first page that the browser loads.

**To Test:**

- Load up the code editor by editing a template or script file, click Ctrl + F and check the buttons render correctly.

![image](https://github.com/user-attachments/assets/2aa912d2-9b96-4afa-a4fc-a97591e1d1fb)
