### PR TITLE
Localize the recycle bin tree root

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/recycle-bin/tree/media-recycle-bin-tree.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/recycle-bin/tree/media-recycle-bin-tree.repository.ts
@@ -21,7 +21,7 @@ export class UmbMediaRecycleBinTreeRepository
 		const data = {
 			unique: null,
 			entityType: UMB_MEDIA_RECYCLE_BIN_ROOT_ENTITY_TYPE,
-			name: 'Recycle Bin',
+			name: '#treeHeaders_contentRecycleBin',
 			icon: 'icon-trash',
 			hasChildren,
 			isContainer: false,


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/18058

### Description

The document tree root for the recycle bin was localized, but not the media one.  With this PR merged, it is.

**To Test:**

- Login to the backoffice and set your user's language to something other than English (that we have translations for - e.g. Danish).
- View the document (content) and media trees, and note that both recycle bin nodes are now translated into the selected language.