### PR TITLE
Fixed button label on media crop screen.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper.element.ts
@@ -335,7 +335,7 @@ export class UmbImageCropperElement extends UmbLitElement {
 				step="0.001">
 			</uui-slider>
 			<div id="actions">
-				<uui-button @click=${this.#onReset} label="${this.localize.term('general_reset')}"></uui-button>
+				<uui-button @click=${this.#onReset} label="${this.localize.term('imagecropper_reset')}"></uui-button>
 				<uui-button
 					look="secondary"
 					@click=${this.#onCancel}


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/16821

### Description

On review, I don't think the reported issue is actually one.  Seems it's just that the "Save" button has been missed, and needs to be clicked when you amend a crop so the value is saved before you click away.  When you click save, it works as expected.

I only found one small issue in that the "Reset" button wasn't localized, so I've done that in this PR.

**To Test:**

- Main thing is just to validate my view that this isn't really an issue, as there is a Save button and you need to click it.  It may be different to 13, but works fine.
- Then just see that you get a "Reset crop" label on the button.