### PR TITLE
Replace paths, so they are equal on every OS

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeGraphicsController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeGraphicsController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
@@ -55,8 +56,8 @@ public class BackOfficeGraphicsController : Controller
 
     private IActionResult HandleFileRequest(string virtualPath)
     {
-        var filePath = Path.Combine(Constants.SystemDirectories.Umbraco, virtualPath).TrimStart(Constants.CharArrays.Tilde);
-        var fileInfo = _webHostEnvironment.WebRootFileProvider.GetFileInfo(filePath);
+        var filePath = Path.Combine(Constants.SystemDirectories.Umbraco, virtualPath).TrimStart(Constants.CharArrays.Tilde).Replace(Path.DirectorySeparatorChar, '/');
+        IFileInfo fileInfo = _webHostEnvironment.WebRootFileProvider.GetFileInfo(filePath);
 
         if (fileInfo.PhysicalPath is null)
         {

--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeGraphicsController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeGraphicsController.cs
@@ -56,7 +56,7 @@ public class BackOfficeGraphicsController : Controller
 
     private IActionResult HandleFileRequest(string virtualPath)
     {
-        var filePath = Path.Combine(Constants.SystemDirectories.Umbraco, virtualPath).TrimStart(Constants.CharArrays.Tilde).Replace(Path.DirectorySeparatorChar, '/');
+        var filePath = $"{Constants.SystemDirectories.Umbraco}/{virtualPath}".TrimStart(Constants.CharArrays.Tilde);
         IFileInfo fileInfo = _webHostEnvironment.WebRootFileProvider.GetFileInfo(filePath);
 
         if (fileInfo.PhysicalPath is null)


### PR DESCRIPTION
# Notes
- Fixes an issue, where you could not get the logos on windows.
This was because of the newly introduced https://github.com/umbraco/Umbraco-CMS/pull/17696. Which uses `Path.Combine`, which in turn on windows, combines paths with `\`, but all our static paths are `/`.
  - Note: The jumbled path works with Physical Files, but as when we ship this, its in an RCL, it does not work with that.
- This PR remedies that by just not using Path.Combine, and instead just having the `/` in there always

# How to test
- Run the backoffice, you should still see the Logos
- You can also pack the project, and run the template to make sure its still there.