### PR TITLE
Avoid an exception on sign out when the principal is populated from an incomplete external login

### DIFF
--- a/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
@@ -282,8 +282,8 @@ public class BackOfficeUserStore : UmbracoUserStore<BackOfficeIdentityUser, Iden
         ThrowIfDisposed();
 
         // In the external login flow - see BackOfficeController.ExternalSignInAsync - we can have a situation where an
-        // error has occured but the user is signed in. For that reason, at the end of the process, when the errors are
-        // found the user is signed out.
+        // error has occured but the user is signed in. For that reason, at the end of the process, if errors are
+        // recorded, the user is signed out.
         // Before signing out, we request the user in order to update the security stamp - see UmbracoSignInManager.SignOutAsync.
         // But we can have a situation where the signed in principal has the ID from the external provider, which may not be something
         // we can parse to an integer.

--- a/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
@@ -281,7 +281,20 @@ public class BackOfficeUserStore : UmbracoUserStore<BackOfficeIdentityUser, Iden
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfDisposed();
 
-        IUser? user = _userService.GetUserById(UserIdToInt(userId));
+        // In the external login flow - see BackOfficeController.ExternalSignInAsync - we can have a situation where an
+        // error has occured but the user is signed in. For that reason, at the end of the process, when the errors are
+        // found the user is signed out.
+        // Before signing out, we request the user in order to update the security stamp - see UmbracoSignInManager.SignOutAsync.
+        // But we can have a situation where the signed in principal has the ID from the external provider, which may not be something
+        // we can parse to an integer.
+        // If that's the case, return null rather than throwing an exception. Without an Umbraco user, we can't update the security stamp,
+        // so no need to fail here.
+        if (!TryUserIdToInt(userId, out var userIdAsInt))
+        {
+            return Task.FromResult((BackOfficeIdentityUser?)null)!;
+        }
+
+        IUser? user = _userService.GetUserById(userIdAsInt);
         if (user == null)
         {
             return Task.FromResult((BackOfficeIdentityUser?)null)!;

--- a/src/Umbraco.Infrastructure/Security/UmbracoUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/UmbracoUserStore.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Identity;

--- a/src/Umbraco.Infrastructure/Security/UmbracoUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/UmbracoUserStore.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Identity;
@@ -33,18 +34,29 @@ public abstract class UmbracoUserStore<TUser, TRole>
 
     protected static int UserIdToInt(string? userId)
     {
-        if (int.TryParse(userId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result))
+        if (TryUserIdToInt(userId, out int result))
         {
             return result;
+        }
+
+        throw new InvalidOperationException($"Unable to convert user ID ({userId})to int using InvariantCulture");
+    }
+
+    protected static bool TryUserIdToInt(string? userId, out int result)
+    {
+        if (int.TryParse(userId, NumberStyles.Integer, CultureInfo.InvariantCulture, out result))
+        {
+            return true;
         }
 
         if (Guid.TryParse(userId, out Guid key))
         {
             // Reverse the IntExtensions.ToGuid
-            return BitConverter.ToInt32(key.ToByteArray(), 0);
+            result = BitConverter.ToInt32(key.ToByteArray(), 0);
+            return true;
         }
 
-        throw new InvalidOperationException($"Unable to convert user ID ({userId})to int using InvariantCulture");
+        return false;
     }
 
     protected static string UserIdToString(int userId) => string.Intern(userId.ToString(CultureInfo.InvariantCulture));


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Potentially fixes: https://github.com/umbraco/Umbraco-CMS/issues/18002

### Description

This one has proved tricky as I've not been able to reproduce - but I've seen two people who can, so it's a real issue.  I can sort of see what's happening, and believe this will fix it, but it's difficult to fully get to the bottom of it without being able to reproduce the issue and verify the fix.

So I've mostly diagnosed by following the stack trace on the issue:

```
Umbraco.Cms.Core.Security.UmbracoUserStore<TUser, TRole>.UserIdToInt(string userId)
Umbraco.Cms.Core.Security.BackOfficeUserStore.FindUserAsync(string userId, CancellationToken cancellationToken)
Umbraco.Cms.Core.Security.UmbracoUserStore<TUser, TRole>.FindByIdAsync(string userId, CancellationToken cancellationToken)
Microsoft.AspNetCore.Identity.UserManager<TUser>.GetUserAsync(ClaimsPrincipal principal)
Umbraco.Cms.Web.Common.Security.UmbracoSignInManager<TUser>.SignOutAsync()
Umbraco.Cms.Web.BackOffice.Controllers.BackOfficeController.ExternalSignInAsync(ExternalLoginInfo loginInfo, Func<IActionResult> response)
Umbraco.Cms.Web.BackOffice.Controllers.BackOfficeController.RenderDefaultOrProcessExternalLoginAsync(AuthenticateResult authenticateResult, Func<IActionResult> defaultResponse)
Umbraco.Cms.Web.BackOffice.Controllers.BackOfficeController.Default()
```

In `ExternalSignInAsync`, at the end of the method, if there has been an error, we call `SignOutAsync`.  This attempts to retrieve the current Umbraco user, in order to update the security stamp.  It seems that in some cases - at least in the once who have been able to reproduce - the _current principal at this point has an ID that's not the integer Umbraco ID, but the provider key from the external login provider_.

In the Google case, it's a long integer, so the previous `UserIdToInt` method would throw an exception.  I've added a new `TryUserIdToInt` instead, and where that fails returned a null user (the same as if we had a valid integer but no matching user in the database).  That way the sign out method will just not update the security stamp - it can't anyway if it hasn't found an Umbraco user) - rather it will continue with the other sign out steps and return to the caller for the usual error handling of external logins.

Presumably the real issue here is something else, which is why we have this "partially logged in" state.  With this update, we would now see the errors as we wouldn't get this exception thrown on the sign out, so hopefully it'll reveal what's going on.  Which may be something to do with the reproducer's environment, or maybe something else to resolve in Umbraco.

**To Test:**

- Set up Google external login and auto linking for the backoffice [as per the documentation](https://docs.umbraco.com/umbraco-cms/13.latest/tutorials/add-google-authentication).
- Verify you can login with a Google account.
- Ideally put a breakpoint in the new `TryUserIdToInt` method and see what `userId` has arrived here.  For me, it's always the Umbraco integer ID, but perhaps you'll see the long integer Google provider key, in which case you may be able to see what's actually going on to get in this situation.

