### PR TITLE
Provides an option to remove the inessential version number from the generated models

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/ModelsBuilderSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ModelsBuilderSettings.cs
@@ -86,8 +86,8 @@ public class ModelsBuilderSettings
     /// <remarks>
     ///     By default this is written to the <see cref="System.CodeDom.Compiler.GeneratedCodeAttribute"/> output in
     ///     generated code for each property of the model. This can be useful for debugging purposes but isn't essential,
-    ///     and it has the downside of causing the generated code to change every time the version number changes, leading
-    ///     to unnecessary changes that need to be checked into source control. Default is <c>true</c>.
+    ///     and it has the causes the generated code to change every time Umbraco is upgraded. In turn, this leads
+    ///     to unnecessary code file changes that need to be checked into source control. Default is <c>true</c>.
     /// </remarks>
     [DefaultValue(StaticIncludeVersionNumberInGeneratedModels)]
     public bool IncludeVersionNumberInGeneratedModels { get; set; } = StaticIncludeVersionNumberInGeneratedModels;

--- a/src/Umbraco.Core/Configuration/Models/ModelsBuilderSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ModelsBuilderSettings.cs
@@ -16,6 +16,7 @@ public class ModelsBuilderSettings
     internal const string StaticModelsDirectory = "~/umbraco/models";
     internal const bool StaticAcceptUnsafeModelsDirectory = false;
     internal const int StaticDebugLevel = 0;
+    internal const bool StaticIncludeVersionNumberInGeneratedModels = true;
     private bool _flagOutOfDateModels = true;
 
     /// <summary>
@@ -78,4 +79,16 @@ public class ModelsBuilderSettings
     /// <remarks>0 means minimal (safe on live site), anything else means more and more details (maybe not safe).</remarks>
     [DefaultValue(StaticDebugLevel)]
     public int DebugLevel { get; set; } = StaticDebugLevel;
+
+    /// <summary>
+    ///     Gets or sets a value indicating whether the version number should be included in generated models.
+    /// </summary>
+    /// <remarks>
+    ///     By default this is written to the <see cref="System.CodeDom.Compiler.GeneratedCodeAttribute"/> output in
+    ///     generated code for each property of the model. This can be useful for debugging purposes but isn't essential,
+    ///     and it has the downside of causing the generated code to change every time the version number changes, leading
+    ///     to unnecessary changes that need to be checked into source control. Default is <c>true</c>.
+    /// </remarks>
+    [DefaultValue(StaticIncludeVersionNumberInGeneratedModels)]
+    public bool IncludeVersionNumberInGeneratedModels { get; set; } = StaticIncludeVersionNumberInGeneratedModels;
 }

--- a/src/Umbraco.Infrastructure/ModelsBuilder/Building/TextBuilder.cs
+++ b/src/Umbraco.Infrastructure/ModelsBuilder/Building/TextBuilder.cs
@@ -143,14 +143,17 @@ public class TextBuilder : Builder
     //
     // note that the blog post above clearly states that "Nor should it be applied at the type level if the type being generated is a partial class."
     // and since our models are partial classes, we have to apply the attribute against the individual members, not the class itself.
-    private static void WriteGeneratedCodeAttribute(StringBuilder sb, string tabs) => sb.AppendFormat(
+    private void WriteGeneratedCodeAttribute(StringBuilder sb, string tabs) => sb.AppendFormat(
         "{0}[global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"Umbraco.ModelsBuilder.Embedded\", \"{1}\")]\n",
-        tabs, ApiVersion.Current.Version);
+        tabs,
+        Config.IncludeVersionNumberInGeneratedModels ? ApiVersion.Current.Version : null);
 
     // writes an attribute that specifies that an output may be null.
     // (useful for consuming projects with nullable reference types enabled)
     private static void WriteMaybeNullAttribute(StringBuilder sb, string tabs, bool isReturn = false) =>
-        sb.AppendFormat("{0}[{1}global::System.Diagnostics.CodeAnalysis.MaybeNull]\n", tabs,
+        sb.AppendFormat(
+            "{0}[{1}global::System.Diagnostics.CodeAnalysis.MaybeNull]\n",
+            tabs,
             isReturn ? "return: " : string.Empty);
 
     private static string MixinStaticGetterName(string clrName) => string.Format("Get{0}", clrName);


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/15597

### Description

The linked issue started with a point raised on why we include the commit hash in the version number.  This does no harm to keep.  But the discussion continued to ask if it's necessary to output the version number at all and established that it's not essential, but could be useful for debugging.

The downside - and we found this when working on umbraco.com - is every Umbraco upgrade leads to a lot of changes to these files, which are seemingly unnecessary and can clutter pull requests.

To avoid a behavioural breaking change, even if a harmless one, I've added configuration option to allow you to switch off the inclusion of the version number.

We could consider making this option default to `false` in a future version, but it's probably OK as is and can be turned on for people that want to avoid the version writing behaviour.

**To Test:**

- Configure models builder with source code manual:

```
"ModelsBuilder": {
  "ModelsMode": "SourceCodeManual",
}
```

- Create or edit a document type and verify changes are written to the output folder (by default at `\umbraco\models\`), and that they include the version number in the `[GeneratedCode]` attribute.
- Modify the configuration:

```
"ModelsBuilder": {
  "ModelsMode": "SourceCodeManual",
  "IncludeVersionNumberInGeneratedModels": false
}
```

- Create or edit a document type and verify changes are written to the output folder (by default at `\umbraco\models\`), and that they don't include the version number.