### PR TITLE
Fix parsing exception for RTEs

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
@@ -92,7 +92,6 @@ public class RichTextPropertyEditor : DataEditor
         private readonly HtmlLocalLinkParser _localLinkParser;
         private readonly RichTextEditorPastedImages _pastedImages;
         private readonly IJsonSerializer _jsonSerializer;
-        private readonly IBlockEditorElementTypeCache _elementTypeCache;
         private readonly IRichTextRequiredValidator _richTextRequiredValidator;
         private readonly ILogger<RichTextPropertyValueEditor> _logger;
 
@@ -122,12 +121,12 @@ public class RichTextPropertyEditor : DataEditor
             _localLinkParser = localLinkParser;
             _pastedImages = pastedImages;
             _htmlSanitizer = htmlSanitizer;
-            _elementTypeCache = elementTypeCache;
             _richTextRequiredValidator = richTextRequiredValidator;
             _jsonSerializer = jsonSerializer;
             _logger = logger;
 
-            Validators.Add(new RichTextEditorBlockValidator(propertyValidationService, CreateBlockEditorValues(), elementTypeCache, jsonSerializer, logger));
+            BlockEditorValues = new(new RichTextEditorBlockDataConverter(_jsonSerializer), elementTypeCache, logger);
+            Validators.Add(new RichTextEditorBlockValidator(propertyValidationService, BlockEditorValues, elementTypeCache, jsonSerializer, logger));
         }
 
         public override IValueRequiredValidator RequiredValidator => _richTextRequiredValidator;
@@ -340,12 +339,6 @@ public class RichTextPropertyEditor : DataEditor
         }
 
         private BlockEditorData<RichTextBlockValue, RichTextBlockLayoutItem>? ConvertAndClean(RichTextBlockValue blockValue)
-        {
-            BlockEditorValues<RichTextBlockValue, RichTextBlockLayoutItem> blockEditorValues = CreateBlockEditorValues();
-            return blockEditorValues.ConvertAndClean(blockValue);
-        }
-
-        private BlockEditorValues<RichTextBlockValue, RichTextBlockLayoutItem> CreateBlockEditorValues()
-            => new(new RichTextEditorBlockDataConverter(_jsonSerializer), _elementTypeCache, _logger);
+            => BlockEditorValues.ConvertAndClean(blockValue);
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Affected version: V15.2 RC2

An exception is thrown when attempting to save a variant document with an an invariant RTE property:

[18085.webm](https://github.com/user-attachments/assets/5b579193-7e84-4d74-8f95-dd3e0da242aa)

### Testing this PR

The screencast above was recorded using [this SQLite DB](https://github.com/user-attachments/files/18518512/Umbraco.sqlite.18085.db.zip), so it can be used to verify the fix as well 😄 

Admin login is:

- Username: admin@localhost
- Password: SuperSecret123