### PR TITLE
Bugfix: Remove sidebar bottom space

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/section/section-sidebar/section-sidebar.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/section/section-sidebar/section-sidebar.element.ts
@@ -37,7 +37,6 @@ export class UmbSectionSidebarElement extends UmbLitElement {
 				flex-direction: column;
 				z-index: 10;
 				position: relative;
-				padding-bottom: var(--uui-size-4);
 				box-sizing: border-box;
 			}
 


### PR DESCRIPTION
Currently we have this annoying white space in the bottom of the sidebar.. this pr removes it.

![image](https://github.com/user-attachments/assets/f0c70dbb-d858-4e12-bff6-4081142068fa)
