### PR TITLE
Fixed userResource request to get all users.

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
@@ -322,7 +322,7 @@ public class UsersController : BackOfficeNotificationsController
     /// <returns></returns>
     [OutgoingEditorModelEvent]
     [Authorize(Policy = AuthorizationPolicies.AdminUserEditsRequireAdmin)]
-    public ActionResult<IEnumerable<UserDisplay?>> GetByIds([FromJsonPath] int[] ids)
+    public ActionResult<IEnumerable<UserDisplay?>> GetByIds([FromQuery] int[] ids)
     {
         if (ids == null)
         {

--- a/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilder.BackOfficeAuth.cs
+++ b/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilder.BackOfficeAuth.cs
@@ -202,6 +202,7 @@ public static partial class UmbracoBuilderExtensions
         {
             policy.AuthenticationSchemes.Add(backOfficeAuthenticationScheme);
             policy.Requirements.Add(new AdminUsersRequirement());
+            policy.Requirements.Add(new AdminUsersRequirement("ids"));
             policy.Requirements.Add(new AdminUsersRequirement("userIds"));
         });
 

--- a/src/Umbraco.Web.UI.Client/src/common/resources/users.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/users.resource.js
@@ -318,12 +318,14 @@
           */
         function getUsers(userIds) {
 
+            var idQuery = "";
+            userIds.forEach(id => idQuery += `ids=${id}&`);
             return umbRequestHelper.resourcePromise(
                 $http.get(
                     umbRequestHelper.getApiUrl(
                         "userApiBaseUrl",
                         "GetByIds",
-                        { ids: userIds })),
+                        idQuery)),
                 "Failed to retrieve data for users " + userIds);
         }
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/12471

### Description

This PR fixes the request `usersResource.getUsers` that you can issue from the backoffice in angularjs.  It's not actually used in the backoffice code, but could be used in packages or custom backoffice extensions.

There were two issues:

- The model binding of the request wasn't correct.  I've aligned it with similar `GetByIds` requests in other controllers so it works now.
- The authentication wasn't correctly checking the querystring value for ensuring that only admin users can retrieve admin user details.

**To Test:**

- Throw the following code in somewhere where you have or have added an injected `userResource`:

```
      usersResource.getUsers([-1]).then(function (data) {
        console.log(data);
      })
```

- Check that it works correctly for an admin user but doesn't for a non-admin  one.