### PR TITLE
V15/bugfix/Reset image crop button fix

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper.element.ts
@@ -335,7 +335,7 @@ export class UmbImageCropperElement extends UmbLitElement {
 				step="0.001">
 			</uui-slider>
 			<div id="actions">
-				<uui-button @click=${this.#onReset} label="${this.localize.term('general_reset')}"></uui-button>
+				<uui-button @click=${this.#onReset} label="${this.localize.term('imagecropper_reset')}"></uui-button>
 				<uui-button
 					look="secondary"
 					@click=${this.#onCancel}


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description

When doing some testing of the image cropper I noticed that the button for resetting the crop was broken:
![image](https://github.com/user-attachments/assets/5aa128ed-e92b-42d2-b6b8-7329e63fac61)

This PR aims to fix it by using the correct localization key.
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
