### PR TITLE
Fix: stop using redirects in collections

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/collection/collection-view.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/collection/collection-view.manager.ts
@@ -80,7 +80,7 @@ export class UmbCollectionViewManager extends UmbControllerBase {
 		if (views && views.length > 0) {
 			// find the default view from the config. If it doesn't exist, use the first view
 			const defaultView = views.find((view) => view.alias === this.#defaultViewAlias);
-			const fallbackView = defaultView?.meta.pathName || views[0].meta.pathName;
+			const fallbackView = defaultView ?? views[0];
 
 			routes = views.map((view) => {
 				return {
@@ -95,7 +95,10 @@ export class UmbCollectionViewManager extends UmbControllerBase {
 			if (routes.length > 0) {
 				routes.push({
 					path: '',
-					redirectTo: fallbackView,
+					component: () => createExtensionElement(fallbackView),
+					setup: () => {
+						this.setCurrentView(fallbackView);
+					},
 				});
 			}
 


### PR DESCRIPTION
This is not a certain fix, but we generally seen redirects as bad. 
Its because we sometimes have a case where the browser loads the Media section before Content, and a redirect of the Media Section changes the URl so they user now stays on Media, despite the user did not want to navigate to the media section.

It only happens occasionally so this is more of a try, by doing the thing we have done elsewhere to fix this issue — which is stop using redirects. :-D