### PR TITLE
Bugfix: Align collection item entity actions with menu item entity actions

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/entity-action/global-components/entity-actions-table-column-view/entity-actions-table-column-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/entity-action/global-components/entity-actions-table-column-view/entity-actions-table-column-view.element.ts
@@ -11,25 +11,12 @@ export class UmbEntityActionsTableColumnViewElement extends UmbLitElement {
 	@state()
 	_isOpen = false;
 
-	#onActionExecuted() {
-		this._isOpen = false;
-	}
-
-	#onClick(event: Event) {
-		event.stopPropagation();
-	}
-
 	override render() {
 		if (!this.value) return nothing;
 
 		return html`
-			<umb-dropdown .open=${this._isOpen} @click=${this.#onClick} compact hide-expand>
-				<uui-symbol-more slot="label"></uui-symbol-more>
-				<umb-entity-action-list
-					@action-executed=${this.#onActionExecuted}
-					entity-type=${this.value.entityType}
-					.unique=${this.value.unique}></umb-entity-action-list>
-			</umb-dropdown>
+			<umb-entity-actions-bundle .entityType=${this.value.entityType} .unique=${this.value.unique}>
+			</umb-entity-actions-bundle>
 		`;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/tree/tree-item-children/collection/views/data-type-tree-item-table-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/tree/tree-item-children/collection/views/data-type-tree-item-table-collection-view.element.ts
@@ -26,6 +26,7 @@ export class UmbDataTypeTreeItemTableCollectionViewElement extends UmbLitElement
 		{
 			name: '',
 			alias: 'entityActions',
+			align: 'right',
 		},
 	];
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/tree/tree-item-children/collection/views/document-type-tree-item-table-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/tree/tree-item-children/collection/views/document-type-tree-item-table-collection-view.element.ts
@@ -31,6 +31,7 @@ export class UmbDocumentTypeTreeItemTableCollectionViewElement extends UmbLitEle
 		{
 			name: '',
 			alias: 'entityActions',
+			align: 'right',
 		},
 	];
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/collection/views/table/document-table-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/collection/views/table/document-table-collection-view.element.ts
@@ -125,7 +125,11 @@ export class UmbDocumentTableCollectionViewElement extends UmbLitElement {
 				};
 			});
 
-			this._tableColumns = [...this.#systemColumns, ...userColumns, { name: '', alias: 'entityActions' }];
+			this._tableColumns = [
+				...this.#systemColumns,
+				...userColumns,
+				{ name: '', alias: 'entityActions', align: 'right' },
+			];
 		}
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/extension-insights/collection/views/table/extension-table-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/extension-insights/collection/views/table/extension-table-collection-view.element.ts
@@ -34,6 +34,7 @@ export class UmbExtensionTableCollectionViewElement extends UmbLitElement {
 		{
 			name: '',
 			alias: 'entityActions',
+			align: 'right',
 		},
 	];
 

--- a/src/Umbraco.Web.UI.Client/src/packages/language/collection/views/table/language-table-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/language/collection/views/table/language-table-collection-view.element.ts
@@ -41,6 +41,7 @@ export class UmbLanguageTableCollectionViewElement extends UmbLitElement {
 		{
 			name: '',
 			alias: 'entityActions',
+			align: 'right',
 		},
 	];
 

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/tree/tree-item-children/collection/views/media-type-tree-item-table-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/tree/tree-item-children/collection/views/media-type-tree-item-table-collection-view.element.ts
@@ -26,6 +26,7 @@ export class UmbMediaTypeTreeItemTableCollectionViewElement extends UmbLitElemen
 		{
 			name: '',
 			alias: 'entityActions',
+			align: 'right',
 		},
 	];
 

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/views/table/media-table-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/views/table/media-table-collection-view.element.ts
@@ -112,9 +112,13 @@ export class UmbMediaTableCollectionViewElement extends UmbLitElement {
 				};
 			});
 
-			this._tableColumns = [...this.#systemColumns, ...userColumns, { name: '', alias: 'entityActions' }];
+			this._tableColumns = [
+				...this.#systemColumns,
+				...userColumns,
+				{ name: '', alias: 'entityActions', align: 'right' },
+			];
 		} else {
-			this._tableColumns = [...this.#systemColumns, { name: '', alias: 'entityActions' }];
+			this._tableColumns = [...this.#systemColumns, { name: '', alias: 'entityActions', align: 'right' }];
 		}
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-group/collection/views/table/member-group-table-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-group/collection/views/table/member-group-table-collection-view.element.ts
@@ -22,6 +22,7 @@ export class UmbMemberGroupTableCollectionViewElement extends UmbLitElement {
 		{
 			name: '',
 			alias: 'entityActions',
+			align: 'right',
 		},
 	];
 

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/collection/views/table/member-table-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/collection/views/table/member-table-collection-view.element.ts
@@ -40,6 +40,7 @@ export class UmbMemberTableCollectionViewElement extends UmbLitElement {
 		{
 			name: '',
 			alias: 'entityActions',
+			align: 'right',
 		},
 	];
 

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user-group/collection/views/user-group-table-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user-group/collection/views/user-group-table-collection-view.element.ts
@@ -50,6 +50,7 @@ export class UmbUserGroupCollectionTableViewElement extends UmbLitElement {
 		{
 			name: '',
 			alias: 'entityActions',
+			align: 'right',
 		},
 	];
 

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/collection/views/table/user-table-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/collection/views/table/user-table-collection-view.element.ts
@@ -51,6 +51,7 @@ export class UmbUserTableCollectionViewElement extends UmbLitElement {
 		{
 			name: '',
 			alias: 'entityActions',
+			align: 'right',
 		},
 	];
 

--- a/src/Umbraco.Web.UI.Client/src/packages/webhook/collection/views/table/webhook-table-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/webhook/collection/views/table/webhook-table-collection-view.element.ts
@@ -42,6 +42,7 @@ export class UmbWebhookTableCollectionViewElement extends UmbLitElement {
 		{
 			name: '',
 			alias: 'entityActions',
+			align: 'right',
 		},
 	];
 


### PR DESCRIPTION
This PR aligns the UX of entity actions on a collection item with a menu item.

Until now we have always rendered a dropdown with the entity actions. It doesn't make a lot of sense if there is only 1 action available. This PR changes to code to reuse the same element as in a menu item so it will "highlight" the first action but also skip the dropdown if there is only 1 entity action available.

**Single Action Before**
<img width="1215" alt="Screenshot 2025-01-25 at 12 43 13" src="https://github.com/user-attachments/assets/35664890-4cc6-4294-88e3-113bca102402" />

**Single Action After**
<img width="1210" alt="Screenshot 2025-01-25 at 12 43 30" src="https://github.com/user-attachments/assets/c845c049-5793-41cb-b250-c09c6d7a45ef" />

**Multiple Actions Before**
<img width="1212" alt="Screenshot 2025-01-25 at 12 47 10" src="https://github.com/user-attachments/assets/8a0b9788-f0d7-4d4f-905e-8c24c57bf963" />


**Multiple Actions After**
<img width="1213" alt="Screenshot 2025-01-25 at 12 46 56" src="https://github.com/user-attachments/assets/624f60eb-9689-45c4-8adf-651224b4a216" />
