### PR TITLE
Avoid wasting a whole thread watching for a filesystem change 😬

### DIFF
--- a/src/Umbraco.Infrastructure/Runtime/FileSystemMainDomLock.cs
+++ b/src/Umbraco.Infrastructure/Runtime/FileSystemMainDomLock.cs
@@ -108,7 +108,7 @@ internal class FileSystemMainDomLock : IMainDomLock
     public void DeleteLockReleaseSignalFile() =>
         File.Delete(_releaseSignalFilePath);
 
-    private void ListeningLoop()
+    private async Task ListeningLoop()
     {
         while (true)
         {
@@ -132,7 +132,7 @@ internal class FileSystemMainDomLock : IMainDomLock
                 break;
             }
 
-            Thread.Sleep(_globalSettings.CurrentValue.MainDomReleaseSignalPollingInterval);
+            await Task.Delay(_globalSettings.CurrentValue.MainDomReleaseSignalPollingInterval);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description

I was profiling an Umbraco v15 solution last week and noticed that about 1% of the CPU time was spent... sleeping 😱

![image](https://github.com/user-attachments/assets/d96fc8d5-1948-4c74-bba6-08a63fd3db9c)

Turns out a whole thread was spending most of their time sleeping on the job! Woken up every 2 seconds to do a miniscule amount of work, then sent back to sleep. 

That thread's clearly not pulling their weight - so I figured I'd send them to the pool to hang out with their friends and maybe do something else useful in the meantime. Serve some webpages, run a scheduled task or two, anything except sleeping!

### Testing
Profile the site (I used DotTrace) before and after the change and notice how much CPU time is spent sleeping...

#### Before
Idling on my test site - 2.6% 😴

![image](https://github.com/user-attachments/assets/f1eed68a-b1d6-4028-b270-4de22e76807f)


#### After
Absolutely none 😃

![image](https://github.com/user-attachments/assets/b727f8a4-fe41-4a72-a727-4733b265b64e)


![3298fr](https://github.com/user-attachments/assets/757146dc-2165-4cbd-a31f-43dd08a1b48f)

---

As an aside, the approach in this method isn't ideal. There are more efficient and robust ways to handle this than a while loop, e.g. `System.Threading.Timer` or a `FileSystemWatcher` but I didn't want to embark on a refactoring without some HQ guidance and `Task.Delay` at least solves the immediate performance problem.

