### PR TITLE
Pass user Id to audit when saving and deleting members

### DIFF
--- a/src/Umbraco.Core/Services/MemberService.cs
+++ b/src/Umbraco.Core/Services/MemberService.cs
@@ -791,7 +791,7 @@ namespace Umbraco.Cms.Core.Services
 
             scope.Notifications.Publish(new MemberSavedNotification(member, evtMsgs).WithStateFrom(savingNotification));
 
-            Audit(AuditType.Save, 0, member.Id);
+            Audit(AuditType.Save, userId, member.Id);
 
             scope.Complete();
             return OperationResult.Attempt.Succeed(evtMsgs);
@@ -858,7 +858,7 @@ namespace Umbraco.Cms.Core.Services
             scope.WriteLock(Constants.Locks.MemberTree);
             DeleteLocked(scope, member, evtMsgs, deletingNotification.State);
 
-            Audit(AuditType.Delete, 0, member.Id);
+            Audit(AuditType.Delete, userId, member.Id);
             scope.Complete();
 
             return OperationResult.Attempt.Succeed(evtMsgs);


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes https://github.com/umbraco/Umbraco-CMS/issues/18116

### Description
As noted in the linked issue, we have details of the user performing the action in the service methods for saving and deleting members, but we aren't passing those to the audit recording.

With this PR merged, the audit log will record the performing user for these actions.

To Test:

- Save and/or delete a member
- Query the audit records and note that the record written is associated with the user you are logged in as:

```
select top 5 * from umbracoAudit order by id desc
```