### PR TITLE
Feature: Code Editor modal, adds pretty-print support

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/code-editor/code-editor-modal/code-editor-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/code-editor/code-editor-modal/code-editor-modal.element.ts
@@ -1,6 +1,6 @@
 import type { UmbCodeEditorElement } from '../components/code-editor.element.js';
 import type { UmbCodeEditorModalData, UmbCodeEditorModalValue } from './code-editor-modal.token.js';
-import { css, html, ifDefined, customElement, query } from '@umbraco-cms/backoffice/external/lit';
+import { css, customElement, html, ifDefined, query } from '@umbraco-cms/backoffice/external/lit';
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 
 @customElement('umb-code-editor-modal')
@@ -29,18 +29,16 @@ export class UmbCodeEditorModalElement extends UmbModalBaseElement<UmbCodeEditor
 		return html`
 			<umb-body-layout .headline=${this.data?.headline ?? 'Code Editor'}>
 				<div id="editor-box">${this.#renderCodeEditor()}</div>
-				<div slot="actions">
 				<uui-button
-						id="cancel"
+					slot="actions"
 					label=${this.localize.term('general_cancel')}
 					@click=${this.#handleCancel}></uui-button>
 				<uui-button
-						id="confirm"
-						color="${this.data?.color || 'positive'}"
+					slot="actions"
+					color=${this.data?.color || 'positive'}
 					look="primary"
-						label="${this.data?.confirmLabel || this.localize.term('general_submit')}"
+					label=${this.data?.confirmLabel || this.localize.term('general_submit')}
 					@click=${this.#handleConfirm}></uui-button>
-				</div>
 			</umb-body-layout>
 		`;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/code-editor/code-editor-modal/code-editor-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/code-editor/code-editor-modal/code-editor-modal.element.ts
@@ -3,9 +3,7 @@ import type { UmbCodeEditorModalData, UmbCodeEditorModalValue } from './code-edi
 import { css, html, ifDefined, customElement, query } from '@umbraco-cms/backoffice/external/lit';
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 
-const elementName = 'umb-code-editor-modal';
-
-@customElement(elementName)
+@customElement('umb-code-editor-modal')
 export class UmbCodeEditorModalElement extends UmbModalBaseElement<UmbCodeEditorModalData, UmbCodeEditorModalValue> {
 	@query('umb-code-editor')
 	_codeEditor?: UmbCodeEditorElement;
@@ -63,6 +61,6 @@ export default UmbCodeEditorModalElement;
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbCodeEditorModalElement;
+		'umb-code-editor-modal': UmbCodeEditorModalElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/code-editor/code-editor-modal/code-editor-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/code-editor/code-editor-modal/code-editor-modal.element.ts
@@ -16,21 +16,30 @@ export class UmbCodeEditorModalElement extends UmbModalBaseElement<UmbCodeEditor
 	#handleCancel() {
 		this.modalContext?.reject();
 	}
+
+	#onLoaded() {
+		if (this.data?.formatOnLoad) {
+			setTimeout(() => {
+				this._codeEditor?.editor?.monacoEditor?.getAction('editor.action.formatDocument')?.run();
+			}, 100);
+		}
+	}
+
 	override render() {
 		return html`
 			<umb-body-layout .headline=${this.data?.headline ?? 'Code Editor'}>
 				<div id="editor-box">${this.#renderCodeEditor()}</div>
 				<div slot="actions">
-					<uui-button
+				<uui-button
 						id="cancel"
-						label=${this.localize.term('general_cancel')}
-						@click=${this.#handleCancel}></uui-button>
-					<uui-button
+					label=${this.localize.term('general_cancel')}
+					@click=${this.#handleCancel}></uui-button>
+				<uui-button
 						id="confirm"
 						color="${this.data?.color || 'positive'}"
-						look="primary"
+					look="primary"
 						label="${this.data?.confirmLabel || this.localize.term('general_submit')}"
-						@click=${this.#handleConfirm}></uui-button>
+					@click=${this.#handleConfirm}></uui-button>
 				</div>
 			</umb-body-layout>
 		`;
@@ -38,7 +47,10 @@ export class UmbCodeEditorModalElement extends UmbModalBaseElement<UmbCodeEditor
 
 	#renderCodeEditor() {
 		return html`
-			<umb-code-editor language=${ifDefined(this.data?.language)} .code=${this.data?.content ?? ''}></umb-code-editor>
+			<umb-code-editor
+				language=${ifDefined(this.data?.language)}
+				.code=${this.data?.content ?? ''}
+				@loaded=${this.#onLoaded}></umb-code-editor>
 		`;
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/code-editor/code-editor-modal/code-editor-modal.token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/code-editor/code-editor-modal/code-editor-modal.token.ts
@@ -9,6 +9,7 @@ export interface UmbCodeEditorModalData {
 	language: 'razor' | 'typescript' | 'javascript' | 'css' | 'markdown' | 'json' | 'html';
 	color?: 'positive' | 'danger';
 	confirmLabel?: string;
+	formatOnLoad?: boolean;
 }
 
 export interface UmbCodeEditorModalValue {

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/toolbar/source-editor.tiptap-toolbar-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/toolbar/source-editor.tiptap-toolbar-api.ts
@@ -13,6 +13,7 @@ export default class UmbTiptapToolbarSourceEditorExtensionApi extends UmbTiptapT
 				headline: 'Edit source code',
 				content: editor?.getHTML() ?? '',
 				language: 'html',
+				formatOnLoad: true,
 			},
 		});
 


### PR DESCRIPTION
### Description

Adds `formatOnLoad` option to the Code Editor modal configuration.

When enabled, once the Monaco editor has loaded, the `'editor.action.formatDocument'` action is ran against it to pretty-print the code contents. Currently, this only seems to work when using `setTimeout` to delay the action execution.

#### How to test?

Load up a Tiptap RTE, (the more content the better, e.g. more than a couple of paragraphs), press the "View Source Code" toolbar button. See the Code Editor modal opens and that the code contents is formatted, (e.g. on multiple lines, not on a single line).