### PR TITLE
Hotfix: Detail Repository custom notifications

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
@@ -403,6 +403,11 @@ export default {
 		copyFailed: 'Failed to copy content type',
 		moveFailed: 'Failed to move content type',
 	},
+	documentType: {
+		created: 'Document Type created',
+		updated: 'Document Type saved',
+		deleted: 'Document Type deleted',
+	},
 	mediaType: {
 		copyFailed: 'Failed to copy media type',
 		moveFailed: 'Failed to move media type',
@@ -1384,6 +1389,9 @@ export default {
 		validationFailedMessage: 'Validation errors must be fixed before the item can be saved',
 		operationFailedHeader: 'Failed',
 		operationSavedHeader: 'Saved',
+		created: 'Created',
+		updated: 'Saved',
+		deleted: 'Deleted',
 		operationSavedHeaderReloadUser: 'Saved. To view the changes please reload your browser',
 		invalidUserPermissionsText: 'Insufficient user permissions, could not complete the operation',
 		operationCancelledHeader: 'Cancelled',
@@ -1508,8 +1516,10 @@ export default {
 		tabRules: 'Rich Text Editor',
 	},
 	template: {
+		created: 'Template created',
 		runtimeModeProduction: 'Content is not editable when using runtime mode <code>Production</code>.',
 		deleteByIdFailed: 'Failed to delete template with ID %0%',
+		deleted: 'Template deleted',
 		edittemplate: 'Edit template',
 		insertSections: 'Sections',
 		insertContentArea: 'Insert content area',
@@ -1573,6 +1583,7 @@ export default {
 		ascending: 'ascending',
 		descending: 'descending',
 		template: 'Template',
+		updated: 'Template saved',
 	},
 	grid: {
 		media: 'Image',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -390,6 +390,11 @@ export default {
 		copyFailed: 'Failed to copy content type',
 		moveFailed: 'Failed to move content type',
 	},
+	documentType: {
+		created: 'Document Type created',
+		updated: 'Document Type saved',
+		deleted: 'Document Type deleted',
+	},
 	mediaType: {
 		copyFailed: 'Failed to copy media type',
 		moveFailed: 'Failed to move media type',
@@ -1385,6 +1390,9 @@ export default {
 		validationFailedMessage: 'Validation errors must be fixed before the item can be saved',
 		operationFailedHeader: 'Failed',
 		operationSavedHeader: 'Saved',
+		created: 'Created',
+		updated: 'Saved',
+		deleted: 'Deleted',
 		invalidUserPermissionsText: 'Insufficient user permissions, could not complete the operation',
 		operationCancelledHeader: 'Cancelled',
 		operationCancelledText: 'Operation was cancelled by a 3rd party add-in',
@@ -1511,8 +1519,10 @@ export default {
 		tabRules: 'Editor',
 	},
 	template: {
+		created: 'Template created',
 		runtimeModeProduction: 'Content is not editable when using runtime mode <code>Production</code>.',
 		deleteByIdFailed: 'Failed to delete template with ID %0%',
+		deleted: 'Template deleted',
 		edittemplate: 'Edit template',
 		insertSections: 'Sections',
 		insertContentArea: 'Insert content area',
@@ -1579,6 +1589,7 @@ export default {
 		descending: 'descending',
 		template: 'Template',
 		systemFields: 'System fields',
+		updated: 'Template saved',
 	},
 	grid: {
 		media: 'Image',

--- a/src/Umbraco.Web.UI.Client/src/packages/clipboard/clipboard-entry/detail/clipboard-entry-detail.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/clipboard/clipboard-entry/detail/clipboard-entry-detail.repository.ts
@@ -9,7 +9,7 @@ export class UmbClipboardEntryDetailRepository extends UmbDetailRepositoryBase<U
 		super(host, UmbClipboardEntryDetailLocalStorageDataSource, UMB_CLIPBOARD_ENTRY_DETAIL_STORE_CONTEXT, {
 			create: {
 				success: {
-					message: (model) => {
+					message: async (model) => {
 						return `${model.name} copied to clipboard`;
 					},
 				},

--- a/src/Umbraco.Web.UI.Client/src/packages/clipboard/clipboard-entry/detail/clipboard-entry-detail.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/clipboard/clipboard-entry/detail/clipboard-entry-detail.repository.ts
@@ -6,7 +6,15 @@ import { UmbDetailRepositoryBase } from '@umbraco-cms/backoffice/repository';
 
 export class UmbClipboardEntryDetailRepository extends UmbDetailRepositoryBase<UmbClipboardEntryDetailModel> {
 	constructor(host: UmbControllerHost) {
-		super(host, UmbClipboardEntryDetailLocalStorageDataSource, UMB_CLIPBOARD_ENTRY_DETAIL_STORE_CONTEXT);
+		super(host, UmbClipboardEntryDetailLocalStorageDataSource, UMB_CLIPBOARD_ENTRY_DETAIL_STORE_CONTEXT, {
+			create: {
+				success: {
+					message: (model) => {
+						return `${model.name} copied to clipboard`;
+					},
+				},
+			},
+		});
 	}
 
 	override async create(model: UmbClipboardEntryDetailModel) {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/repository/detail/detail-repository-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/repository/detail/detail-repository-base.ts
@@ -9,6 +9,7 @@ import type { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
 import type { UmbDetailStore } from '@umbraco-cms/backoffice/store';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
 import type { UmbEntityModel } from '@umbraco-cms/backoffice/entity';
+import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
 
 interface UmbDetailRepositoryBaseNotification<DetailModelType extends UmbEntityModel> {
 	create?: {
@@ -41,6 +42,7 @@ export abstract class UmbDetailRepositoryBase<
 	protected detailDataSource: UmbDetailDataSourceType;
 	#notificationContext?: UmbNotificationContext;
 	#notification?: UmbDetailRepositoryBaseNotification<DetailModelType>;
+	protected readonly _localize = new UmbLocalizationController(this);
 
 	constructor(
 		host: UmbControllerHost,
@@ -116,8 +118,11 @@ export abstract class UmbDetailRepositoryBase<
 		if (createdData) {
 			this.#detailStore?.append(createdData);
 
+			debugger;
 			// TODO: Is this the correct place to do it?
-			const message = this.#notification?.create?.success?.message?.(createdData) ?? `Created`;
+			const message =
+				this._localize.string(this.#notification?.create?.success?.message?.(createdData)) ??
+				this._localize.term('speechBubbles_created');
 			const notification = { data: { message } };
 			this.#notificationContext!.peek('positive', notification);
 		}
@@ -140,9 +145,10 @@ export abstract class UmbDetailRepositoryBase<
 
 		if (updatedData) {
 			this.#detailStore!.updateItem(model.unique, updatedData);
-
 			// TODO: Is this the correct place to do it?
-			const message = this.#notification?.save?.success?.message?.(updatedData) ?? `Saved`;
+			const message =
+				this._localize.string(this.#notification?.save?.success?.message?.(updatedData)) ??
+				this._localize.term('speechBubbles_updated');
 			const notification = { data: { message } };
 			this.#notificationContext!.peek('positive', notification);
 		}
@@ -166,7 +172,9 @@ export abstract class UmbDetailRepositoryBase<
 			this.#detailStore!.removeItem(unique);
 
 			// TODO: Is this the correct place to do it?
-			const message = this.#notification?.delete?.success.message?.(unique) ?? `Deleted`;
+			const message =
+				this._localize.string(this.#notification?.delete?.success.message?.(unique)) ??
+				this._localize.term('speechBubbles_deleted');
 			const notification = { data: { message } };
 			this.#notificationContext!.peek('positive', notification);
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/repository/detail/detail-repository-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/repository/detail/detail-repository-base.ts
@@ -14,17 +14,17 @@ import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-
 interface UmbDetailRepositoryBaseNotification<DetailModelType extends UmbEntityModel> {
 	create?: {
 		success?: {
-			message?: (model: DetailModelType) => string;
+			message?: (model: DetailModelType) => Promise<string>;
 		};
 	};
 	save?: {
 		success?: {
-			message?: (model: DetailModelType) => string;
+			message?: (model: DetailModelType) => Promise<string>;
 		};
 	};
 	delete?: {
 		success?: {
-			message?: (unique: string) => string;
+			message?: (unique: string) => Promise<string>;
 		};
 	};
 }
@@ -120,7 +120,7 @@ export abstract class UmbDetailRepositoryBase<
 
 			// TODO: Is this the correct place to do it?
 			const message = this.#notification?.create?.success?.message
-				? this._localize.string(this.#notification.create.success.message?.(createdData))
+				? this._localize.string(await this.#notification.create.success.message?.(createdData))
 				: this._localize.term('speechBubbles_created');
 			const notification = { data: { message } };
 			this.#notificationContext!.peek('positive', notification);
@@ -146,7 +146,7 @@ export abstract class UmbDetailRepositoryBase<
 			this.#detailStore!.updateItem(model.unique, updatedData);
 			// TODO: Is this the correct place to do it?
 			const message = this.#notification?.save?.success?.message
-				? this._localize.string(this.#notification.save.success.message?.(updatedData))
+				? this._localize.string(await this.#notification.save.success.message?.(updatedData))
 				: this._localize.term('speechBubbles_updated');
 			const notification = { data: { message } };
 			this.#notificationContext!.peek('positive', notification);
@@ -172,7 +172,7 @@ export abstract class UmbDetailRepositoryBase<
 
 			// TODO: Is this the correct place to do it?
 			const message = this.#notification?.delete?.success?.message
-				? this._localize.string(this.#notification.delete.success.message?.(unique))
+				? this._localize.string(await this.#notification.delete.success.message?.(unique))
 				: this._localize.term('speechBubbles_deleted');
 			const notification = { data: { message } };
 			this.#notificationContext!.peek('positive', notification);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/repository/detail/detail-repository-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/repository/detail/detail-repository-base.ts
@@ -23,7 +23,7 @@ interface UmbDetailRepositoryBaseNotification<DetailModelType extends UmbEntityM
 		};
 	};
 	delete?: {
-		success: {
+		success?: {
 			message?: (unique: string) => string;
 		};
 	};
@@ -118,11 +118,10 @@ export abstract class UmbDetailRepositoryBase<
 		if (createdData) {
 			this.#detailStore?.append(createdData);
 
-			debugger;
 			// TODO: Is this the correct place to do it?
-			const message =
-				this._localize.string(this.#notification?.create?.success?.message?.(createdData)) ??
-				this._localize.term('speechBubbles_created');
+			const message = this.#notification?.create?.success?.message
+				? this._localize.string(this.#notification.create.success.message?.(createdData))
+				: this._localize.term('speechBubbles_created');
 			const notification = { data: { message } };
 			this.#notificationContext!.peek('positive', notification);
 		}
@@ -146,9 +145,9 @@ export abstract class UmbDetailRepositoryBase<
 		if (updatedData) {
 			this.#detailStore!.updateItem(model.unique, updatedData);
 			// TODO: Is this the correct place to do it?
-			const message =
-				this._localize.string(this.#notification?.save?.success?.message?.(updatedData)) ??
-				this._localize.term('speechBubbles_updated');
+			const message = this.#notification?.save?.success?.message
+				? this._localize.string(this.#notification.save.success.message?.(updatedData))
+				: this._localize.term('speechBubbles_updated');
 			const notification = { data: { message } };
 			this.#notificationContext!.peek('positive', notification);
 		}
@@ -172,9 +171,9 @@ export abstract class UmbDetailRepositoryBase<
 			this.#detailStore!.removeItem(unique);
 
 			// TODO: Is this the correct place to do it?
-			const message =
-				this._localize.string(this.#notification?.delete?.success.message?.(unique)) ??
-				this._localize.term('speechBubbles_deleted');
+			const message = this.#notification?.delete?.success?.message
+				? this._localize.string(this.#notification.delete.success.message?.(unique))
+				: this._localize.term('speechBubbles_deleted');
 			const notification = { data: { message } };
 			this.#notificationContext!.peek('positive', notification);
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/repository/detail/document-type-detail.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/repository/detail/document-type-detail.repository.ts
@@ -5,7 +5,29 @@ import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbDetailRepositoryBase } from '@umbraco-cms/backoffice/repository';
 export class UmbDocumentTypeDetailRepository extends UmbDetailRepositoryBase<UmbDocumentTypeDetailModel> {
 	constructor(host: UmbControllerHost) {
-		super(host, UmbDocumentTypeDetailServerDataSource, UMB_DOCUMENT_TYPE_DETAIL_STORE_CONTEXT);
+		super(host, UmbDocumentTypeDetailServerDataSource, UMB_DOCUMENT_TYPE_DETAIL_STORE_CONTEXT, {
+			create: {
+				success: {
+					message: () => {
+						return `Document Type created`;
+					},
+				},
+			},
+			save: {
+				success: {
+					message: () => {
+						return `Document Type saved`;
+					},
+				},
+			},
+			delete: {
+				success: {
+					message: () => {
+						return `Document Type deleted`;
+					},
+				},
+			},
+		});
 	}
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/repository/detail/document-type-detail.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/repository/detail/document-type-detail.repository.ts
@@ -9,21 +9,21 @@ export class UmbDocumentTypeDetailRepository extends UmbDetailRepositoryBase<Umb
 			create: {
 				success: {
 					message: () => {
-						return `Document Type created`;
+						return `#documentType_created`;
 					},
 				},
 			},
 			save: {
 				success: {
 					message: () => {
-						return `Document Type saved`;
+						return `#documentType_updated`;
 					},
 				},
 			},
 			delete: {
 				success: {
 					message: () => {
-						return `Document Type deleted`;
+						return `#documentType_deleted`;
 					},
 				},
 			},

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/repository/detail/document-type-detail.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/repository/detail/document-type-detail.repository.ts
@@ -8,21 +8,21 @@ export class UmbDocumentTypeDetailRepository extends UmbDetailRepositoryBase<Umb
 		super(host, UmbDocumentTypeDetailServerDataSource, UMB_DOCUMENT_TYPE_DETAIL_STORE_CONTEXT, {
 			create: {
 				success: {
-					message: () => {
+					message: async () => {
 						return `#documentType_created`;
 					},
 				},
 			},
 			save: {
 				success: {
-					message: () => {
+					message: async () => {
 						return `#documentType_updated`;
 					},
 				},
 			},
 			delete: {
 				success: {
-					message: () => {
+					message: async () => {
 						return `#documentType_deleted`;
 					},
 				},

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/repository/detail/template-detail.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/repository/detail/template-detail.repository.ts
@@ -10,7 +10,21 @@ export class UmbTemplateDetailRepository extends UmbDetailRepositoryBase<UmbTemp
 			create: {
 				success: {
 					message: () => {
-						return `Template created`;
+						return `#template_created`;
+					},
+				},
+			},
+			save: {
+				success: {
+					message: () => {
+						return `#template_updated`;
+					},
+				},
+			},
+			delete: {
+				success: {
+					message: () => {
+						return `#template_deleted`;
 					},
 				},
 			},

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/repository/detail/template-detail.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/repository/detail/template-detail.repository.ts
@@ -6,7 +6,15 @@ import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
 export class UmbTemplateDetailRepository extends UmbDetailRepositoryBase<UmbTemplateDetailModel> {
 	constructor(host: UmbControllerHost) {
-		super(host, UmbTemplateServerDataSource, UMB_TEMPLATE_DETAIL_STORE_CONTEXT);
+		super(host, UmbTemplateServerDataSource, UMB_TEMPLATE_DETAIL_STORE_CONTEXT, {
+			create: {
+				success: {
+					message: () => {
+						return `Template created`;
+					},
+				},
+			},
+		});
 	}
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/repository/detail/template-detail.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/repository/detail/template-detail.repository.ts
@@ -9,21 +9,21 @@ export class UmbTemplateDetailRepository extends UmbDetailRepositoryBase<UmbTemp
 		super(host, UmbTemplateServerDataSource, UMB_TEMPLATE_DETAIL_STORE_CONTEXT, {
 			create: {
 				success: {
-					message: () => {
+					message: async () => {
 						return `#template_created`;
 					},
 				},
 			},
 			save: {
 				success: {
-					message: () => {
+					message: async () => {
 						return `#template_updated`;
 					},
 				},
 			},
 			delete: {
 				success: {
-					message: () => {
+					message: async () => {
 						return `#template_deleted`;
 					},
 				},


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/16092

This PR allows for custom notification messages when extending the Detail Repository Base. Ideally, I prefer to remove the notifications entirely from the repository because informing the user about what has happened should be a UI concern. However, to avoid breaking changes, I have made it possible to pass a custom message to the constructor.

This is particularly helpful for the Clipboard feature. When an item is copied to the clipboard, the message now reads: "Copied to clipboard" instead of "Created." I have also revised the code for creating a document type with a template and made the notifications clearer.

We can add a "disable" option moving forward so we can slowly transition out of the repo notifications.

How to test:
* Copy something to the clipboard (Block List, Block Grid).
* Create a doc type with a template
