### PR TITLE
Added a check that we have a route before attempting to include it in the other URLs for a published document

### DIFF
--- a/src/Umbraco.Core/Routing/NewDefaultUrlProvider.cs
+++ b/src/Umbraco.Core/Routing/NewDefaultUrlProvider.cs
@@ -117,7 +117,7 @@ public class NewDefaultUrlProvider : IUrlProvider
 
             // although we are passing in culture here, if any node in this path is invariant, it ignores the culture anyways so this is ok
             var route = GetLegacyRouteFormatById(key, culture);
-            if (route == null)
+            if (route == null || route == "#")
             {
                 continue;
             }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/18130

### Description
Looks like we had an issue here with the code that has a null check for if a route is found for a given node and culture, but it wasn't checking for a result of "#", which is the actual value returned when a route isn't found.