### PR TITLE
Fixes rollback of variant page name

### DIFF
--- a/src/Umbraco.Core/Models/ContentRepositoryExtensions.cs
+++ b/src/Umbraco.Core/Models/ContentRepositoryExtensions.cs
@@ -237,7 +237,7 @@ public static class ContentRepositoryExtensions
         {
             foreach (ContentCultureInfos cultureInfo in other.CultureInfos)
             {
-                if (culture == "*" || culture == cultureInfo.Culture)
+                if (culture == "*" || culture.InvariantEquals(cultureInfo.Culture))
                 {
                     content.SetCultureName(cultureInfo.Name, cultureInfo.Culture);
                 }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description
In internal testing we found an issue with rollback and variant pages - in that the variant page name wasn't rolled back.  This PR fixes a string comparison casing issue such that it is.

**To Test:**

- Create a piece of variant content and publish it.
- Change the page name for one of the cultures and publish again.
- Roll back to the first version and verify that the page name for the culture is now updated.
