### PR TITLE
Fix for bug #18129

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="myLocalFeed" value="Build.Out" />
   </packageSources>
   <packageSourceMapping>
     <!-- Ensure all packages are pulled from NuGet -->


### PR DESCRIPTION
Change base class of ContentFinderByUrlAndTemplate to ContentFinderByUrlNew and update deprecated services

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

This fixes https://github.com/umbraco/Umbraco-CMS/issues/18129

### Description
* I changed the base class of ContentFinderByUrlAndTemplate  to ContentFinderByUrlNew.
* I removed dependency from IFileService
* I added dependency from ITemplateService
* I changed the code that fetches the ITemplate of the alternate template to use ITemplateService.GetAsync
* Minor code changes to get the compiler to run (added "async" in the function definition, changed all the return statements to boolean instead of Task.Complete<boolean>)
