### PR TITLE
URL encodes member user names when passing information for public access setting such that those with user names as emails containing a plus will be included in the rule

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/publicaccess.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/publicaccess.resource.js
@@ -79,7 +79,7 @@ function publicAccessResource($http, umbRequestHelper) {
                 publicAccess.groups = groups;
             }
             else if (Utilities.isArray(usernames) && usernames.length) {
-                publicAccess.usernames = usernames;
+                publicAccess.usernames = usernames.map(u => encodeURIComponent(u));
             }
             else {
                 throw "must supply either userName/password or roles";


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/15723

### Description
Resolves the linked issue by URL encoding the provided user names.

**To Test:**

- Create a member with a plus sign in the login name:

![image](https://github.com/user-attachments/assets/6633ebba-2a5d-4a56-8d2e-5ca64dfe93a7)

- Use the member when setting up a public access rule on a content item, and restricting access to specific members.
- Note that the member is now correctly saved to the rule.