### PR TITLE
Fix task return and apply correct disposal pattern for FileSystemMainDomLock

### DIFF
--- a/src/Umbraco.Infrastructure/Runtime/FileSystemMainDomLock.cs
+++ b/src/Umbraco.Infrastructure/Runtime/FileSystemMainDomLock.cs
@@ -15,6 +15,7 @@ internal class FileSystemMainDomLock : IMainDomLock
     private readonly string _lockFilePath;
     private readonly ILogger<FileSystemMainDomLock> _logger;
     private readonly string _releaseSignalFilePath;
+    private bool _disposed;
     private Task? _listenForReleaseSignalFileTask;
 
     private FileStream? _lockFileStream;
@@ -89,16 +90,14 @@ internal class FileSystemMainDomLock : IMainDomLock
             ListeningLoop,
             _cancellationTokenSource.Token,
             TaskCreationOptions.LongRunning,
-            TaskScheduler.Default);
+            TaskScheduler.Default)
+            .Unwrap(); // Because ListeningLoop is an async method, we need to use Unwrap to return the inner task.
 
         return _listenForReleaseSignalFileTask;
     }
 
-    public void Dispose()
-    {
-        _lockFileStream?.Close();
-        _lockFileStream = null;
-    }
+    /// <summary>Releases the resources used by this <see cref="FileSystemMainDomLock" />.</summary>
+    public void Dispose() => Dispose(true);
 
     public void CreateLockReleaseSignalFile() =>
         File.Open(_releaseSignalFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite,
@@ -107,6 +106,26 @@ internal class FileSystemMainDomLock : IMainDomLock
 
     public void DeleteLockReleaseSignalFile() =>
         File.Delete(_releaseSignalFilePath);
+
+    /// <summary>Releases the resources used by this <see cref="FileSystemMainDomLock" />.</summary>
+    /// <param name="disposing">true to release both managed resources.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing && !_disposed)
+        {
+            _logger.LogDebug($"{nameof(FileSystemMainDomLock)} Disposing...");
+            _cancellationTokenSource.Cancel();
+            _cancellationTokenSource.Dispose();
+            ReleaseLock();
+            _disposed = true;
+        }
+    }
+
+    private void ReleaseLock()
+    {
+        _lockFileStream?.Close();
+        _lockFileStream = null;
+    }
 
     private async Task ListeningLoop()
     {
@@ -118,6 +137,7 @@ internal class FileSystemMainDomLock : IMainDomLock
                 {
                     _logger.LogDebug("ListenAsync Task canceled, exiting loop");
                 }
+
                 return;
             }
 
@@ -127,12 +147,12 @@ internal class FileSystemMainDomLock : IMainDomLock
                 {
                     _logger.LogDebug("Found lock release signal file, releasing lock on {lockFilePath}", _lockFilePath);
                 }
-                _lockFileStream?.Close();
-                _lockFileStream = null;
+
+                ReleaseLock();
                 break;
             }
 
-            await Task.Delay(_globalSettings.CurrentValue.MainDomReleaseSignalPollingInterval);
+            await Task.Delay(_globalSettings.CurrentValue.MainDomReleaseSignalPollingInterval, _cancellationTokenSource.Token);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Firstly:

This PR adds a fix to a bug I introduced in #18119 😬

Using an async method inside `Task.Factory.StartNew()` results in the outer task being returned, instead of the inner long-running task. When the outer task completes (which it does pretty much right away) the `MainDom` releases the lock early.

Adding an `Unwrap()` returns the inner task so that the [`_listenCompleteTask` inside `MainDom`](https://github.com/umbraco/Umbraco-CMS/blob/1395d498b7691dc74eb22933bc311e65c033d55a/src/Umbraco.Core/Runtime/MainDom.cs#L200-L217) fires only when the inner task is finished.

### Secondly:

This PR adds a similar Dispose pattern as used by the `SqlMainDomLock` in order to call the cancellation token and stop the long-running task when Disposed by the `MainDom` [at shutdown](https://github.com/umbraco/Umbraco-CMS/blob/1395d498b7691dc74eb22933bc311e65c033d55a/src/Umbraco.Core/Runtime/MainDom.cs#L151).


### Testing

Drop a breakpoint inside [`_listenCompleteTask` ](https://github.com/umbraco/Umbraco-CMS/blob/1395d498b7691dc74eb22933bc311e65c033d55a/src/Umbraco.Core/Runtime/MainDom.cs#L200-L217) .
Before the changes in this PR, that breakpoint will be hit erroneously soon after boot.
After this PR it will be hit only when the lock is intentionally released, or at shutdown.