### PR TITLE
V15: Show upload progress for dropped files in the Media Library

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/mocks/data/data-type/data-type.data.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/data/data-type/data-type.data.ts
@@ -975,8 +975,16 @@ export const data: Array<UmbMockDataTypeModel> = [
 			{
 				alias: 'layouts',
 				value: [
-					{ icon: 'icon-grid', isSystem: true, name: 'Grid', path: '', selected: true },
-					{ icon: 'icon-list', isSystem: true, name: 'Table', path: '', selected: true },
+					{
+						icon: 'icon-grid',
+						name: 'Media Grid Collection View',
+						collectionView: 'Umb.CollectionView.Media.Grid',
+					},
+					{
+						icon: 'icon-list',
+						name: 'Media Table Collection View',
+						collectionView: 'Umb.CollectionView.Media.Table',
+					},
 				],
 			},
 			{ alias: 'icon', value: 'icon-layers' },

--- a/src/Umbraco.Web.UI.Client/src/mocks/data/data-type/data-type.data.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/data/data-type/data-type.data.ts
@@ -722,7 +722,70 @@ export const data: Array<UmbMockDataTypeModel> = [
 		values: [
 			{
 				alias: 'fileExtensions',
-				value: ['jpg', 'jpeg', 'png', 'pdf', 'mov', 'iso'],
+				value: ['jpg', 'jpeg', 'png', 'svg'],
+			},
+			{
+				alias: 'multiple',
+				value: true,
+			},
+		],
+	},
+	{
+		name: 'Upload Field (Files)',
+		id: 'dt-uploadFieldFiles',
+		parent: null,
+		editorAlias: 'Umbraco.UploadField',
+		editorUiAlias: 'Umb.PropertyEditorUi.UploadField',
+		hasChildren: false,
+		isFolder: false,
+		isDeletable: true,
+		canIgnoreStartNodes: false,
+		values: [
+			{
+				alias: 'fileExtensions',
+				value: ['pdf', 'iso'],
+			},
+			{
+				alias: 'multiple',
+				value: true,
+			},
+		],
+	},
+	{
+		name: 'Upload Field (Movies)',
+		id: 'dt-uploadFieldMovies',
+		parent: null,
+		editorAlias: 'Umbraco.UploadField',
+		editorUiAlias: 'Umb.PropertyEditorUi.UploadField',
+		hasChildren: false,
+		isFolder: false,
+		isDeletable: true,
+		canIgnoreStartNodes: false,
+		values: [
+			{
+				alias: 'fileExtensions',
+				value: ['mp4', 'mov'],
+			},
+			{
+				alias: 'multiple',
+				value: true,
+			},
+		],
+	},
+	{
+		name: 'Upload Field (Vector)',
+		id: 'dt-uploadFieldVector',
+		parent: null,
+		editorAlias: 'Umbraco.UploadField',
+		editorUiAlias: 'Umb.PropertyEditorUi.UploadField',
+		hasChildren: false,
+		isFolder: false,
+		isDeletable: true,
+		canIgnoreStartNodes: false,
+		values: [
+			{
+				alias: 'fileExtensions',
+				value: ['svg'],
 			},
 			{
 				alias: 'multiple',

--- a/src/Umbraco.Web.UI.Client/src/mocks/data/data-type/data-type.data.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/data/data-type/data-type.data.ts
@@ -722,7 +722,7 @@ export const data: Array<UmbMockDataTypeModel> = [
 		values: [
 			{
 				alias: 'fileExtensions',
-				value: ['jpg', 'jpeg', 'png', 'pdf'],
+				value: ['jpg', 'jpeg', 'png', 'pdf', 'mov', 'iso'],
 			},
 			{
 				alias: 'multiple',

--- a/src/Umbraco.Web.UI.Client/src/mocks/data/media-type/media-type.data.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/data/media-type/media-type.data.ts
@@ -15,7 +15,7 @@ export type UmbMockMediaTypeUnionModel =
 
 export const data: Array<UmbMockMediaTypeModel> = [
 	{
-		name: 'Media Type 1',
+		name: 'Image',
 		id: 'media-type-1-id',
 		parent: null,
 		description: 'Media type 1 description',
@@ -105,7 +105,7 @@ export const data: Array<UmbMockMediaTypeModel> = [
 		aliasCanBeChanged: false,
 	},
 	{
-		name: 'Media Type 2',
+		name: 'Audio',
 		id: 'media-type-2-id',
 		parent: null,
 		description: 'Media type 2 description',
@@ -118,7 +118,7 @@ export const data: Array<UmbMockMediaTypeModel> = [
 				alias: 'umbracoFile',
 				name: 'File',
 				description: '',
-				dataType: { id: 'dt-uploadField' },
+				dataType: { id: 'dt-uploadFieldFiles' },
 				variesByCulture: false,
 				variesBySegment: false,
 				sortOrder: 0,
@@ -155,7 +155,7 @@ export const data: Array<UmbMockMediaTypeModel> = [
 		aliasCanBeChanged: false,
 	},
 	{
-		name: 'Media Type 3',
+		name: 'Vector Graphics',
 		id: 'media-type-3-id',
 		parent: null,
 		description: 'Media type 3 description',
@@ -168,7 +168,7 @@ export const data: Array<UmbMockMediaTypeModel> = [
 				alias: 'umbracoFile',
 				name: 'File',
 				description: '',
-				dataType: { id: 'dt-uploadField' },
+				dataType: { id: 'dt-uploadFieldVector' },
 				variesByCulture: false,
 				variesBySegment: false,
 				sortOrder: 0,
@@ -205,7 +205,7 @@ export const data: Array<UmbMockMediaTypeModel> = [
 		aliasCanBeChanged: false,
 	},
 	{
-		name: 'Media Type 4',
+		name: 'Movie',
 		id: 'media-type-4-id',
 		parent: null,
 		description: 'Media type 4 description',
@@ -218,7 +218,7 @@ export const data: Array<UmbMockMediaTypeModel> = [
 				alias: 'umbracoFile',
 				name: 'File',
 				description: '',
-				dataType: { id: 'dt-uploadField' },
+				dataType: { id: 'dt-uploadFieldMovies' },
 				variesByCulture: false,
 				variesBySegment: false,
 				sortOrder: 0,
@@ -268,7 +268,7 @@ export const data: Array<UmbMockMediaTypeModel> = [
 				alias: 'umbracoFile',
 				name: 'File',
 				description: '',
-				dataType: { id: 'dt-uploadField' },
+				dataType: { id: 'dt-uploadFieldFiles' },
 				variesByCulture: false,
 				variesBySegment: false,
 				sortOrder: 0,

--- a/src/Umbraco.Web.UI.Client/src/mocks/data/media-type/media-type.db.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/data/media-type/media-type.db.ts
@@ -52,7 +52,7 @@ class UmbMediaTypeMockDB extends UmbEntityMockDbBase<UmbMockMediaTypeModel> {
 		const allowedTypes = this.data.filter((field) => {
 			const allProperties = field.properties.flat();
 
-			const fileUploadType = allProperties.find((prop) => prop.alias === 'umbracoFile');
+			const fileUploadType = allProperties.find((prop) => prop.alias === 'umbracoFile' || prop.alias === 'mediaPicker');
 			if (!fileUploadType) return false;
 
 			const dataType = umbDataTypeMockDb.read(fileUploadType.dataType.id);

--- a/src/Umbraco.Web.UI.Client/src/mocks/data/media/media.data.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/data/media/media.data.ts
@@ -21,7 +21,10 @@ export const data: Array<UmbMockMediaModel> = [
 		values: [
 			{
 				editorAlias: 'Umbraco.UploadField',
-				alias: 'dt-uploadField',
+				alias: 'mediaPicker',
+				value: {
+					src: '/umbraco/backoffice/assets/installer-illustration.svg',
+				},
 			},
 			{
 				editorAlias: 'Umbraco.TextBox',

--- a/src/Umbraco.Web.UI.Client/src/mocks/data/media/media.data.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/data/media/media.data.ts
@@ -42,7 +42,12 @@ export const data: Array<UmbMockMediaModel> = [
 				updateDate: '2023-02-06T15:31:51.354764',
 			},
 		],
-		urls: [],
+		urls: [
+			{
+				culture: null,
+				url: '/umbraco/backoffice/assets/installer-illustration.svg',
+			},
+		],
 	},
 	{
 		hasChildren: false,

--- a/src/Umbraco.Web.UI.Client/src/mocks/data/media/media.data.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/data/media/media.data.ts
@@ -16,19 +16,23 @@ export const data: Array<UmbMockMediaModel> = [
 		isTrashed: false,
 		mediaType: {
 			id: 'media-type-1-id',
-			icon: 'icon-bug',
+			icon: 'icon-picture',
 		},
 		values: [
 			{
+				editorAlias: 'Umbraco.UploadField',
+				alias: 'dt-uploadField',
+			},
+			{
 				editorAlias: 'Umbraco.TextBox',
-				alias: 'myMediaHeadline',
+				alias: 'mediaType1Property1',
 				value: 'The daily life at Umbraco HQ',
 			},
 		],
 		variants: [
 			{
 				publishDate: '2023-02-06T15:31:51.354764',
-				culture: 'en-us',
+				culture: null,
 				segment: null,
 				name: 'Flipped Car',
 				createDate: '2023-02-06T15:31:46.876902',
@@ -51,14 +55,14 @@ export const data: Array<UmbMockMediaModel> = [
 		values: [
 			{
 				editorAlias: 'Umbraco.TextBox',
-				alias: 'myMediaDescription',
+				alias: 'mediaType1Property1',
 				value: 'Every day, a rabbit in a military costume greets me at the front door',
 			},
 		],
 		variants: [
 			{
 				publishDate: '2023-02-06T15:31:51.354764',
-				culture: 'en-us',
+				culture: null,
 				segment: null,
 				name: 'Umbracoffee',
 				createDate: '2023-02-06T15:31:46.876902',
@@ -83,7 +87,7 @@ export const data: Array<UmbMockMediaModel> = [
 		variants: [
 			{
 				publishDate: '2023-02-06T15:31:51.354764',
-				culture: 'en-us',
+				culture: null,
 				segment: null,
 				name: 'People',
 				createDate: '2023-02-06T15:31:46.876902',
@@ -108,7 +112,7 @@ export const data: Array<UmbMockMediaModel> = [
 		variants: [
 			{
 				publishDate: '2023-02-06T15:31:51.354764',
-				culture: 'en-us',
+				culture: null,
 				segment: null,
 				name: 'John Smith',
 				createDate: '2023-02-06T15:31:46.876902',
@@ -131,14 +135,14 @@ export const data: Array<UmbMockMediaModel> = [
 		values: [
 			{
 				editorAlias: 'Umbraco.TextBox',
-				alias: 'myMediaDescription',
+				alias: 'mediaType1Property1',
 				value: 'Every day, a rabbit in a military costume greets me at the front door',
 			},
 		],
 		variants: [
 			{
 				publishDate: '2023-02-06T15:31:51.354764',
-				culture: 'en-us',
+				culture: null,
 				segment: null,
 				name: 'Jane Doe',
 				createDate: '2023-02-06T15:31:46.876902',
@@ -161,14 +165,14 @@ export const data: Array<UmbMockMediaModel> = [
 		values: [
 			{
 				editorAlias: 'Umbraco.TextBox',
-				alias: 'myMediaDescription',
+				alias: 'mediaType1Property1',
 				value: 'Every day, a rabbit in a military costume greets me at the front door',
 			},
 		],
 		variants: [
 			{
 				publishDate: '2023-02-06T15:31:51.354764',
-				culture: 'en-us',
+				culture: null,
 				segment: null,
 				name: 'John Doe',
 				createDate: '2023-02-06T15:31:46.876902',
@@ -191,14 +195,14 @@ export const data: Array<UmbMockMediaModel> = [
 		values: [
 			{
 				editorAlias: 'Umbraco.TextBox',
-				alias: 'myMediaDescription',
+				alias: 'mediaType1Property1',
 				value: 'Every day, a rabbit in a military costume greets me at the front door',
 			},
 		],
 		variants: [
 			{
 				publishDate: '2023-02-06T15:31:51.354764',
-				culture: 'en-us',
+				culture: null,
 				segment: null,
 				name: 'A very nice hat',
 				createDate: '2023-02-06T15:31:46.876902',
@@ -221,14 +225,14 @@ export const data: Array<UmbMockMediaModel> = [
 		values: [
 			{
 				editorAlias: 'Umbraco.TextBox',
-				alias: 'myMediaDescription',
+				alias: 'mediaType1Property1',
 				value: 'Every day, a rabbit in a military costume greets me at the front door',
 			},
 		],
 		variants: [
 			{
 				publishDate: '2023-02-06T15:31:51.354764',
-				culture: 'en-us',
+				culture: null,
 				segment: null,
 				name: 'Fancy old chair',
 				createDate: '2023-02-06T15:31:46.876902',

--- a/src/Umbraco.Web.UI.Client/src/mocks/handlers/media/detail.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/handlers/media/detail.handlers.ts
@@ -8,6 +8,7 @@ import type {
 	UpdateMediaRequestModel,
 } from '@umbraco-cms/backoffice/external/backend-api';
 import { umbracoPath } from '@umbraco-cms/backoffice/utils';
+import type { UmbMediaDetailModel } from '@umbraco-cms/backoffice/media';
 
 export const detailHandlers = [
 	rest.post(umbracoPath(`${UMB_SLUG}`), async (req, res, ctx) => {
@@ -42,6 +43,23 @@ export const detailHandlers = [
 		if (!id) return res(ctx.status(400));
 		const response = umbMediaMockDb.detail.read(id);
 		return res(ctx.status(200), ctx.json(response));
+	}),
+
+	rest.put<UmbMediaDetailModel>(umbracoPath(`${UMB_SLUG}/:id/validate`), async (req, res, ctx) => {
+		const id = req.params.id as string;
+		if (!id) return res(ctx.status(400));
+		const model = await req.json<UmbMediaDetailModel>();
+		if (!model) return res(ctx.status(400));
+
+		const hasMediaPickerOrFileUploadValue = model.values.some((v) => {
+			return v.editorAlias === 'Umbraco.UploadField' && v.value;
+		});
+
+		if (!hasMediaPickerOrFileUploadValue) {
+			return res(ctx.status(400, 'No media picker or file upload value found'));
+		}
+
+		return res(ctx.status(200));
 	}),
 
 	rest.put(umbracoPath(`${UMB_SLUG}/:id`), async (req, res, ctx) => {

--- a/src/Umbraco.Web.UI.Client/src/mocks/handlers/media/imaging.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/handlers/media/imaging.handlers.ts
@@ -1,0 +1,24 @@
+const { rest } = window.MockServiceWorker;
+import { umbMediaMockDb } from '../../data/media/media.db.js';
+import type { GetImagingResizeUrlsResponse } from '@umbraco-cms/backoffice/external/backend-api';
+import { umbracoPath } from '@umbraco-cms/backoffice/utils';
+
+export const imagingHandlers = [
+	rest.get(umbracoPath('/imaging/resize/urls'), (req, res, ctx) => {
+		const ids = req.url.searchParams.getAll('id');
+		if (!ids) return res(ctx.status(404));
+
+		const media = umbMediaMockDb.getAll().filter((item) => ids.includes(item.id));
+
+		const response: GetImagingResizeUrlsResponse = media.map((item) => ({
+			id: item.id,
+			urlInfos: item.urls,
+		}));
+
+		return res(
+			// Respond with a 200 status code
+			ctx.status(200),
+			ctx.json(response),
+		);
+	}),
+];

--- a/src/Umbraco.Web.UI.Client/src/mocks/handlers/media/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/handlers/media/index.ts
@@ -3,6 +3,7 @@ import { treeHandlers } from './tree.handlers.js';
 import { itemHandlers } from './item.handlers.js';
 import { detailHandlers } from './detail.handlers.js';
 import { collectionHandlers } from './collection.handlers.js';
+import { imagingHandlers } from './imaging.handlers.js';
 
 export const handlers = [
 	...recycleBinHandlers,
@@ -10,4 +11,5 @@ export const handlers = [
 	...itemHandlers,
 	...detailHandlers,
 	...collectionHandlers,
+	...imagingHandlers,
 ];

--- a/src/Umbraco.Web.UI.Client/src/mocks/handlers/media/tree.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/handlers/media/tree.handlers.ts
@@ -19,4 +19,11 @@ export const treeHandlers = [
 		const response = umbMediaMockDb.tree.getChildrenOf({ parentId, skip, take });
 		return res(ctx.status(200), ctx.json(response));
 	}),
+
+	rest.get(umbracoPath(`/tree${UMB_SLUG}/ancestors`), (req, res, ctx) => {
+		const descendantId = req.url.searchParams.get('descendantId');
+		if (!descendantId) return;
+		const response = umbMediaMockDb.tree.getAncestorsOf({ descendantId });
+		return res(ctx.status(200), ctx.json(response));
+	}),
 ];

--- a/src/Umbraco.Web.UI.Client/src/mocks/handlers/temporary-file/temporary-file.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/handlers/temporary-file/temporary-file.handlers.ts
@@ -7,6 +7,12 @@ const UMB_SLUG = 'temporary-file';
 
 export const handlers = [
 	rest.post(umbracoPath(`/${UMB_SLUG}`), async (_req, res, ctx) => {
-		return res(ctx.delay(), ctx.status(201), ctx.text<PostTemporaryFileResponse>(UmbId.new()));
+		const guid = UmbId.new();
+		return res(
+			ctx.delay(),
+			ctx.status(201),
+			ctx.set('Umb-Generated-Resource', guid),
+			ctx.text<PostTemporaryFileResponse>(guid),
+		);
 	}),
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/core/resources/tryXhrRequest.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/resources/tryXhrRequest.function.ts
@@ -1,23 +1,16 @@
-import { UMB_AUTH_CONTEXT } from '../auth/auth.context.token.js';
 import type { XhrRequestOptions } from './types.js';
 import { UmbResourceController } from './resource.controller.js';
-import { UmbContextConsumerController } from '@umbraco-cms/backoffice/context-api';
-import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { OpenAPI, type CancelablePromise } from '@umbraco-cms/backoffice/external/backend-api';
 
 /**
  * Make an XHR request.
- * @param host The controller host for this controller to be appended to.
- * @param options The options for the XHR request.
+ * @param {XhrRequestOptions} options The options for the XHR request.
+ * @returns {CancelablePromise} A promise that can be cancelled.
  */
-export function tryXhrRequest<T>(host: UmbControllerHost, options: XhrRequestOptions): CancelablePromise<T> {
+export function tryXhrRequest<T>(options: XhrRequestOptions): CancelablePromise<T> {
 	return UmbResourceController.xhrRequest<T>({
 		...options,
 		baseUrl: OpenAPI.BASE,
-		async token() {
-			const contextConsumer = new UmbContextConsumerController(host, UMB_AUTH_CONTEXT).asPromise();
-			const authContext = await contextConsumer;
-			return authContext.getLatestToken();
-		},
+		token: OpenAPI.TOKEN as never,
 	});
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/components/temporary-file-badge.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/components/temporary-file-badge.element.ts
@@ -4,19 +4,15 @@ import { clamp } from '@umbraco-cms/backoffice/utils';
 
 @customElement('umb-temporary-file-badge')
 export class UmbTemporaryFileBadgeElement extends UmbLitElement {
-	private _progress = 0;
+	#progress = 0;
 
 	@property({ type: Number })
 	public set progress(v: number) {
-		const oldVal = this._progress;
-
-		const p = clamp(v, 0, 100);
-		this._progress = p;
-
-		this.requestUpdate('progress', oldVal);
+		const p = clamp(Math.ceil(v), 0, 100);
+		this.#progress = p;
 	}
 	public get progress(): number {
-		return this._progress;
+		return this.#progress;
 	}
 
 	@property({ type: Boolean, reflect: true })
@@ -26,12 +22,10 @@ export class UmbTemporaryFileBadgeElement extends UmbLitElement {
 	public error = false;
 
 	override render() {
-		return html`<uui-badge>
-			<div id="wrapper">
-				<uui-loader-circle .progress=${this.complete || this.error ? 100 : this.progress}></uui-loader-circle>
-				${this.#renderIcon()}
-			</div>
-		</uui-badge>`;
+		return html` <div id="wrapper">
+			<uui-loader-circle .progress=${this.complete || this.error ? 100 : this.progress}></uui-loader-circle>
+			<div id="icon">${this.#renderIcon()}</div>
+		</div>`;
 	}
 
 	#renderIcon() {
@@ -43,50 +37,39 @@ export class UmbTemporaryFileBadgeElement extends UmbLitElement {
 			return html`<uui-icon name="icon-check"></uui-icon>`;
 		}
 
-		return html`<uui-icon name="icon-arrow-up"></uui-icon>`;
+		return `${this.progress}%`;
 	}
 
 	static override readonly styles = css`
-		:host {
-			display: block;
-		}
-
 		#wrapper {
-			box-sizing: border-box;
-			box-shadow: inset 0px 0px 0px 6px var(--uui-color-surface);
-			background-color: var(--uui-color-selected);
 			position: relative;
-			border-radius: 100%;
-			font-size: var(--uui-size-6);
+			height: 75%;
 		}
 
-		:host([complete]) #wrapper {
-			background-color: var(--uui-color-positive);
+		:host([complete]) {
+			uui-loader-circle,
+			#icon {
+				color: var(--uui-color-positive);
+			}
 		}
-		:host([complete]) uui-loader-circle {
-			color: var(--uui-color-positive);
-		}
-		:host([error]) #wrapper {
-			background-color: var(--uui-color-danger);
-		}
-		:host([error]) uui-loader-circle {
-			color: var(--uui-color-danger);
+		:host([error]) {
+			uui-loader-circle,
+			#icon {
+				color: var(--uui-color-danger);
+			}
 		}
 
 		uui-loader-circle {
-			display: absolute;
 			z-index: 2;
 			inset: 0;
 			color: var(--uui-color-focus);
 			font-size: var(--uui-size-12);
+			width: 100%;
+			height: 100%;
 		}
 
-		uui-badge {
-			padding: 0;
-			background-color: transparent;
-		}
-
-		uui-icon {
+		#icon {
+			color: var(--uui-color-text);
 			font-size: var(--uui-size-6);
 			position: absolute;
 			top: 50%;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/temporary-file-manager.class.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/temporary-file-manager.class.ts
@@ -34,7 +34,7 @@ export class UmbTemporaryFileManager<
 	): Promise<Array<UploadableItem>> {
 		this.#queue.setValue([]);
 
-		const items = queueItems.map((item): UploadableItem => ({ status: TemporaryFileStatus.WAITING, ...item }));
+		const items = queueItems.map((item): UploadableItem => ({ ...item, status: TemporaryFileStatus.WAITING }));
 		this.#queue.append(items);
 		return this.#handleQueue({ ...options });
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/temporary-file-manager.class.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/temporary-file-manager.class.ts
@@ -74,7 +74,10 @@ export class UmbTemporaryFileManager<
 	async #handleUpload(item: UploadableItem) {
 		if (!item.temporaryUnique) throw new Error(`Unique is missing for item ${item}`);
 
-		const { error } = await this.#temporaryFileRepository.upload(item.temporaryUnique, item.file);
+		const { error } = await this.#temporaryFileRepository.upload(item.temporaryUnique, item.file, (evt) => {
+			// Update progress in percent if a callback is provided
+			if (item.onProgress) item.onProgress((evt.loaded / evt.total) * 100);
+		});
 		const status = error ? TemporaryFileStatus.ERROR : TemporaryFileStatus.SUCCESS;
 
 		this.#queue.updateOne(item.temporaryUnique, { ...item, status });

--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/temporary-file.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/temporary-file.server.data-source.ts
@@ -35,7 +35,7 @@ export class UmbTemporaryFileServerDataSource {
 		const body = new FormData();
 		body.append('Id', id);
 		body.append('File', file);
-		const xhrRequest = tryXhrRequest<PostTemporaryFileResponse>(this.#host, {
+		const xhrRequest = tryXhrRequest<PostTemporaryFileResponse>({
 			url: '/umbraco/management/api/v1/temporary-file',
 			method: 'POST',
 			responseHeader: 'Umb-Generated-Resource',

--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/types.ts
@@ -8,6 +8,7 @@ export interface UmbTemporaryFileModel {
 	file: File;
 	temporaryUnique: string;
 	status?: TemporaryFileStatus;
+	onProgress?: (progress: number) => void;
 }
 
 export type UmbQueueHandlerCallback<TItem extends UmbTemporaryFileModel> = (item: TItem) => Promise<void>;

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/media-collection.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/media-collection.context.ts
@@ -33,6 +33,7 @@ export class UmbMediaCollectionContext extends UmbDefaultCollectionContext<
 				updateDate: date,
 				createDate: date,
 				entityType: UMB_MEDIA_PLACEHOLDER_ENTITY_TYPE,
+				progress: 0,
 				...placeholder,
 			}))
 			.reverse();
@@ -46,6 +47,11 @@ export class UmbMediaCollectionContext extends UmbDefaultCollectionContext<
 	updatePlaceholderStatus(unique: string, status?: UmbFileDropzoneItemStatus) {
 		this._items.updateOne(unique, { status });
 		this.#placeholders.updateOne(unique, { status });
+	}
+
+	updatePlaceholderProgress(unique: string, progress: number) {
+		this._items.updateOne(unique, { progress });
+		this.#placeholders.updateOne(unique, { progress });
 	}
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/media-collection.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/media-collection.context.ts
@@ -33,7 +33,6 @@ export class UmbMediaCollectionContext extends UmbDefaultCollectionContext<
 				updateDate: date,
 				createDate: date,
 				entityType: UMB_MEDIA_PLACEHOLDER_ENTITY_TYPE,
-				progress: 0,
 				...placeholder,
 			}))
 			.reverse();

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/media-collection.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/media-collection.element.ts
@@ -3,7 +3,7 @@ import { UMB_MEDIA_WORKSPACE_CONTEXT } from '../workspace/media-workspace.contex
 import type { UmbDropzoneSubmittedEvent } from '../dropzone/dropzone-submitted.event.js';
 import type { UmbDropzoneElement } from '../dropzone/dropzone.element.js';
 import { UMB_MEDIA_COLLECTION_CONTEXT } from './media-collection.context-token.js';
-import { customElement, html, query, state, when } from '@umbraco-cms/backoffice/external/lit';
+import { customElement, html, ref, state, when, type Ref } from '@umbraco-cms/backoffice/external/lit';
 import { UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection';
 import { UmbRequestReloadChildrenOfEntityEvent } from '@umbraco-cms/backoffice/entity-action';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
@@ -17,9 +17,6 @@ export class UmbMediaCollectionElement extends UmbCollectionDefaultElement {
 
 	@state()
 	private _unique: string | null = null;
-
-	@query('#dropzone')
-	private _dropzone!: UmbDropzoneElement;
 
 	constructor() {
 		super();
@@ -35,9 +32,10 @@ export class UmbMediaCollectionElement extends UmbCollectionDefaultElement {
 		});
 	}
 
-	#observeProgressItems() {
+	#observeProgressItems(dropzone?: Element) {
+		if (!dropzone) return;
 		this.observe(
-			this._dropzone.progressItems(),
+			(dropzone as UmbDropzoneElement).progressItems(),
 			(progressItems) => {
 				progressItems.forEach((item) => {
 					// We do not update folders as it may have children still being uploaded.
@@ -57,7 +55,6 @@ export class UmbMediaCollectionElement extends UmbCollectionDefaultElement {
 			.map((p) => ({ unique: p.unique, status: p.status, name: p.temporaryFile?.file.name ?? p.folder?.name }));
 
 		this.#collectionContext?.setPlaceholders(placeholders);
-		this.#observeProgressItems();
 	}
 
 	async #onComplete(event: Event) {
@@ -89,6 +86,7 @@ export class UmbMediaCollectionElement extends UmbCollectionDefaultElement {
 			${when(this._progress >= 0, () => html`<uui-loader-bar progress=${this._progress}></uui-loader-bar>`)}
 			<umb-dropzone
 				id="dropzone"
+				${ref(this.#observeProgressItems)}
 				multiple
 				.parentUnique=${this._unique}
 				@submitted=${this.#setupPlaceholders}

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/media-collection.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/media-collection.element.ts
@@ -3,7 +3,7 @@ import { UMB_MEDIA_WORKSPACE_CONTEXT } from '../workspace/media-workspace.contex
 import type { UmbDropzoneSubmittedEvent } from '../dropzone/dropzone-submitted.event.js';
 import type { UmbDropzoneElement } from '../dropzone/dropzone.element.js';
 import { UMB_MEDIA_COLLECTION_CONTEXT } from './media-collection.context-token.js';
-import { customElement, html, ref, state, when, type Ref } from '@umbraco-cms/backoffice/external/lit';
+import { customElement, html, ref, state, when } from '@umbraco-cms/backoffice/external/lit';
 import { UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection';
 import { UmbRequestReloadChildrenOfEntityEvent } from '@umbraco-cms/backoffice/entity-action';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/media-collection.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/media-collection.element.ts
@@ -42,6 +42,7 @@ export class UmbMediaCollectionElement extends UmbCollectionDefaultElement {
 					if (item.folder?.name) return;
 
 					this.#collectionContext?.updatePlaceholderStatus(item.unique, item.status);
+					this.#collectionContext?.updatePlaceholderProgress(item.unique, item.progress);
 				});
 			},
 			'_observeProgressItems',

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/types.ts
@@ -23,7 +23,10 @@ export interface UmbMediaCollectionItemModel {
 	values?: Array<{ alias: string; value: string }>;
 	url?: string;
 	status?: UmbFileDropzoneItemStatus;
-	progress: number;
+	/**
+	 * The progress of the item in percentage.
+	 */
+	progress?: number;
 }
 
 export interface UmbEditableMediaCollectionItemModel {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/types.ts
@@ -23,6 +23,7 @@ export interface UmbMediaCollectionItemModel {
 	values?: Array<{ alias: string; value: string }>;
 	url?: string;
 	status?: UmbFileDropzoneItemStatus;
+	progress: number;
 }
 
 export interface UmbEditableMediaCollectionItemModel {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/views/grid/media-grid-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/views/grid/media-grid-collection-view.element.ts
@@ -115,7 +115,10 @@ export class UmbMediaGridCollectionViewElement extends UmbLitElement {
 		const complete = item.status === UmbFileDropzoneItemStatus.COMPLETE;
 		const error = item.status === UmbFileDropzoneItemStatus.ERROR;
 		return html`<uui-card-media disabled class="media-placeholder-item" name=${ifDefined(item.name)}>
-			<umb-temporary-file-badge ?complete=${complete} ?error=${error}></umb-temporary-file-badge>
+			<umb-temporary-file-badge
+				.progress=${item.progress}
+				?complete=${complete}
+				?error=${error}></umb-temporary-file-badge>
 		</uui-card-media>`;
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/views/grid/media-grid-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/views/grid/media-grid-collection-view.element.ts
@@ -136,10 +136,6 @@ export class UmbMediaGridCollectionViewElement extends UmbLitElement {
 				align-items: center;
 			}
 
-			.media-placeholder-item {
-				font-style: italic;
-			}
-
 			/** TODO: Remove this fix when UUI gets upgrade to 1.3 */
 			umb-imaging-thumbnail {
 				pointer-events: none;

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/views/grid/media-grid-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/views/grid/media-grid-collection-view.element.ts
@@ -113,7 +113,7 @@ export class UmbMediaGridCollectionViewElement extends UmbLitElement {
 
 	#renderPlaceholder(item: UmbMediaCollectionItemModel) {
 		const complete = item.status === UmbFileDropzoneItemStatus.COMPLETE;
-		const error = item.status === UmbFileDropzoneItemStatus.ERROR;
+		const error = item.status !== UmbFileDropzoneItemStatus.WAITING && !complete;
 		return html`<uui-card-media disabled class="media-placeholder-item" name=${ifDefined(item.name)}>
 			<umb-temporary-file-badge
 				.progress=${item.progress}

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/views/grid/media-grid-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/views/grid/media-grid-collection-view.element.ts
@@ -116,7 +116,7 @@ export class UmbMediaGridCollectionViewElement extends UmbLitElement {
 		const error = item.status !== UmbFileDropzoneItemStatus.WAITING && !complete;
 		return html`<uui-card-media disabled class="media-placeholder-item" name=${ifDefined(item.name)}>
 			<umb-temporary-file-badge
-				.progress=${item.progress}
+				.progress=${item.progress ?? 0}
 				?complete=${complete}
 				?error=${error}></umb-temporary-file-badge>
 		</uui-card-media>`;

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/dropzone/dropzone-manager.class.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/dropzone/dropzone-manager.class.ts
@@ -20,6 +20,7 @@ import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 import type { UmbAllowedMediaTypeModel } from '@umbraco-cms/backoffice/media-type';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
+import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
 
 /**
  * Manages the dropzone and uploads folders and files to the server.
@@ -50,6 +51,7 @@ export class UmbDropzoneManager extends UmbControllerBase {
 	public readonly progressItems = this.#progressItems.asObservable();
 
 	#notificationContext?: typeof UMB_NOTIFICATION_CONTEXT.TYPE;
+	#localization = new UmbLocalizationController(this);
 
 	constructor(host: UmbControllerHost) {
 		super(host);
@@ -143,7 +145,7 @@ export class UmbDropzoneManager extends UmbControllerBase {
 		if (!options.length) {
 			this.#notificationContext?.peek('warning', {
 				data: {
-					message: `No media types are allowed for ${item.temporaryFile?.file.name}.`,
+					message: `${this.#localization.term('media_disallowedFileType')}: ${item.temporaryFile?.file.name}.`,
 				},
 			});
 			return this.#updateStatus(item, UmbFileDropzoneItemStatus.NOT_ALLOWED);

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/dropzone/dropzone-manager.class.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/dropzone/dropzone-manager.class.ts
@@ -114,16 +114,14 @@ export class UmbDropzoneManager extends UmbControllerBase {
 			const uploaded = await this.#tempFileManager.uploadOne({
 				temporaryUnique: item.temporaryFile.temporaryUnique,
 				file: item.temporaryFile.file,
+				onProgress: (progress) => this.#updateProgress(item, progress),
 			});
 
 			// Update progress
-			const progress = this.#progress.getValue();
-			this.#progress.update({ completed: progress.completed + 1 });
-
 			if (uploaded.status === TemporaryFileStatus.SUCCESS) {
-				this.#progressItems.updateOne(item.unique, { status: UmbFileDropzoneItemStatus.COMPLETE });
+				this.#updateStatus(item, UmbFileDropzoneItemStatus.COMPLETE);
 			} else {
-				this.#progressItems.updateOne(item.unique, { status: UmbFileDropzoneItemStatus.ERROR });
+				this.#updateStatus(item, UmbFileDropzoneItemStatus.ERROR);
 			}
 
 			// Add to return value

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/dropzone/dropzone.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/dropzone/dropzone.element.ts
@@ -1,9 +1,9 @@
 import { UmbDropzoneManager } from './dropzone-manager.class.js';
+import { UmbDropzoneSubmittedEvent } from './dropzone-submitted.event.js';
 import { UmbFileDropzoneItemStatus, type UmbUploadableItem } from './types.js';
 import { css, customElement, html, ifDefined, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { UUIFileDropzoneElement, UUIFileDropzoneEvent } from '@umbraco-cms/backoffice/external/uui';
-import { UmbDropzoneSubmittedEvent } from './dropzone-submitted.event.js';
 
 @customElement('umb-dropzone')
 export class UmbDropzoneElement extends UmbLitElement {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/dropzone/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/dropzone/types.ts
@@ -11,6 +11,7 @@ export interface UmbUploadableItem {
 	unique: string;
 	parentUnique: string | null;
 	status: UmbFileDropzoneItemStatus;
+	progress: number;
 	folder?: { name: string };
 	temporaryFile?: UmbTemporaryFileModel;
 }


### PR DESCRIPTION
## Description

With the change from Fetch to XHR in #18113 we now can follow along on the upload progress on dropped files on the dropzone in the Media Library. This PR aims to wire up the code from the **upload** function all the way back to the **temporary file badge**.

## Changes

- Wires up `onProgress` -> `progress()` through the **progressItems** and into the media collection grid view to show on the temporary file badge
- Changes the design of the **temporary file badge** to fill out the placeholder container, so that it is more visible
- Replaces the **arrow-up** icon in the temporary file badge with the actual **progress in percent** when uploading
- Introduces a new warning message if a dropped file has **no media types** (it was just ignored before)
- Fixes a lot of mock endpoints and data that were missing in MSW (note: XHR upload progress does not work through the service worker, so the progress goes from 0 to 100 without any indication, so test on the live server)
- Changes the signature of the newly introduced `xhrRequest` so it no longer accepts a controller host - it will now use the OpenApi object to infer the token directly instead allowing it to better mimic the generated ts client AND work with the mock server (this hasn't been released yet, so should be safe to break)


https://github.com/user-attachments/assets/54e141e3-9fb8-4714-b0a7-17fb324c4567

Note: The error shown when a file is too large is going to be addressed in another PR.

## How to test

- Drag & drop media on the media library
- Try and test both files that are not allowed and allowed at the same time (you need to go to the media types and type in allowed file extensions)
- Test larger files that take a while to upload to see that the progress is reflected
