### PR TITLE
Backport use of thread delay over sleep and handle dispose in FileSystemMainDomLock

### DIFF
--- a/src/Umbraco.Infrastructure/Runtime/FileSystemMainDomLock.cs
+++ b/src/Umbraco.Infrastructure/Runtime/FileSystemMainDomLock.cs
@@ -145,8 +145,8 @@ internal class FileSystemMainDomLock : IMainDomLock
                 {
                     _logger.LogDebug("Found lock release signal file, releasing lock on {lockFilePath}", _lockFilePath);
                 }
-                _lockFileStream?.Close();
-                _lockFileStream = null;
+
+                ReleaseLock();
                 break;
             }
 

--- a/src/Umbraco.Infrastructure/Runtime/FileSystemMainDomLock.cs
+++ b/src/Umbraco.Infrastructure/Runtime/FileSystemMainDomLock.cs
@@ -15,6 +15,7 @@ internal class FileSystemMainDomLock : IMainDomLock
     private readonly string _lockFilePath;
     private readonly ILogger<FileSystemMainDomLock> _logger;
     private readonly string _releaseSignalFilePath;
+    private bool _disposed;
     private Task? _listenForReleaseSignalFileTask;
 
     private FileStream? _lockFileStream;
@@ -88,16 +89,14 @@ internal class FileSystemMainDomLock : IMainDomLock
             ListeningLoop,
             _cancellationTokenSource.Token,
             TaskCreationOptions.LongRunning,
-            TaskScheduler.Default);
+            TaskScheduler.Default)
+            .Unwrap(); // Because ListeningLoop is an async method, we need to use Unwrap to return the inner task.
 
         return _listenForReleaseSignalFileTask;
     }
 
-    public void Dispose()
-    {
-        _lockFileStream?.Close();
-        _lockFileStream = null;
-    }
+    /// <summary>Releases the resources used by this <see cref="FileSystemMainDomLock" />.</summary>
+    public void Dispose() => Dispose(true);
 
     public void CreateLockReleaseSignalFile() =>
         File.Open(_releaseSignalFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite,
@@ -107,7 +106,27 @@ internal class FileSystemMainDomLock : IMainDomLock
     public void DeleteLockReleaseSignalFile() =>
         File.Delete(_releaseSignalFilePath);
 
-    private void ListeningLoop()
+    /// <summary>Releases the resources used by this <see cref="FileSystemMainDomLock" />.</summary>
+    /// <param name="disposing">true to release both managed resources.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing && !_disposed)
+        {
+            _logger.LogInformation($"{nameof(FileSystemMainDomLock)} Disposing...");
+            _cancellationTokenSource.Cancel();
+            _cancellationTokenSource.Dispose();
+            ReleaseLock();
+            _disposed = true;
+        }
+    }
+
+    private void ReleaseLock()
+    {
+        _lockFileStream?.Close();
+        _lockFileStream = null;
+    }
+
+    private async Task ListeningLoop()
     {
         while (true)
         {
@@ -131,7 +150,7 @@ internal class FileSystemMainDomLock : IMainDomLock
                 break;
             }
 
-            Thread.Sleep(_globalSettings.CurrentValue.MainDomReleaseSignalPollingInterval);
+            await Task.Delay(_globalSettings.CurrentValue.MainDomReleaseSignalPollingInterval, _cancellationTokenSource.Token);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description

This backports the changes applied in PRs https://github.com/umbraco/Umbraco-CMS/pull/18119 and https://github.com/umbraco/Umbraco-CMS/pull/18147.

Test steps are described in the second linked PR.  I've verified these on this PR for Umbraco 13.