### PR TITLE
Do not allow editing read-only properties by clicking their labels

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbtabbedcontent.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbtabbedcontent.directive.js
@@ -218,6 +218,10 @@
 
                 return !canEditCulture || !canEditSegment;
             }
+
+            $scope.isPreview = function(property) {
+              return ((property.readonly || !$scope.allowUpdate) && !property.supportsReadOnly) || ($scope.propertyEditorDisabled(property) && $scope.allowUpdate);
+            }
         }
 
         var directive = {

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbproperty.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbproperty.directive.js
@@ -25,7 +25,8 @@
                 propertyAlias: "@",
                 showInherit: "<",
                 inheritsFrom: "<",
-                hideLabel: "<?"
+                hideLabel: "<?",
+                preview: "<?",
             }
         });
 
@@ -34,14 +35,6 @@
     function UmbPropertyController($scope, userService, serverValidationManager, udiService, angularHelper) {
 
         const vm = this;
-
-        const propertyLockedListener = $scope.$on("umb-property-editor-locked", function(event, value) {
-          vm.preview = value;
-        });
-
-        $scope.$on("$destroy", function () {
-          propertyLockedListener();
-        });
 
         vm.$onInit = onInit;
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbproperty.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbproperty.directive.js
@@ -29,11 +29,19 @@
             }
         });
 
-    
+
 
     function UmbPropertyController($scope, userService, serverValidationManager, udiService, angularHelper) {
 
         const vm = this;
+
+        const propertyLockedListener = $scope.$on("umb-property-editor-locked", function(event, value) {
+          vm.preview = value;
+        });
+
+        $scope.$on("$destroy", function () {
+          propertyLockedListener();
+        });
 
         vm.$onInit = onInit;
 
@@ -55,7 +63,7 @@
         // returns the validation path for the property to be used as the validation key for server side validation logic
         vm.getValidationPath = function () {
 
-            var parentValidationPath = vm.parentUmbProperty ? vm.parentUmbProperty.getValidationPath() : null;            
+            var parentValidationPath = vm.parentUmbProperty ? vm.parentUmbProperty.getValidationPath() : null;
             var propAlias = vm.propertyAlias ? vm.propertyAlias : vm.property.alias;
             // the elementKey will be empty when this is not a nested property
             var valPath = vm.elementKey ? vm.elementKey + "/" + propAlias : propAlias;

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbproperty.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbproperty.directive.js
@@ -26,7 +26,7 @@
                 showInherit: "<",
                 inheritsFrom: "<",
                 hideLabel: "<?",
-                preview: "<?",
+                preview: "<?"
             }
         });
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbpropertyeditor.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbpropertyeditor.directive.js
@@ -1,7 +1,7 @@
 /**
 * @ngdoc directive
 * @function
-* @name umbraco.directives.directive:umbPropertyEditor
+* @name umbraco.directives.directive:umbPropertyEditor 
 * @requires formController
 * @restrict E
 **/
@@ -18,10 +18,10 @@ function umbPropEditor(umbPropEditorHelper, localizationService) {
                 allowUnlock: "<?",
                 onUnlock: "&?"
             },
-
+            
             require: ["^^form", "?^umbProperty"],
             restrict: 'E',
-            replace: true,
+            replace: true,      
             templateUrl: 'views/components/property/umb-property-editor.html',
             link: function (scope, element, attrs, ctrl) {
 
@@ -40,8 +40,6 @@ function umbPropEditor(umbPropEditorHelper, localizationService) {
                    scope.model.alias = Math.random().toString(36).slice(2);
                 }
 
-                emitPropertyLocked(scope.preview);
-
                 localizationService.localize('languages_invariantPropertyUnlockHelp',  [scope.model.label])
                     .then(function(value) {
                         scope.labels.invariantPropertyUnlockHelp = value;
@@ -51,7 +49,7 @@ function umbPropEditor(umbPropEditorHelper, localizationService) {
                     .then(function(value) {
                         scope.labels.invariantCulturePropertyUnlockHelp = value;
                     });
-
+                
                 localizationService.localize('languages_invariantSegmentPropertyUnlockHelp',  [scope.model.label])
                     .then(function(value) {
                         scope.labels.invariantSegmentPropertyUnlockHelp = value;
@@ -66,7 +64,6 @@ function umbPropEditor(umbPropEditorHelper, localizationService) {
                 scope.unlock = function () {
                     if (scope.onUnlock) {
                         scope.onUnlock();
-                        emitPropertyLocked(false);
                     }
                 };
 
@@ -77,10 +74,6 @@ function umbPropEditor(umbPropEditorHelper, localizationService) {
                 scope.$on("$destroy", function () {
                     unbindWatcher();
                 });
-
-                function emitPropertyLocked(locked) {
-                    scope.$emit("umb-property-editor-locked", locked);
-                }
             }
         };
     };

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbpropertyeditor.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/property/umbpropertyeditor.directive.js
@@ -1,7 +1,7 @@
 /**
 * @ngdoc directive
 * @function
-* @name umbraco.directives.directive:umbPropertyEditor 
+* @name umbraco.directives.directive:umbPropertyEditor
 * @requires formController
 * @restrict E
 **/
@@ -18,10 +18,10 @@ function umbPropEditor(umbPropEditorHelper, localizationService) {
                 allowUnlock: "<?",
                 onUnlock: "&?"
             },
-            
+
             require: ["^^form", "?^umbProperty"],
             restrict: 'E',
-            replace: true,      
+            replace: true,
             templateUrl: 'views/components/property/umb-property-editor.html',
             link: function (scope, element, attrs, ctrl) {
 
@@ -40,6 +40,8 @@ function umbPropEditor(umbPropEditorHelper, localizationService) {
                    scope.model.alias = Math.random().toString(36).slice(2);
                 }
 
+                emitPropertyLocked(scope.preview);
+
                 localizationService.localize('languages_invariantPropertyUnlockHelp',  [scope.model.label])
                     .then(function(value) {
                         scope.labels.invariantPropertyUnlockHelp = value;
@@ -49,7 +51,7 @@ function umbPropEditor(umbPropEditorHelper, localizationService) {
                     .then(function(value) {
                         scope.labels.invariantCulturePropertyUnlockHelp = value;
                     });
-                
+
                 localizationService.localize('languages_invariantSegmentPropertyUnlockHelp',  [scope.model.label])
                     .then(function(value) {
                         scope.labels.invariantSegmentPropertyUnlockHelp = value;
@@ -64,6 +66,7 @@ function umbPropEditor(umbPropEditorHelper, localizationService) {
                 scope.unlock = function () {
                     if (scope.onUnlock) {
                         scope.onUnlock();
+                        emitPropertyLocked(false);
                     }
                 };
 
@@ -74,6 +77,10 @@ function umbPropEditor(umbPropEditorHelper, localizationService) {
                 scope.$on("$destroy", function () {
                     unbindWatcher();
                 });
+
+                function emitPropertyLocked(locked) {
+                    scope.$emit("umb-property-editor-locked", locked);
+                }
             }
         };
     };

--- a/src/Umbraco.Web.UI.Client/src/views/components/content/umb-tabbed-content.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/content/umb-tabbed-content.html
@@ -15,12 +15,13 @@
                     property="property"
                     node="contentNodeModel"
                     show-inherit="contentNodeModel.variants.length > 1 && property.variation !== 'CultureAndSegment'"
-                    inherits-from="defaultVariant.displayName">
+                    inherits-from="defaultVariant.displayName"
+                    preview="isPreview(property)">
 
                     <umb-property-editor
                         model="property"
                         node="contentNodeModel"
-                        preview="((property.readonly || !allowUpdate) && !property.supportsReadOnly) || (propertyEditorDisabled(property) && allowUpdate)"
+                        preview="isPreview(property)"
                         allow-unlock="!property.readonly && allowUpdate && allowEditInvariantFromNonDefault"
                         on-unlock="unlockInvariantValue(property)"
                         ng-attr-readonly="{{property.readonly || !allowUpdate || undefined}}">
@@ -49,12 +50,13 @@
                     property="property"
                     node="contentNodeModel"
                     show-inherit="contentNodeModel.variants.length > 1 && property.variation !== 'CultureAndSegment'"
-                    inherits-from="defaultVariant.displayName">
+                    inherits-from="defaultVariant.displayName"
+                    preview="isPreview(property)">
 
                     <umb-property-editor
                         model="property"
                         node="contentNodeModel"
-                        preview="((property.readonly || !allowUpdate) && !property.supportsReadOnly) || (propertyEditorDisabled(property) && allowUpdate)"
+                        preview="isPreview(property)"
                         allow-unlock="!property.readonly && allowUpdate && allowEditInvariantFromNonDefault"
                         on-unlock="unlockInvariantValue(property)"
                         ng-attr-readonly="{{property.readonly || !allowUpdate || undefined}}">

--- a/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/property/umb-property.html
@@ -9,7 +9,7 @@
 
                 <div class="control-header" ng-hide="(vm.hideLabel || vm.property.hideLabel) === true">
 
-                    <label data-element="property-label-{{vm.property.alias}}" class="control-label" for="{{vm.property.alias}}" ng-attr-title="{{vm.controlLabelTitle}}" aria-label="Property alias: {{vm.controlAriaLabel}}">{{vm.property.label}}<span ng-if="vm.property.validation.mandatory || vm.property.ncMandatory"><strong class="umb-control-required">*</strong></span></label>
+                    <label data-element="property-label-{{vm.property.alias}}" class="control-label" for="{{vm.preview ? undefined : vm.property.alias}}" ng-attr-title="{{vm.controlLabelTitle}}" aria-label="Property alias: {{vm.controlAriaLabel}}">{{vm.property.label}}<span ng-if="vm.property.validation.mandatory || vm.property.ncMandatory"><strong class="umb-control-required">*</strong></span></label>
 
                     <umb-property-actions actions="vm.propertyActions"></umb-property-actions>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #16022

### Description

It is possible to edit simple properties despite them being read-only; clicking their labels will do the trick:

[16022.webm](https://github.com/user-attachments/assets/00b2f763-be8a-445e-ae67-b84da4c712dd)

This of course won't stand, so here's a PR to fix 😆 

### Testing this PR

1. It should _only_ be possible to edit "shared" properties in the default language when `AllowEditInvariantFromNonDefault` is configured as `false`.
2. It should _not_ be possible to edit "shared" properties in _any_ language when `AllowEditInvariantFromNonDefault` is configured as `true`, until the properties have explicitly been "unlocked" for editing.

Also test that invariant content (and media) can be edited as per usual.