### PR TITLE
V15/sort by selected icons

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/modal/sort-children-of-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/modal/sort-children-of-modal.element.ts
@@ -287,8 +287,9 @@ export class UmbSortChildrenOfModalElement extends UmbModalBaseElement<
 	}
 
 	#renderChild(item: UmbTreeItemModel) {
+		// TODO: find a way to get the icon for the item. We do not have the icon in the tree item model.
 		return html` <uui-table-row id="content-node" data-unique=${item.unique} class="${this._isSorting ? 'hidden' : ''}">
-			<uui-table-cell><umb-icon name="${item.documentType.icon}"></umb-icon></uui-table-cell>
+			<uui-table-cell><umb-icon name="icon-navigation"></umb-icon></uui-table-cell>
 			<uui-table-cell>${item.name}</uui-table-cell>
 			<uui-table-cell>${this.#renderCreateDate(item)}</uui-table-cell>
 		</uui-table-row>`;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/modal/sort-children-of-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/modal/sort-children-of-modal.element.ts
@@ -286,10 +286,8 @@ export class UmbSortChildrenOfModalElement extends UmbModalBaseElement<
 		</uui-table-head-cell>`;
 	}
 
-	#renderChild(item: UmbTreeItemModel) {	
-		return html`
-		
-		<uui-table-row id="content-node" data-unique=${item.unique} class="${this._isSorting ? 'hidden' : ''}">
+	#renderChild(item: UmbTreeItemModel) {
+		return html` <uui-table-row id="content-node" data-unique=${item.unique} class="${this._isSorting ? 'hidden' : ''}">
 			<uui-table-cell><umb-icon name="${item.documentType.icon}"></umb-icon></uui-table-cell>
 			<uui-table-cell>${item.name}</uui-table-cell>
 			<uui-table-cell>${this.#renderCreateDate(item)}</uui-table-cell>
@@ -313,10 +311,11 @@ export class UmbSortChildrenOfModalElement extends UmbModalBaseElement<
 			}
 
 			uui-table-cell {
-				padding: var(--uui-size-space-2);
+				padding: var(--uui-size-space-2) var(--uui-size-space-5);
 			}
+
 			uui-table-head-cell {
-				padding: 0;
+				padding: 0 var(--uui-size-space-5);
 			}
 
 			uui-table-head-cell button {
@@ -338,13 +337,13 @@ export class UmbSortChildrenOfModalElement extends UmbModalBaseElement<
 			}
 
 			uui-table-row[id='content-node']:hover {
-				cursor: grab; 
+				cursor: grab;
 			}
 
 			uui-icon[name='icon-navigation'] {
 				cursor: hand;
 			}
-			
+
 			uui-box {
 				--uui-box-default-padding: 0;
 			}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/modal/sort-children-of-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/modal/sort-children-of-modal.element.ts
@@ -286,18 +286,11 @@ export class UmbSortChildrenOfModalElement extends UmbModalBaseElement<
 		</uui-table-head-cell>`;
 	}
 
-	#renderChild(item: UmbTreeItemModel) {
-
-		let iconColor = {};
-		const iconInfo = item.documentType.icon.split(" ");
-		if(iconInfo[1]) {
-			iconColor = iconInfo[1].split("-");
-		}
-		
-		
+	#renderChild(item: UmbTreeItemModel) {	
 		return html`
+		
 		<uui-table-row id="content-node" data-unique=${item.unique} class="${this._isSorting ? 'hidden' : ''}">
-			<uui-table-cell><uui-icon  name="${iconInfo[0]}" style="color: ${iconColor[1]}"; aria-hidden="true"></uui-icon></uui-table-cell>
+			<uui-table-cell><umb-icon name="${item.documentType.icon}"></umb-icon></uui-table-cell>
 			<uui-table-cell>${item.name}</uui-table-cell>
 			<uui-table-cell>${this.#renderCreateDate(item)}</uui-table-cell>
 		</uui-table-row>`;
@@ -319,7 +312,10 @@ export class UmbSortChildrenOfModalElement extends UmbModalBaseElement<
 				width: 100%;
 			}
 			uui-table-cell {
-				padding: var(--uui-size-space-2); var(--uui-size-space-0);
+				padding: var(--uui-size-space-2);
+			}
+			uui-table-head-cell {
+				padding: 0;
 			}
 
 			uui-table-head-cell button {
@@ -346,11 +342,15 @@ export class UmbSortChildrenOfModalElement extends UmbModalBaseElement<
 			}
 
 			uui-table-row[id='content-node']:hover {
-			cursor: grab;
+				cursor: grab;
 			}
 
 			uui-icon[name='icon-navigation'] {
 				cursor: hand;
+			}
+			
+			uui-box {
+				--uui-box-default-padding: 0;
 			}
 		`,
 	];

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/modal/sort-children-of-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/modal/sort-children-of-modal.element.ts
@@ -287,8 +287,17 @@ export class UmbSortChildrenOfModalElement extends UmbModalBaseElement<
 	}
 
 	#renderChild(item: UmbTreeItemModel) {
-		return html` <uui-table-row data-unique=${item.unique} class="${this._isSorting ? 'hidden' : ''}">
-			<uui-table-cell><uui-icon name="icon-navigation" aria-hidden="true"></uui-icon></uui-table-cell>
+
+		let iconColor = {};
+		const iconInfo = item.documentType.icon.split(" ");
+		if(iconInfo[1]) {
+			iconColor = iconInfo[1].split("-");
+		}
+		
+		
+		return html`
+		<uui-table-row id="content-node" data-unique=${item.unique} class="${this._isSorting ? 'hidden' : ''}">
+			<uui-table-cell><uui-icon  name="${iconInfo[0]}" style="color: ${iconColor[1]}"; aria-hidden="true"></uui-icon></uui-table-cell>
 			<uui-table-cell>${item.name}</uui-table-cell>
 			<uui-table-cell>${this.#renderCreateDate(item)}</uui-table-cell>
 		</uui-table-row>`;
@@ -309,6 +318,9 @@ export class UmbSortChildrenOfModalElement extends UmbModalBaseElement<
 			#loadMoreButton {
 				width: 100%;
 			}
+			uui-table-cell {
+				padding: var(--uui-size-space-2); var(--uui-size-space-0);
+			}
 
 			uui-table-head-cell button {
 				background-color: transparent;
@@ -326,6 +338,15 @@ export class UmbSortChildrenOfModalElement extends UmbModalBaseElement<
 
 			uui-table-row.hidden {
 				visibility: hidden;
+			}
+
+			uui-table-cell uui-icon {
+				display: flex;
+				
+			}
+
+			uui-table-row[id='content-node']:hover {
+			cursor: grab;
 			}
 
 			uui-icon[name='icon-navigation'] {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/modal/sort-children-of-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/modal/sort-children-of-modal.element.ts
@@ -338,7 +338,7 @@ export class UmbSortChildrenOfModalElement extends UmbModalBaseElement<
 			}
 
 			uui-table-row[id='content-node']:hover {
-				cursor: grab;
+				cursor: grab; 
 			}
 
 			uui-icon[name='icon-navigation'] {

--- a/src/Umbraco.Web.UI/appsettings.Development.template.json
+++ b/src/Umbraco.Web.UI/appsettings.Development.template.json
@@ -25,6 +25,12 @@
   },
   "Umbraco": {
     "CMS": {
+      "Security":{
+			"BackOfficeHost": "http://localhost:5173",
+			"AuthorizeCallbackPathName": "/oauth_complete",
+			"AuthorizeCallbackLogoutPathName": "/logout",
+			"AuthorizeCallbackErrorPathName": "/error",
+		},
       "Examine": {
         "LuceneDirectoryFactory": "TempFileSystemDirectoryFactory"
       },

--- a/src/Umbraco.Web.UI/appsettings.Development.template.json
+++ b/src/Umbraco.Web.UI/appsettings.Development.template.json
@@ -25,12 +25,6 @@
   },
   "Umbraco": {
     "CMS": {
-      "Security":{
-			"BackOfficeHost": "http://localhost:5173",
-			"AuthorizeCallbackPathName": "/oauth_complete",
-			"AuthorizeCallbackLogoutPathName": "/logout",
-			"AuthorizeCallbackErrorPathName": "/error",
-		},
       "Examine": {
         "LuceneDirectoryFactory": "TempFileSystemDirectoryFactory"
       },


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes
Sort children displays default icon instead of selected icon https://github.com/umbraco/Umbraco-CMS/issues/18153

### Description

adds back the custom icon for the content nodes and give a hover effect to indicate that it is grabable, and applys the choosen color

#### Steps to reproduce
- Create a couple of document types and set their icon
- Create some content
- Use the sort children action


<!-- Thanks for contributing to Umbraco CMS! -->
