### PR TITLE
More robust resolving of Delivery API redirects

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Services/RequestRedirectService.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/RequestRedirectService.cs
@@ -42,31 +42,42 @@ internal sealed class RequestRedirectService : RoutingServiceBase, IRequestRedir
     {
         requestedPath = requestedPath.EnsureStartsWith("/");
 
+        IPublishedContent? startItem = GetStartItem();
+
         // must append the root content url segment if it is not hidden by config, because
         // the URL tracking is based on the actual URL, including the root content url segment
-        if (_globalSettings.HideTopLevelNodeFromPath == false)
+        if (_globalSettings.HideTopLevelNodeFromPath == false && startItem?.UrlSegment != null)
         {
-            IPublishedContent? startItem = GetStartItem();
-            if (startItem?.UrlSegment != null)
-            {
-                requestedPath = $"{startItem.UrlSegment.EnsureStartsWith("/")}{requestedPath}";
-            }
+            requestedPath = $"{startItem.UrlSegment.EnsureStartsWith("/")}{requestedPath}";
         }
 
         var culture = _requestCultureService.GetRequestedCulture();
 
-        // append the configured domain content ID to the path if we have a domain bound request,
-        // because URL tracking registers the tracked url like "{domain content ID}/{content path}"
-        Uri contentRoute = GetDefaultRequestUri(requestedPath);
-        DomainAndUri? domainAndUri = GetDomainAndUriForRoute(contentRoute);
-        if (domainAndUri != null)
+        // important: redirect URLs are always tracked without trailing slashes
+        requestedPath = requestedPath.TrimEnd("/");
+        IRedirectUrl? redirectUrl = _redirectUrlService.GetMostRecentRedirectUrl(requestedPath, culture);
+
+        // if a redirect URL was not found, try by appending the start item ID because URL tracking might have tracked
+        // a redirect with "{root content ID}/{content path}"
+        if (redirectUrl is null && startItem is not null)
         {
-            requestedPath = GetContentRoute(domainAndUri, contentRoute);
-            culture ??= domainAndUri.Culture;
+            redirectUrl = _redirectUrlService.GetMostRecentRedirectUrl($"{startItem.Id}{requestedPath}", culture);
         }
 
-        // important: redirect URLs are always tracked without trailing slashes
-        IRedirectUrl? redirectUrl = _redirectUrlService.GetMostRecentRedirectUrl(requestedPath.TrimEnd("/"), culture);
+        // still no redirect URL found - try looking for a configured domain if we have a domain bound request,
+        // because URL tracking might have tracked a redirect with "{domain content ID}/{content path}"
+        if (redirectUrl is null)
+        {
+            Uri contentRoute = GetDefaultRequestUri(requestedPath);
+            DomainAndUri? domainAndUri = GetDomainAndUriForRoute(contentRoute);
+            if (domainAndUri is not null)
+            {
+                requestedPath = GetContentRoute(domainAndUri, contentRoute);
+                culture ??= domainAndUri.Culture;
+                redirectUrl = _redirectUrlService.GetMostRecentRedirectUrl(requestedPath, culture);
+            }
+        }
+
         IPublishedContent? content = redirectUrl != null
             ? _apiPublishedContentCache.GetById(redirectUrl.ContentKey)
             : null;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #16901

### Description

As described in the linked issue, URL redirects can fail to resolve under certain conditions.

The culprit is how URL redirects are tracked - and how it changes over time, depending on content configuration:

- Sometimes a redirect is tracked solely by the original relative path
- Sometimes a redirect is tracked using the magic "root ID prefix" for the relative path - i.e. `1234/original/path` 

The magic "root ID prefix" seems generally to be applied when there are domains configured. Since redirects can be created both before and after domain configurations, we potentially have to look for both permutations when resolving redirect URLs for the Delivery API.

This PR updates the logic to be as follows:

1. If a redirect URL can be found at the naked route, use that.
2. If a redirect URL was not found, and a start item has been provided (which is recommended), use that as "root ID prefix" to resolve a redirect URL.
3. If a redirect URL is still not found, look for domain configurations matching the current request. If any match is found, use the mapped content item as "root ID prefix" in an attempt to resolve a redirect URL.

### Testing this PR

First and foremost you'll likely need to use Postman to test this, and make sure that it's setup to _not_ follow redirects automatically.

Test redirects for content structures

- With and without domain assignments.
- With one and with multiple root items.

The logic outlined above should provide test cases. 

#### To explicitly verify that this PR fixes the linked issue

Create a content setup with:

- Multiple root items with children.
- Explicit, absolute and non-localhost domain mappings for all root items (hint: use localtest.me to be able to perform requests against them).

Request one of the children by path from the Delivery API using **localhost** and its corresponding **start-item** header.

Rename the child and re-publish it. This should result in a tracked redirect URL.

Request the child by path from the Delivery API again. The Delivery API should respond with an appropriate redirect.
