### PR TITLE
Excluded tags from trashed content

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TagRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TagRepository.cs
@@ -387,7 +387,9 @@ WHERE r.tagId IS NULL";
         }).ToList();
 
     /// <inheritdoc />
-    public IEnumerable<ITag> GetTagsForEntityType(TaggableObjectTypes objectType, string? group = null,
+    public IEnumerable<ITag> GetTagsForEntityType(
+        TaggableObjectTypes objectType,
+        string? group = null,
         string? culture = null)
     {
         Sql<ISqlContext> sql = GetTagsSql(culture, true);
@@ -400,6 +402,9 @@ WHERE r.tagId IS NULL";
             sql = sql
                 .Where<NodeDto>(dto => dto.NodeObjectType == nodeObjectType);
         }
+
+        sql = sql
+            .Where<NodeDto>(dto => !dto.Trashed);
 
         if (group.IsNullOrWhiteSpace() == false)
         {


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/15524

### Description

This PR backports the fix provided by @rammi987 in https://github.com/umbraco/Umbraco-CMS/pull/15554.

I found in testing that PR that we didn't need the part around excluding unpublished content and it was sufficient to port over just the part relating to trashed content and media.

Other than the provided integration test, it can be reviewed using the following code added to a template:

```
@{
    @inject ITagQuery _tagQuery;
    var contentTags = _tagQuery.GetAllContentTags().OrderBy(x => x?.Text);
    <div>Content Tags: @string.Join(", ", contentTags.Select(x => x?.Text))</div>
    var mediaTags = _tagQuery.GetAllMediaTags().OrderBy(x => x?.Text);
    <div>Media Tags: @string.Join(", ", mediaTags.Select(x => x?.Text))</div>
}
```

And verifying that tagged content or media in the recycle bin aren't included in the displayed output.

I'll merge this one once the checks are happy as it's come from a community PR, so has already had two sets of eyes.