### PR TITLE
Feature: reworking error toast notifications

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
@@ -583,6 +583,8 @@ export default {
 		deleteLayout: 'You are deleting the layout',
 		deletingALayout:
 			'Modifying layout will result in loss of data for any existing content that is based on this configuration.',
+		seeErrorAction: 'Se fejlen',
+		seeErrorDialogHeadline: 'Fejl detaljer',
 	},
 	dictionary: {
 		noItems: 'Der er ingen ordbogselementer.',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
@@ -614,6 +614,8 @@ export default {
 		deleteLayout: 'You are deleting the layout',
 		deletingALayout:
 			'Modifying layout will result in loss of data for any existing content that is based on this configuration.',
+		seeErrorAction: 'See error',
+		seeErrorDialogHeadline: 'Error details',
 	},
 	dictionary: {
 		importDictionaryItemHelp:

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -606,6 +606,8 @@ export default {
 		deletingALayout:
 			'Modifying layout will result in loss of data for any existing content that is based on this configuration.',
 		selectEditorConfiguration: 'Select configuration',
+		seeErrorAction: 'See error',
+		seeErrorDialogHeadline: 'Error details',
 	},
 	dictionary: {
 		importDictionaryItemHelp:

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/code-block/code-block.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/code-block/code-block.element.ts
@@ -68,7 +68,6 @@ export class UmbCodeBlockElement extends LitElement {
 			}
 
 			uui-scroll-container {
-				max-height: 500px;
 				overflow-y: auto;
 				overflow-wrap: anywhere;
 			}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/manifests.ts
@@ -11,6 +11,7 @@ import { manifests as iconRegistryManifests } from './icon-registry/manifests.js
 import { manifests as localizationManifests } from './localization/manifests.js';
 import { manifests as menuManifests } from './menu/manifests.js';
 import { manifests as modalManifests } from './modal/manifests.js';
+import { manifests as notificationManifests } from './notification/manifests.js';
 import { manifests as pickerManifests } from './picker/manifests.js';
 import { manifests as propertyActionManifests } from './property-action/manifests.js';
 import { manifests as propertyEditorManifests } from './property-editor/manifests.js';
@@ -39,6 +40,7 @@ export const manifests: Array<UmbExtensionManifest | UmbExtensionManifestKind> =
 	...localizationManifests,
 	...menuManifests,
 	...modalManifests,
+	...notificationManifests,
 	...pickerManifests,
 	...propertyActionManifests,
 	...propertyEditorManifests,

--- a/src/Umbraco.Web.UI.Client/src/packages/core/notification/controllers/peek-error/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/notification/controllers/peek-error/index.ts
@@ -1,0 +1,1 @@
+export * from './peek-error.controller.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/notification/controllers/peek-error/peek-error-notification.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/notification/controllers/peek-error/peek-error-notification.element.ts
@@ -1,0 +1,38 @@
+import { customElement, html, ifDefined, nothing, property } from '@umbraco-cms/backoffice/external/lit';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import type { UmbNotificationHandler } from '../../notification-handler';
+import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
+import type { UmbPeekErrorArgs } from '../../types.js';
+import { UMB_ERROR_VIEWER_MODAL } from '../../index.js';
+
+@customElement('umb-peek-error-notification')
+export class UmbPeekErrorNotificationElement extends UmbLitElement {
+	@property({ attribute: false })
+	public data?: UmbPeekErrorArgs;
+
+	public notificationHandler!: UmbNotificationHandler;
+
+	async #onClick() {
+		const modalManager = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);
+
+		modalManager.open(this, UMB_ERROR_VIEWER_MODAL, { data: this.data });
+
+		this.notificationHandler.close();
+	}
+
+	protected override render() {
+		return this.data
+			? html`<uui-toast-notification-layout headline=${ifDefined(this.data.headline)}
+					>${this.data.message}${this.data.details
+						? html`<uui-button slot="action" look="primary" color="danger" @click=${this.#onClick}></uui-button>`
+						: nothing}</uui-toast-notification-layout
+				>`
+			: nothing;
+	}
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-peek-error-notification': UmbPeekErrorNotificationElement;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/notification/controllers/peek-error/peek-error-notification.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/notification/controllers/peek-error/peek-error-notification.element.ts
@@ -15,7 +15,7 @@ export class UmbPeekErrorNotificationElement extends UmbLitElement {
 	async #onClick() {
 		const modalManager = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);
 
-		modalManager.open(this, UMB_ERROR_VIEWER_MODAL, { data: this.data });
+		modalManager.open(this, UMB_ERROR_VIEWER_MODAL, { data: this.data?.details });
 
 		this.notificationHandler.close();
 	}
@@ -24,7 +24,12 @@ export class UmbPeekErrorNotificationElement extends UmbLitElement {
 		return this.data
 			? html`<uui-toast-notification-layout headline=${ifDefined(this.data.headline)}
 					>${this.data.message}${this.data.details
-						? html`<uui-button slot="action" look="primary" color="danger" @click=${this.#onClick}></uui-button>`
+						? html`<uui-button
+								slot="actions"
+								look="primary"
+								color="danger"
+								label=${this.localize.term('defaultdialogs_seeErrorAction')}
+								@click=${this.#onClick}></uui-button>`
 						: nothing}</uui-toast-notification-layout
 				>`
 			: nothing;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/notification/controllers/peek-error/peek-error.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/notification/controllers/peek-error/peek-error.controller.ts
@@ -1,0 +1,33 @@
+import { UMB_NOTIFICATION_CONTEXT } from '../../notification.context.js';
+import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import type { UmbPeekErrorArgs } from '../../types.js';
+
+import './peek-error-notification.element.js';
+
+export class UmbPeekErrorController extends UmbControllerBase {
+	async open(args: UmbPeekErrorArgs): Promise<void> {
+		const context = await this.getContext(UMB_NOTIFICATION_CONTEXT);
+
+		context.peek('danger', {
+			elementName: 'umb-peek-error-notification',
+			data: args,
+		});
+
+		// This is a one time off, so we can destroy our selfs.
+		this.destroy();
+
+		return;
+	}
+}
+
+/**
+ *
+ * @param host {UmbControllerHost} - The host controller
+ * @param args {UmbPeekErrorArgs} - The data to pass to the notification
+ * @returns {UmbPeekErrorController} The notification peek controller instance
+ */
+export function umbPeekError(host: UmbControllerHost, args: UmbPeekErrorArgs) {
+	console.log(host);
+	return new UmbPeekErrorController(host).open(args);
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/notification/extractUmbNotificationColor.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/notification/extractUmbNotificationColor.function.ts
@@ -1,5 +1,5 @@
-import type { UmbNotificationColor } from './notification.context.js';
 import { EventMessageTypeModel } from '@umbraco-cms/backoffice/external/backend-api';
+import type { UmbNotificationColor } from './types';
 
 /**
  *

--- a/src/Umbraco.Web.UI.Client/src/packages/core/notification/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/notification/index.ts
@@ -1,7 +1,9 @@
 import './layouts/default/index.js';
-
-export * from './notification.context.js';
-export * from './notification-handler.js';
-
-export * from './isUmbNotifications.function.js';
+export * from './controllers/peek-error/index.js';
 export * from './extractUmbNotificationColor.function.js';
+export * from './isUmbNotifications.function.js';
+export * from './modals/error-viewer/index.js';
+export * from './notification-handler.js';
+export * from './notification.context.js';
+
+export type * from './types.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/notification/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/notification/manifests.ts
@@ -1,0 +1,3 @@
+import { manifest } from './modals/error-viewer/manifest.js';
+
+export const manifests = [manifest];

--- a/src/Umbraco.Web.UI.Client/src/packages/core/notification/modals/error-viewer/error-viewer-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/notification/modals/error-viewer/error-viewer-modal.element.ts
@@ -1,9 +1,15 @@
 import type { UmbErrorViewerModalData, UmbErrorViewerModalValue } from './error-viewer-modal.token.js';
-import { css, customElement, html, nothing } from '@umbraco-cms/backoffice/external/lit';
+import { css, customElement, html, nothing, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 
 @customElement('umb-error-viewer-modal')
 export class UmbErrorViewerModalElement extends UmbModalBaseElement<UmbErrorViewerModalData, UmbErrorViewerModalValue> {
+	@state()
+	_displayError?: string;
+
+	@state()
+	_displayLang?: string;
+
 	// Code adapted from https://stackoverflow.com/a/57668208/12787
 	// Licensed under the permissions of the CC BY-SA 4.0 DEED
 	#stringify(obj: any): string {
@@ -24,12 +30,26 @@ export class UmbErrorViewerModalElement extends UmbModalBaseElement<UmbErrorView
 		return output + '\n}';
 	}
 
+	public override set data(value: UmbErrorViewerModalData | undefined) {
+		super.data = value;
+		console.log(value, typeof value);
+		// is JSON:
+		if (typeof value === 'string') {
+			this._displayLang = 'String';
+			this._displayError = value;
+		} else {
+			this._displayLang = 'JSON';
+			this._displayError = this.#stringify(value);
+		}
+	}
+	public override get data(): UmbErrorViewerModalData | undefined {
+		return super.data;
+	}
+
 	override render() {
 		return html`
-			<umb-body-layout headline=${this.localize.term('general_manifest')} main-no-padding>
-				${this.data
-					? html`<umb-code-block language="JSON" copy>${this.#stringify(this.data)}</umb-code-block>`
-					: nothing}
+			<umb-body-layout headline=${this.localize.term('defaultdialogs_seeErrorDialogHeadline')} main-no-padding>
+				${this.data ? html`<umb-code-block language=${this._displayLang} copy>${this.data}</umb-code-block>` : nothing}
 				<div slot="actions">
 					<uui-button label=${this.localize.term('general_close')} @click=${this._rejectModal}></uui-button>
 				</div>

--- a/src/Umbraco.Web.UI.Client/src/packages/core/notification/modals/error-viewer/error-viewer-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/notification/modals/error-viewer/error-viewer-modal.element.ts
@@ -1,0 +1,56 @@
+import type { UmbErrorViewerModalData, UmbErrorViewerModalValue } from './error-viewer-modal.token.js';
+import { css, customElement, html, nothing } from '@umbraco-cms/backoffice/external/lit';
+import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
+
+@customElement('umb-error-viewer-modal')
+export class UmbErrorViewerModalElement extends UmbModalBaseElement<UmbErrorViewerModalData, UmbErrorViewerModalValue> {
+	// Code adapted from https://stackoverflow.com/a/57668208/12787
+	// Licensed under the permissions of the CC BY-SA 4.0 DEED
+	#stringify(obj: any): string {
+		let output = '{';
+		for (const key in obj) {
+			let value = obj[key];
+			if (typeof value === 'function') {
+				value = value.toString();
+			} else if (value instanceof Array) {
+				value = JSON.stringify(value);
+			} else if (typeof value === 'object') {
+				value = this.#stringify(value);
+			} else {
+				value = `"${value}"`;
+			}
+			output += `\n  ${key}: ${value},`;
+		}
+		return output + '\n}';
+	}
+
+	override render() {
+		return html`
+			<umb-body-layout headline=${this.localize.term('general_manifest')} main-no-padding>
+				${this.data
+					? html`<umb-code-block language="JSON" copy>${this.#stringify(this.data)}</umb-code-block>`
+					: nothing}
+				<div slot="actions">
+					<uui-button label=${this.localize.term('general_close')} @click=${this._rejectModal}></uui-button>
+				</div>
+			</umb-body-layout>
+		`;
+	}
+
+	static override styles = [
+		css`
+			umb-code-block {
+				border: none;
+				height: 100%;
+			}
+		`,
+	];
+}
+
+export default UmbErrorViewerModalElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-error-viewer-modal': UmbErrorViewerModalElement;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/notification/modals/error-viewer/error-viewer-modal.token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/notification/modals/error-viewer/error-viewer-modal.token.ts
@@ -1,0 +1,17 @@
+import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
+import type { UmbPeekErrorArgs } from '../../types';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface UmbErrorViewerModalData extends UmbPeekErrorArgs {}
+
+export type UmbErrorViewerModalValue = undefined;
+
+export const UMB_ERROR_VIEWER_MODAL = new UmbModalToken<UmbErrorViewerModalData, UmbErrorViewerModalValue>(
+	'Umb.Modal.ErrorViewer',
+	{
+		modal: {
+			type: 'sidebar',
+			size: 'medium',
+		},
+	},
+);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/notification/modals/error-viewer/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/notification/modals/error-viewer/index.ts
@@ -1,0 +1,2 @@
+export * from './error-viewer-modal.token.js';
+export * from './manifest.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/notification/modals/error-viewer/manifest.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/notification/modals/error-viewer/manifest.ts
@@ -1,0 +1,8 @@
+import type { ManifestModal } from '@umbraco-cms/backoffice/modal';
+
+export const manifest: ManifestModal = {
+	type: 'modal',
+	alias: 'Umb.Modal.ErrorViewer',
+	name: 'Error Viewer Modal',
+	element: () => import('./error-viewer-modal.element.js'),
+};

--- a/src/Umbraco.Web.UI.Client/src/packages/core/notification/notification-handler.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/notification/notification-handler.test.ts
@@ -1,5 +1,5 @@
 import { UmbNotificationHandler } from './notification-handler.js';
-import type { UmbNotificationOptions } from './notification.context.js';
+import type { UmbNotificationOptions } from './types.js';
 import { assert, expect } from '@open-wc/testing';
 import { UmbId } from '@umbraco-cms/backoffice/id';
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/notification/notification-handler.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/notification/notification-handler.ts
@@ -1,10 +1,8 @@
-import type {
-	UmbNotificationOptions,
-	UmbNotificationColor,
-	UmbNotificationDefaultData,
-} from './notification.context.js';
+import type { UmbNotificationOptions, UmbNotificationColor, UmbNotificationDefaultData } from './types.js';
 import type { UUIToastNotificationElement } from '@umbraco-cms/backoffice/external/uui';
 import { UmbId } from '@umbraco-cms/backoffice/id';
+
+const DEFAULT_LAYOUT = 'umb-notification-layout-default';
 
 /**
  * @class UmbNotificationHandler
@@ -17,10 +15,9 @@ export class UmbNotificationHandler {
 
 	private _defaultColor: UmbNotificationColor = 'default';
 	private _defaultDuration = 6000;
-	private _defaultLayout = 'umb-notification-layout-default';
 
 	public key: string;
-	public element: any;
+	public element!: UUIToastNotificationElement;
 	public color: UmbNotificationColor;
 	public duration: number | null;
 
@@ -34,22 +31,12 @@ export class UmbNotificationHandler {
 		this.color = options.color || this._defaultColor;
 		this.duration = options.duration !== undefined ? options.duration : this._defaultDuration;
 
-		this._elementName = options.elementName || this._defaultLayout;
+		this._elementName = options.elementName || DEFAULT_LAYOUT;
 		this._data = options.data;
 
 		this._closePromise = new Promise((res) => {
 			this._closeResolver = res;
 		});
-
-		this._createElement();
-	}
-
-	/**
-	 * @private
-	 * @memberof UmbNotificationHandler
-	 */
-	private _createElement() {
-		if (!this._elementName) return;
 
 		const notification: UUIToastNotificationElement = document.createElement('uui-toast-notification');
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/notification/notification.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/notification/notification.context.ts
@@ -3,29 +3,7 @@ import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
 import { UmbBasicState } from '@umbraco-cms/backoffice/observable-api';
-
-/**
- * The default data of notifications
- * @interface UmbNotificationDefaultData
- */
-export interface UmbNotificationDefaultData {
-	message: string;
-	headline?: string;
-	structuredList?: Record<string, Array<unknown>>;
-}
-
-/**
- * @interface UmbNotificationOptions
- * @template UmbNotificationData
- */
-export interface UmbNotificationOptions<UmbNotificationData = UmbNotificationDefaultData> {
-	color?: UmbNotificationColor;
-	duration?: number | null;
-	elementName?: string;
-	data?: UmbNotificationData;
-}
-
-export type UmbNotificationColor = '' | 'default' | 'positive' | 'warning' | 'danger';
+import type { UmbNotificationColor, UmbNotificationOptions } from './types.js';
 
 export class UmbNotificationContext extends UmbContextBase<UmbNotificationContext> {
 	// Notice this cannot use UniqueBehaviorSubject as it holds a HTML Element. which cannot be Serialized to JSON (it has some circular references)
@@ -42,9 +20,9 @@ export class UmbNotificationContext extends UmbContextBase<UmbNotificationContex
 	 * @returns {*}  {UmbNotificationHandler}
 	 * @memberof UmbNotificationContext
 	 */
-	private _open(options: UmbNotificationOptions): UmbNotificationHandler {
+	#open<T extends UmbNotificationOptions = UmbNotificationOptions>(options: T): UmbNotificationHandler {
 		const notificationHandler = new UmbNotificationHandler(options);
-		notificationHandler.element.addEventListener('closed', () => this._handleClosed(notificationHandler));
+		notificationHandler.element?.addEventListener('closed', () => this._handleClosed(notificationHandler));
 
 		this._notifications.setValue([...this._notifications.getValue(), notificationHandler]);
 
@@ -78,8 +56,11 @@ export class UmbNotificationContext extends UmbContextBase<UmbNotificationContex
 	 * @returns {*}
 	 * @memberof UmbNotificationContext
 	 */
-	public peek(color: UmbNotificationColor, options: UmbNotificationOptions): UmbNotificationHandler {
-		return this._open({ color, ...options });
+	public peek<T extends UmbNotificationOptions = UmbNotificationOptions>(
+		color: UmbNotificationColor,
+		options: T,
+	): UmbNotificationHandler {
+		return this.#open({ color, ...options });
 	}
 
 	/**
@@ -89,8 +70,11 @@ export class UmbNotificationContext extends UmbContextBase<UmbNotificationContex
 	 * @returns {*}
 	 * @memberof UmbNotificationContext
 	 */
-	public stay(color: UmbNotificationColor, options: UmbNotificationOptions): UmbNotificationHandler {
-		return this._open({ ...options, color, duration: null });
+	public stay<T extends UmbNotificationOptions = UmbNotificationOptions>(
+		color: UmbNotificationColor,
+		options: T,
+	): UmbNotificationHandler {
+		return this.#open({ ...options, color, duration: null });
 	}
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/notification/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/notification/types.ts
@@ -1,0 +1,29 @@
+/**
+ * The default data of notifications
+ * @interface UmbNotificationDefaultData
+ */
+export interface UmbNotificationDefaultData {
+	message: string;
+	headline?: string;
+	/**
+	 * @deprecated, do not use this. It will be removed in v.16 — Use UmbPeekError instead
+	 */
+	structuredList?: Record<string, Array<unknown>>;
+}
+
+/**
+ * @interface UmbNotificationOptions
+ * @template UmbNotificationData
+ */
+export interface UmbNotificationOptions<UmbNotificationData = UmbNotificationDefaultData> {
+	color?: UmbNotificationColor;
+	duration?: number | null;
+	elementName?: string;
+	data?: UmbNotificationData;
+}
+
+export type UmbNotificationColor = '' | 'default' | 'positive' | 'warning' | 'danger';
+
+export interface UmbPeekErrorArgs extends UmbNotificationDefaultData {
+	details?: any;
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/resources/resource.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/resources/resource.controller.ts
@@ -4,12 +4,7 @@ import { isApiError, isCancelError, isCancelablePromise } from './apiTypeValidat
 import type { XhrRequestOptions } from './types.js';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
-import { UmbContextConsumerController } from '@umbraco-cms/backoffice/context-api';
-import {
-	UMB_NOTIFICATION_CONTEXT,
-	umbPeekError,
-	type UmbNotificationOptions,
-} from '@umbraco-cms/backoffice/notification';
+import { umbPeekError, type UmbNotificationOptions } from '@umbraco-cms/backoffice/notification';
 import type { UmbDataSourceResponse } from '@umbraco-cms/backoffice/repository';
 import {
 	ApiError,
@@ -122,13 +117,10 @@ export class UmbResourceController extends UmbControllerBase {
 									'The Umbraco object cache is corrupt, but your action may still have been executed. Please restart the server to reset the cache. This is a work in progress.';
 							}
 
-							const notificationContext = await this.getContext(UMB_NOTIFICATION_CONTEXT);
-							notificationContext.peek('danger', {
-								data: {
-									headline,
-									message,
-								},
-								...options,
+							umbPeekError(this, {
+								headline: headline,
+								message: message,
+								details: problemDetails?.errors ?? problemDetails?.detail,
 							});
 						}
 						break;
@@ -136,7 +128,6 @@ export class UmbResourceController extends UmbControllerBase {
 						// Other errors
 						if (!isCancelledByNotification) {
 							/*
-
 							const notificationContext = await this.getContext(UMB_NOTIFICATION_CONTEXT);
 							notificationContext.peek('danger', {
 								data: {
@@ -151,9 +142,8 @@ export class UmbResourceController extends UmbControllerBase {
 							*/
 							const headline = problemDetails?.title ?? error.name ?? 'Server Error';
 							umbPeekError(this, {
-								headline: problemDetails?.detail ? headline : undefined,
-								message: problemDetails?.detail ?? headline,
-								details: problemDetails?.errors,
+								message: headline,
+								details: problemDetails?.errors ?? problemDetails?.detail,
 							});
 						}
 				}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/entity-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/entity-detail-workspace-base.ts
@@ -382,7 +382,7 @@ export abstract class UmbEntityDetailWorkspaceContextBase<
 			this,
 			umbExtensionsRegistry,
 			repositoryAlias,
-			[this._host],
+			[],
 			(permitted, ctrl) => {
 				this._detailRepository = permitted ? ctrl.api : undefined;
 				this.#checkIfInitialized();

--- a/src/Umbraco.Web.UI.Client/src/packages/models-builder/models-builder-dashboard.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/models-builder/models-builder-dashboard.element.ts
@@ -95,7 +95,7 @@ export class UmbModelsBuilderDashboardElement extends UmbLitElement {
 				</p>
 				${this._modelsBuilder?.lastError
 					? html`<p class="error">Last generation failed with the following error:</p>
-							<umb-code-block>${this._modelsBuilder.lastError}</umb-code-block>`
+							<umb-code-block style="max-height:500px;">${this._modelsBuilder.lastError}</umb-code-block>`
 					: nothing}
 			</uui-box>
 		`;

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/modals/templating-page-field-builder/templating-page-field-builder-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/modals/templating-page-field-builder/templating-page-field-builder-modal.element.ts
@@ -94,7 +94,7 @@ export class UmbTemplatingPageFieldBuilderModalElement extends UmbModalBaseEleme
 							?disabled=${this._field ? false : true}></uui-checkbox>
 
 						<uui-label><umb-localize key="templateEditor_outputSample">Output sample</umb-localize></uui-label>
-						<umb-code-block language="C#" copy
+						<umb-code-block style="max-height:500px;" language="C#" copy
 							>${this._field ? getUmbracoFieldSnippet(this._field, this._default, this._recursive) : ''}</umb-code-block
 						>
 					</div>

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/modals/query-builder/query-builder-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/modals/query-builder/query-builder-modal.element.ts
@@ -254,7 +254,9 @@ export default class UmbTemplateQueryBuilderModalElement extends UmbModalBaseEle
 								(sample) => html`<span><umb-icon name=${sample.icon}></umb-icon>${sample.name}</span>`,
 							) ?? ''}
 						</div>
-						<umb-code-block language="C#" copy>${this._templateQuery?.queryExpression ?? ''}</umb-code-block>
+						<umb-code-block style="max-height:500px;" language="C#" copy
+							>${this._templateQuery?.queryExpression ?? ''}</umb-code-block
+						>
 					</uui-box>
 				</div>
 


### PR DESCRIPTION
Making errors appear in a dialog + displaying errors for both 'detail' and 'errors'.

See screenshots:

**Case 1:**
Insert this somewhere in a Server Controller code:
`throw new NotImplementedException();`

![image](https://github.com/user-attachments/assets/b7f0b36b-29f0-4555-a8bd-e2be76be9261)
![image](https://github.com/user-attachments/assets/c2ff822c-4cfc-4246-b2ff-06d8705df584)

**Case 2**
Remove the front-end code of `${umbBindToValidation(this)}` from name input in `src/Umbraco.Web.UI.Client/src/packages/templating/templates/workspace/template-workspace-editor.element.ts`.

![image](https://github.com/user-attachments/assets/7094306d-4786-4123-9104-739c344c042d)
![image](https://github.com/user-attachments/assets/6da27cb7-a58e-41bb-b174-9ef617c526a8)
