### PR TITLE
Use variant context for determining requested culture

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Querying/QueryOptionBase.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Querying/QueryOptionBase.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Extensions;
 
@@ -10,8 +11,8 @@ public abstract class QueryOptionBase
 {
     private readonly IRequestRoutingService _requestRoutingService;
     private readonly IRequestPreviewService _requestPreviewService;
-    private readonly IRequestCultureService _requestCultureService;
     private readonly IApiDocumentUrlService _apiDocumentUrlService;
+    private readonly IVariationContextAccessor _variationContextAccessor;
 
     [Obsolete("Please use the non-obsolete constructor. Will be removed in V17.")]
     public QueryOptionBase(
@@ -20,8 +21,8 @@ public abstract class QueryOptionBase
         : this(
             requestRoutingService,
             StaticServiceProvider.Instance.GetRequiredService<IRequestPreviewService>(),
-            StaticServiceProvider.Instance.GetRequiredService<IRequestCultureService>(),
-            StaticServiceProvider.Instance.GetRequiredService<IApiDocumentUrlService>())
+            StaticServiceProvider.Instance.GetRequiredService<IApiDocumentUrlService>(),
+            StaticServiceProvider.Instance.GetRequiredService<IVariationContextAccessor>())
     {
     }
 
@@ -31,21 +32,22 @@ public abstract class QueryOptionBase
         IRequestRoutingService requestRoutingService,
         IRequestPreviewService requestPreviewService,
         IRequestCultureService requestCultureService,
-        IApiDocumentUrlService apiDocumentUrlService)
-        : this(requestRoutingService, requestPreviewService, requestCultureService, apiDocumentUrlService)
+        IApiDocumentUrlService apiDocumentUrlService,
+        IVariationContextAccessor variationContextAccessor)
+        : this(requestRoutingService, requestPreviewService, apiDocumentUrlService, variationContextAccessor)
     {
     }
 
     public QueryOptionBase(
         IRequestRoutingService requestRoutingService,
         IRequestPreviewService requestPreviewService,
-        IRequestCultureService requestCultureService,
-        IApiDocumentUrlService apiDocumentUrlService)
+        IApiDocumentUrlService apiDocumentUrlService,
+        IVariationContextAccessor variationContextAccessor)
     {
         _requestRoutingService = requestRoutingService;
         _requestPreviewService = requestPreviewService;
-        _requestCultureService = requestCultureService;
         _apiDocumentUrlService = apiDocumentUrlService;
+        _variationContextAccessor = variationContextAccessor;
     }
 
     protected Guid? GetGuidFromQuery(string queryStringValue)
@@ -64,7 +66,7 @@ public abstract class QueryOptionBase
         var contentRoute = _requestRoutingService.GetContentRoute(queryStringValue);
         return _apiDocumentUrlService.GetDocumentKeyByRoute(
             contentRoute,
-            _requestCultureService.GetRequestedCulture(),
+            _variationContextAccessor.VariationContext?.Culture,
             _requestPreviewService.IsPreview());
     }
 }

--- a/src/Umbraco.Cms.Api.Delivery/Querying/Selectors/AncestorsSelector.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Querying/Selectors/AncestorsSelector.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Api.Delivery.Indexing.Selectors;
 using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Services.Navigation;
 
@@ -20,10 +21,9 @@ public sealed class AncestorsSelector : QueryOptionBase, ISelectorHandler
         IRequestPreviewService requestPreviewService)
         : this(
             requestRoutingService,
-            StaticServiceProvider.Instance.GetRequiredService<IPublishedContentCache>(),
-            StaticServiceProvider.Instance.GetRequiredService<IRequestPreviewService>(),
-            StaticServiceProvider.Instance.GetRequiredService<IRequestCultureService>(),
+            requestPreviewService,
             StaticServiceProvider.Instance.GetRequiredService<IApiDocumentUrlService>(),
+            StaticServiceProvider.Instance.GetRequiredService<IVariationContextAccessor>(),
             navigationQueryService)
     {
     }
@@ -35,10 +35,9 @@ public sealed class AncestorsSelector : QueryOptionBase, ISelectorHandler
         IDocumentNavigationQueryService navigationQueryService)
         : this(
             requestRoutingService,
-            StaticServiceProvider.Instance.GetRequiredService<IPublishedContentCache>(),
             StaticServiceProvider.Instance.GetRequiredService<IRequestPreviewService>(),
-            StaticServiceProvider.Instance.GetRequiredService<IRequestCultureService>(),
             StaticServiceProvider.Instance.GetRequiredService<IApiDocumentUrlService>(),
+            StaticServiceProvider.Instance.GetRequiredService<IVariationContextAccessor>(),
             navigationQueryService)
     {
     }
@@ -47,10 +46,9 @@ public sealed class AncestorsSelector : QueryOptionBase, ISelectorHandler
     public AncestorsSelector(IPublishedContentCache publishedContentCache, IRequestRoutingService requestRoutingService)
         : this(
             requestRoutingService,
-            StaticServiceProvider.Instance.GetRequiredService<IPublishedContentCache>(),
             StaticServiceProvider.Instance.GetRequiredService<IRequestPreviewService>(),
-            StaticServiceProvider.Instance.GetRequiredService<IRequestCultureService>(),
             StaticServiceProvider.Instance.GetRequiredService<IApiDocumentUrlService>(),
+            StaticServiceProvider.Instance.GetRequiredService<IVariationContextAccessor>(),
             StaticServiceProvider.Instance.GetRequiredService<IDocumentNavigationQueryService>())
     {
     }
@@ -58,10 +56,10 @@ public sealed class AncestorsSelector : QueryOptionBase, ISelectorHandler
     public AncestorsSelector(
         IRequestRoutingService requestRoutingService,
         IRequestPreviewService requestPreviewService,
-        IRequestCultureService requestCultureService,
         IApiDocumentUrlService apiDocumentUrlService,
+        IVariationContextAccessor variationContextAccessor,
         IDocumentNavigationQueryService navigationQueryService)
-        : base(requestRoutingService, requestPreviewService, requestCultureService, apiDocumentUrlService)
+        : base(requestRoutingService, requestPreviewService, apiDocumentUrlService, variationContextAccessor)
         => _navigationQueryService = navigationQueryService;
 
     [Obsolete("Use the constructor that takes all parameters. Scheduled for removal in V17.")]
@@ -69,10 +67,10 @@ public sealed class AncestorsSelector : QueryOptionBase, ISelectorHandler
         IRequestRoutingService requestRoutingService,
         IPublishedContentCache publishedContentCache,
         IRequestPreviewService requestPreviewService,
-        IRequestCultureService requestCultureService,
         IApiDocumentUrlService apiDocumentUrlService,
+        IVariationContextAccessor variationContextAccessor,
         IDocumentNavigationQueryService navigationQueryService)
-        : this(requestRoutingService, requestPreviewService, requestCultureService, apiDocumentUrlService, navigationQueryService)
+        : this(requestRoutingService, requestPreviewService, apiDocumentUrlService, variationContextAccessor, navigationQueryService)
     {
     }
 

--- a/src/Umbraco.Cms.Api.Delivery/Querying/Selectors/ChildrenSelector.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Querying/Selectors/ChildrenSelector.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Api.Delivery.Indexing.Selectors;
 using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Extensions;
 
@@ -16,8 +17,8 @@ public sealed class ChildrenSelector : QueryOptionBase, ISelectorHandler
         : this(
             requestRoutingService,
             StaticServiceProvider.Instance.GetRequiredService<IRequestPreviewService>(),
-            StaticServiceProvider.Instance.GetRequiredService<IRequestCultureService>(),
-            StaticServiceProvider.Instance.GetRequiredService<IApiDocumentUrlService>())
+            StaticServiceProvider.Instance.GetRequiredService<IApiDocumentUrlService>(),
+            StaticServiceProvider.Instance.GetRequiredService<IVariationContextAccessor>())
     {
     }
 
@@ -26,18 +27,18 @@ public sealed class ChildrenSelector : QueryOptionBase, ISelectorHandler
         IPublishedContentCache publishedContentCache,
         IRequestRoutingService requestRoutingService,
         IRequestPreviewService requestPreviewService,
-        IRequestCultureService requestCultureService,
-        IApiDocumentUrlService apiDocumentUrlService)
-        : this(requestRoutingService, requestPreviewService, requestCultureService, apiDocumentUrlService)
+        IApiDocumentUrlService apiDocumentUrlService,
+        IVariationContextAccessor variationContextAccessor)
+        : this(requestRoutingService, requestPreviewService, apiDocumentUrlService, variationContextAccessor)
     {
     }
 
     public ChildrenSelector(
         IRequestRoutingService requestRoutingService,
         IRequestPreviewService requestPreviewService,
-        IRequestCultureService requestCultureService,
-        IApiDocumentUrlService apiDocumentUrlService)
-        : base(requestRoutingService, requestPreviewService, requestCultureService, apiDocumentUrlService)
+        IApiDocumentUrlService apiDocumentUrlService,
+        IVariationContextAccessor variationContextAccessor)
+        : base(requestRoutingService, requestPreviewService, apiDocumentUrlService, variationContextAccessor)
     {
     }
 

--- a/src/Umbraco.Cms.Api.Delivery/Querying/Selectors/DescendantsSelector.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Querying/Selectors/DescendantsSelector.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Api.Delivery.Indexing.Selectors;
 using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Extensions;
 
@@ -16,8 +17,8 @@ public sealed class DescendantsSelector : QueryOptionBase, ISelectorHandler
         : this(
             requestRoutingService,
             StaticServiceProvider.Instance.GetRequiredService<IRequestPreviewService>(),
-            StaticServiceProvider.Instance.GetRequiredService<IRequestCultureService>(),
-            StaticServiceProvider.Instance.GetRequiredService<IApiDocumentUrlService>())
+            StaticServiceProvider.Instance.GetRequiredService<IApiDocumentUrlService>(),
+            StaticServiceProvider.Instance.GetRequiredService<IVariationContextAccessor>())
     {
     }
 
@@ -26,18 +27,18 @@ public sealed class DescendantsSelector : QueryOptionBase, ISelectorHandler
         IPublishedContentCache publishedContentCache,
         IRequestRoutingService requestRoutingService,
         IRequestPreviewService requestPreviewService,
-        IRequestCultureService requestCultureService,
-        IApiDocumentUrlService apiDocumentUrlService)
-        : this(requestRoutingService, requestPreviewService, requestCultureService, apiDocumentUrlService)
+        IApiDocumentUrlService apiDocumentUrlService,
+        IVariationContextAccessor variationContextAccessor)
+        : this(requestRoutingService, requestPreviewService, apiDocumentUrlService, variationContextAccessor)
     {
     }
 
     public DescendantsSelector(
         IRequestRoutingService requestRoutingService,
         IRequestPreviewService requestPreviewService,
-        IRequestCultureService requestCultureService,
-        IApiDocumentUrlService apiDocumentUrlService)
-        : base(requestRoutingService, requestPreviewService, requestCultureService, apiDocumentUrlService)
+        IApiDocumentUrlService apiDocumentUrlService,
+        IVariationContextAccessor variationContextAccessor)
+        : base(requestRoutingService, requestPreviewService, apiDocumentUrlService, variationContextAccessor)
     {
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/Selectors/AncestorsSelectorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/Selectors/AncestorsSelectorTests.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using Umbraco.Cms.Api.Delivery.Querying.Selectors;
 using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.Navigation;
 
@@ -47,8 +48,8 @@ public class AncestorsSelectorTests
         var subject = new AncestorsSelector(
             requestRoutingServiceMock.Object,
             Mock.Of<IRequestPreviewService>(),
-            Mock.Of<IRequestCultureService>(),
             new ApiDocumentUrlService(documentUrlServiceMock.Object),
+            Mock.Of<IVariationContextAccessor>(),
             _documentNavigationQueryService);
 
         var result = subject.BuildSelectorOption("ancestors:/some/where");
@@ -63,8 +64,8 @@ public class AncestorsSelectorTests
         var subject = new AncestorsSelector(
             Mock.Of<IRequestRoutingService>(),
             Mock.Of<IRequestPreviewService>(),
-            Mock.Of<IRequestCultureService>(),
             Mock.Of<IApiDocumentUrlService>(),
+            Mock.Of<IVariationContextAccessor>(),
             _documentNavigationQueryService);
 
         var result = subject.BuildSelectorOption($"ancestors:{_documentKey:D}");

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/Selectors/ChildrenSelectorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/Selectors/ChildrenSelectorTests.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using Umbraco.Cms.Api.Delivery.Querying.Selectors;
 using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.DeliveryApi.Selectors;
@@ -30,8 +31,8 @@ public class ChildrenSelectorTests
         var subject = new ChildrenSelector(
             requestRoutingServiceMock.Object,
             Mock.Of<IRequestPreviewService>(),
-            Mock.Of<IRequestCultureService>(),
-            new ApiDocumentUrlService(documentUrlServiceMock.Object));
+            new ApiDocumentUrlService(documentUrlServiceMock.Object),
+            Mock.Of<IVariationContextAccessor>());
 
         var result = subject.BuildSelectorOption("children:/some/where");
         Assert.AreEqual(1, result.Values.Length);
@@ -46,8 +47,8 @@ public class ChildrenSelectorTests
         var subject = new ChildrenSelector(
             Mock.Of<IRequestRoutingService>(),
             Mock.Of<IRequestPreviewService>(),
-            Mock.Of<IRequestCultureService>(),
-            Mock.Of<IApiDocumentUrlService>());
+            Mock.Of<IApiDocumentUrlService>(),
+            Mock.Of<IVariationContextAccessor>());
 
         var result = subject.BuildSelectorOption($"children:{documentKey:D}");
         Assert.AreEqual(1, result.Values.Length);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/Selectors/DescendantsSelectorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/Selectors/DescendantsSelectorTests.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using Umbraco.Cms.Api.Delivery.Querying.Selectors;
 using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.DeliveryApi.Selectors;
@@ -30,8 +31,8 @@ public class DescendantsSelectorTests
         var subject = new DescendantsSelector(
             requestRoutingServiceMock.Object,
             Mock.Of<IRequestPreviewService>(),
-            Mock.Of<IRequestCultureService>(),
-            new ApiDocumentUrlService(documentUrlServiceMock.Object));
+            new ApiDocumentUrlService(documentUrlServiceMock.Object),
+            Mock.Of<IVariationContextAccessor>());
 
         var result = subject.BuildSelectorOption("descendants:/some/where");
         Assert.AreEqual(1, result.Values.Length);
@@ -46,8 +47,8 @@ public class DescendantsSelectorTests
         var subject = new DescendantsSelector(
             Mock.Of<IRequestRoutingService>(),
             Mock.Of<IRequestPreviewService>(),
-            Mock.Of<IRequestCultureService>(),
-            Mock.Of<IApiDocumentUrlService>());
+            Mock.Of<IApiDocumentUrlService>(),
+            Mock.Of<IVariationContextAccessor>());
 
         var result = subject.BuildSelectorOption($"descendants:{documentKey:D}");
         Assert.AreEqual(1, result.Values.Length);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

It seems the Delivery API is broadly using `IRequestCultureService` to determine the requested culture, when it should be using the variant context.

While it works splendidly when actively providing the expected culture context in the `accept-language` header, it works less well when using domain mappings to achieve culture context.

The whole thing seems to originate in the V15 redo of routing, and #18036 (by yours truly) has only made it worse 🙈 

This PR ensures that we only use `IRequestCultureService` the way it was intended (the way it's used in V13), and use the variant context to figure out the request culture context when needed.

### Testing this PR

First and foremost, the steps for testing #18036 should be re-iterated, because this PR changes a lot of the same code.

Next, given the languages `en-US` and `da-DK` exists, create a culture variant content structure like this:

```
# en-US language version
> Root EN
  > Child EN
    > Grandchild EN

# da-DK language version
> Root DA
  > Child DA
    > Grandchild DA
```

Add these domain mappings to `Root`:

- `/` = `en-US`
- `/da` = `da-DK`

Verify that language specific versions of the structure can be fetched by using the domain mappings - e.g.:

- `/` should yield `Root` in English.
- `/child-en/grandchild-en` should yield `Grandchild` in English.
- `/da` should yield `Root` in Danish.
- `/da/child-da/grandchild-da` should yield `Grandchild` Danish.
