### PR TITLE
Show notifications menu only to users with permission for the feature

### DIFF
--- a/src/Umbraco.Web.BackOffice/Trees/ContentTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/ContentTreeController.cs
@@ -317,13 +317,7 @@ public class ContentTreeController : ContentTreeControllerBase, ISearchableTreeW
 
         if (_emailSender.CanSendRequiredEmail())
         {
-            menu.Items.Add(new MenuItem("notify", LocalizedTextService)
-            {
-                Icon = "icon-megaphone",
-                SeparatorBefore = true,
-                OpensDialog = true,
-                UseLegacyIcon = false
-            });
+            AddActionNode<ActionNotify>(item, menu, hasSeparator: true, opensDialog: true, useLegacyIcon: false);
         }
 
         if ((item is DocumentEntitySlim documentEntity && documentEntity.IsContainer) == false)


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/18167

### Description
Issue seemed to be caused by using a different method to add this action to the menu.  When we do it the way we were, we have no `Action` property set, and hence the menu item is considered as one that's not affected by permissions.

Switching it to be registered in the way the other menu items were resolves this, and I don't see any downsides in doing so.

**To Test:**

- Verify that a user in a user group with the "Notifications" permission can manage notifications.
- Verify that a user in a user group without the "Notifications" permission cannot manage notifications. 