### PR TITLE
V15/feature/notification-whitespace

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/notification/layouts/default/notification-layout-default.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/notification/layouts/default/notification-layout-default.element.ts
@@ -6,7 +6,6 @@ import {
 	ifDefined,
 	nothing,
 	css,
-	styleMap,
 } from '@umbraco-cms/backoffice/external/lit';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import type { UmbNotificationDefaultData, UmbNotificationHandler } from '@umbraco-cms/backoffice/notification';
@@ -24,7 +23,7 @@ export class UmbNotificationLayoutDefaultElement extends LitElement {
 	override render() {
 		return html`
 			<uui-toast-notification-layout id="layout" headline="${ifDefined(this.data.headline)}" class="uui-text">
-				<div id="message" style=${styleMap({ whiteSpace: this.data.whitespace })}>${this.data.message}</div>
+				<div id="message">${this.data.message}</div>
 				${this.#renderStructuredList(this.data.structuredList)}
 			</uui-toast-notification-layout>
 		`;
@@ -56,6 +55,9 @@ export class UmbNotificationLayoutDefaultElement extends LitElement {
 	static override styles = [
 		UmbTextStyles,
 		css`
+			#message {
+				white-space: pre-line;
+			}
 			.structured-list ul {
 				margin: 0;
 			}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/notification/notification.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/notification/notification.context.ts
@@ -12,7 +12,6 @@ export interface UmbNotificationDefaultData {
 	message: string;
 	headline?: string;
 	structuredList?: Record<string, Array<unknown>>;
-	whitespace?: 'normal' | 'pre-line' | 'pre-wrap' | 'nowrap' | 'pre';
 }
 
 /**

--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/temporary-file-manager.class.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/temporary-file-manager.class.ts
@@ -89,10 +89,9 @@ export class UmbTemporaryFileManager<
 						headline: 'Upload',
 						message: `
 	${this.#localization.term('media_invalidFileSize')}: ${item.file.name} (${formatBytes(item.file.size)}).
-	
+
 	${this.#localization.term('media_maxFileSize')} ${formatBytes(maxFileSize)}.
 						`,
-						whitespace: 'pre-line',
 					},
 				});
 				return false;


### PR DESCRIPTION
## Description

Adds default `white-space: pre-line` to all notification messages. This is helpful to show multiline content. This shouldn't have an effect on one-line notifications. It will only have an effect, if you do something like this:

```js
const message = `
this
is
all
on
one
line
`;
```