### PR TITLE
Fixes #17206

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/property-editors/block-list-editor/property-editor-ui-block-list.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/property-editors/block-list-editor/property-editor-ui-block-list.element.ts
@@ -54,10 +54,6 @@ export class UmbPropertyEditorUIBlockListElement
 	#contentDataPathTranslator?: UmbBlockElementDataValidationPathTranslator;
 	#settingsDataPathTranslator?: UmbBlockElementDataValidationPathTranslator;
 
-	//#catalogueModal: UmbModalRouteRegistrationController<typeof UMB_BLOCK_CATALOGUE_MODAL.DATA, undefined>;
-
-	private _value: UmbBlockListValueModel | undefined = undefined;
-
 	#lastValue: UmbBlockListValueModel | undefined = undefined;
 
 	@property({ attribute: false })
@@ -65,7 +61,7 @@ export class UmbPropertyEditorUIBlockListElement
 		this.#lastValue = value;
 
 		if (!value) {
-			this._value = undefined;
+			super.value = undefined;
 			return;
 		}
 
@@ -74,15 +70,15 @@ export class UmbPropertyEditorUIBlockListElement
 		buildUpValue.contentData ??= [];
 		buildUpValue.settingsData ??= [];
 		buildUpValue.expose ??= [];
-		this._value = buildUpValue as UmbBlockListValueModel;
+		super.value = buildUpValue as UmbBlockListValueModel;
 
-		this.#managerContext.setLayouts(this._value.layout[UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS] ?? []);
-		this.#managerContext.setContents(this._value.contentData);
-		this.#managerContext.setSettings(this._value.settingsData);
-		this.#managerContext.setExposes(this._value.expose);
+		this.#managerContext.setLayouts(super.value.layout[UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS] ?? []);
+		this.#managerContext.setContents(super.value.contentData);
+		this.#managerContext.setSettings(super.value.settingsData);
+		this.#managerContext.setExposes(super.value.expose);
 	}
 	public override get value(): UmbBlockListValueModel | undefined {
-		return this._value;
+		return super.value;
 	}
 
 	@state()
@@ -214,10 +210,10 @@ export class UmbPropertyEditorUIBlockListElement
 				]).pipe(debounceTime(20)),
 				([layouts, contents, settings, exposes]) => {
 					if (layouts.length === 0) {
-						this._value = undefined;
+						super.value = undefined;
 					} else {
-						this._value = {
-							...this._value,
+						super.value = {
+							...super.value,
 							layout: { [UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS]: layouts },
 							contentData: contents,
 							settingsData: settings,
@@ -227,11 +223,11 @@ export class UmbPropertyEditorUIBlockListElement
 
 					// If we don't have a value set from the outside or an internal value, we don't want to set the value.
 					// This is added to prevent the block list from setting an empty value on startup.
-					if (this.#lastValue === undefined && this._value === undefined) {
+					if (this.#lastValue === undefined && super.value === undefined) {
 						return;
 					}
 
-					context.setValue(this._value);
+					context.setValue(super.value);
 				},
 				'motherObserver',
 			);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/validation.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/validation.controller.ts
@@ -131,6 +131,11 @@ export class UmbValidationController extends UmbControllerBase implements UmbVal
 					this.#parentMessages = msgs;
 					msgs.forEach((msg) => {
 						const path = ReplaceStartOfPath(msg.path, this.#baseDataPath!, '$');
+						if (path === undefined) {
+							throw new Error(
+								'Path was not transformed correctly and can therefor not be transfered to the local validation context messages.',
+							);
+						}
 						// Notice, the local message uses the same key. [NL]
 						this.messages.addMessage(msg.type, path, msg.body, msg.key);
 					});
@@ -152,6 +157,11 @@ export class UmbValidationController extends UmbControllerBase implements UmbVal
 					msgs.forEach((msg) => {
 						// replace this.#baseDataPath (if it starts with it) with $ in the path, so it becomes relative to the parent context
 						const path = ReplaceStartOfPath(msg.path, '$', this.#baseDataPath!);
+						if (path === undefined) {
+							throw new Error(
+								'Path was not transformed correctly and can therefor not be synced with parent messages.',
+							);
+						}
 						// Notice, the parent message uses the same key. [NL]
 						this.#parent!.messages.addMessage(msg.type, path, msg.body, msg.key);
 					});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/validation.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/validation.controller.ts
@@ -7,20 +7,7 @@ import type { UmbContextProviderController } from '@umbraco-cms/backoffice/conte
 import { type UmbClassInterface, UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
-
-/**
- * Helper method to replace the start of a string with another string.
- * @param path {string}
- * @param startFrom {string}
- * @param startTo {string}
- * @returns {string}
- */
-function ReplaceStartOfString(path: string, startFrom: string, startTo: string): string {
-	if (path.startsWith(startFrom + '.')) {
-		return startTo + path.slice(startFrom.length);
-	}
-	return path;
-}
+import { ReplaceStartOfPath } from '../utils/replace-start-of-path.function.js';
 
 /**
  * Validation Context is the core of Validation.
@@ -143,7 +130,7 @@ export class UmbValidationController extends UmbControllerBase implements UmbVal
 					}
 					this.#parentMessages = msgs;
 					msgs.forEach((msg) => {
-						const path = ReplaceStartOfString(msg.path, this.#baseDataPath!, '$');
+						const path = ReplaceStartOfPath(msg.path, this.#baseDataPath!, '$');
 						// Notice, the local message uses the same key. [NL]
 						this.messages.addMessage(msg.type, path, msg.body, msg.key);
 					});
@@ -164,7 +151,7 @@ export class UmbValidationController extends UmbControllerBase implements UmbVal
 					this.#localMessages = msgs;
 					msgs.forEach((msg) => {
 						// replace this.#baseDataPath (if it starts with it) with $ in the path, so it becomes relative to the parent context
-						const path = ReplaceStartOfString(msg.path, '$', this.#baseDataPath!);
+						const path = ReplaceStartOfPath(msg.path, '$', this.#baseDataPath!);
 						// Notice, the parent message uses the same key. [NL]
 						this.#parent!.messages.addMessage(msg.type, path, msg.body, msg.key);
 					});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/mixins/form-control.mixin.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/mixins/form-control.mixin.ts
@@ -125,11 +125,11 @@ export function UmbFormControlMixin<
 		 */
 		@property({ reflect: false }) // Do not 'reflect' as the attribute value is used as fallback. [NL]
 		get value(): ValueType | DefaultValueType {
+			// For some reason we need to keep this as setters and getters for inherited classes for work properly when they override these methods. [NL]
 			return this.#value;
 		}
 		set value(newValue: ValueType | DefaultValueType) {
 			this.#value = newValue;
-			this._runValidators();
 		}
 
 		// Validation

--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/mixins/form-control.mixin.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/mixins/form-control.mixin.ts
@@ -124,7 +124,7 @@ export function UmbFormControlMixin<
 		 * @default
 		 */
 		@property({ reflect: false }) // Do not 'reflect' as the attribute value is used as fallback. [NL]
-		value: ValueType | DefaultValueType;
+		value: ValueType | DefaultValueType = defaultValue as unknown as DefaultValueType;
 
 		// Validation
 		//private _validityState = new UmbValidityState();
@@ -148,7 +148,6 @@ export function UmbFormControlMixin<
 		}
 		private _pristine: boolean = true;
 
-		#value: ValueType | DefaultValueType = defaultValue as unknown as DefaultValueType;
 		protected _internals: ElementInternals;
 		#form: HTMLFormElement | null = null;
 		#validators: UmbFormControlValidatorConfig[] = [];

--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/mixins/form-control.mixin.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/mixins/form-control.mixin.ts
@@ -124,7 +124,13 @@ export function UmbFormControlMixin<
 		 * @default
 		 */
 		@property({ reflect: false }) // Do not 'reflect' as the attribute value is used as fallback. [NL]
-		value: ValueType | DefaultValueType;
+		get value(): ValueType | DefaultValueType {
+			return this.#value;
+		}
+		set value(newValue: ValueType | DefaultValueType) {
+			this.#value = newValue;
+			this._runValidators();
+		}
 
 		// Validation
 		//private _validityState = new UmbValidityState();

--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/mixins/form-control.mixin.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/mixins/form-control.mixin.ts
@@ -124,13 +124,7 @@ export function UmbFormControlMixin<
 		 * @default
 		 */
 		@property({ reflect: false }) // Do not 'reflect' as the attribute value is used as fallback. [NL]
-		get value(): ValueType | DefaultValueType {
-			return this.#value;
-		}
-		set value(newValue: ValueType | DefaultValueType) {
-			this.#value = newValue;
-			this._runValidators();
-		}
+		value: ValueType | DefaultValueType;
 
 		// Validation
 		//private _validityState = new UmbValidityState();

--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/mixins/form-control.mixin.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/mixins/form-control.mixin.ts
@@ -124,7 +124,7 @@ export function UmbFormControlMixin<
 		 * @default
 		 */
 		@property({ reflect: false }) // Do not 'reflect' as the attribute value is used as fallback. [NL]
-		value: ValueType | DefaultValueType = defaultValue as unknown as DefaultValueType;
+		value: ValueType | DefaultValueType;
 
 		// Validation
 		//private _validityState = new UmbValidityState();
@@ -148,6 +148,7 @@ export function UmbFormControlMixin<
 		}
 		private _pristine: boolean = true;
 
+		#value: ValueType | DefaultValueType = defaultValue as unknown as DefaultValueType;
 		protected _internals: ElementInternals;
 		#form: HTMLFormElement | null = null;
 		#validators: UmbFormControlValidatorConfig[] = [];

--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/utils/replace-start-of-path.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/utils/replace-start-of-path.function.ts
@@ -1,0 +1,14 @@
+/**
+ * Helper method to replace the start of a JSON Path with another JSON Path.
+ * @param path {string}
+ * @param startFrom {string}
+ * @param startTo {string}
+ * @returns {string}
+ */
+export function ReplaceStartOfPath(path: string, startFrom: string, startTo: string): string {
+	// if the path conitnues with a . or [ aftr startFrom, then replace it with startTo, otherwise if identical then it is also a match. [NL]
+	if (path.startsWith(startFrom + '.') || path === startFrom) {
+		return startTo + path.slice(startFrom.length);
+	}
+	return path;
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/utils/replace-start-of-path.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/utils/replace-start-of-path.function.ts
@@ -5,10 +5,10 @@
  * @param startTo {string}
  * @returns {string}
  */
-export function ReplaceStartOfPath(path: string, startFrom: string, startTo: string): string {
+export function ReplaceStartOfPath(path: string, startFrom: string, startTo: string): string | undefined {
 	// if the path conitnues with a . or [ aftr startFrom, then replace it with startTo, otherwise if identical then it is also a match. [NL]
 	if (path.startsWith(startFrom + '.') || path === startFrom) {
 		return startTo + path.slice(startFrom.length);
 	}
-	return path;
+	return;
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/utils/replace-start-of-path.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/utils/replace-start-of-path.test.ts
@@ -1,0 +1,22 @@
+import { expect } from '@open-wc/testing';
+import { ReplaceStartOfPath } from './replace-start-of-path.function.js';
+
+describe('ReplaceStartOfPath', () => {
+	it('replaces a dot path', () => {
+		const result = ReplaceStartOfPath('$.start.test', '$.start', '$');
+
+		expect(result).to.eq('$.test');
+	});
+
+	it('replaces a array path', () => {
+		const result = ReplaceStartOfPath('$.start[0].test', '$.start[0]', '$');
+
+		expect(result).to.eq('$.test');
+	});
+
+	it('replaces a exact path', () => {
+		const result = ReplaceStartOfPath('$.start.test', '$.start.test', '$');
+
+		expect(result).to.eq('$');
+	});
+});


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/17206

Correcting validation context inheritance when the sub path is identical to the path of a message.

Before the path got messed-up when there was an exact match(because the old method expected there to be a dot after the match) resulting in not giving the right path and therefor never begin able to remove that again. Fixed with a improve the replacer method and writing tests.

After this PR there will be errors if similar should happen again.