### PR TITLE
Set Smidge cachebuster type

### DIFF
--- a/src/Umbraco.Web.Common/RuntimeMinification/SmidgeOptionsSetup.cs
+++ b/src/Umbraco.Web.Common/RuntimeMinification/SmidgeOptionsSetup.cs
@@ -7,10 +7,10 @@ namespace Umbraco.Cms.Web.Common.RuntimeMinification;
 
 public class SmidgeOptionsSetup : IConfigureOptions<SmidgeOptions>
 {
-    private readonly IOptions<RuntimeMinificationSettings> _runtimeMinificatinoSettings;
+    private readonly IOptions<RuntimeMinificationSettings> _runtimeMinificationSettings;
 
     public SmidgeOptionsSetup(IOptions<RuntimeMinificationSettings> runtimeMinificatinoSettings)
-        => _runtimeMinificatinoSettings = runtimeMinificatinoSettings;
+        => _runtimeMinificationSettings = runtimeMinificatinoSettings;
 
     /// <summary>
     ///     Configures Smidge to use in-memory caching if configured that way or if certain cache busters are used. As well as the cache buster type.
@@ -18,17 +18,16 @@ public class SmidgeOptionsSetup : IConfigureOptions<SmidgeOptions>
     /// <param name="options"></param>
     public void Configure(SmidgeOptions options)
     {
-        options.CacheOptions.UseInMemoryCache = _runtimeMinificatinoSettings.Value.UseInMemoryCache ||
-                                                   _runtimeMinificatinoSettings.Value.CacheBuster ==
+        options.CacheOptions.UseInMemoryCache = _runtimeMinificationSettings.Value.UseInMemoryCache ||
+                                                   _runtimeMinificationSettings.Value.CacheBuster ==
                                                    RuntimeMinificationCacheBuster.Timestamp;
 
-
-        Type cacheBusterType = _runtimeMinificatinoSettings.Value.CacheBuster switch
+        Type cacheBusterType = _runtimeMinificationSettings.Value.CacheBuster switch
         {
             RuntimeMinificationCacheBuster.AppDomain => typeof(AppDomainLifetimeCacheBuster),
             RuntimeMinificationCacheBuster.Version => typeof(UmbracoSmidgeConfigCacheBuster),
             RuntimeMinificationCacheBuster.Timestamp => typeof(TimestampCacheBuster),
-            _ => throw new NotImplementedException(),
+            _ => throw new ArgumentOutOfRangeException("CacheBuster", "RuntimeMinification.CacheBuster is not a valid value")
         };
 
         options.DefaultBundleOptions.DebugOptions.SetCacheBusterType(cacheBusterType);

--- a/src/Umbraco.Web.Common/RuntimeMinification/SmidgeOptionsSetup.cs
+++ b/src/Umbraco.Web.Common/RuntimeMinification/SmidgeOptionsSetup.cs
@@ -13,9 +13,10 @@ public class SmidgeOptionsSetup : IConfigureOptions<SmidgeOptions>
         => _runtimeMinificationSettings = runtimeMinificatinoSettings;
 
     /// <summary>
-    ///     Configures Smidge to use in-memory caching if configured that way or if certain cache busters are used. As well as the cache buster type.
+    /// Configures Smidge to use in-memory caching if configured that way or if certain cache busters are used.
+    /// Also sets the cache buster type such that public facing bundles will use the configured method.
     /// </summary>
-    /// <param name="options"></param>
+    /// <param name="options">Instance of <see cref="SmidgeOptions"></see> to configure.</param>
     public void Configure(SmidgeOptions options)
     {
         options.CacheOptions.UseInMemoryCache = _runtimeMinificationSettings.Value.UseInMemoryCache ||
@@ -27,7 +28,7 @@ public class SmidgeOptionsSetup : IConfigureOptions<SmidgeOptions>
             RuntimeMinificationCacheBuster.AppDomain => typeof(AppDomainLifetimeCacheBuster),
             RuntimeMinificationCacheBuster.Version => typeof(UmbracoSmidgeConfigCacheBuster),
             RuntimeMinificationCacheBuster.Timestamp => typeof(TimestampCacheBuster),
-            _ => throw new ArgumentOutOfRangeException("CacheBuster", "RuntimeMinification.CacheBuster is not a valid value")
+            _ => throw new ArgumentOutOfRangeException("CacheBuster", $"{_runtimeMinificationSettings.Value.CacheBuster} is not a valid value for RuntimeMinificationCacheBuster."),
         };
 
         options.DefaultBundleOptions.DebugOptions.SetCacheBusterType(cacheBusterType);

--- a/src/Umbraco.Web.Common/RuntimeMinification/SmidgeRuntimeMinifier.cs
+++ b/src/Umbraco.Web.Common/RuntimeMinification/SmidgeRuntimeMinifier.cs
@@ -79,7 +79,7 @@ public class SmidgeRuntimeMinifier : IRuntimeMinifier
             RuntimeMinificationCacheBuster.AppDomain => typeof(AppDomainLifetimeCacheBuster),
             RuntimeMinificationCacheBuster.Version => typeof(UmbracoSmidgeConfigCacheBuster),
             RuntimeMinificationCacheBuster.Timestamp => typeof(TimestampCacheBuster),
-            _ => throw new NotImplementedException(),
+            _ => throw new ArgumentOutOfRangeException("CacheBuster", "RuntimeMinification.CacheBuster is not a valid value")
         };
 
         _cacheBusterType = cacheBusterType;

--- a/src/Umbraco.Web.Common/RuntimeMinification/SmidgeRuntimeMinifier.cs
+++ b/src/Umbraco.Web.Common/RuntimeMinification/SmidgeRuntimeMinifier.cs
@@ -79,7 +79,7 @@ public class SmidgeRuntimeMinifier : IRuntimeMinifier
             RuntimeMinificationCacheBuster.AppDomain => typeof(AppDomainLifetimeCacheBuster),
             RuntimeMinificationCacheBuster.Version => typeof(UmbracoSmidgeConfigCacheBuster),
             RuntimeMinificationCacheBuster.Timestamp => typeof(TimestampCacheBuster),
-            _ => throw new ArgumentOutOfRangeException("CacheBuster", "RuntimeMinification.CacheBuster is not a valid value")
+            _ => throw new ArgumentOutOfRangeException("CacheBuster", $"{runtimeMinificationSettings.Value.CacheBuster} is not a valid value for RuntimeMinificationCacheBuster."),
         };
 
         _cacheBusterType = cacheBusterType;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes : [15165](https://github.com/umbraco/Umbraco-CMS/issues/15165)

### Description

Sets the cachebuster type for Smidge correctly, so that the version is correctly set on the URL

### Testing

Replication steps for the bug from HQ are here:
https://github.com/umbraco/Umbraco-CMS/issues/15165#issuecomment-1818799724

Set the smidge cache buster to AppDomain
Confirm that the version in the URLs is no longer 1
