### PR TITLE
V13: Fix members while using basic auth.

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Snippets/LoginStatus.cshtml
+++ b/src/Umbraco.Core/EmbeddedResources/Snippets/LoginStatus.cshtml
@@ -5,7 +5,7 @@
 @using Umbraco.Extensions
 
 @{
-    var isLoggedIn = Context.User?.Identity?.IsAuthenticated ?? false;
+    var isLoggedIn = Context.User.GetMemberIdentity()?.IsAuthenticated ?? false;
     var logoutModel = new PostRedirectModel();
     // You can modify this to redirect to a different URL instead of the current one
     logoutModel.RedirectUrl = null;
@@ -15,7 +15,7 @@
 {
     <div class="login-status">
 
-        <p>Welcome back <strong>@Context?.User?.Identity?.Name</strong>!</p>
+        <p>Welcome back <strong>@Context.User?.GetMemberIdentity()?.Name</strong>!</p>
 
         @using (Html.BeginUmbracoForm<UmbLoginStatusController>("HandleLogout", new { RedirectUrl = logoutModel.RedirectUrl }))
         {

--- a/src/Umbraco.Web.Common/Extensions/MemberClaimsPrincipalExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/MemberClaimsPrincipalExtensions.cs
@@ -1,0 +1,19 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Identity;
+
+namespace Umbraco.Extensions;
+
+public static class MemberClaimsPrincipalExtensions
+{
+
+    /// <summary>
+    /// Tries to get specifically the member identity from the ClaimsPrincipal
+    /// <remarks>
+    /// The identity returned is the one with default authentication type.
+    /// </remarks>
+    /// </summary>
+    /// <param name="principal">The principal to find the identity in.</param>
+    /// <returns>The default authenticated authentication type identity.</returns>
+    public static ClaimsIdentity? GetMemberIdentity(this ClaimsPrincipal principal)
+        => principal.Identities.FirstOrDefault(x => x.AuthenticationType == IdentityConstants.ApplicationScheme);
+}

--- a/src/Umbraco.Web.Common/Extensions/MemberClaimsPrincipalExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/MemberClaimsPrincipalExtensions.cs
@@ -5,13 +5,12 @@ namespace Umbraco.Extensions;
 
 public static class MemberClaimsPrincipalExtensions
 {
-
     /// <summary>
     /// Tries to get specifically the member identity from the ClaimsPrincipal
+    /// </summary>
     /// <remarks>
     /// The identity returned is the one with default authentication type.
     /// </remarks>
-    /// </summary>
     /// <param name="principal">The principal to find the identity in.</param>
     /// <returns>The default authenticated authentication type identity.</returns>
     public static ClaimsIdentity? GetMemberIdentity(this ClaimsPrincipal principal)

--- a/src/Umbraco.Web.Common/Security/MemberManager.cs
+++ b/src/Umbraco.Web.Common/Security/MemberManager.cs
@@ -204,8 +204,8 @@ public class MemberManager : UmbracoUserManager<MemberIdentityUser, MemberPasswo
 
     public virtual IPublishedContent? AsPublishedMember(MemberIdentityUser user) => _store.GetPublishedMember(user);
 
-    /// This will check if the member has access to this path
     /// <summary>
+    /// This will check if the member has access to this path.
     /// </summary>
     /// <param name="path"></param>
     /// <returns></returns>

--- a/src/Umbraco.Web.Common/Security/MemberManager.cs
+++ b/src/Umbraco.Web.Common/Security/MemberManager.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
@@ -124,8 +125,11 @@ public class MemberManager : UmbracoUserManager<MemberIdentityUser, MemberPasswo
     /// <inheritdoc />
     public virtual bool IsLoggedIn()
     {
-        HttpContext? httpContext = _httpContextAccessor.HttpContext;
-        return httpContext?.User.Identity?.IsAuthenticated ?? false;
+        // We have to try and specifically find the member identity, it's entirely possible for there to be both backoffice and member.
+        ClaimsIdentity? memberIdentity = _httpContextAccessor.HttpContext?.User.GetMemberIdentity();
+
+        return memberIdentity is not null &&
+               memberIdentity.IsAuthenticated;
     }
 
     /// <inheritdoc />
@@ -181,23 +185,27 @@ public class MemberManager : UmbracoUserManager<MemberIdentityUser, MemberPasswo
     /// <inheritdoc />
     public virtual async Task<MemberIdentityUser?> GetCurrentMemberAsync()
     {
-        if (_currentMember == null)
+        if (_currentMember is not null)
         {
-            if (!IsLoggedIn())
-            {
-                return null;
-            }
-
-            _currentMember = await GetUserAsync(_httpContextAccessor.HttpContext?.User!);
+            return _currentMember;
         }
+
+        if (IsLoggedIn() is false)
+        {
+            return null;
+        }
+
+        // Create a principal the represents the member security context.
+        var memberPrincipal = new ClaimsPrincipal(_httpContextAccessor.HttpContext?.User.GetMemberIdentity()!);
+        _currentMember = await GetUserAsync(memberPrincipal);
 
         return _currentMember;
     }
 
     public virtual IPublishedContent? AsPublishedMember(MemberIdentityUser user) => _store.GetPublishedMember(user);
 
+    /// This will check if the member has access to this path
     /// <summary>
-    ///     This will check if the member has access to this path
     /// </summary>
     /// <param name="path"></param>
     /// <returns></returns>


### PR DESCRIPTION
Fixes #18186.

Using basic auth breaks member functionality. This turned out to be multiple issues.

1.  `AuthenticateBackOfficeAsync` updated the HttpContext user to the backoffice authenticated one, this breaks members entirely when using basic auth since the backoffice identity will then be the only one ever assigned to the user. I've fixed this by any authenticated identity that is not the backoffice one to the new principal.
2. The Member manager always assumed that the member was the only identity, I've fixed this by now specifically looking for the identity with `IdentityConstants.ApplicationScheme' as the authentication type, I've created an extension for this since it's also used in 3. 
3. The login status snippet also assumed that the member identity would be the only one, I've fixed that by using the extension from point 2. 


## Testing

1. Enable basic auth: 

```json
  "Umbraco": {
    "CMS": {
      "BasicAuth": {
        "Enabled": true
      },
{...}
```
2. Create a member
3. Login to the site
4. Ensure that `MemberManager.IsLoggedIn()` returns the correct response
5. Ensure that `MemberManager.GetCurrentMemberAsync()` returns the correct member. 
6. Ensure that the Login status work
7. Ensure that backoffice still works. 


I used this beauty of a test page to test: 

```html
@using Umbraco.Cms.Core.Security
@using Umbraco.Cms.Web.Common.PublishedModels;
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage;
@using ContentModels = Umbraco.Cms.Web.Common.PublishedModels;
@inject IMemberManager MemberManager
@{
	Layout = null;
}

<h1>Member Tester 90000</h1>

<p>Is member logged in: @MemberManager.IsLoggedIn()</p>

@{
    if (MemberManager.IsLoggedIn())
    {
        var currentMember = await MemberManager.GetCurrentMemberAsync();

        if (currentMember is null)
        {
            <p>Current member not found :(</p>
        }
        else
        {
            <p>@currentMember.Name is here...</p>
        }
    }
}


<hr>

<h1>Login</h1>

@await Html.PartialAsync("MyMemberLogin")

<hr>

<h1>Login Status</h1>

@await Html.PartialAsync("MyMemberStatus")
```
