### PR TITLE
V13: Introduce publishNotifications method on IMembershipMemberService

### DIFF
--- a/src/Umbraco.Core/Services/IMembershipMemberService.cs
+++ b/src/Umbraco.Core/Services/IMembershipMemberService.cs
@@ -136,6 +136,14 @@ public interface IMembershipMemberService<T> : IService
     void Save(T entity);
 
     /// <summary>
+    ///     Saves an <see cref="IMembershipUser" />
+    /// </summary>
+    /// <remarks>An <see cref="IMembershipUser" /> can be of type <see cref="IMember" /> or <see cref="IUser" /></remarks>
+    /// <param name="entity"><see cref="IMember" /> or <see cref="IUser" /> to Save</param>
+    /// <param name="publishNotifications"> Whether notifications should be published or not</param>
+    void Save(T entity, bool publishNotifications) => Save(entity);
+
+    /// <summary>
     ///     Saves a list of <see cref="IMembershipUser" /> objects
     /// </summary>
     /// <remarks>An <see cref="IMembershipUser" /> can be of type <see cref="IMember" /> or <see cref="IUser" /></remarks>

--- a/src/Umbraco.Core/Services/MemberService.cs
+++ b/src/Umbraco.Core/Services/MemberService.cs
@@ -736,7 +736,9 @@ namespace Umbraco.Cms.Core.Services
         public void SetLastLogin(string username, DateTime date) => throw new NotImplementedException();
 
         /// <inheritdoc />
-        public void Save(IMember member)
+        public void Save(IMember member) => Save(member, true);
+
+        public void Save(IMember member, bool publishNotifications)
         {
             // trimming username and email to make sure we have no trailing space
             member.Username = member.Username.Trim();
@@ -761,7 +763,10 @@ namespace Umbraco.Cms.Core.Services
 
             _memberRepository.Save(member);
 
-            scope.Notifications.Publish(new MemberSavedNotification(member, evtMsgs).WithStateFrom(savingNotification));
+            if (publishNotifications)
+            {
+                scope.Notifications.Publish(new MemberSavedNotification(member, evtMsgs).WithStateFrom(savingNotification));
+            }
 
             Audit(AuditType.Save, 0, member.Id);
 

--- a/src/Umbraco.Infrastructure/Security/MemberUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/MemberUserStore.cs
@@ -110,7 +110,7 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
             UpdateMemberProperties(memberEntity, user, out bool _);
 
             // create the member
-            _memberService.Save(memberEntity);
+            _memberService.Save(memberEntity, false);
 
             // We need to add roles now that the member has an Id. It do not work implicit in UpdateMemberProperties
             _memberService.AssignRoles(


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/12673

# Notes
- MemberSavedNotification would fire twice when creating a new member, why is explained in the original issue here: https://github.com/umbraco/Umbraco-CMS/issues/12673#issuecomment-1178996872
-  This PR remedies that by introducing a `publishNotifications` in the Save method, so you can pass in whether or not you'd like to fire your notifications when using the Save.
- Note that ´scope.Notifications.Supress()´ does not work in this scenario, as it would suppress all the notifications, even from the parent scope..

# How to test
- Follow steps in original issue, here is a notification handler you can use:
```
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Notifications;

public class MyNotificationHandler : INotificationAsyncHandler<MemberSavedNotification>
{
    public async Task HandleAsync(MemberSavedNotification notification, CancellationToken cancellationToken)
    {
        IMember? member = notification.SavedEntities.FirstOrDefault();
        if (member is null)
        {
            return;
        }
    }
}


public class MyComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder) => builder.AddNotificationAsyncHandler<MemberSavedNotification, MyNotificationHandler>();
}

```