### PR TITLE
Don't filter on published state for media descendent queries

### DIFF
--- a/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
@@ -4497,9 +4497,13 @@ public static class PublishedContentExtensions
             yield break;
         }
 
+        // Only documents can be published. For any other cached types we should by-pass the check for being published
+        // in the LINQ statement below.
+        var canBePublished = publishedCache is IPublishedContentCache;
+
         culture ??= variationContextAccessor?.VariationContext?.Culture ?? string.Empty;
         IEnumerable<IPublishedContent> descendants = descendantsKeys
-            .Where(x => publishStatusQueryService.IsDocumentPublished(x, culture))
+            .Where(x => canBePublished is false || publishStatusQueryService.IsDocumentPublished(x, culture))
             .Select(publishedCache.GetById)
             .WhereNotNull()
             .FilterByCulture(culture, variationContextAccessor);


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/18211

### Description
This PR should resolve the reported issue.  On stepping through I could see we were filtering on published state, without first checking we are looking at an entity that can be published.  So for documents it worked, but not for media.

**To Test:**
- See the code sample in the reported issue.
- Previously this would return just the root nodes, but with this update you should get all media.
- A similar query for content should continue to omit unpublished items.
