### PR TITLE
Deprecate get unique param on UmbPickerInputContext and UmbRepositoryItemsManager

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-area-type-permission/block-grid-area-type-permission.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-area-type-permission/block-grid-area-type-permission.element.ts
@@ -40,7 +40,6 @@ export class UmbPropertyEditorUIBlockGridAreaTypePermissionElement
 	#itemsManager = new UmbRepositoryItemsManager<UmbDocumentTypeItemModel>(
 		this,
 		UMB_DOCUMENT_TYPE_ITEM_REPOSITORY_ALIAS,
-		(x) => x.unique,
 	);
 
 	constructor() {

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-type/components/block-type-card/block-type-card.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-type/components/block-type-card/block-type-card.element.ts
@@ -18,7 +18,6 @@ export class UmbBlockTypeCardElement extends UmbLitElement {
 	readonly #itemManager = new UmbRepositoryItemsManager<UmbDocumentTypeItemModel>(
 		this,
 		UMB_DOCUMENT_TYPE_ITEM_REPOSITORY_ALIAS,
-		(x) => x.unique,
 	);
 
 	@property({ type: String })

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-type/workspace/block-type-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-type/workspace/block-type-workspace-editor.element.ts
@@ -8,11 +8,7 @@ import { UMB_DOCUMENT_TYPE_ITEM_REPOSITORY_ALIAS } from '@umbraco-cms/backoffice
 
 @customElement('umb-block-type-workspace-editor')
 export class UmbBlockTypeWorkspaceEditorElement extends UmbLitElement {
-	#itemManager = new UmbRepositoryItemsManager<UmbDocumentTypeItemModel>(
-		this,
-		UMB_DOCUMENT_TYPE_ITEM_REPOSITORY_ALIAS,
-		(x) => x.unique,
-	);
+	#itemManager = new UmbRepositoryItemsManager<UmbDocumentTypeItemModel>(this, UMB_DOCUMENT_TYPE_ITEM_REPOSITORY_ALIAS);
 
 	#workspaceContext?: typeof UMB_BLOCK_TYPE_WORKSPACE_CONTEXT.TYPE;
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker-input/picker-input.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker-input/picker-input.context.ts
@@ -5,6 +5,7 @@ import { UMB_MODAL_MANAGER_CONTEXT, umbConfirmModal } from '@umbraco-cms/backoff
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { UmbItemRepository } from '@umbraco-cms/backoffice/repository';
 import type { UmbModalToken, UmbPickerModalData, UmbPickerModalValue } from '@umbraco-cms/backoffice/modal';
+import { UmbDeprecation } from '@umbraco-cms/backoffice/utils';
 
 type PickerItemBaseType = { name: string; unique: string };
 export class UmbPickerInputContext<
@@ -44,8 +45,14 @@ export class UmbPickerInputContext<
 	}
 	private _min = 0;
 
-	/* TODO: find a better way to have a getUniqueMethod. If we want to support trees/items of different types,
-	then it need to be bound to the type and can't be a generic method we pass in. */
+	/**
+	 * Creates an instance of UmbPickerInputContext.
+	 * @param {UmbControllerHost} host - The host for the controller.
+	 * @param {string} repositoryAlias - The alias of the repository to use.
+	 * @param {(string | UmbModalToken<UmbPickerModalData<PickerItemType>, PickerModalValueType>)} modalAlias - The alias of the modal to use.
+	 * @param {((entry: PickedItemType) => string | undefined)} [getUniqueMethod] - DEPRECATED since 15.3. Will be removed in v. 17: A method to get the unique key from the item.
+	 * @memberof UmbPickerInputContext
+	 */
 	constructor(
 		host: UmbControllerHost,
 		repositoryAlias: string,
@@ -55,6 +62,17 @@ export class UmbPickerInputContext<
 		super(host);
 		this.modalAlias = modalAlias;
 		this.#getUnique = getUniqueMethod || ((entry) => entry.unique);
+
+		this.#getUnique = getUniqueMethod
+			? (entry: PickedItemType) => {
+					new UmbDeprecation({
+						deprecated: 'The getUniqueMethod parameter.',
+						removeInVersion: '17.0.0',
+						solution: 'The required unique property on the item will be used instead.',
+					}).warn();
+					return getUniqueMethod(entry);
+				}
+			: (entry) => entry.unique;
 
 		this.#itemManager = new UmbRepositoryItemsManager<PickedItemType>(this, repositoryAlias, this.#getUnique);
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/repository/repository-items.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/repository/repository-items.manager.ts
@@ -1,3 +1,4 @@
+import { UmbDeprecation } from '@umbraco-cms/backoffice/utils';
 import type { UmbItemRepository } from '@umbraco-cms/backoffice/repository';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
@@ -6,7 +7,6 @@ import { UmbExtensionApiInitializer } from '@umbraco-cms/backoffice/extension-ap
 import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 import { UmbEntityUpdatedEvent } from '@umbraco-cms/backoffice/entity-action';
-import { UmbDeprecation } from '../utils';
 
 const ObserveRepositoryAlias = Symbol();
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/repository/repository-items.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/repository/repository-items.manager.ts
@@ -49,7 +49,7 @@ export class UmbRepositoryItemsManager<ItemType extends { unique: string }> exte
 			? (entry: ItemType) => {
 					new UmbDeprecation({
 						deprecated: 'The getUniqueMethod parameter.',
-						removeInVersion: '17',
+						removeInVersion: '17.0.0',
 						solution: 'The required unique property on the item will be used instead.',
 					}).warn();
 					return getUniqueMethod(entry);

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/components/input-document/input-document.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/components/input-document/input-document.context.ts
@@ -21,7 +21,7 @@ export class UmbDocumentPickerInputContext extends UmbPickerInputContext<
 	UmbDocumentPickerModalValue
 > {
 	constructor(host: UmbControllerHost) {
-		super(host, UMB_DOCUMENT_ITEM_REPOSITORY_ALIAS, UMB_DOCUMENT_PICKER_MODAL, (entry) => entry.unique);
+		super(host, UMB_DOCUMENT_ITEM_REPOSITORY_ALIAS, UMB_DOCUMENT_PICKER_MODAL);
 	}
 
 	override async openPicker(

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace.context.ts
@@ -297,7 +297,7 @@ export class UmbDocumentWorkspaceContext
 	public async publish() {
 		new UmbDeprecation({
 			deprecated: 'The Publish method on the UMB_DOCUMENT_WORKSPACE_CONTEXT is deprecated.',
-			removeInVersion: '17',
+			removeInVersion: '17.0.0',
 			solution: 'Use the Publish method on the UMB_DOCUMENT_PUBLISHING_WORKSPACE_CONTEXT instead.',
 		}).warn();
 		if (!this.#publishingContext) throw new Error('Publishing context is missing');
@@ -311,7 +311,7 @@ export class UmbDocumentWorkspaceContext
 	public async saveAndPublish(): Promise<void> {
 		new UmbDeprecation({
 			deprecated: 'The SaveAndPublish method on the UMB_DOCUMENT_WORKSPACE_CONTEXT is deprecated.',
-			removeInVersion: '17',
+			removeInVersion: '17.0.0',
 			solution: 'Use the SaveAndPublish method on the UMB_DOCUMENT_PUBLISHING_WORKSPACE_CONTEXT instead.',
 		}).warn();
 		if (!this.#publishingContext) throw new Error('Publishing context is missing');
@@ -325,7 +325,7 @@ export class UmbDocumentWorkspaceContext
 	public async schedule() {
 		new UmbDeprecation({
 			deprecated: 'The Schedule method on the UMB_DOCUMENT_WORKSPACE_CONTEXT is deprecated.',
-			removeInVersion: '17',
+			removeInVersion: '17.0.0',
 			solution: 'Use the Schedule method on the UMB_DOCUMENT_PUBLISHING_WORKSPACE_CONTEXT instead.',
 		}).warn();
 		if (!this.#publishingContext) throw new Error('Publishing context is missing');
@@ -339,7 +339,7 @@ export class UmbDocumentWorkspaceContext
 	public async unpublish() {
 		new UmbDeprecation({
 			deprecated: 'The Unpublish method on the UMB_DOCUMENT_WORKSPACE_CONTEXT is deprecated.',
-			removeInVersion: '17',
+			removeInVersion: '17.0.0',
 			solution: 'Use the Unpublish method on the UMB_DOCUMENT_PUBLISHING_WORKSPACE_CONTEXT instead.',
 		}).warn();
 		if (!this.#publishingContext) throw new Error('Publishing context is missing');
@@ -353,7 +353,7 @@ export class UmbDocumentWorkspaceContext
 	public async publishWithDescendants() {
 		new UmbDeprecation({
 			deprecated: 'The PublishWithDescendants method on the UMB_DOCUMENT_WORKSPACE_CONTEXT is deprecated.',
-			removeInVersion: '17',
+			removeInVersion: '17.0.0',
 			solution: 'Use the PublishWithDescendants method on the UMB_DOCUMENT_PUBLISHING_WORKSPACE_CONTEXT instead.',
 		}).warn();
 		if (!this.#publishingContext) throw new Error('Publishing context is missing');

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
@@ -173,11 +173,7 @@ export class UmbInputRichMediaElement extends UmbFormControlMixin<
 	@state()
 	private _routeBuilder?: UmbModalRouteBuilder;
 
-	readonly #itemManager = new UmbRepositoryItemsManager<UmbMediaItemModel>(
-		this,
-		UMB_MEDIA_ITEM_REPOSITORY_ALIAS,
-		(x) => x.unique,
-	);
+	readonly #itemManager = new UmbRepositoryItemsManager<UmbMediaItemModel>(this, UMB_MEDIA_ITEM_REPOSITORY_ALIAS);
 
 	constructor() {
 		super();

--- a/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook/repository/detail/webhook-detail.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook/repository/detail/webhook-detail.repository.ts
@@ -22,7 +22,7 @@ export class UmbWebhookDetailRepository extends UmbDetailRepositoryBase<UmbWebho
 	async requestEvents(): Promise<{ data: { items: string[]; total: number }; error: any }> {
 		new UmbDeprecation({
 			deprecated: 'The requestEvents method on the UmbWebhookDetailRepository is deprecated.',
-			removeInVersion: '17',
+			removeInVersion: '17.0.0',
 			solution: 'Use the requestEvents method on UmbWebhookEventRepository instead.',
 		}).warn();
 


### PR DESCRIPTION
This PR deprecates the obsolete `getUnique` parameter on the `UmbPickerInputContext` and `UmbRepositoryItemsManager`, as we now require a unique field for all models.