### PR TITLE
Entity permission translation for US, UK and DK

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
@@ -93,6 +93,10 @@ export default {
 		createblueprint: 'Tillad adgang til at oprette en indholdsskabelon',
 		notify: 'Tillad adgang til at oprette notificeringer for noder',
 	},
+	userRights: {
+		permissionLabel: 'Handlingsrettigheder',
+		permissionsDescription: 'Tildel tilladelser til en handlingstype',
+	},
 	apps: {
 		umbContent: 'Indhold',
 		umbInfo: 'Info',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
@@ -99,6 +99,10 @@ export default {
 		createblueprint: 'Allow access to create a Document Blueprint',
 		notify: 'Allow access to setup notifications for content nodes',
 	},
+	userRights: {
+		permissionLabel: 'Permissions',
+		permissionsDescription: 'Assign permissions for an action type',
+	},
 	apps: {
 		umbContent: 'Content',
 		umbInfo: 'Info',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -99,6 +99,10 @@ export default {
 		createblueprint: 'Allow access to create a Document Blueprint',
 		notify: 'Allow access to setup notifications for content nodes',
 	},
+	userRights: {
+		permissionLabel: 'Permissions',
+		permissionsDescription: 'Assign permissions for an action type',
+	},
 	apps: {
 		umbContent: 'Content',
 		umbInfo: 'Info',

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user-group/workspace/user-group/user-group-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user-group/workspace/user-group/user-group-workspace-editor.element.ts
@@ -244,9 +244,10 @@ export class UmbUserGroupWorkspaceEditorElement extends UmbLitElement {
 					<uui-box>
 						<div slot="headline"><umb-localize key="user_permissionsDefault"></umb-localize></div>
 
-						<umb-property-layout label="Entity permissions" description="Assign permissions for an entity type">
+						<umb-property-layout label=${this.localize.term('userRights_permissionLabel')} description=${this.localize.term('userRights_permissionsDescription')}>
 							<umb-user-group-entity-user-permission-list slot="editor"></umb-user-group-entity-user-permission-list>
 						</umb-property-layout>
+						${this.#renderLanguageAccess()} ${this.#renderDocumentAccess()} ${this.#renderMediaAccess()}
 					</uui-box>
 
 					<uui-box>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Translation was missing for User permissions in EN, EN-US and DK in the backoffice User groups settings section.
Added this in all 3 translation .ts files. You can see the changes in the backoffice:
- change your language to DK
- Go to Users > User Groups and edit Administrators user group
- Under Default permissions the Permissions header and description are now in Danish, and 

![image](https://github.com/user-attachments/assets/d047510b-80d1-4b9a-9fa3-8c9201db2486)