### PR TITLE
Make clearer the link picker option to choose an item from the content tree

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -554,7 +554,7 @@ export default {
 		relateToOriginalLabel: 'Relate to original',
 		includeDescendants: 'Include descendants',
 		theFriendliestCommunity: 'The friendliest community',
-		linkToPage: 'Link to document',
+		linkToPage: 'Link to content',
 		openInNewWindow: 'Opens the link in a new window or tab',
 		linkToMedia: 'Link to media',
 		selectContentStartNode: 'Select content start node',


### PR DESCRIPTION
The Link picker gives you two options for Internal Link

'Link to document'
'Link to media'

![image](https://github.com/user-attachments/assets/5fc5eb35-69c3-4730-8b8b-a83e64bcdb04)

However, editors tend to think of content that they create in their content management system in the content section as content, so when they want to choose to pick a content item from the content tree, the word 'document' (even though we know a document type is the terminology to define the content type) is slightly misdirecting.

Particularly because you might associate 'document' with a PDF document file

and presented next to the option to pick 'media' makes you think you can either pick an image, or a PDF...

... when it is also possible to form links to content items...

... this is a grey area, as 'content types' are an over arching concept for both documents and media, but I think this is a mismatch with the editors perspective, as it is very much called the 'content tree' in the 'content section' and really perhaps it should be called 'the document tree' (my favourite U2 album) in the document section...

???

Umbraco 15.