### PR TITLE
Decimal `umb-property-editor-ui-number` fixes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/Umbraco.Decimal.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/Umbraco.Decimal.ts
@@ -12,24 +12,24 @@ export const manifests: Array<UmbExtensionManifest> = [
 						label: 'Minimum',
 						description: 'Enter the minimum amount of number to be entered',
 						propertyEditorUiAlias: 'Umb.PropertyEditorUi.Decimal',
+						config: [{ alias: 'step', value: '0.001' }],
 					},
 					{
 						alias: 'max',
 						label: 'Maximum',
 						description: 'Enter the maximum amount of number to be entered',
 						propertyEditorUiAlias: 'Umb.PropertyEditorUi.Decimal',
+						config: [
+							{ alias: 'placeholder', value: '∞' },
+							{ alias: 'step', value: '0.001' },
+						],
 					},
 					{
 						alias: 'step',
 						label: 'Step size',
 						description: 'Enter the intervals amount between each step of number to be entered',
 						propertyEditorUiAlias: 'Umb.PropertyEditorUi.Decimal',
-						config: [
-							{
-								alias: 'step',
-								value: '0.01',
-							},
-						],
+						config: [{ alias: 'step', value: '0.001' }],
 					},
 				],
 			},

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/Umbraco.Integer.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/Umbraco.Integer.ts
@@ -18,6 +18,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 						label: 'Maximum',
 						description: 'Enter the maximum amount of number to be entered',
 						propertyEditorUiAlias: 'Umb.PropertyEditorUi.Integer',
+						config: [{ alias: 'placeholder', value: '∞' }],
 					},
 					{
 						alias: 'step',

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/property-editor-ui-number.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/property-editor-ui-number.element.ts
@@ -39,9 +39,9 @@ export class UmbPropertyEditorUINumberElement
 
 	public set config(config: UmbPropertyEditorConfigCollection | undefined) {
 		if (!config) return;
-		this._min = this.#parseInt(config.getValueByAlias('min')) || 0;
-		this._max = this.#parseInt(config.getValueByAlias('max')) || Infinity;
-		this._step = this.#parseInt(config.getValueByAlias('step'));
+		this._min = this.#parseNumber(config.getValueByAlias('min')) || 0;
+		this._max = this.#parseNumber(config.getValueByAlias('max')) || Infinity;
+		this._step = this.#parseNumber(config.getValueByAlias('step'));
 		this._placeholder = config.getValueByAlias('placeholder');
 	}
 
@@ -80,13 +80,15 @@ export class UmbPropertyEditorUINumberElement
 		}
 	}
 
-	#parseInt(input: unknown): number | undefined {
+	#parseNumber(input: unknown): number | undefined {
 		const num = Number(input);
 		return Number.isNaN(num) ? undefined : num;
 	}
 
 	#onInput(e: InputEvent & { target: HTMLInputElement }) {
-		this.value = this.#parseInt(e.target.value);
+		const newValue = event.target.value === '' ? undefined : this.#parseNumber(event.target.value);
+		if (newValue === this.value) return;
+		this.value = newValue;
 		this.dispatchEvent(new UmbPropertyValueChangeEvent());
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/property-editor-ui-number.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/property-editor-ui-number.element.ts
@@ -39,8 +39,8 @@ export class UmbPropertyEditorUINumberElement
 
 	public set config(config: UmbPropertyEditorConfigCollection | undefined) {
 		if (!config) return;
-		this._min = this.#parseNumber(config.getValueByAlias('min')) || 0;
-		this._max = this.#parseNumber(config.getValueByAlias('max')) || Infinity;
+		this._min = this.#parseNumber(config.getValueByAlias('min'));
+		this._max = this.#parseNumber(config.getValueByAlias('max'));
 		this._step = this.#parseNumber(config.getValueByAlias('step'));
 		this._placeholder = config.getValueByAlias('placeholder');
 	}
@@ -82,7 +82,7 @@ export class UmbPropertyEditorUINumberElement
 
 	#parseNumber(input: unknown): number | undefined {
 		const num = Number(input);
-		return Number.isNaN(num) ? undefined : num;
+		return Number.isFinite(num) ? num : undefined;
 	}
 
 	#onChange(event: InputEvent & { target: HTMLInputElement }) {

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/property-editor-ui-number.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/property-editor-ui-number.element.ts
@@ -85,7 +85,7 @@ export class UmbPropertyEditorUINumberElement
 		return Number.isNaN(num) ? undefined : num;
 	}
 
-	#onInput(e: InputEvent & { target: HTMLInputElement }) {
+	#onChange(event: InputEvent & { target: HTMLInputElement }) {
 		const newValue = event.target.value === '' ? undefined : this.#parseNumber(event.target.value);
 		if (newValue === this.value) return;
 		this.value = newValue;
@@ -101,8 +101,8 @@ export class UmbPropertyEditorUINumberElement
 				max=${ifDefined(this._max)}
 				step=${ifDefined(this._step)}
 				placeholder=${ifDefined(this._placeholder)}
-				value=${this.value?.toString() ?? (this._placeholder ? '' : '0')}
-				@input=${this.#onInput}
+				value=${this.value?.toString() ?? ''}
+				@change=${this.#onChange}
 				?readonly=${this.readonly}>
 			</uui-input>
 		`;


### PR DESCRIPTION
### Description

Fixes #18150.

Issue #18150 outlines several problems with the Number input when configured for use with the Decimal property-editor.

Changes in this PR:

- Renamed `#parseInt` function to `#parseNumber`, it's a private function, renamed for readability.
- Changed from using the `@input` to `@change` event for updating the property value.
- Relaxed always setting an empty value (e.g. `''`) to `0`, as the empty value may be intentional.
- Fixed up invalid HTML, e.g. we had `max="Infinity"`, when omitting the attribute is preferred.
- Added `step` configuration for the Decimal data-type configuration, meaning that decimal places can be entered for minimum/maximum configuration.

There is one outstanding issue which will need to be resolved in the UUI library, re: https://github.com/umbraco/Umbraco.UI/issues/1004

#### How to test?

Try configuring a Decimal data-type/property-editor and using it with various decimal/integer values.