### PR TITLE
Hotfix block grid area data disappearing

### DIFF
--- a/src/Umbraco.Core/Models/Blocks/BlockGridLayoutAreaItem.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockGridLayoutAreaItem.cs
@@ -11,4 +11,10 @@ public class BlockGridLayoutAreaItem
 
     public BlockGridLayoutAreaItem(Guid key)
         => Key = key;
+
+    public bool ContainsContent(Guid key)
+        => Items.Any(item => item.ReferencesContent(key));
+
+    public bool ContainsSetting(Guid key)
+        => Items.Any(item => item.ReferencesSetting(key));
 }

--- a/src/Umbraco.Core/Models/Blocks/BlockGridLayoutItem.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockGridLayoutItem.cs
@@ -38,4 +38,10 @@ public class BlockGridLayoutItem : BlockLayoutItemBase
         : base(contentKey, settingsKey)
     {
     }
+
+    public override bool ReferencesContent(Guid key)
+        => ContentKey == key || Areas.Any(area => area.ContainsContent(key));
+
+    public override bool ReferencesSetting(Guid key)
+        => SettingsKey == key || Areas.Any(area => area.ContainsSetting(key));
 }

--- a/src/Umbraco.Core/Models/Blocks/BlockLayoutItemBase.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockLayoutItemBase.cs
@@ -81,4 +81,10 @@ public abstract class BlockLayoutItemBase : IBlockLayoutItem
         SettingsKey = settingsKey;
         SettingsUdi = new GuidUdi(Constants.UdiEntityType.Element, settingsKey);
     }
+
+    public virtual bool ReferencesContent(Guid key)
+        => ContentKey == key;
+
+    public virtual bool ReferencesSetting(Guid key)
+        => SettingsKey == key;
 }

--- a/src/Umbraco.Core/Models/Blocks/IBlockLayoutItem.cs
+++ b/src/Umbraco.Core/Models/Blocks/IBlockLayoutItem.cs
@@ -14,4 +14,8 @@ public interface IBlockLayoutItem
     public Guid ContentKey { get; set; }
 
     public Guid? SettingsKey { get; set; }
+
+    public bool ReferencesContent(Guid key) => ContentKey == key;
+
+    public bool ReferencesSetting(Guid key) => SettingsKey == key;
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
@@ -320,10 +320,10 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
 
         // remove all the blocks that are no longer part of the layout
         target.BlockValue.ContentData.RemoveAll(contentBlock =>
-            target.Layout!.Any(layoutItem => layoutItem.ContentKey == contentBlock.Key) is false);
+            target.Layout!.Any(layoutItem => layoutItem.ReferencesContent(contentBlock.Key)) is false);
 
         target.BlockValue.SettingsData.RemoveAll(settingsBlock =>
-            target.Layout!.Any(layoutItem => layoutItem.SettingsKey == settingsBlock.Key) is false);
+            target.Layout!.Any(layoutItem => layoutItem.ReferencesSetting(settingsBlock.Key)) is false);
 
         CleanupVariantValues(source.BlockValue.ContentData, target.BlockValue.ContentData, canUpdateInvariantData, allowedCultures);
         CleanupVariantValues(source.BlockValue.SettingsData, target.BlockValue.SettingsData, canUpdateInvariantData, allowedCultures);


### PR DESCRIPTION
### Description
Fixes a bug introduced in https://github.com/umbraco/Umbraco-CMS/pull/17707/ where a blockgrid with sub layout would have its sub layout data (not the definition) removed.

### Test setup
- element type with a textbox
- element type without properties
- block grid datatype with
  - textbox element type allowed at root and areas, spanning all columns
  - layout element type allowed at root and areas, with 2 areas setup
- doctype with the grid datatype defined above
- a new page with the content setup like this
![image](https://github.com/user-attachments/assets/d791c29d-f37c-49e3-b78e-dc32b81b1259)

### Test the fix
Adding a layout with data like shown below
![image](https://github.com/user-attachments/assets/0b056ae2-14da-4e12-a110-83634991812c)
Should result in the same thing when saving and refreshing the page

Example of the data being removed before this fix
![image](https://github.com/user-attachments/assets/a8300e92-00e9-48fa-bc92-52145e263369)

### Additional testing
Would be appreciated if the logic introduced in https://github.com/umbraco/Umbraco-CMS/pull/17707/ could be retested as well for sub layouts. I think I am sure, but I might be missing something.
