### PR TITLE
Renamed URL picker document link to content (more familiar to editors).

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
@@ -242,7 +242,7 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 				<uui-button
 					data-mark="action:document"
 					look="placeholder"
-					label=${this.localize.term('general_document')}
+					label=${this.localize.term('general_content')}
 					@click=${this.#triggerDocumentPicker}></uui-button>
 				<uui-button
 					data-mark="action:media"


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Implements the label rename intended in https://github.com/umbraco/Umbraco-CMS/pull/18226

### Description
Consideration is that whilst we have a developer distinctions between documents and content - with the latter being a general term for documents, media and members - editors have a "content" section so that's a better term to use here.

![image](https://github.com/user-attachments/assets/17a9f317-3a7b-4d2a-89f6-bcdd4b46fae1)
