### PR TITLE
Management API authorization for requests to rollback.

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentVersion/RollbackDocumentVersionController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentVersion/RollbackDocumentVersionController.cs
@@ -1,10 +1,18 @@
 using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Security.Authorization;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Web.Common.Authorization;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DocumentVersion;
 
@@ -13,13 +21,29 @@ public class RollbackDocumentVersionController : DocumentVersionControllerBase
 {
     private readonly IContentVersionService _contentVersionService;
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+    private readonly IAuthorizationService _authorizationService;
 
+    [ActivatorUtilitiesConstructor]
     public RollbackDocumentVersionController(
         IContentVersionService contentVersionService,
-        IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
+        IAuthorizationService authorizationService)
     {
         _contentVersionService = contentVersionService;
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+        _authorizationService = authorizationService;
+    }
+
+    // TODO (V16): Remove this constructor.
+    [Obsolete("Please use the constructor taking all parameters. This constructor will be removed in V16.")]
+    public RollbackDocumentVersionController(
+        IContentVersionService contentVersionService,
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+        : this(
+              contentVersionService,
+              backOfficeSecurityAccessor,
+              StaticServiceProvider.Instance.GetRequiredService<IAuthorizationService>())
+    {
     }
 
     [MapToApiVersion("1.0")]
@@ -29,11 +53,29 @@ public class RollbackDocumentVersionController : DocumentVersionControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Rollback(CancellationToken cancellationToken, Guid id, string? culture)
     {
-        Attempt<ContentVersionOperationStatus> attempt =
+        Attempt<IContent?, ContentVersionOperationStatus> getContentAttempt =
+            await _contentVersionService.GetAsync(id);
+        if (getContentAttempt.Success is false || getContentAttempt.Result is null)
+        {
+            return MapFailure(getContentAttempt.Status);
+        }
+
+        IContent content = getContentAttempt.Result;
+        AuthorizationResult authorizationResult = await _authorizationService.AuthorizeResourceAsync(
+            User,
+            ContentPermissionResource.WithKeys(ActionRollback.ActionLetter, content.Key),
+            AuthorizationPolicies.ContentPermissionByResource);
+
+        if (!authorizationResult.Succeeded)
+        {
+            return Forbidden();
+        }
+
+        Attempt<ContentVersionOperationStatus> rollBackAttempt =
             await _contentVersionService.RollBackAsync(id, culture, CurrentUserKey(_backOfficeSecurityAccessor));
 
-        return attempt.Success
+        return rollBackAttempt.Success
             ? Ok()
-            : MapFailure(attempt.Result);
+            : MapFailure(rollBackAttempt.Result);
     }
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/18232#issuecomment-2636279603

### Description
The linked issue notes that a user without explicit rollback permission can still perform the action.

As far as I can see it's resolved in the UI now.  The rollback button has a condition on it, and only appears if the user has permission for the operations.  But we should also validate this on the server, which is what this PR does.

**To Test:**

- Open two independent browser windows, log in as one as an admin and one as an editor.
- Make sure the editor has rollback permissions.
- In the editor browser, navigate to the screen where you can rollback content and verify you can do it.
- In the admin one, disable the rollback permission for the editor.
- In the editor browser, rollback again and verify you get forbidden API response.