### PR TITLE
Fixes new "Document Type with Template" filename casing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/workspace/document-type/document-type-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/workspace/document-type/document-type-workspace.context.ts
@@ -169,7 +169,7 @@ export class UmbDocumentTypeWorkspaceContext
 	async #createAndAssignTemplate() {
 		const { data: templateScaffold } = await this.#templateRepository.createScaffold({
 			name: this.getName(),
-			alias: this.getAlias(),
+			alias: this.getName(), // NOTE: Uses "name" over alias, as the server handle the template filename. [LK]
 		});
 
 		if (!templateScaffold) throw new Error('Could not create template scaffold');


### PR DESCRIPTION
### Description

Fixes #17458.

When creating a "Document Type with Template", the Document Type **name** is now passed to the server, instead of the **alias**, so that the server can case the Template filename appropriately, (using PascalCase). re: https://github.com/umbraco/Umbraco-CMS/issues/17458#issuecomment-2639213085.
