### PR TITLE
Picker search result item icons for Documents and Members

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/search/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/search/index.ts
@@ -1,3 +1,4 @@
 export * from './manager/index.js';
+export * from './result-item/index.js';
 export * from './picker-search-field.element.js';
 export * from './picker-search-result.element.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/search/result-item/default/default-picker-search-result-item.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/search/result-item/default/default-picker-search-result-item.element.ts
@@ -1,53 +1,12 @@
-import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { customElement, html, nothing, property, state } from '@umbraco-cms/backoffice/external/lit';
-import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import type { UmbPickerContext } from '@umbraco-cms/backoffice/picker';
-import { UMB_PICKER_CONTEXT } from '@umbraco-cms/backoffice/picker';
+import { UmbPickerSearchResultItemElementBase } from '../picker-search-result-item-element-base.js';
+import { customElement, html, nothing } from '@umbraco-cms/backoffice/external/lit';
 import type { UmbSearchResultItemModel } from '@umbraco-cms/backoffice/search';
 
-const elementName = 'umb-default-picker-search-result-item';
-@customElement(elementName)
-export class UmbDefaultPickerSearchResultItemElement extends UmbLitElement {
-	#item: UmbSearchResultItemModel | undefined;
-	@property({ type: Object })
-	public get item(): UmbSearchResultItemModel | undefined {
-		return this.#item;
-	}
-	public set item(value: UmbSearchResultItemModel | undefined) {
-		this.#item = value;
-		this.#observeIsSelected();
-	}
-
-	@state()
-	_isSelected = false;
-
-	#pickerContext?: UmbPickerContext;
-
-	constructor() {
-		super();
-
-		this.consumeContext(UMB_PICKER_CONTEXT, (context) => {
-			this.#pickerContext = context;
-			this.#observeIsSelected();
-		});
-	}
-
-	#observeIsSelected() {
-		const selectionManager = this.#pickerContext?.selection;
-		if (!selectionManager) return;
-
-		const unique = this.item?.unique;
-		if (unique === undefined) return;
-
-		this.observe(selectionManager.selection, () => {
-			this._isSelected = selectionManager.isSelected(unique);
-		});
-	}
-
+@customElement('umb-default-picker-search-result-item')
+export class UmbDefaultPickerSearchResultItemElement extends UmbPickerSearchResultItemElementBase<UmbSearchResultItemModel> {
 	override render() {
 		const item = this.item;
 		if (!item) return nothing;
-
 		return html`
 			<umb-ref-item
 				name=${item.name}
@@ -55,20 +14,18 @@ export class UmbDefaultPickerSearchResultItemElement extends UmbLitElement {
 				icon=${item.icon ?? 'icon-document'}
 				select-only
 				selectable
-				@selected=${() => this.#pickerContext?.selection.select(item.unique)}
-				@deselected=${() => this.#pickerContext?.selection.deselect(item.unique)}
-				?selected=${this._isSelected}>
+				?selected=${this._isSelected}
+				@deselected=${() => this.pickerContext?.selection.deselect(item.unique)}
+				@selected=${() => this.pickerContext?.selection.select(item.unique)}>
 			</umb-ref-item>
 		`;
 	}
-
-	static override readonly styles = [UmbTextStyles];
 }
 
 export { UmbDefaultPickerSearchResultItemElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbDefaultPickerSearchResultItemElement;
+		'umb-default-picker-search-result-item': UmbDefaultPickerSearchResultItemElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/search/result-item/default/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/search/result-item/default/index.ts
@@ -1,0 +1,2 @@
+export { UmbDefaultPickerSearchResultItemContext } from './default-picker-search-result-item.context.js';
+export { UMB_PICKER_SEARCH_RESULT_ITEM_CONTEXT } from './default-picker-search-result-item.context.token.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/search/result-item/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/search/result-item/index.ts
@@ -1,0 +1,2 @@
+export { UmbPickerSearchResultItemElementBase } from './picker-search-result-item-element-base.js';
+export * from './default/index.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/search/result-item/picker-search-result-item-element-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/search/result-item/picker-search-result-item-element-base.ts
@@ -1,0 +1,59 @@
+import type { UmbNamedEntityModel } from '@umbraco-cms/backoffice/entity';
+import { html, nothing, property, state } from '@umbraco-cms/backoffice/external/lit';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UMB_PICKER_CONTEXT } from '@umbraco-cms/backoffice/picker';
+import type { UmbPickerContext } from '@umbraco-cms/backoffice/picker';
+
+export abstract class UmbPickerSearchResultItemElementBase<ItemType extends UmbNamedEntityModel> extends UmbLitElement {
+	#item: ItemType | undefined;
+
+	protected pickerContext?: UmbPickerContext;
+
+	@property({ type: Object })
+	public set item(value: ItemType | undefined) {
+		this.#item = value;
+		this.#observeIsSelected();
+	}
+	public get item(): ItemType | undefined {
+		return this.#item;
+	}
+
+	@state()
+	_isSelected = false;
+
+	constructor() {
+		super();
+
+		this.consumeContext(UMB_PICKER_CONTEXT, (context) => {
+			this.pickerContext = context;
+			this.#observeIsSelected();
+		});
+	}
+
+	#observeIsSelected() {
+		const selectionManager = this.pickerContext?.selection;
+		if (!selectionManager) return;
+
+		const unique = this.item?.unique;
+		if (unique === undefined) return;
+
+		this.observe(selectionManager.selection, () => {
+			this._isSelected = selectionManager.isSelected(unique);
+		});
+	}
+
+	override render() {
+		const item = this.item;
+		if (!item) return nothing;
+		return html`
+			<umb-ref-item
+				name=${item.name}
+				select-only
+				selectable
+				?selected=${this._isSelected}
+				@deselected=${() => this.pickerContext?.selection.deselect(item.unique)}
+				@selected=${() => this.pickerContext?.selection.select(item.unique)}>
+			</umb-ref-item>
+		`;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/picker/document-picker-search-result-item.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/picker/document-picker-search-result-item.element.ts
@@ -1,0 +1,31 @@
+import type { UmbDocumentSearchItemModel } from '../search/types.js';
+import { customElement, html, nothing } from '@umbraco-cms/backoffice/external/lit';
+import { UmbPickerSearchResultItemElementBase } from '@umbraco-cms/backoffice/picker';
+
+@customElement('umb-document-picker-search-result-item')
+export class UmbDocumentPickerSearchResultItemElement extends UmbPickerSearchResultItemElementBase<UmbDocumentSearchItemModel> {
+	override render() {
+		if (!this.item) return nothing;
+		const item = this.item;
+		return html`
+			<umb-ref-item
+				name=${item.name}
+				id=${item.unique}
+				icon=${item.documentType.icon ?? 'icon-document'}
+				select-only
+				selectable
+				?selected=${this._isSelected}
+				@deselected=${() => this.pickerContext?.selection.deselect(item.unique)}
+				@selected=${() => this.pickerContext?.selection.select(item.unique)}>
+			</umb-ref-item>
+		`;
+	}
+}
+
+export { UmbDocumentPickerSearchResultItemElement as element };
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-document-picker-search-result-item': UmbDocumentPickerSearchResultItemElement;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/picker/manifests.ts
@@ -6,6 +6,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		kind: 'default',
 		alias: 'Umb.PickerSearchResultItem.Document',
 		name: 'Document Picker Search Result Item',
+		element: () => import('./document-picker-search-result-item.element.js'),
 		forEntityTypes: [UMB_DOCUMENT_ENTITY_TYPE],
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/picker/manifests.ts
@@ -6,6 +6,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		kind: 'default',
 		alias: 'Umb.PickerSearchResultItem.Member',
 		name: 'Member Picker Search Result Item',
+		element: () => import('./member-picker-search-result-item.element.js'),
 		forEntityTypes: [UMB_MEMBER_ENTITY_TYPE],
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/picker/member-picker-search-result-item.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/picker/member-picker-search-result-item.element.ts
@@ -1,0 +1,31 @@
+import type { UmbMemberSearchItemModel } from '../search/types.js';
+import { customElement, html, nothing } from '@umbraco-cms/backoffice/external/lit';
+import { UmbPickerSearchResultItemElementBase } from '@umbraco-cms/backoffice/picker';
+
+@customElement('umb-member-picker-search-result-item')
+export class UmbMemberPickerSearchResultItemElement extends UmbPickerSearchResultItemElementBase<UmbMemberSearchItemModel> {
+	override render() {
+		if (!this.item) return nothing;
+		const item = this.item;
+		return html`
+			<umb-ref-item
+				name=${item.name}
+				id=${item.unique}
+				icon=${item.memberType.icon ?? 'icon-user'}
+				select-only
+				selectable
+				?selected=${this._isSelected}
+				@deselected=${() => this.pickerContext?.selection.deselect(item.unique)}
+				@selected=${() => this.pickerContext?.selection.select(item.unique)}>
+			</umb-ref-item>
+		`;
+	}
+}
+
+export { UmbMemberPickerSearchResultItemElement as element };
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-member-picker-search-result-item': UmbMemberPickerSearchResultItemElement;
+	}
+}


### PR DESCRIPTION
### Description

Partial fix for #17664, _(this PR only fixes the icon not the URL part)_.

Added `pickerSearchResultItem` elements for Document and Member pickers.

To do cut down on the boilerplate code, I've abstracted `UmbDefaultPickerSearchResultItemElement` to `UmbPickerSearchResultItemElementBase<T>`, so to reuse the base class on the Document and Member elements.

Let me know if any files/folders need moving around or renaming. 