### PR TITLE
Granular permissions translation DK, EN, US

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
@@ -1914,6 +1914,8 @@ export default {
 		permissionsDefault: 'Standardrettigheder',
 		permissionsGranular: 'Granulære rettigheder',
 		permissionsGranularHelp: 'Sæt rettigheder for specifikke noder',
+		granularRightsLabel: 'Dokumenter',
+		granularRightsDescription: 'Tillad adgang til specifikke dokumenter',
 		permissionsEntityGroup_document: 'Indhold',
 		permissionsEntityGroup_media: 'Medie',
 		permissionsEntityGroup_member: 'Medlemmer',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
@@ -93,6 +93,10 @@ export default {
 		createblueprint: 'Tillad adgang til at oprette en indholdsskabelon',
 		notify: 'Tillad adgang til at oprette notificeringer for noder',
 	},
+	userRights: {
+		permissionLabel: 'Handlingsrettigheder',
+		permissionsDescription: 'Tildel tilladelser til en handlingstype',
+	},
 	apps: {
 		umbContent: 'Indhold',
 		umbInfo: 'Info',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
@@ -93,10 +93,6 @@ export default {
 		createblueprint: 'Tillad adgang til at oprette en indholdsskabelon',
 		notify: 'Tillad adgang til at oprette notificeringer for noder',
 	},
-	userRights: {
-		permissionLabel: 'Handlingsrettigheder',
-		permissionsDescription: 'Tildel tilladelser til en handlingstype',
-	},
 	apps: {
 		umbContent: 'Indhold',
 		umbInfo: 'Info',
@@ -1934,6 +1930,8 @@ export default {
 		chooseUserGroup: (multiple: boolean) => {
 			return multiple ? 'Vælg brugergrupper' : 'Vælg brugergruppe';
 		},
+		entityPermissionsLabel: 'Handlingsrettigheder',
+		entityPermissionsDescription: 'Tildel tilladelser til handlinger',
 		noStartNode: 'Ingen startnode valgt',
 		noStartNodes: 'Ingen startnoder valgt',
 		startnode: 'Indhold startnode',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
@@ -99,10 +99,6 @@ export default {
 		createblueprint: 'Allow access to create a Document Blueprint',
 		notify: 'Allow access to setup notifications for content nodes',
 	},
-	userRights: {
-		permissionLabel: 'Permissions',
-		permissionsDescription: 'Assign permissions for an action type',
-	},
 	apps: {
 		umbContent: 'Content',
 		umbInfo: 'Info',
@@ -1987,6 +1983,8 @@ export default {
 		chooseUserGroup: (multiple: boolean) => {
 			return multiple ? 'Choose User Groups' : 'Choose User Group';
 		},
+		entityPermissionsLabel: 'Permissions',
+		entityPermissionsDescription: 'Assign permissions for actions',
 		noStartNode: 'No start node selected',
 		noStartNodes: 'No start nodes selected',
 		startnode: 'Content start node',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
@@ -99,6 +99,10 @@ export default {
 		createblueprint: 'Allow access to create a Document Blueprint',
 		notify: 'Allow access to setup notifications for content nodes',
 	},
+	userRights: {
+		permissionLabel: 'Permissions',
+		permissionsDescription: 'Assign permissions for an action type',
+	},
 	apps: {
 		umbContent: 'Content',
 		umbInfo: 'Info',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
@@ -1967,6 +1967,8 @@ export default {
 		permissionsDefault: 'Default permissions',
 		permissionsGranular: 'Granular permissions',
 		permissionsGranularHelp: 'Set permissions for specific nodes',
+		granularRightsLabel: 'Documents',
+		granularRightsDescription: 'Assign permissions to specific documents',
 		permissionsEntityGroup_document: 'Content',
 		permissionsEntityGroup_media: 'Media',
 		permissionsEntityGroup_member: 'Member',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -99,6 +99,10 @@ export default {
 		createblueprint: 'Allow access to create a Document Blueprint',
 		notify: 'Allow access to setup notifications for content nodes',
 	},
+	userRights: {
+		permissionLabel: 'Permissions',
+		permissionsDescription: 'Assign permissions for an action type',
+	},
 	apps: {
 		umbContent: 'Content',
 		umbInfo: 'Info',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -2009,6 +2009,8 @@ export default {
 		permissionsDefault: 'Default permissions',
 		permissionsGranular: 'Granular permissions',
 		permissionsGranularHelp: 'Set permissions for specific nodes',
+		granularRightsLabel: 'Documents',
+		granularRightsDescription: 'Assign permissions to specific documents',
 		permissionsEntityGroup_document: 'Content',
 		permissionsEntityGroup_media: 'Media',
 		permissionsEntityGroup_member: 'Member',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -99,10 +99,6 @@ export default {
 		createblueprint: 'Allow access to create a Document Blueprint',
 		notify: 'Allow access to setup notifications for content nodes',
 	},
-	userRights: {
-		permissionLabel: 'Permissions',
-		permissionsDescription: 'Assign permissions for an action type',
-	},
 	apps: {
 		umbContent: 'Content',
 		umbInfo: 'Info',
@@ -2029,6 +2025,8 @@ export default {
 		chooseUserGroup: (multiple: boolean) => {
 			return multiple ? 'Choose User Groups' : 'Choose User Group';
 		},
+		entityPermissionsLabel: 'Permissions',
+		entityPermissionsDescription: 'Assign permissions for actions',
 		noStartNode: 'No start node selected',
 		noStartNodes: 'No start nodes selected',
 		startnode: 'Content start node',

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/user-permissions/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/user-permissions/manifests.ts
@@ -206,8 +206,8 @@ export const granularPermissions: Array<ManifestGranularUserPermission> = [
 			import('./input-document-granular-user-permission/input-document-granular-user-permission.element.js'),
 		meta: {
 			schemaType: 'DocumentPermissionPresentationModel',
-			label: 'Documents',
-			description: 'Assign permissions to specific documents',
+			label: '#user_granularRightsLabel',
+			description: '{#user_granularRightsDescription}',
 		},
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user-group/workspace/user-group/user-group-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user-group/workspace/user-group/user-group-workspace-editor.element.ts
@@ -247,7 +247,6 @@ export class UmbUserGroupWorkspaceEditorElement extends UmbLitElement {
 						<umb-property-layout label=${this.localize.term('userRights_permissionLabel')} description=${this.localize.term('userRights_permissionsDescription')}>
 							<umb-user-group-entity-user-permission-list slot="editor"></umb-user-group-entity-user-permission-list>
 						</umb-property-layout>
-						${this.#renderLanguageAccess()} ${this.#renderDocumentAccess()} ${this.#renderMediaAccess()}
 					</uui-box>
 
 					<uui-box>

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user-group/workspace/user-group/user-group-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user-group/workspace/user-group/user-group-workspace-editor.element.ts
@@ -244,7 +244,7 @@ export class UmbUserGroupWorkspaceEditorElement extends UmbLitElement {
 					<uui-box>
 						<div slot="headline"><umb-localize key="user_permissionsDefault"></umb-localize></div>
 
-						<umb-property-layout label=${this.localize.term('userRights_permissionLabel')} description=${this.localize.term('userRights_permissionsDescription')}>
+						<umb-property-layout label=${this.localize.term('user_entityPermissionsLabel')} description=${this.localize.term('user_entityPermissionsDescription')}>
 							<umb-user-group-entity-user-permission-list slot="editor"></umb-user-group-entity-user-permission-list>
 						</umb-property-layout>
 					</uui-box>

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user-group/workspace/user-group/user-group-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user-group/workspace/user-group/user-group-workspace-editor.element.ts
@@ -244,9 +244,10 @@ export class UmbUserGroupWorkspaceEditorElement extends UmbLitElement {
 					<uui-box>
 						<div slot="headline"><umb-localize key="user_permissionsDefault"></umb-localize></div>
 
-						<umb-property-layout label="Entity permissions" description="Assign permissions for an entity type">
+						<umb-property-layout label=${this.localize.term('userRights_permissionLabel')} description=${this.localize.term('userRights_permissionsDescription')}>
 							<umb-user-group-entity-user-permission-list slot="editor"></umb-user-group-entity-user-permission-list>
 						</umb-property-layout>
+						${this.#renderLanguageAccess()} ${this.#renderDocumentAccess()} ${this.#renderMediaAccess()}
 					</uui-box>
 
 					<uui-box>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Translated granular permissions label and description EN, US-EN, and DK for the backoffice UI, as these were missing.
Changes can be verified in the backoffice, under User Group settings, at the bottom of the page. 
![image](https://github.com/user-attachments/assets/538a1e0f-be50-45c5-a2ab-9baab4ac2154)