### PR TITLE
Fix 11643

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.component.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/rte.component.js
@@ -83,6 +83,7 @@
           }
       }));
 
+
       vm.layout = []; // The layout object specific to this Block Editor, will be a direct reference from Property Model.
       vm.availableBlockTypes = []; // Available block entries of this property editor.
       vm.labels = {};
@@ -189,6 +190,9 @@
           vm.containerWidth = "auto";
           vm.containerHeight = "auto";
           vm.containerOverflow = "inherit"
+
+          // Add client validation for the markup part.
+          unsubscribe.push($scope.$watch(() => vm.model?.value?.markup, validate));
 
           //queue file loading
           tinyMceAssets.forEach(function (tinyJsAsset) {
@@ -336,6 +340,18 @@
           vm.tinyMceEditor.focus();
         }
       }
+
+      function validate() {
+        var isValid = !vm.model.validation.mandatory || (
+            vm.model.value != null
+            && vm.model.value.markup != null
+            && vm.model.value.markup != ""
+        );
+        vm.propertyForm.$setValidity("required", isValid);
+        if (vm.umbProperty) {
+          vm.umbProperty.setPropertyError(vm.model.validation.mandatoryMessage || "Value cannot be empty");
+        }
+    };
 
       // Called when we save the value, the server may return an updated data and our value is re-synced
       // we need to deal with that here so that our model values are all in sync so we basically re-initialize.


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/11643

After Blocks was added to the Rich text Editor, the built-in Mandatory validation check has no effect, as we always will have a Object.

This adds a custom validation to check for the markup field, and thereby ensure that we have markup when a field is mandatory.

This fix is not viable to cherry pick for previous versions as the data model of the Rich Text editor was changed in v.13.

See issue for test cases