### PR TITLE
Remove the hard upper limit for SQL write lock timeout

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/Validation/GlobalSettingsValidator.cs
+++ b/src/Umbraco.Core/Configuration/Models/Validation/GlobalSettingsValidator.cs
@@ -32,16 +32,14 @@ public class GlobalSettingsValidator
 
     private bool ValidateSqlWriteLockTimeOutSetting(TimeSpan configuredTimeOut, out string message)
     {
-        // Only apply this setting if it's not excessively high or low
+        // Only apply this setting if it's not excessively low
         const int minimumTimeOut = 100;
-        const int maximumTimeOut = 20000;
 
         // between 0.1 and 20 seconds
-        if (configuredTimeOut.TotalMilliseconds < minimumTimeOut ||
-            configuredTimeOut.TotalMilliseconds > maximumTimeOut)
+        if (configuredTimeOut.TotalMilliseconds < minimumTimeOut)
         {
             message =
-                $"The `{Constants.Configuration.ConfigGlobal}:{nameof(GlobalSettings.DistributedLockingWriteLockDefaultTimeout)}` setting is not between the minimum of {minimumTimeOut} ms and maximum of {maximumTimeOut} ms";
+                $"The `{Constants.Configuration.ConfigGlobal}:{nameof(GlobalSettings.DistributedLockingWriteLockDefaultTimeout)}` should not be configured as less than {minimumTimeOut} ms";
             return false;
         }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Configuration/Models/Validation/GlobalSettingsValidatorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Configuration/Models/Validation/GlobalSettingsValidatorTests.cs
@@ -40,16 +40,6 @@ public class GlobalSettingsValidatorTests
     }
 
     [Test]
-    public void Returns_Fail_For_Configuration_With_Excessive_SqlWriteLockTimeOut()
-    {
-        var validator = new GlobalSettingsValidator();
-        var options = new GlobalSettings { DistributedLockingWriteLockDefaultTimeout = TimeSpan.Parse("00:00:21") };
-
-        var result = validator.Validate("settings", options);
-        Assert.False(result.Succeeded);
-    }
-
-    [Test]
     public void Returns_Success_For_Configuration_With_Valid_SqlWriteLockTimeOut()
     {
         var validator = new GlobalSettingsValidator();


### PR DESCRIPTION
### Prerequisites

If there's an existing issue for this PR then this fixes #18143

### Description

As mentioned in #18143, there is a somewhat arbitrary hard upper limit of 20s for obtaining the distributed SQL write lock. While this limit is more than sufficient in any normal scenario, there is really no reason for us imposing a hard upper limit.

This PR removes the hard upper limit 😄 