### PR TITLE
Add validation to prevent update of a user or member to an invalid username (13)

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/MemberController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MemberController.cs
@@ -723,6 +723,17 @@ public class MemberController : ContentControllerBase
             return false;
         }
 
+        // User names can only contain the configured allowed characters. This is validated by ASP.NET Identity on create
+        // as the setting is applied to the IdentityOptions, but we need to check ourselves for updates.
+        var allowedUserNameCharacters = _securitySettings.AllowedUserNameCharacters;
+        if (contentItem.Username.Any(c => allowedUserNameCharacters.Contains(c) == false))
+        {
+            ModelState.AddPropertyError(
+                new ValidationResult("Username contains invalid characters"),
+                $"{Constants.PropertyEditors.InternalGenericPropertiesPrefix}login");
+            return false;
+        }
+
         if (contentItem.Password != null && !contentItem.Password.NewPassword.IsNullOrWhiteSpace())
         {
             IdentityResult validPassword = await _memberManager.ValidatePasswordAsync(contentItem.Password.NewPassword);

--- a/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
@@ -714,6 +714,15 @@ public class UsersController : BackOfficeNotificationsController
 
         var hasErrors = false;
 
+        // User names can only contain the configured allowed characters. This is validated by ASP.NET Identity on create
+        // as the setting is applied to the BackOfficeIdentityOptions, but we need to check ourselves for updates.
+        var allowedUserNameCharacters = _securitySettings.AllowedUserNameCharacters;
+        if (userSave.Username.Any(c => allowedUserNameCharacters.Contains(c) == false))
+        {
+            ModelState.AddModelError("Username", "Username contains invalid characters");
+            hasErrors = true;
+        }
+
         // we need to check if there's any Deny Local login providers present, if so we need to ensure that the user's email address cannot be changed
         var hasDenyLocalLogin = _externalLogins.HasDenyLocalLogin();
         if (hasDenyLocalLogin)

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/user/details.html
@@ -1,4 +1,4 @@
-﻿<div ng-controller="Umbraco.Editors.Users.DetailsController as vm" class="umb-user-details-details">
+<div ng-controller="Umbraco.Editors.Users.DetailsController as vm" class="umb-user-details-details">
 
     <div class="umb-user-details-details__main-content">
 
@@ -45,6 +45,8 @@
                                ng-model="model.user.username"
                                umb-auto-focus name="username"
                                required
+                               autocomplete="off"
+                               no-password-manager
                                val-server-field="Username" />
                         <span ng-messages="userProfileForm.username.$error" show-validation-on-submit>
                             <span class="help-inline" ng-message="required"><localize key="general_required">Required</localize></span>


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes https://github.com/umbraco/Umbraco-CMS/issues/17347 and https://github.com/umbraco/Umbraco-CMS/issues/14823

### Description
The core of both reported issues is that whilst we can rely on ASP.NET Identity validating the user name characters, for updates we need to do it ourselves.  So I've added that into the validation checks for both users and members.

I also fixed an annoyance with LastPass attempting to fill the user name and leading to accidental updates.

**To Test:**

- Allow for example a space to be a valid character by configuring:

```
  "Umbraco": {
    "CMS": {
      "Security": {
        "UsernameIsEmail": false,
        "AllowedUserNameCharacters": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._ @+\\",
```

- Create a member and a user with a space in the user name.
- Update configuration to remove space from being a valid character.
- Before the PR you'll find you can update members and users that have a space in their username.
- After the code in the PR is applied, you won't be able to.