### PR TITLE
Property editor settings translation for DK&US

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
@@ -1673,6 +1673,7 @@ export default {
 		elementDoesNotSupport: 'Dette benyttes ikke for en Element-type',
 		propertyHasChanges: 'Du har lavet ændringer til denne egenskab. Er du sikker på at du vil kassere dem?\n    ',
 		displaySettingsHeadline: 'Visning',
+		displaySettingsLabelOnLeft: 'Label på venstre side',
 		displaySettingsLabelOnTop: 'Label hen over (fuld bredde)',
 		removeChildNode: 'Du fjerner noden',
 		removeChildNodeWarning:
@@ -2020,6 +2021,7 @@ export default {
 	},
 	validation: {
 		validation: 'Validering',
+		validateNothing: 'Ingen validering',
 		validateAsEmail: 'Valider som e-mail',
 		validateAsNumber: 'Valider som tal',
 		validateAsUrl: 'Valider som URL',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
@@ -1711,6 +1711,7 @@ export default {
 		elementDoesNotSupport: 'This is not applicable for an Element Type',
 		propertyHasChanges: 'You have made changes to this property. Are you sure you want to discard them?',
 		displaySettingsHeadline: 'Appearance',
+		displaySettingsLabelOnLeft: 'Label to the left',
 		displaySettingsLabelOnTop: 'Label above (full-width)',
 		confirmDeleteTabMessage: 'Are you sure you want to delete the tab <strong>%0%</strong>?',
 		confirmDeleteGroupMessage: 'Are you sure you want to delete the group <strong>%0%</strong>?',
@@ -2060,6 +2061,7 @@ export default {
 	},
 	validation: {
 		validation: 'Validation',
+		validateNothing: 'No validation',
 		validateAsEmail: 'Validate as an email address',
 		validateAsNumber: 'Validate as a number',
 		validateAsUrl: 'Validate as a URL',


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Description
Translated property editor settings for DK and EN-US, as these keys did not exist before. 
Changes can be verified in the backoffice, in the Add property overlay. 
![image](https://github.com/user-attachments/assets/b0312c5d-8ba4-4684-ac8c-f32dd4e62f96)
