### PR TITLE
Fixing the background color of the "re-login" screen when your session has timed out.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/modals/umb-app-auth-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/modals/umb-app-auth-modal.element.ts
@@ -170,7 +170,7 @@ export class UmbAppAuthModalElement extends UmbModalBaseElement<UmbModalAppAuthC
 		css`
 			:host {
 				display: block;
-				background: var(--uui-modal-dialog-background, #f4f4f4);
+				background: var(--uui-color-surface, #f4f4f4);
 
 				--curves-color: var(--umb-login-curves-color, #f5c1bc);
 				--curves-display: var(--umb-login-curves-display, inline);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/modals/umb-app-auth-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/modals/umb-app-auth-modal.element.ts
@@ -170,7 +170,7 @@ export class UmbAppAuthModalElement extends UmbModalBaseElement<UmbModalAppAuthC
 		css`
 			:host {
 				display: block;
-				background: rgb(244, 244, 244);
+				background: var(--uui-modal-dialog-background, #f4f4f4);
 
 				--curves-color: var(--umb-login-curves-color, #f5c1bc);
 				--curves-display: var(--umb-login-curves-display, inline);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

To replicate the issue:

- Log into the back office of Umbraco 15 
- Change into the "Dark" theme
- Wait for your session to expire
- Try and use the back office, it should redirect you to log back in again

This is where the issue appears, because you are using the dark theme, the fonts are all light fonts, but the background color is not using the theme, so the text disappears.

The fix is to correctly us the theme color and fall back to the default, which is what I have done :)

Tiny change, far more typing for this description :)