### PR TITLE
Fix #17695

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/router/components/router-slot/route.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/router/components/router-slot/route.context.ts
@@ -91,6 +91,14 @@ export class UmbRouteContext extends UmbContextBase<UmbRouteContext> {
 		const routesToRemove = this.#modalRoutes.filter(
 			(route) => !this.#modalRegistrations.find((x) => x.key === route.__modalKey),
 		);
+		// If one the of the removed modals are active we should close it.
+		routesToRemove.some((route) => {
+			if (route.path === this.#activeModalPath) {
+				this.#modalContext?.close(route.__modalKey);
+				return true;
+			}
+			return false;
+		});
 
 		const cleanedRoutes = this.#modalRoutes.filter((route) => !routesToRemove.includes(route));
 


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/17695

Issue was grounded in the modal begin unregistered as the property Group was cloned to the local Document Type, and thereby unregistering the modal as a new one with the newly created group id was registered.

This PR fixes to modal that are begin removed and are active will be closed in that act.