### PR TITLE
Only filter post retrieval of entities for start nodes if working with entities that support start nodes

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/EntityController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/EntityController.cs
@@ -895,6 +895,7 @@ public class EntityController : UmbracoAuthorizedJsonController
                     // Filtering out child nodes after getting a paged result is an active choice here, even though the pagination might get off.
                     // This has been the case with this functionality in Umbraco for a long time.
                     .Where(entity => ignoreUserStartNodes ||
+                                     (objectType == UmbracoObjectTypes.Document || objectType == UmbracoObjectTypes.Media) is false ||
                                      (ContentPermissions.IsInBranchOfStartNode(entity.Path, startNodeIds, startNodePaths, out var hasPathAccess) &&
                                      hasPathAccess))
                     .Select(source =>


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/18286

### Description
As the issue notes, you can't retrieve any members via the "All members" view of the member picker (although you do get the paging information).  This was due to some code looking to filter post retrieval into a paged model for user start nodes.

I've modified this so it only applies for documents and media, which are the only entities that support start nodes.

**To Test:**

- Set up one or two member accounts.
- Add a member picker to a document type.
- Use the member picker when editing content and verify that you can now pick a member via the "All members" search.