### PR TITLE
Prevents folder selection in media picker when used from the multi URL picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.controller.js
@@ -189,6 +189,7 @@ angular.module("umbraco").controller("Umbraco.Editors.LinkPickerController",
           startNodeId: startNodeId,
           startNodeIsVirtual: startNodeIsVirtual,
           dataTypeKey: dialogOptions.dataTypeKey,
+          disableFolderSelect: true,
           submit: function (model) {
             var media = model.selection[0];
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/18266

### Description
As the issue notes, you can select a media folder in the multi URL picker which doesn't make sense as it's not possible to get a URL from a media folder.  This PR provides the option to prevent selection of folders.

**To Test:**

- Add a multi-URL picker to a document type
- Create a media item within a folder
- Pick media from the URL picker and note you now can't select folders.
