### PR TITLE
Add custom sub variancy support for the RTE

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
@@ -296,6 +296,18 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
         BlockEditorData<TValue, TLayout>? source = BlockEditorValues.DeserializeAndClean(sourceValue);
         BlockEditorData<TValue, TLayout>? target = BlockEditorValues.DeserializeAndClean(targetValue);
 
+        TValue? mergedBlockValue =
+            MergeVariantInvariantPropertyValueTyped(source, target, canUpdateInvariantData, allowedCultures);
+
+        return _jsonSerializer.Serialize(mergedBlockValue);
+    }
+
+    internal virtual TValue? MergeVariantInvariantPropertyValueTyped(
+        BlockEditorData<TValue, TLayout>? source,
+        BlockEditorData<TValue, TLayout>? target,
+        bool canUpdateInvariantData,
+        HashSet<string> allowedCultures)
+    {
         source = UpdateSourceInvariantData(source, target, canUpdateInvariantData);
 
         if (source is null && target is null)
@@ -328,7 +340,7 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
         CleanupVariantValues(source.BlockValue.ContentData, target.BlockValue.ContentData, canUpdateInvariantData, allowedCultures);
         CleanupVariantValues(source.BlockValue.SettingsData, target.BlockValue.SettingsData, canUpdateInvariantData, allowedCultures);
 
-        return _jsonSerializer.Serialize(target.BlockValue);
+        return target.BlockValue;
     }
 
     private void CleanupVariantValues(


### PR DESCRIPTION
### Description
fixes #18252

Since the RTE wraps its block values into its own custom model, we need to pull them apart before letting the base class handle the actual merging.
We also need to merge the html as you might not be allowed to update this based on language settings

### Testing
![image](https://github.com/user-attachments/assets/91cd698b-9dc5-46a8-b544-8b58c77ebe92)