### PR TITLE
Added $type to ReferenceResponseModels

### DIFF
--- a/src/Umbraco.Cms.Api.Management/ViewModels/TrackedReferences/IReferenceResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/TrackedReferences/IReferenceResponseModel.cs
@@ -1,6 +1,8 @@
-﻿namespace Umbraco.Cms.Api.Management.ViewModels.TrackedReferences;
+﻿using Umbraco.Cms.Api.Common.OpenApi;
 
-public interface IReferenceResponseModel
+namespace Umbraco.Cms.Api.Management.ViewModels.TrackedReferences;
+
+public interface IReferenceResponseModel : IOpenApiDiscriminator
 {
     public Guid Id { get; }
 


### PR DESCRIPTION
### Description
Add the $type to the openApimodel for ReferenceResponseModels so the client can improve their typing.