### PR TITLE
Allow for multiple backoffice hosts

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Security/BackOfficeApplicationManager.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/BackOfficeApplicationManager.cs
@@ -48,7 +48,7 @@ public class BackOfficeApplicationManager : OpenIdDictApplicationManagerBase, IB
         Uri[] backOfficeHostsAsArray = backOfficeHosts as Uri[] ?? backOfficeHosts.ToArray();
         if (backOfficeHostsAsArray.Any(url => url.IsAbsoluteUri) is false)
         {
-            throw new ArgumentException($"Expected an absolute URLs, got: {string.Join(", ", backOfficeHostsAsArray.Select(url => url.ToString()))}", nameof(backOfficeHosts));
+            throw new ArgumentException($"Expected absolute URLs, got: {string.Join(", ", backOfficeHostsAsArray.Select(url => url.ToString()))}", nameof(backOfficeHosts));
         }
 
         await CreateOrUpdate(

--- a/src/Umbraco.Cms.Api.Management/Security/BackOfficeApplicationManager.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/BackOfficeApplicationManager.cs
@@ -32,7 +32,11 @@ public class BackOfficeApplicationManager : OpenIdDictApplicationManagerBase, IB
         _authorizeCallbackLogoutPathName = securitySettings.Value.AuthorizeCallbackLogoutPathName;
     }
 
+    [Obsolete("Please use the overload that allows for multiple back-office hosts. Will be removed in V17.")]
     public async Task EnsureBackOfficeApplicationAsync(Uri backOfficeUrl, CancellationToken cancellationToken = default)
+        => await EnsureBackOfficeApplicationAsync([backOfficeUrl], cancellationToken);
+
+    public async Task EnsureBackOfficeApplicationAsync(IEnumerable<Uri> backOfficeHosts, CancellationToken cancellationToken = default)
     {
         // Install is okay without this, because we do not need a token to install,
         // but upgrades do, so we need to execute for everything higher then or equal to upgrade.
@@ -41,13 +45,14 @@ public class BackOfficeApplicationManager : OpenIdDictApplicationManagerBase, IB
             return;
         }
 
-        if (backOfficeUrl.IsAbsoluteUri is false)
+        Uri[] backOfficeHostsAsArray = backOfficeHosts as Uri[] ?? backOfficeHosts.ToArray();
+        if (backOfficeHostsAsArray.Any(url => url.IsAbsoluteUri) is false)
         {
-            throw new ArgumentException($"Expected an absolute URL, got: {backOfficeUrl}", nameof(backOfficeUrl));
+            throw new ArgumentException($"Expected an absolute URLs, got: {string.Join(", ", backOfficeHostsAsArray.Select(url => url.ToString()))}", nameof(backOfficeHosts));
         }
 
         await CreateOrUpdate(
-            BackofficeOpenIddictApplicationDescriptor(backOfficeUrl),
+            BackofficeOpenIddictApplicationDescriptor(backOfficeHostsAsArray),
             cancellationToken);
 
         if (_webHostEnvironment.IsProduction())
@@ -57,88 +62,20 @@ public class BackOfficeApplicationManager : OpenIdDictApplicationManagerBase, IB
         }
         else
         {
-            var developerClientTimeOutValue = new GlobalSettings().TimeOut.ToString("c", CultureInfo.InvariantCulture);
-
             await CreateOrUpdate(
-                new OpenIddictApplicationDescriptor
-                {
-                    DisplayName = "Umbraco Swagger access",
-                    ClientId = Constants.OAuthClientIds.Swagger,
-                    RedirectUris =
-                    {
-                        CallbackUrlFor(backOfficeUrl, "/umbraco/swagger/oauth2-redirect.html")
-                    },
-                    ClientType = OpenIddictConstants.ClientTypes.Public,
-                    Permissions =
-                    {
-                        OpenIddictConstants.Permissions.Endpoints.Authorization,
-                        OpenIddictConstants.Permissions.Endpoints.Token,
-                        OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode,
-                        OpenIddictConstants.Permissions.ResponseTypes.Code
-                    },
-                    Settings =
-                    {
-                        // use a fixed access token lifetime for tokens issued to the Swagger application.
-                        [OpenIddictConstants.Settings.TokenLifetimes.AccessToken] = developerClientTimeOutValue
-                    }
-                },
+                DeveloperOpenIddictApplicationDescriptor(
+                    "Umbraco Swagger access",
+                    Constants.OAuthClientIds.Swagger,
+                    backOfficeHostsAsArray.Select(backOfficeUrl => CallbackUrlFor(backOfficeUrl, "/umbraco/swagger/oauth2-redirect.html")).ToArray()),
                 cancellationToken);
 
             await CreateOrUpdate(
-                new OpenIddictApplicationDescriptor
-                {
-                    DisplayName = "Umbraco Postman access",
-                    ClientId = Constants.OAuthClientIds.Postman,
-                    RedirectUris =
-                    {
-                        new Uri("https://oauth.pstmn.io/v1/callback"), new Uri("https://oauth.pstmn.io/v1/browser-callback")
-                    },
-                    ClientType = OpenIddictConstants.ClientTypes.Public,
-                    Permissions =
-                    {
-                        OpenIddictConstants.Permissions.Endpoints.Authorization,
-                        OpenIddictConstants.Permissions.Endpoints.Token,
-                        OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode,
-                        OpenIddictConstants.Permissions.ResponseTypes.Code
-                    },
-                    Settings =
-                    {
-                        // use a fixed access token lifetime for tokens issued to the Postman application.
-                        [OpenIddictConstants.Settings.TokenLifetimes.AccessToken] = developerClientTimeOutValue
-                    }
-                },
+                DeveloperOpenIddictApplicationDescriptor(
+                    "Umbraco Postman access",
+                    Constants.OAuthClientIds.Postman,
+                    [new Uri("https://oauth.pstmn.io/v1/callback"), new Uri("https://oauth.pstmn.io/v1/browser-callback")]),
                 cancellationToken);
         }
-    }
-
-    public OpenIddictApplicationDescriptor BackofficeOpenIddictApplicationDescriptor(Uri backOfficeUrl)
-    {
-        Uri CallbackUrl(string path) => CallbackUrlFor(_backOfficeHost ?? backOfficeUrl, path);
-        return new OpenIddictApplicationDescriptor
-        {
-            DisplayName = "Umbraco back-office access",
-            ClientId = Constants.OAuthClientIds.BackOffice,
-            RedirectUris =
-            {
-                CallbackUrl(_authorizeCallbackPathName),
-            },
-            ClientType = OpenIddictConstants.ClientTypes.Public,
-            PostLogoutRedirectUris =
-            {
-                CallbackUrl(_authorizeCallbackPathName),
-                CallbackUrl(_authorizeCallbackLogoutPathName),
-            },
-            Permissions =
-            {
-                OpenIddictConstants.Permissions.Endpoints.Authorization,
-                OpenIddictConstants.Permissions.Endpoints.Token,
-                OpenIddictConstants.Permissions.Endpoints.EndSession,
-                OpenIddictConstants.Permissions.Endpoints.Revocation,
-                OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode,
-                OpenIddictConstants.Permissions.GrantTypes.RefreshToken,
-                OpenIddictConstants.Permissions.ResponseTypes.Code,
-            },
-        };
     }
 
     public async Task EnsureBackOfficeClientCredentialsApplicationAsync(string clientId, string clientSecret, CancellationToken cancellationToken = default)
@@ -162,6 +99,75 @@ public class BackOfficeApplicationManager : OpenIdDictApplicationManagerBase, IB
 
     public async Task DeleteBackOfficeClientCredentialsApplicationAsync(string clientId, CancellationToken cancellationToken = default)
         => await Delete(clientId, cancellationToken);
+
+    [Obsolete("Do not use - for internal usage only. Will be made internal in V17.")]
+    public OpenIddictApplicationDescriptor BackofficeOpenIddictApplicationDescriptor(Uri backOfficeUrl)
+        => BackofficeOpenIddictApplicationDescriptor([backOfficeUrl]);
+
+    internal OpenIddictApplicationDescriptor BackofficeOpenIddictApplicationDescriptor(Uri[] backOfficeHosts)
+    {
+        if (_backOfficeHost is not null)
+        {
+            backOfficeHosts = [_backOfficeHost];
+        }
+
+        var descriptor = new OpenIddictApplicationDescriptor
+        {
+            DisplayName = "Umbraco back-office access",
+            ClientId = Constants.OAuthClientIds.BackOffice,
+            ClientType = OpenIddictConstants.ClientTypes.Public,
+            Permissions =
+            {
+                OpenIddictConstants.Permissions.Endpoints.Authorization,
+                OpenIddictConstants.Permissions.Endpoints.Token,
+                OpenIddictConstants.Permissions.Endpoints.EndSession,
+                OpenIddictConstants.Permissions.Endpoints.Revocation,
+                OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode,
+                OpenIddictConstants.Permissions.GrantTypes.RefreshToken,
+                OpenIddictConstants.Permissions.ResponseTypes.Code,
+            },
+        };
+
+        foreach (Uri backOfficeHost in backOfficeHosts)
+        {
+            descriptor.RedirectUris.Add(CallbackUrlFor(backOfficeHost, _authorizeCallbackPathName));
+            descriptor.PostLogoutRedirectUris.Add(CallbackUrlFor(backOfficeHost, _authorizeCallbackPathName));
+            descriptor.PostLogoutRedirectUris.Add(CallbackUrlFor(backOfficeHost, _authorizeCallbackLogoutPathName));
+        }
+
+        return descriptor;
+    }
+
+    internal OpenIddictApplicationDescriptor DeveloperOpenIddictApplicationDescriptor(string name, string clientId, Uri[] redirectUrls)
+    {
+        var developerClientTimeOutValue = new GlobalSettings().TimeOut.ToString("c", CultureInfo.InvariantCulture);
+
+        var descriptor = new OpenIddictApplicationDescriptor
+        {
+            DisplayName = name,
+            ClientId = clientId,
+            ClientType = OpenIddictConstants.ClientTypes.Public,
+            Permissions =
+            {
+                OpenIddictConstants.Permissions.Endpoints.Authorization,
+                OpenIddictConstants.Permissions.Endpoints.Token,
+                OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode,
+                OpenIddictConstants.Permissions.ResponseTypes.Code
+            },
+            Settings =
+            {
+                // use a fixed access token lifetime for tokens issued to the developer applications.
+                [OpenIddictConstants.Settings.TokenLifetimes.AccessToken] = developerClientTimeOutValue
+            }
+        };
+
+        foreach (Uri redirectUrl in redirectUrls)
+        {
+            descriptor.RedirectUris.Add(redirectUrl);
+        }
+
+        return descriptor;
+    }
 
     private static Uri CallbackUrlFor(Uri url, string relativePath) => new Uri($"{url.GetLeftPart(UriPartial.Authority)}/{relativePath.TrimStart(Constants.CharArrays.ForwardSlash)}");
 }

--- a/src/Umbraco.Cms.Api.Management/Umbraco.Cms.Api.Management.csproj
+++ b/src/Umbraco.Cms.Api.Management/Umbraco.Cms.Api.Management.csproj
@@ -3,7 +3,7 @@
     <Title>Umbraco CMS - Management API</Title>
     <Description>Contains the presentation layer for the Umbraco CMS Management API.</Description>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <!--
       TODO: Fix and remove overrides:
@@ -22,7 +22,7 @@
     -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors),SA1117,SA1401,SA1134,CS0108,CS0618,CS9042,CS1998,CS8524,IDE0060,SA1649,CS0419,CS1573,CS1574</WarningsNotAsErrors>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="JsonPatch.Net" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
@@ -37,6 +37,9 @@
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Umbraco.Tests.UnitTests</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Umbraco.Tests.Integration</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>DynamicProxyGenAssembly2</_Parameter1>

--- a/src/Umbraco.Infrastructure/Security/IBackOfficeApplicationManager.cs
+++ b/src/Umbraco.Infrastructure/Security/IBackOfficeApplicationManager.cs
@@ -2,7 +2,11 @@
 
 public interface IBackOfficeApplicationManager
 {
+    [Obsolete("Please use the overload that allows for multiple back-office hosts. Will be removed in V17.")]
     Task EnsureBackOfficeApplicationAsync(Uri backOfficeUrl, CancellationToken cancellationToken = default);
+
+    Task EnsureBackOfficeApplicationAsync(IEnumerable<Uri> backOfficeHosts, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
 
     Task EnsureBackOfficeClientCredentialsApplicationAsync(string clientId, string clientSecret, CancellationToken cancellationToken = default);
 

--- a/tests/Umbraco.Tests.Integration/ManagementApi/ManagementApiTest.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/ManagementApiTest.cs
@@ -113,7 +113,7 @@ public abstract class ManagementApiTest<T> : UmbracoTestServerTestBase
                 serviceScope.ServiceProvider.GetRequiredService<IBackOfficeApplicationManager>() as
                     BackOfficeApplicationManager;
             backofficeOpenIddictApplicationDescriptor =
-                backOfficeApplicationManager.BackofficeOpenIddictApplicationDescriptor(client.BaseAddress);
+                backOfficeApplicationManager.BackofficeOpenIddictApplicationDescriptor([client.BaseAddress]);
 
             scope.Complete();
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

It is currently not possible to have multiple backoffice hosts. This poses an issue for sites that require multiple hostnames providing access to the backoffice.

Here's a PR to fix 😄 

### Details

As-is, the first backoffice request "wins"; if I request _my.host/umbraco_, _my.host_ becomes the allowed backoffice host. If I subsequently request _my-other.host/umbraco_ (provided both hostnames point to the same Umbraco instance), I will be met with a somewhat unfriendly message stating that it is not permitted.

This is all because we need to explicitly configure hosts as allowed for redirection in OpenId Connect (via OpenIddict).

With this PR, backoffice hosts are accumulated over time instead of the current "first in wins" strategy.

To retain backwards compatability, the `SecuritySettings.BackOfficeHost` takes precedence over any accumulated backoffice hosts (if configured).

### Testing this PR

Fire up Umbraco on multiple ports (use `launchSettings.json`) and verify that you can access Umbraco on all ports.

While you're at it, also verify that the corresponding _localtest.me:[port]/umbraco_ work.

Using a debugger, verify that `WebRoutingSettings.UmbracoApplicationUrl` is always applied as allowed backoffice host (if configured).

Lastly, verify that `SecuritySettings.BackOfficeHost` (when configured) takes precedence over both the accumulated hosts and `WebRoutingSettings.UmbracoApplicationUrl`.