### PR TITLE
Prevent saving or publishing not created variants

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/content/workspace/content-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content/workspace/content-detail-workspace-base.ts
@@ -482,10 +482,6 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 	}
 
 	protected _saveableVariantsFilter = (option: VariantOptionModelType) => {
-		if (!option.variant) {
-			// If not created then it cannot be picked.
-			return false;
-		}
 		const readOnlyCultures = this.readOnlyState.getStates().map((s) => s.variantId.culture);
 		return readOnlyCultures.includes(option.culture) === false;
 	};

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content/workspace/content-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content/workspace/content-detail-workspace-base.ts
@@ -517,7 +517,7 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 			throw new Error('One or more selected variants have not been created');
 		}
 		// Check variants have a name:
-		const variantsWithoutAName = saveData.variants.filter((x) => !x.name || x.name === '');
+		const variantsWithoutAName = saveData.variants.filter((x) => !x.name);
 		if (variantsWithoutAName.length > 0) {
 			const validationContext = await this.getContext(UMB_VALIDATION_CONTEXT);
 			variantsWithoutAName.forEach((variant) => {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/modals/save-modal/document-save-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/modals/save-modal/document-save-modal.element.ts
@@ -17,6 +17,14 @@ export class UmbDocumentSaveModalElement extends UmbModalBaseElement<
 	@state()
 	_options: Array<UmbDocumentVariantOptionModel> = [];
 
+	#pickableFilter = (option: UmbDocumentVariantOptionModel) => {
+		if (!option.variant) {
+			// If not data present, then its not pickable.
+			return false;
+		}
+		return this.data?.pickableFilter ? this.data.pickableFilter(option) : true;
+	};
+
 	override firstUpdated() {
 		this.#configureSelectionManager();
 	}
@@ -30,9 +38,7 @@ export class UmbDocumentSaveModalElement extends UmbModalBaseElement<
 
 		let selected = this.value?.selection ?? [];
 
-		const validOptions = this.data?.pickableFilter
-			? this._options.filter((o) => this.data!.pickableFilter!(o))
-			: this._options;
+		const validOptions = this._options.filter((o) => this.#pickableFilter!(o));
 
 		// Filter selection based on options:
 		selected = selected.filter((s) => validOptions.some((o) => o.unique === s));
@@ -58,7 +64,7 @@ export class UmbDocumentSaveModalElement extends UmbModalBaseElement<
 			<umb-document-variant-language-picker
 				.selectionManager=${this.#selectionManager}
 				.variantLanguageOptions=${this._options}
-				.pickableFilter=${this.data?.pickableFilter}></umb-document-variant-language-picker>
+				.pickableFilter=${this.#pickableFilter}></umb-document-variant-language-picker>
 
 			<div slot="actions">
 				<uui-button label=${this.localize.term('general_close')} @click=${this.#close}></uui-button>

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/modals/save-modal/document-save-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/modals/save-modal/document-save-modal.element.ts
@@ -30,8 +30,12 @@ export class UmbDocumentSaveModalElement extends UmbModalBaseElement<
 
 		let selected = this.value?.selection ?? [];
 
+		const validOptions = this.data?.pickableFilter
+			? this._options.filter((o) => this.data!.pickableFilter!(o))
+			: this._options;
+
 		// Filter selection based on options:
-		selected = selected.filter((s) => this._options.some((o) => o.unique === s));
+		selected = selected.filter((s) => validOptions.some((o) => o.unique === s));
 
 		this.#selectionManager.setSelection(selected);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/modals/shared/document-variant-language-picker.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/modals/shared/document-variant-language-picker.element.ts
@@ -41,7 +41,7 @@ export class UmbDocumentVariantLanguagePickerElement extends UmbLitElement {
 	_selection: Array<string> = [];
 
 	@state()
-	_isAllSelected?: boolean;
+	_isAllSelected: boolean = false;
 
 	/**
 	 * A filter function that determines if an item is pickableFilter or not.
@@ -61,6 +61,10 @@ export class UmbDocumentVariantLanguagePickerElement extends UmbLitElement {
 
 	protected override updated(_changedProperties: PropertyValues): void {
 		super.updated(_changedProperties);
+
+		if (_changedProperties.has('variantLanguageOptions')) {
+			this._isAllSelected = this.#isAllSelected();
+		}
 
 		if (this.selectionManager && this.pickableFilter) {
 			this.#selectionManager.setAllowLimitation((unique) => {
@@ -86,7 +90,7 @@ export class UmbDocumentVariantLanguagePickerElement extends UmbLitElement {
 		const allUniques = this.variantLanguageOptions.map((o) => o.unique);
 		const filter = this.selectionManager.getAllowLimitation();
 		const allowedUniques = allUniques.filter((unique) => filter(unique));
-		return this._selection.length === allowedUniques.length;
+		return this._selection.length !== 0 && this._selection.length === allowedUniques.length;
 	}
 
 	override render() {
@@ -160,16 +164,18 @@ export class UmbDocumentVariantLanguagePickerElement extends UmbLitElement {
 			.required {
 				color: var(--uui-color-danger);
 				--uui-menu-item-color-hover: var(--uui-color-danger-emphasis);
+				--uui-menu-item-color-disabled: var(--uui-color-danger);
 			}
 			.label {
-				padding: 0.5rem 0;
+				padding: var(--uui-size-space-3) 0;
 			}
 			.label-status {
-				font-size: 0.8rem;
+				font-size: var(--uui-type-small-size);
 			}
 
 			uui-menu-item {
 				--uui-menu-item-flat-structure: 1;
+				--uui-menu-item-border-radius: var(--uui-border-radius);
 			}
 
 			uui-checkbox {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish-with-descendants/modal/document-publish-with-descendants-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish-with-descendants/modal/document-publish-with-descendants-modal.element.ts
@@ -42,8 +42,12 @@ export class UmbDocumentPublishWithDescendantsModalElement extends UmbModalBaseE
 
 		let selected = this.value?.selection ?? [];
 
+		const validOptions = this.data?.pickableFilter
+			? this._options.filter((o) => this.data!.pickableFilter!(o))
+			: this._options;
+
 		// Filter selection based on options:
-		selected = selected.filter((s) => this._options.some((o) => o.unique === s));
+		selected = selected.filter((s) => validOptions.some((o) => o.unique === s));
 
 		// Additionally select mandatory languages:
 		// [NL]: I think for now lets make it an active choice to select the languages. If you just made them, they would be selected. So it just to underline the act of actually selecting these languages.
@@ -140,7 +144,7 @@ export class UmbDocumentPublishWithDescendantsModalElement extends UmbModalBaseE
 		css`
 			:host {
 				display: block;
-				width: 400px;
+				min-width: 460px;
 				max-width: 90vw;
 			}
 		`,

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish-with-descendants/modal/document-publish-with-descendants-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish-with-descendants/modal/document-publish-with-descendants-modal.element.ts
@@ -26,6 +26,14 @@ export class UmbDocumentPublishWithDescendantsModalElement extends UmbModalBaseE
 	@state()
 	_hasNotSelectedMandatory?: boolean;
 
+	#pickableFilter = (option: UmbDocumentVariantOptionModel) => {
+		if (!option.variant) {
+			// If not data present, then its not pickable.
+			return false;
+		}
+		return this.data?.pickableFilter ? this.data.pickableFilter(option) : true;
+	};
+
 	override firstUpdated() {
 		this.#configureSelectionManager();
 	}
@@ -42,9 +50,7 @@ export class UmbDocumentPublishWithDescendantsModalElement extends UmbModalBaseE
 
 		let selected = this.value?.selection ?? [];
 
-		const validOptions = this.data?.pickableFilter
-			? this._options.filter((o) => this.data!.pickableFilter!(o))
-			: this._options;
+		const validOptions = this._options.filter((o) => this.#pickableFilter!(o));
 
 		// Filter selection based on options:
 		selected = selected.filter((s) => validOptions.some((o) => o.unique === s));
@@ -109,7 +115,7 @@ export class UmbDocumentPublishWithDescendantsModalElement extends UmbModalBaseE
 				.selectionManager=${this.#selectionManager}
 				.variantLanguageOptions=${this._options}
 				.requiredFilter=${isNotPublishedMandatory}
-				.pickableFilter=${this.data?.pickableFilter}></umb-document-variant-language-picker>
+				.pickableFilter=${this.#pickableFilter}></umb-document-variant-language-picker>
 
 			<uui-form-layout-item>
 				<uui-toggle

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish/modal/document-publish-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish/modal/document-publish-modal.element.ts
@@ -41,8 +41,12 @@ export class UmbDocumentPublishModalElement extends UmbModalBaseElement<
 
 		let selected = this.value?.selection ?? [];
 
+		const validOptions = this.data?.pickableFilter
+			? this._options.filter((o) => this.data!.pickableFilter!(o))
+			: this._options;
+
 		// Filter selection based on options:
-		selected = selected.filter((s) => this._options.some((o) => o.unique === s));
+		selected = selected.filter((s) => validOptions.some((o) => o.unique === s));
 
 		// Additionally select mandatory languages:
 		// [NL]: I think for now lets make it an active choice to select the languages. If you just made them, they would be selected. So it just to underline the act of actually selecting these languages.
@@ -98,7 +102,7 @@ export class UmbDocumentPublishModalElement extends UmbModalBaseElement<
 					?disabled=${this._hasNotSelectedMandatory}
 					@click=${this.#submit}></uui-button>
 			</div>
-		</umb-body-layout> `;
+		</umb-body-layout>`;
 	}
 
 	static override styles = [
@@ -106,7 +110,7 @@ export class UmbDocumentPublishModalElement extends UmbModalBaseElement<
 		css`
 			:host {
 				display: block;
-				width: 400px;
+				min-width: 460px;
 				max-width: 90vw;
 			}
 		`,

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish/modal/document-publish-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish/modal/document-publish-modal.element.ts
@@ -21,6 +21,13 @@ export class UmbDocumentPublishModalElement extends UmbModalBaseElement<
 	@state()
 	_hasNotSelectedMandatory?: boolean;
 
+	#pickableFilter = (option: UmbDocumentVariantOptionModel) => {
+		if (!option.variant || option.variant.state === UmbDocumentVariantState.NOT_CREATED) {
+			return false;
+		}
+		return this.data?.pickableFilter ? this.data.pickableFilter(option) : true;
+	};
+
 	override firstUpdated() {
 		this.#configureSelectionManager();
 	}
@@ -41,9 +48,7 @@ export class UmbDocumentPublishModalElement extends UmbModalBaseElement<
 
 		let selected = this.value?.selection ?? [];
 
-		const validOptions = this.data?.pickableFilter
-			? this._options.filter((o) => this.data!.pickableFilter!(o))
-			: this._options;
+		const validOptions = this._options.filter((o) => this.#pickableFilter(o));
 
 		// Filter selection based on options:
 		selected = selected.filter((s) => validOptions.some((o) => o.unique === s));
@@ -91,7 +96,7 @@ export class UmbDocumentPublishModalElement extends UmbModalBaseElement<
 				.selectionManager=${this.#selectionManager}
 				.variantLanguageOptions=${this._options}
 				.requiredFilter=${isNotPublishedMandatory}
-				.pickableFilter=${this.data?.pickableFilter}></umb-document-variant-language-picker>
+				.pickableFilter=${this.#pickableFilter}></umb-document-variant-language-picker>
 
 			<div slot="actions">
 				<uui-button label=${this.localize.term('general_close')} @click=${this.#close}></uui-button>

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.element.ts
@@ -1,4 +1,4 @@
-import { UmbDocumentVariantState, type UmbDocumentVariantOptionModel } from '../../../types.js';
+import type { UmbDocumentVariantOptionModel } from '../../../types.js';
 import { UmbDocumentVariantLanguagePickerElement } from '../../../modals/index.js';
 import type { UmbDocumentScheduleModalData, UmbDocumentScheduleModalValue } from './document-schedule-modal.token.js';
 import { css, customElement, html, repeat, state, when } from '@umbraco-cms/backoffice/external/lit';
@@ -56,16 +56,16 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 		}
 
 		// Only display variants that are relevant to pick from, i.e. variants that are draft or published with pending changes:
-		// TODO:[NL] I would say we should change this, the act of scheduling should be equivalent to save & publishing. Resulting in content begin saved as part of carrying out the action. (But this requires a update in the workspace.)
-		this._options =
-			this.data?.options.filter(
-				(option) => option.variant && option.variant.state !== UmbDocumentVariantState.NOT_CREATED,
-			) ?? [];
+		this._options = this.data?.options ?? [];
+
+		const validOptions = this.data?.pickableFilter
+			? this._options.filter((o) => this.data!.pickableFilter!(o))
+			: this._options;
 
 		let selected = this.value?.selection ?? [];
 
 		// Filter selection based on options:
-		selected = selected.filter((s) => this._options.some((o) => o.unique === s.unique));
+		selected = selected.filter((s) => validOptions.some((o) => o.unique === s.unique));
 
 		this.#selectionManager.setSelection(selected.map((s) => s.unique));
 	}
@@ -99,7 +99,7 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 		const allUniques = this._options.map((o) => o.unique);
 		const filter = this.#selectionManager.getAllowLimitation();
 		const allowedUniques = allUniques.filter((unique) => filter(unique));
-		return this._selection.length === allowedUniques.length;
+		return this._selection.length !== 0 && this._selection.length === allowedUniques.length;
 	}
 
 	override render() {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/unpublish/modal/document-unpublish-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/unpublish/modal/document-unpublish-modal.element.ts
@@ -50,6 +50,13 @@ export class UmbDocumentUnpublishModalElement extends UmbModalBaseElement<
 	@state()
 	_isInvariant = false;
 
+	#pickableFilter = (option: UmbDocumentVariantOptionModel) => {
+		if (!option.variant) {
+			return false;
+		}
+		return this.data?.pickableFilter ? this.data.pickableFilter(option) : true;
+	};
+
 	override firstUpdated() {
 		this.#getReferences();
 
@@ -75,9 +82,7 @@ export class UmbDocumentUnpublishModalElement extends UmbModalBaseElement<
 
 		let selected = this.value?.selection ?? [];
 
-		const validOptions = this.data?.pickableFilter
-			? this._options.filter((o) => this.data!.pickableFilter!(o))
-			: this._options;
+		const validOptions = this._options.filter((o) => this.#pickableFilter(o));
 
 		// Filter selection based on options:
 		selected = selected.filter((s) => validOptions.some((o) => o.unique === s));
@@ -151,7 +156,7 @@ export class UmbDocumentUnpublishModalElement extends UmbModalBaseElement<
 							.selectionManager=${this._selectionManager}
 							.variantLanguageOptions=${this._options}
 							.requiredFilter=${this._hasInvalidSelection ? this._requiredFilter : undefined}
-							.pickableFilter=${this.data?.pickableFilter}></umb-document-variant-language-picker>
+							.pickableFilter=${this.#pickableFilter}></umb-document-variant-language-picker>
 					`
 				: nothing}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/unpublish/modal/document-unpublish-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/unpublish/modal/document-unpublish-modal.element.ts
@@ -75,8 +75,12 @@ export class UmbDocumentUnpublishModalElement extends UmbModalBaseElement<
 
 		let selected = this.value?.selection ?? [];
 
+		const validOptions = this.data?.pickableFilter
+			? this._options.filter((o) => this.data!.pickableFilter!(o))
+			: this._options;
+
 		// Filter selection based on options:
-		selected = selected.filter((s) => this._options.some((o) => o.unique === s));
+		selected = selected.filter((s) => validOptions.some((o) => o.unique === s));
 
 		this._selectionManager.setSelection(selected);
 
@@ -192,7 +196,7 @@ export class UmbDocumentUnpublishModalElement extends UmbModalBaseElement<
 		css`
 			:host {
 				display: block;
-				width: 600px;
+				min-width: 600px;
 				max-width: 90vw;
 			}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
@@ -90,7 +90,7 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase<UmbDoc
 			.open(this, UMB_DOCUMENT_SCHEDULE_MODAL, {
 				data: {
 					options,
-					pickableFilter: this.#readOnlyLanguageVariantsFilter,
+					pickableFilter: this.#publishableVariantsFilter,
 				},
 				value: { selection: selected.map((unique) => ({ unique, schedule: {} })) },
 			})
@@ -143,7 +143,7 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase<UmbDoc
 			.open(this, UMB_DOCUMENT_PUBLISH_WITH_DESCENDANTS_MODAL, {
 				data: {
 					options,
-					pickableFilter: this.#readOnlyLanguageVariantsFilter,
+					pickableFilter: this.#publishableVariantsFilter,
 				},
 				value: { selection: selected },
 			})
@@ -222,7 +222,7 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase<UmbDoc
 				.open(this, UMB_DOCUMENT_PUBLISH_MODAL, {
 					data: {
 						options,
-						pickableFilter: this.#readOnlyLanguageVariantsFilter,
+						pickableFilter: this.#publishableVariantsFilter,
 					},
 					value: { selection: selected },
 				})
@@ -235,7 +235,7 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase<UmbDoc
 		}
 
 		const saveData = await this.#documentWorkspaceContext.constructSaveData(variantIds);
-		await this.#documentWorkspaceContext.runMandatoryValidationForSaveData(saveData);
+		await this.#documentWorkspaceContext.runMandatoryValidationForSaveData(saveData, variantIds);
 		await this.#documentWorkspaceContext.askServerToValidate(saveData, variantIds);
 
 		// TODO: Only validate the specified selection.. [NL]
@@ -286,7 +286,11 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase<UmbDoc
 		}
 	}
 
-	#readOnlyLanguageVariantsFilter = (option: UmbDocumentVariantOptionModel) => {
+	#publishableVariantsFilter = (option: UmbDocumentVariantOptionModel) => {
+		if (!option.variant) {
+			// Not created variants are not publishable
+			return false;
+		}
 		const readOnlyCultures =
 			this.#documentWorkspaceContext?.readOnlyState.getStates().map((s) => s.variantId.culture) ?? [];
 		return readOnlyCultures.includes(option.culture) === false;
@@ -309,6 +313,8 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase<UmbDoc
 		selected = selected.filter((x) => options.some((o) => o.unique === x));
 
 		// Filter out read-only variants
+		// TODO: This would not work with segments, as the 'selected'-array is an array of strings, not UmbVariantId's. [NL]
+		// Please have a look at the implementation in the content-detail workspace context, as that one compares variantIds. [NL]
 		const readOnlyCultures = this.#documentWorkspaceContext.readOnlyState.getStates().map((s) => s.variantId.culture);
 		selected = selected.filter((x) => readOnlyCultures.includes(x) === false);
 
@@ -322,8 +328,7 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase<UmbDoc
 		if (!this.#documentWorkspaceContext) throw new Error('Document workspace context is missing');
 		const activeVariants = this.#documentWorkspaceContext.splitView
 			.getActiveVariants()
-			.map((activeVariant) => UmbVariantId.Create(activeVariant))
-			.map((x) => x.toString());
+			.map((activeVariant) => UmbVariantId.Create(activeVariant).toString());
 		const changedVariants = this.#documentWorkspaceContext.getChangedVariants().map((x) => x.toString());
 		const selection = [...activeVariants, ...changedVariants];
 		return [...new Set(selection)];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
@@ -287,10 +287,6 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase<UmbDoc
 	}
 
 	#publishableVariantsFilter = (option: UmbDocumentVariantOptionModel) => {
-		if (!option.variant) {
-			// Not created variants are not publishable
-			return false;
-		}
 		const readOnlyCultures =
 			this.#documentWorkspaceContext?.readOnlyState.getStates().map((s) => s.variantId.culture) ?? [];
 		return readOnlyCultures.includes(option.culture) === false;


### PR DESCRIPTION
Preventing an issue where a user without consent sends of not created variant.

This happend because we pre-selected all active and mandatory variants, but these might not be created and therefor not a valid choice, but the selection was never filtered based on the pickableFilter, and the pickableFilter was not sensitive enough about created variants.

This PR moves some pickableFilter logic into the modal as that one knows the best in regards to the variant and what is required for the action.

**test notes:**
Have two languages that are mandatory
Create a culture variant document.
Only write a name for Language A.
Open split view for Language A & B.
and then try to Save or Save &  Publish.
And you should see a complaint that something went wrong.