### PR TITLE
Chore: Block Manager + Variant ID Polishing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/variant/variant-id.class.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/variant/variant-id.class.ts
@@ -1,3 +1,5 @@
+import { UmbDeprecation } from '../utils/index.js';
+
 export type UmbObjectWithVariantProperties = {
 	culture: string | null;
 	segment: string | null;
@@ -5,9 +7,16 @@ export type UmbObjectWithVariantProperties = {
 
 /**
  *
- * @param variant
+ * @param {UmbObjectWithVariantProperties} variant - An object with variant specifying properties to convert to a string.
+ * @returns {string} A string representation of the variant properties.
+ * @deprecated Use UmbVariantId to make this conversion. Will ve removed in v.17
  */
 export function variantPropertiesObjectToString(variant: UmbObjectWithVariantProperties): string {
+	new UmbDeprecation({
+		deprecated: 'Method `variantPropertiesObjectToString` is deprecated',
+		removeInVersion: '17',
+		solution: 'Use UmbVariantId to make this conversion',
+	}).warn();
 	// Currently a direct copy of the toString method of variantId.
 	return (variant.culture || UMB_INVARIANT_CULTURE) + (variant.segment ? `_${variant.segment}` : '');
 }
@@ -79,6 +88,10 @@ export class UmbVariantId {
 		return this.culture === null && this.segment === null;
 	}
 
+	public clone(): UmbVariantId {
+		return new UmbVariantId(null, this.segment);
+	}
+
 	public toObject(): UmbObjectWithVariantProperties {
 		return { culture: this.culture, segment: this.segment };
 	}
@@ -89,6 +102,14 @@ export class UmbVariantId {
 	public toCultureInvariant(): UmbVariantId {
 		return Object.freeze(new UmbVariantId(null, this.segment));
 	}
+
+	public toCulture(culture: string | null): UmbVariantId {
+		return Object.freeze(new UmbVariantId(culture, this.segment));
+	}
+	public toSegment(segment: string | null): UmbVariantId {
+		return Object.freeze(new UmbVariantId(this.culture, segment));
+	}
+
 	public toVariant(varyByCulture?: boolean, varyBySegment?: boolean): UmbVariantId {
 		return Object.freeze(new UmbVariantId(varyByCulture ? this.culture : null, varyBySegment ? this.segment : null));
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/language/global-contexts/app-language.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/language/global-contexts/app-language.context.ts
@@ -1,7 +1,7 @@
 import { UmbLanguageCollectionRepository } from '../collection/index.js';
 import type { UmbLanguageDetailModel } from '../types.js';
 import { UMB_APP_LANGUAGE_CONTEXT } from './app-language.context-token.js';
-import { UmbArrayState, UmbObjectState, createObservablePart } from '@umbraco-cms/backoffice/observable-api';
+import { UmbArrayState, UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
@@ -20,7 +20,7 @@ export class UmbAppLanguageContext extends UmbContextBase<UmbAppLanguageContext>
 
 	public readonly appLanguageReadOnlyState = new UmbReadOnlyStateManager(this);
 
-	public readonly appDefaultLanguage = createObservablePart(this.#languages.asObservable(), (languages) =>
+	public readonly appDefaultLanguage = this.#languages.asObservablePart((languages) =>
 		languages.find((language) => language.isDefault),
 	);
 


### PR DESCRIPTION
This changes nothing of great interest, marks a method that was not used as deprecated.
Added some new features to the VariantId.
And refactors a bit of code.