### PR TITLE
Code Editor Modal, adds localization support

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/code-editor/code-editor-modal/code-editor-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/code-editor/code-editor-modal/code-editor-modal.element.ts
@@ -37,7 +37,7 @@ export class UmbCodeEditorModalElement extends UmbModalBaseElement<UmbCodeEditor
 					slot="actions"
 					color=${this.data?.color || 'positive'}
 					look="primary"
-					label=${this.data?.confirmLabel || this.localize.term('general_submit')}
+					label=${this.localize.string(this.data?.confirmLabel) || this.localize.term('general_submit')}
 					@click=${this.#handleConfirm}></uui-button>
 			</umb-body-layout>
 		`;


### PR DESCRIPTION
### Description

I'd noticed during Contentment development that the label for Code Editor modal wasn't being localized.

This PR adds localization support.


