### PR TITLE
Chore: Remove the `propertyEditorSchemaAlias` for "Accepted Upload Types"

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/accepted-types/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/accepted-types/manifests.ts
@@ -7,7 +7,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	element: () => import('./property-editor-ui-accepted-upload-types.element.js'),
 	meta: {
 		label: 'Accepted Upload Types',
-		propertyEditorSchemaAlias: 'Umbraco.MultipleTextstring',
 		icon: 'icon-ordered-list',
 		group: 'lists',
 		supportsReadOnly: true,


### PR DESCRIPTION
### Description

I'd noticed that the "Accepted Upload Types" property-editor was showing up in the available editors when creating a Data Type.
This is currently an internal property-editor, and by removing the associated `propertyEditorSchemaAlias`, it will be hidden from the available list.
