### PR TITLE
Data Type create option description

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -438,8 +438,7 @@ export default {
 		compositionDescription:
 			"Defines a re-usable set of properties that can be included in the definition of\n      multiple other Document Types. For example, a set of 'Common Page Settings'.\n    ",
 		folder: 'Folder',
-		folderDescription:
-			'Used to organise the Document Types, Compositions and Element Types created in this\n      Document Type tree.\n    ',
+		folderDescription: 'Used to organize items and other folders. Keep items structured and easy to access.',
 		newFolder: 'New folder',
 		newDataType: 'New Data Type',
 		newDataTypeDescription: 'Used to define a configuration for a Property Type on a Content Type.',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -438,7 +438,7 @@ export default {
 		compositionDescription:
 			"Defines a re-usable set of properties that can be included in the definition of\n      multiple other Document Types. For example, a set of 'Common Page Settings'.\n    ",
 		folder: 'Folder',
-		folderDescription: 'Used to organize items and other folders. Keep items structured and easy to access.',
+		folderDescription: 'Used to organise items and other folders. Keep items structured and easy to access.',
 		newFolder: 'New folder',
 		newDataType: 'New Data Type',
 		newDataTypeDescription: 'Used to define a configuration for a Property Type on a Content Type.',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -442,6 +442,7 @@ export default {
 			'Used to organise the Document Types, Compositions and Element Types created in this\n      Document Type tree.\n    ',
 		newFolder: 'New folder',
 		newDataType: 'New Data Type',
+		newDataTypeDescription: 'Used to define a configuration for a Property Type on a Content Type.',
 		newJavascriptFile: 'New JavaScript file',
 		newEmptyPartialView: 'New empty partial view',
 		newPartialViewMacro: 'New partial view macro',

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/entity-actions/create/default/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/entity-actions/create/default/manifests.ts
@@ -12,6 +12,7 @@ export const manifests: Array<UmbExtensionManifest | UmbExtensionManifestKind> =
 		meta: {
 			icon: 'icon-autofill',
 			label: '#create_newDataType',
+			description: '#create_newDataTypeDescription',
 		},
 	},
 ];


### PR DESCRIPTION
### Description

Fixes #18328.

Adds a description to the Data Type create option.

I'd also noticed that the text for "create_folderDescription" was different between English US and English fallback, so updated English fallback. At some point we should align these localisations, so that English US only contains texts that are culturally different from generic English, e.g. colour vs color, etc. Fewer strings to manage and process.

