### PR TITLE
V15: Add a button to clear schedule

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/bs.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/bs.ts
@@ -1910,9 +1910,6 @@ export default {
 		notificationEmailsCheckSuccessMessage: 'E-mail za obavještenje je postavljen na <strong>%0%</strong>.',
 		notificationEmailsCheckErrorMessage:
 			'E-pošta za obavještenje je i dalje postavljena na zadanu vrijednost od <strong>%0%</strong>.',
-		scheduledHealthCheckEmailBody:
-			'<html><body><p>Rezultati zakazanih Umbraco provjera zdravlja koji se pokreću na %0% na %1% su sljedeći:</p>%2%</body></html>',
-		scheduledHealthCheckEmailSubject: 'Status provjere zdravlja Umbraco: %0%',
 		checkGroup: 'Provjerite grupu',
 		helpText:
 			'\n        <p>Provjera zdravlja procjenjuje različita područja vaše web lokacije u pogledu postavki najbolje prakse, konfiguracije, potencijalnih problema itd. Možete jednostavno riješiti probleme pritiskom na dugme.\n        Možete dodati svoje zdravstvene preglede, pogledajte <a href="https://docs.umbraco.com/umbraco-cms/extending/health-check" target="_blank" rel="noopener" class="btn-link -underline">dokumentaciju za više informacija</a> o prilagođenim zdravstvenim pregledima.</p>\n        ',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/cs-cz.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/cs-cz.ts
@@ -1734,9 +1734,6 @@ export default {
 		notificationEmailsCheckSuccessMessage: 'E-mail s upozorněním byl nastaven na <strong>%0%</strong>.',
 		notificationEmailsCheckErrorMessage:
 			'E-mail s oznámením je stále nastaven na výchozí hodnotu <strong>%0%</strong>.',
-		scheduledHealthCheckEmailBody:
-			'<html><body><p>Výsledky plánovaných kontrol Umbraco Health Checks provedených na %0% v %1% jsou následující:</p>%2%</body></html>',
-		scheduledHealthCheckEmailSubject: 'Stav Umbraco Health Check: %0%',
 		checkGroup: 'Zkontrolovat skupinu',
 		helpText:
 			'\n        <p>Kontrola vyhodnocuje různé oblasti vašeho webu z hlediska nastavení osvědčených postupů, konfigurace, potenciálních problémů atd. Problémy lze snadno vyřešit stisknutím tlačítka. Můžete přidat své vlastní kontroly, podívejte se na <a href="https://docs.umbraco.com/umbraco-cms/extending/health-check" target="_blank" rel="noopener" class="btn-link -underline">dokumentaci pro více informací</a> o vlastních kontrolách.</p>\n        ',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/cy-gb.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/cy-gb.ts
@@ -2076,9 +2076,6 @@ export default {
 			"Gosodiadau SMTP wedi ffurfweddu'n gywir ac mae'r gwasanaeth yn gweithio fel y disgwylir.",
 		notificationEmailsCheckSuccessMessage: "Ebost hysbusu wedi'i osod at <strong>%0%</strong>.",
 		notificationEmailsCheckErrorMessage: "Ebost hysbusu yn dal wedi'i osod at y gwerth diofyn o <strong>%0%</strong>.",
-		scheduledHealthCheckEmailBody:
-			"<html><body><p>Canlyniadau'r gwiriad Statws Iechyd Umbraco ar amserlen rhedwyd ar %0% am %1% fel y ganlyn:</p>%2%</body></html>",
-		scheduledHealthCheckEmailSubject: 'Statws Iechyd Umbraco: %0%',
 		checkGroup: 'Gwiriwch y grŵp',
 		helpText:
 			'\n            <p>Mae\'r gwiriwr iechyd yn gwerthuso gwahanol rannau o\'ch gwefan ar gyfer gosodiadau arfer gorau, cyfluniad, problemau posibl, ac ati. Gallwch chi drwsio problemau yn hawdd trwy wasgu botwm.\n            Gallwch chi ychwanegu eich gwiriadau iechyd eich hun, edrych ar <a href="https://docs.umbraco.com/umbraco-cms/extending/health-check" target="_blank" rel="noopener" class="btn-link -underline">y ddogfennaeth i gael mwy o wybodaeth</a> am wiriadau iechyd arferu.</p>\n            ',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/de-de.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/de-de.ts
@@ -1875,9 +1875,6 @@ export default {
 			'Die E-Mail-Adresse für Benachrichtigungen wurde auf <strong>%0%</strong> eingestellt.',
 		notificationEmailsCheckErrorMessage:
 			'Die E-Mail-Adresse für Benachrichtigungen ist noch auf den Standardwert <strong>%0%</strong> gestellt.',
-		scheduledHealthCheckEmailBody:
-			'\n    <html><body><p>\n    Die Ergebnisse der geplanten Systemzustandsprüfung läuft am %0% um %1% lauten wie folgt:\n    </p>%2%</body></html>\n    ',
-		scheduledHealthCheckEmailSubject: 'Status der Umbraco Systemzustand: %0%',
 	},
 	redirectUrls: {
 		disableUrlTracker: 'URL-Änderungsaufzeichnung abschalten',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -294,7 +294,7 @@ export default {
 		notmemberof: 'Not a member of group(s)',
 		childItems: 'Child items',
 		target: 'Target',
-		scheduledPendingChanges: 'This schedule has changes and will be updated if you keep it active.',
+		scheduledPendingChanges: 'This schedule has changes that will take effect when you click "Schedule".',
 		scheduledPublishServerTime: 'This translates to the following time on the server:',
 		scheduledPublishDocumentation:
 			'<a href="https://docs.umbraco.com/umbraco-cms/fundamentals/data/scheduled-publishing#timezones" target="_blank" rel="noopener">What does this mean?</a>',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -294,7 +294,7 @@ export default {
 		notmemberof: 'Not a member of group(s)',
 		childItems: 'Child items',
 		target: 'Target',
-		scheduledPendingChanges: 'This schedule has changes that will take effect when you click "Schedule".',
+		scheduledPendingChanges: 'This schedule has changes that will take effect when you click "%0%".',
 		scheduledPublishServerTime: 'This translates to the following time on the server:',
 		scheduledPublishDocumentation:
 			'<a href="https://docs.umbraco.com/umbraco-cms/fundamentals/data/scheduled-publishing#timezones" target="_blank" rel="noopener">What does this mean?</a>',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -2211,9 +2211,6 @@ export default {
 		notificationEmailsCheckSuccessMessage: 'Notification email has been set to <strong>%0%</strong>.',
 		notificationEmailsCheckErrorMessage:
 			'Notification email is still set to the default value of <strong>%0%</strong>.',
-		scheduledHealthCheckEmailBody:
-			'<html><body><p>Results of the scheduled Umbraco Health Checks run on %0% at %1% are as follows:</p>%2%</body></html>',
-		scheduledHealthCheckEmailSubject: 'Umbraco Health Check Status: %0%',
 		checkGroup: 'Check group',
 		helpText:
 			'\n        <p>The health checker evaluates various areas of your site for best practice settings, configuration, potential problems, etc. You can easily fix problems by pressing a button.\n        You can add your own health checks, have a look at <a href="https://docs.umbraco.com/umbraco-cms/extending/health-check" target="_blank" rel="noopener" class="btn-link -underline">the documentation for more information</a> about custom health checks.</p>\n        ',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -294,6 +294,7 @@ export default {
 		notmemberof: 'Not a member of group(s)',
 		childItems: 'Child items',
 		target: 'Target',
+		scheduledPendingChanges: 'This schedule has changes and will be updated if you keep it active.',
 		scheduledPublishServerTime: 'This translates to the following time on the server:',
 		scheduledPublishDocumentation:
 			'<a href="https://docs.umbraco.com/umbraco-cms/fundamentals/data/scheduled-publishing#timezones" target="_blank" rel="noopener">What does this mean?</a>',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/es-es.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/es-es.ts
@@ -1414,9 +1414,6 @@ export default {
 		notificationEmailsCheckSuccessMessage: 'Email de notificación has sido configurado como <strong>%0%</strong>.',
 		notificationEmailsCheckErrorMessage:
 			'El email de notificación está todavía configurado en tuvalor por defecto: <strong>%0%</strong>.',
-		scheduledHealthCheckEmailBody:
-			'<html><body><p>Los resultados de los Chequeos de Salud de Umbraco programados para ejecutarse el %0% a las %1% son:</p>%2%</body></html>',
-		scheduledHealthCheckEmailSubject: 'Status de los Chequeos de Salud de Umbraco: %0%',
 	},
 	redirectUrls: {
 		disableUrlTracker: 'Desactivar URL tracker',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/fr-fr.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/fr-fr.ts
@@ -1784,9 +1784,6 @@ export default {
 		notificationEmailsCheckSuccessMessage: 'Un email de notification a été envoyé à <strong>%0%</strong>.',
 		notificationEmailsCheckErrorMessage:
 			"L'adresse email de notification est toujours à sa valeur par défaut : <strong>%0%</strong>.",
-		scheduledHealthCheckEmailBody:
-			"<html><body><p>Les résultats de l'exécution du Umbraco Health Checks planifiée le %0% à %1% sont les suivants :</p>%2%</body></html>",
-		scheduledHealthCheckEmailSubject: 'Statut du Umbraco Health Check: %0%',
 	},
 	redirectUrls: {
 		disableUrlTracker: 'Désactiver URL tracker',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/hr-hr.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/hr-hr.ts
@@ -1970,9 +1970,6 @@ export default {
 		notificationEmailsCheckSuccessMessage: 'E-mail za obavještenje je postavljen na <strong>%0%</strong>.',
 		notificationEmailsCheckErrorMessage:
 			'E-pošta za obavještenje je i dalje postavljena na zadanu vrijednost od <strong>%0%</strong>.',
-		scheduledHealthCheckEmailBody:
-			'<html><body><p>Rezultati zakazanih Umbraco provjera zdravlja koji se pokreću na %0% na %1% su sljedeći:</p>%2%</body></html>',
-		scheduledHealthCheckEmailSubject: 'Status provjere zdravlja Umbraco: %0%',
 		checkGroup: 'Provjerite grupu',
 		helpText:
 			'\n        <p>Provjera zdravlja procjenjuje različita područja vaše web lokacije u pogledu postavki najboljih praksi, konfiguracija, potencijalnih problema itd. Možete jednostavno riješiti probleme pritiskom na gumb.\n        Možete dodati svoje zdravstvene preglede, pogledajte <a href="https://docs.umbraco.com/umbraco-cms/extending/health-check" target="_blank" rel="noopener" class="btn-link -underline">dokumentaciju za više informacija</a> o prilagođenim zdravstvenim pregledima.</p>\n        ',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/it-it.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/it-it.ts
@@ -1980,9 +1980,6 @@ export default {
 		notificationEmailsCheckSuccessMessage: "L'email di notifica è stata impostata a <strong>%0%</strong>.",
 		notificationEmailsCheckErrorMessage:
 			"L'email di notifica è ancora impostata al valore predefinito di <strong>%0%</strong>.",
-		scheduledHealthCheckEmailBody:
-			"<html><body><p>I risultati dell'Health Check programmato di Umbraco del %0% alle %1% è il seguente:</p>%2%</body></html>",
-		scheduledHealthCheckEmailSubject: "Stato dell'Health Check di Umbraco: %0%",
 		checkAllGroups: 'Controlla tutti i gruppi',
 		checkGroup: 'Controlla gruppo',
 		helpText:

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/nl-nl.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/nl-nl.ts
@@ -1850,9 +1850,6 @@ export default {
 		notificationEmailsCheckSuccessMessage: 'Notificatie e-mail is verzonden naar <strong>%0%</strong>.',
 		notificationEmailsCheckErrorMessage:
 			'Notificatie e-mail staat nog steeds op de standaard waarde van <strong>%0%</strong>.',
-		scheduledHealthCheckEmailBody:
-			'<html><body><p>Resultaten van de geplande Umbraco Health Checks uitgevoerd op %0% op %1%:</p>%2%</body></html>',
-		scheduledHealthCheckEmailSubject: 'Umbraco Health Check Status: %0%',
 		checkGroup: 'Groep controleren',
 		helpText:
 			'\n    <p>De health checker evalueert verschillende delen van de website voor best practice instellingen, configuratie, mogelijke problemen, enzovoort. U kunt problemen eenvoudig oplossen met een druk op de knop.\n    U kunt uw eigen health checks toevoegen, kijk even naar <a href="https://docs.umbraco.com/umbraco-cms/extending/health-check" target="_blank" rel="noopener" class="btn-link -underline">de documentatie voor meer informatie</a> over aangepaste health checks.</p>\n    ',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/ru-ru.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/ru-ru.ts
@@ -703,9 +703,6 @@ export default {
 		notificationEmailsCheckSuccessMessage: 'Адрес для отправки уведомлений установлен в <strong>%0%</strong>.',
 		notificationEmailsCheckErrorMessage:
 			'Адрес для отправки уведомлений все еще установлен в значение по-умолчанию <strong>%0%</strong>.',
-		scheduledHealthCheckEmailBody:
-			'<html><body><p>Зафиксированы следующие результаты автоматической проверки состояния Umbraco по расписанию, запущенной на %0% в %1%:</p>%2%</body></html>',
-		scheduledHealthCheckEmailSubject: 'Результат проверки состояния Umbraco: %0%',
 	},
 	help: {
 		theBestUmbracoVideoTutorials: 'Лучшие обучающие видео-курсы по Umbraco',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/tr-tr.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/tr-tr.ts
@@ -1737,9 +1737,6 @@ export default {
 		smtpMailSettingsConnectionSuccess: 'SMTP ayarları doğru yapılandırıldı ve hizmet beklendiği gibi çalışıyor.',
 		notificationEmailsCheckSuccessMessage: 'Bildirim e-postası <strong>%0%</strong> olarak ayarlandı',
 		notificationEmailsCheckErrorMessage: 'Bildirim e-postası hâlâ varsayılan değer olan <strong>%0%</strong>.',
-		scheduledHealthCheckEmailBody:
-			'<html><body><p>%0% tarihinde %1% ile çalıştırılan planlanmış Umbraco Sağlık Kontrollerinin sonuçları aşağıdaki gibidir: </p>%2%</body></html>',
-		scheduledHealthCheckEmailSubject: 'Umbraco Sağlık Kontrolü Durumu: %0%',
 		checkGroup: 'Grubu kontrol et',
 		helpText:
 			'\n        <p> Durum denetleyicisi, sitenizin çeşitli alanlarını en iyi uygulama ayarları, yapılandırma, olası sorunlar vb. için değerlendirir. Sorunları bir düğmeye basarak kolayca düzeltebilirsiniz.\n        Kendi sağlık kontrollerinizi ekleyebilir, <a href="https://docs.umbraco.com/umbraco-cms/extending/health-check" target="_blank" rel="noopener" class="btn-link -underline">özel durum kontrolleri hakkında daha fazla bilgi için belgeler </a>. </p>\n        ',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/uk-ua.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/uk-ua.ts
@@ -701,9 +701,6 @@ export default {
 		notificationEmailsCheckSuccessMessage: 'Адреса для надсилання повідомлень є наступною: <strong>%0%</strong>.',
 		notificationEmailsCheckErrorMessage:
 			'Адреса для надсилання повідомлень все ще встановлена за замовчуванням <strong>%0%</strong>.',
-		scheduledHealthCheckEmailBody:
-			'<html><body><p>Зафіксовано такі результати автоматичної перевірки стану Umbraco за розкладом, запущеним %0% в %1%:</p>%2%</body></html>',
-		scheduledHealthCheckEmailSubject: 'Результат перевірки стану Umbraco: %0%',
 	},
 	help: {
 		theBestUmbracoVideoTutorials: 'Найкращі навчальні відео-курси з Umbraco',

--- a/src/Umbraco.Web.UI.Client/src/mocks/handlers/document/publishing.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/handlers/document/publishing.handlers.ts
@@ -1,4 +1,5 @@
 const { rest } = window.MockServiceWorker;
+import { createProblemDetails } from '../../data/utils.js';
 import { umbDocumentMockDb } from '../../data/document/document.db.js';
 import { UMB_SLUG } from './slug.js';
 import type {
@@ -14,8 +15,16 @@ export const publishingHandlers = [
 		if (!id) return res(ctx.status(400));
 		const requestBody = (await req.json()) as PublishDocumentRequestModel;
 		if (!requestBody) return res(ctx.status(400, 'no body found'));
-		umbDocumentMockDb.publishing.publish(id, requestBody);
-		return res(ctx.status(200));
+
+		try {
+			umbDocumentMockDb.publishing.publish(id, requestBody);
+			return res(ctx.status(200));
+		} catch (error) {
+			if (error instanceof Error) {
+				return res(ctx.status(400), ctx.json(createProblemDetails({ title: 'Schedule', detail: error.message })));
+			}
+			throw new Error('An error occurred while publishing the document');
+		}
 	}),
 
 	rest.put(umbracoPath(`${UMB_SLUG}/:id/unpublish`), async (req, res, ctx) => {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/input-date/input-date.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/input-date/input-date.element.ts
@@ -1,66 +1,32 @@
-import { html, customElement, property, ifDefined } from '@umbraco-cms/backoffice/external/lit';
-import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
-import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
-import type { UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { UUIInputElement } from '@umbraco-cms/backoffice/external/uui';
+
+export type InputDateType = 'date' | 'time' | 'datetime-local';
 
 /**
  * This element passes a datetime string to a regular HTML input element.
- * @remark Be aware that you cannot include a time demonination, i.e. "10:44:00" if you
+ * Be aware that you cannot include a time demonination, i.e. "10:44:00" if you
  * set the input type of this element to "date". If you do, the browser will not show
  * the value at all.
  * @element umb-input-date
  */
 @customElement('umb-input-date')
-export class UmbInputDateElement extends UUIFormControlMixin(UmbLitElement, '') {
-	protected override getFormElement() {
-		return undefined;
+export class UmbInputDateElement extends UUIInputElement {
+	/**
+	 * Specifies the date and time type of the input that will be rendered.
+	 * @type {InputDateType}
+	 * @enum {InputDateType}
+	 */
+	override set type(type: InputDateType) {
+		super.type = type;
+	}
+	override get type(): InputDateType {
+		return super.type as InputDateType;
 	}
 
-	/**
-	 * Sets the input to readonly mode, meaning value cannot be changed but still able to read and select its content.
-	 * @type {boolean}
-	 * @attr
-	 * @default false
-	 */
-	@property({ type: Boolean, reflect: true })
-	readonly: boolean = false;
-
-	/**
-	 * Specifies the type of input that will be rendered.
-	 * @type {'date'| 'time'| 'datetime-local'}
-	 * @attr
-	 * @default date
-	 */
-	@property()
-	type: 'date' | 'time' | 'datetime-local' = 'date';
-
-	@property({ type: String })
-	min?: string;
-
-	@property({ type: String })
-	max?: string;
-
-	@property({ type: Number })
-	step?: number;
-
-	#onChange(event: UUIInputEvent) {
-		this.value = event.target.value;
-		this.dispatchEvent(new UmbChangeEvent());
-	}
-
-	override render() {
-		return html`<uui-input
-			id="datetime"
-			.label=${this.localize.term('placeholders_enterdate')}
-			.min=${this.min}
-			.max=${this.max}
-			.step=${this.step}
-			.type=${this.type}
-			value=${ifDefined(this.value)}
-			@change=${this.#onChange}
-			?readonly=${this.readonly}>
-		</uui-input>`;
+	constructor() {
+		super();
+		this.type = 'date'; // Default to 'date'
 	}
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.element.ts
@@ -193,7 +193,13 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 				${UmbDocumentVariantLanguagePickerElement.renderLabel(option)}
 			</uui-menu-item>
 			${when(this.#isSelected(option.unique), () => this.#renderPublishDateInput(option, fromDate, toDate))}
-			${when(isChanged, () => html`<p>${this.localize.term('content_scheduledPendingChanges')}</p>`)}
+			${when(
+				isChanged,
+				() =>
+					html`<p>
+						${this.localize.term('content_scheduledPendingChanges', this.localize.term('buttons_schedulePublish'))}
+					</p>`,
+			)}
 		`;
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.element.ts
@@ -215,7 +215,7 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 						label=${this.localize.term('general_publishDate')}>
 						<div slot="append">
 							${when(
-								fromDate !== option.variant?.scheduledPublishDate,
+								fromDate,
 								() => html`
 									<uui-button
 										compact
@@ -240,7 +240,7 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 						label=${this.localize.term('general_publishDate')}>
 						<div slot="append">
 							${when(
-								toDate !== option.variant?.scheduledUnpublishDate,
+								toDate,
 								() => html`
 									<uui-button
 										compact

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.element.ts
@@ -193,10 +193,7 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 				${UmbDocumentVariantLanguagePickerElement.renderLabel(option)}
 			</uui-menu-item>
 			${when(this.#isSelected(option.unique), () => this.#renderPublishDateInput(option, fromDate, toDate))}
-			${when(
-				isChanged,
-				() => html`<p class="label-status">${this.localize.term('content_scheduledPendingChanges')}</p>`,
-			)}
+			${when(isChanged, () => html`<p>${this.localize.term('content_scheduledPendingChanges')}</p>`)}
 		`;
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.element.ts
@@ -206,7 +206,22 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 						type="datetime-local"
 						.value=${this.#formatDate(fromDate)}
 						@change=${(e: Event) => this.#onFromDateChange(e, option.unique)}
-						label=${this.localize.term('general_publishDate')}></umb-input-date>
+						label=${this.localize.term('general_publishDate')}>
+						<div slot="append">
+							${when(
+								fromDate !== option.variant?.scheduledPublishDate,
+								() => html`
+									<uui-button
+										compact
+										label=${this.localize.term('general_clear')}
+										title=${this.localize.term('general_clear')}
+										@click=${() => this.#removeFromDate(option.unique)}>
+										<uui-icon name="remove"></uui-icon>
+									</uui-button>
+								`,
+							)}
+						</div>
+					</umb-input-date>
 				</div>
 			</uui-form-layout-item>
 			<uui-form-layout-item>
@@ -216,7 +231,22 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 						type="datetime-local"
 						.value=${this.#formatDate(toDate)}
 						@change=${(e: Event) => this.#onToDateChange(e, option.unique)}
-						label=${this.localize.term('general_publishDate')}></umb-input-date>
+						label=${this.localize.term('general_publishDate')}>
+						<div slot="append">
+							${when(
+								toDate !== option.variant?.scheduledUnpublishDate,
+								() => html`
+									<uui-button
+										compact
+										label=${this.localize.term('general_clear')}
+										title=${this.localize.term('general_clear')}
+										@click=${() => this.#removeToDate(option.unique)}>
+										<uui-icon name="remove"></uui-icon>
+									</uui-button>
+								`,
+							)}
+						</div>
+					</umb-input-date>
 				</div>
 			</uui-form-layout-item>
 		</div>`;
@@ -230,6 +260,26 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 	#toDate(unique: string): string | null {
 		const variant = this._internalValues.find((s) => s.unique === unique);
 		return variant?.schedule?.unpublishTime ?? null;
+	}
+
+	#removeFromDate(unique: string): void {
+		const variant = this._internalValues.find((s) => s.unique === unique);
+		if (!variant) return;
+		variant.schedule = {
+			...variant.schedule,
+			publishTime: null,
+		};
+		this.requestUpdate('_internalValues');
+	}
+
+	#removeToDate(unique: string): void {
+		const variant = this._internalValues.find((s) => s.unique === unique);
+		if (!variant) return;
+		variant.schedule = {
+			...variant.schedule,
+			unpublishTime: null,
+		};
+		this.requestUpdate('_internalValues');
 	}
 
 	/**


### PR DESCRIPTION
## Description

Fixes [AB#45942](https://dev.azure.com/umbraco/D-Team%20Tracker/_workitems/edit/45942)

- Adds a button to clear a set schedule.
- Adds a text if a schedule has changed.
- Removes an unused old body for emails of scheduled content

![image](https://github.com/user-attachments/assets/2fc45221-f5c3-4320-9b8f-b67e917a7baa)

### How to test

1. Schedule a document and try to set a schedule
2. Try to clear the schedule
3. Test that the text does not show up unless there are changes