### PR TITLE
V15: Show duration on time displays

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
@@ -928,6 +928,10 @@ export default {
 		skipToMenu: 'Spring til menu',
 		skipToContent: 'Spring til indhold',
 		newVersionAvailable: 'Ny version tilgængelig',
+		duration: (duration: string, date: Date | string, now: Date | string) => {
+			if (new Date(date).getTime() < new Date(now).getTime()) return `for ${duration} siden`;
+			return `om ${duration}`;
+		},
 	},
 	colors: {
 		blue: 'Blå',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -965,6 +965,10 @@ export default {
 		revert: 'Revert',
 		validate: 'Validate',
 		newVersionAvailable: 'New version available',
+		duration: (duration: string, date: Date | string, now: Date | string) => {
+			if (new Date(date).getTime() < new Date(now).getTime()) return `${duration} ago`;
+			return `in ${duration}`;
+		},
 	},
 	colors: {
 		blue: 'Blue',

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.test.ts
@@ -282,6 +282,47 @@ describe('UmbLocalizeController', () => {
 		});
 	});
 
+	describe('relative compounded time', () => {
+		it('should return a relative compounded time', () => {
+			const now = new Date();
+			const inTwoDays = new Date();
+			inTwoDays.setDate(inTwoDays.getDate() + 3);
+			inTwoDays.setHours(11, 30, 5);
+
+			expect(controller.relativeCompoundedTime(inTwoDays, now)).to.equal('in 2 days, in 22 hours, and in 58 minutes');
+		});
+
+		it('should return a date in seconds if the date is less than a minute away', () => {
+			const now = new Date();
+			const inTenSeconds = new Date(now.getTime() + 10000);
+
+			expect(controller.relativeCompoundedTime(inTenSeconds, now)).to.equal('in 10 seconds');
+		});
+
+		it('should compare between two dates', () => {
+			const twoDaysAgo = new Date();
+			twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+			const inTwoDays = new Date();
+			inTwoDays.setDate(inTwoDays.getDate() + 2);
+
+			expect(controller.relativeCompoundedTime(inTwoDays, twoDaysAgo)).to.equal('in 4 days');
+		});
+
+		it('should update the relative compounded time when the language changes', async () => {
+			const now = new Date();
+			const inTwoDays = new Date();
+			inTwoDays.setDate(inTwoDays.getDate() + 2);
+
+			expect(controller.relativeCompoundedTime(inTwoDays, now)).to.equal('in 2 days');
+
+			// Switch browser to Danish
+			document.documentElement.lang = danishRegional.$code;
+			await aTimeout(0);
+
+			expect(controller.relativeCompoundedTime(inTwoDays, now)).to.equal('om 2 dage');
+		});
+	});
+
 	describe('list format', () => {
 		it('should return a list with conjunction', () => {
 			expect(controller.listFormat(['one', 'two', 'three'], { type: 'conjunction' })).to.equal('one, two, and three');

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.test.ts
@@ -282,6 +282,16 @@ describe('UmbLocalizeController', () => {
 		});
 	});
 
+	describe('list format', () => {
+		it('should return a list with conjunction', () => {
+			expect(controller.listFormat(['one', 'two', 'three'], { type: 'conjunction' })).to.equal('one, two, and three');
+		});
+
+		it('should return a list with disjunction', () => {
+			expect(controller.listFormat(['one', 'two', 'three'], { type: 'disjunction' })).to.equal('one, two, or three');
+		});
+	});
+
 	describe('string', () => {
 		it('should replace words prefixed with a # with translated value', async () => {
 			const str = '#close';

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.test.ts
@@ -309,11 +309,7 @@ describe('UmbLocalizeController', () => {
 		});
 
 		it('should return a negative duration', () => {
-			const now = new Date();
-			const twoDaysAgo = new Date(now.getTime());
-			twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
-
-			expect(controller.duration(now, twoDaysAgo)).to.equal('2 days');
+			expect(controller.duration('2020-01-01', '2019-12-30')).to.equal('2 days');
 		});
 
 		it('should update the relative compounded time when the language changes', async () => {

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.test.ts
@@ -284,12 +284,12 @@ describe('UmbLocalizeController', () => {
 
 	describe('relative compounded time', () => {
 		it('should return a relative compounded time', () => {
-			const now = new Date();
-			const inTwoDays = new Date();
-			inTwoDays.setDate(inTwoDays.getDate() + 3);
+			const now = new Date('2020-01-01T00:00:00');
+			const inTwoDays = new Date(now.getTime());
+			inTwoDays.setDate(inTwoDays.getDate() + 2);
 			inTwoDays.setHours(11, 30, 5);
 
-			expect(controller.relativeCompoundedTime(inTwoDays, now)).to.equal('in 2 days, in 22 hours, and in 58 minutes');
+			expect(controller.relativeCompoundedTime(inTwoDays, now)).to.equal('in 2 days, in 11 hours, and in 30 minutes');
 		});
 
 		it('should return a date in seconds if the date is less than a minute away', () => {

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.test.ts
@@ -282,21 +282,21 @@ describe('UmbLocalizeController', () => {
 		});
 	});
 
-	describe('relative compounded time', () => {
-		it('should return a relative compounded time', () => {
+	describe('duration', () => {
+		it('should return a duration', () => {
 			const now = new Date('2020-01-01T00:00:00');
 			const inTwoDays = new Date(now.getTime());
 			inTwoDays.setDate(inTwoDays.getDate() + 2);
 			inTwoDays.setHours(11, 30, 5);
 
-			expect(controller.relativeCompoundedTime(inTwoDays, now)).to.equal('in 2 days, in 11 hours, and in 30 minutes');
+			expect(controller.duration(inTwoDays, now)).to.equal('2 days, 11 hours, 30 minutes, 5 seconds');
 		});
 
 		it('should return a date in seconds if the date is less than a minute away', () => {
 			const now = new Date();
 			const inTenSeconds = new Date(now.getTime() + 10000);
 
-			expect(controller.relativeCompoundedTime(inTenSeconds, now)).to.equal('in 10 seconds');
+			expect(controller.duration(inTenSeconds, now)).to.equal('10 seconds');
 		});
 
 		it('should compare between two dates', () => {
@@ -305,7 +305,15 @@ describe('UmbLocalizeController', () => {
 			const inTwoDays = new Date();
 			inTwoDays.setDate(inTwoDays.getDate() + 2);
 
-			expect(controller.relativeCompoundedTime(inTwoDays, twoDaysAgo)).to.equal('in 4 days');
+			expect(controller.duration(inTwoDays, twoDaysAgo)).to.equal('4 days');
+		});
+
+		it('should return a negative duration', () => {
+			const now = new Date();
+			const twoDaysAgo = new Date(now.getTime());
+			twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+
+			expect(controller.duration(now, twoDaysAgo)).to.equal('2 days');
 		});
 
 		it('should update the relative compounded time when the language changes', async () => {
@@ -313,23 +321,23 @@ describe('UmbLocalizeController', () => {
 			const inTwoDays = new Date();
 			inTwoDays.setDate(inTwoDays.getDate() + 2);
 
-			expect(controller.relativeCompoundedTime(inTwoDays, now)).to.equal('in 2 days');
+			expect(controller.duration(inTwoDays, now)).to.equal('2 days');
 
 			// Switch browser to Danish
 			document.documentElement.lang = danishRegional.$code;
 			await aTimeout(0);
 
-			expect(controller.relativeCompoundedTime(inTwoDays, now)).to.equal('om 2 dage');
+			expect(controller.duration(inTwoDays, now)).to.equal('2 dage');
 		});
 	});
 
 	describe('list format', () => {
 		it('should return a list with conjunction', () => {
-			expect(controller.listFormat(['one', 'two', 'three'], { type: 'conjunction' })).to.equal('one, two, and three');
+			expect(controller.list(['one', 'two', 'three'], { type: 'conjunction' })).to.equal('one, two, and three');
 		});
 
 		it('should return a list with disjunction', () => {
-			expect(controller.listFormat(['one', 'two', 'three'], { type: 'disjunction' })).to.equal('one, two, or three');
+			expect(controller.list(['one', 'two', 'three'], { type: 'disjunction' })).to.equal('one, two, or three');
 		});
 	});
 

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.ts
@@ -191,6 +191,17 @@ export class UmbLocalizationController<LocalizationSetType extends UmbLocalizati
 		return new Intl.RelativeTimeFormat(this.lang(), options).format(value, unit);
 	}
 
+	/**
+	 * Outputs a localized list of values in the specified format.
+	 * @example "one, two, and three"
+	 * @param {Iterable<string>} values - the values to format.
+	 * @param {Intl.ListFormatOptions} options - the options to use when formatting the list.
+	 * @returns {string} - the formatted list.
+	 */
+	listFormat(values: Iterable<string>, options?: Intl.ListFormatOptions): string {
+		return new Intl.ListFormat(this.lang(), options).format(values);
+	}
+
 	// TODO: for V.16 we should set type to be string | undefined. [NL]
 	/**
 	 * Translates a string containing one or more terms. The terms should be prefixed with a `#` character.

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.ts
@@ -192,6 +192,51 @@ export class UmbLocalizationController<LocalizationSetType extends UmbLocalizati
 	}
 
 	/**
+	 * Outputs a localized compounded time in a relative list format.
+	 * @example "2 days, 3 hours, 5 minutes"
+	 * @param {Date} fromDate - the date to compare from.
+	 * @param {Date} toDate - the date to compare to, usually the current date (default: current date).
+	 * @param {Intl.RelativeTimeFormatOptions} options - the options to use when formatting the time.
+	 * @param {Intl.ListFormatOptions} listOptions - the options to use when formatting the list.
+	 * @returns {string} - the formatted time, example: "2 days, 3 hours, 5 minutes"
+	 */
+	relativeCompoundedTime(
+		fromDate: Date,
+		toDate?: Date,
+		options?: Intl.RelativeTimeFormatOptions,
+		listOptions?: Intl.ListFormatOptions,
+	): string {
+		const diff = fromDate.getTime() - (toDate?.getTime() ?? Date.now());
+		const diffInDays = Math.floor(diff / (1000 * 60 * 60 * 24));
+		const restDiffInHours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+		const restDiffInMins = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+
+		const relativeTimeArr: string[] = [];
+
+		if (diffInDays) {
+			relativeTimeArr.push(this.relativeTime(diffInDays, diffInDays > 1 ? 'days' : 'day', options));
+		}
+
+		if (restDiffInHours) {
+			relativeTimeArr.push(this.relativeTime(restDiffInHours, restDiffInHours > 1 ? 'hours' : 'hour', options));
+		}
+
+		if (restDiffInMins) {
+			relativeTimeArr.push(this.relativeTime(restDiffInMins, restDiffInMins > 1 ? 'minutes' : 'minute', options));
+		}
+
+		// If we have no days, hours or minutes, we should at least show seconds.
+		if (!relativeTimeArr.length) {
+			const diffInSeconds = Math.floor(diff / 1000);
+			relativeTimeArr.push(this.relativeTime(diffInSeconds, diffInSeconds > 1 ? 'seconds' : 'second', options));
+		}
+
+		const relativeTime = this.listFormat(relativeTimeArr, { type: 'conjunction', ...listOptions });
+
+		return relativeTime;
+	}
+
+	/**
 	 * Outputs a localized list of values in the specified format.
 	 * @example "one, two, and three"
 	 * @param {Iterable<string>} values - the values to format.

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.ts
@@ -245,7 +245,7 @@ export class UmbLocalizationController<LocalizationSetType extends UmbLocalizati
 	 * @param {Intl.ListFormatOptions} options - the options to use when formatting the list.
 	 * @returns {string} - the formatted list.
 	 */
-	listFormat(values: Iterable<string>, options?: Intl.ListFormatOptions): string {
+	list(values: Iterable<string>, options?: Intl.ListFormatOptions): string {
 		return new Intl.ListFormat(this.lang(), options).format(values);
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.ts
@@ -201,12 +201,14 @@ export class UmbLocalizationController<LocalizationSetType extends UmbLocalizati
 	 * @returns {string} - the formatted time, example: "2 days, 3 hours, 5 minutes"
 	 */
 	relativeCompoundedTime(
-		fromDate: Date,
-		toDate?: Date,
+		fromDate: Date | string,
+		toDate?: Date | string,
 		options?: Intl.RelativeTimeFormatOptions,
 		listOptions?: Intl.ListFormatOptions,
 	): string {
-		const diff = fromDate.getTime() - (toDate?.getTime() ?? Date.now());
+		const d1 = new Date(fromDate);
+		const d2 = new Date(toDate ?? Date.now());
+		const diff = d1.getTime() - d2.getTime();
 		const diffInDays = Math.floor(diff / (1000 * 60 * 60 * 24));
 		const restDiffInHours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
 		const restDiffInMins = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.ts
@@ -182,6 +182,7 @@ export class UmbLocalizationController<LocalizationSetType extends UmbLocalizati
 
 	/**
 	 * Outputs a localized time in relative format.
+	 * @example "in 2 days"
 	 * @param {number} value - the value to format.
 	 * @param {Intl.RelativeTimeFormatUnit} unit - the unit of time to format.
 	 * @param {Intl.RelativeTimeFormatOptions} options - the options to use when formatting the time.
@@ -192,50 +193,46 @@ export class UmbLocalizationController<LocalizationSetType extends UmbLocalizati
 	}
 
 	/**
-	 * Outputs a localized compounded time in a relative list format.
-	 * @example "2 days, 3 hours, 5 minutes"
+	 * Outputs a localized compounded time in a duration format.
+	 * @example "2 days, 3 hours and 5 minutes"
 	 * @param {Date} fromDate - the date to compare from.
 	 * @param {Date} toDate - the date to compare to, usually the current date (default: current date).
-	 * @param {Intl.RelativeTimeFormatOptions} options - the options to use when formatting the time.
-	 * @param {Intl.ListFormatOptions} listOptions - the options to use when formatting the list.
+	 * @param {object} options - the options to use when formatting the time.
 	 * @returns {string} - the formatted time, example: "2 days, 3 hours, 5 minutes"
 	 */
-	relativeCompoundedTime(
-		fromDate: Date | string,
-		toDate?: Date | string,
-		options?: Intl.RelativeTimeFormatOptions,
-		listOptions?: Intl.ListFormatOptions,
-	): string {
+	duration(fromDate: Date | string, toDate?: Date | string, options?: any): string {
 		const d1 = new Date(fromDate);
 		const d2 = new Date(toDate ?? Date.now());
 		const diff = d1.getTime() - d2.getTime();
+		const diffInSecs = Math.floor(diff / 1000);
+
+		if (false === 'DurationFormat' in Intl) {
+			return `${diffInSecs} seconds`;
+		}
+
 		const diffInDays = Math.floor(diff / (1000 * 60 * 60 * 24));
 		const restDiffInHours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
 		const restDiffInMins = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+		const restDiffInSecs = Math.floor((diff % (1000 * 60)) / 1000);
 
-		const relativeTimeArr: string[] = [];
+		const formatOptions = {
+			style: 'long',
+			...options,
+		};
 
-		if (diffInDays) {
-			relativeTimeArr.push(this.relativeTime(diffInDays, diffInDays > 1 ? 'days' : 'day', options));
+		// TODO: This is a hack to get around the fact that the DurationFormat is not yet available in the TypeScript typings. [JOV]
+		const formatter = new (Intl as any).DurationFormat(this.lang(), formatOptions);
+
+		if (diffInDays === 0 && restDiffInHours === 0 && restDiffInMins === 0) {
+			return formatter.format({ seconds: diffInSecs });
 		}
 
-		if (restDiffInHours) {
-			relativeTimeArr.push(this.relativeTime(restDiffInHours, restDiffInHours > 1 ? 'hours' : 'hour', options));
-		}
-
-		if (restDiffInMins) {
-			relativeTimeArr.push(this.relativeTime(restDiffInMins, restDiffInMins > 1 ? 'minutes' : 'minute', options));
-		}
-
-		// If we have no days, hours or minutes, we should at least show seconds.
-		if (!relativeTimeArr.length) {
-			const diffInSeconds = Math.floor(diff / 1000);
-			relativeTimeArr.push(this.relativeTime(diffInSeconds, diffInSeconds > 1 ? 'seconds' : 'second', options));
-		}
-
-		const relativeTime = this.listFormat(relativeTimeArr, { type: 'conjunction', ...listOptions });
-
-		return relativeTime;
+		return formatter.format({
+			days: diffInDays,
+			hours: restDiffInHours,
+			minutes: restDiffInMins,
+			seconds: restDiffInSecs,
+		});
 	}
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.ts
@@ -203,8 +203,8 @@ export class UmbLocalizationController<LocalizationSetType extends UmbLocalizati
 	duration(fromDate: Date | string, toDate?: Date | string, options?: any): string {
 		const d1 = new Date(fromDate);
 		const d2 = new Date(toDate ?? Date.now());
-		const diff = d1.getTime() - d2.getTime();
-		const diffInSecs = Math.floor(diff / 1000);
+		const diff = Math.abs(d1.getTime() - d2.getTime());
+		const diffInSecs = Math.abs(Math.floor(diff / 1000));
 
 		if (false === 'DurationFormat' in Intl) {
 			return `${diffInSecs} seconds`;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/localization/localize-date.element.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/localization/localize-date.element.test.ts
@@ -49,5 +49,12 @@ describe('umb-localize-date', () => {
 			await aTimeout(0);
 			expect(element.title).to.equal('2 years ago');
 		});
+
+		it('should not set a title', async () => {
+			element.skipDuration = true;
+			element.title = 'Another title';
+			await element.updateComplete;
+			expect(element.title).to.equal('Another title');
+		});
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/core/localization/localize-date.element.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/localization/localize-date.element.test.ts
@@ -1,0 +1,53 @@
+import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
+import { UmbLocalizeDateElement } from './localize-date.element.js';
+import { aTimeout, expect, fixture, html } from '@open-wc/testing';
+
+const english = {
+	type: 'localization',
+	alias: 'test.en',
+	name: 'Test English',
+	meta: {
+		culture: 'en',
+		localizations: {
+			general: {
+				duration: () => {
+					return '2 years ago'; // This is a simplified version of the actual implementation
+				},
+			},
+		},
+	},
+};
+
+describe('umb-localize-date', () => {
+	let date: Date;
+	let element: UmbLocalizeDateElement;
+
+	beforeEach(async () => {
+		date = new Date('2020-01-01T00:00:00');
+		element = await fixture(html`<umb-localize-date .date=${date}>Fallback value</umb-localize-date>`);
+	});
+
+	it('should be defined', () => {
+		expect(element).to.be.instanceOf(UmbLocalizeDateElement);
+	});
+
+	describe('localization', () => {
+		umbExtensionsRegistry.register(english);
+
+		it('should localize a date', () => {
+			expect(element.shadowRoot?.textContent).to.equal('1/1/2020');
+		});
+
+		it('should localize a date with options', async () => {
+			element.options = { dateStyle: 'full' };
+			await element.updateComplete;
+
+			expect(element.shadowRoot?.textContent).to.equal('Wednesday, January 1, 2020');
+		});
+
+		it('should set a title', async () => {
+			await aTimeout(0);
+			expect(element.title).to.equal('2 years ago');
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/localization/localize-date.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/localization/localize-date.element.ts
@@ -1,4 +1,4 @@
-import { css, customElement, html, property, state, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
+import { css, customElement, nothing, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
 /**
@@ -24,13 +24,25 @@ export class UmbLocalizeDateElement extends UmbLitElement {
 	@property({ type: Object })
 	options?: Intl.DateTimeFormatOptions;
 
-	@state()
-	protected get text(): string {
-		return this.localize.date(this.date!, this.options);
+	override updated() {
+		this.#setTitle();
 	}
 
 	override render() {
-		return this.date ? html`${unsafeHTML(this.text)}` : html`<slot></slot>`;
+		return this.date ? this.localize.date(this.date, this.options) : nothing;
+	}
+
+	#setTitle() {
+		let title = '';
+
+		if (this.date) {
+			const now = new Date();
+			const d = new Date(this.date);
+			const duration = this.localize.duration(d, now);
+			title = this.localize.term('general_duration', duration, d, now);
+		}
+
+		this.title = title;
 	}
 
 	static override styles = [

--- a/src/Umbraco.Web.UI.Client/src/packages/core/localization/localize-date.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/localization/localize-date.element.ts
@@ -24,6 +24,12 @@ export class UmbLocalizeDateElement extends UmbLitElement {
 	@property({ type: Object })
 	options?: Intl.DateTimeFormatOptions;
 
+	/**
+	 * Do not show the duration in the title.
+	 */
+	@property({ type: Boolean })
+	skipDuration = false;
+
 	override updated() {
 		this.#setTitle();
 	}
@@ -33,6 +39,10 @@ export class UmbLocalizeDateElement extends UmbLitElement {
 	}
 
 	#setTitle() {
+		if (this.skipDuration) {
+			return;
+		}
+
 		let title = '';
 
 		if (this.date) {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/localization/localize-relative-time.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/localization/localize-relative-time.element.ts
@@ -13,7 +13,7 @@ export class UmbLocalizeRelativeTimeElement extends UmbLitElement {
 	 * @attr
 	 * @example time=10
 	 */
-	@property()
+	@property({ type: Number })
 	time!: number;
 
 	/**
@@ -21,7 +21,7 @@ export class UmbLocalizeRelativeTimeElement extends UmbLitElement {
 	 * @attr
 	 * @example options={ dateStyle: 'full', timeStyle: 'long', timeZone: 'Australia/Sydney' }
 	 */
-	@property()
+	@property({ type: Object })
 	options?: Intl.RelativeTimeFormatOptions;
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/views/info/document-workspace-view-info.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/views/info/document-workspace-view-info.element.ts
@@ -280,10 +280,7 @@ export class UmbDocumentWorkspaceViewInfoElement extends UmbLitElement {
 			<div class="general-item">
 				<strong><umb-localize .key=${labelKey}>${labelText}</umb-localize></strong>
 				<span>
-					<umb-localize-date
-						title=${this.localize.relativeCompoundedTime(date)}
-						.date=${date}
-						.options=${TimeOptions}></umb-localize-date>
+					<umb-localize-date .date=${date} .options=${TimeOptions}></umb-localize-date>
 				</span>
 			</div>
 		`;

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/views/info/document-workspace-view-info.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/views/info/document-workspace-view-info.element.ts
@@ -280,7 +280,10 @@ export class UmbDocumentWorkspaceViewInfoElement extends UmbLitElement {
 			<div class="general-item">
 				<strong><umb-localize .key=${labelKey}>${labelText}</umb-localize></strong>
 				<span>
-					<umb-localize-date .date=${date} .options=${TimeOptions}></umb-localize-date>
+					<umb-localize-date
+						title=${this.localize.relativeCompoundedTime(date)}
+						.date=${date}
+						.options=${TimeOptions}></umb-localize-date>
 				</span>
 			</div>
 		`;


### PR DESCRIPTION
## Description

- Adds helper functions to show a localized duration between two points in time using the [Intl.DurationFormat API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DurationFormat), which is available in most browsers (Firefox behind a flag).
- Uses the helper function in the `<umb-localize-date />` element to show the duration between **now** and the time in the  title attribute

![image](https://github.com/user-attachments/assets/8670d905-259b-443b-9325-de53f5c89db9)

- Improves the **UmbLocalizeDateElement** to avoid re-rendering
- The longer-term idea is to use this in the schedule publishing modal to let the user know more details about their scheduling