### PR TITLE
HTML encodes the user's name in the invite email

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
@@ -664,10 +664,11 @@ public class UsersController : BackOfficeNotificationsController
         var emailSubject = _localizedTextService.Localize("user", "inviteEmailCopySubject",
             // Ensure the culture of the found user is used for the email!
             UmbracoUserExtensions.GetUserCulture(to?.Language, _localizedTextService, _globalSettings));
+        var name = userDisplay is null ? string.Empty : System.Web.HttpUtility.HtmlEncode(userDisplay.Name);
         var emailBody = _localizedTextService.Localize("user", "inviteEmailCopyFormat",
             // Ensure the culture of the found user is used for the email!
             UmbracoUserExtensions.GetUserCulture(to?.Language, _localizedTextService, _globalSettings),
-            new[] { userDisplay?.Name, from, WebUtility.HtmlEncode(message)!.ReplaceLineEndings("<br/>"), inviteUri.ToString(), senderEmail });
+            new[] { name, from, WebUtility.HtmlEncode(message)!.ReplaceLineEndings("<br/>"), inviteUri.ToString(), senderEmail });
 
         // This needs to be in the correct mailto format including the name, else
         // the name cannot be captured in the email sending notification.


### PR DESCRIPTION
As per discussion.  Have considered that we don't need to be concerned from a security perspective about this, as the invite email can only be sent if you know the recipients email, and hence could craft whatever email you wanted from outside Umbraco.  But it's still worth ensuring you can't provide HTML in the email,

**To Test:**

- Invite a user with a name of `Test <a href="https://umbraco.com">Click me</a>`
- Verify the name in the received email is HTML encoded

![image](https://github.com/user-attachments/assets/b504def4-e2a9-4f95-bd8b-9105b66720c9)
