### PR TITLE
Relax block data contract

### DIFF
--- a/src/Umbraco.Infrastructure/Models/RichTextEditorValue.cs
+++ b/src/Umbraco.Infrastructure/Models/RichTextEditorValue.cs
@@ -10,5 +10,5 @@ public class RichTextEditorValue
     public required string Markup { get; set; }
 
     [DataMember(Name = "blocks")]
-    public required RichTextBlockValue? Blocks { get; set; }
+    public RichTextBlockValue? Blocks { get; set; }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/RichTextPropertyEditorHelperTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/RichTextPropertyEditorHelperTests.cs
@@ -95,6 +95,22 @@ public class RichTextPropertyEditorHelperTests
     }
 
     [Test]
+    public void Can_Parse_JObject_With_Missing_Blocks()
+    {
+        var input = JsonNode.Parse(""""
+                                   {
+                                    "markup": "<h2>Vælg et af vores mest populære produkter</h2>"
+                                   }
+                                   """");
+
+        var result = RichTextPropertyEditorHelper.TryParseRichTextEditorValue(input, JsonSerializer(), Logger(), out RichTextEditorValue? value);
+        Assert.IsTrue(result);
+        Assert.IsNotNull(value);
+        Assert.AreEqual("<h2>Vælg et af vores mest populære produkter</h2>", value.Markup);
+        Assert.IsNull(value.Blocks);
+    }
+
+    [Test]
     public void Can_Parse_Blocks_With_Both_Content_And_Settings()
     {
         const string input = """


### PR DESCRIPTION
### Description
https://github.com/umbraco/Umbraco-CMS/issues/18275 is caused by
- A very strict data contract
- Data in the database that does not adhere to the contract

When the migration runs, part of the nested data fails to deserialize and to not make the entire migration fail, a message is logged and the data is cleared.
Since we currently have been unable to figure out how the malformed data has been entered trough the client **and** we think relaxing the data contract will not have any adverse effects, this pr does just that

### Testing
I added a unit test that covers the change. You should be able to update the database manually to contain some problematic data. If not, feel free to reach out to obtain a database.