### PR TITLE
Limit referenced-by document and media endpoints to references only

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/References/ReferencedByDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/References/ReferencedByDocumentController.cs
@@ -1,4 +1,4 @@
-﻿using Asp.Versioning;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -37,7 +37,7 @@ public class ReferencedByDocumentController : DocumentControllerBase
         int skip = 0,
         int take = 20)
     {
-        PagedModel<RelationItemModel> relationItems = await _trackedReferencesService.GetPagedRelationsForItemAsync(id, skip, take, false);
+        PagedModel<RelationItemModel> relationItems = await _trackedReferencesService.GetPagedRelationsForItemAsync(id, skip, take, true);
 
         var pagedViewModel = new PagedViewModel<IReferenceResponseModel>
         {

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/References/ReferencedByMediaController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/References/ReferencedByMediaController.cs
@@ -1,4 +1,4 @@
-﻿using Asp.Versioning;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -37,7 +37,7 @@ public class ReferencedByMediaController : MediaControllerBase
         int skip = 0,
         int take = 20)
     {
-        PagedModel<RelationItemModel> relationItems = await _trackedReferencesService.GetPagedRelationsForItemAsync(id, skip, take, false);
+        PagedModel<RelationItemModel> relationItems = await _trackedReferencesService.GetPagedRelationsForItemAsync(id, skip, take, true);
 
         var pagedViewModel = new PagedViewModel<IReferenceResponseModel>
         {


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description
The existing `/referenced-by/` endpoints for documents and media return all relations, but really it seems the intention of these endpoints is just to show where the item is used elsewhere.  We aren't interested in exposing the "system references", such as the folder or root to restore to from a deleted item.  As such I've modified the endpoints to only return the relations that are marked with "is dependency".

This does change behaviour, but I would argue only in a correcting way for what the intention of these endpoints are.

See (internal) discussion here:
https://umbraco.slack.com/archives/C07K2QDB7DY/p1739802387977499

To Test:

- Delete a document from the root of the content section so that it's in the recycle bin.
- Request 
  `/umbraco/management/api/v1/document/{id}/referenced-by` for the document.
- Note that with this PR in place there is now no reference to "SYSTEM DATA: umbraco master root" returned.