### PR TITLE
On retrieving other URLs, don't attempt to walk up the navigation structure to find parents when content is trashed

### DIFF
--- a/src/Umbraco.Core/Routing/NewDefaultUrlProvider.cs
+++ b/src/Umbraco.Core/Routing/NewDefaultUrlProvider.cs
@@ -89,8 +89,6 @@ public class NewDefaultUrlProvider : IUrlProvider
             yield break;
         }
 
-
-
         // look for domains, walking up the tree
         IPublishedContent? n = node;
         IEnumerable<DomainAndUri>? domainUris =

--- a/src/Umbraco.Core/Routing/PublishedUrlInfoProvider.cs
+++ b/src/Umbraco.Core/Routing/PublishedUrlInfoProvider.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Services;
@@ -66,6 +66,12 @@ public class PublishedUrlInfoProvider : IPublishedUrlInfoProvider
             }
 
             urlInfos.Add(UrlInfo.Url(url, culture));
+        }
+
+        // If the content is trashed, we can't get the other URLs, as we have no parent structure to navigate through.
+        if (content.Trashed)
+        {
+            return urlInfos;
         }
 
         // Then get "other" urls - I.E. Not what you'd get with GetUrl(), this includes all the urls registered using domains.


### PR DESCRIPTION
### Description
Avoids an exception triggered when attempting to resolve "other URLs" for a content item when it's trashed, and their is no ancestor structure available to walk up to find the domains.

See (internal) discussion at:
https://umbraco.slack.com/archives/C027U315T54/p1739795960326179

**To Test:**

- Delete a node and try to view it in the recycle bin.
- Note that now no exception is thrown.