### PR TITLE
Fixes the Fatal icon text so it's readable in Dark Mode.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/views/search/components/log-viewer-level-tag.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/views/search/components/log-viewer-level-tag.element.ts
@@ -24,7 +24,7 @@ export class UmbLogViewerLevelTagElement extends LitElement {
 		Error: { look: 'primary', color: 'danger' },
 		Fatal: {
 			look: 'primary',
-			style: 'background-color: var(--umb-log-viewer-fatal-color); color: var(--uui-color-surface)',
+			style: 'background-color: var(--umb-log-viewer-fatal-color)',
 		},
 	};
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

[Issue 18374](https://github.com/umbraco/Umbraco-CMS/issues/18374)

### Description
- Open up Umbraco 15
- Navigate to Settings
- Navigate to Log Viewer
- Open one of the detailed logs, like "All"
- Change your Umbraco settings to use "Dark Mode"

If you are using the client project, you should see a "Fatal" error icon and the text is too dark to be able to read, dark grey on black.

This PR fixes that :)