### PR TITLE
 Added option for filtering the content types allowed as children based on the parent node

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/AllowedChildrenDocumentTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/AllowedChildrenDocumentTypeController.cs
@@ -24,7 +24,7 @@ public class AllowedChildrenDocumentTypeController : DocumentTypeControllerBase
     }
 
     [NonAction]
-    [Obsolete("Scheduled to be removed in v16, use the non obsoleted method instead")]
+    [Obsolete("Use the non obsoleted method instead. Scheduled to be removed in v16")]
     public async Task<IActionResult> AllowedChildrenByKey(
         CancellationToken cancellationToken,
         Guid id,

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/AllowedChildrenDocumentTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/AllowedChildrenDocumentTypeController.cs
@@ -1,5 +1,4 @@
-﻿using Asp.Versioning;
-using Microsoft.AspNetCore.Authorization;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -9,7 +8,6 @@ using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
-using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.DocumentType;
 
@@ -25,6 +23,15 @@ public class AllowedChildrenDocumentTypeController : DocumentTypeControllerBase
         _umbracoMapper = umbracoMapper;
     }
 
+    [NonAction]
+    [Obsolete("Scheduled to be removed in v16, use the non obsoleted method instead")]
+    public async Task<IActionResult> AllowedChildrenByKey(
+        CancellationToken cancellationToken,
+        Guid id,
+        int skip = 0,
+        int take = 100)
+        => await AllowedChildrenByKey(cancellationToken, id, null, skip, take);
+
     [HttpGet("{id:guid}/allowed-children")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<AllowedDocumentType>), StatusCodes.Status200OK)]
@@ -32,10 +39,11 @@ public class AllowedChildrenDocumentTypeController : DocumentTypeControllerBase
     public async Task<IActionResult> AllowedChildrenByKey(
         CancellationToken cancellationToken,
         Guid id,
+        Guid? parentContentKey = null,
         int skip = 0,
         int take = 100)
     {
-        Attempt<PagedModel<IContentType>?, ContentTypeOperationStatus> attempt = await _contentTypeService.GetAllowedChildrenAsync(id, skip, take);
+        Attempt<PagedModel<IContentType>?, ContentTypeOperationStatus> attempt = await _contentTypeService.GetAllowedChildrenAsync(id, parentContentKey, skip, take);
         if (attempt.Success is false)
         {
             return OperationStatusResult(attempt.Status);

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/AllowedChildrenMediaTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/AllowedChildrenMediaTypeController.cs
@@ -1,4 +1,4 @@
-﻿using Asp.Versioning;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -23,6 +23,15 @@ public class AllowedChildrenMediaTypeController : MediaTypeControllerBase
         _umbracoMapper = umbracoMapper;
     }
 
+    [NonAction]
+    [Obsolete("Scheduled to be removed in v16, use the non obsoleted method instead")]
+    public async Task<IActionResult> AllowedChildrenByKey(
+        CancellationToken cancellationToken,
+        Guid id,
+        int skip = 0,
+        int take = 100)
+        => await AllowedChildrenByKey(cancellationToken, id, null, skip, take);
+
     [HttpGet("{id:guid}/allowed-children")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<AllowedMediaType>), StatusCodes.Status200OK)]
@@ -30,10 +39,11 @@ public class AllowedChildrenMediaTypeController : MediaTypeControllerBase
     public async Task<IActionResult> AllowedChildrenByKey(
         CancellationToken cancellationToken,
         Guid id,
+        Guid? parentContentKey = null,
         int skip = 0,
         int take = 100)
     {
-        Attempt<PagedModel<IMediaType>?, ContentTypeOperationStatus> attempt = await _mediaTypeService.GetAllowedChildrenAsync(id, skip, take);
+        Attempt<PagedModel<IMediaType>?, ContentTypeOperationStatus> attempt = await _mediaTypeService.GetAllowedChildrenAsync(id, parentContentKey, skip, take);
         if (attempt.Success is false)
         {
             return OperationStatusResult(attempt.Status);

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/AllowedChildrenMediaTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/AllowedChildrenMediaTypeController.cs
@@ -24,7 +24,7 @@ public class AllowedChildrenMediaTypeController : MediaTypeControllerBase
     }
 
     [NonAction]
-    [Obsolete("Scheduled to be removed in v16, use the non obsoleted method instead")]
+    [Obsolete("Use the non obsoleted method instead. Scheduled for removal in Umbraco 16.")]
     public async Task<IActionResult> AllowedChildrenByKey(
         CancellationToken cancellationToken,
         Guid id,

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -4672,6 +4672,14 @@
             }
           },
           {
+            "name": "parentContentKey",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
             "name": "skip",
             "in": "query",
             "schema": {
@@ -13954,6 +13962,14 @@
             "name": "id",
             "in": "path",
             "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "parentContentKey",
+            "in": "query",
             "schema": {
               "type": "string",
               "format": "uuid"
@@ -36826,6 +36842,8 @@
         "required": [
           "documentType",
           "id",
+          "isProtected",
+          "isTrashed",
           "sortOrder",
           "values",
           "variants"
@@ -36870,6 +36888,12 @@
                 "$ref": "#/components/schemas/DocumentTypeCollectionReferenceResponseModel"
               }
             ]
+          },
+          "isTrashed": {
+            "type": "boolean"
+          },
+          "isProtected": {
+            "type": "boolean"
           },
           "updater": {
             "type": "string",

--- a/src/Umbraco.Core/Services/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
+++ b/src/Umbraco.Core/Services/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
@@ -1183,8 +1183,13 @@ public abstract class ContentTypeServiceBase<TRepository, TItem> : ContentTypeSe
         return pagedModel;
     }
 
+
     /// <inheritdoc />
     public async Task<Attempt<PagedModel<TItem>?, ContentTypeOperationStatus>> GetAllowedChildrenAsync(Guid key, int skip, int take)
+        => await GetAllowedChildrenAsync(key, Guid.Empty, skip, take);
+
+    /// <inheritdoc />
+    public async Task<Attempt<PagedModel<TItem>?, ContentTypeOperationStatus>> GetAllowedChildrenAsync(Guid key, Guid? parentContentKey, int skip, int take)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
         TItem? parent = Get(key);
@@ -1197,7 +1202,7 @@ public abstract class ContentTypeServiceBase<TRepository, TItem> : ContentTypeSe
         IEnumerable<ContentTypeSort> allowedContentTypes = parent.AllowedContentTypes;
         foreach (IContentTypeFilter filter in _contentTypeFilters)
         {
-            allowedContentTypes = await filter.FilterAllowedChildrenAsync(allowedContentTypes, key);
+            allowedContentTypes = await filter.FilterAllowedChildrenAsync(allowedContentTypes, key, parentContentKey);
         }
 
         PagedModel<TItem> result;

--- a/src/Umbraco.Core/Services/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
+++ b/src/Umbraco.Core/Services/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
@@ -1186,7 +1186,7 @@ public abstract class ContentTypeServiceBase<TRepository, TItem> : ContentTypeSe
 
     /// <inheritdoc />
     public async Task<Attempt<PagedModel<TItem>?, ContentTypeOperationStatus>> GetAllowedChildrenAsync(Guid key, int skip, int take)
-        => await GetAllowedChildrenAsync(key, Guid.Empty, skip, take);
+        => await GetAllowedChildrenAsync(key, null, skip, take);
 
     /// <inheritdoc />
     public async Task<Attempt<PagedModel<TItem>?, ContentTypeOperationStatus>> GetAllowedChildrenAsync(Guid key, Guid? parentContentKey, int skip, int take)

--- a/src/Umbraco.Core/Services/Filters/IContentTypeFilter.cs
+++ b/src/Umbraco.Core/Services/Filters/IContentTypeFilter.cs
@@ -22,7 +22,7 @@ public interface IContentTypeFilter
     /// <param name="contentTypes">Retrieved collection of content types.</param>
     /// <param name="parentKey">The parent content key.</param>
     /// <returns>Filtered collection of content types.</returns>
-    [Obsolete("Please the method overload taking all parameters. This method will be removed in Umbraco 17.")]
+    [Obsolete("Please use the method overload taking all parameters. Scheduled for removal in Umbraco 17.")]
     Task<IEnumerable<ContentTypeSort>> FilterAllowedChildrenAsync(IEnumerable<ContentTypeSort> contentTypes, Guid parentKey)
         => Task.FromResult(contentTypes);
 

--- a/src/Umbraco.Core/Services/Filters/IContentTypeFilter.cs
+++ b/src/Umbraco.Core/Services/Filters/IContentTypeFilter.cs
@@ -13,13 +13,28 @@ public interface IContentTypeFilter
     /// <param name="contentTypes">Retrieved collection of content types.</param>
     /// <returns>Filtered collection of content types.</returns>
     Task<IEnumerable<TItem>> FilterAllowedAtRootAsync<TItem>(IEnumerable<TItem> contentTypes)
-        where TItem : IContentTypeComposition;
+        where TItem : IContentTypeComposition
+        => Task.FromResult(contentTypes);
 
     /// <summary>
     /// Filters the content types retrieved for being allowed as children of a parent content type.
     /// </summary>
     /// <param name="contentTypes">Retrieved collection of content types.</param>
-    /// <param name="parentKey">The parent content type key.</param>
+    /// <param name="parentKey">The parent content key.</param>
     /// <returns>Filtered collection of content types.</returns>
-    Task<IEnumerable<ContentTypeSort>> FilterAllowedChildrenAsync(IEnumerable<ContentTypeSort> contentTypes, Guid parentKey);
+    [Obsolete("Please the method overload taking all parameters. This method will be removed in Umbraco 17.")]
+    Task<IEnumerable<ContentTypeSort>> FilterAllowedChildrenAsync(IEnumerable<ContentTypeSort> contentTypes, Guid parentKey)
+        => Task.FromResult(contentTypes);
+
+    /// <summary>
+    /// Filters the content types retrieved for being allowed as children of a parent content type.
+    /// </summary>
+    /// <param name="contentTypes">Retrieved collection of content types.</param>
+    /// <param name="parentContentTypeKey">The parent content type key.</param>
+    /// <param name="parentContentKey">The parent content key (provided to allow for custom filtering of the returned list of children based on the content context).</param>
+    /// <returns>Filtered collection of content types.</returns>
+    Task<IEnumerable<ContentTypeSort>> FilterAllowedChildrenAsync(IEnumerable<ContentTypeSort> contentTypes, Guid parentContentTypeKey, Guid? parentContentKey)
+#pragma warning disable CS0618 // Type or member is obsolete
+        => FilterAllowedChildrenAsync(contentTypes, parentContentTypeKey);
+#pragma warning restore CS0618 // Type or member is obsolete
 }

--- a/src/Umbraco.Core/Services/IContentTypeServiceBase.cs
+++ b/src/Umbraco.Core/Services/IContentTypeServiceBase.cs
@@ -159,12 +159,20 @@ public interface IContentTypeBaseService<TItem> : IContentTypeBaseService, IServ
     /// <summary>
     /// Returns all the content type allowed as root.
     /// </summary>
-    /// <returns></returns>
     Task<PagedModel<TItem>> GetAllAllowedAsRootAsync(int skip, int take);
 
     /// <summary>
     /// Returns all content types allowed as children for a given content type key.
     /// </summary>
-    /// <returns></returns>
+    /// <param name="key">The content type key.</param>
     Task<Attempt<PagedModel<TItem>?, ContentTypeOperationStatus>> GetAllowedChildrenAsync(Guid key, int skip, int take);
+
+    /// <summary>
+    /// Returns all content types allowed as children for a given content type key.
+    /// </summary>
+    /// <param name="key">The content type key.</param>
+    /// <param name="parentContentKey">The parent content key.</param>
+    Task<Attempt<PagedModel<TItem>?, ContentTypeOperationStatus>> GetAllowedChildrenAsync(Guid key, Guid? parentContentKey, int skip, int take)
+        => GetAllowedChildrenAsync(key, skip, take);
+
 }

--- a/src/Umbraco.Web.UI.Client/src/external/backend-api/src/sdk.gen.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/backend-api/src/sdk.gen.ts
@@ -2138,6 +2138,7 @@ export class DocumentTypeService {
     /**
      * @param data The data for the request.
      * @param data.id
+     * @param data.parentContentKey
      * @param data.skip
      * @param data.take
      * @returns unknown OK
@@ -2151,6 +2152,7 @@ export class DocumentTypeService {
                 id: data.id
             },
             query: {
+                parentContentKey: data.parentContentKey,
                 skip: data.skip,
                 take: data.take
             },
@@ -4258,6 +4260,7 @@ export class MediaTypeService {
     /**
      * @param data The data for the request.
      * @param data.id
+     * @param data.parentContentKey
      * @param data.skip
      * @param data.take
      * @returns unknown OK
@@ -4271,6 +4274,7 @@ export class MediaTypeService {
                 id: data.id
             },
             query: {
+                parentContentKey: data.parentContentKey,
                 skip: data.skip,
                 take: data.take
             },

--- a/src/Umbraco.Web.UI.Client/src/external/backend-api/src/types.gen.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/backend-api/src/types.gen.ts
@@ -3536,6 +3536,7 @@ export type PutDocumentTypeByIdResponse = (string);
 
 export type GetDocumentTypeByIdAllowedChildrenData = {
     id: string;
+    parentContentKey?: string;
     skip?: number;
     take?: number;
 };
@@ -4141,6 +4142,7 @@ export type PutMediaTypeByIdResponse = (string);
 
 export type GetMediaTypeByIdAllowedChildrenData = {
     id: string;
+    parentContentKey?: string;
     skip?: number;
     take?: number;
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content-type/repository/structure/content-type-structure-data-source.interface.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content-type/repository/structure/content-type-structure-data-source.interface.ts
@@ -6,5 +6,5 @@ export interface UmbContentTypeStructureDataSourceConstructor<ItemType> {
 }
 
 export interface UmbContentTypeStructureDataSource<ItemType> {
-	getAllowedChildrenOf(unique: string | null): Promise<UmbDataSourceResponse<UmbPagedModel<ItemType>>>;
+	getAllowedChildrenOf(unique: string | null, parentContentUnique: string | null): Promise<UmbDataSourceResponse<UmbPagedModel<ItemType>>>;
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content-type/repository/structure/content-type-structure-repository-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content-type/repository/structure/content-type-structure-repository-base.ts
@@ -23,7 +23,7 @@ export abstract class UmbContentTypeStructureRepositoryBase<ItemType>
 	 * @returns {*}
 	 * @memberof UmbContentTypeStructureRepositoryBase
 	 */
-	requestAllowedChildrenOf(unique: string | null) {
-		return this.#structureSource.getAllowedChildrenOf(unique);
+	requestAllowedChildrenOf(unique: string | null, parentContentUnique: string | null) {
+		return this.#structureSource.getAllowedChildrenOf(unique, parentContentUnique);
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content-type/repository/structure/content-type-structure-repository.interface.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content-type/repository/structure/content-type-structure-repository.interface.ts
@@ -1,5 +1,5 @@
 import type { UmbDataSourceResponse, UmbPagedModel } from '@umbraco-cms/backoffice/repository';
 
 export interface UmbContentTypeStructureRepository<ItemType> {
-	requestAllowedChildrenOf(unique: string): Promise<UmbDataSourceResponse<UmbPagedModel<ItemType>>>;
+	requestAllowedChildrenOf(unique: string, parentContentUnique: string | null): Promise<UmbDataSourceResponse<UmbPagedModel<ItemType>>>;
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content-type/repository/structure/content-type-structure-server-data-source-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content-type/repository/structure/content-type-structure-server-data-source-base.ts
@@ -16,7 +16,7 @@ export interface UmbContentTypeStructureServerDataSourceBaseArgs<
 	ServerItemType extends AllowedContentTypeBaseModel,
 	ClientItemType extends UmbEntityModel,
 > {
-	getAllowedChildrenOf: (unique: string | null) => Promise<UmbPagedModel<ServerItemType>>;
+	getAllowedChildrenOf: (unique: string | null, parentContentUnique: string | null) => Promise<UmbPagedModel<ServerItemType>>;
 	mapper: (item: ServerItemType) => ClientItemType;
 }
 
@@ -50,8 +50,8 @@ export abstract class UmbContentTypeStructureServerDataSourceBase<
 	 * @returns {*}
 	 * @memberof UmbContentTypeStructureServerDataSourceBase
 	 */
-	async getAllowedChildrenOf(unique: string | null) {
-		const { data, error } = await tryExecuteAndNotify(this.#host, this.#getAllowedChildrenOf(unique));
+	async getAllowedChildrenOf(unique: string | null, parentContentUnique: string | null) {
+		const { data, error } = await tryExecuteAndNotify(this.#host, this.#getAllowedChildrenOf(unique, parentContentUnique));
 
 		if (data) {
 			const items = data.items.map((item) => this.#mapper(item));

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/repository/structure/document-type-structure.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/repository/structure/document-type-structure.server.data-source.ts
@@ -7,7 +7,7 @@ import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
 /**
  *
- 
+
  * @class UmbDocumentTypeStructureServerDataSource
  * @augments {UmbContentTypeStructureServerDataSourceBase}
  */
@@ -20,10 +20,10 @@ export class UmbDocumentTypeStructureServerDataSource extends UmbContentTypeStru
 	}
 }
 
-const getAllowedChildrenOf = (unique: string | null) => {
+const getAllowedChildrenOf = (unique: string | null, parentContentUnique: string | null) => {
 	if (unique) {
 		// eslint-disable-next-line local-rules/no-direct-api-import
-		return DocumentTypeService.getDocumentTypeByIdAllowedChildren({ id: unique });
+		return DocumentTypeService.getDocumentTypeByIdAllowedChildren({ id: unique, parentContentKey: parentContentUnique ?? undefined });
 	} else {
 		// eslint-disable-next-line local-rules/no-direct-api-import
 		return DocumentTypeService.getDocumentTypeAllowedAtRoot({});

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/collection/action/create-document-collection-action.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/collection/action/create-document-collection-action.element.ts
@@ -56,12 +56,12 @@ export class UmbCreateDocumentCollectionActionElement extends UmbLitElement {
 
 	override async firstUpdated() {
 		if (this._documentTypeUnique) {
-			this.#retrieveAllowedDocumentTypesOf(this._documentTypeUnique);
+			this.#retrieveAllowedDocumentTypesOf(this._documentTypeUnique, this._documentUnique || null);
 		}
 	}
 
-	async #retrieveAllowedDocumentTypesOf(unique: string | null) {
-		const { data } = await this.#documentTypeStructureRepository.requestAllowedChildrenOf(unique);
+	async #retrieveAllowedDocumentTypesOf(unique: string | null, parentContentUnique: string | null) {
+		const { data } = await this.#documentTypeStructureRepository.requestAllowedChildrenOf(unique, parentContentUnique);
 
 		if (data && data.items) {
 			this._allowedDocumentTypes = data.items;
@@ -69,7 +69,7 @@ export class UmbCreateDocumentCollectionActionElement extends UmbLitElement {
 	}
 
 	#onPopoverToggle(event: ToggleEvent) {
-		// TODO: This ignorer is just neede for JSON SCHEMA TO WORK, As its not updated with latest TS jet.
+		// TODO: This ignorer is just needed for JSON SCHEMA TO WORK, As its not updated with latest TS jet.
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		this._popoverOpen = event.newState === 'open';

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/create/document-create-options-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/create/document-create-options-modal.element.ts
@@ -47,15 +47,15 @@ export class UmbDocumentCreateOptionsModalElement extends UmbModalBaseElement<
 		const parentUnique = this.data?.parent.unique;
 		const documentTypeUnique = this.data?.documentType?.unique || null;
 
-		this.#retrieveAllowedDocumentTypesOf(documentTypeUnique);
+		this.#retrieveAllowedDocumentTypesOf(documentTypeUnique, parentUnique || null);
 
 		if (parentUnique) {
 			this.#retrieveHeadline(parentUnique);
 		}
 	}
 
-	async #retrieveAllowedDocumentTypesOf(unique: string | null) {
-		const { data } = await this.#documentTypeStructureRepository.requestAllowedChildrenOf(unique);
+	async #retrieveAllowedDocumentTypesOf(unique: string | null, parentContentUnique: string | null) {
+		const { data } = await this.#documentTypeStructureRepository.requestAllowedChildrenOf(unique, parentContentUnique);
 
 		if (data) {
 			// TODO: implement pagination, or get 1000?

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/repository/structure/media-type-structure.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/repository/structure/media-type-structure.server.data-source.ts
@@ -26,10 +26,10 @@ export class UmbMediaTypeStructureServerDataSource extends UmbContentTypeStructu
 	}
 }
 
-const getAllowedChildrenOf = (unique: string | null) => {
+const getAllowedChildrenOf = (unique: string | null, parentContentUnique: string | null) => {
 	if (unique) {
 		// eslint-disable-next-line local-rules/no-direct-api-import
-		return MediaTypeService.getMediaTypeByIdAllowedChildren({ id: unique });
+		return MediaTypeService.getMediaTypeByIdAllowedChildren({ id: unique, parentContentKey: parentContentUnique ?? undefined });
 	} else {
 		// eslint-disable-next-line local-rules/no-direct-api-import
 		return MediaTypeService.getMediaTypeAllowedAtRoot({});

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/action/create-media-collection-action.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/action/create-media-collection-action.element.ts
@@ -53,11 +53,11 @@ export class UmbCreateMediaCollectionActionElement extends UmbLitElement {
 	}
 
 	override async firstUpdated() {
-		this.#retrieveAllowedMediaTypesOf(this._mediaTypeUnique ?? '');
+		this.#retrieveAllowedMediaTypesOf(this._mediaTypeUnique ?? '', this._mediaUnique || null);
 	}
 
-	async #retrieveAllowedMediaTypesOf(unique: string | null) {
-		const { data } = await this.#mediaTypeStructureRepository.requestAllowedChildrenOf(unique);
+	async #retrieveAllowedMediaTypesOf(unique: string | null, parentContentUnique: string | null) {
+		const { data } = await this.#mediaTypeStructureRepository.requestAllowedChildrenOf(unique, parentContentUnique);
 		if (data && data.items) {
 			this._allowedMediaTypes = data.items;
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/dropzone/dropzone-manager.class.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/dropzone/dropzone-manager.class.ts
@@ -226,7 +226,7 @@ export class UmbDropzoneManager extends UmbControllerBase {
 	async #getMediaTypeOptions(item: UmbUploadableItem): Promise<Array<UmbAllowedMediaTypeModel>> {
 		// Check the parent which children media types are allowed
 		const parent = item.parentUnique ? await this.#mediaDetailRepository.requestByUnique(item.parentUnique) : null;
-		const allowedChildren = await this.#getAllowedChildrenOf(parent?.data?.mediaType.unique ?? null);
+		const allowedChildren = await this.#getAllowedChildrenOf(parent?.data?.mediaType.unique ?? null, item.parentUnique);
 
 		const extension = item.temporaryFile?.file.name.split('.').pop() ?? null;
 
@@ -255,7 +255,7 @@ export class UmbDropzoneManager extends UmbControllerBase {
 		return availableMediaTypes;
 	}
 
-	async #getAllowedChildrenOf(mediaTypeUnique: string | null) {
+	async #getAllowedChildrenOf(mediaTypeUnique: string | null, parentUnique: string | null) {
 		//Check if we already got information on this media type.
 		const allowed = this.#allowedChildrenOf
 			.getValue()
@@ -263,7 +263,7 @@ export class UmbDropzoneManager extends UmbControllerBase {
 		if (allowed) return allowed;
 
 		// Request information on this media type.
-		const { data } = await this.#mediaTypeStructure.requestAllowedChildrenOf(mediaTypeUnique);
+		const { data } = await this.#mediaTypeStructure.requestAllowedChildrenOf(mediaTypeUnique, parentUnique);
 		if (!data) throw new Error('Parent media type does not exists');
 
 		this.#allowedChildrenOf.appendOne({ mediaTypeUnique, allowedChildren: data.items });

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/entity-actions/create/media-create-options-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/entity-actions/create/media-create-options-modal.element.ts
@@ -26,15 +26,15 @@ export class UmbMediaCreateOptionsModalElement extends UmbModalBaseElement<
 		const mediaUnique = this.data?.parent.unique;
 		const mediaTypeUnique = this.data?.mediaType?.unique || null;
 
-		this.#retrieveAllowedMediaTypesOf(mediaTypeUnique);
+		this.#retrieveAllowedMediaTypesOf(mediaTypeUnique, mediaUnique || null);
 
 		if (mediaUnique) {
 			this.#retrieveHeadline(mediaUnique);
 		}
 	}
 
-	async #retrieveAllowedMediaTypesOf(unique: string | null) {
-		const { data } = await this.#mediaTypeStructureRepository.requestAllowedChildrenOf(unique);
+	async #retrieveAllowedMediaTypesOf(unique: string | null, parentContentUnique: string | null) {
+		const { data } = await this.#mediaTypeStructureRepository.requestAllowedChildrenOf(unique, parentContentUnique);
 
 		if (data) {
 			// TODO: implement pagination, or get 1000?

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/components/media-picker-create-item.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/components/media-picker-create-item.element.ts
@@ -36,7 +36,7 @@ export class UmbMediaPickerCreateItemElement extends UmbLitElement {
 	async #getAllowedMediaTypes() {
 		const mediaType = await this.#getNodeMediaType();
 
-		const { data: allowedMediaTypes } = await this.#mediaTypeStructure.requestAllowedChildrenOf(mediaType);
+		const { data: allowedMediaTypes } = await this.#mediaTypeStructure.requestAllowedChildrenOf(mediaType, this._node);
 		this._allowedMediaTypes = allowedMediaTypes?.items ?? [];
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
@@ -69,7 +69,7 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 	async #getMediaTypes() {
 		// Get all the media types, excluding the folders, so that files are selectable media items.
 		const mediaTypeStructureRepository = new UmbMediaTypeStructureRepository(this);
-		const { data: mediaTypes } = await mediaTypeStructureRepository.requestAllowedChildrenOf(null);
+		const { data: mediaTypes } = await mediaTypeStructureRepository.requestAllowedChildrenOf(null, null);
 		this._allowedMediaTypeUniques =
 			(mediaTypes?.items.map((x) => x.unique).filter((x) => x && !isUmbracoFolder(x)) as Array<string>) ?? [];
 	}


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves issue raised in discussion: https://github.com/umbraco/Umbraco-CMS/discussions/16329#discussioncomment-12239268

### Description
We discussed and introduced a server-side replacement for "sending allowed children notification" in 15.2, via [this PR](https://github.com/umbraco/Umbraco-CMS/pull/18029), but it had a bit of a design flaw for use for a typical use case where you want to allow only a certain number of items of content of a given type to be created.

We made available the parent document type to the filter, but not the parent content item.  So when filtering allowed types under a given item, you didn't have the details of that item available.

I've resolved with this PR but it needed a bit more update than the previous, as we need to pass the detail of which item we are creating under up to the method that retrieves the allowed children, and where the filtering occurs.

**To Test:**

I've used and registered the following example to verify and test this, that can be adapted for other use cases:

```
using Umbraco.Cms.Core;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Services;
using Umbraco.Cms.Core.Services.Filters;

namespace Umbraco.Cms.Web.UI.Composers;

public class TestingComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder) =>
        builder.ContentTypeFilters()
            .Append<MyContentTypeFilterService>();
}

internal class MyContentTypeFilterService : IContentTypeFilter
{
    private readonly IContentService _contentService;
    private readonly IContentTypeService _contentTypeService;
    private readonly IIdKeyMap _idKeyMap;

    public MyContentTypeFilterService(IContentService contentService, IContentTypeService contentTypeService, IIdKeyMap idKeyMap)
    {
        _contentService = contentService;
        _contentTypeService = contentTypeService;
        _idKeyMap = idKeyMap;
    }

    public Task<IEnumerable<TItem>> FilterAllowedAtRootAsync<TItem>(IEnumerable<TItem> contentTypes)
        where TItem : IContentTypeComposition
    {
        // Only allow one home page at the root.
        var docTypeAliasesToExclude = new List<string>();

        const string HomePageDocTypeAlias = "homePage";
        var docTypeAliasesAtRoot = _contentService.GetRootContent()
            .Select(x => x.ContentType.Alias)
            .Distinct()
            .ToList();
        if (docTypeAliasesAtRoot.Contains(HomePageDocTypeAlias))
        {
            docTypeAliasesToExclude.Add(HomePageDocTypeAlias);
        }

        return Task.FromResult(contentTypes
            .Where(x => docTypeAliasesToExclude.Contains(x.Alias) is false));
    }

    public Task<IEnumerable<ContentTypeSort>> FilterAllowedChildrenAsync(IEnumerable<ContentTypeSort> contentTypes, Guid parentContentTypeKey, Guid? parentContentKey)
    {
        // Only allow one landing page when under a home page.
        const string HomePageDocTypeAlias = "homePage";
        const string LandingPageDocTypeAlias = "landingPage";

        if (parentContentKey.HasValue is false)
        {
            return Task.FromResult(contentTypes);
        }

        IContentType? docType = _contentTypeService.Get(parentContentTypeKey);
        if (docType is null || docType.Alias != HomePageDocTypeAlias)
        {
            return Task.FromResult(contentTypes);
        }

        var docTypeAliasesToExclude = new List<string>();

        Attempt<int> parentContentIdAttempt = _idKeyMap.GetIdForKey(parentContentKey.Value, UmbracoObjectTypes.Document);
        if (parentContentIdAttempt.Success is false)
        {
            return Task.FromResult(contentTypes);
        }

        var docTypeAliasesAtFolder = _contentService.GetPagedChildren(parentContentIdAttempt.Result, 0, int.MaxValue, out _)
            .Select(x => x.ContentType.Alias)
            .Distinct()
            .ToList();
        if (docTypeAliasesAtFolder.Contains(LandingPageDocTypeAlias))
        {
            docTypeAliasesToExclude.Add(LandingPageDocTypeAlias);
        }

        return Task.FromResult(contentTypes
            .Where(x => docTypeAliasesToExclude.Contains(x.Alias) is false));
    }
}
```