### PR TITLE
Tiptap RTE: Ensure core extension is loaded

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/core/rich-text-essentials.tiptap-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/core/rich-text-essentials.tiptap-api.ts
@@ -9,7 +9,7 @@ import {
 	TextStyle,
 } from '@umbraco-cms/backoffice/external/tiptap';
 
-export default class UmbTiptapRichTextEssentialsExtensionApi extends UmbTiptapExtensionApiBase {
+export class UmbTiptapRichTextEssentialsExtensionApi extends UmbTiptapExtensionApiBase {
 	#localize = new UmbLocalizationController(this);
 
 	getTiptapExtensions = () => [
@@ -55,3 +55,7 @@ export default class UmbTiptapRichTextEssentialsExtensionApi extends UmbTiptapEx
 		Span,
 	];
 }
+
+export default UmbTiptapRichTextEssentialsExtensionApi;
+
+export { UmbTiptapRichTextEssentialsExtensionApi as api };


### PR DESCRIPTION
### Description

We previously moved some of the Tiptap RTE core extensions to a bundled "Rich Text Essentials" extension, however we found that our unit test doesn't register the manifests, so the core extension isn't loaded in. This PR refactors how the core extension is loaded to use the `api` class directly.

### How to test?

Try running the test and checking if there are any errors/warnings/logs.

```
npx web-test-runner .\src\packages\tiptap\property-editors\tiptap\property-editor-ui-tiptap.test.ts
```