### PR TITLE
Ported changes from Umbraco 13 around not throwing exceptions with identity IDs that can't be parsed to an integer or GUID

### DIFF
--- a/src/Umbraco.Infrastructure/Security/UmbracoUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/UmbracoUserStore.cs
@@ -35,29 +35,18 @@ public abstract class UmbracoUserStore<TUser, TRole>
     [Obsolete("Use TryConvertIdentityIdToInt instead. Scheduled for removal in V15.")]
     protected static int UserIdToInt(string? userId)
     {
-        if (TryUserIdToInt(userId, out int result))
+        if (int.TryParse(userId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result))
         {
             return result;
-        }
-
-        throw new InvalidOperationException($"Unable to convert user ID ({userId})to int using InvariantCulture");
-    }
-
-    protected static bool TryUserIdToInt(string? userId, out int result)
-    {
-        if (int.TryParse(userId, NumberStyles.Integer, CultureInfo.InvariantCulture, out result))
-        {
-            return true;
         }
 
         if (Guid.TryParse(userId, out Guid key))
         {
             // Reverse the IntExtensions.ToGuid
-            result = BitConverter.ToInt32(key.ToByteArray(), 0);
-            return true;
+            return BitConverter.ToInt32(key.ToByteArray(), 0);
         }
 
-        return false;
+        throw new InvalidOperationException($"Unable to convert user ID ({userId})to int using InvariantCulture");
     }
 
     protected abstract Task<int> ResolveEntityIdFromIdentityId(string? identityId);


### PR DESCRIPTION
This PR ports over the updates made in:

- https://github.com/umbraco/Umbraco-CMS/pull/18078
- https://github.com/umbraco/Umbraco-CMS/pull/18320

The were resolving reports of issues with external login providers where we would have an identity id that wasn't an integer or GUID.  These would fail in conversion in the attempts to find a local user matching those IDs.

- https://github.com/umbraco/Umbraco-CMS/issues/14713
- https://github.com/umbraco/Umbraco-CMS/issues/18002

Given the rework in this area these didn't merge up from 13, so I'm re-implementing them here.