### PR TITLE
Add Localization to Document Type - Settings - Vary by Culture and Segments

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/workspace/document-type/views/settings/document-type-workspace-view-settings.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/workspace/document-type/views/settings/document-type-workspace-view-settings.element.ts
@@ -100,7 +100,7 @@ export class UmbDocumentTypeWorkspaceViewSettingsElement extends UmbLitElement i
 							@change=${(e: CustomEvent) => {
 								this.#workspaceContext?.setVariesByCulture((e.target as UUIToggleElement).checked);
 							}}
-							label="Vary by culture"></uui-toggle>
+							label=${this.localize.term('contentTypeEditor_cultureVariantLabel')}></uui-toggle>
 					</div>
 				</umb-property-layout>
 				<umb-property-layout
@@ -117,7 +117,7 @@ export class UmbDocumentTypeWorkspaceViewSettingsElement extends UmbLitElement i
 							@change=${(e: CustomEvent) => {
 								this.#workspaceContext?.setVariesBySegment((e.target as UUIToggleElement).checked);
 							}}
-							label="Vary by segments"></uui-toggle>
+							label=${this.localize.term('contentTypeEditor_segmentVariantLabel')}></uui-toggle>
 					</div>
 				</umb-property-layout>
 				<umb-property-layout alias="ElementType" label=${this.localize.term('contentTypeEditor_elementHeading')}>


### PR DESCRIPTION
### Reason for change

I found two toggle buttons that weren't translated when I changed my Backoffice language to Danish.
To match the rest of the translation I translated the buttons.

### Description

- Removed the hardcoded label in document-type-workspace-view-settings.element.ts and made the toggle buttons for variesByCulture and variesBySegment dynamic with the contentTypeEditor category and the keys cultureVariantLabel and segmentVariantLabel

### Image before changes 

![Screenshot 2025-02-20 at 12 46 10](https://github.com/user-attachments/assets/0fd6e89b-3fce-4448-a7ab-f810868493bf)


### Image after changes 
![Screenshot 2025-02-20 at 12 46 29](https://github.com/user-attachments/assets/3eb039b2-dc86-4f46-aa7e-9f1daec11dd7)
