### PR TITLE
Bugfix: can't remove items from a picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/repository/repository-items.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/repository/repository-items.manager.ts
@@ -213,7 +213,7 @@ export class UmbRepositoryItemsManager<ItemType extends { unique: string }> exte
 			this.observe(
 				asObservable(),
 				(data) => {
-					this.#items.append(this.#sortByUniques(data));
+					this.#items.setValue(this.#sortByUniques(data));
 				},
 				ObserveRepositoryAlias,
 			);


### PR DESCRIPTION
After an update to the item manager to include loading and error states, we have changed the logic to append the requested data instead of replacing it. This has resulted in a bug when removing items from the picker. Because the data is appended, removing items will not work correctly when new data with fewer items is returned.

This PR is ignored from release as this bug hasn't been part of any released versions.
