### PR TITLE
Adds warning to publish descendants dialog when force re-publish is selected (13)

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
@@ -298,6 +298,9 @@
     <key alias="removeTextBox">Fjern denne tekstboks</key>
     <key alias="contentRoot">Indholdsrod</key>
     <key alias="includeUnpublished">Inkluder ikke-udgivet indhold.</key>
+    <key alias="forceRepublish">Udgiv uændrede elementer.</key>
+    <key alias="forceRepublishWarning">ADVARSEL: Udgivelse af alle sider under denne i indholdstræet, uanset om de er ændret eller ej, kan være en ressourcekrævende og langvarig proces.</key>
+    <key alias="forceRepublishAdvisory">Dette bør ikke være nødvendigt under normale omstændigheder, så fortsæt kun med denne handling, hvis du er sikker på, at det er nødvendigt.</key>
     <key alias="isSensitiveValue">Denne værdi er skjult. Hvis du har brug for adgang til at se denne værdi, bedes du
       kontakte din administrator.
     </key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -310,6 +310,8 @@
     <key alias="contentRoot">Content root</key>
     <key alias="includeUnpublished">Include unpublished content items.</key>
     <key alias="forceRepublish">Publish unchanged items.</key>
+    <key alias="forceRepublishWarning">WARNING: Publishing all pages below this one in the content tree, whether or not they have changed, can be an expensive and long-running operation.</key>
+    <key alias="forceRepublishAdvisory">This should not be necessary in normal circumstances so please only proceed with this option selected if you are certain it is required.</key>
     <key alias="isSensitiveValue">This value is hidden. If you need access to view this value please contact your
       website administrator.
     </key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -309,6 +309,8 @@
     <key alias="contentRoot">Content root</key>
     <key alias="includeUnpublished">Include unpublished content items.</key>
     <key alias="forceRepublish">Publish unchanged items.</key>
+    <key alias="forceRepublishWarning">WARNING: Publishing all pages below this one in the content tree, whether or not they have changed, can be an expensive and long-running operation.</key>
+    <key alias="forceRepublishAdvisory">This should not be necessary in normal circumstances so please only proceed with this option selected if you are certain it is required.</key>
     <key alias="isSensitiveValue">This value is hidden. If you need access to view this value please contact your
       website administrator.
     </key>

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.html
@@ -28,7 +28,10 @@
                         show-labels="true">
             </umb-toggle>
         </div>
-
+        <div ng-if="vm.forceRepublish" class="umb-alert umb-alert--warning">
+            <p><localize key="content_forceRepublishWarning"></localize></p>
+            <p><localize key="content_forceRepublishAdvisory"></localize></p>
+        </div>
     </div>
 
     <div ng-if="vm.displayVariants.length > 1">
@@ -58,6 +61,10 @@
                         label-position="right"
                         show-labels="true">
             </umb-toggle>
+        </div>
+        <div ng-if="vm.forceRepublish" class="umb-alert umb-alert--warning">
+            <p><localize key="content_forceRepublishWarning"></localize></p>
+            <p><localize key="content_forceRepublishAdvisory"></localize></p>
         </div>
 
         <div class="umb-list umb-list--condensed">


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

This is addition to https://github.com/umbraco/Umbraco-CMS/pull/18249 tackling issue https://github.com/umbraco/Umbraco-CMS/issues/13739

### Description
It was brought to my attention that we should include a warning on the "force re-publish" option, just to avoid people getting into the habit of selecting this option when it's not necessary.

**To Test:**

- Activate the "Publish unchanged items" option when publishing with descendants.
- Verify the warning message is displayed.

![image](https://github.com/user-attachments/assets/fb602dc0-d2e9-451a-945b-8bb2bb59ee63)

