### PR TITLE
Adds warning to publish descendants dialog when force re-publish is selected (15)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
@@ -298,6 +298,9 @@ export default {
 		removeTextBox: 'Fjern denne tekstboks',
 		contentRoot: 'Indholdsrod',
 		includeUnpublished: 'Inkluder ikke-udgivet indhold.',
+		forceRepublish: 'Udgiv uændrede elementer.',
+		forceRepublishWarning: 'ADVARSEL: Udgivelse af alle sider under denne i indholdstræet, uanset om de er ændret eller ej, kan være en ressourcekrævende og langvarig proces.',
+		forceRepublishAdvisory: 'Dette bør ikke være nødvendigt under normale omstændigheder, så fortsæt kun med denne handling, hvis du er sikker på, at det er nødvendigt.',
 		isSensitiveValue:
 			'Denne værdi er skjult.Hvis du har brug for adgang til at se denne værdi, bedes du\n      kontakte din web-administrator.\n    ',
 		isSensitiveValue_short: 'Denne værdi er skjult.',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
@@ -320,6 +320,8 @@ export default {
 		contentRoot: 'Content root',
 		includeUnpublished: 'Include unpublished content items.',
 		forceRepublish: 'Publish unchanged items.',
+		forceRepublishWarning: 'WARNING: Publishing all pages below this one in the content tree, whether or not they have changed, can be an expensive and long-running operation.',
+		forceRepublishAdvisory: 'This should not be necessary in normal circumstances so please only proceed with this option selected if you are certain it is required.',
 		isSensitiveValue:
 			'This value is hidden. If you need access to view this value please contact your\n      website administrator.\n    ',
 		isSensitiveValue_short: 'This value is hidden.',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -317,6 +317,8 @@ export default {
 		contentRoot: 'Content root',
 		includeUnpublished: 'Include unpublished content items.',
 		forceRepublish: 'Publish unchanged items.',
+		forceRepublishWarning: 'WARNING: Publishing all pages below this one in the content tree, whether or not they have changed, can be an expensive and long-running operation.',
+		forceRepublishAdvisory: 'This should not be necessary in normal circumstances so please only proceed with this option selected if you are certain it is required.',
 		isSensitiveValue:
 			'This value is hidden. If you need access to view this value please contact your\n      website administrator.\n    ',
 		isSensitiveValue_short: 'This value is hidden.',

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish-with-descendants/modal/document-publish-with-descendants-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish-with-descendants/modal/document-publish-with-descendants-modal.element.ts
@@ -5,7 +5,7 @@ import type {
 	UmbDocumentPublishWithDescendantsModalValue,
 } from './document-publish-with-descendants-modal.token.js';
 import { css, customElement, html, state } from '@umbraco-cms/backoffice/external/lit';
-import { UMB_CONFIRM_MODAL, UMB_MODAL_MANAGER_CONTEXT, UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
+import { umbConfirmModal, UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UmbSelectionManager } from '@umbraco-cms/backoffice/utils';
 
@@ -82,7 +82,6 @@ export class UmbDocumentPublishWithDescendantsModalElement extends UmbModalBaseE
 
 	#onIncludeUnpublishedDescendantsChange() {
 		this.#includeUnpublishedDescendants = !this.#includeUnpublishedDescendants;
-		console.log(this.#includeUnpublishedDescendants);
 	}
 
 	async #onForceRepublishChange() {
@@ -92,22 +91,12 @@ export class UmbDocumentPublishWithDescendantsModalElement extends UmbModalBaseE
 	async #submit() {
 
 		if (this.#forceRepublish) {
-			const modalManagerContext = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);
-			const confirm = await modalManagerContext
-				.open(this, UMB_CONFIRM_MODAL, {
-					data: {
-						headline: this.localize.term('content_forceRepublishWarning'),
-						content: this.localize.term('content_forceRepublishAdvisory'),
-						color: 'warning',
-						confirmLabel: this.localize.term('actions_publish'),
-					},
-				})
-				.onSubmit()
-				.catch(() => false);
-			console.log(confirm);
-			if (confirm === false) {
-				return;
-			}
+			await umbConfirmModal(this, {
+				headline: this.localize.term('content_forceRepublishWarning'),
+				content: this.localize.term('content_forceRepublishAdvisory'),
+				color: 'warning',
+				confirmLabel: this.localize.term('actions_publish'),
+			});
 		}
 
 		this.value = {


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

This is addition to https://github.com/umbraco/Umbraco-CMS/pull/18270 tackling issue https://github.com/umbraco/Umbraco-CMS/issues/13739

### Description
It was brought to my attention that we should include a warning on the "force re-publish" option, just to avoid people getting into the habit of selecting this option when it's not necessary.

**To Test:**

- Activate the "Publish unchanged items" option when publishing with descendants.
- Verify the warning message is displayed when you proceed to publish.

![image](https://github.com/user-attachments/assets/21499ea4-ffd6-44b3-b572-ed519becd889)


