### PR TITLE
Add localization for Approved color/Color Picker Data type

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
@@ -1217,6 +1217,12 @@ export default {
 	colorpicker: {
 		noColors: 'Du har ikke konfigureret nogen godkendte farver',
 	},
+	colorPickerConfigurations: {
+		colorsTitle: 'Farver',
+		colorsDescription: 'Tilføj, fjern eller sorter farver',
+		showLabelTitle: 'Inkluder label?',
+		showLabelDescription: 'Gemmer farver som et Json-objekt, der både indeholder farvens hex streng og label, i stedet for kun at gemme hex strengen.',
+	},
 	contentPicker: {
 		allowedItemTypes: 'Du kan kun vælge følgende type(r) dokumenter: %0%',
 		defineDynamicRoot: 'Definer Dynamisk Udgangspunkt',
@@ -2444,8 +2450,8 @@ export default {
 		searchResults: 'resultater',
 	},
 	propertyEditorPicker: {
-		title: 'Select Property Editor',
-		openPropertyEditorPicker: 'Select Property Editor',
+		title: 'Vælg Property Editor',
+		openPropertyEditorPicker: 'Vælg Property Editor',
 	},
 	healthcheck: {
 		checkSuccessMessage: "Value is set to the recommended value: '%0%'.",

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
@@ -1241,6 +1241,12 @@ export default {
 	colorpicker: {
 		noColors: 'You have not configured any approved colors',
 	},
+	colorPickerConfigurations: {
+		colorsTitle: 'Colors',
+		colorsDescription: 'Add, remove or sort colors',
+		showLabelTitle: 'Include labels?',
+		showLabelDescription: 'Stores colors as a Json object containing both the color hex string and label, rather than just the hex string.',
+	},
 	contentPicker: {
 		allowedItemTypes: 'You can only select items of type(s): %0%',
 		defineDynamicRoot: 'Specify root node',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
@@ -1245,7 +1245,7 @@ export default {
 		colorsTitle: 'Colors',
 		colorsDescription: 'Add, remove or sort colors',
 		showLabelTitle: 'Include labels?',
-		showLabelDescription: 'Stores colors as a Json object containing both the color hex string and label, rather than just the hex string.',
+		showLabelDescription: 'Stores colors as a JSON object containing both the color hex string and label, rather than just the hex string.',
 	},
 	contentPicker: {
 		allowedItemTypes: 'You can only select items of type(s): %0%',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -1256,6 +1256,12 @@ export default {
 	colorpicker: {
 		noColors: 'You have not configured any approved colours',
 	},
+	colorPickerConfigurations: {
+		colorsTitle: 'Colors',
+		colorsDescription: 'Add, remove or sort colors',
+		showLabelTitle: 'Include labels?',
+		showLabelDescription: 'Stores colors as a Json object containing both the color hex string and label, rather than just the hex string.',
+	},
 	contentPicker: {
 		allowedItemTypes: 'You can only select items of type(s): %0%',
 		pickedTrashedItem: 'You have picked a content item currently deleted or in the recycle bin',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -1257,10 +1257,10 @@ export default {
 		noColors: 'You have not configured any approved colours',
 	},
 	colorPickerConfigurations: {
-		colorsTitle: 'Colors',
-		colorsDescription: 'Add, remove or sort colors',
+		colorsTitle: 'Colours',
+		colorsDescription: 'Add, remove or sort colours',
 		showLabelTitle: 'Include labels?',
-		showLabelDescription: 'Stores colors as a Json object containing both the color hex string and label, rather than just the hex string.',
+		showLabelDescription: 'Stores colours as a JSON object containing both the colour hex string and label, rather than just the hex string.',
 	},
 	contentPicker: {
 		allowedItemTypes: 'You can only select items of type(s): %0%',

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/color-picker/Umbraco.ColorPicker.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/color-picker/Umbraco.ColorPicker.ts
@@ -10,15 +10,15 @@ export const manifest: ManifestPropertyEditorSchema = {
 			properties: [
 				{
 					alias: 'useLabel',
-					label: 'Include labels?',
+					label: '#colorPickerConfigurations_showLabelTitle',
 					description:
-						'Stores colors as a Json object containing both the color hex string and label, rather than just the hex string.',
+						'{umbLocalize: colorPickerConfigurations_showLabelDescription}',
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Toggle',
 				},
 				{
 					alias: 'items',
-					label: 'Colors',
-					description: 'Add, remove or sort colors',
+					label: '#colorPickerConfigurations_colorsTitle',
+					description: '{umbLocalize: colorPickerConfigurations_colorsDescription}',
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.ColorSwatchesEditor',
 				},
 			],


### PR DESCRIPTION
### Reson for change

The data type for Approved color/Color Picker, wasn't translated when I changed my Backoffice language to Danish. 
I translated the missing translations into Danish to match the rest of the Danish Backoffice. 

### Description

- Created a colorPickerConfigurations category to the code in the en.ts, en-us.ts, and da-dk.ts file
- Added a translation for the label title and description and the color title and description. 
- Removed the hardcoded label in Umbraco.ColorPicker.ts and made it dynamic with the new colorPickerConfigurations category and key.

### Image of change
![Screenshot 2025-02-21 at 10 11 58](https://github.com/user-attachments/assets/5e539f9f-ebdc-4486-9129-2094fe783ba8)