### PR TITLE
Removed unused href

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/collection/action/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/collection/action/manifests.ts
@@ -9,7 +9,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		weight: 200,
 		meta: {
 			label: '#general_create',
-			href: 'section/member-management/workspace/member/create/member-type-1-id', // TODO: remove hardcoded member type id
 		},
 		element: () => import('./create-member-collection-action.element.js'),
 		conditions: [


### PR DESCRIPTION
Removing an unused href from meta. The manifest has an element that loads all the correct member type options and pass them correctly to the workspace.