### PR TITLE
V15: A user cannot switch back to the default language 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -1261,7 +1261,8 @@ export default {
 		colorsTitle: 'Colours',
 		colorsDescription: 'Add, remove or sort colours',
 		showLabelTitle: 'Include labels?',
-		showLabelDescription: 'Stores colours as a JSON object containing both the colour hex string and label, rather than just the hex string.',
+		showLabelDescription:
+			'Stores colours as a JSON object containing both the colour hex string and label, rather than just the hex string.',
 	},
 	contentPicker: {
 		allowedItemTypes: 'You can only select items of type(s): %0%',

--- a/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.test.ts
@@ -4,15 +4,30 @@ import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registr
 import type { ManifestLocalization } from '../extensions/localization.extension.js';
 
 //#region Localizations
-const english: ManifestLocalization = {
+const englishUk: ManifestLocalization = {
 	type: 'localization',
 	alias: 'test.en',
-	name: 'Test English',
+	name: 'Test English (UK)',
+	meta: {
+		culture: 'en',
+		localizations: {
+			general: {
+				color: 'Colour',
+			},
+		},
+	},
+};
+
+const english: ManifestLocalization = {
+	type: 'localization',
+	alias: 'test.en-us',
+	name: 'Test English (US)',
 	meta: {
 		culture: 'en-us',
 		direction: 'ltr',
 		localizations: {
 			general: {
+				color: 'Color',
 				close: 'Close',
 				logout: 'Log out',
 				withInlineToken: '{0} {1}',
@@ -72,6 +87,7 @@ const danishRegional: ManifestLocalization = {
 //#endregion
 
 describe('UmbLocalizeController', () => {
+	umbExtensionsRegistry.register(englishUk);
 	umbExtensionsRegistry.register(english);
 	umbExtensionsRegistry.register(danish);
 	umbExtensionsRegistry.register(danishRegional);
@@ -109,6 +125,32 @@ describe('UmbLocalizeController', () => {
 		const current = registry.localizations.get(english.meta.culture);
 		expect(current).to.have.property('general_close', 'Close 2');
 		expect(current).to.have.property('general_logout', 'Log out');
+	});
+
+	it('should be able to switch to the fallback language', async () => {
+		// Verify that the document language and direction is set correctly to the default language
+		expect(document.documentElement.lang).to.equal(english.meta.culture);
+		expect(document.documentElement.dir).to.equal(english.meta.direction);
+
+		// Switch to the fallback language, which is the UK version of English
+		registry.loadLanguage('en');
+		await aTimeout(0);
+
+		expect(document.documentElement.lang).to.equal('en');
+		expect(document.documentElement.dir).to.equal('ltr');
+
+		const current = registry.localizations.get(englishUk.meta.culture);
+		expect(current).to.have.property('general_color', 'Colour');
+
+		// And switch back again
+		registry.loadLanguage('en-us');
+		await aTimeout(0);
+
+		expect(document.documentElement.lang).to.equal('en-us');
+		expect(document.documentElement.dir).to.equal('ltr');
+
+		const newCurrent = registry.localizations.get(english.meta.culture);
+		expect(newCurrent).to.have.property('general_color', 'Color');
 	});
 
 	it('should load a new language', async () => {


### PR DESCRIPTION
## Description

If a user changes the UI language in their profile settings, they will not be able to switch back to the default language, or any other language that they may have loaded due to a caching mechanism.

This PR splits up the caching to calculate the "diff of languages to load" side-by-side with the browser language switcher. That ensures that the browser is updated even if you switch back to a previously loaded language.

## How to test
1. Go to the current user profile and switch from English (US) to English (UK)
2. Verify that the browser HTML tag is updated to `lang="en"`
3. Verify, if possible, that the translations are actually coming from the en.js file, check the approved color picker for example