### PR TITLE
Fix: #18350

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/rte/components/rte-base.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/rte/components/rte-base.element.ts
@@ -153,7 +153,7 @@ export abstract class UmbPropertyEditorUiRteElementBase extends UmbLitElement im
 
 					// If we don't have a value set from the outside or an internal value, we don't want to set the value.
 					// This is added to prevent the block list from setting an empty value on startup.
-					if (!this._latestMarkup && !this._value?.markup) {
+					if (this._value?.markup === undefined) {
 						return;
 					}
 


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/18350

By not preventing an update when lastMarkup is not set... This is because maybe the markup was set in another session, so its okay for that to be undefined.