### PR TITLE
Fix: #18421 - Added Max Length validation to PropertyTypeBasic Alias

### DIFF
--- a/src/Umbraco.Core/Models/ContentEditing/PropertyTypeBasic.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/PropertyTypeBasic.cs
@@ -25,6 +25,7 @@ public class PropertyTypeBasic
 
     [Required]
     [RegularExpression(@"^([a-zA-Z]\w.*)$", ErrorMessage = "Invalid alias")]
+    [MaxLength(255, ErrorMessage = "Alias is too long")]
     [DataMember(Name = "alias")]
     public string Alias { get; set; } = null!;
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-locked-field.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-locked-field.html
@@ -31,28 +31,28 @@
     </div>
 
     <div ng-messages="lockedFieldForm.lockedField.$error" show-validation-on-submit>
-      <div class="umb-validation-label"
-           ng-class="{ '-left': validationPosition === 'left', '-right': validationPosition === 'right' }"
-           ng-message="required">
-        <localize key="general_required">Required</localize> <localize key="content_alias">alias</localize>
-      </div>
-      <div class="umb-validation-label"
-           ng-class="{ '-left': validationPosition === 'left', '-right': validationPosition === 'right' }"
-           ng-if="regexValidation.length > 0"
-           ng-message="valRegex">
-        <localize key="general_invalid">Invalid</localize> <localize key="content_alias">alias</localize>
-      </div>
-      <div class="umb-validation-label"
-           ng-class="{ '-left': validationPosition === 'left', '-right': validationPosition === 'right' }"
-           ng-if="serverValidationField.length > 0"
-           ng-message="valServerField">
-        {{lockedFieldForm.lockedField.errorMsg}}
-      </div>
-      <div class="umb-validation-label"
-           ng-class="{ '-left': validationPosition === 'left', '-right': validationPosition === 'right' }"
-           ng-if="ngModel.length > 255">
-        <localize key="general_invalid">Invalid</localize> <localize key="content_alias">alias</localize>
-      </div>
+        <div class="umb-validation-label"
+             ng-class="{ '-left': validationPosition === 'left', '-right': validationPosition === 'right' }"
+             ng-message="required">
+          <localize key="general_required">Required</localize> <localize key="content_alias">alias</localize>
+        </div>
+        <div class="umb-validation-label"
+             ng-class="{ '-left': validationPosition === 'left', '-right': validationPosition === 'right' }"
+             ng-if="regexValidation.length > 0"
+             ng-message="valRegex">
+          <localize key="general_invalid">Invalid</localize> <localize key="content_alias">alias</localize>
+        </div>
+        <div class="umb-validation-label"
+             ng-class="{ '-left': validationPosition === 'left', '-right': validationPosition === 'right' }"
+             ng-if="serverValidationField.length > 0"
+             ng-message="valServerField">
+          {{lockedFieldForm.lockedField.errorMsg}}
+        </div>
+        <div class="umb-validation-label"
+             ng-class="{ '-left': validationPosition === 'left', '-right': validationPosition === 'right' }"
+             ng-if="ngModel.length > 255">
+          <localize key="general_invalid">Invalid</localize> <localize key="content_alias">alias</localize>
+        </div>
     </div>
 
 </ng-form>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-locked-field.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-locked-field.html
@@ -34,24 +34,24 @@
         <div class="umb-validation-label"
              ng-class="{ '-left': validationPosition === 'left', '-right': validationPosition === 'right' }"
              ng-message="required">
-          <localize key="general_required">Required</localize> <localize key="content_alias">alias</localize>
+            <localize key="general_required">Required</localize> <localize key="content_alias">alias</localize>
         </div>
         <div class="umb-validation-label"
              ng-class="{ '-left': validationPosition === 'left', '-right': validationPosition === 'right' }"
              ng-if="regexValidation.length > 0"
              ng-message="valRegex">
-          <localize key="general_invalid">Invalid</localize> <localize key="content_alias">alias</localize>
+            <localize key="general_invalid">Invalid</localize> <localize key="content_alias">alias</localize>
         </div>
         <div class="umb-validation-label"
              ng-class="{ '-left': validationPosition === 'left', '-right': validationPosition === 'right' }"
              ng-if="serverValidationField.length > 0"
              ng-message="valServerField">
-          {{lockedFieldForm.lockedField.errorMsg}}
+            {{lockedFieldForm.lockedField.errorMsg}}
         </div>
         <div class="umb-validation-label"
              ng-class="{ '-left': validationPosition === 'left', '-right': validationPosition === 'right' }"
              ng-if="ngModel.length > 255">
-          <localize key="general_invalid">Invalid</localize> <localize key="content_alias">alias</localize>
+            <localize key="general_invalid">Invalid</localize> <localize key="content_alias">alias</localize>
         </div>
     </div>
 

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-locked-field.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-locked-field.html
@@ -25,27 +25,34 @@
                title="{{ngModel}}"
                focus-when="{{!locked}}"
                umb-select-when="{{!locked}}"
-               ng-blur="lock()" />
+               ng-blur="lock()"
+               ng-maxlength="255" />
 
     </div>
 
     <div ng-messages="lockedFieldForm.lockedField.$error" show-validation-on-submit>
-        <div class="umb-validation-label"
-             ng-class="{ '-left': validationPosition === 'left', '-right': validationPosition === 'right' }"
-             ng-message="required">
-            <localize key="general_required">Required</localize> <localize key="content_alias">alias</localize>
-        </div>
-        <div class="umb-validation-label"
-             ng-class="{ '-left': validationPosition === 'left', '-right': validationPosition === 'right' }"
-             ng-if="regexValidation.length > 0"
-             ng-message="valRegex">
-            <localize key="general_invalid">Invalid</localize> <localize key="content_alias">alias</localize>
-        </div>
-        <div class="umb-validation-label"
-             ng-class="{ '-left': validationPosition === 'left', '-right': validationPosition === 'right' }"
-             ng-if="serverValidationField.length > 0"
-             ng-message="valServerField">{{lockedFieldForm.lockedField.errorMsg}}
-        </div>
+      <div class="umb-validation-label"
+           ng-class="{ '-left': validationPosition === 'left', '-right': validationPosition === 'right' }"
+           ng-message="required">
+        <localize key="general_required">Required</localize> <localize key="content_alias">alias</localize>
+      </div>
+      <div class="umb-validation-label"
+           ng-class="{ '-left': validationPosition === 'left', '-right': validationPosition === 'right' }"
+           ng-if="regexValidation.length > 0"
+           ng-message="valRegex">
+        <localize key="general_invalid">Invalid</localize> <localize key="content_alias">alias</localize>
+      </div>
+      <div class="umb-validation-label"
+           ng-class="{ '-left': validationPosition === 'left', '-right': validationPosition === 'right' }"
+           ng-if="serverValidationField.length > 0"
+           ng-message="valServerField">
+        {{lockedFieldForm.lockedField.errorMsg}}
+      </div>
+      <div class="umb-validation-label"
+           ng-class="{ '-left': validationPosition === 'left', '-right': validationPosition === 'right' }"
+           ng-if="ngModel.length > 255">
+        <localize key="general_invalid">Invalid</localize> <localize key="content_alias">alias</localize>
+      </div>
     </div>
 
 </ng-form>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-locked-field.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-locked-field.html
@@ -45,8 +45,7 @@
         <div class="umb-validation-label"
              ng-class="{ '-left': validationPosition === 'left', '-right': validationPosition === 'right' }"
              ng-if="serverValidationField.length > 0"
-             ng-message="valServerField">
-            {{lockedFieldForm.lockedField.errorMsg}}
+             ng-message="valServerField">{{lockedFieldForm.lockedField.errorMsg}}
         </div>
         <div class="umb-validation-label"
              ng-class="{ '-left': validationPosition === 'left', '-right': validationPosition === 'right' }"


### PR DESCRIPTION
### Description
Fixes Umbraco 13.X Back Office exception caused by a user attempting to save a PropertyType with an alias over 255 characters long.
This is fixed by adding a MaxLength attribute to the property in the PropertyTypeBasic class.

Fixes #18421.