### PR TITLE
Fix: remember validation state when creating

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/utils/state-manager/state.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/utils/state-manager/state.manager.ts
@@ -92,4 +92,9 @@ export class UmbStateManager<StateType extends UmbState = UmbState> extends UmbC
 	clear() {
 		this._states.setValue([]);
 	}
+
+	override destroy() {
+		super.destroy();
+		this._states.destroy();
+	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/workspace-is-new-redirect.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/workspace-is-new-redirect.controller.ts
@@ -34,7 +34,7 @@ export class UmbWorkspaceIsNewRedirectController extends UmbControllerBase {
 							id: unique,
 						});
 						this.destroy();
-						window.history.replaceState({}, '', newPath);
+						window.history.replaceState(null, '', newPath);
 					}
 				}
 			}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/entity-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/entity-detail-workspace-base.ts
@@ -167,7 +167,9 @@ export abstract class UmbEntityDetailWorkspaceContextBase<
 	}
 
 	async load(unique: string) {
-		if (unique === this.getUnique()) return;
+		if (unique === this.getUnique() && this._getDataPromise) {
+			return (await this._getDataPromise) as GetDataType;
+		}
 		this.resetState();
 		this.#entityContext.setUnique(unique);
 		this.loading.addState({ unique: LOADING_STATE_UNIQUE, message: `Loading ${this.getEntityType()} Details` });
@@ -393,6 +395,7 @@ export abstract class UmbEntityDetailWorkspaceContextBase<
 		this.loading.clear();
 		this._data.clear();
 		this.#allowNavigateAway = false;
+		this._getDataPromise = undefined;
 	}
 
 	#checkIfInitialized() {
@@ -449,6 +452,7 @@ export abstract class UmbEntityDetailWorkspaceContextBase<
 		);
 		this._detailRepository?.destroy();
 		this.#entityContext.destroy();
+		this._getDataPromise = undefined;
 		super.destroy();
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/entity-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/entity-detail-workspace-base.ts
@@ -167,6 +167,7 @@ export abstract class UmbEntityDetailWorkspaceContextBase<
 	}
 
 	async load(unique: string) {
+		if (unique === this.getUnique()) return;
 		this.resetState();
 		this.#entityContext.setUnique(unique);
 		this.loading.addState({ unique: LOADING_STATE_UNIQUE, message: `Loading ${this.getEntityType()} Details` });
@@ -389,6 +390,7 @@ export abstract class UmbEntityDetailWorkspaceContextBase<
 
 	override resetState() {
 		super.resetState();
+		this.loading.clear();
 		this._data.clear();
 		this.#allowNavigateAway = false;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/submittable/submittable-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/submittable/submittable-workspace-context-base.ts
@@ -57,7 +57,6 @@ export abstract class UmbSubmittableWorkspaceContextBase<WorkspaceDataModelType>
 	}
 
 	protected resetState() {
-		//this.validation.reset();
 		this.#validationContexts.forEach((context) => context.reset());
 		this.#isNew.setValue(undefined);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace.context.ts
@@ -177,10 +177,15 @@ export class UmbDocumentWorkspaceContext
 		]);
 	}
 
+	override resetState(): void {
+		super.resetState();
+		this.#isTrashedContext.setIsTrashed(false);
+	}
+
 	override async load(unique: string) {
 		const response = await super.load(unique);
 
-		if (response.data) {
+		if (response?.data) {
 			this.#isTrashedContext.setIsTrashed(response.data.isTrashed);
 		}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace.context.ts
@@ -89,13 +89,14 @@ export class UmbMediaWorkspaceContext
 
 	public override resetState() {
 		super.resetState();
+		this.#isTrashedContext.setIsTrashed(false);
 		this.removeUmbControllerByAlias(UmbWorkspaceIsNewRedirectControllerAlias);
 	}
 
 	public override async load(unique: string) {
 		const response = await super.load(unique);
 
-		if (response.data) {
+		if (response?.data) {
 			this.#isTrashedContext.setIsTrashed(response.data.isTrashed);
 		}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/member-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/member-workspace.context.ts
@@ -78,7 +78,7 @@ export class UmbMemberWorkspaceContext
 			preset: {
 				memberType: {
 					unique: memberTypeUnique,
-					icon: "icon-user"
+					icon: 'icon-user',
 				},
 			},
 		});


### PR DESCRIPTION
Does not reset state when going from 'create' to 'edit'. There is still a flash going on, but that must be resolved later. But for now it does remember the validation which this sets out to fix.

As well resets the trash state, minor discovery by looking into this.