### PR TITLE
Fix validation for blocks in variant block editors

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorValidatorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorValidatorBase.cs
@@ -27,6 +27,7 @@ public abstract class BlockEditorValidatorBase<TValue, TLayout> : ComplexEditorV
 
         if (validationContextCulture is null)
         {
+            // make sure we extend validation to variant block value (element level variation)
             IEnumerable<string> validationContextCulturesBeingValidated = isWildcardCulture
                 ? blockEditorData.BlockValue.Expose.Select(e => e.Culture).WhereNotNull().Distinct()
                 : validationContext.CulturesBeingValidated;
@@ -36,6 +37,14 @@ public abstract class BlockEditorValidatorBase<TValue, TLayout> : ComplexEditorV
                 {
                     elementTypeValidation.AddRange(GetBlockEditorDataValidation(blockEditorData, culture, segment));
                 }
+            }
+        }
+        else
+        {
+            // make sure we extend validation to invariant block values (no element level variation)
+            foreach (var segment in validationContext.SegmentsBeingValidated.DefaultIfEmpty(null))
+            {
+                elementTypeValidation.AddRange(GetBlockEditorDataValidation(blockEditorData, null, segment));
             }
         }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.cs
@@ -148,9 +148,9 @@ internal partial class BlockListElementLevelVariationTests : BlockEditorElementV
         return GetPublishedContent(content.Key);
     }
 
-    private IContentType CreateElementTypeWithValidation()
+    private IContentType CreateElementTypeWithValidation(ContentVariation contentVariation = ContentVariation.Culture)
     {
-        var elementType = CreateElementType(ContentVariation.Culture);
+        var elementType = CreateElementType(contentVariation);
         foreach (var propertyType in elementType.PropertyTypes)
         {
             propertyType.Mandatory = true;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #17753

### Description

See the linked issue for an excellent guide to reproduction and test 💪 

Note that the issue is generic and applies to all block editors.