### PR TITLE
Fix #18431

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/content/manager/content-data-manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content/manager/content-data-manager.ts
@@ -19,25 +19,13 @@ export class UmbContentWorkspaceDataManager<
 		this.#variantScaffold = variantScaffold;
 	}
 
-	override setCurrent(data: ModelType | undefined): void {
-		if (data) {
-			const persistedData = this.getPersisted();
-			if (persistedData) {
-				// Sort the values in the same order as the persisted data:
-				const persistedValues = persistedData.values;
-				data.values.sort(function (a, b) {
-					return persistedValues.indexOf(a) - persistedValues.indexOf(b);
-				});
-
-				// Sort the variants in the same order as the persisted data:
-				const persistedVariants = persistedData.variants;
-				data.variants.sort(function (a, b) {
-					return persistedVariants.indexOf(a) - persistedVariants.indexOf(b);
-				});
-			}
-		}
-
-		super.setCurrent(data);
+	protected override _sortCurrentData(persistedData: ModelType, currentData: Partial<ModelType>) {
+		super._sortCurrentData(persistedData, currentData);
+		// Sort the variants in the same order as the persisted data:
+		const persistedVariants = persistedData.variants;
+		currentData.variants?.sort(function (a, b) {
+			return persistedVariants.indexOf(a) - persistedVariants.indexOf(b);
+		});
 	}
 
 	/**
@@ -71,8 +59,7 @@ export class UmbContentWorkspaceDataManager<
 				} as ModelVariantType,
 				(x) => variantId.compare(x),
 			) as Array<ModelVariantType>;
-			// TODO: I have some trouble with TypeScript here, I does not look like me, but i had to give up. [NL]
-			this._current.update({ variants: newVariants } as any);
+			this.updateCurrent({ variants: newVariants } as unknown as ModelType);
 		} else if (this._varies === false) {
 			// TODO: Beware about segments, in this case we need to also consider segments, if its allowed to vary by segments.
 			const invariantVariantId = UmbVariantId.CreateInvariant();
@@ -86,8 +73,7 @@ export class UmbContentWorkspaceDataManager<
 					...update,
 				} as ModelVariantType,
 			];
-			// TODO: I have some trouble with TypeScript here, I does not look like me, but i had to give up. [NL]
-			this._current.update({ variants: newVariants } as any);
+			this.updateCurrent({ variants: newVariants } as unknown as ModelType);
 		} else {
 			throw new Error('Varies by culture is missing');
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content/manager/content-data-manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content/manager/content-data-manager.ts
@@ -19,6 +19,27 @@ export class UmbContentWorkspaceDataManager<
 		this.#variantScaffold = variantScaffold;
 	}
 
+	override setCurrent(data: ModelType | undefined): void {
+		if (data) {
+			const persistedData = this.getPersisted();
+			if (persistedData) {
+				// Sort the values in the same order as the persisted data:
+				const persistedValues = persistedData.values;
+				data.values.sort(function (a, b) {
+					return persistedValues.indexOf(a) - persistedValues.indexOf(b);
+				});
+
+				// Sort the variants in the same order as the persisted data:
+				const persistedVariants = persistedData.variants;
+				data.variants.sort(function (a, b) {
+					return persistedVariants.indexOf(a) - persistedVariants.indexOf(b);
+				});
+			}
+		}
+
+		super.setCurrent(data);
+	}
+
 	/**
 	 * Sets the variant scaffold data
 	 * @param {ModelVariantType} variantScaffold The variant scaffold data

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content/manager/content-data-manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content/manager/content-data-manager.ts
@@ -2,7 +2,7 @@ import type { UmbContentDetailModel } from '../types.js';
 import { UmbElementWorkspaceDataManager } from './element-data-manager.js';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { appendToFrozenArray, jsonStringComparison } from '@umbraco-cms/backoffice/observable-api';
-import { UmbVariantId, type UmbEntityVariantModel } from '@umbraco-cms/backoffice/variant';
+import { UmbVariantId, umbVariantObjectCompare, type UmbEntityVariantModel } from '@umbraco-cms/backoffice/variant';
 
 export class UmbContentWorkspaceDataManager<
 	ModelType extends UmbContentDetailModel,
@@ -30,7 +30,10 @@ export class UmbContentWorkspaceDataManager<
 			return {
 				...currentData,
 				variants: [...currentData.variants].sort(function (a, b) {
-					return persistedVariants.indexOf(a) - persistedVariants.indexOf(b);
+					return (
+						persistedVariants.findIndex((x) => umbVariantObjectCompare(x, a)) -
+						persistedVariants.findIndex((x) => umbVariantObjectCompare(x, b))
+					);
 				}),
 			};
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content/manager/content-data-manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content/manager/content-data-manager.ts
@@ -19,15 +19,22 @@ export class UmbContentWorkspaceDataManager<
 		this.#variantScaffold = variantScaffold;
 	}
 
-	protected override _sortCurrentData(persistedData: Partial<ModelType>, currentData: Partial<ModelType>) {
-		super._sortCurrentData(persistedData, currentData);
+	protected override _sortCurrentData<GivenType extends Partial<ModelType> = Partial<ModelType>>(
+		persistedData: Partial<ModelType>,
+		currentData: GivenType,
+	): GivenType {
+		currentData = super._sortCurrentData(persistedData, currentData);
 		// Sort the variants in the same order as the persisted data:
 		const persistedVariants = persistedData.variants;
-		if (persistedVariants) {
-			currentData.variants?.sort(function (a, b) {
-				return persistedVariants.indexOf(a) - persistedVariants.indexOf(b);
-			});
+		if (persistedVariants && currentData.variants) {
+			return {
+				...currentData,
+				variants: [...currentData.variants].sort(function (a, b) {
+					return persistedVariants.indexOf(a) - persistedVariants.indexOf(b);
+				}),
+			};
 		}
+		return currentData;
 	}
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content/manager/content-data-manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content/manager/content-data-manager.ts
@@ -19,13 +19,15 @@ export class UmbContentWorkspaceDataManager<
 		this.#variantScaffold = variantScaffold;
 	}
 
-	protected override _sortCurrentData(persistedData: ModelType, currentData: Partial<ModelType>) {
+	protected override _sortCurrentData(persistedData: Partial<ModelType>, currentData: Partial<ModelType>) {
 		super._sortCurrentData(persistedData, currentData);
 		// Sort the variants in the same order as the persisted data:
 		const persistedVariants = persistedData.variants;
-		currentData.variants?.sort(function (a, b) {
-			return persistedVariants.indexOf(a) - persistedVariants.indexOf(b);
-		});
+		if (persistedVariants) {
+			currentData.variants?.sort(function (a, b) {
+				return persistedVariants.indexOf(a) - persistedVariants.indexOf(b);
+			});
+		}
 	}
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content/manager/element-data-manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content/manager/element-data-manager.ts
@@ -11,6 +11,15 @@ export class UmbElementWorkspaceDataManager<ModelType extends UmbElementDetailMo
 	//#variesByCulture?: boolean;
 	//#variesBySegment?: boolean;
 
+	protected override _sortCurrentData(persistedData: ModelType, currentData: Partial<ModelType>) {
+		super._sortCurrentData(persistedData, currentData);
+		// Sort the values in the same order as the persisted data:
+		const persistedValues = persistedData.values;
+		currentData.values?.sort(function (a, b) {
+			return persistedValues.indexOf(a) - persistedValues.indexOf(b);
+		});
+	}
+
 	#updateLock = 0;
 	initiatePropertyValueChange() {
 		this.#updateLock++;
@@ -54,7 +63,7 @@ export class UmbElementWorkspaceDataManager<ModelType extends UmbElementDetailMo
 			variantsToStore = [...selectedVariants, invariantVariantId];
 		}
 
-		const data = this._current.getValue();
+		const data = this.getCurrent();
 		if (!data) throw new Error('Current data is missing');
 		//if (!data.unique) throw new Error('Unique of current data is missing');
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content/manager/element-data-manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content/manager/element-data-manager.ts
@@ -11,13 +11,15 @@ export class UmbElementWorkspaceDataManager<ModelType extends UmbElementDetailMo
 	//#variesByCulture?: boolean;
 	//#variesBySegment?: boolean;
 
-	protected override _sortCurrentData(persistedData: ModelType, currentData: Partial<ModelType>) {
+	protected override _sortCurrentData(persistedData: Partial<ModelType>, currentData: Partial<ModelType>) {
 		super._sortCurrentData(persistedData, currentData);
 		// Sort the values in the same order as the persisted data:
 		const persistedValues = persistedData.values;
-		currentData.values?.sort(function (a, b) {
-			return persistedValues.indexOf(a) - persistedValues.indexOf(b);
-		});
+		if (persistedValues) {
+			currentData.values?.sort(function (a, b) {
+				return persistedValues.indexOf(a) - persistedValues.indexOf(b);
+			});
+		}
 	}
 
 	#updateLock = 0;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content/manager/element-data-manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content/manager/element-data-manager.ts
@@ -1,7 +1,11 @@
 import { UmbMergeContentVariantDataController } from '../controller/merge-content-variant-data.controller.js';
 import type { UmbElementDetailModel } from '../types.js';
-import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
+import { UmbVariantId, umbVariantObjectCompare } from '@umbraco-cms/backoffice/variant';
 import { UmbEntityWorkspaceDataManager, type UmbWorkspaceDataManager } from '@umbraco-cms/backoffice/workspace';
+
+function valueObjectCompare(a: any, b: any) {
+	return a.alias === b.alias && umbVariantObjectCompare(a, b);
+}
 
 export class UmbElementWorkspaceDataManager<ModelType extends UmbElementDetailModel>
 	extends UmbEntityWorkspaceDataManager<ModelType>
@@ -22,7 +26,10 @@ export class UmbElementWorkspaceDataManager<ModelType extends UmbElementDetailMo
 			return {
 				...currentData,
 				values: [...currentData.values].sort(function (a, b) {
-					return persistedValues.indexOf(a) - persistedValues.indexOf(b);
+					return (
+						persistedValues.findIndex((x) => valueObjectCompare(x, a)) -
+						persistedValues.findIndex((x) => valueObjectCompare(x, b))
+					);
 				}),
 			};
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content/manager/element-data-manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content/manager/element-data-manager.ts
@@ -11,15 +11,22 @@ export class UmbElementWorkspaceDataManager<ModelType extends UmbElementDetailMo
 	//#variesByCulture?: boolean;
 	//#variesBySegment?: boolean;
 
-	protected override _sortCurrentData(persistedData: Partial<ModelType>, currentData: Partial<ModelType>) {
-		super._sortCurrentData(persistedData, currentData);
+	protected override _sortCurrentData<GivenType extends Partial<ModelType> = Partial<ModelType>>(
+		persistedData: Partial<ModelType>,
+		currentData: GivenType,
+	): GivenType {
+		currentData = super._sortCurrentData(persistedData, currentData);
 		// Sort the values in the same order as the persisted data:
 		const persistedValues = persistedData.values;
-		if (persistedValues) {
-			currentData.values?.sort(function (a, b) {
-				return persistedValues.indexOf(a) - persistedValues.indexOf(b);
-			});
+		if (persistedValues && currentData.values) {
+			return {
+				...currentData,
+				values: [...currentData.values].sort(function (a, b) {
+					return persistedValues.indexOf(a) - persistedValues.indexOf(b);
+				}),
+			};
 		}
+		return currentData;
 	}
 
 	#updateLock = 0;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/variant/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/variant/index.ts
@@ -1,2 +1,3 @@
 export * from './variant-id.class.js';
+export * from './variant-object-compare.function.js';
 export type * from './types.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/variant/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/variant/types.ts
@@ -3,6 +3,11 @@ import type { UmbLanguageDetailModel } from '@umbraco-cms/backoffice/language';
 import type { ScheduleRequestModel } from '@umbraco-cms/backoffice/external/backend-api';
 import type { UmbPropertyValueData } from '@umbraco-cms/backoffice/property';
 
+export type UmbObjectWithVariantProperties = {
+	culture: string | null;
+	segment: string | null;
+};
+
 export interface UmbVariantDataModel {
 	culture: string | null;
 	segment: string | null;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/variant/variant-id.class.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/variant/variant-id.class.ts
@@ -1,9 +1,5 @@
 import { UmbDeprecation } from '../utils/index.js';
-
-export type UmbObjectWithVariantProperties = {
-	culture: string | null;
-	segment: string | null;
-};
+import type { UmbObjectWithVariantProperties } from './types.js';
 
 /**
  *

--- a/src/Umbraco.Web.UI.Client/src/packages/core/variant/variant-object-compare.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/variant/variant-object-compare.function.ts
@@ -1,0 +1,5 @@
+import type { UmbObjectWithVariantProperties } from './types.js';
+
+export function umbVariantObjectCompare(a: UmbObjectWithVariantProperties, b: UmbObjectWithVariantProperties): boolean {
+	return a.culture === b.culture && a.segment === b.segment;
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity/entity-workspace-data-manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity/entity-workspace-data-manager.ts
@@ -28,7 +28,7 @@ export class UmbEntityWorkspaceDataManager<ModelType>
 	 */
 	public readonly current = this._current.asObservable();
 
-	protected _sortCurrentData(persistedData: ModelType, currentData: Partial<ModelType>) {
+	protected _sortCurrentData(persistedData: Partial<ModelType>, currentData: Partial<ModelType>) {
 		// do nothing.
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity/entity-workspace-data-manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity/entity-workspace-data-manager.ts
@@ -28,8 +28,12 @@ export class UmbEntityWorkspaceDataManager<ModelType>
 	 */
 	public readonly current = this._current.asObservable();
 
-	protected _sortCurrentData(persistedData: Partial<ModelType>, currentData: Partial<ModelType>) {
+	protected _sortCurrentData<GivenType extends Partial<ModelType> = Partial<ModelType>>(
+		persistedData: Partial<ModelType>,
+		currentData: GivenType,
+	): GivenType {
 		// do nothing.
+		return currentData;
 	}
 
 	/**
@@ -88,7 +92,7 @@ export class UmbEntityWorkspaceDataManager<ModelType>
 		if (data) {
 			const persistedData = this._persisted.getValue();
 			if (persistedData) {
-				this._sortCurrentData(persistedData, data);
+				data = this._sortCurrentData(persistedData, data);
 			}
 		}
 		this._current.setValue(data);
@@ -103,7 +107,7 @@ export class UmbEntityWorkspaceDataManager<ModelType>
 		if (partialData) {
 			const persistedData = this._persisted.getValue();
 			if (persistedData) {
-				this._sortCurrentData(persistedData, partialData);
+				partialData = this._sortCurrentData(persistedData, partialData);
 			}
 		}
 		this._current.update(partialData);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity/entity-workspace-data-manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity/entity-workspace-data-manager.ts
@@ -28,6 +28,10 @@ export class UmbEntityWorkspaceDataManager<ModelType>
 	 */
 	public readonly current = this._current.asObservable();
 
+	protected _sortCurrentData(persistedData: ModelType, currentData: Partial<ModelType>) {
+		// do nothing.
+	}
+
 	/**
 	 * Gets persisted data
 	 * @returns {(ModelType | undefined)}
@@ -81,6 +85,12 @@ export class UmbEntityWorkspaceDataManager<ModelType>
 	 * @memberof UmbSubmittableWorkspaceDataManager
 	 */
 	setCurrent(data: ModelType | undefined) {
+		if (data) {
+			const persistedData = this._persisted.getValue();
+			if (persistedData) {
+				this._sortCurrentData(persistedData, data);
+			}
+		}
 		this._current.setValue(data);
 	}
 
@@ -90,6 +100,12 @@ export class UmbEntityWorkspaceDataManager<ModelType>
 	 * @memberof UmbSubmittableWorkspaceDataManager
 	 */
 	updateCurrent(partialData: Partial<ModelType>) {
+		if (partialData) {
+			const persistedData = this._persisted.getValue();
+			if (persistedData) {
+				this._sortCurrentData(persistedData, partialData);
+			}
+		}
 		this._current.update(partialData);
 	}
 


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/18431

Does so by making sure the current data respects the order from the persisted data.

This both fixes the case represented in the issue, but also ensures a similar issue that happens with Property Value Presets.
The problem is that we cannot in general be indifferent about array orders in our difference comparison, but in the case of Content Values and Content Variants we can and therefor we can sort them to be like the persisted.
The reason why we go with the persisted, is because persisted is set directly to the version we get back from the server, keeping the order the server insists on. meaning once we got a persisted version we can adjust our to it and avoid differences on values or variant sort orders.