### PR TITLE
Tiptap RTE: Trailing Node extension

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/external/tiptap/extensions/tiptap-trailing-node.extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/tiptap/extensions/tiptap-trailing-node.extension.ts
@@ -1,0 +1,71 @@
+/* This Source Code has been derived from Tiptap.
+ * https://github.com/ueberdosis/tiptap/blob/v2.11.5/demos/src/Experiments/TrailingNode/Vue/trailing-node.ts
+ * SPDX-License-Identifier: MIT
+ * Copyright © 2023 Tiptap GmbH.
+ * Modifications are licensed under the MIT License.
+ */
+
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+
+// @ts-ignore
+function nodeEqualsType({ types, node }) {
+	return (Array.isArray(types) && types.includes(node.type)) || node.type === types;
+}
+
+export interface TrailingNodeOptions {
+	node: string;
+	notAfter: string[];
+}
+
+export const TrailingNode = Extension.create<TrailingNodeOptions>({
+	name: 'trailingNode',
+
+	addOptions() {
+		return {
+			node: 'paragraph',
+			notAfter: ['paragraph'],
+		};
+	},
+
+	addProseMirrorPlugins() {
+		const plugin = new PluginKey(this.name);
+		const disabledNodes = Object.entries(this.editor.schema.nodes)
+			.map(([, value]) => value)
+			.filter((node) => this.options.notAfter.includes(node.name));
+
+		return [
+			new Plugin({
+				key: plugin,
+				appendTransaction: (_, __, state) => {
+					const { doc, tr, schema } = state;
+					const shouldInsertNodeAtEnd = plugin.getState(state);
+					const endPosition = doc.content.size;
+					const type = schema.nodes[this.options.node];
+
+					if (!shouldInsertNodeAtEnd) {
+						return;
+					}
+
+					return tr.insert(endPosition, type.create());
+				},
+				state: {
+					init: (_, state) => {
+						const lastNode = state.tr.doc.lastChild;
+
+						return !nodeEqualsType({ node: lastNode, types: disabledNodes });
+					},
+					apply: (tr, value) => {
+						if (!tr.docChanged) {
+							return value;
+						}
+
+						const lastNode = tr.doc.lastChild;
+
+						return !nodeEqualsType({ node: lastNode, types: disabledNodes });
+					},
+				},
+			}),
+		];
+	},
+});

--- a/src/Umbraco.Web.UI.Client/src/external/tiptap/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/tiptap/index.ts
@@ -33,6 +33,7 @@ export * from './extensions/tiptap-figcaption.extension.js';
 export * from './extensions/tiptap-figure.extension.js';
 export * from './extensions/tiptap-span.extension.js';
 export * from './extensions/tiptap-html-global-attributes.extension.js';
+export * from './extensions/tiptap-trailing-node.extension.js';
 export * from './extensions/tiptap-umb-embedded-media.extension.js';
 export * from './extensions/tiptap-umb-image.extension.js';
 export * from './extensions/tiptap-umb-link.extension.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/core/rich-text-essentials.tiptap-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/core/rich-text-essentials.tiptap-api.ts
@@ -7,6 +7,7 @@ import {
 	Span,
 	StarterKit,
 	TextStyle,
+	TrailingNode,
 } from '@umbraco-cms/backoffice/external/tiptap';
 
 export class UmbTiptapRichTextEssentialsExtensionApi extends UmbTiptapExtensionApiBase {
@@ -53,6 +54,7 @@ export class UmbTiptapRichTextEssentialsExtensionApi extends UmbTiptapExtensionA
 		}),
 		Div,
 		Span,
+		TrailingNode,
 	];
 }
 


### PR DESCRIPTION
### Description

Adds the Trailing Node extension for Tiptap RTE.

**Why would we need this?**

To quote the Tiptap documentation... https://tiptap.dev/docs/examples/experiments/trailing-node

> The Trailing Node extension automatically appends an invisible node at the end of the document. This is useful for purposes like adding a consistent footer or signature.
> 
> In the example shown here, the trailing node is left empty to enable you to place your caret behind the code block.
> 
> Since this extension is **not yet published officially**, you may need to copy the source code and create your own extension.

I have copied the code verbatim, so that we can easily replace it if/when Tiptap decide to release an official extension.

### How to test?

Try adding a code block to the end of the Tiptap RTE content. You'll notice that you can't place the cursor after the code block. This extension adds a trailing paragraph, so the cursor can be placed at the end of the content.