### PR TITLE
Localize the email property editor validation and add tests

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/Validators/EmailValidator.cs
+++ b/src/Umbraco.Core/PropertyEditors/Validators/EmailValidator.cs
@@ -31,14 +31,14 @@ public sealed class EmailValidator : IValueValidator
     /// <inheritdoc />
     public IEnumerable<ValidationResult> Validate(object? value, string? valueType, object? dataTypeConfiguration, PropertyValidationContext validationContext)
     {
-        var asString = value?.ToString()?.Trim() ?? string.Empty;
+        var valueAsString = value?.ToString() ?? string.Empty;
 
-        var emailVal = new EmailAddressAttribute();
+        var emailAddressAttribute = new EmailAddressAttribute();
 
-        if (asString != string.Empty && emailVal.IsValid(asString) == false)
+        if (valueAsString != string.Empty && emailAddressAttribute.IsValid(valueAsString) == false)
         {
             yield return new ValidationResult(
-                _localizedTextService.Localize("validation", "invalidEmail", [asString]),
+                _localizedTextService.Localize("validation", "invalidEmail", [valueAsString]),
                 ["value"]);
         }
     }

--- a/src/Umbraco.Core/PropertyEditors/Validators/EmailValidator.cs
+++ b/src/Umbraco.Core/PropertyEditors/Validators/EmailValidator.cs
@@ -1,24 +1,45 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models.Validation;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors.Validators;
 
 /// <summary>
-///     A validator that validates an email address
+/// A validator that validates an email address.
 /// </summary>
 public sealed class EmailValidator : IValueValidator
 {
+    private readonly ILocalizedTextService _localizedTextService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EmailValidator"/> class.
+    /// </summary>
+    [Obsolete("Please use the constructor taking all parameters. Scheduled for removal in Umbraco 17.")]
+    public EmailValidator()
+        : this(StaticServiceProvider.Instance.GetRequiredService<ILocalizedTextService>())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EmailValidator"/> class.
+    /// </summary>
+    public EmailValidator(ILocalizedTextService localizedTextService) => _localizedTextService = localizedTextService;
+
     /// <inheritdoc />
     public IEnumerable<ValidationResult> Validate(object? value, string? valueType, object? dataTypeConfiguration, PropertyValidationContext validationContext)
     {
-        var asString = value == null ? string.Empty : value.ToString();
+        var asString = value?.ToString()?.Trim() ?? string.Empty;
 
         var emailVal = new EmailAddressAttribute();
 
         if (asString != string.Empty && emailVal.IsValid(asString) == false)
         {
-            // TODO: localize these!
-            yield return new ValidationResult("Email is invalid", new[] { "value" });
+            yield return new ValidationResult(
+                _localizedTextService.Localize("validation", "invalidEmail", [asString]),
+                ["value"]);
         }
     }
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/EmailAddressPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/EmailAddressPropertyEditor.cs
@@ -1,29 +1,50 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors.Validators;
+using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
+/// <summary>
+/// Defines an email address property editor.
+/// </summary>
 [DataEditor(
     Constants.PropertyEditors.Aliases.EmailAddress,
     ValueEditorIsReusable = true)]
 public class EmailAddressPropertyEditor : DataEditor
 {
-    /// <summary>
-    ///     The constructor will setup the property editor based on the attribute if one is found
-    /// </summary>
-    public EmailAddressPropertyEditor(IDataValueEditorFactory dataValueEditorFactory)
-        : base(dataValueEditorFactory)
-        => SupportsReadOnly = true;
+    private readonly ILocalizedTextService _localizedTextService;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EmailAddressPropertyEditor"/> class.
+    /// </summary>
+    [Obsolete("Please use the constructor taking all parameters. Scheduled for removal in Umbraco 17.")]
+    public EmailAddressPropertyEditor(IDataValueEditorFactory dataValueEditorFactory)
+        : this(
+              dataValueEditorFactory,
+              StaticServiceProvider.Instance.GetRequiredService<ILocalizedTextService>())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EmailAddressPropertyEditor"/> class.
+    /// </summary>
+    public EmailAddressPropertyEditor(IDataValueEditorFactory dataValueEditorFactory, ILocalizedTextService localizedTextService)
+        : base(dataValueEditorFactory)
+    {
+        SupportsReadOnly = true;
+        _localizedTextService = localizedTextService;
+    }
+
+    /// <inheritdoc/>
     protected override IDataValueEditor CreateValueEditor()
     {
         IDataValueEditor editor = base.CreateValueEditor();
-
-        // add an email address validator
-        editor.Validators.Add(new EmailValidator());
+        editor.Validators.Add(new EmailValidator(_localizedTextService));
         return editor;
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/Validators/EmailValidatorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/Validators/EmailValidatorTests.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Globalization;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Models.Validation;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.PropertyEditors.Validators;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.PropertyEditors.Validators;
+
+[TestFixture]
+public class EmailValidatorTests
+{
+    [TestCase(null, true)]
+    [TestCase("", true)]
+    [TestCase("test@test.com", true)]
+    [TestCase("invalid", false)]
+    public void Validates_Email_Address(object? email, bool expectedSuccess)
+    {
+        var validator = CreateValidator();
+        var result = validator.Validate(email, ValueTypes.String, null, PropertyValidationContext.Empty());
+        if (expectedSuccess)
+        {
+            Assert.IsEmpty(result);
+        }
+        else
+        {
+            Assert.AreEqual(1, result.Count());
+
+            var validationResult = result.First();
+            Assert.AreEqual("validation_invalidEmail", validationResult.ErrorMessage);
+        }
+    }
+
+    private static EmailValidator CreateValidator()
+    {
+        var localizedTextServiceMock = new Mock<ILocalizedTextService>();
+        localizedTextServiceMock.Setup(x => x.Localize(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CultureInfo>(),
+                It.IsAny<IDictionary<string, string>>()))
+            .Returns((string key, string alias, CultureInfo culture, IDictionary<string, string> args) => $"{key}_{alias}");
+        return new EmailValidator(localizedTextServiceMock.Object);
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/Validators/EmailValidatorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/Validators/EmailValidatorTests.cs
@@ -16,6 +16,7 @@ public class EmailValidatorTests
 {
     [TestCase(null, true)]
     [TestCase("", true)]
+    [TestCase(" ", false)]
     [TestCase("test@test.com", true)]
     [TestCase("invalid", false)]
     public void Validates_Email_Address(object? email, bool expectedSuccess)


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description
Next one for server-side validation was the email address property editor.  This already had the necessary validation so I've just updated to use localization and added some tests.

Unlike the others I've looked at this didn't have a custom nested `DataValueEditor` class.  I didn't think it necessary to introduce it so have kept the class structure as is.  Means the unit test is on the `EmailValidator` itself but I think this is OK, as the property editor itself just delegates to this.

To test I've used Swagger, manipulating requests to `PUT /umbraco/management/api/v1.1/document/{id}/validate`.