### PR TITLE
Fix: Front-end/UX of #18402

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/content-type/structure/content-type-structure-manager.class.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content-type/structure/content-type-structure-manager.class.ts
@@ -375,7 +375,6 @@ export class UmbContentTypeStructureManager<
 			...(this.#contentTypes.getValue().find((x) => x.unique === toContentTypeUnique)?.containers ?? []),
 		];
 
-		//.filter((x) => x.name !== clonedContainer.name && x.type === clonedContainer.type);
 		containers.push(clonedContainer);
 
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -410,6 +409,14 @@ export class UmbContentTypeStructureManager<
 	): Promise<UmbPropertyTypeContainerModel> {
 		await this.#init;
 		contentTypeUnique = contentTypeUnique ?? this.#ownerContentTypeUnique!;
+
+		if (parentId) {
+			const duplicatedParentContainer = await this.ensureContainerOf(parentId, contentTypeUnique);
+			if (!duplicatedParentContainer) {
+				throw new Error('Parent container for creating a new container could not be found or created');
+			}
+			parentId = duplicatedParentContainer.id;
+		}
 
 		const container: UmbPropertyTypeContainerModel = {
 			id: UmbId.new(),


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/18402

When creating a container this makes sure to duplicate the parent container, so the parent as well exists on the owner document. This is the same approach used on creation of properties, was just never implemented on Container Creation.