### PR TITLE
Remove the hardcoded color for the text in error message

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/views/search/components/log-viewer-message.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/views/search/components/log-viewer-message.element.ts
@@ -237,7 +237,6 @@ export class UmbLogViewerMessageElement extends UmbLitElement {
 
 			pre {
 				border-left: 4px solid #d42054;
-				color: #303033;
 				display: block;
 				font-family:
 					Lato,


### PR DESCRIPTION
When using Dark mode in the Back Office, the text you see in the error messages in the log viewer is hardcoded to a black color, which makes it pretty impossible to read.

By removing the hard-coded color, it defaults to the --uui-color-text for all the themes, giving the text the right color.