### PR TITLE
Backport `ShowUnroutableContentWarnings` to V13

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/ContentSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ContentSettings.cs
@@ -160,6 +160,7 @@ public class ContentSettings
     internal const bool StaticDisableUnpublishWhenReferenced = false;
     internal const bool StaticAllowEditInvariantFromNonDefault = false;
     internal const bool StaticShowDomainWarnings = true;
+    internal const bool StaticShowUnroutableContentWarnings = true;
 
     /// <summary>
     ///     Gets or sets a value for the content notification settings.
@@ -285,4 +286,10 @@ public class ContentSettings
     /// </summary>
     [DefaultValue(StaticShowDomainWarnings)]
     public bool ShowDomainWarnings { get; set; } = StaticShowDomainWarnings;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show unroutable content warnings.
+    /// </summary>
+    [DefaultValue(StaticShowUnroutableContentWarnings)]
+    public bool ShowUnroutableContentWarnings { get; set; } = StaticShowUnroutableContentWarnings;
 }

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
@@ -1278,6 +1278,11 @@ public class ContentController : ContentControllerBase
         SimpleNotificationModel globalNotifications,
         string[]? successfulCultures)
     {
+        if (_contentSettings.ShowUnroutableContentWarnings is false)
+        {
+            return;
+        }
+
         IContent? content = publishStatus.FirstOrDefault()?.Content;
         if (content is null)
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

#17837 introduced a configuration option (`ShowUnroutableContentWarnings`) to disable warnings for unroutable content in V15 (the warnings were originally introduced for V13 in #17705).

This PR backports the same configuration from V15 to V13 😄 

### Testing this PR

1. Create content with conflicting routes.
2. Verify that warnings are conditionally displayed at publish time for that content, depending on the current value of  `ShowUnroutableContentWarnings` 

Note that you must have `ShowDomainWarnings` disabled to reliably test this, because `ShowDomainWarnings` overrules `ShowUnroutableContentWarnings` in certain scenarios:

```
"Umbraco": {
    "CMS": {
      "Content": {
        "ShowDomainWarnings": false,
        "ShowUnroutableContentWarnings": true/false
      }
```