### PR TITLE
Remove Tip tap placeholder text

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/core/rich-text-essentials.tiptap-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/core/rich-text-essentials.tiptap-api.ts
@@ -1,20 +1,9 @@
 import { UmbTiptapExtensionApiBase } from '../base.js';
-import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
-import {
-	Div,
-	HtmlGlobalAttributes,
-	Placeholder,
-	Span,
-	StarterKit,
-	TrailingNode,
-} from '@umbraco-cms/backoffice/external/tiptap';
+import { Div, HtmlGlobalAttributes, Span, StarterKit, TrailingNode } from '@umbraco-cms/backoffice/external/tiptap';
 
 export class UmbTiptapRichTextEssentialsExtensionApi extends UmbTiptapExtensionApiBase {
-	#localize = new UmbLocalizationController(this);
-
 	getTiptapExtensions = () => [
 		StarterKit,
-		Placeholder.configure({ placeholder: this.#localize.term('placeholders_rteParagraph') }),
 		Div,
 		Span,
 		HtmlGlobalAttributes.configure({


### PR DESCRIPTION
We currently have a placeholder in Tip Tap that says "Write something amazing...". We don’t use similar placeholders anywhere else, so I don't think it fits here either.