### PR TITLE
15.3: Hotfix: Content type discard changes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/workspace/document-type/document-type-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/workspace/document-type/document-type-workspace-editor.element.ts
@@ -78,7 +78,7 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 
 	override render() {
 		return html`
-			<umb-workspace-editor>
+			<umb-entity-detail-workspace-editor>
 				<div id="header" slot="header">
 					<uui-button id="icon" compact label="icon" look="outline" @click=${this._handleIconClick}>
 						<umb-icon name=${ifDefined(this._icon)}></umb-icon>
@@ -105,7 +105,7 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 							@input=${this.#onDescriptionChange}></uui-input>
 					</div>
 				</div>
-			</umb-workspace-editor>
+			</umb-entity-detail-workspace-editor>
 		`;
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/workspace/media-type-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/workspace/media-type-workspace-editor.element.ts
@@ -82,7 +82,7 @@ export class UmbMediaTypeWorkspaceEditorElement extends UmbLitElement {
 
 	override render() {
 		return html`
-			<umb-workspace-editor>
+			<umb-entity-detail-workspace-editor>
 				<div id="header" slot="header">
 					<uui-button id="icon" compact label="icon" look="outline" @click=${this._handleIconClick}>
 						<umb-icon name=${ifDefined(this._icon)}></umb-icon>
@@ -107,7 +107,7 @@ export class UmbMediaTypeWorkspaceEditorElement extends UmbLitElement {
 							@input=${this.#onDescriptionChange}></uui-input>
 					</div>
 				</div>
-			</umb-workspace-editor>
+			</umb-entity-detail-workspace-editor>
 		`;
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/workspace/member-type-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/workspace/member-type-workspace-editor.element.ts
@@ -77,7 +77,7 @@ export class UmbMemberTypeWorkspaceEditorElement extends UmbLitElement {
 
 	override render() {
 		return html`
-			<umb-workspace-editor>
+			<umb-entity-detail-workspace-editor>
 				<div id="header" slot="header">
 					<uui-button id="icon" compact label="icon" look="outline" @click=${this._handleIconClick}>
 						<umb-icon name=${ifDefined(this._icon)}></umb-icon>
@@ -102,7 +102,7 @@ export class UmbMemberTypeWorkspaceEditorElement extends UmbLitElement {
 							@input=${this.#onDescriptionChange}></uui-input>
 					</div>
 				</div>
-			</umb-workspace-editor>
+			</umb-entity-detail-workspace-editor>
 		`;
 	}
 


### PR DESCRIPTION
This PR fixes an unnecessary "discard changes" dialog that appears in the Content-Type workspaces.

Additionally, it introduces the `<umb-entity-detail-workspace-editor>` element for those workspaces, enabling an error screen to display when deleting a Content Type that is currently open.

